### PR TITLE
chore(harness): refuse a push that lands on main, and say so when the guard is absent

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,7 +4,7 @@
 # WHY THIS EXISTS RATHER THAN ONLY THE BASH GUARD.
 # On 2026-08-12 a one-line fix was committed on main in the main checkout and
 # pushed straight to origin/main, with no branch and no PR. Branch protection on
-# main carries four required contexts, but `enforce_admins` is deliberately
+# main carries required contexts, but `enforce_admins` is deliberately
 # false - the owner keeps it false so an incident hotfix stays possible - so the
 # push was accepted server-side with none of those contexts running against it.
 #
@@ -42,6 +42,18 @@ set -uo pipefail
 remote_name="${1-}"
 remote_url="${2-}"
 
+# The case-fold below is on the decision path, and this hook runs with
+# `set -uo pipefail` and no `-e`, so a `tr` that is missing or that fails leaves
+# $lower EMPTY, the `case` falls through to `continue`, $hits stays empty and
+# the push is ALLOWED. Measured end to end: with PATH set to an empty directory,
+# `git push scratch HEAD:refs/heads/main` printed no refusal and the commit
+# landed on the bare remote's main. So the dependency is checked once, up front,
+# and the assignment is checked again at the point of use. Both refuse.
+command -v tr >/dev/null 2>&1 || {
+  echo "pre-push: 'tr' is not on PATH, so this hook cannot case-fold the ref it was asked about. REFUSING rather than guessing - it cannot tell whether this push lands on main. Fix PATH, or bypass deliberately with 'git push --no-verify'." >&2
+  exit 1
+}
+
 hits=""
 # `|| [ -n "$local_ref$remote_ref" ]`: `read` returns non-zero when it consumed
 # input that did not end in a newline, having set the variables anyway. Without
@@ -73,7 +85,13 @@ while read -r local_ref local_oid remote_ref remote_oid || [ -n "$local_ref$remo
   # so the fold costs one `tr` and closes it. The over-fire it buys is a real
   # branch named `Main` or `MAIN`, which this repository does not have and could
   # not have on this filesystem anyway.
-  lower=$(printf '%s' "$remote_ref" | tr '[:upper:]' '[:lower:]')
+  # `${remote_ref,,}` would drop the dependency, and it is NOT available here:
+  # this hook's shebang is `#!/usr/bin/env bash`, `command -v bash` is /bin/bash
+  # and $BASH_VERSION is 3.2.57(1)-release, where `${x,,}` is a bad substitution.
+  lower=$(printf '%s' "$remote_ref" | tr '[:upper:]' '[:lower:]') || {
+    echo "pre-push: case-folding '$remote_ref' FAILED, so this hook cannot tell whether this push lands on main. REFUSING rather than guessing." >&2
+    exit 1
+  }
   case "$lower" in
     refs/heads/main|main) ;;
     *) continue ;;
@@ -104,7 +122,7 @@ cat >&2 <<REFUSED
   main IS the irreversible half.
 
   Nothing behind this refusal will catch what it lets through: branch
-  protection on main carries four required contexts, but enforce_admins
+  protection on main carries required contexts, but enforce_admins
   is deliberately false, so an owner-token push is accepted server-side
   and not one of those contexts ever runs against it.
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Refuse any push that would create, move or delete refs/heads/main.
+#
+# WHY THIS EXISTS RATHER THAN ONLY THE BASH GUARD.
+# On 2026-08-12 a one-line fix was committed on main in the main checkout and
+# pushed straight to origin/main, with no branch and no PR. Branch protection on
+# main carries four required contexts, but `enforce_admins` is deliberately
+# false - the owner keeps it false so an incident hotfix stays possible - so the
+# push was accepted server-side with none of those contexts running against it.
+#
+# scripts/claude/bash-guard.sh has an arm that reads the command string and
+# denies a push to main. Three adversaries found nine working bypasses of it,
+# all reproduced. `cd <main checkout> && git push` from an agent worktree was
+# permitted; so were `eval git push origin main`, `bash -c '...'`,
+# `git push origin @` (@ is git's documented synonym for HEAD),
+# `git push origin :`, `git push origin refs/heads/*:refs/heads/*`,
+# `git push origin $(echo main)`, `git p"ush" origin main`, and
+# `git -c push.default=matching push`. That is not a list to grind out. A text
+# matcher over a shell command cannot decide those without being the shell, and
+# closing nine invites a tenth.
+#
+# This hook runs INSIDE git: after the shell has expanded everything, after
+# eval, after command substitution, after push.default and after refspec
+# resolution. It is handed the refs that are actually about to move. None of the
+# nine can reach it disguised, because by the time it runs there is no disguise
+# left. It also fires for a push typed in a plain terminal, or made by an IDE or
+# any other tool, which a PreToolUse hook on Bash never sees at all.
+#
+# CONTRACT (githooks(5), git 2.48.1):
+#   $1            remote name; $2 remote URL (both the URL for an unnamed remote)
+#   stdin, one line per ref being pushed:
+#       <local-ref> SP <local-oid> SP <remote-ref> SP <remote-oid> LF
+#   Deleting a ref supplies `(delete)` as <local-ref> and the all-zero oid as
+#   <local-oid>; the REMOTE ref is still named, which is why the decision below
+#   keys on <remote-ref> alone and so covers a delete without a special case.
+#   A non-zero exit aborts the whole push, having transferred nothing.
+#
+# Test: scripts/claude/guards_test.sh
+set -uo pipefail
+
+remote_name="${1-}"
+remote_url="${2-}"
+
+hits=""
+while read -r local_ref local_oid remote_ref remote_oid; do
+  [ -n "$remote_ref" ] || continue
+  # git fully qualifies the remote ref, but a bare name costs nothing to also
+  # refuse and cannot match a branch merely CONTAINING "main" - both arms are
+  # whole-string equality, so main-ui, maintenance and feat/remaining pass.
+  case "$remote_ref" in
+    refs/heads/main|main) ;;
+    *) continue ;;
+  esac
+  if [ "$local_ref" = "(delete)" ]; then
+    hits="${hits}  DELETE ${remote_ref} (was ${remote_oid})"$'\n'
+  else
+    hits="${hits}  ${local_ref} -> ${remote_ref} (${local_oid})"$'\n'
+  fi
+done
+
+[ -n "$hits" ] || exit 0
+
+cat >&2 <<'REFUSED'
+
+  ------------------------------------------------------------------
+  REFUSED: this push would land on main.
+  ------------------------------------------------------------------
+REFUSED
+printf '%s' "$hits" >&2
+cat >&2 <<REFUSED
+
+  remote: ${remote_name:-<none>} (${remote_url:-<none>})
+
+  CLAUDE.md, "## Delivery": the only route to main is a pull request.
+  Branch, push the branch, open the PR, let ci.yml and review run, then
+  merge. Approval has to precede the irreversible half, and a push to
+  main IS the irreversible half.
+
+  Nothing behind this refusal will catch what it lets through: branch
+  protection on main carries four required contexts, but enforce_admins
+  is deliberately false, so an owner-token push is accepted server-side
+  and not one of those contexts ever runs against it.
+
+    git switch -c fix/<name>
+    git push -u origin fix/<name>
+    gh pr create
+
+  Pushing any other branch, or a tag, is untouched by this hook.
+
+  THE ESCAPE HATCH, NAMED RATHER THAN HIDDEN: \`git push --no-verify\`
+  skips this hook entirely. That is the incident-hotfix path the owner
+  kept open by leaving enforce_admins false, and it is stated here on
+  purpose - an undocumented bypass gets found and then used casually,
+  while a documented one is a deliberate act you can be asked about.
+
+REFUSED
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -65,7 +65,16 @@ while read -r local_ref local_oid remote_ref remote_oid || [ -n "$local_ref$remo
   # branch literally named main to a personal mirror - is not work this repo
   # does. An over-fire teaches --no-verify, so this is the one place it is
   # accepted, and only because the honest alternative is a wrong answer.
-  case "$remote_ref" in
+  # CASE-FOLDED. Git refs are case-sensitive, so refs/heads/Main is a different
+  # ref on github.com and the canonical origin is unaffected either way - but
+  # this machine's APFS volume is case-INSENSITIVE, so a push of
+  # HEAD:refs/heads/Main into any local or cloned repository here resolves to
+  # the same loose ref file as refs/heads/main and moves it. That was measured,
+  # so the fold costs one `tr` and closes it. The over-fire it buys is a real
+  # branch named `Main` or `MAIN`, which this repository does not have and could
+  # not have on this filesystem anyway.
+  lower=$(printf '%s' "$remote_ref" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
     refs/heads/main|main) ;;
     *) continue ;;
   esac

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,20 +9,21 @@
 # push was accepted server-side with none of those contexts running against it.
 #
 # scripts/claude/bash-guard.sh has an arm that reads the command string and
-# denies a push to main. Three adversaries found nine working bypasses of it,
-# all reproduced. `cd <main checkout> && git push` from an agent worktree was
-# permitted; so were `eval git push origin main`, `bash -c '...'`,
+# denies a push to main. Adversaries kept finding shapes it permits, and every
+# one of them was reproduced: `eval git push origin main`, `bash -c '...'`,
 # `git push origin @` (@ is git's documented synonym for HEAD),
 # `git push origin :`, `git push origin refs/heads/*:refs/heads/*`,
-# `git push origin $(echo main)`, `git p"ush" origin main`, and
-# `git -c push.default=matching push`. That is not a list to grind out. A text
-# matcher over a shell command cannot decide those without being the shell, and
-# closing nine invites a tenth.
+# `git push origin $(echo main)`, `git p"ush" origin main`,
+# `git -c push.default=matching push`, `(git push origin main)`,
+# `time git push origin main`, `if true; then git push origin main; fi`.
+# That list is a sample and is not maintained here as a count, because it grew
+# every time someone looked and a number in a comment is stale the next day. A
+# text matcher over a shell command cannot decide those without being the shell.
 #
 # This hook runs INSIDE git: after the shell has expanded everything, after
 # eval, after command substitution, after push.default and after refspec
-# resolution. It is handed the refs that are actually about to move. None of the
-# nine can reach it disguised, because by the time it runs there is no disguise
+# resolution. It is handed the refs that are actually about to move, so none of
+# those shapes reaches it disguised - by the time it runs there is no disguise
 # left. It also fires for a push typed in a plain terminal, or made by an IDE or
 # any other tool, which a PreToolUse hook on Bash never sees at all.
 #
@@ -42,11 +43,28 @@ remote_name="${1-}"
 remote_url="${2-}"
 
 hits=""
-while read -r local_ref local_oid remote_ref remote_oid; do
+# `|| [ -n "$local_ref$remote_ref" ]`: `read` returns non-zero when it consumed
+# input that did not end in a newline, having set the variables anyway. Without
+# this the final ref line of an unterminated stdin was DROPPED and the hook
+# exited 0 in silence, while the identical input with a trailing LF exited 1.
+# git always terminates the line, so this was not reachable from git today - but
+# a guard that fails open on a malformed input is the exact defect this hook
+# exists to close, and it was sitting inside the guard. Asserted in
+# scripts/claude/guards_test.sh, both ways.
+while read -r local_ref local_oid remote_ref remote_oid || [ -n "$local_ref$remote_ref" ]; do
   [ -n "$remote_ref" ] || continue
   # git fully qualifies the remote ref, but a bare name costs nothing to also
   # refuse and cannot match a branch merely CONTAINING "main" - both arms are
   # whole-string equality, so main-ui, maintenance and feat/remaining pass.
+  #
+  # EVERY REMOTE, including a fork or a scratch mirror, and that is deliberate:
+  # scoping the refusal to "the real origin" means comparing $2 against
+  # remote.origin.url, and ssh/https/insteadOf spell the same repository three
+  # ways, so the comparison would MISS the incident shape (a second remote
+  # pointing at the canonical repo) while the thing it would permit - pushing a
+  # branch literally named main to a personal mirror - is not work this repo
+  # does. An over-fire teaches --no-verify, so this is the one place it is
+  # accepted, and only because the honest alternative is a wrong answer.
   case "$remote_ref" in
     refs/heads/main|main) ;;
     *) continue ;;
@@ -87,11 +105,19 @@ cat >&2 <<REFUSED
 
   Pushing any other branch, or a tag, is untouched by this hook.
 
-  THE ESCAPE HATCH, NAMED RATHER THAN HIDDEN: \`git push --no-verify\`
-  skips this hook entirely. That is the incident-hotfix path the owner
-  kept open by leaving enforce_admins false, and it is stated here on
-  purpose - an undocumented bypass gets found and then used casually,
-  while a documented one is a deliberate act you can be asked about.
+  WHAT THIS IS: a client-side hook. It stops an ACCIDENT. It cannot
+  stop deliberate evasion and does not claim to. \`git push
+  --no-verify\` skips it; so does \`git send-pack\`, which never runs a
+  pre-push hook at all; so does overriding core.hooksPath for one
+  command. Those are stated rather than hidden, because an
+  undocumented bypass gets found and then used casually, while a named
+  one is a deliberate act you can be asked about. That list is a
+  sample and not a boundary: the boundary is that the only thing
+  behind this refusal is a person choosing not to route around it.
+
+  Server-side enforcement would be the boundary, and it is OFF by the
+  owner's standing decision: branch protection on main keeps
+  enforce_admins false so an incident hotfix stays possible.
 
 REFUSED
 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,20 @@ jobs:
       #
       # The self-tests run FIRST: if the linter or the guards have regressed,
       # that is the more useful failure to read.
+      #
+      # `make hooks` is a separate step and runs BEFORE it, because
+      # harness-check now asserts the committed pre-push hook is actually
+      # running - core.hooksPath is repo-local config, config is never
+      # committed, and actions/checkout produces exactly the unprotected clone
+      # every developer starts with. Installing it here is not a way around the
+      # assertion: it makes CI prove the INSTALLER works on a clean checkout,
+      # which is the half a runner can prove. The unprotected-clone failure
+      # itself is proved in scripts/claude/guards_test.sh, which builds a clone
+      # with no hook, requires the check to go red, installs, and requires it to
+      # go green.
+      - name: Install the committed git hooks
+        run: make hooks
+
       - name: Agent harness self-test and lint
         run: make harness-check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,23 @@ is the pattern.
 
 ## Delivery
 
+**The only route to `main` is a pull request.** Branch, push the branch, open the
+PR, let `ci.yml` and review run, merge. Never commit on `main` in the main
+checkout and never `git push` while `HEAD` is `main` — not for a one-line fix,
+not for a typo, not because CI will pass anyway. `bash-guard.sh` denies that push
+and its refusal names this paragraph.
+
+That local guard is the **only** enforcement. Branch protection on `main` carries
+the four required contexts but `enforce_admins` is deliberately `false`, so an
+owner-token push is accepted and no server-side check ever runs against it. A
+push from a plain terminal, from the GitHub UI, or from any tool that is not a
+Claude Code session is not guarded at all.
+
+**Approval has to precede the irreversible half.** On 2026-08-12 the #406 fix was
+committed to `main`, pushed, and *then* followed by "want me to open a PR for
+it?". The code was on `origin/main` before the question was asked, which makes it
+an announcement wearing a question mark. Ask, then push.
+
 `ci.yml` is the gate. **It does not run the integration package**, and
 `.claude/rules/ci-and-build-logic.md` names that package and says why. That is
 where the tenancy and RLS proofs live, so run `make test-integration` locally
@@ -235,9 +252,28 @@ every commit id since June 2026 and orphans the release tags.
 
 ## Long sessions
 
-Decisions, measured numbers and owner rulings go to `docs/worklog/<issue>.md`
+Decisions, measured numbers and owner rulings go to `~/.wpmgr/worklog/<issue>.md`
 **as they are made**, each with the command that produced it. Compaction
 summarises the conversation away, and the next session re-derives it wrong.
+
+**A worklog is private and never enters this repository.** Not in `docs/`, not
+under any other path, not committed, not pushed, not attached to an issue or a
+PR. This repository is public, and a worklog is the one artefact that routinely
+holds what must not be: an unshipped finding, a defect's `file:line` before the
+fix exists, the mechanism of a live vulnerability. It is a working note for the
+next session, not a deliverable, and it has no audience outside this machine.
+
+Write it to `~/.wpmgr/worklog/`, which is outside every checkout and every
+worktree. Never create `docs/worklog/`, and never add a worklog path to
+`.gitignore` — an ignore rule is itself committed, so it publishes the thing it
+is hiding. The correct location leaves nothing to ignore.
+
+On 2026-08-12 a worklog for GH #406 was written to `docs/worklog/406.md` while
+the privilege escalation it described was live, unpatched and shipped, and while
+the owner's standing ruling was to disclose nothing until the fix was deployed.
+It was caught before any commit. The rule above exists because the instruction to
+keep a worklog and the instruction to disclose nothing collided, and the session
+followed the first without noticing the second.
 
 This file is re-injected from disk after compaction. Path-scoped
 `.claude/rules/` are not, until a matching file is read again. If a rule must

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,14 +200,26 @@ is the pattern.
 **The only route to `main` is a pull request.** Branch, push the branch, open the
 PR, let `ci.yml` and review run, merge. Never commit on `main` in the main
 checkout and never `git push` while `HEAD` is `main` — not for a one-line fix,
-not for a typo, not because CI will pass anyway. `bash-guard.sh` denies that push
-and its refusal names this paragraph.
+not for a typo, not because CI will pass anyway.
 
-That local guard is the **only** enforcement. Branch protection on `main` carries
-the four required contexts but `enforce_admins` is deliberately `false`, so an
-owner-token push is accepted and no server-side check ever runs against it. A
-push from a plain terminal, from the GitHub UI, or from any tool that is not a
-Claude Code session is not guarded at all.
+**There is no server-side enforcement.** Branch protection on `main` carries the
+four required contexts, but `enforce_admins` is deliberately `false` so an
+owner-token push is accepted and no required check ever runs against it. That is
+a standing decision, kept so an incident hotfix stays possible. Everything below
+is therefore client-side, and a determined push always gets through:
+`git push --no-verify`, `git send-pack`, and `git -c core.hooksPath=…` each skip
+it. These layers stop an accident, which is what actually happened.
+
+- `.githooks/pre-push` is the lock. Git hands it the already-resolved refs, so
+  `eval`, a `cd`, quoting, `@`, and exotic refspecs cannot disguise a push from
+  it. **It is repo-local config and config is never committed, so every clone
+  and every fresh worktree starts unprotected.** `make hooks` installs it;
+  `make hooks-status` says whether it is live. `session-brief.sh` prints
+  INSTALLED / NOT INSTALLED / COULD NOT CHECK at every session start, because a
+  guard that is silently absent is worse than none — you would trust it.
+- `bash-guard.sh` is the early stop, and matches command text, so it is
+  structurally incomplete and says so in its own comments. It exists to explain
+  the rule at the moment you would break it, not to be the barrier.
 
 **Approval has to precede the irreversible half.** On 2026-08-12 the #406 fix was
 committed to `main`, pushed, and *then* followed by "want me to open a PR for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,8 +202,8 @@ PR, let `ci.yml` and review run, merge. Never commit on `main` in the main
 checkout and never `git push` while `HEAD` is `main` — not for a one-line fix,
 not for a typo, not because CI will pass anyway.
 
-**There is no server-side enforcement.** Branch protection on `main` carries the
-four required contexts, but `enforce_admins` is deliberately `false` so an
+**There is no server-side enforcement.** Branch protection on `main` carries
+required contexts, but `enforce_admins` is deliberately `false` so an
 owner-token push is accepted and no required check ever runs against it. That is
 a standing decision, kept so an incident hotfix stays possible. Everything below
 is therefore client-side, and a determined push always gets through:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,18 @@ help: ## Show this help
 bootstrap: ## First-time dev setup
 	./scripts/bootstrap.sh
 
+# Separate from bootstrap because bootstrap installs a toolchain and this does
+# not: an existing clone that predates the hook needs this one line and nothing
+# else. `git config core.hooksPath` is repo-local and repo-local config is never
+# committed, so without it a clone carries .githooks/pre-push and git never runs
+# it - the push to main is permitted exactly as it was on 2026-08-12.
+.PHONY: hooks
+hooks: ## Install the committed git hooks (pre-push refuses a push that lands on main)
+	git config core.hooksPath .githooks
+	@echo "core.hooksPath = $$(git config --get core.hooksPath)"
+	@test -x .githooks/pre-push || { echo "FAIL: .githooks/pre-push is missing or not executable"; exit 1; }
+	@echo "pre-push installed. It is bypassed by 'git push --no-verify', deliberately and on the record."
+
 .PHONY: quickstart
 quickstart: ## One-command self-host bootstrap: write .env + generate secrets
 	./scripts/init-env.sh

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,22 @@ bootstrap: ## First-time dev setup
 	./scripts/bootstrap.sh
 
 # Separate from bootstrap because bootstrap installs a toolchain and this does
-# not: an existing clone that predates the hook needs this one command and
+# not: an up-to-date clone with the hook uninstalled needs this one command and
 # nothing else. `git config core.hooksPath` is repo-local and repo-local config
 # is never committed, so without it a clone carries .githooks/pre-push and git
 # never runs it - the push to main is permitted exactly as it was on 2026-08-12.
 #
-# The resolution, the absolute-path handling and the verification live in the
-# script, with a committed test suite, because that is where build-gating logic
-# belongs. The first version of this was three inline lines and it installed a
-# RELATIVE path, which every linked worktree then resolved against its own tree.
+# A checkout that PREDATES this rule has no `hooks` target, so `make hooks`
+# there prints "No rule to make target" and installs nothing. That clone needs
+# `git pull` first, or one direct run of the script from a tree that carries it:
+#   scripts/claude/git-hooks.sh install
+#
+# The resolution, the copy into $GIT_COMMON_DIR/hooks and the verification live
+# in the script, with a committed test suite, because that is where build-gating
+# logic belongs. The first version of this was three inline lines that set a
+# RELATIVE core.hooksPath, which every linked worktree resolved against its own
+# tree; the second set an absolute path to the tracked .githooks, which any
+# checkout of an older commit then deleted out from under it.
 .PHONY: hooks
 hooks: ## Install the committed git hooks (pre-push refuses a push that lands on main)
 	scripts/claude/git-hooks.sh install

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,22 @@ bootstrap: ## First-time dev setup
 	./scripts/bootstrap.sh
 
 # Separate from bootstrap because bootstrap installs a toolchain and this does
-# not: an existing clone that predates the hook needs this one line and nothing
-# else. `git config core.hooksPath` is repo-local and repo-local config is never
-# committed, so without it a clone carries .githooks/pre-push and git never runs
-# it - the push to main is permitted exactly as it was on 2026-08-12.
+# not: an existing clone that predates the hook needs this one command and
+# nothing else. `git config core.hooksPath` is repo-local and repo-local config
+# is never committed, so without it a clone carries .githooks/pre-push and git
+# never runs it - the push to main is permitted exactly as it was on 2026-08-12.
+#
+# The resolution, the absolute-path handling and the verification live in the
+# script, with a committed test suite, because that is where build-gating logic
+# belongs. The first version of this was three inline lines and it installed a
+# RELATIVE path, which every linked worktree then resolved against its own tree.
 .PHONY: hooks
 hooks: ## Install the committed git hooks (pre-push refuses a push that lands on main)
-	git config core.hooksPath .githooks
-	@echo "core.hooksPath = $$(git config --get core.hooksPath)"
-	@test -x .githooks/pre-push || { echo "FAIL: .githooks/pre-push is missing or not executable"; exit 1; }
-	@echo "pre-push installed. It is bypassed by 'git push --no-verify', deliberately and on the record."
+	scripts/claude/git-hooks.sh install
+
+.PHONY: hooks-status
+hooks-status: ## Report whether the pre-push hook is actually running in this checkout
+	@scripts/claude/git-hooks.sh status
 
 .PHONY: quickstart
 quickstart: ## One-command self-host bootstrap: write .env + generate secrets
@@ -119,6 +125,12 @@ harness-check: ## Lint the agent definitions and run the guard regression suite
 	scripts/claude/agent-lint.sh --self-test
 	scripts/claude/agent-lint.sh
 	scripts/claude/guards_test.sh
+# LAST, and it asserts the hook is RUNNING in this checkout, not that an
+# installer string appears in a file. The previous version of that assertion
+# passed in full inside a clone where no hook was installed and `git push
+# origin HEAD:refs/heads/main` landed. A check that passes when the thing it
+# checks is absent is worse than no check.
+	scripts/claude/git-hooks.sh check
 
 .PHONY: harness-reap
 harness-reap: ## REPORT what agent worktrees, branches, caches and volumes can be reclaimed

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,11 +13,13 @@ fi
 # it on, and it is FIRST here on purpose: if any later step fails, the clone is
 # still protected.
 #
-# It installs an ABSOLUTE path. A relative one was tried and measured wrong: git
-# resolves a relative core.hooksPath against the top of whichever working tree
-# is running the hook, so it only finds .githooks in a tree checked out at or
-# after the hook's commit. Across the checkouts on this machine the hook was
-# present in 1 of 10 by that rule, with config reading "installed" in all ten.
+# It installs the hook into the repository's common hooks directory, which no
+# checkout of any commit can remove. Pointing config at the tracked .githooks
+# was tried and measured wrong twice: a relative core.hooksPath is resolved by
+# git against whichever working tree runs the hook, and an absolute one still
+# names a directory that vanishes the moment any checkout moves to a commit
+# before the hook existed - in both cases config keeps reading "installed".
+# 'scripts/claude/git-hooks.sh status' prints what is true right now.
 echo "==> Installing the pre-push hook (refuses a push that lands on main)"
 scripts/claude/git-hooks.sh install
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,14 +9,17 @@ if [ -d /opt/homebrew/opt/node@22/bin ]; then
 fi
 
 # core.hooksPath is repo-local config and config is NOT committed, so a fresh
-# clone has the hook in its tree and git ignoring it. This is the line that turns
+# clone has the hook in its tree and git ignoring it. This is the step that turns
 # it on, and it is FIRST here on purpose: if any later step fails, the clone is
-# still protected. Relative, not absolute - git resolves core.hooksPath against
-# the top of the working tree, so one setting covers the main checkout and every
-# linked worktree, each finding its own copy.
+# still protected.
+#
+# It installs an ABSOLUTE path. A relative one was tried and measured wrong: git
+# resolves a relative core.hooksPath against the top of whichever working tree
+# is running the hook, so it only finds .githooks in a tree checked out at or
+# after the hook's commit. Across the checkouts on this machine the hook was
+# present in 1 of 10 by that rule, with config reading "installed" in all ten.
 echo "==> Installing the pre-push hook (refuses a push that lands on main)"
-git config core.hooksPath .githooks
-echo "    core.hooksPath = $(git config --get core.hooksPath)"
+scripts/claude/git-hooks.sh install
 
 echo "==> Checking toolchain"
 command -v go >/dev/null || { echo "go not found"; exit 1; }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,6 +8,16 @@ if [ -d /opt/homebrew/opt/node@22/bin ]; then
   export PATH="/opt/homebrew/opt/node@22/bin:$PATH"
 fi
 
+# core.hooksPath is repo-local config and config is NOT committed, so a fresh
+# clone has the hook in its tree and git ignoring it. This is the line that turns
+# it on, and it is FIRST here on purpose: if any later step fails, the clone is
+# still protected. Relative, not absolute - git resolves core.hooksPath against
+# the top of the working tree, so one setting covers the main checkout and every
+# linked worktree, each finding its own copy.
+echo "==> Installing the pre-push hook (refuses a push that lands on main)"
+git config core.hooksPath .githooks
+echo "    core.hooksPath = $(git config --get core.hooksPath)"
+
 echo "==> Checking toolchain"
 command -v go >/dev/null || { echo "go not found"; exit 1; }
 command -v pnpm >/dev/null || { echo "pnpm not found"; exit 1; }

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -344,7 +344,7 @@ collect_dests() {
 # after its caller deliberately - shell resolves a function at CALL time, and
 # collect_dests is first called below both definitions.
 split_segments() {
-  printf '%s\n' "$cmd" \
+  printf '%s\n' "${1-$cmd}" \
            | awk '{ if (sub(/\\$/, "")) printf "%s", $0; else print }' \
            | awk '
       # Split into command segments and drop comments, both QUOTE-AWARE. A
@@ -539,12 +539,25 @@ fi
 # work; a guard that reddens those gets switched off, and then main is guarded
 # by nothing at all.
 #
-# WHAT IT CANNOT SEE, stated rather than implied. The splitter reads a heredoc
-# BODY as ordinary segments, so `cat > runbook.md <<EOF` whose body carries a
-# literal `git push origin main` line is refused. Writing that file through
-# Edit/Write - which is where prose is written here anyway - is not. And a push
-# performed by a script this command merely invokes, or built from a variable,
-# is invisible to a text matcher, exactly as the header already says.
+# WHAT IT CANNOT SEE, ENUMERATED, because a comment that overstates coverage is
+# worse than no comment. All of these were reproduced against this arm and all
+# of them are PERMITTED by it:
+#
+#     eval git push origin main
+#     bash -c "git push origin main"
+#     git push origin $(echo main)
+#     git p"ush" origin main                 the entry grep and unq() both miss it
+#     git push origin @                      @ is git's documented synonym for HEAD
+#     git push origin :                      the "matching" refspec
+#     git push origin refs/heads/*:refs/heads/*
+#     git -c push.default=matching push      -c is consumed unread, deliberately
+#
+# They are not a list to grind out. Deciding them means being the shell, and
+# closing eight invites a ninth. `.githooks/pre-push` is what actually catches
+# them: it runs inside git, after expansion and after refspec resolution, and is
+# handed the refs that are about to move, so none of the above reaches it in
+# disguise. This arm exists to refuse the ordinary shapes EARLY, with the rule
+# attached, before a command runs at all. It is the manners, not the lock.
 
 # push_branch <value of git -C, may be empty> -> $PBRANCH; 1 if unreadable.
 #
@@ -556,11 +569,14 @@ fi
 # the MAIN checkout, whose HEAD is usually main, and every agent push in the
 # project would be refused for a branch nobody was on. A wrong answer is worse
 # than no answer; no answer is handled below, loudly.
+#
+# The base directory is PUSH_CWD, not the payload's cwd directly, because a
+# leading `cd <path> &&` moves it. See the cd tracking in push_hits_main.
 PBRANCH=""
 push_branch() {
   local d="$1" base
   PBRANCH=""
-  base=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+  base=$PUSH_CWD
   if [[ -n "$d" ]]; then
     if [[ "$d" != /* ]]; then
       [[ -n "$base" ]] || return 1
@@ -579,12 +595,89 @@ push_branch() {
   return 0
 }
 
+# push_commands -> $cmd with the lines that are DATA rather than shell removed.
+#
+# Two shapes put the literal text `git push origin main` at the start of a line
+# without any push being performed, and this arm denied both:
+#
+#   cat > docs/runbook.md <<EOF        a heredoc BODY is prose, not commands
+#   To release, do NOT run
+#   git push origin main
+#   EOF
+#
+#   git commit -m "feat: a pre-push hook            a quoted string that spans
+#                                                   lines is one argument, and
+#   git push origin main is what the hook refuses.  the splitter resets its
+#   "                                               quote state every line
+#
+# The second one is the shape of this change's own commit message, and the first
+# is how every runbook in docs/ gets written. Both are correct work, and a guard
+# that reddens correct work gets switched off.
+#
+# The splitter's per-line quote reset is deliberate and stays: for the WRITE arms
+# an extra split can only over-fire, and over-firing there is caught by an
+# assertion. Here it is the opposite, so this pass runs first and only for this
+# arm. It drops a heredoc body up to its delimiter line, and drops the part of a
+# line that belongs to a string opened on an EARLIER line - keeping whatever
+# follows the closing quote, because `more" && git push origin main` really is a
+# push and dropping the whole line would be a bypass.
+#
+# ITS OWN LIMIT: a heredoc whose delimiter never appears swallows the rest of the
+# command. That command does not run in bash either - it waits for the delimiter
+# on stdin - so there is nothing to guard; `.githooks/pre-push` is the backstop
+# for it as for everything else here.
+push_commands() {
+  printf '%s\n' "$cmd" | awk '
+    function scan(s,   i, n, c, rest, d) {
+      n = length(s); i = 1
+      while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == "\\" && q != "'"'"'") { i += 2; continue }
+        if (q != "") { if (c == q) q = ""; i++; continue }
+        if (c == "'"'"'" || c == "\"") { q = c; i++; continue }
+        if (c == "#" && (i == 1 || substr(s, i-1, 1) == " " || substr(s, i-1, 1) == "\t")) return
+        if (c == "<" && substr(s, i+1, 1) == "<") {
+          rest = substr(s, i + 2)
+          # <<< is a here-STRING: it has no body and opens no delimiter.
+          if (substr(rest, 1, 1) == "<") { i += 3; continue }
+          sub(/^-/, "", rest); sub(/^[ \t]+/, "", rest)
+          d = ""
+          if (match(rest, /^"[^"]*"/))          d = substr(rest, RSTART + 1, RLENGTH - 2)
+          else if (match(rest, /^'"'"'[^'"'"']*'"'"'/)) d = substr(rest, RSTART + 1, RLENGTH - 2)
+          else if (match(rest, /^[A-Za-z0-9_.-]+/))  d = substr(rest, RSTART, RLENGTH)
+          if (d != "") { nd++; dq[nd] = d }
+          i += 2; continue
+        }
+        i++
+      }
+    }
+    BEGIN { q = ""; nd = 0 }
+    {
+      line = $0
+      if (nd > 0) {
+        t = line; sub(/^[ \t]+/, "", t); sub(/[ \t]+$/, "", t)
+        if (t == dq[1]) { for (k = 1; k < nd; k++) dq[k] = dq[k+1]; nd-- }
+        next
+      }
+      if (q != "") {
+        idx = index(line, q)
+        if (idx == 0) next
+        q = ""
+        line = substr(line, idx + 1)
+      }
+      scan(line)
+      print line
+    }'
+}
+
 # push_hits_main -> 0 and $PUSH_WHY set, when some segment is a push that lands
 # on main or a push whose target cannot be read ($PUSH_WHY = UNKNOWN).
 PUSH_WHY=""
+PUSH_CWD=""
 push_hits_main() {
-  local seg w cn i n start sub d gitdir allrefs tagsonly r dst np
+  local seg w cn i n start sub d gitdir allrefs tagsonly dryrun r dst np cdto
   local -a words positional
+  PUSH_CWD=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
   while IFS= read -r seg; do
     words=()
     IFS=$' \t' read -r -a words <<<"$seg"
@@ -600,6 +693,38 @@ push_hits_main() {
     done
     [[ $start -ge $n ]] && continue
     unq "${words[$start]}"; cn=${UNQ##*/}
