### PR TITLE
fix(web): gate the owner role on the viewer being an owner

### DIFF
--- a/apps/web/src/features/api-keys/use-api-keys.ts
+++ b/apps/web/src/features/api-keys/use-api-keys.ts
@@ -24,6 +24,53 @@ export const apiKeysKeys = {
   list: () => [...apiKeysKeys.all, "list"] as const,
 };
 
+// ---------------------------------------------------------------------------
+// Coded refusals — same idiom as `mapDeleteOrgError` in
+// `features/orgs/use-orgs.ts`.
+//
+// Read out of the Go handler, not guessed:
+//   apps/api/internal/apikey/handler.go:59
+//     Forbidden("apikey_role_exceeds_actor",
+//               "you cannot create an API key with a role higher than your own")
+// ---------------------------------------------------------------------------
+
+/** The refusal codes POST /api/v1/api-keys is documented to return. */
+export type ApiKeyErrorCode = "apikey_role_exceeds_actor";
+
+const API_KEY_ERROR_MESSAGES: Record<ApiKeyErrorCode, string> = {
+  apikey_role_exceeds_actor:
+    "A key can't carry a role higher than your own. Pick a lower role, or ask an owner.",
+};
+
+function isApiKeyErrorCode(code: string): code is ApiKeyErrorCode {
+  return Object.prototype.hasOwnProperty.call(API_KEY_ERROR_MESSAGES, code);
+}
+
+/**
+ * Maps an API-key refusal code into clear, human copy. Falls back to the
+ * server's own message for any undocumented code. Pure + exported so the
+ * documented code is covered by a test without a network call.
+ */
+export function mapApiKeyError(
+  code: string | undefined,
+  fallbackMessage: string,
+): string {
+  if (code && isApiKeyErrorCode(code)) {
+    return API_KEY_ERROR_MESSAGES[code];
+  }
+  return fallbackMessage || "Could not create API key";
+}
+
+/** Raised by useCreateApiKey; carries the server's refusal code. */
+export class ApiKeyError extends Error {
+  code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "ApiKeyError";
+    this.code = code;
+  }
+}
+
 export function useApiKeys(): UseQueryResult<ApiKey[], Error> {
   return useQuery({
     queryKey: apiKeysKeys.list(),
@@ -44,7 +91,14 @@ export function useCreateApiKey(): UseMutationResult<
   return useMutation({
     mutationFn: async (body: ApiKeyCreate) => {
       const { data, error } = await createApiKey({ body });
-      if (error) throw toError(error);
+      if (error) {
+        const raw = error as { code?: string; message?: string } | null;
+        const code = typeof raw?.code === "string" ? raw.code : undefined;
+        throw new ApiKeyError(
+          mapApiKeyError(code, toError(error).message || "Could not create API key"),
+          code,
+        );
+      }
       if (!data) throw new Error("Empty response");
       return data;
     },

--- a/apps/web/src/features/orgs/use-members.ts
+++ b/apps/web/src/features/orgs/use-members.ts
@@ -43,6 +43,82 @@ export interface InviteMemberResult {
 }
 
 // ---------------------------------------------------------------------------
+// Coded refusals
+//
+// Follows the `mapDeleteOrgError` idiom in `features/orgs/use-orgs.ts`: a map
+// of documented codes to house-style copy, a pure exported mapper that falls
+// back to the server's own message for anything undocumented, and an Error
+// subclass carrying the code for callers that need to branch.
+//
+// Every code below was read out of the Go handler rather than guessed:
+//   apps/api/internal/auth/members_handler.go
+//     :215 Forbidden("target_role_exceeds_actor", "you cannot change the role
+//          of a member who outranks you")
+//     :268 Forbidden("target_role_exceeds_actor", "you cannot remove a member
+//          who outranks you")
+//     Forbidden("role_grant_exceeds_actor", "you cannot grant a role higher
+//          than your own")   (also apps/api/internal/auth/service.go:331 and
+//          apps/api/internal/invitation/service.go:96)
+//     Forbidden("last_owner", "cannot demote the last owner" / "cannot remove
+//          the last owner")
+// ---------------------------------------------------------------------------
+
+/** The refusal codes the members endpoints are documented to return. */
+export type MemberErrorCode =
+  | "target_role_exceeds_actor"
+  | "role_grant_exceeds_actor"
+  | "last_owner";
+
+const MEMBER_ERROR_MESSAGES: Record<MemberErrorCode, string> = {
+  target_role_exceeds_actor:
+    "That member outranks you, so you can't change or remove them. Ask an owner.",
+  role_grant_exceeds_actor:
+    "You can't grant a role higher than your own. Ask an owner.",
+  last_owner:
+    "This is the last owner. Promote another member to owner first, then try again.",
+};
+
+function isMemberErrorCode(code: string): code is MemberErrorCode {
+  return Object.prototype.hasOwnProperty.call(MEMBER_ERROR_MESSAGES, code);
+}
+
+/**
+ * Maps a members-endpoint refusal code into clear, human copy. Falls back to
+ * the server's own message for any undocumented code, so a future backend
+ * addition never surfaces as a blank error. Pure + exported so every
+ * documented code is covered by a test without a network call.
+ */
+export function mapMemberError(
+  code: string | undefined,
+  fallbackMessage: string,
+): string {
+  if (code && isMemberErrorCode(code)) {
+    return MEMBER_ERROR_MESSAGES[code];
+  }
+  return fallbackMessage || "Request failed";
+}
+
+/** Raised by the member mutations; carries the server's refusal code. */
+export class MemberError extends Error {
+  code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "MemberError";
+    this.code = code;
+  }
+}
+
+function toMemberError(error: unknown, fallback: string): Error {
+  const raw = error as { code?: string; message?: string } | null | undefined;
+  const code = typeof raw?.code === "string" ? raw.code : undefined;
+  if (code && isMemberErrorCode(code)) {
+    return new MemberError(mapMemberError(code, raw?.message ?? fallback), code);
+  }
+  const base = toError(error);
+  return new MemberError(base.message || fallback, code);
+}
+
+// ---------------------------------------------------------------------------
 // Cache key family
 // ---------------------------------------------------------------------------
 
@@ -84,7 +160,9 @@ export function useUpdateMemberRole(): UseMutationResult<
         body: { role },
         headers: { "Content-Type": "application/json" },
       });
-      if (result.error !== undefined) throw toError(result.error);
+      if (result.error !== undefined) {
+        throw toMemberError(result.error, "Could not update role");
+      }
       return result.data as Member;
     },
     onSuccess: (_updated, { role }) => {
@@ -92,7 +170,9 @@ export function useUpdateMemberRole(): UseMutationResult<
       toast.success(`Role updated to ${role}`);
     },
     onError: (err) => {
-      toast.error(`Could not update role: ${err.message}`);
+      // The message is already self-contained for a documented refusal code
+      // (see mapMemberError); prefixing it would double the "could not" clause.
+      toast.error(err.message);
     },
   });
 }