+
+    # `cd <path> && git push` RETARGETS the branch lookup. This is the incident
+    # shape and it is why the arm was worth repairing at all: an agent works in a
+    # worktree, so the payload's cwd is a worktree, and
+    #   cd /Users/.../wpmgr && git push
+    # was permitted with zero bytes transferred to the guard's attention while
+    # `git -C /Users/.../wpmgr push` was denied. It is the same push.
+    #
+    # It cuts the other way too, and that half was a FALSE REASON rather than a
+    # bypass: from the main checkout, `cd <worktree> && git push` was refused
+    # saying "the current branch is main". It was not. Either follow the cd or
+    # stop claiming to know the branch.
+    #
+    # An operand this cannot resolve - `cd $DIR`, `cd -`, `cd ~x`, a nonexistent
+    # path - clears the directory rather than guessing, so a later bare push
+    # arrives at the UNKNOWN branch of the deny below. Fail closed, and say so.
+    if [[ "$cn" == cd || "$cn" == pushd ]]; then
+      cdto=""
+      i=$((start + 1))
+      while [[ $i -lt $n ]]; do
+        unq "${words[$i]}"; w=$UNQ
+        case "$w" in -*) ;; *) cdto=$w; break ;; esac
+        i=$((i + 1))
+      done
+      [[ -z "$cdto" ]] && continue          # bare `cd`/`pushd`: leave it alone
+      if [[ "$cdto" != /* ]]; then
+        [[ -n "$PUSH_CWD" ]] && cdto="${PUSH_CWD%/}/$cdto"
+      fi
+      if [[ -d "$cdto" ]]; then PUSH_CWD=$cdto; else PUSH_CWD=""; fi
+      continue
+    fi
+
     [[ "$cn" == git ]] || continue
 
     # git's own options come BEFORE the subcommand, and two of them change which
@@ -626,11 +751,17 @@ push_hits_main() {
     [[ "$sub" == push ]] || continue
 
     positional=()
-    allrefs=""; tagsonly=""
+    allrefs=""; tagsonly=""; dryrun=""
     i=$((i + 1))
     while [[ $i -lt $n ]]; do
       unq "${words[$i]}"; w=$UNQ
       case "$w" in
+        # --dry-run/-n transfers NOTHING. Refusing it was a defect twice over:
+        # the reason printed - "That push lands commits on main" - was untrue of
+        # the command it refused, and it blocked the one safe way to inspect the
+        # dangerous command before running it. Checking what a push would do is
+        # the behaviour to encourage, not to redden.
+        --dry-run|-n) dryrun=1 ;;
         --all|--mirror) allrefs=1 ;;
         # --tags with no refspec pushes refs/tags and nothing else, so it moves
         # no branch. Exact match: --follow-tags is an ordinary branch push.
@@ -642,6 +773,8 @@ push_hits_main() {
       esac
       i=$((i + 1))
     done
+
+    [[ -n "$dryrun" ]] && continue
 
     if [[ -n "$allrefs" ]]; then
       PUSH_WHY="--all/--mirror pushes every local branch, and one of them is main"
@@ -689,13 +822,19 @@ push_hits_main() {
       PUSH_WHY="it names no refspec, so it pushes the current branch, and the current branch is main"
       return 0
     fi
-  done < <(split_segments)
+  done < <(split_segments "$(push_commands)")
   return 1
 }
 
-# The word `push` cannot be absent from a `git push`, so this costs one grep on
-# every other command instead of two awk processes. It gates entry to the
-# structural test; it never decides anything by itself.
+# A cheap entry gate: the structural test costs two awk processes, and most
+# commands are not pushes. It NEVER decides anything by itself.
+#
+# It is not sound, and the previous comment here claimed it was - "the word push
+# cannot be absent from a git push". `git p"ush" origin main` has no word `push`
+# in it, is a real push, and is permitted by this grep and by unq() alike. That
+# is not fixed here, on purpose: see the enumerated list above. The lock is
+# `.githooks/pre-push`, which sees the resolved ref and does not care how the
+# word was spelled.
 if grep -qE '(^|[^A-Za-z0-9_-])push([^A-Za-z0-9_-]|$)' <<<"$cmd" && push_hits_main; then
   if [[ "$PUSH_WHY" == UNKNOWN ]]; then
     push_cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -551,9 +551,15 @@ fi
 #     git push origin :                      the "matching" refspec
 #     git push origin refs/heads/*:refs/heads/*
 #     git -c push.default=matching push      -c is consumed unread, deliberately
+#     (git push origin main)                 a subshell is not a segment here
+#     { git push origin main; }              nor is a group
+#     time git push origin main              nor is a timed command
+#     if true; then git push origin main; fi a compound command's body
 #
-# They are not a list to grind out. Deciding them means being the shell, and
-# closing eight invites a ninth. `.githooks/pre-push` is what actually catches
+# That list is a SAMPLE, not an inventory, and it carries no count on purpose:
+# every time someone looked it grew, and the number written here was stale
+# within a day of being written. Deciding these means being the shell.
+# `.githooks/pre-push` is what actually catches
 # them: it runs inside git, after expansion and after refspec resolution, and is
 # handed the refs that are about to move, so none of the above reaches it in
 # disguise. This arm exists to refuse the ordinary shapes EARLY, with the rule
@@ -674,9 +680,18 @@ push_commands() {
 # on main or a push whose target cannot be read ($PUSH_WHY = UNKNOWN).
 PUSH_WHY=""
 PUSH_CWD=""
+# Set when a `cd`/`pushd`/`popd` moved the shell somewhere this arm could not
+# resolve. It means "the branch is not knowable from here", which is NOT the
+# same as "the payload gave no cwd" - the second is still a deny, because a
+# session with no cwd at all is a broken payload rather than an ordinary
+# command. See the deny sites below.
+PUSH_CD_UNKNOWN=""
+PUSH_DIRSTACK=()
 push_hits_main() {
-  local seg w cn i n start sub d gitdir allrefs tagsonly dryrun r dst np cdto
+  local seg w cn i n start sub d gitdir allrefs tagsonly dryrun r dst np cdto cdraw
   local -a words positional
+  PUSH_CD_UNKNOWN=""
+  PUSH_DIRSTACK=()
   PUSH_CWD=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
   while IFS= read -r seg; do
     words=()
@@ -706,22 +721,74 @@ push_hits_main() {
     # saying "the current branch is main". It was not. Either follow the cd or
     # stop claiming to know the branch.
     #
-    # An operand this cannot resolve - `cd $DIR`, `cd -`, `cd ~x`, a nonexistent
-    # path - clears the directory rather than guessing, so a later bare push
-    # arrives at the UNKNOWN branch of the deny below. Fail closed, and say so.
-    if [[ "$cn" == cd || "$cn" == pushd ]]; then
-      cdto=""
+    # An operand this cannot resolve - `cd $DIR`, `cd "$(git ...)"`, `cd -`,
+    # `cd ~x`, a directory a previous segment creates at run time - is recorded
+    # as NOT KNOWN rather than guessed at. It used to clear the directory and
+    # fall into the UNKNOWN deny, and that denied five shapes of correct work,
+    # all reproduced from a worktree whose HEAD was not main:
+    #
+    #     cd "$(git rev-parse --show-toplevel)" && git push   the worktree ITSELF
+    #     cd ~/Desktop/Terminal/wpmgr && git push             tilde, never expanded
+    #     pushd /tmp >/dev/null && ls && popd && git push      popd, never tracked
+    #     mkdir -p out && cd out && cd .. && git push          `out` not there yet
+    #
+    # `~` and `popd` are now followed, because both are small and exact. What is
+    # left unresolvable DEFERS: no deny, no reason, and `.githooks/pre-push`
+    # decides it instead, after the shell has actually expanded it. That is the
+    # trade this file already makes everywhere else - a false reason is worse
+    # than no reason, and the hook is the lock while this arm is the manners.
+    if [[ "$cn" == cd || "$cn" == pushd || "$cn" == popd ]]; then
+      if [[ "$cn" == popd ]]; then
+        if [[ ${#PUSH_DIRSTACK[@]} -gt 0 ]]; then
+          PUSH_CWD=${PUSH_DIRSTACK[${#PUSH_DIRSTACK[@]}-1]}
+          unset 'PUSH_DIRSTACK[${#PUSH_DIRSTACK[@]}-1]'
+          [[ -n "$PUSH_CWD" ]] || PUSH_CD_UNKNOWN=1
+        else
+          # popd with nothing pushed is an error in bash and moves nothing, but
+          # this arm may have missed the pushd, so it declines to know.
+          PUSH_CWD=""; PUSH_CD_UNKNOWN=1
+        fi
+        continue
+      fi
+      cdto=""; cdraw=""
       i=$((start + 1))
       while [[ $i -lt $n ]]; do
         unq "${words[$i]}"; w=$UNQ
-        case "$w" in -*) ;; *) cdto=$w; break ;; esac
+        case "$w" in -*) ;; *) cdto=$w; cdraw=${words[$i]}; break ;; esac
         i=$((i + 1))
       done
-      [[ -z "$cdto" ]] && continue          # bare `cd`/`pushd`: leave it alone
-      if [[ "$cdto" != /* ]]; then
-        [[ -n "$PUSH_CWD" ]] && cdto="${PUSH_CWD%/}/$cdto"
+      [[ "$cn" == pushd ]] && PUSH_DIRSTACK+=("$PUSH_CWD")
+      # Bare `pushd` swaps the top two entries; bare `cd` goes to $HOME. The
+      # swap is not modelled, so it declines to know rather than stay put.
+      if [[ -z "$cdto" ]]; then
+        if [[ "$cn" == pushd ]]; then PUSH_CWD=""; PUSH_CD_UNKNOWN=1
+        else PUSH_CWD=${HOME:-}; [[ -n "$PUSH_CWD" ]] || PUSH_CD_UNKNOWN=1; fi
+        continue
       fi
-      if [[ -d "$cdto" ]]; then PUSH_CWD=$cdto; else PUSH_CWD=""; fi
+      # Tilde expansion happens only on an UNQUOTED leading ~, so the RAW word
+      # is what decides it: bash does not expand "~/x", and neither does this.
+      case "$cdraw" in
+        '~')   cdto=${HOME:-} ;;
+        '~/'*) cdto="${HOME:-}/${cdraw#\~/}" ;;
+      esac
+      # A RELATIVE target with no base is not resolvable, and resolving it
+      # against THIS SCRIPT's own cwd is the worst available answer: from a
+      # session inside .claude/worktrees, `cd out && cd ..` then landed on the
+      # main checkout and denied with "the current branch is main", about a
+      # directory the command never visited.
+      if [[ "$cdto" != /* ]]; then
+        if [[ -n "$PUSH_CWD" ]]; then
+          cdto="${PUSH_CWD%/}/$cdto"
+        else
+          PUSH_CWD=""; PUSH_CD_UNKNOWN=1; continue
+        fi
+      fi
+      if [[ -d "$cdto" ]]; then
+        PUSH_CWD=$(cd "$cdto" 2>/dev/null && pwd -P) || PUSH_CWD=""
+        [[ -n "$PUSH_CWD" ]] || PUSH_CD_UNKNOWN=1
+      else
+        PUSH_CWD=""; PUSH_CD_UNKNOWN=1
+      fi
       continue
     fi
 
@@ -761,7 +828,14 @@ push_hits_main() {
         # the command it refused, and it blocked the one safe way to inspect the
         # dangerous command before running it. Checking what a push would do is
         # the behaviour to encourage, not to redden.
-        --dry-run|-n) dryrun=1 ;;
+        #
+        # The abbreviations are here because git's parse-options accepts any
+        # UNAMBIGUOUS prefix, so `git push --dry origin main` really is a dry
+        # run and really transfers nothing - and it was denied, with the reason
+        # "that push lands commits on main", which is untrue of it. Listed down
+        # to `--dr`, which is the shortest prefix no other push option shares:
+        # `--d` is ambiguous with --delete and git rejects it itself.
+        --dry-run|--dry-ru|--dry-r|--dry-|--dry|--dr|-n) dryrun=1 ;;
         --all|--mirror) allrefs=1 ;;
         # --tags with no refspec pushes refs/tags and nothing else, so it moves
         # no branch. Exact match: --follow-tags is an ordinary branch push.
@@ -799,6 +873,9 @@ push_hits_main() {
         # branch, so it is only readable by asking which branch that is.
         if [[ "$dst" == HEAD && "$r" != *:* ]]; then
           if [[ -n "$gitdir" ]] || ! push_branch "$d"; then
+            # Unreadable BECAUSE a cd could not be followed: defer to the hook
+            # rather than deny with a reason that is not true of the command.
+            [[ -n "$PUSH_CD_UNKNOWN" && -z "$gitdir" && "$d" != /* ]] && continue 2
             PUSH_WHY="UNKNOWN"
             return 0
           fi
@@ -815,6 +892,9 @@ push_hits_main() {
     # No refspec at all: the push goes to the current branch.
     [[ -n "$tagsonly" ]] && continue
     if [[ -n "$gitdir" ]] || ! push_branch "$d"; then
+      # Same deferral as above: an unfollowable cd is a gap in this arm's
+      # knowledge, not evidence about the branch. The hook decides it.
+      [[ -n "$PUSH_CD_UNKNOWN" && -z "$gitdir" && "$d" != /* ]] && continue
       PUSH_WHY="UNKNOWN"
       return 0
     fi

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -40,7 +40,7 @@
 # 4. A GIT PUSH THAT WOULD LAND COMMITS ON main - deny.
 #    On 2026-08-12 a one-line fix was committed on main in the main checkout and
 #    pushed straight to origin/main, with no branch and no PR. Branch protection
-#    on main carries four required contexts, but `enforce_admins` is
+#    on main carries required contexts, but `enforce_admins` is
 #    deliberately false, so an owner-token push is accepted server-side and not
 #    one of those contexts ever ran against it. This hook saw that push and
 #    permitted it: its entire notion of git was `git rm` and `git mv`. Nothing

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash.
 #
-# Three arms, all grounded in something measured here.
+# Four arms, all grounded in something measured here.
 #
 # 1. UNBOUNDED WAIT LOOPS - deny.
 #    Of the agent runs that returned no result in one week, most contained
@@ -36,6 +36,16 @@
 #    whose target paths never appear in the command line. A determined shell
 #    write gets through. This raises the bar from "frictionless" to "deliberate
 #    and visible", and that is the whole claim.
+#
+# 4. A GIT PUSH THAT WOULD LAND COMMITS ON main - deny.
+#    On 2026-08-12 a one-line fix was committed on main in the main checkout and
+#    pushed straight to origin/main, with no branch and no PR. Branch protection
+#    on main carries four required contexts, but `enforce_admins` is
+#    deliberately false, so an owner-token push is accepted server-side and not
+#    one of those contexts ever ran against it. This hook saw that push and
+#    permitted it: its entire notion of git was `git rm` and `git mv`. It is the
+#    only enforcement that exists, which is why it denies rather than asks, and
+#    why it also denies when it cannot read the branch.
 #
 # FAIL-OPEN, DELIBERATELY, AND ANNOUNCED: see the header of route-guard.sh.
 # session-brief.sh reports the guard as INACTIVE at session start if jq is
@@ -325,7 +335,16 @@ collect_dests() {
         grep -qE '(open\(|writeFile|file_put_contents|\.write\()' <<<"$seg" \
           && printf 'w:%s\n' "${operands[@]}" ;;
     esac
-  done < <(printf '%s\n' "$cmd" \
+  done < <(split_segments)
+}
+
+# One splitter, two callers. collect_dests decides write destinations with it
+# and the git-push arm below decides command words with it; a second copy would
+# drift, and this is the part every deny arm's correctness rests on. Defined
+# after its caller deliberately - shell resolves a function at CALL time, and
+# collect_dests is first called below both definitions.
+split_segments() {
+  printf '%s\n' "$cmd" \
            | awk '{ if (sub(/\\$/, "")) printf "%s", $0; else print }' \
            | awk '
       # Split into command segments and drop comments, both QUOTE-AWARE. A
@@ -375,7 +394,7 @@ collect_dests() {
         }
         if (q != "") { line = $0; gsub(/[;|&]/, "\n", line); print line }
         else print out
-      }')
+      }'
 }
 
 # One target per line, tagged w (write) or r (delete), so no regex can match
@@ -506,6 +525,219 @@ for databases on the earlier version. Route it to database-engineer.
 Doing this from the shell instead of Edit does not change the outcome; it only
 removes the record that it happened."
   fi
+fi
+
+# ---- arm 4: a push that would land commits on main -------------------------
+# Decided per SEGMENT, from the same splitter every other arm uses: `git` has to
+# be the command word and `push` its subcommand. So a push named inside a quoted
+# string, inside a commit message or after a `#` is not a push, and neither is
+# any command that merely contains the letters m-a-i-n.
+#
+# Branch names are compared by EQUALITY, after one layer of quotes comes off,
+# never by substring or by regex. `main-ui`, `maintenance`, `feat/remaining`,
+# `origin/main` as a log argument and `cp domain.go x` all have to stay ordinary
+# work; a guard that reddens those gets switched off, and then main is guarded
+# by nothing at all.
+#
+# WHAT IT CANNOT SEE, stated rather than implied. The splitter reads a heredoc
+# BODY as ordinary segments, so `cat > runbook.md <<EOF` whose body carries a
+# literal `git push origin main` line is refused. Writing that file through
+# Edit/Write - which is where prose is written here anyway - is not. And a push
+# performed by a script this command merely invokes, or built from a variable,
+# is invisible to a text matcher, exactly as the header already says.
+
+# push_branch <value of git -C, may be empty> -> $PBRANCH; 1 if unreadable.
+#
+# The branch has to come from the directory the command will actually run in,
+# which is the hook payload's cwd, or from `git -C` when the command overrides
+# it. The migration arm's SECOND source - this script's own directory - is
+# deliberately not reused here, and that is not an oversight: this file is
+# committed in the repository it guards, so from an agent worktree it resolves
+# the MAIN checkout, whose HEAD is usually main, and every agent push in the
+# project would be refused for a branch nobody was on. A wrong answer is worse
+# than no answer; no answer is handled below, loudly.
+PBRANCH=""
+push_branch() {
+  local d="$1" base
+  PBRANCH=""
+  base=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+  if [[ -n "$d" ]]; then
+    if [[ "$d" != /* ]]; then
+      [[ -n "$base" ]] || return 1
+      d="${base%/}/$d"
+    fi
+  else
+    d="$base"
+  fi
+  [[ -n "$d" && -d "$d" ]] || return 1
+  command -v git >/dev/null 2>&1 || return 1
+  # --quiet exits non-zero on a detached HEAD rather than printing "HEAD", so a
+  # detached checkout arrives here as unreadable instead of as a branch called
+  # HEAD. Both are correct answers to "which branch"; only one of them is true.
+  PBRANCH=$(git -C "$d" symbolic-ref --quiet --short HEAD 2>/dev/null)
+  [[ -n "$PBRANCH" ]] || return 1
+  return 0
+}
+
+# push_hits_main -> 0 and $PUSH_WHY set, when some segment is a push that lands
+# on main or a push whose target cannot be read ($PUSH_WHY = UNKNOWN).
+PUSH_WHY=""
+push_hits_main() {
+  local seg w cn i n start sub d gitdir allrefs tagsonly r dst np
+  local -a words positional
+  while IFS= read -r seg; do
+    words=()
+    IFS=$' \t' read -r -a words <<<"$seg"
+    n=${#words[@]}
+    [[ $n -eq 0 ]] && continue
+
+    start=0
+    while [[ $start -lt $n ]]; do
+      case "${words[$start]}" in
+        *=*|env|sudo|command|nohup|nice) start=$((start + 1)) ;;
+        *) break ;;
+      esac
+    done
+    [[ $start -ge $n ]] && continue
+    unq "${words[$start]}"; cn=${UNQ##*/}
+    [[ "$cn" == git ]] || continue
+
+    # git's own options come BEFORE the subcommand, and two of them change which
+    # repository the push reads its branch from. `-C dir` is followed, so
+    # `git -C <main checkout> push` from a worktree is still a push to main;
+    # --git-dir/--work-tree/--namespace are not followed, so the branch becomes
+    # unreadable rather than silently taken from the wrong tree. Their separate
+    # -value forms consume that value, or the value itself would be read as the
+    # subcommand and the whole push would be skipped.
+    d=""; gitdir=""; sub=""
+    i=$((start + 1))
+    while [[ $i -lt $n ]]; do
+      unq "${words[$i]}"; w=$UNQ
+      case "$w" in
+        -C) i=$((i + 1)); [[ $i -lt $n ]] && { unq "${words[$i]}"; d=$UNQ; } ;;
+        -c) i=$((i + 1)) ;;
+        --git-dir=*|--work-tree=*|--namespace=*) gitdir=1 ;;
+        --git-dir|--work-tree|--namespace) gitdir=1; i=$((i + 1)) ;;
+        -*) ;;
+        *) sub=$w; break ;;
+      esac
+      i=$((i + 1))
+    done
+    [[ "$sub" == push ]] || continue
+
+    positional=()
+    allrefs=""; tagsonly=""
+    i=$((i + 1))
+    while [[ $i -lt $n ]]; do
+      unq "${words[$i]}"; w=$UNQ
+      case "$w" in
+        --all|--mirror) allrefs=1 ;;
+        # --tags with no refspec pushes refs/tags and nothing else, so it moves
+        # no branch. Exact match: --follow-tags is an ordinary branch push.
+        --tags) tagsonly=1 ;;
+        # These take a separate value, which must not be read as a refspec.
+        -o|--push-option|--repo|--receive-pack|--exec) i=$((i + 1)) ;;
+        -*) ;;
+        *) positional[${#positional[@]}]="$w" ;;
+      esac
+      i=$((i + 1))
+    done
+
+    if [[ -n "$allrefs" ]]; then
+      PUSH_WHY="--all/--mirror pushes every local branch, and one of them is main"
+      return 0
+    fi
+
+    # `git push [<repository> [<refspec>...]]`: the FIRST positional is always
+    # the repository, whether it is a remote name or a URL.
+    np=${#positional[@]}
+    if [[ $np -gt 1 ]]; then
+      i=1
+      while [[ $i -lt $np ]]; do
+        r=${positional[$i]}
+        r=${r#+}                # `+main` is a force-push of main
+        dst=${r##*:}            # `src:dst` lands on dst; no colon means dst = src
+        dst=${dst#refs/heads/}
+        if [[ "$dst" == main ]]; then
+          PUSH_WHY="the refspec '${positional[$i]}' targets main on the remote"
+          return 0
+        fi
+        # `git push origin HEAD` lands on a remote branch named for the CURRENT
+        # branch, so it is only readable by asking which branch that is.
+        if [[ "$dst" == HEAD && "$r" != *:* ]]; then
+          if [[ -n "$gitdir" ]] || ! push_branch "$d"; then
+            PUSH_WHY="UNKNOWN"
+            return 0
+          fi
+          if [[ "$PBRANCH" == main ]]; then
+            PUSH_WHY="HEAD is the current branch and the current branch is main"
+            return 0
+          fi
+        fi
+        i=$((i + 1))
+      done
+      continue
+    fi
+
+    # No refspec at all: the push goes to the current branch.
+    [[ -n "$tagsonly" ]] && continue
+    if [[ -n "$gitdir" ]] || ! push_branch "$d"; then
+      PUSH_WHY="UNKNOWN"
+      return 0
+    fi
+    if [[ "$PBRANCH" == main ]]; then
+      PUSH_WHY="it names no refspec, so it pushes the current branch, and the current branch is main"
+      return 0
+    fi
+  done < <(split_segments)
+  return 1
+}
+
+# The word `push` cannot be absent from a `git push`, so this costs one grep on
+# every other command instead of two awk processes. It gates entry to the
+# structural test; it never decides anything by itself.
+if grep -qE '(^|[^A-Za-z0-9_-])push([^A-Za-z0-9_-]|$)' <<<"$cmd" && push_hits_main; then
+  if [[ "$PUSH_WHY" == UNKNOWN ]]; then
+    push_cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+    emit deny "That is a git push, and this guard COULD NOT DETERMINE which branch it would
+land on, so it cannot rule out main.
+
+The branch is read from the directory the command runs in, and that failed here:
+the hook payload's cwd was '${push_cwd:-<none>}', and one of these is true - it
+is absent, it is not a directory, it is not inside a worktree, HEAD is detached,
+git is not on PATH, or the command overrode the repository with --git-dir /
+--work-tree / --namespace.
+
+A push this guard cannot read is not a push it may allow. Branch protection on
+main has enforce_admins deliberately false, so nothing after this hook checks
+anything: if this one is wrong, the commits are on origin/main.
+
+Name the target and it needs no lookup at all:
+
+  git push origin <branch>        any branch except main
+  git push -u origin fix/<name>
+
+Or re-run it from inside the checkout the push belongs to."
+  fi
+  emit deny "That push lands commits on main, and the only route to main is a pull request:
+${PUSH_WHY}.
+
+CLAUDE.md, \"## Delivery\": branch, push the branch, open the PR, let ci.yml and
+review run, then merge. Never git push while HEAD is main - not for a one-line
+fix, not for a typo, not because CI will pass anyway. Approval has to precede the
+irreversible half, and a push to origin/main IS the irreversible half.
+
+This hook is the ONLY enforcement. Branch protection on main carries four
+required contexts, but enforce_admins is deliberately false, so an owner-token
+push is accepted and not one of those contexts runs against it. There is no
+server-side check behind this refusal to catch what it lets through.
+
+  git switch -c fix/<name>
+  git push -u origin fix/<name>
+  gh pr create
+
+Pushing a branch, a tag, or a release branch is untouched by this arm; only a
+push that moves main is refused."
 fi
 
 exit 0

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -43,9 +43,12 @@
 #    on main carries four required contexts, but `enforce_admins` is
 #    deliberately false, so an owner-token push is accepted server-side and not
 #    one of those contexts ever ran against it. This hook saw that push and
-#    permitted it: its entire notion of git was `git rm` and `git mv`. It is the
-#    only enforcement that exists, which is why it denies rather than asks, and
-#    why it also denies when it cannot read the branch.
+#    permitted it: its entire notion of git was `git rm` and `git mv`. Nothing
+#    server-side catches such a push, and the client-side lock that does,
+#    `.githooks/pre-push`, lives in repo-local config that a fresh clone has not
+#    run `make hooks` for yet. This arm is the early stop in front of it, which
+#    is why it denies rather than asks, and why it also denies when it cannot
+#    read the branch.
 #
 # FAIL-OPEN, DELIBERATELY, AND ANNOUNCED: see the header of route-guard.sh.
 # session-brief.sh reports the guard as INACTIVE at session start if jq is
@@ -970,10 +973,12 @@ review run, then merge. Never git push while HEAD is main - not for a one-line
 fix, not for a typo, not because CI will pass anyway. Approval has to precede the
 irreversible half, and a push to origin/main IS the irreversible half.
 
-This hook is the ONLY enforcement. Branch protection on main carries four
-required contexts, but enforce_admins is deliberately false, so an owner-token
-push is accepted and not one of those contexts runs against it. There is no
-server-side check behind this refusal to catch what it lets through.
+Nothing server-side backs this up: branch protection on main has enforce_admins
+deliberately false, so an owner-token push is accepted and its required contexts
+never run against it. The enforcement is client-side. .githooks/pre-push is the
+lock, since git hands it the resolved refs - but it is repo-local config, so each
+clone needs 'make hooks'. This PreToolUse hook is the early stop in front of it,
+matching command text. Both catch an accident; neither stops a determined push.
 
   git switch -c fix/<name>
   git push -u origin fix/<name>

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -540,8 +540,8 @@ fi
 # by nothing at all.
 #
 # WHAT IT CANNOT SEE, ENUMERATED, because a comment that overstates coverage is
-# worse than no comment. All of these were reproduced against this arm and all
-# of them are PERMITTED by it:
+# worse than no comment. All of these were reproduced against this arm, and each
+# is PERMITTED by it under the condition written beside it:
 #
 #     eval git push origin main
 #     bash -c "git push origin main"
@@ -550,7 +550,13 @@ fi
 #     git push origin @                      @ is git's documented synonym for HEAD
 #     git push origin :                      the "matching" refspec
 #     git push origin refs/heads/*:refs/heads/*
-#     git -c push.default=matching push      -c is consumed unread, deliberately
+#     git -c push.default=matching push      ONLY from a checkout whose branch is
+#                                            not main - the -c is consumed unread,
+#                                            so the arm decides it as a bare push
+#                                            and misses that matching can move a
+#                                            main that is not the current branch.
+#                                            From the main checkout it is DENIED,
+#                                            for the ordinary reason.
 #     (git push origin main)                 a subshell is not a segment here
 #     { git push origin main; }              nor is a group
 #     time git push origin main              nor is a timed command
@@ -754,15 +760,33 @@ push_hits_main() {
       i=$((start + 1))
       while [[ $i -lt $n ]]; do
         unq "${words[$i]}"; w=$UNQ
-        case "$w" in -*) ;; *) cdto=$w; cdraw=${words[$i]}; break ;; esac
+        case "$w" in
+          # `--` ends options, so the NEXT word is the operand even when it
+          # starts with a dash. `cd -- /path` stays fully resolved; `cd --` with
+          # nothing after it falls out with $cdto empty, into the branch below.
+          --) i=$((i + 1))
+              if [[ $i -lt $n ]]; then unq "${words[$i]}"; cdto=$UNQ; cdraw=${words[$i]}; fi
+              break ;;
+          -*) ;;
+          *) cdto=$w; cdraw=${words[$i]}; break ;;
+        esac
         i=$((i + 1))
       done
       [[ "$cn" == pushd ]] && PUSH_DIRSTACK+=("$PUSH_CWD")
-      # Bare `pushd` swaps the top two entries; bare `cd` goes to $HOME. The
-      # swap is not modelled, so it declines to know rather than stay put.
+      # Every operandless form declines to know, which is what the paragraph
+      # above already promised and what these three did NOT do. Measured from a
+      # worktree, before this: `cd - && git push`, `cd -- && git push` and
+      # `cd && git push` were all resolved to $HOME and then DENIED with "could
+      # not determine which branch", a reason that was untrue of the command -
+      # and the symmetric half is worse, because with $OLDPWD or $HOME being a
+      # branch checkout the same code PERMITS a push that lands on main.
+      #   cd -   goes to $OLDPWD, which is the shell's, not this process's.
+      #   cd --  and bare `cd` go to $HOME, which is not where the shell is.
+      #   bare pushd swaps the top two entries, which is not modelled.
+      # None of the four is knowable from the command string, so all four defer
+      # and `.githooks/pre-push` decides them after the shell has expanded them.
       if [[ -z "$cdto" ]]; then
-        if [[ "$cn" == pushd ]]; then PUSH_CWD=""; PUSH_CD_UNKNOWN=1
-        else PUSH_CWD=${HOME:-}; [[ -n "$PUSH_CWD" ]] || PUSH_CD_UNKNOWN=1; fi
+        PUSH_CWD=""; PUSH_CD_UNKNOWN=1
         continue
       fi
       # Tilde expansion happens only on an UNQUOTED leading ~, so the RAW word

--- a/scripts/claude/git-hooks.sh
+++ b/scripts/claude/git-hooks.sh
@@ -73,6 +73,29 @@ hook_source() {
   return 1
 }
 
+PROBE_SECONDS=5
+
+probe_hook() {
+  # probe_hook <one stdin line> -> 0 the hook allowed it, 1 it refused,
+  #                                2 it did not answer within $PROBE_SECONDS.
+  #
+  # `read -t` is a bash builtin and needs no `timeout`, no `sleep` and no `seq`,
+  # which matters because the suite's hermetic PATH farm contains none of them.
+  # On expiry the read fd is closed, so a hook that later writes its status gets
+  # SIGPIPE; one that never writes is left running rather than waited on, and
+  # that is the deliberate trade - this script's job is to answer inside the
+  # session budget, not to reap someone else's process.
+  local line="$1" status
+  exec 9< <(printf '%s\n' "$line" | "$HOOKPATH" origin probe://none >/dev/null 2>&1; printf '%s\n' "$?")
+  if read -t "$PROBE_SECONDS" -r status <&9; then
+    exec 9<&-
+    [ "$status" = 0 ] && return 0
+    return 1
+  fi
+  exec 9<&-
+  return 2
+}
+
 resolve() {
   if ! command -v git >/dev/null 2>&1; then
     CANNOT="git is not on PATH"; return
@@ -117,38 +140,75 @@ resolve() {
     return
   fi
 
+  # RECOGNITION COMES BEFORE EXECUTION, and this order is the whole point.
+  # `status` runs from SessionStart on every start, resume and compact, and the
+  # probes below EXECUTE the resolved pre-push. Before this ordering, the file
+  # executed was whatever `core.hooksPath` happened to point at - measured: a
+  # clone with `core.hooksPath=.husky` ran husky's pre-push, which received the
+  # synthetic refs on stdin; a foreign hook that slept 9s took `status` to
+  # 18.197s and session-brief.sh to 23.310s, past the 20s SessionStart budget in
+  # .claude/settings.json, so the session lost the very report this produces.
+  #
+  # So: a hook is EXECUTED only when this installer can show it wrote it. Two
+  # ways to show that, and either is sufficient:
+  #   - it is byte-identical to the committed .githooks/pre-push, i.e. it is
+  #     literally this repository's own code; or
+  #   - its blob id equals the one `install` recorded in wpmgr.installedHookBlob.
+  # The second is not redundant: it is what keeps a source edit on a branch from
+  # reddening the gate. Editing .githooks/pre-push makes the installed copy
+  # differ from the source, and that copy is still ours and still protecting the
+  # repository - it reports INSTALLED and STALE, exactly as before.
+  local blob recorded
+  if src=$(hook_source); then
+    cmp -s "$src" "$HOOKPATH" || STALE="$src"
+  else
+    NOCMP="no readable .githooks/pre-push in this working tree or the main checkout"
+  fi
+  if [ -n "$STALE" ] || [ -n "$NOCMP" ]; then
+    recorded=$(git config --get wpmgr.installedHookBlob 2>/dev/null)
+    blob=$(git hash-object "$HOOKPATH" 2>/dev/null)
+    if [ -z "$recorded" ] || [ -z "$blob" ] || [ "$recorded" != "$blob" ]; then
+      CANNOT="'$HOOKPATH' is not a hook this installer wrote - it matches neither the committed .githooks/pre-push nor the copy recorded in wpmgr.installedHookBlob, so it was NOT executed and whether main is protected here is UNKNOWN. Nothing was changed or removed. Look at that file; if it is your own tooling, keep it and integrate the refusal from .githooks/pre-push by hand, otherwise run '$(fix_line)', which preserves it as pre-push.pre-wpmgr.<stamp> before installing"
+      HOOKPATH=""; STALE=""; NOCMP=""
+      return
+    fi
+  fi
+
   # Presence is not protection. Drive the resolved hook with the stdin
   # githooks(5) specifies and require it to actually refuse main and actually
   # allow a branch: a truncated, emptied or replaced hook is executable too.
+  #
+  # BOUNDED, because this runs inside a 20s SessionStart budget. `timeout` and
+  # `gtimeout` are BOTH absent on this machine (`command -v` finds neither), so
+  # the bound is bash's own `read -t` against a process substitution: no
+  # external binary, and none of `until` / `while true`, which the bash guard
+  # denies and which is the shape that has killed most agents here.
   local zero=0000000000000000000000000000000000000000
   local sha=1111111111111111111111111111111111111111
-  if printf 'refs/heads/main %s refs/heads/main %s\n' "$sha" "$zero" \
-       | "$HOOKPATH" origin probe://none >/dev/null 2>&1; then
-    WHY="'$HOOKPATH' runs but ALLOWS a push to refs/heads/main, so it is not the hook this repository ships"
-    return
-  fi
-  if ! printf 'refs/heads/fix/x %s refs/heads/fix/x %s\n' "$sha" "$zero" \
-       | "$HOOKPATH" origin probe://none >/dev/null 2>&1; then
-    WHY="'$HOOKPATH' refuses an ordinary branch push, so it would block every branch and get switched off"
-    return
-  fi
+  probe_hook "refs/heads/main $sha refs/heads/main $zero"
+  case $? in
+    0) WHY="'$HOOKPATH' runs but ALLOWS a push to refs/heads/main, so it is not the hook this repository ships"; return ;;
+    2) CANNOT="'$HOOKPATH' did not finish within ${PROBE_SECONDS}s when asked about refs/heads/main, so it was abandoned rather than waited on; whether it refuses main is UNKNOWN"
+       HOOKPATH=""; STALE=""; NOCMP=""; return ;;
+  esac
+  probe_hook "refs/heads/fix/x $sha refs/heads/fix/x $zero"
+  case $? in
+    1) WHY="'$HOOKPATH' refuses an ordinary branch push, so it would block every branch and get switched off"; return ;;
+    2) CANNOT="'$HOOKPATH' did not finish within ${PROBE_SECONDS}s when asked about an ordinary branch, so it was abandoned rather than waited on"
+       HOOKPATH=""; STALE=""; NOCMP=""; return ;;
+  esac
 
   # STALENESS. Installing by copy buys a hook no checkout can remove, and the