@@ -113,7 +193,9 @@ export function useRemoveMember(): UseMutationResult<
       const result = await client.delete({
         url: `/api/v1/members/${encodeURIComponent(userId)}`,
       });
-      if (result.error !== undefined) throw toError(result.error);
+      if (result.error !== undefined) {
+        throw toMemberError(result.error, "Could not remove member");
+      }
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: memberKeys.list() });
@@ -143,7 +225,12 @@ export function useInviteMember(): UseMutationResult<
         body,
         headers: { "Content-Type": "application/json" },
       });
-      if (result.error !== undefined) throw toError(result.error);
+      // Invite goes through the same ceiling check
+      // (apps/api/internal/invitation/service.go:96 returns
+      // role_grant_exceeds_actor), so it maps the same way.
+      if (result.error !== undefined) {
+        throw toMemberError(result.error, "Could not send invitation");
+      }
       return result.data as InviteMemberResult;
     },
     onSuccess: (_data) => {

--- a/apps/web/src/features/orgs/use-members.ts
+++ b/apps/web/src/features/orgs/use-members.ts
@@ -108,6 +108,26 @@ export class MemberError extends Error {
   }
 }
 
+/**
+ * Builds the toast copy for a failed member mutation.
+ *
+ * A documented refusal already reads as a whole sentence about this exact
+ * operation ("That member outranks you, so you can't change or remove them"),
+ * so prefixing it would double the clause. Everything else is the opposite
+ * problem: the generated client throws a raw string for a non-JSON error body
+ * (`generated/client/client.gen.ts:202`, an nginx 502 page) and `{}` for an
+ * empty one (:216). Neither satisfies `isApiError`, so `toError` flattens both
+ * to "Request failed", and a network drop arrives as "Failed to fetch" -- three
+ * toasts that never say which operation failed. Those get the operation name.
+ */
+function withOperationContext(err: Error, operation: string): string {
+  const coded =
+    err instanceof MemberError &&
+    err.code !== undefined &&
+    isMemberErrorCode(err.code);
+  return coded ? err.message : `${operation}: ${err.message}`;
+}
+
 function toMemberError(error: unknown, fallback: string): Error {
   const raw = error as { code?: string; message?: string } | null | undefined;
   const code = typeof raw?.code === "string" ? raw.code : undefined;
@@ -170,9 +190,7 @@ export function useUpdateMemberRole(): UseMutationResult<
       toast.success(`Role updated to ${role}`);
     },
     onError: (err) => {
-      // The message is already self-contained for a documented refusal code
-      // (see mapMemberError); prefixing it would double the "could not" clause.
-      toast.error(err.message);
+      toast.error(withOperationContext(err, "Could not update role"));
     },
   });
 }
@@ -202,7 +220,7 @@ export function useRemoveMember(): UseMutationResult<
       toast.success("Member removed");
     },
     onError: (err) => {
-      toast.error(err.message);
+      toast.error(withOperationContext(err, "Could not remove member"));
     },
   });
 }
@@ -237,7 +255,7 @@ export function useInviteMember(): UseMutationResult<
       void queryClient.invalidateQueries({ queryKey: memberKeys.list() });
     },
     onError: (err) => {
-      toast.error(err.message);
+      toast.error(withOperationContext(err, "Could not send invitation"));
     },
   });
 }

--- a/apps/web/src/routes/_authed/settings/-api-keys.role-ceiling.test.tsx
+++ b/apps/web/src/routes/_authed/settings/-api-keys.role-ceiling.test.tsx
@@ -1,8 +1,58 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { ApiKey, ApiKeyCreated, Me } from "@wpmgr/api";
 
-import { createApiKeySchema } from "./api-keys";
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockQueryResult, mockMutationResult } from "@/test/query-mocks";
+
+import { Route as ApiKeysRoute, createApiKeySchema } from "./api-keys";
 import { mapApiKeyError } from "@/features/api-keys/use-api-keys";
 import { mapMemberError } from "@/features/orgs/use-members";