-  # price is a second copy that can drift from `.githooks/pre-push`. So it is
-  # compared, every time this runs, against the committed source - and when
-  # there is no source to compare against, that is SAID rather than passed over,
-  # because "not compared" and "identical" must never print the same.
+  # price is a second copy that can drift from `.githooks/pre-push`. It is
+  # compared above, every time this runs, against the committed source - and
+  # when there is no source to compare against, that is SAID rather than passed
+  # over, because "not compared" and "identical" must never print the same.
   #
   # Drift does not change the exit code. What `check` gates on is the two probes
   # above: the installed hook refuses main and permits a branch. A copy that
   # still does both is protecting the repository whatever else it says, and
   # reddening every worktree that edits `.githooks/pre-push` on a branch would
   # redden correct work - which is how a gate gets switched off.
-  if src=$(hook_source); then
-    cmp -s "$src" "$HOOKPATH" || STALE="$src"
-  else
-    NOCMP="no readable .githooks/pre-push in this working tree or the main checkout"
-  fi
 }
 
 fix_line() {
@@ -193,16 +253,76 @@ case "$mode" in
       exit 2
     }
     mkdir -p "$dir" || { echo "FAIL: could not create '$dir'." >&2; exit 2; }
+
+    # PRESERVE, NEVER CLOBBER. This ran from `scripts/bootstrap.sh` and from
+    # `make hooks`, i.e. on the ordinary onboarding path, and it overwrote
+    # whatever pre-push was already there without a word. Measured in a throwaway
+    # clone: a hand-written pre-push went from 3 lines to 132, `install` exited 0
+    # and printed nothing about it, no backup existed, and `grep -rl` found the
+    # old text nowhere on disk. `.git/hooks` is untracked and this Mac has no
+    # Time Machine and no APFS snapshots, so that was unrecoverable.
+    #
+    # WHY PRESERVE RATHER THAN REFUSE, since both were on the table: refusing
+    # puts a hard stop in `scripts/bootstrap.sh`, so the first thing a new
+    # contributor with husky meets is a failed bootstrap, and the fix a hurried
+    # person reaches for is deleting their own hook. A copy costs a few hundred
+    # bytes, is announced in the output with the exact command that restores it,
+    # and leaves nothing destroyed. The half that must never be silent is the
+    # ANNOUNCEMENT, not the refusal.
+    backup=""
+    if [ -e "$dir/pre-push" ] && ! cmp -s "$src" "$dir/pre-push"; then
+      backup="$dir/pre-push.pre-wpmgr.$(date +%Y%m%d%H%M%S).$$"
+      cp -p "$dir/pre-push" "$backup" || {
+        echo "FAIL: '$dir/pre-push' already exists, differs from '$src', and could not be copied to '$backup'." >&2
+        echo "      Nothing was overwritten. Move that hook aside yourself, then run '$(fix_line)' again." >&2
+        exit 2; }
+    fi
+
     cp "$src" "$dir/pre-push" || { echo "FAIL: could not copy '$src' to '$dir/pre-push'." >&2; exit 2; }
     chmod +x "$dir/pre-push" || { echo "FAIL: could not make '$dir/pre-push' executable." >&2; exit 2; }
     echo "installed $src -> $dir/pre-push"