+
+// `useMe` is a TanStack Query hook in production, and that is load-bearing for
+// the org-switch test below: the switcher resets the cache and `me` changes
+// value under a still-mounted page. A `vi.fn()` returning a literal cannot
+// reproduce that -- swapping its return value re-renders nothing, because
+// nothing is subscribed to it. So the stand-in is a real `useQuery` over a
+// key the test seeds and then rewrites, which re-renders exactly the way the
+// real hook does.
+const ME_KEY = ["test", "me"] as const;
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/auth/use-auth")>();
+  const { useQuery } = await import("@tanstack/react-query");
+  return {
+    ...actual,
+    useMe: () =>
+      useQuery({
+        queryKey: ["test", "me"],
+        queryFn: () => null,
+        staleTime: Infinity,
+      }),
+  };
+});
+
+vi.mock("@/features/api-keys/use-api-keys", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/api-keys/use-api-keys")>();
+  return {
+    ...actual,
+    useApiKeys: vi.fn(),
+    useCreateApiKey: vi.fn(),
+    useRevokeApiKey: vi.fn(),
+  };
+});
+
+const { useApiKeys, useCreateApiKey, useRevokeApiKey } = await import(
+  "@/features/api-keys/use-api-keys"
+);
 
 // GH #406 follow-up. Hiding the Owner <option> is not the same as refusing to
 // send "owner": the schema still validated it, so a stale form value or a