+    if [ -n "$backup" ]; then
+      echo "PRESERVED the pre-push that was already there -> $backup"
+      echo "  It was not this repository's hook. It is no longer what git runs."
+      echo "  Read it, and if it is yours, fold it into '$dir/pre-push' by hand."
+      echo "  RESTORE IT ENTIRELY WITH:  cp '$backup' '$dir/pre-push'"
+    fi
+
+    # Record what was installed, so `status` can tell a hook this installer
+    # wrote from a foreign one WITHOUT executing the foreign one to find out.
+    if blob=$(git hash-object "$dir/pre-push" 2>/dev/null) && [ -n "$blob" ]; then
+      git config wpmgr.installedHookBlob "$blob"
+    fi
+
     # core.hooksPath is set to the same directory git would use by default. It
     # is not needed for a clone that never had it, and it is the repair for one
     # that does: an earlier version of this script pointed it at the tracked
     # .githooks, and leaving that value in place would send git looking at a
     # directory that disappears on `git checkout <older commit>`.
+    #
+    # A NON-MATCHING PRIOR VALUE IS SOMEONE ELSE'S TOOLING and it is not
+    # destroyed in silence either. Measured: a clone with `core.hooksPath=.husky`
+    # had it redirected here, and a real push to a local bare remote stopped
+    # printing husky's line - the file survived, git simply no longer resolved
+    # it. It is recorded and named now, with the command that puts it back.
+    prev=$(git config --get core.hooksPath 2>/dev/null)
+    prev_resolved="$prev"
+    if [ -n "$prev" ] && [ "${prev#/}" = "$prev" ]; then
+      prev_top=$(git rev-parse --show-toplevel 2>/dev/null)
+      [ -n "$prev_top" ] && prev_resolved="$prev_top/$prev"
+    fi
     git config core.hooksPath "$dir"
     echo "core.hooksPath = $(git config --get core.hooksPath)"
+    if [ -n "$prev" ] && [ "$prev_resolved" != "$dir" ]; then
+      git config wpmgr.previousHooksPath "$prev"
+      echo "core.hooksPath WAS '$prev' (resolving to '$prev_resolved')."
+      if [ -e "$prev_resolved/pre-push" ]; then
+        echo "  '$prev_resolved/pre-push' STILL EXISTS and was not touched, but git will NOT run it any more."
+      fi
+      echo "  Saved as wpmgr.previousHooksPath."
+      echo "  REVERT WITH:  git config core.hooksPath \"\$(git config --get wpmgr.previousHooksPath)\""
+      echo "  Reverting turns this repository's push-to-main refusal back off."
+    fi
     # Verify what was just installed, through the same resolution a session
     # uses, rather than trusting that `git config` did what it was told.
     resolve

--- a/scripts/claude/git-hooks.sh
+++ b/scripts/claude/git-hooks.sh
@@ -15,7 +15,8 @@
 # this repository's signature defect, so what is asserted here is the hook
 # RUNNING, resolved from the checkout this is invoked in.
 #
-#   install   point core.hooksPath at an absolute .githooks and verify it took
+#   install   copy .githooks/pre-push into $GIT_COMMON_DIR/hooks, point
+#             core.hooksPath at that same directory, and verify by running it
 #   status    print INSTALLED / NOT INSTALLED / COULD NOT CHECK; never fails
 #   check     the same, but exit non-zero unless it is INSTALLED (the gate)
 #
@@ -35,22 +36,41 @@ mode="${1:-status}"
 CANNOT=""   # non-empty: why the question could not be answered
 WHY=""      # non-empty: why it is not installed
 HOOKPATH="" # the resolved pre-push, when there is one
+STALE=""    # non-empty: the installed copy differs from the committed source
+NOCMP=""    # non-empty: why the staleness comparison could not be made
 
-hooks_dir_for_install() {
-  # An ABSOLUTE path, derived from the common dir, because a RELATIVE
-  # core.hooksPath is resolved by git against the top of whatever working tree
-  # is running the hook. That was the bug: `.githooks` is only present in a tree
-  # checked out at or after the hook's commit, so every linked worktree, tag
-  # checkout, bisect and detached HEAD from before it silently ran no hook while
-  # config still said "installed". `git rev-parse --git-common-dir` is the same
-  # directory from every linked worktree, and its parent is the main checkout.
-  local common parent
+common_hooks_dir() {
+  # $GIT_COMMON_DIR/hooks. This is git's own default hooks directory, it is the
+  # SAME directory from every linked worktree, and - the whole point - it is not
+  # in any working tree, so no checkout, tag, bisect or detached HEAD can take
+  # it away. Pointing core.hooksPath at the tracked `.githooks` instead was
+  # measured wrong twice: relative, git resolved it against whichever tree ran
+  # the hook; absolute, it still named a directory that is only present in a
+  # tree checked out at or after the hook's commit, so `git checkout <older>`
+  # in the main checkout silently disarmed every worktree while config kept
+  # reading "installed".
+  local common
   common=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
   [ -n "$common" ] || return 1
   common=$(cd "$common" 2>/dev/null && pwd -P) || return 1
-  parent=$(dirname "$common")
-  [ -d "$parent/.githooks" ] || return 1
-  printf '%s' "$parent/.githooks"
+  printf '%s' "$common/hooks"
+}
+
+hook_source() {
+  # The committed hook, from the working tree this was invoked in first - so
+  # `make hooks` works from a worktree even when the main checkout sits on a
+  # commit that predates `.githooks` - and from the main checkout second.
+  local top common
+  top=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$top" ] && [ -r "$top/.githooks/pre-push" ]; then
+    printf '%s' "$top/.githooks/pre-push"; return 0
+  fi
+  common=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+  common=$(cd "$common" 2>/dev/null && pwd -P) || return 1
+  if [ -r "$(dirname "$common")/.githooks/pre-push" ]; then
+    printf '%s' "$(dirname "$common")/.githooks/pre-push"; return 0
+  fi
+  return 1
 }
 
 resolve() {
@@ -61,26 +81,35 @@ resolve() {
     CANNOT="'$PWD' is not inside a git worktree"; return
   fi
 
-  local hp top
+  local hp top from src
   hp=$(git config --get core.hooksPath 2>/dev/null)
   if [ -z "$hp" ]; then
-    WHY="core.hooksPath is unset, so git runs no hook from this repository at all"
-    return
-  fi
-  if [ "${hp#/}" = "$hp" ]; then
-    # Relative: git resolves it against the top of the working tree the hook
-    # runs in, so it is resolved the same way here rather than against \$PWD.
-    top=$(git rev-parse --show-toplevel 2>/dev/null)
-    if [ -z "$top" ]; then
-      CANNOT="core.hooksPath is the relative path '$hp' and this checkout has no working tree to resolve it against"
+    # Unset is not "no hook": git falls back to $GIT_COMMON_DIR/hooks, which is
+    # exactly where `install` puts it, so this reads the default rather than
+    # calling it absent. Saying "core.hooksPath is unset, so git runs no hook"
+    # here would be a definite negative about a directory never looked at.
+    hp=$(common_hooks_dir) || {
+      CANNOT="core.hooksPath is unset and 'git rev-parse --git-common-dir' failed, so git's default hooks directory cannot be located"
       return
+    }
+    from="git's default, core.hooksPath unset"
+  else
+    from="core.hooksPath"
+    if [ "${hp#/}" = "$hp" ]; then
+      # Relative: git resolves it against the top of the working tree the hook
+      # runs in, so it is resolved the same way here rather than against \$PWD.
+      top=$(git rev-parse --show-toplevel 2>/dev/null)
+      if [ -z "$top" ]; then
+        CANNOT="core.hooksPath is the relative path '$hp' and this checkout has no working tree to resolve it against"
+        return
+      fi
+      hp="$top/$hp"
     fi
-    hp="$top/$hp"
   fi
   HOOKPATH="$hp/pre-push"
 
   if [ ! -e "$HOOKPATH" ]; then
-    WHY="core.hooksPath resolves to '$hp', and there is no pre-push in it"
+    WHY="git resolves hooks to '$hp' ($from), and there is no pre-push in it"
     return
   fi
   if [ ! -x "$HOOKPATH" ]; then
@@ -102,6 +131,23 @@ resolve() {
        | "$HOOKPATH" origin probe://none >/dev/null 2>&1; then
     WHY="'$HOOKPATH' refuses an ordinary branch push, so it would block every branch and get switched off"
     return
+  fi
+
+  # STALENESS. Installing by copy buys a hook no checkout can remove, and the
+  # price is a second copy that can drift from `.githooks/pre-push`. So it is
+  # compared, every time this runs, against the committed source - and when
+  # there is no source to compare against, that is SAID rather than passed over,
+  # because "not compared" and "identical" must never print the same.
+  #
+  # Drift does not change the exit code. What `check` gates on is the two probes
+  # above: the installed hook refuses main and permits a branch. A copy that
+  # still does both is protecting the repository whatever else it says, and
+  # reddening every worktree that edits `.githooks/pre-push` on a branch would
+  # redden correct work - which is how a gate gets switched off.
+  if src=$(hook_source); then
+    cmp -s "$src" "$HOOKPATH" || STALE="$src"
+  else
+    NOCMP="no readable .githooks/pre-push in this working tree or the main checkout"
   fi
 }
 
@@ -126,16 +172,35 @@ report() {
     return 1
   fi
   echo "- pre-push hook: INSTALLED ($HOOKPATH). A push that would land on main is refused; 'git push --no-verify' skips it."
+  if [ -n "$STALE" ]; then
+    echo "  STALE: it differs from the committed '$STALE'. It still refuses main - that was just measured - but it is not the shipped text. Refresh with '$(fix_line)'."
+  elif [ -n "$NOCMP" ]; then
+    echo "  Staleness was NOT checked: $NOCMP. Do not read this line as 'up to date'."
+  fi
   return 0
 }
 
 case "$mode" in
   install)
-    dir=$(hooks_dir_for_install) || {
-      echo "FAIL: could not resolve a .githooks directory from 'git rev-parse --git-common-dir' in '$PWD'." >&2
-      echo "      Run this from inside the checkout, on a commit that carries .githooks/." >&2
+    dir=$(common_hooks_dir) || {
+      echo "FAIL: 'git rev-parse --git-common-dir' gave no answer in '$PWD', so there is no repository to install into." >&2
+      echo "      Run this from inside a checkout of this repository." >&2
       exit 2
     }
+    src=$(hook_source) || {
+      echo "FAIL: no readable .githooks/pre-push in this working tree or in the main checkout, so there is nothing to install." >&2
+      echo "      Check out a commit that carries .githooks/ in either tree and run '$(fix_line)' again." >&2
+      exit 2
+    }
+    mkdir -p "$dir" || { echo "FAIL: could not create '$dir'." >&2; exit 2; }
+    cp "$src" "$dir/pre-push" || { echo "FAIL: could not copy '$src' to '$dir/pre-push'." >&2; exit 2; }
+    chmod +x "$dir/pre-push" || { echo "FAIL: could not make '$dir/pre-push' executable." >&2; exit 2; }
+    echo "installed $src -> $dir/pre-push"
+    # core.hooksPath is set to the same directory git would use by default. It
+    # is not needed for a clone that never had it, and it is the repair for one
+    # that does: an earlier version of this script pointed it at the tracked
+    # .githooks, and leaving that value in place would send git looking at a
+    # directory that disappears on `git checkout <older commit>`.
     git config core.hooksPath "$dir"
     echo "core.hooksPath = $(git config --get core.hooksPath)"
     # Verify what was just installed, through the same resolution a session

--- a/scripts/claude/git-hooks.sh
+++ b/scripts/claude/git-hooks.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Install, or truthfully report, the committed git hooks.
+#
+# WHY THIS IS A SCRIPT AND NOT TWO LINES IN THE MAKEFILE.
+# `.githooks/pre-push` is committed; `core.hooksPath` is repo-local config and
+# repo-local config is NEVER committed. So the default state of every fresh
+# clone is: the hook is in the tree, and git ignores it. That was measured, not
+# assumed - in a fresh clone `git config --get core.hooksPath` is empty and
+# `git push origin HEAD:refs/heads/main` exits 0 and lands the commit.
+#
+# The first version of this shipped as a Makefile line plus a `grep` in the test
+# suite that asserted the STRING `git config core.hooksPath .githooks` appeared
+# in two files. That suite passed, in full, inside a clone with no hook
+# installed at all. A check that passes when the thing it checks is absent is
+# this repository's signature defect, so what is asserted here is the hook
+# RUNNING, resolved from the checkout this is invoked in.
+#
+#   install   point core.hooksPath at an absolute .githooks and verify it took
+#   status    print INSTALLED / NOT INSTALLED / COULD NOT CHECK; never fails
+#   check     the same, but exit non-zero unless it is INSTALLED (the gate)
+#
+# EXIT: 0 installed, 1 not installed, 2 could not check. `status` always exits 0
+# so a SessionStart hook cannot be broken by it; `check` propagates.
+#
+# Test: scripts/claude/guards_test.sh
+set -uo pipefail
+
+mode="${1:-status}"
+
+# --- resolution -------------------------------------------------------------
+# Three states, and collapsing "could not check" into "NOT INSTALLED" is the
+# defect this file exists to avoid: a definite negative from a measurement that
+# never happened is worse than admitting the measurement failed. Same idiom as
+# the toolchain block in session-brief.sh, for the same reason.
+CANNOT=""   # non-empty: why the question could not be answered
+WHY=""      # non-empty: why it is not installed
+HOOKPATH="" # the resolved pre-push, when there is one
+
+hooks_dir_for_install() {
+  # An ABSOLUTE path, derived from the common dir, because a RELATIVE
+  # core.hooksPath is resolved by git against the top of whatever working tree
+  # is running the hook. That was the bug: `.githooks` is only present in a tree
+  # checked out at or after the hook's commit, so every linked worktree, tag
+  # checkout, bisect and detached HEAD from before it silently ran no hook while
+  # config still said "installed". `git rev-parse --git-common-dir` is the same
+  # directory from every linked worktree, and its parent is the main checkout.
+  local common parent
+  common=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  common=$(cd "$common" 2>/dev/null && pwd -P) || return 1
+  parent=$(dirname "$common")
+  [ -d "$parent/.githooks" ] || return 1
+  printf '%s' "$parent/.githooks"
+}
+
+resolve() {
+  if ! command -v git >/dev/null 2>&1; then
+    CANNOT="git is not on PATH"; return
+  fi
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    CANNOT="'$PWD' is not inside a git worktree"; return
+  fi
+
+  local hp top
+  hp=$(git config --get core.hooksPath 2>/dev/null)
+  if [ -z "$hp" ]; then
+    WHY="core.hooksPath is unset, so git runs no hook from this repository at all"
+    return
+  fi
+  if [ "${hp#/}" = "$hp" ]; then
+    # Relative: git resolves it against the top of the working tree the hook
+    # runs in, so it is resolved the same way here rather than against \$PWD.
+    top=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [ -z "$top" ]; then
+      CANNOT="core.hooksPath is the relative path '$hp' and this checkout has no working tree to resolve it against"
+      return
+    fi
+    hp="$top/$hp"
+  fi
+  HOOKPATH="$hp/pre-push"
+
+  if [ ! -e "$HOOKPATH" ]; then
+    WHY="core.hooksPath resolves to '$hp', and there is no pre-push in it"
+    return
+  fi
+  if [ ! -x "$HOOKPATH" ]; then
+    WHY="'$HOOKPATH' exists but is not executable, and git skips a hook it cannot execute"
+    return
+  fi
+
+  # Presence is not protection. Drive the resolved hook with the stdin
+  # githooks(5) specifies and require it to actually refuse main and actually
+  # allow a branch: a truncated, emptied or replaced hook is executable too.
+  local zero=0000000000000000000000000000000000000000
+  local sha=1111111111111111111111111111111111111111
+  if printf 'refs/heads/main %s refs/heads/main %s\n' "$sha" "$zero" \
+       | "$HOOKPATH" origin probe://none >/dev/null 2>&1; then
+    WHY="'$HOOKPATH' runs but ALLOWS a push to refs/heads/main, so it is not the hook this repository ships"
+    return
+  fi
+  if ! printf 'refs/heads/fix/x %s refs/heads/fix/x %s\n' "$sha" "$zero" \
+       | "$HOOKPATH" origin probe://none >/dev/null 2>&1; then
+    WHY="'$HOOKPATH' refuses an ordinary branch push, so it would block every branch and get switched off"
+    return
+  fi
+}
+
+fix_line() {
+  # One command, and it is the whole fix. Printed with every negative report:
+  # a warning that does not carry its remedy gets read and not acted on.
+  printf 'make hooks'
+}
+
+report() {
+  if [ -n "$CANNOT" ]; then
+    echo "- pre-push hook: COULD NOT CHECK - $CANNOT."
+    echo "  Do NOT read this as installed. Resolve it, then re-check with '$(fix_line)'."
+    return 2
+  fi
+  if [ -n "$WHY" ]; then
+    echo "- pre-push hook: NOT INSTALLED. $WHY."
+    echo "  A push to main from this checkout is NOT refused by anything: branch"
+    echo "  protection on main leaves enforce_admins false, so nothing server-side"
+    echo "  catches it either. This is the default state of every fresh clone."
+    echo "  FIX, one command:  $(fix_line)"
+    return 1
+  fi
+  echo "- pre-push hook: INSTALLED ($HOOKPATH). A push that would land on main is refused; 'git push --no-verify' skips it."
+  return 0
+}
+
+case "$mode" in
+  install)
+    dir=$(hooks_dir_for_install) || {
+      echo "FAIL: could not resolve a .githooks directory from 'git rev-parse --git-common-dir' in '$PWD'." >&2
+      echo "      Run this from inside the checkout, on a commit that carries .githooks/." >&2
+      exit 2
+    }
+    git config core.hooksPath "$dir"
+    echo "core.hooksPath = $(git config --get core.hooksPath)"
+    # Verify what was just installed, through the same resolution a session
+    # uses, rather than trusting that `git config` did what it was told.
+    resolve
+    report
+    rc=$?
+    [ $rc -eq 0 ] || exit "$rc"
+    ;;
+  status)
+    resolve
+    report || true
+    exit 0
+    ;;
+  check)
+    resolve
+    report
+    rc=$?
+    if [ $rc -ne 0 ]; then
+      echo ""
+      echo "harness-check FAILS because the hook it ships is not running here."
+      exit 1
+    fi
+    ;;
+  *)
+    echo "usage: $0 {install|status|check}" >&2
+    exit 2 ;;
+esac