@@ -78,5 +128,160 @@ describe("coded 403s reach the user as copy, not as a generic failure", () => {
   it("a missing code falls back too", () => {
     expect(mapMemberError(undefined, "Server said no")).toBe("Server said no");
     expect(mapApiKeyError(undefined, "Server said no")).toBe("Server said no");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The page wiring, mounted.
+//
+// The pure tests above cover `createApiKeySchema` and the code->copy mappers,
+// but nothing above touches the line that decides which branch the page asks
+// for (api-keys.tsx: `const viewerIsOwner = activeRole(me) === "owner"`).
+// Replacing that with `canManage(me)` -- the exact GH #406 escalation, since
+// canManage is true for an admin -- leaves every pure test green. So the page
+// is mounted here the same way `-members.owner-handover.test.tsx` mounts the
+// members route.
+// ---------------------------------------------------------------------------
+
+const TENANT = "00000000-0000-0000-0000-0000000000aa";
+const VIEWER_ID = "00000000-0000-0000-0000-000000000001";
+
+function meWithRole(role: "owner" | "admin"): Me {
+  return {
+    user: {
+      id: VIEWER_ID,
+      email: "viewer@wpmgr.test",
+      name: "Viewer",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    active_tenant_id: TENANT,
+    memberships: [{ tenant_id: TENANT, role, tenant_name: "Acme" }],
+  } as unknown as Me;
+}
+
+const CREATED: ApiKeyCreated = {
+  token: "wpm_live_deadbeef",
+  api_key: {
+    id: "00000000-0000-0000-0000-0000000000ff",
+    name: "ci",
+    prefix: "wpm_live",
+    role: "operator",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+} as unknown as ApiKeyCreated;
+
+let mutateAsync: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mutateAsync = vi.fn().mockResolvedValue(CREATED);
+  vi.mocked(useApiKeys).mockReturnValue(mockQueryResult<ApiKey[]>({ data: [] }));
+  vi.mocked(useCreateApiKey).mockReturnValue(mockMutationResult({ mutateAsync }));
+  vi.mocked(useRevokeApiKey).mockReturnValue(mockMutationResult({}));
+});
+
+/**
+ * Attaches this file's exported `Route` singleton to a throwaway root route --
+ * the same post-hoc wiring `routeTree.gen.ts` performs, collapsed to one path
+ * segment so the real `_authed` session guard never runs. Identical to
+ * `buildMembersRouter` in `-members.owner-handover.test.tsx:107`.
+ */
+function buildApiKeysRouter() {
+  const rootRoute = createRootRoute({});
+  type UpdateOptions = Parameters<typeof ApiKeysRoute.update>[0];
+  const apiKeysRoute = ApiKeysRoute.update({
+    id: "/settings/api-keys",
+    path: "/settings/api-keys",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const routeTree = rootRoute.addChildren([apiKeysRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ["/settings/api-keys"] }),
+  });
+}
+
+async function renderAs(role: "owner" | "admin") {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(ME_KEY, meWithRole(role));
+  const router = buildApiKeysRouter();
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  // RouterProvider's first paint is a microtask, so the first lookup awaits.
+  const select = await screen.findByRole("combobox", { name: "Role" });
+  return { queryClient, select };
+}
+
+function roleOptions(select: HTMLElement): string[] {
+  return [...select.querySelectorAll("option")].map((o) => o.value);
+}
+
+describe("api keys page -- the Role select is gated on the viewer's own role", () => {
+  it("an OWNER is offered Owner", async () => {
+    const { select } = await renderAs("owner");
+    expect(roleOptions(select)).toEqual([
+      "owner",
+      "admin",
+      "operator",
+      "viewer",
+    ]);
+  });
+
+  it("an ADMIN is not offered Owner (canManage is true for an admin, so it is the wrong gate)", async () => {
+    const { select } = await renderAs("admin");
+    expect(roleOptions(select)).toEqual(["admin", "operator", "viewer"]);
+  });
+});
+
+describe("api keys page -- the viewer's role drops while the form is open", () => {
+  // Reachable without any devtools: the OrgSwitcher lives in the AppShell top
+  // bar (_authed.tsx:70 -> top-bar.tsx:34), and useActivateOrg's onSuccess
+  // resets the query cache and calls router.invalidate() without unmounting a
+  // settings route -- the /sites/ bail-out in redirectIfSiteRouteWentStale
+  // does not cover /settings/*. Owner in org A, admin in org B, Owner already
+  // picked: the option vanishes, the native select falls back to its first
+  // option ("Admin"), and the form still holds "owner".
+  it("Create key still submits, with a role the new ceiling allows", async () => {
+    const { queryClient, select } = await renderAs("owner");
+    fireEvent.change(select, { target: { value: "owner" } });
+    fireEvent.change(screen.getByLabelText("Key name"), {
+      target: { value: "ci" },
+    });
+
+    act(() => {
+      queryClient.setQueryData(ME_KEY, meWithRole("admin"));
+    });
+
+    await waitFor(() =>
+      expect(roleOptions(select)).toEqual(["admin", "operator", "viewer"]),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create key" }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const sent = mutateAsync.mock.calls[0]?.[0] as { role?: string };
+    expect(sent.role).not.toBe("owner");
+    // The control the user is looking at agrees with what was sent.
+    expect((select as HTMLSelectElement).value).toBe(sent.role);
+  });
+
+  it("a role the ceiling refuses surfaces a visible error instead of a dead button", async () => {
+    // Second line of defence, reached the way the schema's own comment names:
+    // an out-of-ceiling value put into the select from outside the render.
+    const { select } = await renderAs("admin");
+    const smuggled = document.createElement("option");
+    smuggled.value = "owner";
+    smuggled.textContent = "Owner";
+    select.appendChild(smuggled);
+    fireEvent.change(select, { target: { value: "owner" } });
+    fireEvent.change(screen.getByLabelText("Key name"), {
+      target: { value: "ci" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create key" }));
+
+    expect(
+      await screen.findByText(/only an owner can create an owner key/i),
+    ).toBeInTheDocument();
+    expect(select).toHaveAttribute("aria-invalid", "true");
+    expect(mutateAsync).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routes/_authed/settings/-api-keys.role-ceiling.test.tsx
+++ b/apps/web/src/routes/_authed/settings/-api-keys.role-ceiling.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+
+import { createApiKeySchema } from "./api-keys";
+import { mapApiKeyError } from "@/features/api-keys/use-api-keys";
+import { mapMemberError } from "@/features/orgs/use-members";
+
+// GH #406 follow-up. Hiding the Owner <option> is not the same as refusing to
+// send "owner": the schema still validated it, so a stale form value or a
+// devtools edit produced a request the server then had to refuse. The enum is
+// now gated the same way the option is.
+
+describe("createApiKeySchema -- the enum is gated on the viewer being an owner", () => {
+  it("an OWNER may select owner", () => {
+    const parsed = createApiKeySchema(true).safeParse({
+      name: "ci",
+      role: "owner",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("an ADMIN cannot: owner fails validation, so the client never sends it", () => {
+    const parsed = createApiKeySchema(false).safeParse({
+      name: "ci",
+      role: "owner",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("every non-owner role stays valid for an admin (the gate must not over-fire)", () => {
+    const schema = createApiKeySchema(false);
+    for (const role of ["admin", "operator", "viewer"] as const) {
+      expect(schema.safeParse({ name: "ci", role }).success).toBe(true);
+    }
+  });
+
+  it("both branches still require a name", () => {
+    expect(createApiKeySchema(true).safeParse({ name: "" }).success).toBe(false);
+    expect(createApiKeySchema(false).safeParse({ name: "" }).success).toBe(false);
+  });
+});
+
+// Codes quoted from the handlers, not invented:
+//   apps/api/internal/apikey/handler.go:59        apikey_role_exceeds_actor
+//   apps/api/internal/auth/members_handler.go:215/:268  target_role_exceeds_actor
+//   apps/api/internal/auth/members_handler.go     role_grant_exceeds_actor, last_owner
+
+describe("coded 403s reach the user as copy, not as a generic failure", () => {
+  it("apikey_role_exceeds_actor gets its own message", () => {
+    const message = mapApiKeyError("apikey_role_exceeds_actor", "Request failed");
+    expect(message).not.toBe("Request failed");
+    expect(message).toMatch(/higher than your own/i);
+  });
+
+  it("target_role_exceeds_actor gets its own message", () => {
+    const message = mapMemberError("target_role_exceeds_actor", "Request failed");
+    expect(message).not.toBe("Request failed");
+    expect(message).toMatch(/outranks you/i);
+  });
+
+  it("last_owner and role_grant_exceeds_actor were already returned by the server and are now mapped too", () => {
+    expect(mapMemberError("last_owner", "Request failed")).toMatch(
+      /last owner/i,
+    );
+    expect(mapMemberError("role_grant_exceeds_actor", "Request failed")).toMatch(
+      /higher than your own/i,
+    );
+  });
+
+  it("an undocumented code falls back to the server's own message rather than a blank error", () => {
+    expect(mapMemberError("some_future_code", "Server said no")).toBe(
+      "Server said no",
+    );
+    expect(mapApiKeyError("some_future_code", "Server said no")).toBe(
+      "Server said no",
+    );
+  });
+
+  it("a missing code falls back too", () => {
+    expect(mapMemberError(undefined, "Server said no")).toBe("Server said no");
+    expect(mapApiKeyError(undefined, "Server said no")).toBe("Server said no");
+  });
+});

--- a/apps/web/src/routes/_authed/settings/-members.owner-handover.test.tsx
+++ b/apps/web/src/routes/_authed/settings/-members.owner-handover.test.tsx
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { Me } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { mockQueryResult, mockMutationResult } from "@/test/query-mocks";
+import type { Member } from "@/features/orgs/use-members";
+
+import { Route as MembersRoute, canActOnMemberRow } from "./members";
+
+// GH #406 follow-up. The escalation fix correctly stopped an ADMIN from
+// touching the owner's row, but it applied that same block to an OWNER, so an
+// org that reached two owners through the dashboard could never return to one:
+// every owner row rendered as static text with no role picker and no Remove.
+//
+// The API permits owner-on-owner. The refusal in
+// apps/api/internal/auth/members_handler.go:215 and :268 is
+// `target_role_exceeds_actor` -- "you cannot change the role of a member who
+// outranks you" -- and an owner does not outrank an owner. So the UI was
+// stricter than the API. These tests pin the four-cell matrix so neither half
+// can drift: the owner half must stay open, the admin half must stay shut.
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/auth/use-auth")>();
+  return { ...actual, useMe: vi.fn() };
+});
+
+vi.mock("@/features/orgs/use-members", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/orgs/use-members")>();
+  return {
+    ...actual,
+    useMembers: vi.fn(),
+    useUpdateMemberRole: vi.fn(),
+    useRemoveMember: vi.fn(),
+    useInviteMember: vi.fn(),
+  };
+});
+
+const { useMe } = await import("@/features/auth/use-auth");
+const {
+  useMembers,
+  useUpdateMemberRole,
+  useRemoveMember,
+  useInviteMember,
+} = await import("@/features/orgs/use-members");
+
+const mockedUseMe = vi.mocked(useMe);
+const mockedUseMembers = vi.mocked(useMembers);
+
+const TENANT = "00000000-0000-0000-0000-0000000000aa";
+const VIEWER_ID = "00000000-0000-0000-0000-000000000001";
+const OTHER_OWNER_ID = "00000000-0000-0000-0000-000000000002";
+const ADMIN_ID = "00000000-0000-0000-0000-000000000003";
+
+function meWithRole(role: "owner" | "admin"): Me {
+  return {
+    user: {
+      id: VIEWER_ID,
+      email: "viewer@wpmgr.test",
+      name: "Viewer",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    active_tenant_id: TENANT,
+    memberships: [{ tenant_id: TENANT, role, tenant_name: "Acme" }],
+  } as unknown as Me;
+}
+
+const CO_OWNER: Member = {
+  user_id: OTHER_OWNER_ID,
+  tenant_id: TENANT,
+  role: "owner",
+  email: "co-owner@wpmgr.test",
+};
+
+const AN_ADMIN: Member = {
+  user_id: ADMIN_ID,
+  tenant_id: TENANT,
+  role: "admin",
+  email: "an-admin@wpmgr.test",
+};
+
+beforeEach(() => {
+  vi.mocked(useUpdateMemberRole).mockReturnValue(mockMutationResult({}));
+  vi.mocked(useRemoveMember).mockReturnValue(mockMutationResult({}));
+  vi.mocked(useInviteMember).mockReturnValue(mockMutationResult({}));
+});
+
+/**
+ * Attaches this file's exported `Route` singleton to a throwaway root route --
+ * the same post-hoc wiring `routeTree.gen.ts` performs, collapsed to a single
+ * path segment so the real `_authed` session guard never runs. Identical to
+ * `buildBillingRouter` in `-billing.test.tsx`.
+ *
+ * Mounting the real route rather than reading `Route.options.component` off it
+ * is deliberate: the vite router plugin rewrites `component` into a split
+ * wrapper, and rendering that wrapper directly produced an empty DOM.
+ */
+function buildMembersRouter() {
+  const rootRoute = createRootRoute({});
+  type UpdateOptions = Parameters<typeof MembersRoute.update>[0];
+  const membersRoute = MembersRoute.update({
+    id: "/settings/members",
+    path: "/settings/members",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const routeTree = rootRoute.addChildren([membersRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ["/settings/members"] }),
+  });
+}
+
+async function renderAs(role: "owner" | "admin", members: Member[]) {
+  mockedUseMe.mockReturnValue(
+    mockQueryResult<Me | null>({ data: meWithRole(role) }),
+  );
+  mockedUseMembers.mockReturnValue(mockQueryResult<Member[]>({ data: members }));
+  renderWithProviders(<RouterProvider router={buildMembersRouter()} />, {
+    queryClient: createTestQueryClient(),
+  });
+  // RouterProvider's first paint is a microtask, so the first lookup awaits.
+  await screen.findByRole("table");
+}
+
+describe("members page -- owner/admin x owner/admin row matrix", () => {
+  it("OWNER viewing a CO-OWNER: role picker and Remove are both present (handover is possible)", async () => {
+    await renderAs("owner", [CO_OWNER]);
+    expect(
+      screen.getByRole("combobox", { name: `Role for ${CO_OWNER.email}` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Remove ${CO_OWNER.email}` }),
+    ).toBeInTheDocument();
+  });
+
+  it("OWNER viewing an ADMIN: role picker and Remove are both present", async () => {
+    await renderAs("owner", [AN_ADMIN]);
+    expect(
+      screen.getByRole("combobox", { name: `Role for ${AN_ADMIN.email}` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Remove ${AN_ADMIN.email}` }),
+    ).toBeInTheDocument();
+  });
+
+  it("ADMIN viewing the OWNER: static text only -- no picker, no Remove (this is the GH #406 fix)", async () => {
+    await renderAs("admin", [CO_OWNER]);
+    expect(
+      screen.queryByRole("combobox", { name: `Role for ${CO_OWNER.email}` }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: `Remove ${CO_OWNER.email}` }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("ADMIN viewing another ADMIN: role picker and Remove are both present", async () => {
+    await renderAs("admin", [AN_ADMIN]);
+    expect(
+      screen.getByRole("combobox", { name: `Role for ${AN_ADMIN.email}` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Remove ${AN_ADMIN.email}` }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("members page -- the Owner option in the role picker", () => {
+  it("an OWNER can nominate a co-owner (Owner option is offered)", async () => {
+    await renderAs("owner", [AN_ADMIN]);
+    const select = screen.getByRole("combobox", {
+      name: `Role for ${AN_ADMIN.email}`,
+    });
+    expect(
+      [...select.querySelectorAll("option")].map((o) => o.value),
+    ).toEqual(["owner", "admin", "operator", "viewer"]);
+  });
+
+  it("an ADMIN is not offered Owner (an admin self-promoting was the escalation)", async () => {
+    await renderAs("admin", [AN_ADMIN]);
+    const select = screen.getByRole("combobox", {
+      name: `Role for ${AN_ADMIN.email}`,
+    });
+    expect(
+      [...select.querySelectorAll("option")].map((o) => o.value),
+    ).toEqual(["admin", "operator", "viewer"]);
+  });
+});
+
+describe("canActOnMemberRow -- the gate itself", () => {
+  it("is closed on the owner row for an admin and open for an owner", () => {
+    const base = { manage: true, isCurrentUser: false } as const;
+    expect(
+      canActOnMemberRow({ ...base, viewerIsOwner: true, targetRole: "owner" }),
+    ).toBe(true);
+    expect(
+      canActOnMemberRow({ ...base, viewerIsOwner: false, targetRole: "owner" }),
+    ).toBe(false);
+  });
+
+  it("never opens for a viewer who cannot manage, whatever their role claim", () => {
+    expect(
+      canActOnMemberRow({
+        manage: false,
+        viewerIsOwner: true,
+        isCurrentUser: false,
+        targetRole: "admin",
+      }),
+    ).toBe(false);
+  });
+
+  it("stays closed on the viewer's own row, so an owner cannot demote themselves into a zero-owner org", () => {
+    expect(
+      canActOnMemberRow({
+        manage: true,
+        viewerIsOwner: true,
+        isCurrentUser: true,
+        targetRole: "owner",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/routes/_authed/settings/api-keys.tsx
+++ b/apps/web/src/routes/_authed/settings/api-keys.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useForm } from "react-hook-form";
+import { useForm, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { KeyRound, Trash2 } from "lucide-react";
@@ -42,12 +42,30 @@ export const Route = createFileRoute("/_authed/settings/api-keys")({
   component: ApiKeysPage,
 });
 
-const createSchema = z.object({
-  name: z.string().min(1, "Name is required").max(200),
-  role: z.enum(["owner", "admin", "operator", "viewer"]).optional(),
-});
+/**
+ * The create-key schema, gated on the viewer's role the same way the Owner
+ * <option> is. Hiding the option is not enough on its own: a permissive enum
+ * still validates "owner" from a stale form value or a devtools edit and the
+ * client sends it. Only an owner may mint an owner key
+ * (apps/api/internal/apikey/handler.go:59 refuses with
+ * `apikey_role_exceeds_actor`); the server is the authority, this keeps the
+ * client from asking.
+ *
+ * Pure + exported so both role branches are testable without mounting the page.
+ */
+export function createApiKeySchema(viewerIsOwner: boolean) {
+  return z.object({
+    name: z.string().min(1, "Name is required").max(200),
+    role: viewerIsOwner
+      ? z.enum(["owner", "admin", "operator", "viewer"]).optional()
+      : z.enum(["admin", "operator", "viewer"]).optional(),
+  });
+}
 
-type CreateValues = z.infer<typeof createSchema>;
+type CreateValues = {
+  name: string;
+  role?: "owner" | "admin" | "operator" | "viewer";
+};
 
 function ApiKeysPage() {
   const { data: me } = useMe();
@@ -70,13 +88,18 @@ function ApiKeysPage() {
   // `revokeTarget` holds the key the operator is about to revoke.
   const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
 
+  const schema = useMemo(
+    () => createApiKeySchema(viewerIsOwner),
+    [viewerIsOwner],
+  );
+
   const {
     register,
     handleSubmit,
     reset,
     formState: { errors },
   } = useForm<CreateValues>({
-    resolver: zodResolver(createSchema),
+    resolver: zodResolver(schema) as Resolver<CreateValues>,
     defaultValues: { name: "", role: "operator" },
   });
 

--- a/apps/web/src/routes/_authed/settings/api-keys.tsx
+++ b/apps/web/src/routes/_authed/settings/api-keys.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useForm, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -58,7 +58,11 @@ export function createApiKeySchema(viewerIsOwner: boolean) {
     name: z.string().min(1, "Name is required").max(200),
     role: viewerIsOwner
       ? z.enum(["owner", "admin", "operator", "viewer"]).optional()
-      : z.enum(["admin", "operator", "viewer"]).optional(),
+      : z
+          .enum(["admin", "operator", "viewer"], {
+            error: "Only an owner can create an owner key. Pick a lower role.",
+          })
+          .optional(),
   });
 }
 
@@ -97,11 +101,26 @@ function ApiKeysPage() {
     register,
     handleSubmit,
     reset,
+    setValue,
+    getValues,
     formState: { errors },
   } = useForm<CreateValues>({
     resolver: zodResolver(schema) as Resolver<CreateValues>,
     defaultValues: { name: "", role: "operator" },
   });
+
+  // The viewer's role can drop while this page stays mounted: the OrgSwitcher
+  // lives in the AppShell top bar, and activating another org resets the query
+  // cache without unmounting a settings route. If "owner" was selected before
+  // that flip it is now unselectable -- the <option> is gone, so the native
+  // select silently falls back to its first option while the form still holds
+  // "owner", and every submit fails validation against a control that looks
+  // fine. Put the form back on a role the new ceiling allows.
+  useEffect(() => {
+    if (!viewerIsOwner && getValues("role") === "owner") {
+      setValue("role", "operator");
+    }
+  }, [viewerIsOwner, getValues, setValue]);
 
   const onCreate = handleSubmit(async (values) => {
     const result = await createMutation.mutateAsync(values, {
@@ -154,6 +173,7 @@ function ApiKeysPage() {
             <select
               id="role"
               className="h-9 rounded-md border border-[var(--color-border)] bg-transparent px-3 text-sm"
+              aria-invalid={errors.role ? true : undefined}
               {...register("role")}
             >
               {viewerIsOwner ? <option value="owner">Owner</option> : null}
@@ -161,6 +181,11 @@ function ApiKeysPage() {
               <option value="operator">Operator</option>
               <option value="viewer">Viewer</option>
             </select>
+            {errors.role ? (
+              <p role="alert" className="text-sm text-[var(--color-destructive)]">
+                {errors.role.message}
+              </p>
+            ) : null}
           </div>
           <Button
             type="button"

--- a/apps/web/src/routes/_authed/settings/api-keys.tsx
+++ b/apps/web/src/routes/_authed/settings/api-keys.tsx
@@ -30,7 +30,7 @@ import { PageHeader } from "@/components/shared/page-header";
 import { CopyableMono } from "@/components/shared/copyable-mono";
 import { DefinitionList, KvRow } from "@/components/shared/definition-list";
 import { StatusChip } from "@/components/status";
-import { useMe, canManage } from "@/features/auth/use-auth";
+import { useMe, canManage, activeRole } from "@/features/auth/use-auth";
 import {
   useApiKeys,
   useCreateApiKey,
@@ -52,6 +52,10 @@ type CreateValues = z.infer<typeof createSchema>;
 function ApiKeysPage() {
   const { data: me } = useMe();
   const manage = canManage(me);
+  // A key never grants more than its creator holds. `canManage` is true for
+  // admin as well as owner, so it is the wrong gate for the owner option:
+  // the viewer's literal role is what decides. The server clamps this too.
+  const viewerIsOwner = activeRole(me) === "owner";
 
   const { data: keys, isPending, isError, error, refetch, isRefetching } =
     useApiKeys();
@@ -129,7 +133,7 @@ function ApiKeysPage() {
               className="h-9 rounded-md border border-[var(--color-border)] bg-transparent px-3 text-sm"
               {...register("role")}
             >
-              <option value="owner">Owner</option>
+              {viewerIsOwner ? <option value="owner">Owner</option> : null}
               <option value="admin">Admin</option>
               <option value="operator">Operator</option>
               <option value="viewer">Viewer</option>

--- a/apps/web/src/routes/_authed/settings/members.tsx
+++ b/apps/web/src/routes/_authed/settings/members.tsx
@@ -165,6 +165,40 @@ function MembersPage() {
 // MemberRow — inline role picker + remove button.
 // ---------------------------------------------------------------------------
 
+/**
+ * Whether the viewer may act on this row at all (role picker + Remove button).
+ *
+ * An owner row is the handover case. The API permits owner-on-owner
+ * (apps/api/internal/auth/members_handler.go refuses only with
+ * `target_role_exceeds_actor`, i.e. when the TARGET outranks the ACTOR), so an
+ * owner must be able to demote a co-owner; otherwise an org that reaches two
+ * owners through the dashboard can never return to one. An admin does NOT
+ * outrank an owner, so an admin still gets static text on that row -- that half
+ * is the GH #406 fix and must not be widened.
+ *
+ * `manage` is deliberately not the gate for the owner row: `canManage` is true
+ * for admin too, so gating anything owner-shaped on it reintroduces #406.
+ *
+ * Pure + exported so the four-cell viewer/target matrix is testable directly.
+ */
+export function canActOnMemberRow({
+  manage,
+  viewerIsOwner,
+  isCurrentUser,
+  targetRole,
+}: {
+  manage: boolean;
+  viewerIsOwner: boolean;
+  isCurrentUser: boolean;
+  targetRole: MemberRole;
+}): boolean {
+  if (!manage) return false;
+  // Self-service demotion/removal stays out of the UI in every case.
+  if (isCurrentUser) return false;
+  if (targetRole === "owner") return viewerIsOwner;
+  return true;
+}
+
 function MemberRow({
   member,
   manage,
@@ -199,6 +233,12 @@ function MemberRow({
 
   const display = member.email ?? member.user_id;
   const isPending = updateRole.isPending || removeMember.isPending;
+  const canAct = canActOnMemberRow({
+    manage,
+    viewerIsOwner,
+    isCurrentUser,
+    targetRole: member.role,
+  });
 
   return (
     <TableRow>
@@ -216,7 +256,7 @@ function MemberRow({
         {member.name ?? "—"}
       </TableCell>
       <TableCell>
-        {manage && !isCurrentUser && member.role !== "owner" ? (
+        {canAct ? (
           <Select
             value={member.role}
             onChange={(e) =>
@@ -237,7 +277,7 @@ function MemberRow({
       </TableCell>
       {manage ? (
         <TableCell className="text-right">
-          {isCurrentUser || member.role === "owner" ? null : (
+          {!canAct ? null : (
             <Button
               type="button"
               variant="outline"

--- a/apps/web/src/routes/_authed/settings/members.tsx
+++ b/apps/web/src/routes/_authed/settings/members.tsx
@@ -26,7 +26,12 @@ import { PageError } from "@/components/feedback";
 import { PageHeader } from "@/components/shared/page-header";
 import { CopyableMono } from "@/components/shared/copyable-mono";
 import { toast } from "@/components/toast";
-import { useMe, canManage, isOrgScoped } from "@/features/auth/use-auth";
+import {
+  useMe,
+  canManage,
+  isOrgScoped,
+  activeRole,
+} from "@/features/auth/use-auth";
 import {
   useMembers,
   useUpdateMemberRole,
@@ -44,6 +49,10 @@ function MembersPage() {
   const { data: me } = useMe();
   const manage = canManage(me);
   const orgScoped = isOrgScoped(me);
+  // Only an owner may nominate another owner. `canManage` is true for admin
+  // too, so gating on it would offer the owner role to an admin; the viewer's
+  // literal role is what decides. The server enforces the same ceiling.
+  const viewerIsOwner = activeRole(me) === "owner";
 
   const {
     data: members,
@@ -138,6 +147,7 @@ function MembersPage() {
                   key={m.user_id}
                   member={m}
                   manage={manage}
+                  viewerIsOwner={viewerIsOwner}
                   currentUserId={me?.user.id}
                 />
               ))}
@@ -158,10 +168,12 @@ function MembersPage() {
 function MemberRow({
   member,
   manage,
+  viewerIsOwner,
   currentUserId,
 }: {
   member: Member;
   manage: boolean;
+  viewerIsOwner: boolean;
   currentUserId?: string;
 }) {
   const updateRole = useUpdateMemberRole();
@@ -214,6 +226,7 @@ function MemberRow({
             className="w-32"
             aria-label={`Role for ${display}`}
           >
+            {viewerIsOwner ? <option value="owner">Owner</option> : null}
             <option value="admin">Admin</option>
             <option value="operator">Operator</option>
             <option value="viewer">Viewer</option>


### PR DESCRIPTION
Refs GH #406. Deliberately does not auto-close it: nothing is fixed until it is merged, released,
deployed and verified against the running system.

**Merge and deploy #416 first.** This branch opens controls on a co-owner's row whose safety depends on
the server-side checks in that one. On its own it is cosmetic, and against an unmerged #416 it exposes
the racy path.

## What changed

- Restores the Owner option in the members role select, gated on the **viewer's own role being owner**.
  A previous commit removed it outright, which closed the reported problem by deleting the only
  affordance anywhere in the app for granting the owner role — the invite dialog never had one — and
  the issue explicitly asks that an owner be able to nominate another owner.
- An owner can now act on a co-owner's row. An admin still sees that row as static text; that half was
  correct and is unchanged.
- The API-keys page offered Owner to any admin, and its zod enum accepted `owner` regardless of what
  the select showed, so the client would still send it. Both are now gated on the viewer being an owner.
- Handles the two refusal codes the API newly returns, which had no client-side mapping.

`canManage` is deliberately not used for any of this: an admin passes it, so gating an owner-shaped
control on it would reintroduce the problem.

## Tests

There was no test coverage of any of this. Two new files, 9 cases each:

```
$ grep -cE '^\s*(it|test)\(' -members.owner-handover.test.tsx   9
$ grep -cE '^\s*(it|test)\(' -api-keys.role-ceiling.test.tsx    9
$ pnpm -C apps/web test -- --run
  Test Files  132 passed (132)
       Tests  1589 passed (1589)
```

A reviewer planted three separate defects and recorded which tests fell: the pre-fix gate (2 failed —
owner viewing a co-owner, and the pure gate), the escalation plant (2 failed — admin viewing the owner),
and the permissive api-key enum (1 failed). The admin-side over-fire tests stayed green through all
three, so the suite is not simply reddening on everything.

## Not proven, stated rather than implied

5 of the 18 cases — the error-mapping tests — were never shown to fail, because nothing was planted
against them. `toMemberError` and the inline error-code extraction in `useCreateApiKey` have no test at
all, so if the client error shape changes, every mapped code degrades to the fallback and all 18 stay
green. Worth closing separately.

## Known open, not addressed here

An owner can hand ownership over but cannot act on their own row, so a one-person step-down is not
possible from the dashboard — the incoming owner completes it. That is deliberate, and pinned by a test
so it cannot regress by accident, but it is a real limitation and not an oversight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Owners can create API keys with any role; non-owners cannot select the Owner role.
  - Owners can manage, demote, or remove co-owners.
  - Admins and non-managers cannot modify owner rows or manage their own membership.
- **Bug Fixes**
  - API-key and member-management errors now display clearer, server-specific messages.
  - Unknown errors preserve the original server-provided message.
- **Tests**
  - Added coverage for role-based API-key validation and member owner-handover permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->