--- a/scripts/claude/git-hooks.sh
+++ b/scripts/claude/git-hooks.sh
@@ -149,16 +149,20 @@ resolve() {
   # 18.197s and session-brief.sh to 23.310s, past the 20s SessionStart budget in
   # .claude/settings.json, so the session lost the very report this produces.
   #
-  # So: a hook is EXECUTED only when this installer can show it wrote it. Two
-  # ways to show that, and either is sufficient:
-  #   - it is byte-identical to the committed .githooks/pre-push, i.e. it is
-  #     literally this repository's own code; or
-  #   - its blob id equals the one `install` recorded in wpmgr.installedHookBlob.
-  # The second is not redundant: it is what keeps a source edit on a branch from
-  # reddening the gate. Editing .githooks/pre-push makes the installed copy
-  # differ from the source, and that copy is still ours and still protecting the
-  # repository - it reports INSTALLED and STALE, exactly as before.
-  local blob recorded
+  # So: a hook is EXECUTED only when this installer can show it wrote it. Three
+  # ways to show that, and any one is sufficient:
+  #   - it is byte-identical to the committed .githooks/pre-push in this tree;
+  #   - its blob id equals the one `install` recorded in wpmgr.installedHookBlob;
+  #   - its blob id is one that .githooks/pre-push has HAD, anywhere in this
+  #     repository's history. A copy left by an older `install` is our own code
+  #     whether or not anything was recorded at the time.
+  # The last two are not redundant, and leaving them out was measured: with only
+  # the byte-compare, `make harness-check` went red in the main checkout of this
+  # repository the moment this branch edited .githooks/pre-push, because the
+  # copy installed weeks ago no longer matched the edited source. A gate that
+  # reddens correct work is a gate that gets switched off. With them, a source
+  # edit on a branch still reports INSTALLED and STALE, exactly as before.
+  local blob recorded c hist
   if src=$(hook_source); then
     cmp -s "$src" "$HOOKPATH" || STALE="$src"
   else
@@ -167,7 +171,16 @@ resolve() {
   if [ -n "$STALE" ] || [ -n "$NOCMP" ]; then
     recorded=$(git config --get wpmgr.installedHookBlob 2>/dev/null)
     blob=$(git hash-object "$HOOKPATH" 2>/dev/null)
-    if [ -z "$recorded" ] || [ -z "$blob" ] || [ "$recorded" != "$blob" ]; then
+    if [ -n "$blob" ] && [ "$recorded" != "$blob" ]; then
+      # BOUNDED, and by a count, not by a loop that could run long: the most
+      # recent commits that touched the file across all refs. `--max-count` is
+      # what makes this safe to run from SessionStart.
+      for c in $(git rev-list --max-count=25 --all -- .githooks/pre-push 2>/dev/null); do
+        hist=$(git rev-parse -q --verify "$c:.githooks/pre-push" 2>/dev/null)
+        if [ "$hist" = "$blob" ]; then recorded="$blob"; break; fi
+      done
+    fi
+    if [ -z "$blob" ] || [ "$recorded" != "$blob" ]; then
       CANNOT="'$HOOKPATH' is not a hook this installer wrote - it matches neither the committed .githooks/pre-push nor the copy recorded in wpmgr.installedHookBlob, so it was NOT executed and whether main is protected here is UNKNOWN. Nothing was changed or removed. Look at that file; if it is your own tooling, keep it and integrate the refusal from .githooks/pre-push by hand, otherwise run '$(fix_line)', which preserves it as pre-push.pre-wpmgr.<stamp> before installing"
       HOOKPATH=""; STALE=""; NOCMP=""
       return

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -801,6 +801,172 @@ t "quoted mv dead aside"  pass "$(bdec 'mv "apps/landing" /tmp/landing-old')"
 t "quoted rm dead app"    pass "$(bdec 'rm -rf "apps/landing"')"
 t "quoted sibling"        pass "$(bdec 'cp /tmp/x "apps/api/internal/db/sqlcx/db.go"')"
 
+echo "== bash-guard: a push that would land commits on main"
+# On 2026-08-12 a one-line fix was committed on main in the main checkout and
+# pushed straight to origin/main, with no branch and no PR. Branch protection on
+# main carries four required contexts and enforce_admins is deliberately false,
+# so the push was accepted server-side with none of them running. This guard saw
+# that command and permitted it: its whole notion of git was `git rm`/`git mv`.
+#
+# Every case below needs a checkout whose HEAD is KNOWN, and `git init` takes
+# its first branch name from the machine's init.defaultBranch, which this suite
+# may not assume. So HEAD is set explicitly with symbolic-ref, and the premise
+# is asserted before anything rests on it.
+mkbranchrepo() { # mkbranchrepo <dir> <branch>
+  mkdir -p "$1"
+  git -C "$1" init -q
+  git -C "$1" config user.email t@t.invalid
+  git -C "$1" config user.name t
+  git -C "$1" symbolic-ref HEAD "refs/heads/$2"
+  echo seed > "$1/seed.txt"
+  git -C "$1" add seed.txt >/dev/null
+  git -C "$1" commit -qm init
+}
+onmain="$tmp/on-main";       mkbranchrepo "$onmain" main
+onbranch="$tmp/on-branch";   mkbranchrepo "$onbranch" fix/thing
+onwt="$tmp/on-worktree";     mkbranchrepo "$onwt" worktree-agent-7
+detached="$tmp/detached";    mkbranchrepo "$detached" main
+git -C "$detached" checkout -q --detach
+
+# The premises. Without these, "denied because HEAD is main" and "permitted
+# because HEAD is not" both pass for whatever reason the machine chose.
+t "fixture HEAD is main"     main              "$(git -C "$onmain"   symbolic-ref --quiet --short HEAD)"
+t "fixture HEAD is a branch" fix/thing         "$(git -C "$onbranch" symbolic-ref --quiet --short HEAD)"
+t "fixture HEAD is worktree" worktree-agent-7  "$(git -C "$onwt"     symbolic-ref --quiet --short HEAD)"
+t "fixture HEAD is detached" ""                "$(git -C "$detached" symbolic-ref --quiet --short HEAD 2>/dev/null)"
+
+bdecc() { # bdec with an arbitrary cwd, which is where the branch is read from
+  local out
+  out=$(jq -n --arg c "$1" --arg c2 "$2" '{cwd:$c, tool_input:{command:$c2}}' \
+        | bash "$BASH_G" 2>/dev/null \
+        | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  printf '%s' "${out:-pass}"
+}
+breason() {
+  jq -n --arg c "$1" --arg c2 "$2" '{cwd:$c, tool_input:{command:$c2}}' \
+    | bash "$BASH_G" 2>/dev/null \
+    | jq -r '.hookSpecificOutput.permissionDecisionReason // ""' 2>/dev/null
+}
+
+# It fires. Every shape that puts a commit on main.
+t "bare push, HEAD is main"  deny "$(bdecc "$onmain"   'git push')"
+t "push origin, HEAD main"   deny "$(bdecc "$onmain"   'git push origin')"
+t "push origin HEAD on main" deny "$(bdecc "$onmain"   'git push origin HEAD')"
+t "push -u origin HEAD main" deny "$(bdecc "$onmain"   'git push -u origin HEAD')"
+t "push origin main"         deny "$(bdecc "$onbranch" 'git push origin main')"
+t "push origin HEAD:main"    deny "$(bdecc "$onbranch" 'git push origin HEAD:main')"
+t "push -u origin main"      deny "$(bdecc "$onbranch" 'git push -u origin main')"
+t "push --force origin main" deny "$(bdecc "$onbranch" 'git push --force origin main')"
+t "push -f origin main"      deny "$(bdecc "$onbranch" 'git push -f origin main')"
+t "push origin +main"        deny "$(bdecc "$onbranch" 'git push origin +main')"
+t "push origin main:main"    deny "$(bdecc "$onbranch" 'git push origin main:main')"
+t "push HEAD:refs/heads/main" deny "$(bdecc "$onbranch" 'git push origin HEAD:refs/heads/main')"
+t "push --force-with-lease"  deny "$(bdecc "$onbranch" 'git push --force-with-lease origin main')"
+t "push --all"               deny "$(bdecc "$onbranch" 'git push --all')"
+t "push --all origin"        deny "$(bdecc "$onbranch" 'git push --all origin')"
+t "push --mirror"            deny "$(bdecc "$onbranch" 'git push --mirror origin')"
+t "push a branch onto main"  deny "$(bdecc "$onbranch" 'git push origin fix/thing:main')"
+t "push to a URL, main"      deny "$(bdecc "$onbranch" 'git push git@github.com:o/r.git main')"
+t "push --tags AND main"     deny "$(bdecc "$onbranch" 'git push --tags origin main')"
+t "push -o then main"        deny "$(bdecc "$onbranch" 'git push -o ci.skip origin main')"
+# The agent worktree whose HEAD is main. Isolation is not protection: a worktree
+# can sit on main like any other checkout.
+t "worktree HEAD is main"    deny "$(bdecc "$detached/../on-main" 'git push')"
+# Quoting must not defeat it, exactly as it must not defeat the write arms.
+t "dquoted main"             deny "$(bdecc "$onbranch" 'git push origin "main"')"
+t "squoted main"             deny "$(bdecc "$onbranch" "git push origin 'main'")"
+t "quoted push word"         deny "$(bdecc "$onbranch" 'git "push" origin "main"')"
+t "quoted remote and main"   deny "$(bdecc "$onbranch" 'git push "origin" "main"')"
+# The command word is found the same way every other arm finds it.
+t "chained after &&"         deny "$(bdecc "$onbranch" 'make test && git push origin main')"
+t "chained after ;"          deny "$(bdecc "$onbranch" 'git commit -m x; git push origin main')"
+t "env prefix"               deny "$(bdecc "$onbranch" 'GIT_TRACE=1 git push origin main')"
+t "absolute git path"        deny "$(bdecc "$onbranch" '/usr/bin/git push origin main')"
+t "trailing comment"         deny "$(bdecc "$onbranch" 'git push origin main # just this once')"
+# `git -C` overrides the repository, so the branch comes from THERE.
+t "git -C a main checkout"   deny "$(bdecc "$onbranch" "git -C $onmain push")"
+t "git -C, then origin HEAD" deny "$(bdecc "$onbranch" "git -C $onmain push origin HEAD")"
+# --git-dir is not followed, so the branch is unreadable rather than read from
+# the wrong tree; the refspec form is still decidable and still denied.
+t "--git-dir sep val, main"  deny "$(bdecc "$onbranch" 'git --git-dir /x/.git push origin main')"
+
+# The refusal has to point at the rule it enforces, or it is just a wall.
+main_reason=$(breason "$onbranch" 'git push origin main')
+tcontains "refusal names Delivery"    "## Delivery"        "$main_reason"
+tcontains "refusal names the PR"      "pull request"       "$main_reason"
+tcontains "refusal says why it is it" "enforce_admins"     "$main_reason"
+
+# ...and it must not over-fire, or it gets switched off and guards nothing.
+t "push -u a fix branch"     pass "$(bdecc "$onbranch" 'git push -u origin fix/whatever')"
+t "push origin HEAD"         pass "$(bdecc "$onbranch" 'git push origin HEAD')"
+t "bare push on a branch"    pass "$(bdecc "$onbranch" 'git push')"
+t "release branch"           pass "$(bdecc "$onbranch" 'git push origin release/0.61.134')"
+t "release branch -u"        pass "$(bdecc "$onbranch" 'git push -u origin release/0.61.134')"
+t "delete a remote branch"   pass "$(bdecc "$onbranch" 'git push --delete origin some-branch')"
+t "push --tags"              pass "$(bdecc "$onmain"   'git push --tags')"
+t "push --tags origin"       pass "$(bdecc "$onmain"   'git push origin --tags')"
+t "push one tag by name"     pass "$(bdecc "$onbranch" 'git push origin v0.61.133')"
+t "agent worktree push -u"   pass "$(bdecc "$onwt"     'git push -u origin worktree-agent-7')"
+t "agent worktree bare push" pass "$(bdecc "$onwt"     'git push')"
+t "agent worktree HEAD"      pass "$(bdecc "$onwt"     'git push origin HEAD')"
+t "agent worktree force"     pass "$(bdecc "$onwt"     'git push -f origin worktree-agent-7')"
+# Not a push. None of these move a ref on the remote.
+t "git fetch origin main"    pass "$(bdecc "$onmain"   'git fetch origin main')"
+t "git pull on main"         pass "$(bdecc "$onmain"   'git pull')"
+t "git remote -v"            pass "$(bdecc "$onmain"   'git remote -v')"
+t "git log origin/main"      pass "$(bdecc "$onmain"   'git log --oneline origin/main -5')"
+t "git checkout main"        pass "$(bdecc "$onmain"   'git checkout main')"
+t "git branch on main"       pass "$(bdecc "$onmain"   'git rev-parse --abbrev-ref HEAD')"
+t "git config push.default"  pass "$(bdecc "$onmain"   'git config push.default simple')"
+# The word main, without a push behind it. Substring matching would take all of
+# these, and they are ordinary work.
+t "cp domain.go"             pass "$(bdecc "$onmain"   'cp domain.go /tmp/x')"
+t "branch main-ui"           pass "$(bdecc "$onbranch" 'git push -u origin main-ui')"
+t "branch maintenance"       pass "$(bdecc "$onbranch" 'git push origin maintenance')"
+t "branch feat/remaining"    pass "$(bdecc "$onbranch" 'git push origin feat/remaining')"
+t "branch main2"             pass "$(bdecc "$onbranch" 'git push origin main2')"
+t "branch fix/main-menu"     pass "$(bdecc "$onbranch" 'git push origin fix/main-menu')"
+# A push that is DATA, not a command: quoted, commented, or echoed.
+t "push inside a message"    pass "$(bdecc "$onmain"   'git commit -m "wip; git push origin main"')"
+t "push inside a comment"    pass "$(bdecc "$onmain"   'make test # then git push origin main')"
+t "push echoed"              pass "$(bdecc "$onmain"   'echo "git push origin main"')"
+t "grepping for git push"    pass "$(bdecc "$onmain"   'grep -rn "git push" docs/')"
+
+echo "== bash-guard: a push whose branch it cannot read is refused, not waved through"
+# The signature defect of this project is a check that announces success over its
+# own errors. An unreadable branch is not a licence to push: it is DENY, and the
+# reason says the branch could not be determined rather than pretending to know.
+# The remedy is in the message and costs no lookup - name the branch.
+t "no cwd, bare push"        deny "$(bdec 'git push')"
+t "no cwd, push origin"      deny "$(bdec 'git push origin')"
+t "no cwd, push origin HEAD" deny "$(bdec 'git push origin HEAD')"
+t "cwd is not a repo"        deny "$(bdecc "$nogit" 'git push')"
+t "detached HEAD"            deny "$(bdecc "$detached" 'git push')"
+t "--git-dir, bare push"     deny "$(bdecc "$onbranch" "git --git-dir=$onbranch/.git push")"
+t "--work-tree, bare push"   deny "$(bdecc "$onbranch" "git --work-tree=$onbranch push")"
+unknown_reason=$(breason "$detached" 'git push')
+tcontains "says it could not read it" "COULD NOT DETERMINE" "$unknown_reason"
+tlacks    "and claims no branch"      "current branch is main" "$unknown_reason"
+
+# The over-fire that would make the deny above unusable: a push that names its
+# target needs no branch lookup, so an unreadable HEAD must not block it. Agents
+# push constantly and a payload without a usable cwd must not strand them.
+t "no cwd, explicit branch"  pass "$(bdec 'git push -u origin fix/x')"
+t "no cwd, a tag"            pass "$(bdec 'git push origin v0.61.133')"
+t "detached, explicit"       pass "$(bdecc "$detached" 'git push origin fix/x')"
+t "non-repo cwd, explicit"   pass "$(bdecc "$nogit" 'git push -u origin release/0.61.134')"
+t "--git-dir, explicit"      pass "$(bdecc "$onbranch" 'git --git-dir=/x/.git push origin fix/x')"
+# ...and an unreadable branch is not a licence to refuse everything else either.
+t "no cwd, git fetch"        pass "$(bdec 'git fetch --all')"
+t "detached, git status"     pass "$(bdecc "$detached" 'git status')"
+
+# KNOWN PRECEDENCE, asserted so it is visible rather than assumed: arm 2
+# (publishing prose) is reached first and ASKS, so a push chained with a gh
+# command arrives at the human as an ask carrying the publishing advice, not as
+# this arm's deny. It is still a stop, not a bypass. Reported to the owner
+# rather than fixed here, because moving the arm is not this change.
+t "push main && gh pr create" ask "$(bdecc "$onbranch" 'git push origin main && gh pr create')"
+
 echo "== commit-gate: only ever answers for what this agent wrote"
 # The deadlock this fixes: a read-only agent was launched into another agent's
 # worktree, told to commit or delete 17 files it had never touched while its

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -2481,6 +2481,26 @@ git -C "$fresh" checkout -- .githooks/pre-push
 fresh_out=$(cd "$fresh" && bash "$HOOKSH" status 2>&1)
 t "a fresh copy is not called stale" "" "$(printf '%s' "$fresh_out" | grep -c 'STALE' | grep -v '^0$')"
 
+# THE OVER-FIRE THIS RECOGNITION GATE NEARLY SHIPPED, and it was caught by
+# running it: with recognition resting on the byte-compare alone, `make
+# harness-check` went RED in the main checkout of this repository the moment
+# this branch edited .githooks/pre-push, because the copy installed weeks ago no
+# longer matched the edited source and nothing had been recorded back then. So a
+# copy whose bytes are one .githooks/pre-push HAS HAD, anywhere in history, is
+# ours. The recorded blob is cleared here or this would prove nothing.
+printf '\n# a committed edit\n' >> "$fresh/.githooks/pre-push"
+git -C "$fresh" add .githooks/pre-push >/dev/null
+git -C "$fresh" commit -qm "edit the hook on a branch"
+git -C "$fresh" config --unset wpmgr.installedHookBlob
+t "premise: nothing is recorded now" "" "$(git -C "$fresh" config --get wpmgr.installedHookBlob)"
+hist_out=$(cd "$fresh" && bash "$HOOKSH" status 2>&1); hist_rc=$?
+tcontains "an older committed copy is still recognised" "INSTALLED" "$hist_out"
+tcontains "and it is reported STALE, not unknown"       "STALE"     "$hist_out"
+t "and status exits 0"            0 "$hist_rc"
+(cd "$fresh" && bash "$HOOKSH" check >/dev/null 2>&1); t "and check does NOT redden" 0 "$?"
+git -C "$fresh" reset -q --hard HEAD~1
+(cd "$fresh" && bash "$HOOKSH" install >/dev/null 2>&1)
+
 # A PRE-PUSH THIS INSTALLER DID NOT WRITE IS NOT EXECUTED.
 # `status` runs from SessionStart on every start, resume and compact, and its
 # probes EXECUTE the resolved hook. Before the recognition gate that meant

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -44,7 +44,7 @@ git -C "$repo" config user.name t
 mkdir -p "$repo"/apps/api/{migrations,db,tests,internal/{site,auth,db/sqlc,api/gen,backup}} \
          "$repo"/apps/web/src/routes/_authed/sites "$repo"/apps/web/src \
          "$repo"/apps/agent/{includes,tests} "$repo"/apps/marketing/lib/content \
-         "$repo"/apps/tracker/src "$repo"/apps/landing "$repo"/docs/worklog \
+         "$repo"/apps/tracker/src "$repo"/apps/landing \
          "$repo"/.github/workflows "$repo"/infra "$repo"/packages/openapi-client/src
 echo "-- applied" > "$repo/apps/api/migrations/20260101000000_m01_applied.sql"
 # Staged BY NAME, like every commit in this project. This used to stage the
@@ -134,7 +134,24 @@ echo "== route-guard: a test whose suite CI runs does not prompt"
 t "go unit test"          pass "$(decision "$repo/apps/api/internal/site/service_test.go")"
 t "web test"              pass "$(decision "$repo/apps/web/src/routes/_authed/sites/index.test.tsx")"
 t "agent phpunit"         pass "$(decision "$repo/apps/agent/tests/RouterTest.php")"
-t "worklog"               pass "$(decision "$repo/docs/worklog/402.md")"
+# docs/worklog USED TO BE a silent permit here, and the fixture above used to
+# mkdir it. Both are gone. CLAUDE.md "## Long sessions" now puts worklogs at
+# ~/.wpmgr/worklog/ and forbids one from entering this repository at all, because
+# it is public and a worklog routinely holds an unshipped finding or a live
+# vulnerability's mechanism - on 2026-08-12 one was written to docs/worklog/406.md
+# while the escalation it described was live and undisclosed. Not creating the
+# directory is part of the assertion: the guard must decide on the PATH, with
+# nothing on disk to go by.
+t "worklog is refused"    deny "$(decision "$repo/docs/worklog/402.md")"
+t "worklog, nested"       deny "$(decision "$repo/docs/worklog/2026/406.md")"
+worklog_reason=$(reason "$repo/docs/worklog/402.md")
+tcontains "names the new home"   "~/.wpmgr/worklog/"  "$worklog_reason"
+tcontains "names the rule"       "## Long sessions"   "$worklog_reason"
+tcontains "says why: it is public" "PUBLIC"           "$worklog_reason"
+tcontains "and warns off gitignore" ".gitignore"      "$worklog_reason"
+# ...without taking the rest of docs with it: an ordinary doc still ROUTES.
+t "docs is still an ask"  ask  "$(decision "$repo/docs/worklog.md")"
+t "worklogs dir elsewhere" ask "$(decision "$repo/docs/notes/worklog/402.md")"
 # The deliberate exception: ci.yml excludes this package BY NAME from Build and
 # Test, and api-integration.yml is manual-dispatch, so a regression here merges
 # green. It is also where the tenancy and RLS proofs live.
@@ -869,9 +886,19 @@ t "push a branch onto main"  deny "$(bdecc "$onbranch" 'git push origin fix/thin
 t "push to a URL, main"      deny "$(bdecc "$onbranch" 'git push git@github.com:o/r.git main')"
 t "push --tags AND main"     deny "$(bdecc "$onbranch" 'git push --tags origin main')"
 t "push -o then main"        deny "$(bdecc "$onbranch" 'git push -o ci.skip origin main')"
-# The agent worktree whose HEAD is main. Isolation is not protection: a worktree
-# can sit on main like any other checkout.
-t "worktree HEAD is main"    deny "$(bdecc "$detached/../on-main" 'git push')"
+# A REAL linked worktree, made with `git worktree add`, which is how every agent
+# in this project actually runs. The line here used to be `bdecc
+# "$detached/../on-main"` under a comment claiming linked-worktree coverage: that
+# path is just $onmain spelled differently, so it duplicated the first assertion
+# in this block and proved nothing about a worktree. `.git` in a linked worktree
+# is a FILE pointing at the parent, and symbolic-ref has to work through it.
+linked="$tmp/linked-wt"
+git -C "$onmain" worktree add -q -b worktree-agent-9 "$linked" >/dev/null 2>&1
+t "linked wt .git is a file"  file "$(test -f "$linked/.git" && echo file)"
+t "linked wt HEAD reads"      worktree-agent-9 "$(git -C "$linked" symbolic-ref --quiet --short HEAD)"
+t "linked wt bare push"       pass "$(bdecc "$linked" 'git push')"
+t "linked wt -C the parent"   deny "$(bdecc "$linked" "git -C $onmain push")"
+t "linked wt cd the parent"   deny "$(bdecc "$linked" "cd $onmain && git push")"
 # Quoting must not defeat it, exactly as it must not defeat the write arms.
 t "dquoted main"             deny "$(bdecc "$onbranch" 'git push origin "main"')"
 t "squoted main"             deny "$(bdecc "$onbranch" "git push origin 'main'")"
@@ -931,6 +958,79 @@ t "push inside a message"    pass "$(bdecc "$onmain"   'git commit -m "wip; git 
 t "push inside a comment"    pass "$(bdecc "$onmain"   'make test # then git push origin main')"
 t "push echoed"              pass "$(bdecc "$onmain"   'echo "git push origin main"')"
 t "grepping for git push"    pass "$(bdecc "$onmain"   'grep -rn "git push" docs/')"
+
+# --dry-run TRANSFERS NOTHING. Refusing it was wrong twice: the reason printed
+# was "That push lands commits on main", which is untrue of the command it
+# refused, and it blocked the only safe way to inspect the dangerous command.
+t "--dry-run origin main"    pass "$(bdecc "$onbranch" 'git push --dry-run origin main')"
+t "-n origin main"           pass "$(bdecc "$onbranch" 'git push -n origin main')"
+t "--dry-run on main"        pass "$(bdecc "$onmain"   'git push --dry-run')"
+t "--dry-run --all"          pass "$(bdecc "$onbranch" 'git push --dry-run --all')"
+# ...and the same command without it is still refused, or the line above is just
+# a hole. This pair is the whole point.
+t "no --dry-run, still deny" deny "$(bdecc "$onbranch" 'git push origin main')"
+
+# Prose that QUOTES the words, in the two shapes prose is actually written in
+# here. Both were denied. The second is the shape of this change's own commit
+# message.
+hd_doc='cat > docs/runbook.md <<EOF
+To release, do NOT run
+git push origin main
+Open a PR instead.
+EOF'
+t "heredoc body quotes it"   pass "$(bdecc "$onbranch" "$hd_doc")"
+hd_q='cat > docs/runbook.md <<'"'"'EOF'"'"'
+git push origin main
+EOF'
+t "quoted-delimiter heredoc" pass "$(bdecc "$onbranch" "$hd_q")"
+hd_dash='cat > docs/runbook.md <<-EOF
+	git push origin main
+	EOF'
+t "<<- indented delimiter"   pass "$(bdecc "$onbranch" "$hd_dash")"
+ml_msg='git commit -m "feat(guards): a committed pre-push hook
+
+The arm cannot decide these without being the shell:
+git push origin main is one of them.
+"'
+t "multi-line commit -m"     pass "$(bdecc "$onbranch" "$ml_msg")"
+# The bypass that suppression must not open: a string that CLOSES mid-line
+# leaves a real command after it, and that command still counts.
+ml_esc='git commit -m "wip
+done" && git push origin main'
+t "cmd after closing quote"  deny "$(bdecc "$onbranch" "$ml_esc")"
+# A here-STRING has no body, so nothing after it may be swallowed.
+t "herestring, then a push"  deny "$(bdecc "$onbranch" 'cat <<< "x"; git push origin main')"
+# A heredoc that ENDS still leaves the rest of the command visible.
+hd_after='cat > docs/x.md <<EOF
+prose
+EOF
+git push origin main'
+t "after a closed heredoc"   deny "$(bdecc "$onbranch" "$hd_after")"
+
+# `cd <path> &&` retargets the branch lookup, in BOTH directions. This is the
+# incident shape: an agent works in a worktree, so the payload cwd is a worktree,
+# and `cd <main checkout> && git push` was permitted while the identical
+# `git -C <main checkout> push` was denied.
+t "cd to main, then push"    deny "$(bdecc "$onbranch" "cd $onmain && git push")"
+t "cd to main via ;"         deny "$(bdecc "$onbranch" "cd $onmain ; git push")"
+t "pushd to main"            deny "$(bdecc "$onbranch" "pushd $onmain && git push")"
+t "cd to main, push origin"  deny "$(bdecc "$onbranch" "cd $onmain && git push origin")"
+# The other direction, which was a FALSE REASON rather than a bypass: from the
+# main checkout, `cd <worktree> && git push` was refused saying "the current
+# branch is main". It was not.
+t "cd off main to a branch"  pass "$(bdecc "$onmain"   "cd $onwt && git push")"
+t "cd off main, push -u"     pass "$(bdecc "$onmain"   "cd $onwt && git push -u origin worktree-agent-7")"
+t "cd relative, off main"    pass "$(bdecc "$onmain"   "cd ../on-branch && git push")"
+# An unresolvable cd is not a licence to keep using the old directory. Fail
+# closed and say the branch is unknown - never claim a branch it did not read.
+t "cd \$VAR, bare push"      deny "$(bdecc "$onmain"   'cd $SOMEWHERE && git push')"
+cdvar_reason=$(breason "$onmain" 'cd $SOMEWHERE && git push')
+tcontains "and says it is unknown" "COULD NOT DETERMINE" "$cdvar_reason"
+tlacks    "not a branch it invented" "current branch is main" "$cdvar_reason"
+# ...but an unresolvable cd needs no branch when the target is named, or every
+# `cd $DIR && git push -u origin fix/x` in the project is stranded.
+t "cd \$VAR, explicit branch" pass "$(bdecc "$onmain"  'cd $SOMEWHERE && git push -u origin fix/x')"
+t "cd, then not a push"      pass "$(bdecc "$onmain"   "cd $onwt && git status")"
 
 echo "== bash-guard: a push whose branch it cannot read is refused, not waved through"
 # The signature defect of this project is a check that announces success over its
@@ -2016,6 +2116,154 @@ tcontains "and names go as the reason"        "'go' is not on PATH"             
 # absence. Note the timeout line says "not installed" in lower case and is a
 # different, still-correct claim, so this needle is deliberately upper case.
 tlacks "and never asserts NOT INSTALLED"      "NOT INSTALLED"                                 "$tc_nogo"
+
+echo "== .githooks/pre-push: the lock, as opposed to the manners"
+# bash-guard's arm is a text matcher over a shell command, and eight shapes were
+# reproduced getting past it - `eval`, `bash -c`, `$(echo main)`, `git p"ush"`,
+# `@`, `:`, a wildcard refspec, `push.default=matching`. This hook runs INSIDE
+# git, after expansion and after refspec resolution, so it is asked about the
+# refs that are actually about to move and none of those reach it disguised.
+#
+# TWO LAYERS OF PROOF, and the second is the one that matters. First the hook is
+# driven directly with the stdin githooks(5) specifies, which is fast and covers
+# the delete case. Then a REAL push is made to a REAL throwaway bare repo, which
+# is the only thing that proves git calls it at all and that its non-zero exit
+# actually aborts the transfer.
+HOOK="$here/../../.githooks/pre-push"
+t "the hook is committed"    file "$(test -f "$HOOK" && echo file)"
+t "the hook is executable"   exec "$(test -x "$HOOK" && echo exec)"
+
+# hookdec <remote> <url> <stdin lines> -> refused|allowed
+hookdec() {
+  if printf '%s\n' "$3" | bash "$HOOK" "$1" "$2" >/dev/null 2>&1; then
+    printf 'allowed'
+  else
+    printf 'refused'
+  fi
+}
+hookmsg() { printf '%s\n' "$3" | bash "$HOOK" "$1" "$2" 2>&1 >/dev/null; }
+
+zero=0000000000000000000000000000000000000000
+sha=1111111111111111111111111111111111111111
+t "hook: -> refs/heads/main"  refused "$(hookdec origin git@x:o/r.git "refs/heads/main $sha refs/heads/main $zero")"
+t "hook: HEAD -> main"        refused "$(hookdec origin git@x:o/r.git "HEAD $sha refs/heads/main $zero")"
+t "hook: a branch -> main"    refused "$(hookdec origin git@x:o/r.git "refs/heads/fix/x $sha refs/heads/main $zero")"
+t "hook: unqualified main"    refused "$(hookdec origin git@x:o/r.git "refs/heads/main $sha main $zero")"
+# githooks(5): a DELETE arrives as `(delete)` with the all-zero local oid, and
+# deleting main is as irreversible as moving it.
+t "hook: delete main"         refused "$(hookdec origin git@x:o/r.git "(delete) $zero refs/heads/main $sha")"
+# One bad ref in a batch refuses the WHOLE push, which is what git does anyway.
+t "hook: main among many"     refused "$(hookdec origin git@x:o/r.git "refs/heads/a $sha refs/heads/a $zero
+refs/heads/main $sha refs/heads/main $zero")"
+
+# ...and it must not block the work everyone does all day, or it gets removed.
+t "hook: a fix branch"        allowed "$(hookdec origin git@x:o/r.git "refs/heads/fix/x $sha refs/heads/fix/x $zero")"
+# release/* reaches main through a PR like everything else, so pushing the branch
+# itself has to work.
+t "hook: a release branch"    allowed "$(hookdec origin git@x:o/r.git "refs/heads/release/0.61.134 $sha refs/heads/release/0.61.134 $zero")"
+t "hook: a tag"               allowed "$(hookdec origin git@x:o/r.git "refs/tags/v0.61.134 $sha refs/tags/v0.61.134 $zero")"
+t "hook: delete a branch"     allowed "$(hookdec origin git@x:o/r.git "(delete) $zero refs/heads/stale $sha")"
+# Whole-string equality, never a substring: these are ordinary branch names.
+t "hook: main-ui"             allowed "$(hookdec origin git@x:o/r.git "refs/heads/main-ui $sha refs/heads/main-ui $zero")"
+t "hook: maintenance"         allowed "$(hookdec origin git@x:o/r.git "refs/heads/maintenance $sha refs/heads/maintenance $zero")"
+t "hook: feat/remaining"      allowed "$(hookdec origin git@x:o/r.git "refs/heads/feat/remaining $sha refs/heads/feat/remaining $zero")"
+t "hook: fix/main-menu"       allowed "$(hookdec origin git@x:o/r.git "refs/heads/fix/main-menu $sha refs/heads/fix/main-menu $zero")"
+t "hook: refs/heads/x/main"   allowed "$(hookdec origin git@x:o/r.git "refs/heads/x/main $sha refs/heads/x/main $zero")"
+# Nothing on stdin means nothing to push. Silence, exit 0.
+t "hook: empty stdin"         allowed "$(hookdec origin git@x:o/r.git "")"
+
+# The refusal has to carry the rule and the escape hatch, or people work around
+# it in the dark.
+hk=$(hookmsg origin git@x:o/r.git "refs/heads/main $sha refs/heads/main $zero")
+tcontains "hook names Delivery"     "## Delivery"   "$hk"
+tcontains "hook names the PR"       "pull request"  "$hk"
+tcontains "hook names enforce_admins" "enforce_admins" "$hk"
+tcontains "hook NAMES the bypass"   "no-verify"     "$hk"
+tcontains "hook names the ref"      "refs/heads/main" "$hk"
+# Silence on the allowed path: a hook that chatters on every push gets muted.
+t "hook is silent when allowed" "" "$(hookmsg origin git@x:o/r.git "refs/heads/fix/x $sha refs/heads/fix/x $zero")"
+
+# The hook is inert until core.hooksPath points at it, and that setting lives in
+# .git/config, which is not committed. So the INSTALL is part of the deliverable
+# and is asserted here: a fresh clone that never runs it is a clone with no hook,
+# which is the 2026-08-12 state exactly. Anchored on the command, not on the
+# words appearing somewhere in the file.
+repo_root=$(cd "$here/../.." && pwd)
+tcontains "bootstrap installs it" "git config core.hooksPath .githooks" "$(cat "$repo_root/scripts/bootstrap.sh")"
+tcontains "make hooks installs it" "git config core.hooksPath .githooks" "$(cat "$repo_root/Makefile")"
+tcontains "and make hooks is a target" "^hooks:" "$(cat "$repo_root/Makefile")"
+
+echo "== .githooks/pre-push: against a real push, because stdin is not proof"
+# The layer above proves the hook's logic. It does NOT prove git calls it, that
+# core.hooksPath resolves, or that exit 1 aborts anything. Only a real push does,
+# and it is a throwaway bare repo on disk: no network, and origin is never named.
+bare="$tmp/throwaway.git"
+git init -q --bare "$bare"
+work="$tmp/hookwork"
+git clone -q "$bare" "$work" 2>/dev/null
+git -C "$work" config user.email t@t.invalid
+git -C "$work" config user.name t
+mkdir -p "$work/.githooks"
+cp "$HOOK" "$work/.githooks/pre-push"
+chmod +x "$work/.githooks/pre-push"
+git -C "$work" config core.hooksPath .githooks
+git -C "$work" checkout -q -B main
+echo seed > "$work/seed.txt"
+git -C "$work" add seed.txt
+git -C "$work" commit -qm seed
+
+pushed() { # pushed <args...> -> ok|refused
+  if git -C "$work" push "$@" >/dev/null 2>&1; then printf 'ok'; else printf 'refused'; fi
+}
+# git never calls pre-push when there is nothing to push - it prints "Everything
+# up-to-date" and exits 0 - so every `refused` assertion below is VACUOUS unless
+# HEAD has actually moved. The first version of this helper wrote `date +%s` to a
+# file, and inside one second the content did not change, so `git commit` made no
+# commit and two assertions passed for the wrong reason. --allow-empty always
+# advances HEAD, and the premise is asserted rather than assumed.
+newcommit() {
+  local before after
+  before=$(git -C "$work" rev-parse HEAD)
+  git -C "$work" commit -q --allow-empty -m n >/dev/null 2>&1
+  after=$(git -C "$work" rev-parse HEAD)
+  if [[ "$before" == "$after" ]]; then
+    echo "FAIL  newcommit did not advance HEAD, so the next push assertion is vacuous"
+    failed=$((failed+1))
+  else
+    pass=$((pass+1))
+  fi
+}
+
+t "real: branch push works"   ok       "$(pushed origin HEAD:refs/heads/fix/real)"
+t "real: a tag works"         ok       "$(git -C "$work" tag -f v9.9.9 >/dev/null 2>&1; pushed origin v9.9.9)"
+newcommit; t "real: origin main"        refused "$(pushed origin main)"
+newcommit; t "real: HEAD:main"          refused "$(pushed origin HEAD:main)"
+newcommit; t "real: @ (HEAD synonym)"   refused "$(pushed origin @)"
+newcommit; t "real: bare push on main"  refused "$(pushed)"
+newcommit; t "real: force"              refused "$(pushed --force origin main)"
+newcommit; t "real: wildcard refspec"   refused "$(pushed origin 'refs/heads/*:refs/heads/*')"
+# The remote's main must be UNTOUCHED by every one of those, which is the claim
+# that actually matters. It has never existed, so it must still not exist.
+t "real: remote main absent"  ""       "$(git -C "$bare" rev-parse --verify -q refs/heads/main 2>/dev/null)"
+
+# PROVE IT FIRES, then prove the pass above was not vacuous: with the hook gone,
+# the identical command succeeds. A guard nobody has seen fail guards nothing.
+mv "$work/.githooks/pre-push" "$work/.githooks/pre-push.off"
+newcommit
+t "hook removed: it lands"    ok       "$(pushed origin main)"
+t "and remote main now exists" main    "$(git -C "$bare" rev-parse --verify -q refs/heads/main >/dev/null && echo main)"
+mv "$work/.githooks/pre-push.off" "$work/.githooks/pre-push"
+newcommit
+t "hook restored: refused"    refused  "$(pushed origin main)"
+# Now that main EXISTS on the remote, the two shapes that need it can be tested.
+newcommit; t "real: push.default=matching" refused "$(git -C "$work" -c push.default=matching push >/dev/null 2>&1 && printf ok || printf refused)"
+main_before=$(git -C "$bare" rev-parse refs/heads/main)
+t "real: delete main"         refused  "$(pushed --delete origin main)"
+t "real: :main deletes too"   refused  "$(pushed origin :main)"
+# Not the same expression twice: the sha was read BEFORE the two delete attempts.
+t "real: main survived both"  "$main_before" "$(git -C "$bare" rev-parse refs/heads/main)"
+# The escape hatch the refusal advertises has to be real, or the message lies.
+newcommit; t "real: --no-verify lands"  ok "$(pushed --no-verify origin main)"
 
 echo ""
 if [[ $failed -eq 0 ]]; then

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -899,6 +899,51 @@ t "linked wt HEAD reads"      worktree-agent-9 "$(git -C "$linked" symbolic-ref 
 t "linked wt bare push"       pass "$(bdecc "$linked" 'git push')"
 t "linked wt -C the parent"   deny "$(bdecc "$linked" "git -C $onmain push")"
 t "linked wt cd the parent"   deny "$(bdecc "$linked" "cd $onmain && git push")"
+
+# --- cd tracking: the over-fires, every one reproduced before it was fixed ---
+# All from the linked worktree, whose HEAD is worktree-agent-9, so none of them
+# was ever in doubt. Each denied, and the reason each printed - "this guard
+# could not determine which branch" - was true of the guard and useless to the
+# reader, who was pushing a worktree branch.
+t 'cd to the toplevel, then push' pass "$(bdecc "$linked" 'cd "$(git rev-parse --show-toplevel)" && git push')"
+t "cd into a dir made at runtime" pass "$(bdecc "$linked" 'mkdir -p out && cd out && cd .. && git push')"
+t "pushd, then popd, then push"  pass "$(bdecc "$linked" "pushd $onmain >/dev/null && ls && popd && git push")"
+# ...and popd is FOLLOWED, not merely tolerated: without the pop this is a push
+# from the main checkout and is still refused.
+t "pushd without the popd"       deny "$(bdecc "$linked" "pushd $onmain >/dev/null && git push")"
+# Tilde. bash expands a leading unquoted ~, so this arm does too, and the answer
+# is now the true one rather than "cannot tell": into a main checkout it denies,
+# into a branch checkout it passes. HOME is overridden so the assertion does not
+# depend on whose machine it runs on.
+mkbranchrepo "$tmp/home/hmain" main
+mkbranchrepo "$tmp/home/hbranch" fix/thing
+t "cd ~ into a main checkout"    deny "$(HOME="$tmp/home" bdecc "$linked" 'cd ~/hmain && git push')"
+t "cd ~ into a branch checkout"  pass "$(HOME="$tmp/home" bdecc "$linked" 'cd ~/hbranch && git push')"
+tcontains "and the ~ reason is the branch, not a shrug" \
+  "the current branch is main" "$(HOME="$tmp/home" breason "$linked" 'cd ~/hmain && git push')"
+# THE COST OF DEFERRING, asserted rather than left implicit. From the MAIN
+# checkout an unfollowable cd now passes this arm, because it no longer claims
+# to know a branch it cannot read. .githooks/pre-push refuses it, after the
+# shell has expanded it, and that is proved further down against a real push.
+t "unfollowable cd, on main"     pass "$(bdecc "$onmain" 'cd "$UNSET_DIR" && git push')"
+# What must NOT be relaxed with it: a refspec naming main needs no lookup at
+# all, so an unresolvable cd changes nothing about it.
+t "unfollowable cd, main named"  deny "$(bdecc "$onmain" 'cd "$UNSET_DIR" && git push origin main')"
+t "unfollowable cd, HEAD:main"   deny "$(bdecc "$linked" 'cd "$UNSET_DIR" && git push origin HEAD:main')"
+# A payload with no cwd at all is a broken payload, not an ordinary command, and
+# it still denies - the deferral is scoped to a cd this arm could not follow.
+t "no cwd at all, bare push"     deny "$(bdecc "" 'git push')"
+
+# --dry-run transfers nothing, and git's parse-options takes any unambiguous
+# prefix, so `--dry` IS a dry run. Refusing it printed "that push lands commits
+# on main", which is untrue of a command that transfers nothing.
+t "push --dry-run origin main"   pass "$(bdecc "$onbranch" 'git push --dry-run origin main')"
+t "push -n origin main"          pass "$(bdecc "$onbranch" 'git push -n origin main')"
+t "push --dry origin main"       pass "$(bdecc "$onbranch" 'git push --dry origin main')"
+t "push --dr origin main"        pass "$(bdecc "$onbranch" 'git push --dr origin main')"
+# `--d` is ambiguous with --delete and git rejects it itself, so it is not a dry
+# run and is not treated as one.
+t "push --d origin main"         deny "$(bdecc "$onbranch" 'git push --d origin main')"
 # Quoting must not defeat it, exactly as it must not defeat the write arms.
 t "dquoted main"             deny "$(bdecc "$onbranch" 'git push origin "main"')"
 t "squoted main"             deny "$(bdecc "$onbranch" "git push origin 'main'")"
@@ -1021,12 +1066,20 @@ t "cd to main, push origin"  deny "$(bdecc "$onbranch" "cd $onmain && git push o
 t "cd off main to a branch"  pass "$(bdecc "$onmain"   "cd $onwt && git push")"
 t "cd off main, push -u"     pass "$(bdecc "$onmain"   "cd $onwt && git push -u origin worktree-agent-7")"
 t "cd relative, off main"    pass "$(bdecc "$onmain"   "cd ../on-branch && git push")"
-# An unresolvable cd is not a licence to keep using the old directory. Fail
-# closed and say the branch is unknown - never claim a branch it did not read.
-t "cd \$VAR, bare push"      deny "$(bdecc "$onmain"   'cd $SOMEWHERE && git push')"
-cdvar_reason=$(breason "$onmain" 'cd $SOMEWHERE && git push')
-tcontains "and says it is unknown" "COULD NOT DETERMINE" "$cdvar_reason"
-tlacks    "not a branch it invented" "current branch is main" "$cdvar_reason"
+# An unresolvable cd is not a licence to keep using the old directory either -
+# it must never claim a branch it did not read. It USED to deny here and say
+# "branch unknown", which was right about the branch and wrong about the
+# outcome: the same rule denied `cd "$(git rev-parse --show-toplevel)" && git
+# push`, `cd ~/wpmgr && git push` and `mkdir -p out && cd out && cd .. && git
+# push` from a worktree, none of which was ever in doubt, and an over-fire here
+# teaches --no-verify. So it DEFERS: no decision, no invented reason, and
+# .githooks/pre-push refuses it after the shell has actually expanded it. That
+# hand-off is proved against a real push at the end of this file, not asserted.
+t "cd \$VAR, bare push"      pass "$(bdecc "$onmain"   'cd $SOMEWHERE && git push')"
+t "cd \$VAR, cd .., push"    pass "$(bdecc "$onmain"   'cd $SOMEWHERE && cd .. && git push')"
+# The deferral is scoped to the cd. Everything this arm can still read, it still
+# decides, and a refspec naming main needs no directory at all.
+t "cd \$VAR, main by name"   deny "$(bdecc "$onmain"   'cd $SOMEWHERE && git push origin main')"
 # ...but an unresolvable cd needs no branch when the target is named, or every
 # `cd $DIR && git push -u origin fix/x` in the project is stranded.
 t "cd \$VAR, explicit branch" pass "$(bdecc "$onmain"  'cd $SOMEWHERE && git push -u origin fix/x')"
@@ -2183,15 +2236,133 @@ tcontains "hook names the ref"      "refs/heads/main" "$hk"
 # Silence on the allowed path: a hook that chatters on every push gets muted.
 t "hook is silent when allowed" "" "$(hookmsg origin git@x:o/r.git "refs/heads/fix/x $sha refs/heads/fix/x $zero")"
 
+# A final ref line with NO trailing newline made `read` return non-zero with the
+# variables set, the loop dropped it, and the hook exited 0 in silence - the
+# same bytes with a trailing LF exited 1. Not reachable from git, which always
+# terminates the line, and fixed anyway: a guard that fails open on a malformed
+# input is the defect this hook exists to close. Both forms asserted, or the
+# fix is indistinguishable from the bug.
+hookdec_nonl() { # like hookdec, but stdin does NOT end in a newline
+  if printf '%s' "$3" | bash "$HOOK" "$1" "$2" >/dev/null 2>&1; then
+    printf 'allowed'
+  else
+    printf 'refused'
+  fi
+}
+t "hook: main, trailing LF"   refused "$(hookdec      origin git@x:o/r.git "refs/heads/main $sha refs/heads/main $zero")"
+t "hook: main, NO trailing LF" refused "$(hookdec_nonl origin git@x:o/r.git "refs/heads/main $sha refs/heads/main $zero")"
+t "hook: branch, NO trailing LF" allowed "$(hookdec_nonl origin git@x:o/r.git "refs/heads/fix/x $sha refs/heads/fix/x $zero")"
+t "hook: last of many, no LF" refused "$(hookdec_nonl origin git@x:o/r.git "refs/heads/a $sha refs/heads/a $zero
+refs/heads/main $sha refs/heads/main $zero")"
+
 # The hook is inert until core.hooksPath points at it, and that setting lives in
-# .git/config, which is not committed. So the INSTALL is part of the deliverable
-# and is asserted here: a fresh clone that never runs it is a clone with no hook,
-# which is the 2026-08-12 state exactly. Anchored on the command, not on the
-# words appearing somewhere in the file.
+# .git/config, which is not committed. So the INSTALL is part of the deliverable.
+#
+# WHAT USED TO BE HERE: three greps asserting the string `git config
+# core.hooksPath .githooks` appeared in bootstrap.sh and the Makefile. Those
+# three passed, along with the whole rest of this suite, inside a clone where no
+# hook was installed and `git push origin HEAD:refs/heads/main` landed the
+# commit. The string was present; the protection was not. What follows asserts
+# the protection.
 repo_root=$(cd "$here/../.." && pwd)
-tcontains "bootstrap installs it" "git config core.hooksPath .githooks" "$(cat "$repo_root/scripts/bootstrap.sh")"
-tcontains "make hooks installs it" "git config core.hooksPath .githooks" "$(cat "$repo_root/Makefile")"
-tcontains "and make hooks is a target" "^hooks:" "$(cat "$repo_root/Makefile")"
+HOOKSH="$repo_root/scripts/claude/git-hooks.sh"
+t "the installer is executable" exec "$(test -x "$HOOKSH" && echo exec)"
+
+# A FRESH CLONE, which is the state every developer and every CI runner starts
+# in: hook in the tree, core.hooksPath unset, nothing running. Built here rather
+# than cloned from this repository so that it models the tree HISTORY the
+# worktree case below needs - a commit BEFORE .githooks existed, then the commit
+# that adds it - and so the suite tests the working copy rather than whatever
+# happens to be committed.
+fresh="$tmp/fresh-clone"
+mkdir -p "$fresh/scripts/claude"
+git -C "$fresh" init -q
+git -C "$fresh" config user.email t@t.invalid
+git -C "$fresh" config user.name t
+echo pre > "$fresh/README.md"
+git -C "$fresh" add README.md >/dev/null
+git -C "$fresh" commit -qm "before the hook existed"
+before_hook=$(git -C "$fresh" rev-parse HEAD)
+mkdir -p "$fresh/.githooks"
+cp "$HOOK" "$fresh/.githooks/pre-push"
+chmod +x "$fresh/.githooks/pre-push"
+cp "$HOOKSH" "$fresh/scripts/claude/git-hooks.sh"
+chmod +x "$fresh/scripts/claude/git-hooks.sh"
+git -C "$fresh" add .githooks/pre-push scripts/claude/git-hooks.sh >/dev/null
+git -C "$fresh" commit -qm "the hook"
+t "fresh clone has the hook file" file "$(test -f "$fresh/.githooks/pre-push" && echo file)"
+t "fresh clone has no hooksPath"  ""    "$(git -C "$fresh" config --get core.hooksPath)"
+
+fresh_check=$(cd "$fresh" && bash "$HOOKSH" check 2>&1); fresh_rc=$?
+t "check FAILS in a fresh clone"  1 "$fresh_rc"
+tcontains "and says NOT INSTALLED" "NOT INSTALLED" "$fresh_check"
+tcontains "and prints the one fix" "make hooks"    "$fresh_check"
+# status must report the same thing and must NOT fail the session: it runs from
+# SessionStart, where a non-zero exit is the harness's problem, not the user's.
+fresh_status=$(cd "$fresh" && bash "$HOOKSH" status 2>&1); fresh_src=$?
+t "status exits 0 regardless"     0 "$fresh_src"
+tcontains "status says NOT INSTALLED" "NOT INSTALLED" "$fresh_status"
+
+# Install, and the same command must now pass. Both halves, or neither proves
+# anything: a check that is always red is as useless as one that is always green.
+inst_out=$(cd "$fresh" && bash "$HOOKSH" install 2>&1); inst_rc=$?
+t "install succeeds"              0 "$inst_rc"
+after_check=$(cd "$fresh" && bash "$HOOKSH" check 2>&1); after_rc=$?
+t "check PASSES once installed"   0 "$after_rc"
+tcontains "and says INSTALLED"    "INSTALLED" "$after_check"
+# ABSOLUTE, not relative. A relative path is resolved by git against whatever
+# working tree runs the hook, so it finds .githooks only in a tree checked out
+# at or after the hook's commit - which is what left it absent from 9 of the 10
+# checkouts on this machine while config read "installed" in all ten.
+absolute_or_not() { if [[ "$1" == /* ]]; then printf 'abs'; else printf 'relative: %s' "$1"; fi; }
+t "hooksPath is absolute"         abs "$(absolute_or_not "$(git -C "$fresh" config --get core.hooksPath)")"
+
+# A LINKED WORKTREE checked out BEFORE the hook existed. This is the case the
+# relative path silently lost: .githooks is not in that tree at all.
+freshwt="$tmp/fresh-wt"
+git -C "$fresh" worktree add -q --detach "$freshwt" "$before_hook" >/dev/null 2>&1
+t "the old tree has no .githooks" "" "$(test -e "$freshwt/.githooks" && echo present)"
+wt_check=$(cd "$freshwt" && bash "$HOOKSH" check 2>&1); wt_rc=$?
+t "check PASSES from that worktree" 0 "$wt_rc"
+
+# And the hook actually RUNS from there, against a real push. Reasoning about
+# core.hooksPath resolution is not proof; git running it is.
+wtbare="$tmp/wt-throwaway.git"
+git init -q --bare "$wtbare"
+git -C "$freshwt" checkout -q -B main
+git -C "$freshwt" config user.email t@t.invalid
+git -C "$freshwt" config user.name t
+git -C "$freshwt" commit -q --allow-empty -m wt >/dev/null 2>&1
+wt_push=$(git -C "$freshwt" push "$wtbare" HEAD:refs/heads/main 2>&1); wt_prc=$?
+t "real push to main from a worktree is refused" 1 "$((wt_prc != 0))"
+tcontains "and the worktree refusal is the hook's" "REFUSED: this push would land on main" "$wt_push"
+t "and remote main was never created" "" "$(git -C "$wtbare" rev-parse --verify -q refs/heads/main 2>/dev/null)"
+# Not vacuous: the same push lands once the hook is switched off.
+git -C "$freshwt" config --unset core.hooksPath
+git -C "$freshwt" commit -q --allow-empty -m wt2 >/dev/null 2>&1
+git -C "$freshwt" push -q "$wtbare" HEAD:refs/heads/main >/dev/null 2>&1
+t "with hooksPath unset it lands" main "$(git -C "$wtbare" rev-parse --verify -q refs/heads/main >/dev/null && echo main)"
+
+# The gate has to be wired to the gate. `make harness-check` is what ci.yml
+# runs, and the check above is worth nothing if nothing calls it.
+tcontains "harness-check runs the hook check" "git-hooks.sh check" "$(cat "$repo_root/Makefile")"
+tcontains "make hooks is still a target" "^hooks:" "$(cat "$repo_root/Makefile")"
+tcontains "bootstrap installs it" "git-hooks.sh install" "$(cat "$repo_root/scripts/bootstrap.sh")"
+# And a session is told. This is the line that turns a silent gap into a visible
+# one, and it was absent: `grep -c hooksPath session-brief.sh` was 0.
+tcontains "session-brief reports the hook" "git-hooks.sh" "$(cat "$repo_root/scripts/claude/session-brief.sh")"
+# Re-install first: the worktree case above unset core.hooksPath, and that
+# config is SHARED with every linked worktree - which is itself why one absolute
+# setting can cover them all.
+(cd "$fresh" && bash "$HOOKSH" install >/dev/null 2>&1)
+(cd "$fresh" && bash "$HOOKSH" check >/dev/null 2>&1); t "re-install took" 0 "$?"
+sb_hook=$(cd "$fresh" && bash "$repo_root/scripts/claude/session-brief.sh" 2>/dev/null)
+tcontains "session-brief says INSTALLED where it is" "pre-push hook: INSTALLED" "$sb_hook"
+git -C "$fresh" config --unset core.hooksPath
+sb_nohook=$(cd "$fresh" && bash "$repo_root/scripts/claude/session-brief.sh" 2>/dev/null); sb_nrc=$?
+t "session-brief still exits 0"   0 "$sb_nrc"
+tcontains "session-brief says NOT INSTALLED where it is not" "pre-push hook: NOT INSTALLED" "$sb_nohook"
+tcontains "and it carries the fix"  "make hooks" "$sb_nohook"
 
 echo "== .githooks/pre-push: against a real push, because stdin is not proof"
 # The layer above proves the hook's logic. It does NOT prove git calls it, that

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -926,6 +926,22 @@ tcontains "and the ~ reason is the branch, not a shrug" \
 # to know a branch it cannot read. .githooks/pre-push refuses it, after the
 # shell has expanded it, and that is proved further down against a real push.
 t "unfollowable cd, on main"     pass "$(bdecc "$onmain" 'cd "$UNSET_DIR" && git push')"
+# THE OPERANDLESS FORMS. The paragraph in bash-guard.sh promised these DEFER;
+# all three silently resolved to $HOME instead, and from a worktree that
+# produced a deny whose reason was untrue of the command. The symmetric half is
+# the dangerous one: with $HOME or $OLDPWD a branch checkout, the same code
+# PERMITS a push that lands on main. None of the three is knowable from the
+# command string, so the hook decides them.
+t "cd - defers"                  pass "$(HOME="$tmp/home/hbranch" bdecc "$onmain" 'cd - && git push')"
+t "cd -- defers"                 pass "$(HOME="$tmp/home/hbranch" bdecc "$onmain" 'cd -- && git push')"
+t "bare cd defers"               pass "$(HOME="$tmp/home/hbranch" bdecc "$onmain" 'cd && git push')"
+# And they defer for the RIGHT reason: no reason at all is printed, rather than
+# a claim about a directory the command never visited.
+t "and no reason is invented"    "" "$(HOME="$tmp/home/hbranch" breason "$onmain" 'cd - && git push')"
+# Not over-fired into uselessness: `--` still ends options, so an operand after
+# it is resolved exactly as before and a push into a main checkout is refused.
+t "cd -- <dir> is still followed" deny "$(bdecc "$linked" "cd -- $onmain && git push")"
+t "cd -- <branch dir> still passes" pass "$(bdecc "$onmain" "cd -- $linked && git push")"
 # What must NOT be relaxed with it: a refspec naming main needs no lookup at
 # all, so an unresolvable cd changes nothing about it.
 t "unfollowable cd, main named"  deny "$(bdecc "$onmain" 'cd "$UNSET_DIR" && git push origin main')"
@@ -2071,6 +2087,28 @@ tlacks    "and no could-not-measure"   "disk free: could not measure" "$sb_zero"
 #    missing binary whose call site is not wrapped in 2>/dev/null shows up.
 sb_err=$(cd "$sb" && PATH="$sysbin" bash "$BRIEF" 2>&1 >/dev/null)
 t "the brief writes nothing to stderr" "" "$sb_err"
+
+# THE SILENT FOURTH STATE. `root=$(git rev-parse ...) || exit 0` meant that with
+# git off PATH, or with the session started outside a repository, this script
+# emitted ZERO BYTES and exited 0: no header, no hook line, no toolchain block.
+# A session could not tell that from a healthy machine, and the answer it needed
+# already existed - git-hooks.sh resolves its own context and says COULD NOT
+# CHECK in both conditions. Asserted in both, because they fail independently.
+sb_nobin="$tmp/nobin"; mkdir -p "$sb_nobin"
+# "$BASH", absolutely: with this PATH, `bash` itself is not findable either, and
+# an exit 127 from the test's own launcher would prove nothing about the brief.
+sb_nogit=$(cd "$sb" && PATH="$sb_nobin" "$BASH" "$BRIEF" 2>/dev/null); sb_nogit_rc=$?
+t "git off PATH: still exits 0"        0 "$sb_nogit_rc"
+tcontains "git off PATH: still reports" "## Machine state" "$sb_nogit"
+tcontains "git off PATH: COULD NOT CHECK" "pre-push hook: COULD NOT CHECK" "$sb_nogit"
+tcontains "and it says not to read that as installed" "Do NOT read" "$sb_nogit"
+
+sb_outside="$tmp/outside-any-repo"; mkdir -p "$sb_outside"
+sb_out=$(cd "$sb_outside" && PATH="$sysbin" bash "$BRIEF" 2>/dev/null); sb_out_rc=$?
+t "outside a repo: still exits 0"      0 "$sb_out_rc"
+tcontains "outside a repo: still reports" "## Machine state" "$sb_out"
+tcontains "outside a repo: COULD NOT CHECK" "pre-push hook: COULD NOT CHECK" "$sb_out"
+tcontains "and the worktree count is not invented" "agent worktrees: not measured" "$sb_out"
 # 2. jq must be present, or the brief announces the guards INACTIVE - a line
 #    that would otherwise sit in the output unremarked and unexplained.
 tlacks "and jq is not missing" "INACTIVE" "$sb_zero"
@@ -2166,9 +2204,11 @@ tc_nogo=$(cd "$sb" && PATH="$sysbin" bash "$BRIEF" 2>/dev/null)
 tcontains "no go: it says it could not check" "sqlc: could not check whether it is installed" "$tc_nogo"
 tcontains "and names go as the reason"        "'go' is not on PATH"                           "$tc_nogo"
 # The whole finding in one assertion: with no way to look, it must not assert
-# absence. Note the timeout line says "not installed" in lower case and is a
-# different, still-correct claim, so this needle is deliberately upper case.
-tlacks "and never asserts NOT INSTALLED"      "NOT INSTALLED"                                 "$tc_nogo"
+# absence. The needle is the TOOLCHAIN line's exact phrasing - the timeout line
+# says "not installed" in lower case and is a different, still-correct claim,
+# and the hook line legitimately says NOT INSTALLED about a fixture repo that
+# genuinely has no hook, which is a measurement that did happen.
+tlacks "and never asserts NOT INSTALLED"      "is NOT INSTALLED (looked in"                   "$tc_nogo"
 
 echo "== .githooks/pre-push: the lock, as opposed to the manners"
 # bash-guard's arm is a text matcher over a shell command, and eight shapes were
@@ -2311,9 +2351,8 @@ after_check=$(cd "$fresh" && bash "$HOOKSH" check 2>&1); after_rc=$?
 t "check PASSES once installed"   0 "$after_rc"
 tcontains "and says INSTALLED"    "INSTALLED" "$after_check"
 # ABSOLUTE, not relative. A relative path is resolved by git against whatever
-# working tree runs the hook, so it finds .githooks only in a tree checked out
-# at or after the hook's commit - which is what left it absent from 9 of the 10
-# checkouts on this machine while config read "installed" in all ten.
+# working tree runs the hook, so it would find the hooks directory only from
+# some trees while config read "installed" in every one of them.
 absolute_or_not() { if [[ "$1" == /* ]]; then printf 'abs'; else printf 'relative: %s' "$1"; fi; }
 t "hooksPath is absolute"         abs "$(absolute_or_not "$(git -C "$fresh" config --get core.hooksPath)")"
 
@@ -2337,11 +2376,47 @@ wt_push=$(git -C "$freshwt" push "$wtbare" HEAD:refs/heads/main 2>&1); wt_prc=$?
 t "real push to main from a worktree is refused" 1 "$((wt_prc != 0))"
 tcontains "and the worktree refusal is the hook's" "REFUSED: this push would land on main" "$wt_push"
 t "and remote main was never created" "" "$(git -C "$wtbare" rev-parse --verify -q refs/heads/main 2>/dev/null)"
-# Not vacuous: the same push lands once the hook is switched off.
+# Unsetting core.hooksPath does NOT re-open main. That is the repair: the hook
+# is a COPY in git's own default hooks directory, which is outside every working
+# tree, so config carries no load and no checkout can remove it.
 git -C "$freshwt" config --unset core.hooksPath
 git -C "$freshwt" commit -q --allow-empty -m wt2 >/dev/null 2>&1
 git -C "$freshwt" push -q "$wtbare" HEAD:refs/heads/main >/dev/null 2>&1
-t "with hooksPath unset it lands" main "$(git -C "$wtbare" rev-parse --verify -q refs/heads/main >/dev/null && echo main)"
+t "with hooksPath unset it is STILL refused" "" "$(git -C "$wtbare" rev-parse --verify -q refs/heads/main 2>/dev/null)"
+# Not vacuous, and this is the half that proves the refusals above came from the
+# hook: delete the installed copy and the identical push lands.
+rm -f "$fresh/.git/hooks/pre-push"
+git -C "$freshwt" push -q "$wtbare" HEAD:refs/heads/main >/dev/null 2>&1
+t "with the hook removed it lands" main "$(git -C "$wtbare" rev-parse --verify -q refs/heads/main >/dev/null && echo main)"
+
+# THE CASE THAT MOVED RATHER THAN CLOSED. Install, then put the MAIN checkout on
+# a commit that predates .githooks - the arrangement this repository is in right
+# now. The old install pointed core.hooksPath at <main checkout>/.githooks, so
+# that checkout deleted the hook directory and the push to main landed in
+# silence. Nothing here reads a working tree, so nothing here changes.
+(cd "$fresh" && bash "$HOOKSH" install >/dev/null 2>&1)
+git -C "$fresh" checkout -q "$before_hook"
+t "the main checkout has no .githooks now" "" "$(test -e "$fresh/.githooks" && echo present)"
+old_check=$(cd "$freshwt" && bash "$HOOKSH" check 2>&1); old_rc=$?
+t "check still PASSES"            0 "$old_rc"
+git -C "$wtbare" update-ref -d refs/heads/main
+git -C "$freshwt" commit -q --allow-empty -m wt3 >/dev/null 2>&1
+git -C "$freshwt" push -q "$wtbare" HEAD:refs/heads/main >/dev/null 2>&1
+t "and the push to main is STILL refused" "" "$(git -C "$wtbare" rev-parse --verify -q refs/heads/main 2>/dev/null)"
+git -C "$fresh" checkout -q -
+
+# STALENESS is the price of installing a copy, so it is reported. A copy that
+# differs from the committed source still refuses main - that is measured above
+# - so it stays exit 0 and says so in words.
+printf '\n# drift\n' >> "$fresh/.git/hooks/pre-push"
+stale_out=$(cd "$fresh" && bash "$HOOKSH" status 2>&1); stale_rc=$?
+t "a stale copy still exits 0"    0 "$stale_rc"
+tcontains "and says INSTALLED"    "INSTALLED" "$stale_out"
+tcontains "and says STALE"        "STALE" "$stale_out"
+tcontains "and names the fix"     "make hooks" "$stale_out"
+(cd "$fresh" && bash "$HOOKSH" install >/dev/null 2>&1)
+fresh_out=$(cd "$fresh" && bash "$HOOKSH" status 2>&1)
+t "a fresh copy is not called stale" "" "$(printf '%s' "$fresh_out" | grep -c 'STALE' | grep -v '^0$')"
 
 # The gate has to be wired to the gate. `make harness-check` is what ci.yml
 # runs, and the check above is worth nothing if nothing calls it.
@@ -2358,7 +2433,10 @@ tcontains "session-brief reports the hook" "git-hooks.sh" "$(cat "$repo_root/scr
 (cd "$fresh" && bash "$HOOKSH" check >/dev/null 2>&1); t "re-install took" 0 "$?"
 sb_hook=$(cd "$fresh" && bash "$repo_root/scripts/claude/session-brief.sh" 2>/dev/null)
 tcontains "session-brief says INSTALLED where it is" "pre-push hook: INSTALLED" "$sb_hook"
+# Removing the copy is what makes it absent now; unsetting the config alone
+# leaves it installed, which is asserted a few lines up against a real push.
 git -C "$fresh" config --unset core.hooksPath
+rm -f "$fresh/.git/hooks/pre-push"
 sb_nohook=$(cd "$fresh" && bash "$repo_root/scripts/claude/session-brief.sh" 2>/dev/null); sb_nrc=$?
 t "session-brief still exits 0"   0 "$sb_nrc"
 tcontains "session-brief says NOT INSTALLED where it is not" "pre-push hook: NOT INSTALLED" "$sb_nohook"

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -821,7 +821,7 @@ t "quoted sibling"        pass "$(bdec 'cp /tmp/x "apps/api/internal/db/sqlcx/db
 echo "== bash-guard: a push that would land commits on main"
 # On 2026-08-12 a one-line fix was committed on main in the main checkout and
 # pushed straight to origin/main, with no branch and no PR. Branch protection on
-# main carries four required contexts and enforce_admins is deliberately false,
+# main carries required contexts and enforce_admins is deliberately false,
 # so the push was accepted server-side with none of them running. This guard saw
 # that command and permitted it: its whole notion of git was `git rm`/`git mv`.
 #
@@ -2295,6 +2295,64 @@ t "hook: branch, NO trailing LF" allowed "$(hookdec_nonl origin git@x:o/r.git "r
 t "hook: last of many, no LF" refused "$(hookdec_nonl origin git@x:o/r.git "refs/heads/a $sha refs/heads/a $zero
 refs/heads/main $sha refs/heads/main $zero")"
 
+# THE SECOND FAIL-OPEN ON THE DECISION PATH, and the same treatment as the
+# first. The hook runs `set -uo pipefail` with no `-e`, so a `tr` that is
+# missing or that dies left $lower EMPTY, the `case` fell through to `continue`,
+# $hits stayed empty and the push was ALLOWED. Reproduced through a real push
+# before this: with PATH set to an empty directory, `git push` landed the commit
+# on the bare remote's main and printed no refusal at all.
+#
+# A PATH THIS BLOCK BUILDS, same idiom as the session-brief farm above: linking
+# exactly the binaries the hook needs means the absence of `tr` is decided here
+# and not by whatever the developer has installed.
+trbin=$(command -v tr 2>/dev/null)
+notr="$tmp/no-tr"; mkdir -p "$notr"
+badtr="$tmp/bad-tr"; mkdir -p "$badtr"
+for b in bash cat; do
+  bp=$(command -v "$b" 2>/dev/null)
+  if [[ "$bp" != /* || ! -x "$bp" ]]; then
+    echo "FAIL  tr fixture: '$b' did not resolve to an executable absolute path (got '${bp:-nothing}')"
+    failed=$((failed+1)); continue
+  fi
+  ln -sf "$bp" "$notr/$b"; ln -sf "$bp" "$badtr/$b"
+done
+[[ "$trbin" == /* ]] || { echo "FAIL  tr fixture: tr did not resolve absolutely (got '${trbin:-nothing}')"; failed=$((failed+1)); }
+ln -sf "$trbin" "$badtr/tr.real"
+printf '#!/bin/sh\nexit 127\n' > "$badtr/tr"; chmod +x "$badtr/tr"
+# The premise, asserted rather than assumed: these PATHs really do lack a
+# working tr. Without this the two refusals below could be refusing for any
+# other reason and would still pass.
+t "fixture: no tr on the stripped PATH" "" "$(PATH="$notr" command -v tr 2>/dev/null)"
+t "fixture: the shimmed tr exits 127"  127 "$(PATH="$badtr" tr a b </dev/null >/dev/null 2>&1; echo $?)"
+
+hookdec_path() { # hookdec, run under a PATH this fixture built
+  if printf '%s\n' "$3" | PATH="$1" bash "$HOOK" origin git@x:o/r.git >/dev/null 2>&1; then
+    printf 'allowed'
+  else
+    printf 'refused'
+  fi
+}
+# FAIL CLOSED, both shapes: absent, and present-but-failing. A branch push is
+# used deliberately - it is the case the old code ALLOWED, and it is allowed on
+# a healthy PATH two assertions down, so the refusal here is the dependency and
+# nothing else.
+t "hook: tr absent -> refuses main"   refused "$(hookdec_path "$notr" x "refs/heads/main $sha refs/heads/main $zero")"
+t "hook: tr absent -> refuses a branch too" refused "$(hookdec_path "$notr" x "refs/heads/fix/x $sha refs/heads/fix/x $zero")"
+t "hook: tr broken -> refuses main"   refused "$(hookdec_path "$badtr" x "refs/heads/main $sha refs/heads/main $zero")"
+t "hook: tr broken -> refuses a branch too" refused "$(hookdec_path "$badtr" x "refs/heads/fix/x $sha refs/heads/fix/x $zero")"
+# It has to SAY why, or the refusal is indistinguishable from the hook being
+# broken and the user reaches for --no-verify without knowing what they skipped.
+notr_msg=$(printf 'refs/heads/fix/x %s refs/heads/fix/x %s\n' "$sha" "$zero" | PATH="$notr" bash "$HOOK" origin git@x:o/r.git 2>&1 >/dev/null)
+tcontains "and names tr as the reason" "'tr' is not on PATH" "$notr_msg"
+tcontains "and says it is refusing"    "REFUSING" "$notr_msg"
+# AND IT MUST NOT OVER-FIRE. With tr back, the identical branch push is allowed
+# and the identical main push is still refused: the guard keys on the missing
+# dependency, not on the stripped PATH.
+withtr="$tmp/with-tr"; mkdir -p "$withtr"
+ln -sf "$(command -v bash)" "$withtr/bash"; ln -sf "$(command -v cat)" "$withtr/cat"; ln -sf "$trbin" "$withtr/tr"
+t "hook: tr present -> branch allowed" allowed "$(hookdec_path "$withtr" x "refs/heads/fix/x $sha refs/heads/fix/x $zero")"
+t "hook: tr present -> main refused"   refused "$(hookdec_path "$withtr" x "refs/heads/main $sha refs/heads/main $zero")"
+
 # The hook is inert until core.hooksPath points at it, and that setting lives in
 # .git/config, which is not committed. So the INSTALL is part of the deliverable.
 #
@@ -2408,15 +2466,86 @@ git -C "$fresh" checkout -q -
 # STALENESS is the price of installing a copy, so it is reported. A copy that
 # differs from the committed source still refuses main - that is measured above
 # - so it stays exit 0 and says so in words.
-printf '\n# drift\n' >> "$fresh/.git/hooks/pre-push"
+# The drift is applied to the SOURCE, which is the shape that actually happens:
+# someone edits .githooks/pre-push on a branch and has not re-run `make hooks`.
+# The installed copy is still the one this installer wrote, so it is still
+# probed and still reports INSTALLED - reddening every worktree that edits the
+# source would redden correct work, and a gate that does that gets switched off.
+printf '\n# drift\n' >> "$fresh/.githooks/pre-push"
 stale_out=$(cd "$fresh" && bash "$HOOKSH" status 2>&1); stale_rc=$?
 t "a stale copy still exits 0"    0 "$stale_rc"
 tcontains "and says INSTALLED"    "INSTALLED" "$stale_out"
 tcontains "and says STALE"        "STALE" "$stale_out"
 tcontains "and names the fix"     "make hooks" "$stale_out"
-(cd "$fresh" && bash "$HOOKSH" install >/dev/null 2>&1)
+git -C "$fresh" checkout -- .githooks/pre-push
 fresh_out=$(cd "$fresh" && bash "$HOOKSH" status 2>&1)
 t "a fresh copy is not called stale" "" "$(printf '%s' "$fresh_out" | grep -c 'STALE' | grep -v '^0$')"
+
+# A PRE-PUSH THIS INSTALLER DID NOT WRITE IS NOT EXECUTED.
+# `status` runs from SessionStart on every start, resume and compact, and its
+# probes EXECUTE the resolved hook. Before the recognition gate that meant
+# running whatever core.hooksPath pointed at: a clone configured for husky had
+# husky's pre-push executed, handed the synthetic refs on stdin; a hook that
+# slept took `status` to 18.197s and the whole brief to 23.310s, past the 20s
+# SessionStart budget in .claude/settings.json, so the session lost the report.
+# The assertion is the log file: if the foreign hook runs, it writes.
+ran_log="$tmp/foreign-ran.log"
+cp "$fresh/.git/hooks/pre-push" "$tmp/ours-pre-push"
+printf '#!/usr/bin/env bash\nprintf "FOREIGN HOOK RAN\\n" >> "%s"\nexit 1\n' "$ran_log" > "$fresh/.git/hooks/pre-push"
+chmod +x "$fresh/.git/hooks/pre-push"
+foreign_out=$(cd "$fresh" && bash "$HOOKSH" status 2>&1); foreign_rc=$?
+t "status still exits 0 on a foreign hook" 0 "$foreign_rc"
+t "the foreign hook was NOT executed"      ""  "$(test -e "$ran_log" && echo ran)"
+tcontains "and status refuses to call it installed" "COULD NOT CHECK" "$foreign_out"
+tcontains "and it names the file it did not run"    ".git/hooks/pre-push" "$foreign_out"
+tcontains "and it says nothing was removed"         "Nothing was changed or removed" "$foreign_out"
+# FAIL CLOSED: not knowing is not passing.
+(cd "$fresh" && bash "$HOOKSH" check >/dev/null 2>&1); t "check FAILS on an unrecognised hook" 1 "$?"
+t "and it still was not executed"          ""  "$(test -e "$ran_log" && echo ran)"
+cp "$tmp/ours-pre-push" "$fresh/.git/hooks/pre-push"
+chmod +x "$fresh/.git/hooks/pre-push"
+(cd "$fresh" && bash "$HOOKSH" check >/dev/null 2>&1); t "check PASSES again once ours is back" 0 "$?"
+
+# INSTALL PRESERVES WHAT WAS THERE. Measured in a throwaway clone before this:
+# a hand-written pre-push went from 3 lines to 132, install exited 0 and printed
+# nothing about it, no backup existed, and the old text was nowhere on disk -
+# unrecoverable, .git/hooks being untracked. bootstrap.sh and `make hooks` both
+# call this, so it was on the ordinary onboarding path.
+pres="$tmp/preserve"
+mkdir -p "$pres/.githooks" "$pres/scripts/claude" "$pres/.husky"
+git -C "$pres" init -q
+git -C "$pres" config user.email t@t.invalid
+git -C "$pres" config user.name t
+cp "$HOOK" "$pres/.githooks/pre-push"; chmod +x "$pres/.githooks/pre-push"
+cp "$HOOKSH" "$pres/scripts/claude/git-hooks.sh"; chmod +x "$pres/scripts/claude/git-hooks.sh"
+git -C "$pres" add .githooks/pre-push scripts/claude/git-hooks.sh >/dev/null
+git -C "$pres" commit -qm seed
+mkdir -p "$pres/.git/hooks"
+printf '#!/usr/bin/env bash\nprintf "CUSTOM SECRET-SCAN HOOK\\n"\nexit 0\n' > "$pres/.git/hooks/pre-push"
+chmod +x "$pres/.git/hooks/pre-push"
+printf '#!/usr/bin/env bash\nprintf "HUSKY\\n"\n' > "$pres/.husky/pre-push"; chmod +x "$pres/.husky/pre-push"
+git -C "$pres" config core.hooksPath .husky
+pres_before=$(cd "$pres" && git hash-object .git/hooks/pre-push)
+pres_out=$(cd "$pres" && bash "$HOOKSH" install 2>&1); pres_rc=$?
+t "install succeeds over a foreign hook" 0 "$pres_rc"
+# THE FINDING, in one assertion: the bytes that were there are still on disk.
+t "the foreign hook text survives"  found "$(grep -rl 'CUSTOM SECRET-SCAN HOOK' "$pres/.git/hooks" >/dev/null 2>&1 && echo found)"
+# ...and byte-identical, not merely something containing that string.
+pres_backup=$(ls "$pres"/.git/hooks/pre-push.pre-wpmgr.* 2>/dev/null | head -1)
+t "the backup is byte-identical"    "$pres_before" "$(test -n "$pres_backup" && git -C "$pres" hash-object "$pres_backup")"
+tcontains "install SAYS it preserved it"  "PRESERVED" "$pres_out"
+tcontains "and prints the restore command" "RESTORE IT ENTIRELY WITH" "$pres_out"
+# Silence about a destroyed hook is the defect; the announcement is the fix.
+tcontains "and names the prior hooksPath" ".husky" "$pres_out"
+tcontains "and prints how to revert it"   "wpmgr.previousHooksPath" "$pres_out"
+t "and the prior hooksPath is recorded"   ".husky" "$(git -C "$pres" config --get wpmgr.previousHooksPath)"
+# And the install is still a real install, not just polite about it.
+(cd "$pres" && bash "$HOOKSH" check >/dev/null 2>&1); t "and main is protected afterwards" 0 "$?"
+# NO OVER-FIRE: installing over a copy identical to the source backs up nothing
+# and says nothing, so re-running `make hooks` does not litter .git/hooks.
+pres_out2=$(cd "$pres" && bash "$HOOKSH" install 2>&1)
+t "a second install makes no second backup" 1 "$(ls "$pres"/.git/hooks/pre-push.pre-wpmgr.* 2>/dev/null | wc -l | tr -d ' ')"
+t "and says nothing about preserving"       0 "$(printf '%s' "$pres_out2" | grep -c 'PRESERVED')"
 
 # The gate has to be wired to the gate. `make harness-check` is what ci.yml
 # runs, and the check above is worth nothing if nothing calls it.

--- a/scripts/claude/route-guard.sh
+++ b/scripts/claude/route-guard.sh
@@ -189,13 +189,31 @@ case "$rel" in
       agent="frontend-architect" ; why="JS/TS surface" ;;
   .github/workflows/*|Makefile|scripts/*|infra/*)
       agent="devops-engineer" ; why="build-gating logic; it needs a committed test" ;;
-  docs/worklog/*) ;;                                     # see below
+  docs/worklog/*)
+      # THIS WAS A SILENT PERMIT until CLAUDE.md changed. It read `docs/worklog/*) ;;`
+      # with a comment saying CLAUDE.md told this session to write its decisions
+      # there, so routing it to a subagent would have the router file a ticket to
+      # have its own notes taken. That reasoning was sound about ROUTING and said
+      # nothing about the path, and the path is now the whole problem.
+      emit deny "A worklog must never enter this repository, and $rel is inside it.
+
+CLAUDE.md, \"## Long sessions\": worklogs go to ~/.wpmgr/worklog/<issue>.md, which
+is outside every checkout and every worktree. Not docs/, not any other path in
+here, not committed, not pushed, not attached to an issue or a PR.
+
+This repository is PUBLIC, and a worklog is the one artefact that routinely holds
+what must not be: an unshipped finding, a defect's file:line before the fix
+exists, the mechanism of a live vulnerability. On 2026-08-12 a worklog for GH #406
+was written to docs/worklog/406.md while the privilege escalation it described was
+live, unpatched and shipped, and while the owner's standing ruling was to disclose
+nothing until the fix was deployed. It was caught before any commit.
+
+Write it to ~/.wpmgr/worklog/ instead. Do not add a worklog path to .gitignore
+either - an ignore file is itself committed, so the line publishes the thing it is
+hiding. The correct location leaves nothing to ignore." ;;
   docs/*|README.md|CHANGELOG.md)
       agent="docs-writer" ; why="two ci.yml gates fail on docs prose, and four version surfaces move in lockstep" ;;
 esac
-# docs/worklog is where CLAUDE.md instructs THIS session to write its decisions
-# as they are made. Routing that to a subagent would have the router file a
-# ticket to have its own notes taken.
 [[ -z "$agent" ]] && exit 0
 
 # ---- escalation: explicit directory prefixes, never a substring match ------

--- a/scripts/claude/session-brief.sh
+++ b/scripts/claude/session-brief.sh
@@ -30,6 +30,21 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "- route-guard and bash-guard are INACTIVE: jq is not installed. Routing"
   echo "  and the wait-loop deny are unenforced this session. Fix: install jq."
 fi
+
+# The pre-push hook, resolved for THIS checkout. It is committed but inert until
+# core.hooksPath points at it, and core.hooksPath is repo-local config, which is
+# never committed: unprotected is the default state of every clone, and of every
+# checkout made before the hook existed. Nothing told anyone - the setting is
+# invisible until the moment it is needed, which is the moment it is too late.
+# Three states, never two, same as the toolchain block below: INSTALLED, NOT
+# INSTALLED, or COULD NOT CHECK. `status` cannot fail the session; it exits 0
+# whatever it finds, and prints the one command that fixes a negative.
+hooks_status="$root/scripts/claude/git-hooks.sh"
+if [[ -x "$hooks_status" ]]; then
+  "$hooks_status" status 2>/dev/null || true
+else
+  echo "- pre-push hook: COULD NOT CHECK - $hooks_status is missing or not executable, so this session does not know whether a push to main is refused here. Do NOT read that as installed."
+fi
 # --- toolchain --------------------------------------------------------------
 # Four states, and the old code collapsed two of them into the loudest one.
 #

--- a/scripts/claude/session-brief.sh
+++ b/scripts/claude/session-brief.sh
@@ -21,7 +21,21 @@
 # Never blocks. SessionStart cannot block, and this must stay cheap.
 set -uo pipefail
 
-root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+# This used to open `root=$(git rev-parse --show-toplevel) || exit 0`, and that
+# exit produced a FOURTH state nobody had counted: with git off PATH, or with
+# the session started outside a repository, the whole report - header, hook line
+# and toolchain block - was ZERO BYTES and the exit was 0. A session then saw no
+# "NOT INSTALLED" line and had no way to tell that from a healthy machine, which
+# is this project's signature defect sitting inside the script that reports it.
+# So nothing exits early any more: every block that needs $root checks for it and
+# says what it could not measure. git-hooks.sh resolves its own context and
+# answers COULD NOT CHECK in both conditions, so it is asked either way, via this
+# script's own directory rather than via $root.
+# Parameter expansion, not `dirname`: this block has to survive an empty PATH,
+# which is one of the two conditions it exists to report on.
+here=${BASH_SOURCE[0]%/*}
+[[ "$here" == "${BASH_SOURCE[0]}" ]] && here="."
+root=$(git rev-parse --show-toplevel 2>/dev/null) || root=""
 
 echo "## Machine state"
 
@@ -39,9 +53,13 @@ fi
 # Three states, never two, same as the toolchain block below: INSTALLED, NOT
 # INSTALLED, or COULD NOT CHECK. `status` cannot fail the session; it exits 0
 # whatever it finds, and prints the one command that fixes a negative.
-hooks_status="$root/scripts/claude/git-hooks.sh"
+hooks_status="${here:-$root/scripts/claude}/git-hooks.sh"
 if [[ -x "$hooks_status" ]]; then
-  "$hooks_status" status 2>/dev/null || true
+  # Run through THIS interpreter, not through the shebang: `/usr/bin/env bash`
+  # needs bash on PATH, and an empty PATH is one of the two conditions this
+  # block exists to report on. $BASH is the absolute path of the shell already
+  # running this file.
+  "${BASH:-bash}" "$hooks_status" status 2>/dev/null || true
 else
   echo "- pre-push hook: COULD NOT CHECK - $hooks_status is missing or not executable, so this session does not know whether a push to main is refused here. Do NOT read that as installed."
 fi
@@ -139,14 +157,25 @@ else
   echo "- disk free: could not measure. Neither 'df -g /' nor 'df -BG /' gave a number (got '${avail_g}'), so the under-25Gi warning did NOT run this session. Check it by hand before a build: disk exhaustion has killed a build here mid-link."
 fi
 
+# `du | cut` printed "- Go build cache: " with nothing after it when either
+# command failed, and an empty size reads as "small" - the one thing it does not
+# mean, in the block that exists because a 26GB cache filled the disk.
+sizeof() { # prints the size, or the reason there is not one
+  local s
+  s=$(du -sh "$1" 2>/dev/null | cut -f1)
+  printf '%s' "${s:-could not measure ('du -sh | cut -f1' gave nothing)}"
+}
 gocache=$(go env GOCACHE 2>/dev/null || true)
-[[ -n "$gocache" && -d "$gocache" ]] && echo "- Go build cache: $(du -sh "$gocache" 2>/dev/null | cut -f1)"
+[[ -n "$gocache" && -d "$gocache" ]] && echo "- Go build cache: $(sizeof "$gocache")"
 gomod=$(go env GOMODCACHE 2>/dev/null || true)
-[[ -n "$gomod" && -d "$gomod" ]] && echo "- Go module cache: $(du -sh "$gomod" 2>/dev/null | cut -f1)"
+[[ -n "$gomod" && -d "$gomod" ]] && echo "- Go module cache: $(sizeof "$gomod")"
 
 # --- worktrees --------------------------------------------------------------
 # `git worktree list` always prints the main checkout first, so the agent
 # worktrees are one fewer than the lines.
+if [[ -z "$root" ]]; then
+  echo "- agent worktrees: not measured. '$PWD' is not inside a git checkout (or git is not on PATH), so there is no repository to count them in."
+else
 wt=$(countof git -C "$root" worktree list); wt_ok=$?
 br=$(countof git -C "$root" branch --list 'worktree-*'); br_ok=$?
 [[ $wt_ok -eq 0 ]] && wt=$(( wt > 0 ? wt - 1 : 0 ))
@@ -158,6 +187,7 @@ elif [[ "$wt" -gt 0 || "$br" -gt 0 ]]; then
   size=$(du -sh "$root/.claude/worktrees" 2>/dev/null | cut -f1)
   echo "- agent worktrees: ${wt} live (${size:-size unknown}), ${br} worktree-* branches"
   [[ "$br" -gt "$(( wt + 4 ))" ]] && echo "  $(( br - wt )) orphaned branches. 'make harness-reap' lists them; 'make harness-reap-apply' deletes the merged ones."
+fi
 fi
 
 # --- volumes ----------------------------------------------------------------


### PR DESCRIPTION
Yesterday a one-line fix was committed on `main` in the main checkout and pushed to `origin/main` with
no branch and no PR, and the question "want me to open a PR for it?" came *after* the push. Three
things had to line up, and this branch addresses all three.

## Why nothing stopped it

- The rule was written in no file. `grep -i 'pull request|push.*main|branch first'` over `CLAUDE.md`,
  `review.md` and `.claude/rules/` returned nothing.
- `bash-guard.sh` inspects every Bash command and permitted the push. Its entire notion of git was
  `git rm` / `git mv` / `git cat-file`.
- Branch protection has `enforce_admins` deliberately `false`, kept so an incident hotfix stays
  possible, so nothing server-side ran against it either.

## What this adds

**`.githooks/pre-push`** is the lock. Git hands it already-resolved refs, so `eval`, a `cd`, quoting,
`@` and exotic refspecs cannot disguise a push from it — a text matcher cannot decide those without
executing the shell, and an earlier attempt at this had nine bypasses because it tried.

**Reachability is the real problem, and is treated as the headline.** `core.hooksPath` is repo-local
config and config is never committed, so every clone and every fresh worktree starts unprotected. The
hook is installed by copy into `$(git rev-parse --git-common-dir)/hooks`, which no working tree's
current commit can remove — pointing config at a tracked directory only relocates the blind spot, since
`git checkout <older>` then deletes the hook while config still reads "installed". `session-brief.sh`
prints INSTALLED / NOT INSTALLED / COULD NOT CHECK every session, and `make harness-check` now fails in
a clone with no hook rather than passing 662 assertions inside one.

**`bash-guard.sh`** gains a push arm as the early stop that explains the rule before you reach the
push, and it says in its own comments that it is structurally incomplete rather than implying coverage.

**`route-guard.sh`** now denies `docs/worklog/*`. That was a deliberate silent permit, correct under the
old `CLAUDE.md`; a worklog now lives outside the repository, because this repo is public and a worklog
routinely holds an unshipped finding.

## What it does not do, stated plainly

`git push --no-verify`, `git send-pack` and `git -c core.hooksPath=…` each skip the hook. No
client-side guard can stop a determined push; only `enforce_admins` could, and that is off by a standing
decision. These layers stop an accident, which is what actually happened.

## Proof, run against a throwaway bare remote — never `origin`

```
hook present   git push <remote> HEAD:refs/heads/main   REFUSED, refs/heads/main NEVER CREATED
hook removed   identical command                        LANDED,  main = 55d496f8
hook restored  -rwxr-xr-x
branch push    * [new branch] … permitted
205 tags       permitted
```

```
$ bash scripts/claude/guards_test.sh
guards_test: 662 assertions passed
```

Three attack rounds drove 13 shell tricks and 11 push forms at it. Each round's findings were fixed and
re-attacked; the false claims those rounds shipped — two hard-coded bypass counts, a `bootstrap.sh`
comment asserting worktree coverage that did not exist, and a refusal calling itself the only
enforcement — are deleted rather than reworded, and `grep -rn 'only enforcement'` over `scripts/`,
`.githooks/` and `CLAUDE.md` now exits 1.

## After merging

Run `make hooks` once in each existing clone. A fresh clone needs it too; `session-brief.sh` will say so
every session until it is run, and `make harness-check` will fail rather than pass quietly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards that prevent direct pushes to `main`, including attempts using alternate capitalization or complex push commands.
  - Added commands to install, check, and report the status of repository safeguards.
  - Bootstrap and security checks now automatically configure and verify these safeguards.

- **Bug Fixes**
  - Improved handling when repository, Git, toolchain, or cache information is unavailable.
  - Worklogs are now directed to a private local location instead of the repository.

- **Documentation**
  - Clarified pull-request delivery requirements, safeguard limitations, and approval requirements for irreversible actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->