### PR TITLE
chore(harness): make the guards fail loudly instead of quietly

### DIFF
--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -24,8 +24,10 @@ command is missing, say so and stop, never report a step you did not run.
 banned_counts() {
   f=${1:-.github/workflows/ci.yml}
   [ -f "$f" ] || { echo "cannot read $f: the vocabulary gate moved, so find it before trusting any count" >&2; return 1; }
-  b=$(grep -oE "banned='[^']+'" "$f" | sed "s/banned='//; s/'$//")
-  [ -n "$b" ] || { echo "no single-line banned='...' in $f: renamed, requoted or wrapped, which is not an empty list" >&2; return 1; }
+  raw=$(grep -oE "banned='[^']+'" "$f")
+  n=$(printf '%s' "$raw" | grep -c .)
+  [ "$n" -eq 1 ] || { echo "found $n single-line banned='...' assignments in $f, expected exactly one: renamed, requoted, wrapped, or the gate now has more than one list, and summing them silently is how a partial list reads as the whole one" >&2; return 1; }
+  b=$(printf '%s' "$raw" | sed "s/banned='//; s/'$//")
   echo "alternates        $(printf '%s' "$b" | tr '|' '\n' | grep -c .)"
   echo "distinct products $(printf '%s' "$b" | tr '|' '\n' | tr -d ' -' | sort -u | grep -c .)"
 }
@@ -46,11 +48,20 @@ single time. And an extraction that finds nothing refuses instead of printing
 `0`, because `0` here reads as "there is no banned list to comply with", which
 is the one direction this repository cannot afford to be wrong in.
 
-It only understands a single-line, single-quoted `banned='...'`. Requote it,
-wrap it across lines, or move it to another file and the function says so and
-exits `1`; it does not try to parse the new shape. That is deliberate, because
-the fix for a moved gate is to open the workflow and read it, not to make this
-regex cleverer until it silently matches the wrong thing.
+It only understands **exactly one** single-line, single-quoted `banned='...'`.
+Requote it, wrap it across lines, or move it to another file and the function
+says so and exits `1`; it does not try to parse the new shape. That is
+deliberate, because the fix for a moved gate is to open the workflow and read
+it, not to make this regex cleverer until it silently matches the wrong thing.
+
+Two or more is refused for the same reason zero is. `grep -oE` prints every
+match, so a second `banned='...'` — a split list, a copy left behind by an edit,
+a second job with its own list — made `$b` two lines and the counts became their
+SUM, printed with no hint that more than one list existed. A sum is the right
+answer to a question nobody asked: it is not the length of the list CI actually
+applies to your file, and it is wrong in the reassuring direction, since the
+number it prints is larger than the list you would be complying with. The
+function now prints how many it found and stops.
 
 **Shipped copy check.** `node apps/marketing/scripts/check-copy.mjs`, no em
 dashes, no en dashes, no competitor names in the marketing site, in

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -269,6 +269,233 @@ unq() {
 }
 UNQ=""
 
+# ---- where the shell actually IS: ONE `cd` tracker, both callers ------------
+#
+# This used to exist only inside push_hits_main, and the write arms below had
+# nothing at all: they rebased every relative operand onto the PAYLOAD's cwd and
+# never noticed that the command itself had moved. Seven payloads were proved
+# destructive against this checkout by executing them and watching the target
+# file's sha256 change, every one of them silent - no decision, zero bytes:
+#
+#   cd apps/api && sed -i.bak s/a/b/ migrations/<applied>.sql
+#   cd apps/api/migrations && sed -i.bak s/a/b/ *.sql
+#   cd apps/landing && echo x > index.html
+#   (cd apps/landing; echo x > index.html)
+#   cd apps/api/internal/db/sqlc && echo x > db.go
+#   cd apps/api && python3 -c "open('internal/db/sqlc/db.go','w')..."
+#
+# The push arm's tracker already had exactly the semantics they needed, so it is
+# LIFTED here rather than copied: one set of globals, one function, two callers.
+# A second implementation is what would drift, and a tracker that drifts from
+# the one the push arm trusts is worse than none, because both would still look
+# maintained. Anything about `cd` that is true of one arm is now true of both by
+# construction - guards_test.sh asserts the same cd shapes against a write arm
+# and against the push arm, so a change that helps one and not the other cannot
+# be committed green.
+#
+# `(cd x; ...)` and `{ cd x; ...; }` are stripped of their opening brace here
+# and NOT in push_hits_main's own command-word test. That asymmetry is
+# deliberate and it is the only push decision this refactor moves: a subshell cd
+# now retargets the branch lookup, which is the directory the push really runs
+# in. Making push_hits_main strip the brace too would newly deny `(git push
+# origin main)`, a shape no assertion covers, so it is left for its own change.
+CD_CWD=""
+# Set when a `cd`/`pushd`/`popd` moved the shell somewhere this could not
+# resolve. It means "the directory is not knowable from here", which is NOT the
+# same as "the payload gave no cwd" - see the deny and ask sites below, which
+# answer the two differently.
+CD_UNKNOWN=""
+CD_DIRSTACK=()
+cd_reset() {
+  CD_CWD=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+  CD_UNKNOWN=""
+  CD_DIRSTACK=()
+}
+# cd_track <segment> -> 0 when the segment WAS a cd/pushd/popd, and the three
+# globals above now describe where the shell is afterwards; 1 for anything else,
+# leaving them untouched. Callers `continue` on 0.
+cd_track() {
+  local seg cn w i n start cdto cdraw
+  local -a words
+  seg=$1
+  words=()
+  IFS=$' \t' read -r -a words <<<"$seg"
+  n=${#words[@]}
+  [[ $n -eq 0 ]] && return 1
+
+  start=0
+  while [[ $start -lt $n ]]; do
+    case "${words[$start]}" in
+      *=*|env|sudo|command|nohup|nice) start=$((start + 1)) ;;
+      *) break ;;
+    esac
+  done
+  [[ $start -ge $n ]] && return 1
+
+  w=${words[$start]}
+  w=${w#\(}; w=${w#\{}
+  unq "$w"; cn=${UNQ##*/}
+  [[ "$cn" == cd || "$cn" == pushd || "$cn" == popd ]] || return 1
+
+  # `cd <path> && git push` RETARGETS the branch lookup, and `cd <path> && sed
+  # -i <file>` retargets the file. This is the incident shape for both arms: an
+  # agent works in a worktree, so the payload's cwd is a worktree, and
+  #   cd /Users/.../wpmgr && git push
+  # was permitted with zero bytes transferred to the guard's attention while
+  # `git -C /Users/.../wpmgr push` was denied. It is the same push.
+  #
+  # It cuts the other way too, and that half was a FALSE REASON rather than a
+  # bypass: from the main checkout, `cd <worktree> && git push` was refused
+  # saying "the current branch is main". It was not. Either follow the cd or
+  # stop claiming to know the directory.
+  #
+  # An operand this cannot resolve - `cd $DIR`, `cd "$(git ...)"`, `cd -`,
+  # `cd ~x`, a directory a previous segment creates at run time - is recorded
+  # as NOT KNOWN rather than guessed at. It used to clear the directory and
+  # fall into the push arm's UNKNOWN deny, and that denied five shapes of
+  # correct work, all reproduced from a worktree whose HEAD was not main:
+  #
+  #     cd "$(git rev-parse --show-toplevel)" && git push   the worktree ITSELF
+  #     cd ~/Desktop/Terminal/wpmgr && git push             tilde, never expanded
+  #     pushd /tmp >/dev/null && ls && popd && git push      popd, never tracked
+  #     mkdir -p out && cd out && cd .. && git push          `out` not there yet
+  #
+  # `~` and `popd` are now followed, because both are small and exact. What is
+  # left unresolvable is recorded as unknown, and what each arm DOES with an
+  # unknown directory is that arm's own decision, stated at its own site: the
+  # push arm defers to `.githooks/pre-push`, which has the resolved refs; the
+  # write arms have no such backstop - they ARE the backstop - so they ask.
+  if [[ "$cn" == popd ]]; then
+    if [[ ${#CD_DIRSTACK[@]} -gt 0 ]]; then
+      CD_CWD=${CD_DIRSTACK[${#CD_DIRSTACK[@]}-1]}
+      unset 'CD_DIRSTACK[${#CD_DIRSTACK[@]}-1]'
+      [[ -n "$CD_CWD" ]] || CD_UNKNOWN=1
+    else
+      # popd with nothing pushed is an error in bash and moves nothing, but
+      # this may have missed the pushd, so it declines to know.
+      CD_CWD=""; CD_UNKNOWN=1
+    fi
+    return 0
+  fi
+
+  cdto=""; cdraw=""
+  i=$((start + 1))
+  while [[ $i -lt $n ]]; do
+    unq "${words[$i]}"; w=$UNQ
+    case "$w" in
+      # `--` ends options, so the NEXT word is the operand even when it starts
+      # with a dash. `cd -- /path` stays fully resolved; `cd --` with nothing
+      # after it falls out with $cdto empty, into the branch below.
+      --) i=$((i + 1))
+          if [[ $i -lt $n ]]; then unq "${words[$i]}"; cdto=$UNQ; cdraw=${words[$i]}; fi
+          break ;;
+      -*) ;;
+      *) cdto=$w; cdraw=${words[$i]}; break ;;
+    esac
+    i=$((i + 1))
+  done
+  [[ "$cn" == pushd ]] && CD_DIRSTACK+=("$CD_CWD")
+  # Every operandless form declines to know, which is what the paragraph above
+  # already promised and what these three did NOT do. Measured from a worktree,
+  # before this: `cd - && git push`, `cd -- && git push` and `cd && git push`
+  # were all resolved to $HOME and then DENIED with "could not determine which
+  # branch", a reason that was untrue of the command - and the symmetric half is
+  # worse, because with $OLDPWD or $HOME being a branch checkout the same code
+  # PERMITS a push that lands on main.
+  #   cd -   goes to $OLDPWD, which is the shell's, not this process's.
+  #   cd --  and bare `cd` go to $HOME, which is not where the shell is.
+  #   bare pushd swaps the top two entries, which is not modelled.
+  # None of the four is knowable from the command string.
+  if [[ -z "$cdto" ]]; then
+    CD_CWD=""; CD_UNKNOWN=1
+    return 0
+  fi
+  # Tilde expansion happens only on an UNQUOTED leading ~, so the RAW word is
+  # what decides it: bash does not expand "~/x", and neither does this.
+  case "$cdraw" in
+    '~')   cdto=${HOME:-} ;;
+    '~/'*) cdto="${HOME:-}/${cdraw#\~/}" ;;
+  esac
+  # A RELATIVE target with no base is not resolvable, and resolving it against
+  # THIS SCRIPT's own cwd is the worst available answer: from a session inside
+  # .claude/worktrees, `cd out && cd ..` then landed on the main checkout and
+  # denied with "the current branch is main", about a directory the command
+  # never visited.
+  if [[ "$cdto" != /* ]]; then
+    if [[ -n "$CD_CWD" ]]; then
+      cdto="${CD_CWD%/}/$cdto"
+    else
+      CD_CWD=""; CD_UNKNOWN=1; return 0
+    fi
+  fi
+  if [[ -d "$cdto" ]]; then
+    CD_CWD=$(cd "$cdto" 2>/dev/null && pwd -P) || CD_CWD=""
+    [[ -n "$CD_CWD" ]] || CD_UNKNOWN=1
+  else
+    CD_CWD=""; CD_UNKNOWN=1
+  fi
+  return 0
+}
+
+# emit_dests <tag> <path>... - the ONE way a destination leaves collect_dests.
+#
+# Every destination is emitted as it was spelled, and a RELATIVE one is emitted
+# a second time rebased onto the directory the tracker above says the shell is
+# actually in. That second line is absolute, which normalise_dests already knows
+# how to fold back to a repo-relative path or discard as outside the checkout,
+# so following a `cd` needed no new matching machinery at all.
+#
+# When the directory is UNKNOWN the operand is tagged `u:` instead. No arm below
+# matches `u:`; it exists so the last arm in this file can say out loud that it
+# could not tell where the write would land, rather than falling through to the
+# bare `exit 0` - which is what all seven payloads above did.
+# The checkout the EFFECTIVE directory belongs to. $CWD_ROOT answers only for
+# the payload's cwd, so `cwd=/tmp` plus `cd <repo>/apps/api && ...` left it empty
+# and every operand went unrebased - the payload cwd being outside any worktree
+# is not rare, it is what happens whenever a command is issued from /tmp. Cached
+# on the directory it was resolved for, because emit_dests runs per operand.
+CD_ROOT=""
+CD_ROOT_FOR=$'\0'
+cd_root() {
+  if [[ -n "$CWD_ROOT" ]]; then printf '%s' "$CWD_ROOT"; return; fi
+  if [[ "$CD_ROOT_FOR" != "$CD_CWD" ]]; then
+    CD_ROOT_FOR=$CD_CWD
+    CD_ROOT=$(git -C "$CD_CWD" rev-parse --show-toplevel 2>/dev/null) || CD_ROOT=""
+    [[ -n "$CD_ROOT" ]] && { CD_ROOT=$(cd "$CD_ROOT" 2>/dev/null && pwd -P) || CD_ROOT=""; }
+  fi
+  printf '%s' "$CD_ROOT"
+}
+
+emit_dests() {
+  local tag=$1 p rel root
+  shift
+  for p in "$@"; do
+    [[ -z "$p" ]] && continue
+    printf '%s:%s\n' "$tag" "$p"
+    # An absolute destination means the same file from every directory, so a
+    # `cd` cannot move it and there is nothing to rebase or to be unsure about.
+    [[ "$p" == /* ]] && continue
+    root=""
+    [[ -n "$CD_CWD" ]] && root=$(cd_root)
+    if [[ -n "$root" ]]; then
+      if [[ "$CD_CWD" == "$root" ]]; then rel=""
+      elif [[ "$CD_CWD" == "$root"/* ]]; then rel="${CD_CWD#"$root"/}"
+      # The shell moved OUTSIDE this checkout, so no repo-relative reading of
+      # the operand exists and none is invented. `cd /tmp && echo x > f` writes
+      # /tmp/f, and this is where that stops looking like a repo path.
+      else rel=""; fi
+      printf '%s:%s\n' "$tag" "$p" | normalise_dests "$rel" "$root"
+    elif [[ -n "$CD_UNKNOWN" ]]; then
+      # ITS LIMIT, stated rather than implied: the operand is emitted whole, so
+      # an interpreter expression whose path happens to be absolute -
+      # `python3 -c "open('/tmp/x','w')"` after an unresolvable cd - is asked
+      # about even though the cd cannot move it. That is an extra question, not
+      # a missed write, and the last arm in this file asks rather than denies.
+      printf 'u:%s\n' "$p"
+    fi
+  done
+}
+
 # The interpreter arm's two tests, and the honest statement of where their
 # boundary is.
 #
@@ -327,9 +554,29 @@ IDELETE="(rmtree\(\
 |(^|[^A-Za-z0-9_])rm(dir)?(Sync)?\()"
 
 collect_dests() {
-  local seg cn w f d tdir inplace i n start probe
+  local seg cn w f d tdir inplace i n start probe rd
   local -a words operands
+  cd_reset
   while IFS= read -r seg; do
+    # A `cd` retargets every operand after it, so it is followed BEFORE anything
+    # in this segment is read, and the segment itself contributes no
+    # destination.
+    cd_track "$seg" && continue
+    # A redirection names its destination in the syntax itself, and this loop is
+    # about to strip redirections out. They used to be read only from the whole
+    # of $cmd, by redir_dests below, which has no idea which segment - and so
+    # which directory - any of them belonged to; `cd apps/landing && echo x >
+    # index.html` went out silent for exactly that reason. So they are taken off
+    # THIS segment first, while the tracker still says where it runs. The
+    # whole-$cmd pass stays: it costs nothing and it covers shapes this
+    # per-segment grep does not reach.
+    while IFS= read -r rd; do
+      [[ -z "$rd" ]] && continue
+      unq "$rd"; emit_dests w "$UNQ"
+    done < <(
+      grep -oE ">>?\|?[[:space:]]*[\"']?${tok}" <<<"$seg" | sed -E 's/^>>?\|?[[:space:]]*//'
+      grep -oE "of=[\"']?${tok}" <<<"$seg" | sed -E 's/^of=//'
+    )
     # Comments and separators are already handled, quote-aware, by the splitter
     # below. Only redirections are stripped here.
     seg=$(printf '%s' "$seg" \
@@ -398,25 +645,25 @@ collect_dests() {
         # resolved name is what the applied-migration check has to see - the
         # command line itself never contains it.
         if [[ -n "$tdir" ]]; then
-          printf 'w:%s\n' "$tdir"
-          for w in "${operands[@]}"; do printf 'w:%s/%s\n' "${tdir%/}" "${w##*/}"; done
+          emit_dests w "$tdir"
+          for w in "${operands[@]}"; do emit_dests w "${tdir%/}/${w##*/}"; done
         else
           d=${operands[$((${#operands[@]} - 1))]}
-          printf 'w:%s\n' "$d"
+          emit_dests w "$d"
           i=0
           while [[ $i -lt $((${#operands[@]} - 1)) ]]; do
-            printf 'w:%s/%s\n' "${d%/}" "${operands[$i]##*/}"
+            emit_dests w "${d%/}/${operands[$i]##*/}"
             i=$((i + 1))
           done
         fi ;;
       tee|truncate)
-        printf 'w:%s\n' "${operands[@]}" ;;
+        emit_dests w "${operands[@]}" ;;
       rm)
-        printf 'r:%s\n' "${operands[@]}" ;;
+        emit_dests r "${operands[@]}" ;;
     esac
     case "$cn" in
       sed|perl|ruby)
-        [[ -n "$inplace" ]] && printf 'w:%s\n' "${operands[@]}" ;;
+        [[ -n "$inplace" ]] && emit_dests w "${operands[@]}" ;;
     esac
     # ruby is in both lists deliberately: `ruby -i` edits in place and
     # `ruby -e 'File.write ...'` does not, and neither shape implies the other.
@@ -428,10 +675,10 @@ collect_dests() {
         # expansion, not a subshell: this runs once per segment.
         probe=${seg//sys.stdout.write(/}
         probe=${probe//sys.stderr.write(/}
-        grep -qE "$IWRITE" <<<"$probe" && printf 'w:%s\n' "${operands[@]}"
+        grep -qE "$IWRITE" <<<"$probe" && emit_dests w "${operands[@]}"
         # Deletion is tagged r, the same as `rm`, so the one arm that permits a
         # delete (the dead app) keeps permitting it however it is spelled.
-        grep -qE "$IDELETE" <<<"$probe" && printf 'r:%s\n' "${operands[@]}" ;;
+        grep -qE "$IDELETE" <<<"$probe" && emit_dests r "${operands[@]}" ;;
     esac
   done < <(split_segments)
 }
@@ -566,8 +813,16 @@ fi
 # Character-by-character rather than a bracket expression: `[`, `]` and `-` are
 # all legal in a glob and all awkward inside one, and getting that wrong fails
 # open.
+# normalise_dests [base] [root]
+# The two arguments default to the payload's cwd, which is every caller but one:
+# emit_dests passes the directory an in-command `cd` actually moved to, so the
+# SAME rebase runs against the SAME tokeniser for both. Rebasing a `cd` any other
+# way meant prefixing the operand string, and an interpreter operand is a whole
+# expression - `open('internal/db/sqlc/db.go','w')` - whose path is a token in
+# the middle of it, so the prefix landed on `open(` and the write stayed
+# permitted. Only the tokeniser below knows where the paths are.
 normalise_dests() {
-  awk -v base="$CWD_REL" -v root="$CWD_ROOT" '
+  awk -v base="${1-$CWD_REL}" -v root="${2-$CWD_ROOT}" '
     function ispath(c) {
       return index("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./*?[]{}$~+@%^-", c) > 0
     }
@@ -633,9 +888,9 @@ redir_dests() {
 # across two of them and the dead-app arm can permit deletion on its own.
 DESTS=$(collect_dests)
 DESTS=$(printf '%s\n%s\n' "$DESTS" "$(redir_dests | sed 's/^/w:/')" \
-        | grep -E '^[wr]:.' | sort -u)
+        | grep -E '^[wru]:.' | sort -u)
 DESTS=$(printf '%s\n%s\n' "$DESTS" "$(printf '%s\n' "$DESTS" | normalise_dests)" \
-        | grep -E '^[wr]:.' | sort -u)
+        | grep -E '^[wru]:.' | sort -u)
 
 # dest_matches <kind> <path-regex>
 # The prefix is matched as a whole path component, never as a substring of a
@@ -891,13 +1146,13 @@ fi
 # project would be refused for a branch nobody was on. A wrong answer is worse
 # than no answer; no answer is handled below, loudly.
 #
-# The base directory is PUSH_CWD, not the payload's cwd directly, because a
+# The base directory is CD_CWD, not the payload's cwd directly, because a
 # leading `cd <path> &&` moves it. See the cd tracking in push_hits_main.
 PBRANCH=""
 push_branch() {
   local d="$1" base
   PBRANCH=""
-  base=$PUSH_CWD
+  base=$CD_CWD
   if [[ -n "$d" ]]; then
     if [[ "$d" != /* ]]; then
       [[ -n "$base" ]] || return 1
@@ -994,21 +1249,22 @@ push_commands() {
 # push_hits_main -> 0 and $PUSH_WHY set, when some segment is a push that lands
 # on main or a push whose target cannot be read ($PUSH_WHY = UNKNOWN).
 PUSH_WHY=""
-PUSH_CWD=""
-# Set when a `cd`/`pushd`/`popd` moved the shell somewhere this arm could not
-# resolve. It means "the branch is not knowable from here", which is NOT the
-# same as "the payload gave no cwd" - the second is still a deny, because a
+# The directory this arm reads the branch from, and whether it is knowable, both
+# come from the shared tracker near the top of this file (CD_CWD / CD_UNKNOWN).
+# They used to be this arm's own private pair of variables, and the write
+# arms had no tracker at all; seven payloads reached a protected file through
+# that gap. One tracker, two callers, so neither can be repaired alone.
+# CD_UNKNOWN means "the directory is not knowable from here", which is NOT the
+# same as "the payload gave no cwd" - the second is still a deny here, because a
 # session with no cwd at all is a broken payload rather than an ordinary
 # command. See the deny sites below.
-PUSH_CD_UNKNOWN=""
-PUSH_DIRSTACK=()
 push_hits_main() {
-  local seg w cn i n start sub d gitdir allrefs tagsonly dryrun r dst np cdto cdraw
+  local seg w cn i n start sub d gitdir allrefs tagsonly dryrun r dst np
   local -a words positional
-  PUSH_CD_UNKNOWN=""
-  PUSH_DIRSTACK=()
-  PUSH_CWD=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+  cd_reset
   while IFS= read -r seg; do
+    # `cd`/`pushd`/`popd` retarget the branch lookup and contribute no push.
+    cd_track "$seg" && continue
     words=()
     IFS=$' \t' read -r -a words <<<"$seg"
     n=${#words[@]}
@@ -1023,107 +1279,6 @@ push_hits_main() {
     done
     [[ $start -ge $n ]] && continue
     unq "${words[$start]}"; cn=${UNQ##*/}
-
-    # `cd <path> && git push` RETARGETS the branch lookup. This is the incident
-    # shape and it is why the arm was worth repairing at all: an agent works in a
-    # worktree, so the payload's cwd is a worktree, and
-    #   cd /Users/.../wpmgr && git push
-    # was permitted with zero bytes transferred to the guard's attention while
-    # `git -C /Users/.../wpmgr push` was denied. It is the same push.
-    #
-    # It cuts the other way too, and that half was a FALSE REASON rather than a
-    # bypass: from the main checkout, `cd <worktree> && git push` was refused
-    # saying "the current branch is main". It was not. Either follow the cd or
-    # stop claiming to know the branch.
-    #
-    # An operand this cannot resolve - `cd $DIR`, `cd "$(git ...)"`, `cd -`,
-    # `cd ~x`, a directory a previous segment creates at run time - is recorded
-    # as NOT KNOWN rather than guessed at. It used to clear the directory and
-    # fall into the UNKNOWN deny, and that denied five shapes of correct work,
-    # all reproduced from a worktree whose HEAD was not main:
-    #
-    #     cd "$(git rev-parse --show-toplevel)" && git push   the worktree ITSELF
-    #     cd ~/Desktop/Terminal/wpmgr && git push             tilde, never expanded
-    #     pushd /tmp >/dev/null && ls && popd && git push      popd, never tracked
-    #     mkdir -p out && cd out && cd .. && git push          `out` not there yet
-    #
-    # `~` and `popd` are now followed, because both are small and exact. What is
-    # left unresolvable DEFERS: no deny, no reason, and `.githooks/pre-push`
-    # decides it instead, after the shell has actually expanded it. That is the
-    # trade this file already makes everywhere else - a false reason is worse
-    # than no reason, and the hook is the lock while this arm is the manners.
-    if [[ "$cn" == cd || "$cn" == pushd || "$cn" == popd ]]; then
-      if [[ "$cn" == popd ]]; then
-        if [[ ${#PUSH_DIRSTACK[@]} -gt 0 ]]; then
-          PUSH_CWD=${PUSH_DIRSTACK[${#PUSH_DIRSTACK[@]}-1]}
-          unset 'PUSH_DIRSTACK[${#PUSH_DIRSTACK[@]}-1]'
-          [[ -n "$PUSH_CWD" ]] || PUSH_CD_UNKNOWN=1
-        else
-          # popd with nothing pushed is an error in bash and moves nothing, but
-          # this arm may have missed the pushd, so it declines to know.
-          PUSH_CWD=""; PUSH_CD_UNKNOWN=1
-        fi
-        continue
-      fi
-      cdto=""; cdraw=""
-      i=$((start + 1))
-      while [[ $i -lt $n ]]; do
-        unq "${words[$i]}"; w=$UNQ
-        case "$w" in
-          # `--` ends options, so the NEXT word is the operand even when it
-          # starts with a dash. `cd -- /path` stays fully resolved; `cd --` with
-          # nothing after it falls out with $cdto empty, into the branch below.
-          --) i=$((i + 1))
-              if [[ $i -lt $n ]]; then unq "${words[$i]}"; cdto=$UNQ; cdraw=${words[$i]}; fi
-              break ;;
-          -*) ;;
-          *) cdto=$w; cdraw=${words[$i]}; break ;;
-        esac
-        i=$((i + 1))
-      done
-      [[ "$cn" == pushd ]] && PUSH_DIRSTACK+=("$PUSH_CWD")
-      # Every operandless form declines to know, which is what the paragraph
-      # above already promised and what these three did NOT do. Measured from a
-      # worktree, before this: `cd - && git push`, `cd -- && git push` and
-      # `cd && git push` were all resolved to $HOME and then DENIED with "could
-      # not determine which branch", a reason that was untrue of the command -
-      # and the symmetric half is worse, because with $OLDPWD or $HOME being a
-      # branch checkout the same code PERMITS a push that lands on main.
-      #   cd -   goes to $OLDPWD, which is the shell's, not this process's.
-      #   cd --  and bare `cd` go to $HOME, which is not where the shell is.
-      #   bare pushd swaps the top two entries, which is not modelled.
-      # None of the four is knowable from the command string, so all four defer
-      # and `.githooks/pre-push` decides them after the shell has expanded them.
-      if [[ -z "$cdto" ]]; then
-        PUSH_CWD=""; PUSH_CD_UNKNOWN=1
-        continue
-      fi
-      # Tilde expansion happens only on an UNQUOTED leading ~, so the RAW word
-      # is what decides it: bash does not expand "~/x", and neither does this.
-      case "$cdraw" in
-        '~')   cdto=${HOME:-} ;;
-        '~/'*) cdto="${HOME:-}/${cdraw#\~/}" ;;
-      esac
-      # A RELATIVE target with no base is not resolvable, and resolving it
-      # against THIS SCRIPT's own cwd is the worst available answer: from a
-      # session inside .claude/worktrees, `cd out && cd ..` then landed on the
-      # main checkout and denied with "the current branch is main", about a
-      # directory the command never visited.
-      if [[ "$cdto" != /* ]]; then
-        if [[ -n "$PUSH_CWD" ]]; then
-          cdto="${PUSH_CWD%/}/$cdto"
-        else
-          PUSH_CWD=""; PUSH_CD_UNKNOWN=1; continue
-        fi
-      fi
-      if [[ -d "$cdto" ]]; then
-        PUSH_CWD=$(cd "$cdto" 2>/dev/null && pwd -P) || PUSH_CWD=""
-        [[ -n "$PUSH_CWD" ]] || PUSH_CD_UNKNOWN=1
-      else
-        PUSH_CWD=""; PUSH_CD_UNKNOWN=1
-      fi
-      continue
-    fi
 
     [[ "$cn" == git ]] || continue
 
@@ -1208,7 +1363,7 @@ push_hits_main() {
           if [[ -n "$gitdir" ]] || ! push_branch "$d"; then
             # Unreadable BECAUSE a cd could not be followed: defer to the hook
             # rather than deny with a reason that is not true of the command.
-            [[ -n "$PUSH_CD_UNKNOWN" && -z "$gitdir" && "$d" != /* ]] && continue 2
+            [[ -n "$CD_UNKNOWN" && -z "$gitdir" && "$d" != /* ]] && continue 2
             PUSH_WHY="UNKNOWN"
             return 0
           fi
@@ -1227,7 +1382,7 @@ push_hits_main() {
     if [[ -n "$gitdir" ]] || ! push_branch "$d"; then
       # Same deferral as above: an unfollowable cd is a gap in this arm's
       # knowledge, not evidence about the branch. The hook decides it.
-      [[ -n "$PUSH_CD_UNKNOWN" && -z "$gitdir" && "$d" != /* ]] && continue
+      [[ -n "$CD_UNKNOWN" && -z "$gitdir" && "$d" != /* ]] && continue
       PUSH_WHY="UNKNOWN"
       return 0
     fi
@@ -1292,6 +1447,67 @@ matching command text. Both catch an accident; neither stops a determined push.
 
 Pushing a branch, a tag, or a release branch is untouched by this arm; only a
 push that moves main is refused."
+fi
+
+# ---- arm 5: a write whose directory this guard could not determine ----------
+#
+# LAST, so every certain answer above wins. A deny is a statement about a known
+# file; this arm's whole subject is not knowing, and an ask that fires in front
+# of a deny would replace a correct refusal with a question.
+#
+# ASK, NOT DENY, and the reason is arithmetic rather than taste. After an
+# unresolvable `cd` the effective directory is any directory, so for ANY
+# relative destination there exists a directory that puts it inside a protected
+# tree - `db.go` under apps/api/internal/db/sqlc, `index.html` under
+# apps/landing, `20260527115454_initial.sql` under apps/api/migrations. "Could
+# land on a protected path" is therefore true of every relative write here, so
+# denying on it denies `cd "$(mktemp -d)" && echo x > out.txt` too. CLAUDE.md is
+# explicit that a guard which reddens correct work gets switched off, and a
+# switched-off guard protects nothing. An ask keeps a person in the loop for a
+# shape that is rare (an unresolvable cd is `cd $VAR`, `cd "$(...)"`, `cd -`,
+# bare `cd`, or a directory a previous segment has not created yet) without
+# refusing it.
+#
+# WHAT IS NOT AVAILABLE IS SILENCE. Before this arm existed, all four of these
+# produced no decision, no stdout, no stderr and no record that a guard had
+# looked at them. That is this project's signature defect, and it is the one
+# outcome ruled out here.
+#
+# The scope is deliberately narrow, and each exclusion is a case this must not
+# ask about:
+#   an ABSOLUTE destination      is exact whatever the cwd is, so no `u:` line
+#   a READ                       never reaches DESTS at all
+#   a command with no write      `cd $VAR && npm run build` emits no destination
+#   a RESOLVED cd                `cd /tmp && echo x > f` has a known directory
+#   no cd at all                 CD_UNKNOWN is never set, so no `u:` line
+if [[ -n "$DESTS" ]] && printf '%s\n' "$DESTS" | grep -q '^u:'; then
+  unknown_dests=$(printf '%s\n' "$DESTS" | grep '^u:' | sed 's/^u:/  /' | sort -u)
+  emit ask "That command changes directory to somewhere this guard COULD NOT DETERMINE, and
+then writes to a relative path. Where these land is unknown:
+
+${unknown_dests}
+The directory could not be determined - it is not that the destination was
+checked and found safe. A 'cd' is followed here only when the command string
+says where it goes; \`cd \$VAR\`, \`cd \"\$(...)\"\`, \`cd -\`, a bare \`cd\`, and a
+directory an earlier part of the same command creates at run time are all
+unresolvable before the shell expands them.
+
+So this guard cannot rule out that the write lands in a protected tree:
+
+  apps/api/migrations         editing an applied migration breaks fresh installs
+  apps/api/internal/db/sqlc   hand-editing the generated tree caused a prod 500
+  apps/api/internal/api/gen   likewise
+  apps/landing                dead since 2026-06-20, writes there do nothing
+
+Unlike a push, there is no second lock behind this one - .githooks/pre-push sees
+resolved refs, and nothing sees a resolved cwd - so it asks rather than falling
+silent.
+
+Spell the destination absolutely, or put the directory in the command, and it
+needs no guess at all:
+
+  cd \"\$DIR\" && echo x > \"\$DIR\"/out.txt
+  git -C <dir> ... / sed -i '' <dir>/<file>"
 fi
 
 exit 0

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -50,14 +50,32 @@
 #    is why it denies rather than asks, and why it also denies when it cannot
 #    read the branch.
 #
-# FAIL-OPEN, DELIBERATELY, AND ANNOUNCED: see the header of route-guard.sh.
-# session-brief.sh reports the guard as INACTIVE at session start if jq is
-# absent.
+# FAIL-CLOSED WHEN jq IS MISSING. This used to be `command -v jq || exit 0`,
+# and what that produced was measured: with jq off PATH, a write to an
+# already-applied migration, a glob over the whole migrations directory and a
+# write into the sqlc tree ALL returned no decision, no stdout and no stderr.
+# The three strongest denies in this file disappeared together, and the only
+# announcement was a line in the session brief that nobody re-reads after
+# installing a package. A guard that evaporates when a dependency is missing is
+# this project's signature defect in its purest form, so the absence is now the
+# loud outcome: exit 2, which is how a PreToolUse hook blocks, with the reason
+# on stderr. Every Bash command is refused until jq is installed. That is
+# deliberate - the alternative is an unguarded session that looks guarded.
 #
 # Test: scripts/claude/guards_test.sh
 set -uo pipefail
 
-command -v jq >/dev/null 2>&1 || exit 0
+if ! command -v jq >/dev/null 2>&1; then
+  cat >/dev/null    # drain the payload, so the caller never sees EPIPE
+  echo "bash-guard.sh: jq is NOT installed, so this guard cannot read the hook payload
+and cannot decide anything. It refuses rather than disappearing: without jq
+every deny in it - an already-applied migration, a glob over the migrations
+directory, a write into a generated tree, a push that would land on main -
+silently permits the command instead.
+
+Install it and re-run:  brew install jq" >&2
+  exit 2
+fi
 
 input=$(cat)
 cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null)
@@ -271,12 +289,36 @@ UNQ=""
 # `readFileSync` - because refusing those taught the previous version's users
 # nothing except to route around it.
 IQ='["'"'"']'
+#
+# THREE ADDITIONS, each an in-place overwrite proved destructive against a
+# stand-in file while the shipped pattern permitted it:
+#
+#   fileinput.input(P, inplace=True)   python's own in-place editor. It contains
+#                                      no `open(`, no `.write(` and no `shutil`,
+#                                      so nothing above matched it, and it
+#                                      rewrites the file it is iterating.
+#   fs.openSync(P, 'w')                node. Truncates to zero bytes on the open
+#                                      itself, with no write call anywhere.
+#   fs.writeSync(fd, buf)              node. `\.write\(` needs the paren
+#                                      immediately after `write`, and
+#                                      `writeFile` is a different name, so the
+#                                      form that usually follows an openSync was
+#                                      unmatched too.
+#
+# The mode test is what keeps the read forms out: `openSync(P,'r')` and
+# `open(P,'r')` are permitted, and `fileinput.input(P)` without `inplace` is a
+# read. Positional `fileinput.input(P, 1)` is NOT matched - the second parameter
+# is `inplace`, but it is spelled `inplace=` in every real use and matching a
+# bare `1` would fire on any two-argument call.
 IWRITE="(shutil\.(copy|copy2|copyfile|copytree|move)\(\
 |\.write_(text|bytes)\(\
 |os\.(replace|rename|renames|truncate|ftruncate)\(\
 |open\([^)]*(,|mode=)[[:space:]]*${IQ}[rwaxbt+U]*[wax+][rwaxbt+U]*${IQ}\
+|fileinput\.[A-Za-z_]*\(.*inplace[[:space:]]*=[[:space:]]*(True|1)\
+|openSync\([^)]*,[[:space:]]*${IQ}[rwaxbst+]*[wax+][rwaxbst+]*${IQ}\
 |\.write\(|\.writelines\(\
 |writeFile|appendFile|createWriteStream|copyFile|renameSync|truncateSync\
+|writeSync\(|writevSync\(\
 |file_put_contents|fwrite|fputs|move_uploaded_file\
 |(^|[^A-Za-z0-9_.\$>-])(copy|rename|touch)\()"
 IDELETE="(rmtree\(\
@@ -453,9 +495,147 @@ split_segments() {
       }'
 }
 
+# ---- where the command will actually run, and what its operands resolve to --
+#
+# TWO BYPASSES, ONE CAUSE: every arm below matched repo-relative TEXT, and
+# nothing ever rebased an operand or collapsed a `.`/`..` segment. Both were
+# reproduced against the shipped guard, and both went out silent - no decision,
+# zero bytes, command permitted:
+#
+#   cwd=<repo>/apps/api   sed -i.bak s/a/b/ migrations/*.sql
+#   cwd=<repo>/apps/api   sed -i.bak s/a/b/ migrations/<applied>.sql
+#   cwd=<repo>/apps/api   cp /tmp/db.go internal/db/sqlc/db.go
+#   cwd=<repo>            sed -i.bak s/a/b/ apps/api/../api/migrations/<applied>.sql
+#   cwd=<repo>            sed -i.bak s/a/b/ apps/./api/migrations/<applied>.sql
+#   cwd=<repo>            sed -i.bak s/a/b/ apps/api/internal/db/../db/sqlc/db.go
+#
+# Every protected path in this file was reachable both ways. `cd` into a
+# subdirectory is the ordinary way to work in this repo, so the first shape is
+# not even an attack; it is Tuesday.
+#
+# THE CWD IS THE PAYLOAD'S, NEVER $PWD. This hook runs in a process whose own
+# cwd is wherever the harness started it, which is not where the command will
+# run. `.cwd` in the payload is the only honest source, and when it is absent
+# the operand is left as it arrived - which is the old behaviour, so nothing
+# that is denied today stops being denied.
+#
+# NORMALISATION IS LEXICAL, NEVER FILESYSTEM. Not `realpath`, not
+# `readlink -f`, not `cd && pwd -P`. Two independent reasons, and either alone
+# settles it: the destination of a write usually does NOT EXIST YET, so a
+# resolver either fails or answers about the parent; and resolving a symlink at
+# guard time answers a different question from the one the command will ask
+# when it runs a moment later. So `.` and `..` are collapsed textually and
+# nothing on disk is consulted.
+#
+# BOTH READINGS ARE EMITTED for a relative operand: the operand as-is, and the
+# operand rebased onto the payload cwd. Which one the shell means depends on
+# where it runs, and this cannot narrow that down without guessing; emitting
+# both can only match MORE than the shipped guard, never less, so no assertion
+# that passes today can start failing. The cost is that from cwd=apps/api the
+# spelling `apps/api/migrations/x.sql` is still read as protected even though it
+# would resolve to `apps/api/apps/api/...`. That is the status quo, and it
+# denies a command that would have failed anyway.
+#
+# A `..` that walks off the top is NOT quietly dropped: `../../..` above the
+# base leaves its leading `..` in place, so the result is not a repo-relative
+# path, matches no protected prefix, and is not confused with one.
+PAYLOAD_CWD=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+CWD_ROOT=""
+CWD_REL=""
+if [[ -n "$PAYLOAD_CWD" && -d "$PAYLOAD_CWD" ]]; then
+  CWD_ROOT=$(git -C "$PAYLOAD_CWD" rev-parse --show-toplevel 2>/dev/null) || CWD_ROOT=""
+  if [[ -n "$CWD_ROOT" ]]; then
+    CWD_ROOT=$(cd "$CWD_ROOT" 2>/dev/null && pwd -P) || CWD_ROOT=""
+  fi
+  if [[ -n "$CWD_ROOT" ]]; then
+    # The cwd's own physical path, so the prefix strip below compares like with
+    # like: on macOS /tmp is a symlink to /private/tmp and `show-toplevel` is
+    # always physical.
+    phys=$(cd "$PAYLOAD_CWD" 2>/dev/null && pwd -P) || phys=""
+    if [[ "$phys" == "$CWD_ROOT" ]]; then CWD_REL=""
+    elif [[ "$phys" == "$CWD_ROOT"/* ]]; then CWD_REL="${phys#"$CWD_ROOT"/}"
+    else CWD_ROOT=""; fi   # cwd is not inside the root git reported: trust neither
+  fi
+fi
+
+# normalise_dests: read tagged destination lines, emit the same lines with every
+# path-like token inside them lexically normalised, and additionally rebased
+# onto the payload cwd. Tokens are cut on the characters that cannot appear in
+# a path spelled on a command line, so a path buried inside an interpreter
+# expression - `shutil.copy('/tmp/x','apps/./api/...')` - comes out on its own.
+# Character-by-character rather than a bracket expression: `[`, `]` and `-` are
+# all legal in a glob and all awkward inside one, and getting that wrong fails
+# open.
+normalise_dests() {
+  awk -v base="$CWD_REL" -v root="$CWD_ROOT" '
+    function ispath(c) {
+      return index("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./*?[]{}$~+@%^-", c) > 0
+    }
+    # Collapse "." and resolve ".." textually. A ".." that cannot be resolved
+    # because it walks above the base is KEPT, so the caller can see that the
+    # result left the tree rather than being handed a path that looks inside it.
+    function lexnorm(p,   parts, n, i, k, abs, out, s) {
+      abs = (substr(p, 1, 1) == "/")
+      n = split(p, parts, "/")
+      k = 0
+      for (i = 1; i <= n; i++) {
+        if (parts[i] == "" || parts[i] == ".") continue
+        if (parts[i] == "..") {
+          if (k > 0 && out[k] != "..") { k--; continue }
+          if (abs) continue          # "/.." is "/"
+          out[++k] = ".."; continue
+        }
+        out[++k] = parts[i]
+      }
+      s = ""
+      for (i = 1; i <= k; i++) s = (i == 1 ? out[i] : s "/" out[i])
+      return (abs ? "/" s : s)
+    }
+    function put(tag, p,   n) {
+      if (p == "") return
+      if (substr(p, 1, 1) == "/") {
+        n = lexnorm(p)
+        # An absolute path is only interesting once it is inside the checkout.
+        if (root == "") return
+        if (n == root) { print tag; return }
+        if (index(n, root "/") == 1) print tag substr(n, length(root) + 2)
+        return
+      }
+      print tag lexnorm(p)
+      if (base != "") print tag lexnorm(base "/" p)
+    }
+    {
+      tag = substr($0, 1, 2)
+      if (tag != "w:" && tag != "r:") next
+      body = substr($0, 3)
+      tok = ""
+      L = length(body)
+      for (i = 1; i <= L + 1; i++) {
+        c = (i <= L) ? substr(body, i, 1) : ""
+        if (c != "" && ispath(c)) { tok = tok c; continue }
+        if (tok != "") { put(tag, tok); tok = "" }
+      }
+    }'
+}
+
+# Redirection targets and `dd of=` name their destination in the syntax itself,
+# so collect_dests strips them and the raw greps in writes_to read them straight
+# off $cmd. Those greps are text-only, which is exactly what both bypasses
+# above walked through, so the same targets are extracted here and pushed
+# through normalise_dests with everything else. The raw greps stay: they cost
+# nothing and they cover shapes the extraction below does not tokenise.
+redir_dests() {
+  grep -oE ">>?\|?[[:space:]]*[\"']?${tok}" <<<"$cmd" | sed -E 's/^>>?\|?[[:space:]]*//'
+  grep -oE "of=[\"']?${tok}" <<<"$cmd" | sed -E 's/^of=//'
+}
+
 # One target per line, tagged w (write) or r (delete), so no regex can match
 # across two of them and the dead-app arm can permit deletion on its own.
 DESTS=$(collect_dests)
+DESTS=$(printf '%s\n%s\n' "$DESTS" "$(redir_dests | sed 's/^/w:/')" \
+        | grep -E '^[wr]:.' | sort -u)
+DESTS=$(printf '%s\n%s\n' "$DESTS" "$(printf '%s\n' "$DESTS" | normalise_dests)" \
+        | grep -E '^[wr]:.' | sort -u)
 
 # dest_matches <kind> <path-regex>
 # The prefix is matched as a whole path component, never as a substring of a
@@ -595,9 +775,8 @@ new ordinal plus a converge path, and it routes to database-engineer."
   # available to any payload that happens not to carry a cwd, and silence is
   # the one outcome a guard may never produce. A check that cannot do its job
   # says so.
-  cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
-  root=""
-  [[ -n "$cwd" && -d "$cwd" ]] && root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)
+  cwd=$PAYLOAD_CWD
+  root=$CWD_ROOT
   # Second source, so a missing cwd does not turn into a blanket refusal of
   # ordinary new-migration work: this hook script is itself committed in the
   # repository it guards, so its own directory resolves the same checkout.

--- a/scripts/claude/bash-guard.sh
+++ b/scripts/claude/bash-guard.sh
@@ -215,9 +215,21 @@ lead="(${tok}/)?"
 #
 # KNOWN LIMITS, stated rather than papered over: this splits on whitespace with
 # no quote parsing, so a destination inside quotes, or built from a variable, is
-# not seen; and the interpreter arm treats any `open(` as a write, so reading a
-# protected path through python is refused. Both are conservative in the safe
-# direction, and the header already declares the wider gap.
+# not seen. That is conservative in the safe direction only for the OVER-fire
+# half; it under-fires, and the header already declares that wider gap.
+#
+# This comment used to end "the interpreter arm treats any `open(` as a write,
+# so reading a protected path through python is refused ... conservative in the
+# safe direction". Both halves of that were wrong, and the second half was the
+# damaging one: the arm's test was `(open\(|writeFile|file_put_contents|\.write\()`,
+# which denied
+#   python3 -c "print(open('apps/api/internal/db/sqlc/db.go').read())"   a READ
+# and permitted
+#   python3 -c "import shutil; shutil.copy('/tmp/x','apps/.../sqlc/db.go')"
+# because a `shutil.copy` contains none of those four tokens. It refused the
+# harmless half and waved through the overwrite of the tree whose hand-editing
+# caused a production 500 here. A comment that claims safety in both directions
+# is how that survived; the real boundary is stated at $IWRITE below.
 # Strip ONE surrounding layer of quotes from a word, into $UNQ.
 #
 # `read -a` splits on whitespace and does not unquote, so `"apps/api/migrations"`
@@ -239,8 +251,41 @@ unq() {
 }
 UNQ=""
 
+# The interpreter arm's two tests, and the honest statement of where their
+# boundary is.
+#
+# WHAT THEY DECIDE: whether THIS segment performs a write (or a delete), not
+# whether it mentions a file. An interpreter one-liner names its destination
+# inside its own source text, so there is no positional operand to read; the
+# only signal available is the call being made. So the calls are enumerated.
+#
+# WHAT THEY CANNOT DECIDE, since a comment that overstates coverage is worse
+# than none: a call whose name arrives through a variable, an alias, `getattr`,
+# `eval`, an imported helper, or a path assembled by a function call inside the
+# `open(` argument list - `open(os.path.join('a','b'),'w')` is matched only by
+# the `.write(` that usually follows it, and not at all without one. Where the
+# shape is genuinely ambiguous the choice here is to DENY: `open(P,'r+')` is
+# listed as a write because `r+` can write, and a bare `copy(`/`rename(` with
+# no receiver is listed because PHP's are free functions. What is deliberately
+# NOT denied is a plain read - `open(P)`, `open(P,'r')`, `read_text()`,
+# `readFileSync` - because refusing those taught the previous version's users
+# nothing except to route around it.
+IQ='["'"'"']'
+IWRITE="(shutil\.(copy|copy2|copyfile|copytree|move)\(\
+|\.write_(text|bytes)\(\
+|os\.(replace|rename|renames|truncate|ftruncate)\(\
+|open\([^)]*(,|mode=)[[:space:]]*${IQ}[rwaxbt+U]*[wax+][rwaxbt+U]*${IQ}\
+|\.write\(|\.writelines\(\
+|writeFile|appendFile|createWriteStream|copyFile|renameSync|truncateSync\
+|file_put_contents|fwrite|fputs|move_uploaded_file\
+|(^|[^A-Za-z0-9_.\$>-])(copy|rename|touch)\()"
+IDELETE="(rmtree\(\
+|os\.(remove|removedirs|rmdir)\(\
+|unlink(Sync)?\(\
+|(^|[^A-Za-z0-9_])rm(dir)?(Sync)?\()"
+
 collect_dests() {
-  local seg cn w f d tdir inplace i n start
+  local seg cn w f d tdir inplace i n start probe
   local -a words operands
   while IFS= read -r seg; do
     # Comments and separators are already handled, quote-aware, by the splitter
@@ -335,8 +380,16 @@ collect_dests() {
     # `ruby -e 'File.write ...'` does not, and neither shape implies the other.
     case "$cn" in
       python|python3|ruby|node|php)
-        grep -qE '(open\(|writeFile|file_put_contents|\.write\()' <<<"$seg" \
-          && printf 'w:%s\n' "${operands[@]}" ;;
+        # `.write(` first has its two stream forms removed, because
+        # `sys.stdout.write(open(P).read())` is a read that prints and denying
+        # it is exactly the over-fire that gets a guard switched off. Parameter
+        # expansion, not a subshell: this runs once per segment.
+        probe=${seg//sys.stdout.write(/}
+        probe=${probe//sys.stderr.write(/}
+        grep -qE "$IWRITE" <<<"$probe" && printf 'w:%s\n' "${operands[@]}"
+        # Deletion is tagged r, the same as `rm`, so the one arm that permits a
+        # delete (the dead app) keeps permitting it however it is spelled.
+        grep -qE "$IDELETE" <<<"$probe" && printf 'r:%s\n' "${operands[@]}" ;;
     esac
   done < <(split_segments)
 }
@@ -461,6 +514,80 @@ fi
 # An already-applied migration. Which files are applied is not a fixed list, so
 # it is computed the same way route-guard.sh computes it: presence in HEAD.
 if writes_to "$MIGRATIONS"; then
+  # FIRST: a destination that cannot be resolved to a specific file is not the
+  # same answer as "no migration matched", and reading it as one was a silent
+  # bypass of the strongest deny in this file.
+  #
+  # The literal scan further down extracts a filename with the character class
+  # [A-Za-z0-9_.-]+\.sql, which contains no glob metacharacter. So
+  #   sed -i.bak s/a/b/ apps/api/migrations/*.sql
+  # matched NOTHING, $applied stayed empty, the `if` below was false, and
+  # control fell straight to the bare `exit 0` at the end of this script: no
+  # decision, no stdout, no stderr, and one command rewriting every committed
+  # migration at once - the outage .claude/rules/db-migrations.md calls
+  # non-negotiable, reached by adding a single `*`.
+  #
+  # THE GLOB IS NOT EXPANDED HERE, deliberately. This hook runs BEFORE the
+  # command does, from a process whose cwd is not the payload's. What `*.sql`
+  # names at guard time is not what it names at run time, so an expansion that
+  # happened to find only new files would license a write that lands on an
+  # applied one. The destination is judged on its SHAPE.
+  #
+  # DENY, not ask. Nothing honest reaches here. A new migration is created
+  # under a literal timestamped name - that ordinal IS the file's identity, and
+  # `cat > apps/api/migrations/20260813000000_x.sql` resolves fine. Reading the
+  # directory (`ls`, `cat`, `grep` over `*.sql`) never enters this arm at all,
+  # because none of those is a write and only write and delete destinations are
+  # collected below. An ask would put a prompt in front of a shape that is
+  # always wrong, and a prompt that is always answered the same way stops being
+  # read.
+  mig_targets() {
+    # Redirection and `dd of=` name their destination in the syntax itself, and
+    # collect_dests strips redirections, so those two are read from $cmd. Every
+    # other destination is an already-correlated DESTS line, w (write) or r
+    # (delete). READS are deliberately not scanned: writing a new migration and
+    # then listing the directory,
+    #   cat > apps/api/migrations/<new>.sql && ls apps/api/migrations/*.sql
+    # is ordinary work, and taking the glob from the `ls` would redden it.
+    grep -oE ">>?\|?[[:space:]]*[\"']?${lead}${MIGRATIONS}/${tok}" <<<"$cmd"
+    grep -oE "of=[\"']?${lead}${MIGRATIONS}/${tok}" <<<"$cmd"
+    printf '%s\n' "$DESTS" | grep -E '^[wr]:' | grep -oE "${MIGRATIONS}/${tok}"
+  }
+  unresolved=""
+  while IFS= read -r m; do
+    [[ -z "$m" ]] && continue
+    m=${m##*apps/api/migrations/}
+    # The bare directory, as `cp X apps/api/migrations/` emits it. collect_dests
+    # emits the directory AND the derived `<dir>/<basename>`, and it is that
+    # sibling entry which carries the name; flagging the directory itself would
+    # deny every legitimate copy into it.
+    [[ -z "$m" ]] && continue
+    case "$m" in
+      *'*'*|*'?'*|*'['*|*'{'*|*'$'*|*'`'*)
+        unresolved="$unresolved  ${MIGRATIONS}/$m"$'\n' ;;
+    esac
+  done < <(mig_targets | sort -u)
+
+  if [[ -n "$unresolved" ]]; then
+    emit deny "That command writes under apps/api/migrations/ to a destination this guard
+cannot resolve to a specific file:
+
+${unresolved}
+Whether a migration may be edited is decided by whether that exact file is in
+HEAD, and a pattern has no exact file. It is not expanded here either: this hook
+runs before the command does, so what the pattern matches now is not what it
+will match when the shell runs it.
+
+One glob over this directory rewrites every migration that has already run.
+internal/db/migrate.go skips any version already in schema_migrations, so those
+edits change nothing on an existing database and break every fresh install
+instead - see .claude/rules/db-migrations.md.
+
+Name the one file you mean. Creating a NEW migration under its own timestamped
+name is not blocked. If the change really is to an existing migration, it is a
+new ordinal plus a converge path, and it routes to database-engineer."
+  fi
+
   # Resolve a repository to ask, or refuse. This arm used to leave `root` empty
   # whenever `.cwd` was absent from the payload or was not inside a worktree,
   # and then simply skip the whole check: no decision, no message, command

--- a/scripts/claude/commit-gate.sh
+++ b/scripts/claude/commit-gate.sh
@@ -73,8 +73,47 @@ root=$(cd "$root" 2>/dev/null && pwd -P) || exit 0
 # it into - still matches nothing this agent wrote and still says nothing.
 # Ignored files stay invisible either way: that needs --ignored, which is not
 # passed, so a gitignored node_modules is not listed by this and never was.
-dirty=$(git -C "$cwd" status --porcelain -uall 2>/dev/null)
+#
+# `-z` is load-bearing for a second, independent reason. DEFAULT PORCELAIN
+# QUOTES A PATH that carries a space, a double quote, a backslash, a control
+# character or a non-ASCII byte: it prints `?? "has space.txt"`, wrapped in
+# double quotes with C-style escapes, and `-c core.quotePath=false` does not
+# stop it - that flag only unescapes the non-ASCII case, and a space is still
+# quoted because the plain format is space-delimited. The ownership compare
+# below matches the record's path against the porcelain path column, so EVERY
+# such file failed to match, `owned` came out empty, and this script exited 0 in
+# silence - reporting that the agent had committed everything when it had not,
+# which is exactly how unpushed work gets reaped. `-z` prints paths raw.
+#
+# NUL is translated to newline because a newline inside a filename is already
+# unrepresentable in the ownership record, which agent-writes.sh writes one path
+# per line; so nothing this system can express is lost, and the result is
+# ordinary line-oriented text that command substitution can carry (it cannot
+# carry NUL - bash drops those bytes, silently on the bash 3.2 this machine
+# ships).
+#
+# `pipefail` is set, so a git that fails is not read as a clean tree.
+dirty=$(git -C "$cwd" status --porcelain -uall -z 2>/dev/null | tr '\0' '\n')
+status_rc=$?
+if [[ $status_rc -ne 0 ]]; then
+  {
+    echo "NOTE: 'git status --porcelain -uall -z' failed in '$cwd' (exit $status_rc)."
+    echo "Nothing could be read, so nothing is claimed either way. Not blocking."
+    echo "Check your own uncommitted paths by hand before you stop."
+  } >&2
+  exit 0
+fi
 [[ -z "$dirty" ]] && exit 0
+
+# Drop the ORIGIN half of a rename or copy. Under `-z` git emits a rename as two
+# records - `R  <new path>` and then the OLD path on its own, with no XY prefix -
+# so the line after an R or C entry is a bare path, and matching it as an entry
+# would read its first three characters as a status code and compare the rest.
+# Measured shape: `R  new name.txt<NUL>old name.txt<NUL>`.
+entries=$(printf '%s\n' "$dirty" | awk '
+  skip { skip = 0; next }
+  { print; if (substr($0, 1, 2) ~ /[RC]/) skip = 1 }
+')
 
 # ---- restrict to what this agent wrote -------------------------------------
 aid=$(jq -r '.agent_id // empty' <<<"$input" 2>/dev/null)
@@ -147,19 +186,25 @@ scoped=0
 if [[ -n "$record" && -f "$record" ]]; then
   scoped=1
   # The record holds absolute paths as the tool saw them; git speaks
-  # repo-relative. Compare on the repo-relative form of both.
-  while IFS= read -r w; do
-    [[ -z "$w" ]] && continue
-    rel="${w#"$root"/}"
-    [[ "$rel" == "$w" ]] && continue        # not in this worktree at all
-    # Anchored match against the porcelain path column, so a path is never
-    # matched as a substring of a longer one.
-    line=$(printf '%s\n' "$dirty" | awk -v p="$rel" 'substr($0,4)==p {print; exit}')
-    [[ -z "$line" ]] && continue                       # written, then committed
-    if ! printf '%s' "$owned" | grep -qxF -- "$line"; then
-      owned="$owned$line"$'\n'
-    fi
-  done < <(sort -u "$record")
+  # repo-relative. Reduce the record to repo-relative form once...
+  wrote=$(while IFS= read -r w; do
+            [[ -z "$w" ]] && continue
+            rel="${w#"$root"/}"
+            [[ "$rel" == "$w" ]] && continue    # not in this worktree at all
+            printf '%s\n' "$rel"
+          done < <(sort -u "$record"))
+  # ...then walk the PORCELAIN and ask the record about each entry, rather than
+  # walking the record and searching the porcelain text. The path git prints is
+  # now the authority on its own spelling, so nothing depends on reproducing
+  # git's quoting rules, and `grep -qxF` is a whole-line literal match, so a
+  # path is never matched as a substring or a prefix of a longer one.
+  # No dedup pass: git lists each path once.
+  while IFS= read -r line; do
+    [[ ${#line} -lt 4 ]] && continue
+    rel="${line:3}"
+    printf '%s\n' "$wrote" | grep -qxF -- "$rel" || continue
+    owned="$owned$line"$'\n'
+  done < <(printf '%s\n' "$entries")
   owned=$(printf '%s' "$owned" | sed '/^$/d')
   # Everything this agent wrote is already committed. Nothing to say.
   [[ -z "$owned" ]] && exit 0
@@ -207,7 +252,7 @@ fi
   echo "If any of the following are yours, commit them by name before you stop."
   echo "If none are, ignore this and do not touch them:"
   echo ""
-  printf '%s\n' "$dirty" | head -40
+  printf '%s\n' "$entries" | head -40
 } >&2
 
 exit 0

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -3357,6 +3357,89 @@ t "python open() read"           pass \
 t "the word fileinput alone"     pass \
   "$(bdec_at "$repo" 'grep -n fileinput apps/api/internal/db/sqlc/db.go')"
 
+echo "== bash-guard: an in-command 'cd' moves the deny arms too, not just the push arm"
+# The push arm followed `cd` correctly and the write arms did not look at it at
+# all: they rebased every operand onto the PAYLOAD's cwd, which the command had
+# already left. Seven payloads were proved DESTRUCTIVE against the real checkout
+# by running them and watching the target file's sha256 change, and every one of
+# them was silent - no decision, no stdout, no stderr:
+#   cd apps/api && sed -i.bak s/a/b/ migrations/<applied>.sql
+#   cd apps/api/migrations && sed -i.bak s/a/b/ *.sql
+#   cd apps/landing && echo x > index.html
+#   (cd apps/landing; echo x > index.html)
+#   cd apps/api/internal/db/sqlc && echo x > db.go
+#   cd apps/api && python3 -c "open('internal/db/sqlc/db.go','w')..."
+# The repair was to LIFT the push arm's tracker into a shared cd_track, so the
+# two arms cannot drift. These assertions and the push-arm ones below therefore
+# exercise the SAME code: a cd shape that regresses one regresses both.
+t "cd: applied migration"       deny "$(bdec_at "$repo" 'cd apps/api && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
+t "cd: glob over migrations"    deny "$(bdec_at "$repo" 'cd apps/api/migrations && sed -i.bak s/a/b/ *.sql')"
+t "cd: redirect into dead app"  deny "$(bdec_at "$repo" 'cd apps/landing && echo x > index.html')"
+t "cd: redirect into sqlc"      deny "$(bdec_at "$repo" 'cd apps/api/internal/db/sqlc && echo x > db.go')"
+t "cd in a subshell"            deny "$(bdec_at "$repo" '(cd apps/landing; echo x > index.html)')"
+t "cd: interpreter operand"     deny \
+  "$(bdec_at "$repo" "cd apps/api && python3 -c \"open(${q}internal/db/sqlc/db.go${q},${q}w${q}).write(${q}x${q})\"")"
+t "cd: cp into the mig dir"     deny "$(bdec_at "$repo" 'cd apps/api && cp /tmp/20260101000000_m01_applied.sql migrations')"
+t "cd: rm the sqlc tree"        deny "$(bdec_at "$repo" 'cd apps/api && rm -rf internal/db/sqlc/')"
+t "cd: tee into ogen"           deny "$(bdec_at "$repo" 'cd apps/api && echo x | tee internal/api/gen/oas.go')"
+t "cd: dd of= into sqlc"        deny "$(bdec_at "$repo" 'cd apps/api && dd if=/tmp/x of=internal/db/sqlc/db.go')"
+# `..`, `-` in a directory name and pushd/popd are the tracker's own arithmetic,
+# not the write arm's, so they are asserted through a write.
+t "cd .. then down again"       deny "$(bdec_at "$sub_api" 'cd ../api && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
+# From a cwd that is in NO checkout, so the repository has to come from where
+# the `cd` went. The sqlc tree and not a migration: which migrations are applied
+# is read from HEAD, and that lookup still starts from the payload's cwd, so a
+# migration named from outside any worktree is a gap this change does not close.
+t "cd absolute, cwd outside"    deny "$(bdec_at /tmp "cd $repo/apps/api && sed -i.bak s/a/b/ internal/db/sqlc/db.go")"
+t "pushd then write"            deny "$(bdec_at "$repo" 'pushd apps/api > /dev/null && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
+t "pushd then popd then write"  deny "$(bdec_at "$sub_api" 'pushd /tmp > /dev/null && popd > /dev/null && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
+# DOES NOT OVER-FIRE. A `cd` is how everyone in this repo works, so every one of
+# these has to stay ordinary, from the root AND from a subdirectory.
+t "cd: new migration"           pass "$(bdec_at "$repo" 'cd apps/api/migrations && cat > 20260813000000_m99_new.sql')"
+t "cd: new migration, subdir"   pass "$(bdec_at "$sub_api" 'cd migrations && cat > 20260813000000_m99_new.sql')"
+t "cd: ls the mig dir"          pass "$(bdec_at "$repo" 'cd apps/api && ls migrations/*.sql')"
+t "cd: sed -n over a glob"      pass "$(bdec_at "$repo" 'cd apps/api && sed -n 1,5p migrations/*.sql')"
+t "cd: git log over the dir"    pass "$(bdec_at "$repo" 'cd apps/api && git log --oneline -- migrations')"
+t "cd: grep the sqlc tree"      pass "$(bdec_at "$repo" 'cd apps/api && grep -r Querier internal/db/sqlc/')"
+t "cd /tmp then write there"    pass "$(bdec_at "$repo" 'cd /tmp && echo x > file')"
+t "cd /tmp then write, subdir"  pass "$(bdec_at "$sub_api" 'cd /tmp && echo x > file')"
+t "cd out of the repo"          pass "$(bdec_at "$sub_api" "cd $tmp && cp /tmp/x notes.txt")"
+t "cd: a build"                 pass "$(bdec_at "$repo" 'cd apps/web && npm run build')"
+t "cd: a same-named sibling"    pass "$(bdec_at "$repo" 'cd apps/api && cp /tmp/x migrations-notes.txt')"
+t "cd: apps/landing-old"        pass "$(bdec_at "$repo" 'cd apps && echo x > landing-old/index.html')"
+
+echo "== bash-guard: a write it cannot place ASKS, and says so; it never goes silent"
+# The push arm can defer an unresolvable `cd` to .githooks/pre-push, which sees
+# resolved refs. The write arms have no such backstop - they ARE the backstop -
+# so an unresolvable cd followed by a relative write is asked about rather than
+# permitted in silence. It is an ASK and not a DENY because after an unknown cd
+# EVERY relative destination could be inside a protected tree, so denying on
+# that would redden `cd "$(mktemp -d)" && echo x > out.txt` too.
+t "cd \$VAR then write"          ask  "$(bdec_at "$repo" 'cd "$SOMEDIR" && echo x > db.go')"
+t "cd - then write"              ask  "$(bdec_at "$repo" 'cd - && sed -i.bak s/a/b/ 20260101000000_m01_applied.sql')"
+t "bare cd then delete"          ask  "$(bdec_at "$repo" 'cd && rm index.html')"
+t "cd -- then write"             ask  "$(bdec_at "$repo" 'cd -- && cp /tmp/x db.go')"
+t "cd \$(...) then write"        ask  "$(bdec_at "$repo" 'cd "$(git rev-parse --show-toplevel)" && echo x > db.go')"
+t "cd to a dir made at run time" ask  "$(bdec_at "$repo" 'mkdir -p out && cd out && echo x > db.go')"
+t "popd with no pushd"           ask  "$(bdec_at "$repo" 'popd > /dev/null && echo x > db.go')"
+# The reason has to say the directory could not be determined. A reason that
+# named a specific protected file would be a claim this guard cannot support.
+ask_why=$(breason "$repo" 'cd "$SOMEDIR" && echo x > db.go')
+tcontains "reason: names the cause"   "COULD NOT DETERMINE" "$ask_why"
+tcontains "reason: not a safety claim" "not that the destination was" "$ask_why"
+tcontains "reason: lists the operand"  "db.go" "$ask_why"
+# DOES NOT OVER-FIRE. Each of these has an unresolvable cd and must still pass,
+# so the arm is scoped to relative WRITES and not to "the command contains a cd".
+t "unknown cd, absolute write"   pass "$(bdec_at "$repo" 'cd "$SOMEDIR" && echo x > /tmp/out.txt')"
+t "unknown cd, a read"           pass "$(bdec_at "$repo" 'cd "$SOMEDIR" && cat db.go')"
+t "unknown cd, a build"          pass "$(bdec_at "$repo" 'cd "$SOMEDIR" && npm run build')"
+t "unknown cd, a git command"    pass "$(bdec_at "$repo" 'cd "$SOMEDIR" && git status')"
+t "unknown cd, no write at all"  pass "$(bdec_at "$repo" 'cd "$SOMEDIR" && ls')"
+# A RESOLVED cd is not an unknown one, or the arm above would ask about every
+# command in the section before this and both would be worthless.
+t "resolved cd does not ask"     pass "$(bdec_at "$repo" 'cd /tmp && echo x > db.go')"
+t "no cd at all does not ask"    pass "$(bdec_at "$repo" 'echo x > db.go')"
+
 echo "== bash-guard and route-guard REFUSE when jq is missing, never disappear"
 # Measured against the shipped guards before this: with jq off PATH, a write to
 # an applied migration, a glob over the migrations directory and a write into

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -26,7 +26,13 @@
 set -uo pipefail
 
 here=$(cd "$(dirname "$0")" && pwd)
-ROUTE="$here/route-guard.sh"
+# Overridable for ONE purpose: pointing the suite at a mutated copy of the guard
+# to prove an assertion actually depends on the branch it names. The sister
+# script route-guard-coverage.sh carries --guard for the same reason. An
+# override is announced, because a run against something other than the shipped
+# guard must never be mistaken for a run against it.
+ROUTE="${WPMGR_TEST_ROUTE_GUARD:-$here/route-guard.sh}"
+[[ "$ROUTE" == "$here/route-guard.sh" ]] || echo "NOTE: route-guard under test is $ROUTE (WPMGR_TEST_ROUTE_GUARD), NOT the shipped one"
 BASH_G="$here/bash-guard.sh"
 
 command -v jq >/dev/null 2>&1 || { echo "SKIP: jq is not installed, and the guards fail open without it"; exit 0; }
@@ -80,6 +86,16 @@ reason() {
   jq -n --arg p "$1" --arg c "$repo" '{cwd:$c, tool_input:{file_path:$p}}' \
     | bash "$ROUTE" 2>/dev/null | jq -r '.hookSpecificOutput.permissionDecisionReason // ""' 2>/dev/null
 }
+# The guard's STDERR, which is where every state-directory refusal names itself.
+# Asserting only "it was refused" is what let four refusal branches be deleted
+# with this suite still printing all-passed: a state directory has several
+# independent reasons to be turned down, so an assertion that does not name one
+# is satisfied by any of the others. Pin the branch, not the outcome.
+stderr_of() { # stderr_of <abs file path> <session id>
+  jq -n --arg c "$repo" --arg p "$1" --arg s "$2" \
+    '{cwd:$c, session_id:$s, tool_input:{file_path:$p}}' \
+    | bash "$ROUTE" 2>&1 >/dev/null
+}
 
 t() { # t <label> <expected> <actual>
   if [[ "$2" == "$3" ]]; then pass=$((pass+1))
@@ -122,10 +138,82 @@ echo "== route-guard: it does not over-fire"
 t "inside a subagent"     pass "$(decision "$repo/apps/api/internal/site/service.go" "$repo" "agent-x")"
 t "unrouted root file"    pass "$(decision "$repo/notes.txt")"
 t "outside any repo"      pass "$(decision "/tmp/scratch.go")"
-t "relative path"         pass "$(decision "apps/api/x.go")"
 # The bug that silently disabled the whole guard: cwd in a subdirectory.
 t "cwd=apps/api"          ask  "$(decision "$repo/apps/api/internal/site/service.go" "$repo/apps/api")"
 t "cwd=apps/web/src"      ask  "$(decision "$repo/apps/web/src/routes/_authed/sites/index.tsx" "$repo/apps/web/src")"
+
+echo "== route-guard: a relative file_path is judged, never waved through"
+# THIS SUITE USED TO PIN THE DEFECT AS CORRECT. The line here read
+#   t "relative path"  pass  "$(decision "apps/api/x.go")"
+# and it passed for the wrong reason: the guard did not decide that a relative
+# path was unrouted, it exited 0 at `case "$path" in /*) ;; *) exit 0` before
+# reaching any arm. Every routed path went the same way. Driven at
+# apps/api/internal/auth/members_handler.go - backend-architect plus a mandatory
+# security review - a payload with no cwd produced zero bytes and exit 0, and the
+# generated sqlc tree, which is a hard deny, did the same. bash-guard.sh had
+# already been hardened against this exact shape.
+#
+# "Relative" needs a base, so both sources of one are asserted, and so is the
+# case where neither answers.
+t "relative, cwd resolves it"  ask \
+  "$(decision "apps/api/internal/auth/members_handler.go" "$repo")"
+t "relative, deny arm too"     deny "$(decision "apps/api/internal/db/sqlc/db.go" "$repo")"
+# ...and it is relative to the CWD, not to the repository root. With cwd one
+# level down, the same string names a different file, and that file is unrouted.
+t "relative is cwd-relative"   pass "$(decision "notes.txt" "$repo/apps/api")"
+t "relative, cwd-relative ask" ask  "$(decision "internal/auth/members_handler.go" "$repo/apps/api")"
+
+# Second source: no cwd in the payload at all. The guard script is committed
+# inside the repository it guards, so its own directory resolves that checkout,
+# and a relative path in a cwd-less payload is repo-relative or it is nothing.
+# Asserted against THIS repository, since that is the checkout the shipped guard
+# resolves - the throwaway fixture is not the one under its own feet.
+# `jq '... // "pass"'` on EMPTY stdin prints nothing at all rather than "pass",
+# so the default has to be applied in bash, the way decision() does it. Getting
+# this wrong turns "the guard said nothing" into an empty string that matches no
+# expectation - which at least fails loudly, unlike the shape this suite is here
+# to catch.
+nocwd() { # nocwd <relative path>
+  local out
+  out=$(jq -n --arg p "$1" '{tool_input:{file_path:$p}}' \
+    | bash "$ROUTE" 2>/dev/null \
+    | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  printf '%s' "${out:-pass}"
+}
+t "no cwd: routed path asks"   ask  "$(nocwd apps/api/internal/auth/members_handler.go)"
+t "no cwd: generated denies"   deny "$(nocwd apps/api/internal/db/sqlc/db.go)"
+t "no cwd: dead app denies"    deny "$(nocwd apps/landing/index.html)"
+# ...and the over-fire it must not commit: an unrouted relative path is still a
+# pass, and it is a pass because no arm matched, not because the guard gave up.
+t "no cwd: unrouted passes"    pass "$(nocwd notes.txt)"
+t "no cwd: a test still passes" pass "$(nocwd apps/web/src/thing.test.tsx)"
+
+# Neither source answers: no cwd, and the guard's own copy is not inside any
+# checkout. It still may not fall silent - it judges the literal string as
+# repo-relative, which is the only reading under which a routed prefix means
+# anything - and it still may not over-fire on a path no arm covers.
+orphan="$tmp/orphan"
+mkdir -p "$orphan"
+cp "$ROUTE" "$orphan/route-guard.sh"
+orphan_dec() { # orphan_dec <relative path>
+  local out
+  out=$(jq -n --arg p "$1" '{tool_input:{file_path:$p}}' \
+    | bash "$orphan/route-guard.sh" 2>/dev/null \
+    | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  printf '%s' "${out:-pass}"
+}
+# Guard the premise: if $orphan were somehow inside a worktree, every assertion
+# below would be testing the resolved path instead and would pass for the wrong
+# reason.
+t "orphan copy is outside any repo" "" \
+  "$(git -C "$orphan" rev-parse --show-toplevel 2>/dev/null)"
+t "orphan: generated still denies"  deny "$(orphan_dec apps/api/internal/db/sqlc/db.go)"
+t "orphan: routed still asks"       ask  "$(orphan_dec apps/api/internal/auth/members_handler.go)"
+t "orphan: unrouted still passes"   pass "$(orphan_dec notes.txt)"
+# With no repository there is no HEAD, so "already applied" has no answer. It
+# must not be answered with a deny aimed at brand new work: the migration falls
+# through to the database-engineer ask.
+t "orphan: migration asks, not denies" ask "$(orphan_dec apps/api/migrations/20260101000000_m01_applied.sql)"
 
 echo "== route-guard: a test whose suite CI runs does not prompt"
 # ci.yml runs `go test` over ./internal/..., `pnpm --filter @wpmgr/web test` and
@@ -242,17 +330,45 @@ t "foreign dir: not adopted"   no  "$(exists "$foreign/.wpmgr-harness-state")"
 
 # A relative override is not a state directory; it is a path relative to
 # whatever directory the hook happened to be invoked from.
+#
+# PINNED BY MESSAGE, and here is why it has to be. The two `exists` assertions
+# below both pass with the relative-path refusal DELETED: the guard then runs
+# `mkdir -p relative-state` in whatever directory the hook process happens to
+# have, which is this script's cwd and is neither $tmp nor $repo, so both
+# assertions look for the directory somewhere it was never going to appear. They
+# are worth keeping - they say the guard did not scatter state into either of the
+# two plausible places - but on their own they test nothing about the branch.
 ( export WPMGR_ROUTE_GUARD_STATE="relative-state"
   decision "$repo/apps/api/internal/site/service.go" "$repo" "" sessG >/dev/null )
 t "relative override refused"  no  "$(exists "$tmp/relative-state")"
 t "relative, cwd-relative too" no  "$(exists "$repo/relative-state")"
+t "relative override still asks" ask \
+  "$(export WPMGR_ROUTE_GUARD_STATE="relative-state"; decision "$repo/apps/api/internal/site/rel.go" "$repo" "" sessG)"
+tcontains "relative override: refused by the absolute-path branch" \
+  "is not an absolute path" \
+  "$(export WPMGR_ROUTE_GUARD_STATE="relative-state"; stderr_of "$repo/apps/api/internal/site/service.go" sessG)"
 
 # The filesystem root: refused outright, and never stamped as ours.
+#
+# PINNED BY MESSAGE for the same reason. With the '/' branch deleted, '/' is
+# still refused - by the ownership check one branch further down, because root
+# owns '/' and this user does not - so "no marker at /.wpmgr-harness-state" and
+# "it still asks" are both satisfied by a completely different line of code. As
+# root, which is what CI runs as in a container, that second reason disappears
+# too and the deletion becomes `rm -rf` over every top-level directory.
 ( export WPMGR_ROUTE_GUARD_STATE="/"
   decision "$repo/apps/api/internal/site/service.go" "$repo" "" sessH >/dev/null )
 t "root override refused"      no  "$(exists "/.wpmgr-harness-state")"
 t "root override still asks"   ask \
   "$(export WPMGR_ROUTE_GUARD_STATE="/"; decision "$repo/apps/api/internal/site/thing.go" "$repo" "" sessH)"
+tcontains "root override: refused by the filesystem-root branch" \
+  "is the filesystem root" \
+  "$(export WPMGR_ROUTE_GUARD_STATE="/"; stderr_of "$repo/apps/api/internal/site/service.go" sessH)"
+# ...and a trailing slash is the same path. '/'+'/' and '//' both normalise to
+# the root, and the branch strips before it compares.
+tcontains "root with a trailing slash too" \
+  "is the filesystem root" \
+  "$(export WPMGR_ROUTE_GUARD_STATE="//"; stderr_of "$repo/apps/api/internal/site/service.go" sessH)"
 
 # A directory the guard creates is its own, and inside it the prune removes only
 # entries with the name shape the guard writes - never a bare glob.
@@ -391,6 +507,24 @@ ln -s "$victim" "$adopt/wpmgr-route-guard/.wpmgr-harness-state"
 t "live symlink: target not truncated" "PRECIOUS" "$(cat "$victim")"
 t "live symlink: still asks"        ask \
   "$(unset WPMGR_ROUTE_GUARD_STATE; export TMPDIR="$adopt"; decision "$repo/apps/api/internal/site/w.go" "$repo" "" sessT)"
+# PINNED BY MESSAGE, because both assertions above pass with the marker-claim
+# check DELETED. The PreToolUse arm never writes a marker, so nothing truncates
+# the victim on this path, and the session has no recorded ruling, so it asks
+# anyway. What the deleted check actually costs is invisible to both: the state
+# root gets ACCEPTED on the strength of a symlink, and prune_state then runs
+# `rm -rf` inside a directory whose only claim to being ours points somewhere
+# else.
+tcontains "live symlink: refused by the marker-claim branch" \
+  "is not a plain file owned by this user" \
+  "$(unset WPMGR_ROUTE_GUARD_STATE; export TMPDIR="$adopt"; stderr_of "$repo/apps/api/internal/site/service.go" sessT)"
+# ...and that acceptance is what the refusal prevents: nothing inside the
+# directory is pruned while its claim is a symlink.
+mkdir -p "$adopt/wpmgr-route-guard/sess-stale-claimcheck"
+touch -t 200001010000 "$adopt/wpmgr-route-guard/sess-stale-claimcheck"
+( unset WPMGR_ROUTE_GUARD_STATE; export TMPDIR="$adopt"
+  decision "$repo/apps/api/internal/site/service.go" "$repo" "" sessT >/dev/null )
+t "symlinked claim: nothing pruned" yes "$(exists "$adopt/wpmgr-route-guard/sess-stale-claimcheck")"
+rm -rf "$adopt/wpmgr-route-guard/sess-stale-claimcheck"
 
 # The honest case this must not block: no symlink, a loose directory the guard
 # does own gets adopted, closed, and marked with a REAL file.
@@ -408,6 +542,63 @@ t "created dir is 0700"             700 \
      mkdir -p "$tmp/fresh"
      decision "$repo/apps/api/internal/site/service.go" "$repo" "" sessV >/dev/null
      mode_of "$tmp/fresh/wpmgr-route-guard")"
+
+echo "== route-guard state: the READ side trusts a marker only if it is a plain file this user owns"
+# The marker is what SILENCES the prompt, so the read side is where a planted one
+# would pay off, and silencing the prompt is the one outcome this guard exists to
+# prevent. `-f` is true THROUGH a symlink and `find -mmin` follows it, so without
+# the `! -L` tests a link dropped at the marker's name - or at the session
+# directory's name - hands the whole decision to whatever it points at.
+#
+# ASSERTED AGAINST A STATE ROOT THE GUARD OWNS, DELIBERATELY. The existing
+# "planted marker does not silence" assertion plants into the UNOWNED fixture,
+# where resolve_state refuses the directory long before the read side runs; it
+# therefore passes with every read-side check deleted. Reaching the code under
+# test means getting past resolve_state first.
+# NOT pre-created: an override the guard did not create and that carries no
+# marker is refused, correctly, and the read side would never be reached.
+rstate="$tmp/readside-state"
+( export WPMGR_ROUTE_GUARD_STATE="$rstate"
+  decision "$repo/apps/api/internal/site/service.go" "$repo" "" sessR >/dev/null
+  record_route sessR "$repo/apps/api/internal/site/service.go" )
+t "readside: state root adopted"  yes "$(exists "$rstate/.wpmgr-harness-state")"
+# The marker's NAME is the guard's own business, so it is read back rather than
+# spelled out here. A name written into this file would rot the first time the
+# key changes, and a rotted name makes every assertion below pass for the wrong
+# reason. No `head -1`: head closes the pipe and the producer dies on a write
+# error, which this suite has logged from exactly that shape before.
+rmarks=$(find "$rstate/sessR" -type f 2>/dev/null)
+rmark=${rmarks%%$'\n'*}
+t "readside: a ruling was recorded" yes "$([[ -n "$rmark" ]] && printf yes || printf no)"
+# The honest case first: a real marker this user owns DOES silence the next
+# prompt. Without this, every assertion below would be satisfied by a guard that
+# had simply stopped memoising.
+t "readside: real marker silences"  pass \
+  "$(export WPMGR_ROUTE_GUARD_STATE="$rstate"; decision "$repo/apps/api/internal/site/other.go" "$repo" "" sessR)"
+if [[ -n "$rmark" ]]; then
+  rname=${rmark##*/}
+  rvictim="$tmp/readside-victim"; : > "$rvictim"
+  rm -f "$rmark"
+  ln -s "$rvictim" "$rmark"
+  t "symlinked marker does not silence" ask \
+    "$(export WPMGR_ROUTE_GUARD_STATE="$rstate"; decision "$repo/apps/api/internal/site/three.go" "$repo" "" sessR)"
+  t "symlinked marker: target untouched" yes "$(exists "$rvictim")"
+  # ...and the session DIRECTORY is trusted on the same terms. `-d` is true
+  # through a link too, so a symlink at the session's name would let any
+  # directory this user can write supply the ruling.
+  rm -f "$rmark"
+  relse="$tmp/readside-elsewhere"
+  mkdir -p "$relse"
+  : > "$relse/$rname"
+  rm -rf "$rstate/sessR"
+  ln -s "$relse" "$rstate/sessR"
+  t "symlinked session dir does not silence" ask \
+    "$(export WPMGR_ROUTE_GUARD_STATE="$rstate"; decision "$repo/apps/api/internal/site/four.go" "$repo" "" sessR)"
+  rm -f "$rstate/sessR"
+else
+  echo "FAIL  readside fixture: nothing was recorded under $rstate/sessR, so the read-side checks did not run"
+  failed=$((failed+1))
+fi
 
 echo "== route-guard state: a path component is validated, not merely sanitised"
 # sane() is `tr -c 'a-zA-Z0-9._-'`, and '.' is in the keep-set, so the two

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -510,6 +510,55 @@ t "rm the sqlc tree"    deny "$(bdec 'rm -rf apps/api/internal/db/sqlc/')"
 t "python writes sqlc"  deny "$(bdec "python3 -c \"open('apps/api/internal/db/sqlc/db.go','w').write('x')\"")"
 t "write into dead app" deny "$(bdec 'echo x > apps/landing/index.html')"
 
+echo "== bash-guard: the interpreter arm decides on the CALL, in the right direction"
+# The arm's test was `(open\(|writeFile|file_put_contents|\.write\()`, and its
+# polarity was inverted at both ends: it DENIED a read that happened to say
+# `open(` and PERMITTED a `shutil.copy` onto the generated tree, whose
+# hand-editing caused a production 500 here.
+#
+# This suite did not catch it, and the reason is worth keeping in view: both of
+# its python assertions happened to contain the literal token `open(`, so a bare
+# substring match on `open(` would have passed the suite while shipping the bug.
+# An assertion that passes for the wrong reason tests nothing. Every write case
+# below is therefore spelled WITHOUT `open(`, and every read case is spelled
+# with one, so the two halves cannot be satisfied by the same substring.
+t "shutil.copy"          deny "$(bdec "python3 -c \"import shutil; shutil.copy('/tmp/x','apps/api/internal/db/sqlc/db.go')\"")"
+t "shutil.copyfile"      deny "$(bdec "python3 -c \"import shutil; shutil.copyfile('/tmp/x','apps/api/internal/db/sqlc/db.go')\"")"
+t "shutil.move"          deny "$(bdec "python3 -c \"import shutil; shutil.move('/tmp/x','apps/api/internal/api/gen/oas.go')\"")"
+t "pathlib write_text"   deny "$(bdec "python3 -c \"import pathlib; pathlib.Path('apps/api/internal/db/sqlc/db.go').write_text('x')\"")"
+t "pathlib write_bytes"  deny "$(bdec "python3 -c \"import pathlib; pathlib.Path('apps/web/src/routeTree.gen.ts').write_bytes(b'x')\"")"
+t "os.replace"           deny "$(bdec "python3 -c \"import os; os.replace('/tmp/x','apps/api/internal/db/sqlc/db.go')\"")"
+t "os.rename"            deny "$(bdec "python3 -c \"import os; os.rename('/tmp/x','apps/api/internal/db/sqlc/db.go')\"")"
+t "shutil.rmtree"        deny "$(bdec "python3 -c \"import shutil; shutil.rmtree('apps/api/internal/db/sqlc')\"")"
+t "os.remove"            deny "$(bdec "python3 -c \"import os; os.remove('apps/api/internal/db/sqlc/db.go')\"")"
+t "node copyFileSync"    deny "$(bdec "node -e \"require('fs').copyFileSync('/tmp/x','apps/api/internal/db/sqlc/db.go')\"")"
+t "node renameSync"      deny "$(bdec "node -e \"require('fs').renameSync('/tmp/x','apps/web/src/routeTree.gen.ts')\"")"
+t "node appendFileSync"  deny "$(bdec "node -e \"require('fs').appendFileSync('apps/api/internal/api/gen/oas.go','x')\"")"
+t "php copy()"           deny "$(bdec "php -r \"copy('/tmp/x','apps/api/internal/db/sqlc/db.go');\"")"
+t "php rename()"         deny "$(bdec "php -r \"rename('/tmp/x','apps/api/internal/db/sqlc/db.go');\"")"
+t "php unlink()"         deny "$(bdec "php -r \"unlink('apps/api/internal/db/sqlc/db.go');\"")"
+# The mode is what makes an `open` a write, so each mode is asserted, not assumed.
+t "open mode a"          deny "$(bdec "python3 -c \"f = open('apps/api/internal/db/sqlc/db.go','a'); f.close()\"")"
+t "open mode x"          deny "$(bdec "python3 -c \"f = open('apps/api/internal/db/sqlc/db.go','x'); f.close()\"")"
+t "open mode r+"         deny "$(bdec "python3 -c \"f = open('apps/api/internal/db/sqlc/db.go','r+'); f.close()\"")"
+t "open mode wb"         deny "$(bdec "python3 -c \"f = open('apps/api/internal/db/sqlc/db.go','wb'); f.close()\"")"
+t "open mode= keyword"   deny "$(bdec "python3 -c \"f = open('apps/api/internal/db/sqlc/db.go', mode='w'); f.close()\"")"
+
+# ...and the reads. Every one of these was DENIED before, which is the over-fire
+# that gets a guard switched off: the harness would have taught its users that
+# reading a generated file needs a way around the guard.
+t "python read+print"    pass "$(bdec "python3 -c \"print(open('apps/api/internal/db/sqlc/db.go').read())\"")"
+t "python open mode r"   pass "$(bdec "python3 -c \"print(open('apps/api/internal/db/sqlc/db.go','r').read())\"")"
+t "python open mode rb"  pass "$(bdec "python3 -c \"print(open('apps/api/internal/db/sqlc/db.go','rb').read())\"")"
+t "python io.open read"  pass "$(bdec "python3 -c \"import io; print(io.open('apps/api/internal/api/gen/oas.go').read())\"")"
+t "python readlines"     pass "$(bdec "python3 -c \"print(open('apps/web/src/routeTree.gen.ts').readlines()[0])\"")"
+t "pathlib read_text"    pass "$(bdec "python3 -c \"import pathlib; print(pathlib.Path('apps/api/internal/db/sqlc/db.go').read_text())\"")"
+t "node readFileSync"    pass "$(bdec "node -e \"console.log(require('fs').readFileSync('apps/api/internal/db/sqlc/db.go','utf8'))\"")"
+t "php file_get_contents" pass "$(bdec "php -r \"echo file_get_contents('apps/api/internal/db/sqlc/db.go');\"")"
+# A read that prints through the stream object rather than through print(): the
+# only `.write(` here belongs to stdout, and the file is opened for reading.
+t "stdout.write a read"  pass "$(bdec "python3 -c \"import sys; sys.stdout.write(open('apps/api/internal/db/sqlc/db.go').read())\"")"
+
 # ...and the honest cases it must NOT block. Reading, listing and grepping these
 # paths is ordinary work, and the regeneration commands must obviously survive.
 t "grep sqlc to a file" pass "$(bdec 'grep -r Query apps/api/internal/db/sqlc/ > /tmp/out.txt')"
@@ -563,6 +612,53 @@ t "new migration ok"    pass "$(bdecw 'cat > apps/api/migrations/20260201000000_
 CREATE TABLE t();
 EOF')"
 t "reading a migration" pass "$(bdecw 'cat apps/api/migrations/20260101000000_m01_applied.sql')"
+
+echo "== bash-guard: a migrations destination it cannot resolve is refused, not read as 'none matched'"
+# The hole: the applied-migration scan extracts a filename with [A-Za-z0-9_.-]+,
+# a class holding no glob metacharacter, so a pattern matched NOTHING, $applied
+# stayed empty and the whole script fell to its bare `exit 0` - zero bytes on
+# stdout, zero on stderr, and one `*` rewriting every migration that has already
+# run. Each of these was ALLOWED, silently, before the shape check.
+t "sed -i mig glob"      deny "$(bdecw "sed -i.bak 's/a/b/' apps/api/migrations/*.sql")"
+t "tee mig glob"         deny "$(bdecw 'tee apps/api/migrations/*.sql')"
+t "redirect mig glob"    deny "$(bdecw 'echo x > apps/api/migrations/*.sql')"
+t "perl -pi mig glob"    deny "$(bdecw 'perl -pi -e s/a/b/ apps/api/migrations/2026*.sql')"
+t "mig ? wildcard"       deny "$(bdecw 'tee apps/api/migrations/2026010100000?_m01_applied.sql')"
+t "mig [ class"          deny "$(bdecw 'tee apps/api/migrations/2026[01]*.sql')"
+t "mig brace"            deny "$(bdecw 'tee apps/api/migrations/{a,b}.sql')"
+t "mig from a variable"  deny "$(bdecw 'tee apps/api/migrations/$f.sql')"
+t "mig from a subshell"  deny "$(bdecw 'tee apps/api/migrations/`ls`.sql')"
+# The glob is on the SOURCE, and the destination is the directory: the file that
+# lands is whatever the pattern expands to at run time, which is exactly the
+# question this guard cannot answer.
+t "cp glob src into dir" deny "$(bdecw 'cp /tmp/*.sql apps/api/migrations/')"
+# `rm` reaches this arm too (allow_rm is not set here), and deleting every
+# applied migration is the same outage as rewriting them.
+t "rm mig glob"          deny "$(bdecw 'rm apps/api/migrations/*.sql')"
+# ...and the honest work it must NOT block. Creating a new migration is the
+# entire purpose of the directory, and every read of it stays ordinary: none of
+# these is a write, so the arm is never entered and no glob is ever inspected.
+t "new mig, literal"     pass "$(bdecw 'cat > apps/api/migrations/20260201000000_m02_new.sql <<EOF
+CREATE TABLE t();
+EOF')"
+t "new mig then ls glob" pass "$(bdecw 'printf x > apps/api/migrations/20260201000000_m02_new.sql && ls apps/api/migrations/*.sql')"
+t "ls a mig glob"        pass "$(bdecw 'ls -la apps/api/migrations/*.sql')"
+t "cat a mig glob"       pass "$(bdecw 'cat apps/api/migrations/*.sql')"
+t "grep a mig glob"      pass "$(bdecw 'grep -l CREATE apps/api/migrations/*.sql')"
+t "wc a mig glob"        pass "$(bdecw 'wc -l apps/api/migrations/*.sql')"
+t "sed READ a mig glob"  pass "$(bdecw 'sed -n 1,5p apps/api/migrations/*.sql')"
+t "git add a mig glob"   pass "$(bdecw 'git add apps/api/migrations/*.sql')"
+# A glob over a path that merely CONTAINS the word migrations is not this
+# directory, and a sibling directory is not it either.
+t "glob docs/migrations"  pass "$(bdecw "sed -i.bak 's/a/b/' docs/migrations/*.md")"
+t "glob migrations-notes" pass "$(bdecw 'tee apps/api/migrations-notes/*.txt')"
+t "glob elsewhere"        pass "$(bdecw 'tee /tmp/migrations/*.sql')"
+# The message has to name the unresolved destination, or it teaches nothing.
+mig_glob_reason=$(jq -n --arg c 'tee apps/api/migrations/*.sql' --arg w "$repo" \
+  '{cwd:$w, tool_input:{command:$c}}' | bash "$BASH_G" 2>/dev/null \
+  | jq -r '.hookSpecificOutput.permissionDecisionReason // ""')
+tcontains "names the glob"     'apps/api/migrations/\*.sql' "$mig_glob_reason"
+tcontains "says new is ok"     'NEW migration' "$mig_glob_reason"
 
 echo "== bash-guard: the migration arm never goes quiet because it cannot resolve a root"
 # The hole: the arm resolved its repository from `.cwd` ALONE, and when that was

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -1427,7 +1427,11 @@ echo "== commit-gate: only ever answers for what this agent wrote"
 # The deadlock this fixes: a read-only agent was launched into another agent's
 # worktree, told to commit or delete 17 files it had never touched while its
 # brief said not to touch them, and stopped to ask a human.
-GATE="$here/commit-gate.sh"
+# Overridable for the one reason ROUTE is: pointing the suite at a mutated copy
+# to prove an assertion depends on the branch it names. Announced, so a run
+# against something other than the shipped gate is never mistaken for one.
+GATE="${WPMGR_TEST_COMMIT_GATE:-$here/commit-gate.sh}"
+[[ "$GATE" == "$here/commit-gate.sh" ]] || echo "NOTE: commit-gate under test is $GATE (WPMGR_TEST_COMMIT_GATE), NOT the shipped one"
 WRITES="$here/agent-writes.sh"
 export WPMGR_AGENT_WRITES_STATE="$tmp/agent-writes"
 
@@ -1516,6 +1520,92 @@ tcontains "unscoped reports" "Not blocking" "$(jq -n --arg c "$wt" '{cwd:$c}' | 
 t "stop_hook_active passes" 0 \
   "$(jq -n --arg c "$wt" '{cwd:$c, agent_id:"agent-A", stop_hook_active:true}' \
      | bash "$GATE" >/dev/null 2>&1; printf '%s' "$?")"
+
+# A NAME GIT QUOTES. Default porcelain wraps any path carrying a space, a double
+# quote, a backslash, a control character or a non-ASCII byte in double quotes
+# with C-style escapes. The ownership compare matched the record's raw path
+# against that column, so every one of those files failed to match, `owned` came
+# out empty, and the gate exited 0 IN SILENCE - reporting that the agent had
+# committed everything when it had not, which is how unpushed work gets reaped.
+#
+# Pinned as the porcelain FACT first, exactly like `-uall` above, so this reads
+# as a property of git's output rather than as an unexplained assertion, and so
+# a future flag change is caught here and not in production.
+q_space="has space.txt"
+q_utf8=$'na\xc3\xafve.txt'
+q_bslash='back\slash.txt'
+printf 'x\n' > "$wt/$q_space"
+printf 'x\n' > "$wt/$q_utf8"
+printf 'x\n' > "$wt/$q_bslash"
+t "porcelain quotes a space"      '?? "has space.txt"' \
+  "$(git -C "$wt" status --porcelain -uall | grep 'has space')"
+t "-z prints the same path raw"   "?? $q_space" \
+  "$(git -C "$wt" status --porcelain -uall -z | tr '\0' '\n' | grep 'has space')"
+# `-c core.quotePath=false` is NOT the fix and is pinned as such: it unescapes
+# the non-ASCII case only, and a space is quoted regardless because the plain
+# format is space-delimited.
+t "quotePath=false still quotes"  '?? "has space.txt"' \
+  "$(git -C "$wt" -c core.quotePath=false status --porcelain -uall | grep 'has space')"
+
+record agent-Q "$wt/$q_space"
+record agent-Q "$wt/$q_utf8"
+record agent-Q "$wt/$q_bslash"
+t "Q: quoted names block"     2 "$(gate agent-Q)"
+tcontains "Q sees the spaced name"    "has space.txt"  "$(gate_msg agent-Q)"
+tcontains "Q sees the non-ASCII name" "$q_utf8"        "$(gate_msg agent-Q)"
+tcontains "Q sees the backslash name" 'back.slash.txt' "$(gate_msg agent-Q)"
+# The count is read off the fixture, never written down: three files were
+# recorded just above, and the number in the message has to be that one.
+q_n=$(printf '%s\n' "$q_space" "$q_utf8" "$q_bslash" | grep -c .)
+tcontains "Q's count matches the fixture" "$q_n uncommitted path" "$(gate_msg agent-Q)"
+
+# OVER-FIRE, three ways. A quoted name nobody recorded is still nobody's...
+printf 'x\n' > "$wt/not mine.txt"
+tlacks "Q is not shown another quoted name" "not mine.txt" "$(gate_msg agent-Q)"
+# ...a longer name that merely STARTS with a recorded one is a different file...
+printf 'x\n' > "$wt/$q_space.bak"
+tlacks "prefix is not a match"  "has space.txt.bak" "$(gate_msg agent-Q)"
+tcontains "and the count did not move" "$q_n uncommitted path" "$(gate_msg agent-Q)"
+# ...and an agent that wrote nothing is still never blocked, quoted tree or not.
+t "B still passes, quoted or not" 0 "$(gate agent-B)"
+# Committing them makes it go quiet, so this is a gate and not a permanent block.
+git -C "$wt" add "$q_space" "$q_utf8" "$q_bslash" >/dev/null
+git -C "$wt" commit -qm quoted
+t "Q committed, passes"       0 "$(gate agent-Q)"
+
+# A RENAME. Under `-z` git emits `XY <new path><NUL><old path><NUL>`: the origin
+# half is its own record with NO status prefix, so read as an entry its first
+# three characters are swallowed as a status code and the remainder compared as
+# a path. It is dropped instead.
+printf 'r\n' > "$wt/old name.txt"
+git -C "$wt" add "old name.txt" >/dev/null
+git -C "$wt" commit -qm oldname
+git -C "$wt" mv "old name.txt" "new name.txt"
+t "-z rename layout"  "R  new name.txt|old name.txt|" \
+  "$(git -C "$wt" status --porcelain -uall -z | tr '\0' '|' | grep -o 'R  new name.txt|old name.txt|')"
+unscoped_out=$(jq -n --arg c "$wt" '{cwd:$c}' | bash "$GATE" 2>&1 >/dev/null)
+tcontains "the rename is listed once"  "R  new name.txt" "$unscoped_out"
+tlacks    "its origin half is not an entry" "^old name.txt$" "$unscoped_out"
+record agent-RN "$wt/new name.txt"
+t "RN: the renamed path blocks" 2 "$(gate agent-RN)"
+tcontains "RN sees the new path" "new name.txt" "$(gate_msg agent-RN)"
+
+# A `git status` THAT FAILS is not an empty tree. The stub answers `status` with
+# 128 and passes everything else - including the `rev-parse --git-dir` probe
+# above it - through to the real git, which is the only shape in which this
+# branch is reachable.
+gstub="$tmp/gitstub"
+mkdir -p "$gstub"
+printf '#!/bin/sh\nfor a in "$@"; do [ "$a" = status ] && exit 128; done\nexec %s "$@"\n' \
+  "$(command -v git)" > "$gstub/git"
+chmod +x "$gstub/git"
+gfail_rc=$(PATH="$gstub:$PATH" jq -n --arg c "$wt" --arg a agent-Q '{cwd:$c, agent_id:$a}' \
+             | PATH="$gstub:$PATH" bash "$GATE" >/dev/null 2>&1; printf '%s' "$?")
+gfail_out=$(jq -n --arg c "$wt" --arg a agent-Q '{cwd:$c, agent_id:$a}' \
+            | PATH="$gstub:$PATH" bash "$GATE" 2>&1 >/dev/null)
+t "a failed git status does not block"  0 "$gfail_rc"
+tcontains "but it says so, with the exit" "failed in '$wt' (exit 128)" "$gfail_out"
+tcontains "and claims nothing either way" "nothing is claimed" "$gfail_out"
 
 echo "== harness-reap: it removes only worktrees the harness created"
 # The reaper fed `git worktree list` straight into `git worktree remove --force`
@@ -1621,11 +1711,19 @@ t "and the run goes green"           0 "$ok_rc"
 tcontains "a green run says so"     "0 failed" "$ok_out"
 
 echo "== harness-reap: it refuses to act from anywhere but the root it resolved"
-# SC2164. `cd "$root"` was unchecked, and everything after it - `git worktree
-# remove --force`, `git branch -d`, `go clean -cache`, and the rev-parse that
-# picks the base branch - resolves its repository from the CURRENT DIRECTORY,
-# not from $root. A failed cd therefore did not stop the script; it re-aimed
-# every destructive command at whatever directory the caller was standing in.
+# SC2164. `cd "$root"` was unchecked, and the three GIT commands after it - `git
+# worktree remove --force`, `git branch -d`, and the rev-parse that picks the
+# base branch - resolve their repository from the CURRENT DIRECTORY, not from
+# $root. A failed cd therefore did not stop the script; it re-aimed every
+# destructive git command at whatever directory the caller was standing in.
+#
+# This comment used to name `go clean -cache` as a fourth, and that was false.
+# `go clean -cache` wipes the machine-wide directory `go env GOCACHE` names,
+# which is the same directory from every cwd, so the cd guard neither protects
+# it nor ever could; --apply plus the ceiling check is what stands in front of
+# it. The assertions below passed either way - they are about the git half - so
+# the false premise cost nothing here and was still a claim of coverage this
+# proof does not have.
 #
 # The failure is planted the only way a `cd` to a directory that git just
 # resolved can honestly be made to fail: an exported shell function shadows the
@@ -1657,6 +1755,149 @@ t "a failed cd goes red"           2   "$brk_rc"
 tcontains "and states the reason"  "cannot enter the repository root" "$brk_out"
 t "and nothing was removed"        yes "$(exists "$cdr/.claude/worktrees/agent-cd1")"
 tlacks "no reclaim is claimed"     "removed," "$brk_out"
+
+echo "== harness-reap: a build cache it could not measure is not a cache under the ceiling"
+# The one place in that file where its own countof()/sizeof() discipline was not
+# applied: `kb=$(du -sk "$gocache" | cut -f1)` fed an arithmetic expansion, so a
+# failed du became the empty string, `${kb:-0}` became 0, 0 is below every
+# ceiling, and the section printed "under the ceiling, leaving it". A
+# measurement that never happened, reported as a measurement.
+#
+# `go` and `docker` are stubbed alongside `du` so the section is reachable
+# without a toolchain and without waiting on a docker daemon; the reaper is run
+# WITHOUT --worktrees-only, because that flag skips the section under test.
+rstub="$tmp/reapstub"
+mkdir -p "$rstub"
+fake_cache="$tmp/fakecache"
+mkdir -p "$fake_cache"
+printf 'x\n' > "$fake_cache/blob"
+printf '#!/bin/sh\nif [ "$1" = env ] && [ "$2" = GOCACHE ]; then printf "%%s\\n" "$FAKE_GOCACHE"; exit 0; fi\nif [ "$1" = env ]; then exit 0; fi\nexit 0\n' > "$rstub/go"
+printf '#!/bin/sh\nexit 1\n' > "$rstub/docker"
+chmod +x "$rstub/go" "$rstub/docker"
+# A `du` that fails the way a real one does: no output, non-zero status.
+dustub="$tmp/dustub"
+mkdir -p "$dustub"
+printf '#!/bin/sh\nexit 1\n' > "$dustub/du"
+chmod +x "$dustub/du"
+
+# No helper function here: a function called in `$( )` runs in a SUBSHELL, so an
+# exit code it stashed in a variable never comes back, and reading one that was
+# never set is how this block first failed. The status is taken from the command
+# substitution itself, where `$?` is the reaper's own.
+#
+# FIRES: du fails, so no decision is made and the run goes red.
+du_out=$(cd "$cdr" && PATH="$dustub:$rstub:$PATH" FAKE_GOCACHE="$fake_cache" bash "$REAP" 2>&1); du_rc=$?
+tcontains "an unmeasurable cache says so" "COULD NOT MEASURE the build cache" "$du_out"
+tlacks "and never decides to leave it"    "leaving it"         "$du_out"
+tlacks "and cleans nothing"               "go clean -cache"    "$du_out"
+t "and the run goes red"               1  "$du_rc"
+
+# ...and the sharper shape, which is the one a real `du` produces: it prints a
+# plausible PARTIAL total and exits non-zero because it could not descend into
+# something. A number is there to be read, and it is not the size of the cache.
+# Only the status says so, which is why sizeof() has to return it.
+dupart="$tmp/dupartial"
+mkdir -p "$dupart"
+printf '#!/bin/sh\nprintf "12\\t%%s\\n" "$2"\nexit 1\n' > "$dupart/du"
+chmod +x "$dupart/du"
+part_out=$(cd "$cdr" && PATH="$dupart:$rstub:$PATH" FAKE_GOCACHE="$fake_cache" bash "$REAP" 2>&1); part_rc=$?
+tcontains "a partial du is not a size"  "COULD NOT MEASURE the build cache" "$part_out"
+tlacks "and it is not left as measured" "leaving it" "$part_out"
+t "and that run goes red"            1  "$part_rc"
+
+# DOES NOT OVER-FIRE: the same cache with a working du is measured, found small,
+# left alone, and the run is green. The size is named in the sentence, so a
+# reader can see WHICH number was compared against the ceiling.
+ok_out=$(cd "$cdr" && PATH="$rstub:$PATH" FAKE_GOCACHE="$fake_cache" bash "$REAP" 2>&1); ok_rc=$?
+tcontains "a measured small cache is left" "ceiling, leaving it" "$ok_out"
+tlacks "and is not called unmeasurable"    "COULD NOT MEASURE" "$ok_out"
+t "and that run goes green"             0  "$ok_rc"
+
+# ...and a GOCACHE that could not even be asked for is not "no cache to clean".
+nogo="$tmp/nogostub"
+mkdir -p "$nogo"
+printf '#!/bin/sh\nexit 1\n' > "$nogo/go"
+chmod +x "$nogo/go"
+nogo_out=$(cd "$cdr" && PATH="$nogo:$rstub:$PATH" bash "$REAP" 2>&1); nogo_rc=$?
+tcontains "no GOCACHE answer says so" "returned nothing" "$nogo_out"
+t "and that run goes red too"       1  "$nogo_rc"
+
+echo "== --help prints the whole comment header, never a hardcoded line range"
+# Both of these were mis-slicing in the shipped tree, not hypothetically:
+# quickstart-selfhost.sh's `sed -n '3,42p'` stopped two lines short and dropped
+# two of the three lines under "Host requirements" from the README's headline
+# install script; init-env.sh's `sed -n '3,31p'` overran by one and printed
+# `set -euo pipefail` to the user as help text.
+#
+# The header is re-derived here with a DIFFERENT idiom from the awk under test -
+# sed, quitting at the first non-comment - so this is a comparison and not the
+# same expression written twice.
+real_repo=$(cd "$here/../.." && pwd)
+help_covers() { # help_covers <script> -> "yes" or the first line it dropped
+  local f=$1 out line stripped
+  out=$(bash "$f" --help 2>&1) || { printf '--help exited %s' "$?"; return 1; }
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    stripped=$(printf '%s' "$line" | sed 's/^#\{0,1\} \{0,1\}//')
+    grep -qxF -- "$line" <<<"$out" && continue
+    grep -qxF -- "$stripped" <<<"$out" && continue
+    printf 'DROPPED: %s' "$line"
+    return 1
+  done < <(sed -n '2,$p' "$f" | sed -n '/^#/!q;p')
+  printf 'yes'
+}
+first_code() { awk 'NR>1 && !/^#/ {print; exit}' "$1"; }
+for hs in scripts/quickstart-selfhost.sh scripts/init-env.sh \
+          scripts/claude/harness-reap.sh scripts/claude/route-guard-coverage.sh; do
+  t "$hs: --help covers its whole header" yes "$(help_covers "$real_repo/$hs")"
+  tlacks "$hs: --help stops at the code" \
+    "$(first_code "$real_repo/$hs")" "$(bash "$real_repo/$hs" --help 2>&1)"
+  # ...and asking for help is not a failure. init-env.sh exited 1 here: its EXIT
+  # trap ended on `[ -n "${GEN_FILE}" ]`, false on every run that minted no temp
+  # file, and a trap's return value REPLACES the script's exit status.
+  t "$hs: --help exits 0" 0 "$(bash "$real_repo/$hs" --help >/dev/null 2>&1; printf '%s' "$?")"
+done
+# Named explicitly, because these three lines are the ones that were missing and
+# a coverage loop that silently stopped matching would go green again.
+qs_help=$(bash "$real_repo/scripts/quickstart-selfhost.sh" --help 2>&1)
+tcontains "quickstart help: docker req"  "Docker 24+"  "$qs_help"
+tcontains "quickstart help: curl req"    "curl or wget" "$qs_help"
+tcontains "quickstart help: openssl req" "openssl"      "$qs_help"
+
+echo "== docs-writer's banned-vocabulary snippet refuses what it cannot count once"
+# `grep -oE` prints EVERY match, so a second `banned='...'` made the extraction
+# two lines and both counts became their SUM - printed with no hint that more
+# than one list existed, and larger than the list CI would actually apply. The
+# reassuring direction, on the check that guards the clean-room boundary.
+#
+# The snippet is extracted from the agent definition and run, so this proves the
+# committed text rather than a copy of it that can drift away from it.
+snip="$tmp/banned_counts.sh"
+awk '/^banned_counts\(\) \{/{f=1} f{print} f && /^\}$/{exit}' \
+  "$real_repo/.claude/agents/docs-writer.md" > "$snip"
+t "snippet extracted from the agent file" yes "$([[ -s "$snip" ]] && printf yes || printf no)"
+# shellcheck source=/dev/null
+. "$snip"
+bc_rc() { banned_counts "$1" >/dev/null 2>&1; printf '%s' "$?"; }
+ci_yml="$real_repo/.github/workflows/ci.yml"
+# The honest case first, or every refusal below could be satisfied by a function
+# that refuses everything.
+t "the real ci.yml is accepted"       0 "$(bc_rc "$ci_yml")"
+tcontains "and it reports alternates" "alternates" "$(banned_counts "$ci_yml" 2>&1)"
+# FIRES: a second assignment. The count it prints is the count it found, so this
+# assertion cannot go stale against the real list's length.
+bc_dup="$tmp/ci-dup.yml"
+cp "$ci_yml" "$bc_dup"
+printf "          banned='zzalpha|zzbeta'\n" >> "$bc_dup"
+bc_found=$(grep -oE "banned='[^']+'" "$bc_dup" | grep -c .)
+t "a duplicate banned= is refused"    1 "$(bc_rc "$bc_dup")"
+tcontains "and it says how many"  "found $bc_found single-line" "$(banned_counts "$bc_dup" 2>&1)"
+tlacks "and prints no summed total" "alternates" "$(banned_counts "$bc_dup" 2>&1)"
+# ...and the two directions it already refused stay refused.
+bc_none="$tmp/ci-none.yml"
+grep -v "banned='" "$ci_yml" > "$bc_none"
+t "no banned= at all is refused"      1 "$(bc_rc "$bc_none")"
+t "an unreadable file is refused"     1 "$(bc_rc "$tmp/no-such-workflow.yml")"
 
 # ...and the honest direction, or a reaper that refused unconditionally would
 # pass every assertion above while reclaiming nothing. Same repo, same flags,

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -1889,7 +1889,27 @@ for hs in scripts/quickstart-selfhost.sh scripts/init-env.sh \
   # trap ended on `[ -n "${GEN_FILE}" ]`, false on every run that minted no temp
   # file, and a trap's return value REPLACES the script's exit status.
   t "$hs: --help exits 0" 0 "$(bash "$real_repo/$hs" --help >/dev/null 2>&1; printf '%s' "$?")"
+  # ...and the SHEBANG is not help text. `#!/usr/bin/env bash` is a comment line
+  # to awk, so `!/^#/{exit} {print}' printed it as the first line of the help
+  # output in harness-reap.sh and route-guard-coverage.sh. help_covers above
+  # cannot see this: it re-derives the header with `sed -n '2,$p'`, which skips
+  # line 1, and it only asks whether anything was DROPPED - an EXTRA line is
+  # invisible to it. So reverting the awk in either script reddened nothing.
+  t "$hs: --help does not print the shebang" "" \
+    "$(bash "$real_repo/$hs" --help 2>&1 | head -1 | grep '^#!' )"
 done
+# The failure path of help_covers itself, which is the only path where its
+# diagnostic is ever built. On a healthy script `--help` exits 0 and that printf
+# never runs, so a format string bash could not parse sat there unexercised: it
+# began `--`, which bash 3.2.57's printf builtin reads as its own option list,
+# and the branch returned the empty string with `printf: --: invalid option` on
+# stderr instead of the exit code it meant to report.
+badhelp="$tmp/bad-help.sh"
+printf '%s\n' '#!/usr/bin/env bash' '# a header' 'exit 7' > "$badhelp"
+chmod +x "$badhelp"
+t "help_covers reports the exit code" "--help exited 7" "$(help_covers "$badhelp" 2>/dev/null)"
+t "and builds it without a printf error" "" \
+  "$(help_covers "$badhelp" 2>&1 >/dev/null)"
 # Named explicitly, because these three lines are the ones that were missing and
 # a coverage loop that silently stopped matching would go green again.
 qs_help=$(bash "$real_repo/scripts/quickstart-selfhost.sh" --help 2>&1)
@@ -3312,6 +3332,13 @@ t "node openSync a"           deny \
   "$(bdec_at "$repo" "node -e \"require(${q}fs${q}).openSync(${q}apps/api/internal/db/sqlc/db.go${q},${q}a${q})\"")"
 t "node writeSync after open" deny \
   "$(bdec_at "$repo" "node -e \"const f=require(${q}fs${q}); const d=f.openSync(${q}apps/api/internal/db/sqlc/db.go${q},${q}w${q}); f.writeSync(d,${q}x${q})\"")"
+# writeSync WITHOUT an openSync in the same segment, or the assertion above is
+# satisfied by the openSync pattern alone and deleting writeSync reddens
+# nothing. Proved: with only the openSync alternative removed, the combined
+# command still denied. `\.write\(` needs the paren right after `write` and
+# `writeFile` is a different name, so this shape was matched by neither.
+t "node writeSync on its own"  deny \
+  "$(bdec_at "$repo" "node -e \"require(${q}fs${q}).writeSync(3,${q}x${q},0,${q}apps/api/internal/db/sqlc/db.go${q})\"")"
 # DOES NOT OVER-FIRE: the read forms of the same two calls. Refusing a read is
 # what taught the previous version's users to route around this arm.
 t "python fileinput, no inplace" pass \
@@ -3419,6 +3446,20 @@ t "a deny-everything guard is refused" 1 "$deny_rc"
 tcontains "and the pass probe names it" "zz-coverage-selftest.txt" "$deny_out"
 t "an ask-everything guard is refused"  1 "$ask_rc"
 tcontains "and the deny probe names it" "sqlc/zz_coverage_selftest.go" "$ask_out"
+# The ASK probe needed its own stub. The two above are both caught by the pass
+# and deny probes, so deleting the ask probe left this suite green - the same
+# unpinned-fix shape this whole section exists for, one level down. This guard
+# gets the deny and the pass right and answers `pass` where the routing table
+# says `ask`, which is precisely the "routes nothing to a specialist" guard the
+# self-test is there to reject.
+noask="$tmp/no-ask-guard.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'p=$(cat)' \
+  'case "$p" in *db/sqlc*) jq -n '"'"'{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"x"}}'"'"' ;; esac' \
+  'exit 0' > "$noask"
+chmod +x "$noask"
+noask_out=$(cd "$here/../.." && bash "$COV" --since '30 days ago' --guard "$noask" 2>&1); noask_rc=$?
+t "a guard that never asks is refused"  1 "$noask_rc"
+tcontains "and the ask probe names it" "zzcoverage/zz_coverage_selftest.go" "$noask_out"
 # DOES NOT OVER-FIRE: the SHIPPED guard passes its own self-test and a rate is
 # printed. Without this the four assertions above are satisfied by a self-test
 # that refuses everything, which measures nothing and blocks the real script.

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -1895,8 +1895,15 @@ for hs in scripts/quickstart-selfhost.sh scripts/init-env.sh \
   # cannot see this: it re-derives the header with `sed -n '2,$p'`, which skips
   # line 1, and it only asks whether anything was DROPPED - an EXTRA line is
   # invisible to it. So reverting the awk in either script reddened nothing.
+  #
+  # BOTH SPELLINGS. quickstart-selfhost.sh and init-env.sh pipe the awk through
+  # `sed 's/^#\{0,1\} \{0,1\}//'` to strip the comment marker, so a leaked
+  # shebang reaches the reader as `!/usr/bin/env bash` with no `#`. A needle
+  # anchored on `^#!` matched neither of those two, and reverting their awk
+  # reddened nothing while this line sat in the loop looking like it covered all
+  # four.
   t "$hs: --help does not print the shebang" "" \
-    "$(bash "$real_repo/$hs" --help 2>&1 | head -1 | grep '^#!' )"
+    "$(bash "$real_repo/$hs" --help 2>&1 | head -1 | grep -E '^#?!/' )"
 done
 # The failure path of help_covers itself, which is the only path where its
 # diagnostic is ever built. On a healthy script `--help` exits 0 and that printf

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -3385,14 +3385,27 @@ t "cd: tee into ogen"           deny "$(bdec_at "$repo" 'cd apps/api && echo x |
 t "cd: dd of= into sqlc"        deny "$(bdec_at "$repo" 'cd apps/api && dd if=/tmp/x of=internal/db/sqlc/db.go')"
 # `..`, `-` in a directory name and pushd/popd are the tracker's own arithmetic,
 # not the write arm's, so they are asserted through a write.
-t "cd .. then down again"       deny "$(bdec_at "$sub_api" 'cd ../api && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
+# From the ROOT and via a sibling, so the payload-cwd rebase cannot reach the
+# protected path on its own. Written as cwd=apps/api plus `cd ../api` first, it
+# stayed green with cd tracking deleted outright: rebasing onto apps/api gave the
+# same answer, and the assertion pinned nothing.
+t "cd .. then down again"       deny "$(bdec_at "$repo" 'cd apps/web && cd ../api && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
 # From a cwd that is in NO checkout, so the repository has to come from where
 # the `cd` went. The sqlc tree and not a migration: which migrations are applied
 # is read from HEAD, and that lookup still starts from the payload's cwd, so a
 # migration named from outside any worktree is a gap this change does not close.
 t "cd absolute, cwd outside"    deny "$(bdec_at /tmp "cd $repo/apps/api && sed -i.bak s/a/b/ internal/db/sqlc/db.go")"
 t "pushd then write"            deny "$(bdec_at "$repo" 'pushd apps/api > /dev/null && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
-t "pushd then popd then write"  deny "$(bdec_at "$sub_api" 'pushd /tmp > /dev/null && popd > /dev/null && sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
+# The popd has to be the ONLY thing that puts the shell back in apps/api, or the
+# assertion is satisfied by the payload-cwd rebase and pins nothing. Written the
+# obvious way first - cwd=apps/api, pushd /tmp, popd, write - it stayed green
+# with the whole popd branch replaced by `if false`, because rebasing onto the
+# payload's cwd gave the same answer. So the payload's cwd is the REPO ROOT
+# here, from which the operand below is not protected.
+t "pushd then popd then write"  deny "$(bdec_at "$repo" 'cd apps/api && pushd /tmp > /dev/null && popd > /dev/null && sed -i.bak s/a/b/ internal/db/sqlc/db.go')"
+# And its premise: without the popd, the same command must NOT deny, or the
+# assertion above would pass with the pushd/popd pair doing nothing at all.
+t "  premise: no popd, no deny"  pass "$(bdec_at "$repo" 'cd apps/api && pushd /tmp > /dev/null && sed -i.bak s/a/b/ internal/db/sqlc/db.go')"
 # DOES NOT OVER-FIRE. A `cd` is how everyone in this repo works, so every one of
 # these has to stay ordinary, from the root AND from a subdirectory.
 t "cd: new migration"           pass "$(bdec_at "$repo" 'cd apps/api/migrations && cat > 20260813000000_m99_new.sql')"

--- a/scripts/claude/guards_test.sh
+++ b/scripts/claude/guards_test.sh
@@ -35,7 +35,12 @@ ROUTE="${WPMGR_TEST_ROUTE_GUARD:-$here/route-guard.sh}"
 [[ "$ROUTE" == "$here/route-guard.sh" ]] || echo "NOTE: route-guard under test is $ROUTE (WPMGR_TEST_ROUTE_GUARD), NOT the shipped one"
 BASH_G="$here/bash-guard.sh"
 
-command -v jq >/dev/null 2>&1 || { echo "SKIP: jq is not installed, and the guards fail open without it"; exit 0; }
+# RED, not SKIP. This used to print "SKIP: jq is not installed, and the guards
+# fail open without it" and exit 0, so the one machine state in which the guards
+# were most degraded was also the one state in which their suite reported
+# success. A suite that goes green when it ran nothing is the same defect the
+# guards themselves exist to close, one layer up.
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed. This suite builds every hook payload with it, so it cannot run - and the guards it tests now REFUSE (exit 2) rather than fail open, so this is not a machine you can work on. Fix: brew install jq" >&2; exit 1; }
 
 tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/repo"
@@ -1813,6 +1818,29 @@ tcontains "a measured small cache is left" "ceiling, leaving it" "$ok_out"
 tlacks "and is not called unmeasurable"    "COULD NOT MEASURE" "$ok_out"
 t "and that run goes green"             0  "$ok_rc"
 
+# The ceiling test is `[[ $kbrc -ne 0 ]] || ! [[ "$kb" =~ ^[0-9]+$ ]]`, and the
+# two halves answer different questions. Deleting either one alone used to leave
+# this suite fully green, which means neither was pinned and the guard's own
+# rule - prove it fires - was unmet for both. One stub per half, so a mutation
+# of either is named by the assertion that catches it:
+#
+#   the STATUS half   is pinned by the partial-du stub above: a plausible `12`
+#                     with a non-zero exit. The regex alone passes it.
+#   the SHAPE half    is pinned here: exit 0, so the status alone passes it, and
+#                     a first field that is not a number. `du` answers this way
+#                     on a filesystem whose reporting tool prints a unit, and
+#                     `$(( kb / 1024 / 1024 ))` on a non-number is 0 in bash -
+#                     under every ceiling, the exact silent pass this refuses.
+dushape="$tmp/dushape"
+mkdir -p "$dushape"
+printf '#!/bin/sh\nprintf "12K\\t%%s\\n" "$2"\nexit 0\n' > "$dushape/du"
+chmod +x "$dushape/du"
+shape_out=$(cd "$cdr" && PATH="$dushape:$rstub:$PATH" FAKE_GOCACHE="$fake_cache" bash "$REAP" 2>&1); shape_rc=$?
+tcontains "a non-numeric du is not a size" "COULD NOT MEASURE the build cache" "$shape_out"
+tcontains "and the unreadable value is quoted back" "gave '12K'" "$shape_out"
+tlacks "and it is not left as measured too" "leaving it" "$shape_out"
+t "and the shape run goes red"          1  "$shape_rc"
+
 # ...and a GOCACHE that could not even be asked for is not "no cache to clean".
 nogo="$tmp/nogostub"
 mkdir -p "$nogo"
@@ -1835,7 +1863,12 @@ echo "== --help prints the whole comment header, never a hardcoded line range"
 real_repo=$(cd "$here/../.." && pwd)
 help_covers() { # help_covers <script> -> "yes" or the first line it dropped
   local f=$1 out line stripped
-  out=$(bash "$f" --help 2>&1) || { printf '--help exited %s' "$?"; return 1; }
+  # `printf --` first, because bash 3.2.57's builtin parses a format string
+  # starting with `--` as its own option list: this line used to be
+  # `printf '--help exited %s' "$?"` and printed `printf: --: invalid option`
+  # to stderr while returning the empty string, so the assertion reported
+  # nothing at all where it meant to report the exit code.
+  out=$(bash "$f" --help 2>&1) || { printf -- '--help exited %s' "$?"; return 1; }
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     stripped=$(printf '%s' "$line" | sed 's/^#\{0,1\} \{0,1\}//')
@@ -2637,9 +2670,16 @@ t "outside a repo: still exits 0"      0 "$sb_out_rc"
 tcontains "outside a repo: still reports" "## Machine state" "$sb_out"
 tcontains "outside a repo: COULD NOT CHECK" "pre-push hook: COULD NOT CHECK" "$sb_out"
 tcontains "and the worktree count is not invented" "agent worktrees: not measured" "$sb_out"
-# 2. jq must be present, or the brief announces the guards INACTIVE - a line
-#    that would otherwise sit in the output unremarked and unexplained.
-tlacks "and jq is not missing" "INACTIVE" "$sb_zero"
+# 2. jq must be present, or the brief announces that the guards refuse
+#    everything - a line that would otherwise sit in the output unremarked and
+#    unexplained. The needle is taken from the brief's own source rather than
+#    written out here: when that sentence changed from "are INACTIVE" to
+#    "REFUSE EVERYTHING" this assertion kept passing against a string the script
+#    no longer contains, which is a test asserting nothing.
+jq_line=$(grep -o 'route-guard and bash-guard [A-Z][A-Z ]*[A-Z]' "$BRIEF" | head -1)
+t "the brief has a jq-missing line" 1 \
+  "$( [[ -n "$jq_line" ]] && printf 1 || printf 0 )"
+tlacks "and jq is not missing" "$jq_line" "$sb_zero"
 # 3. A positive measurement, not merely the absence of a complaint: a real
 #    number for disk free proves df AND awk AND the pipeline all ran under the
 #    built PATH. Degrade any of them and this becomes "could not measure".
@@ -3190,6 +3230,202 @@ t "real: :main deletes too"   refused  "$(pushed origin :main)"
 t "real: main survived both"  "$main_before" "$(git -C "$bare" rev-parse refs/heads/main)"
 # The escape hatch the refusal advertises has to be real, or the message lies.
 newcommit; t "real: --no-verify lands"  ok "$(pushed --no-verify origin main)"
+
+echo "== bash-guard: the destination is resolved against the PAYLOAD's cwd"
+# Every arm of arm 3 matched repo-relative TEXT, and nothing rebased an operand.
+# So working from a subdirectory - the ordinary way to work in this repo -
+# bypassed all of them. Reproduced against the shipped guard, all silent:
+#   cwd=<repo>/apps/api   sed -i.bak s/a/b/ migrations/*.sql        -> no decision
+#   cwd=<repo>            sed -i.bak s/a/b/ apps/api/migrations/*.sql -> deny
+# Same command, same file, opposite answers, decided by which directory the
+# session happened to be sitting in.
+#
+# The guard's own cwd is NOT the payload's - it runs wherever the harness
+# started it - so every assertion here passes the cwd in the JSON and none of
+# them relies on $PWD.
+bdec_at() { # bdec_at <cwd> <command>
+  local out
+  out=$(jq -n --arg c "$1" --arg x "$2" '{cwd:$c, tool_input:{command:$x}}' \
+        | bash "$BASH_G" 2>/dev/null \
+        | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  printf '%s' "${out:-pass}"
+}
+sub_api="$repo/apps/api"
+t "subdir: glob over migrations"   deny "$(bdec_at "$sub_api" 'sed -i.bak s/a/b/ migrations/*.sql')"
+t "subdir: applied migration"      deny "$(bdec_at "$sub_api" 'sed -i.bak s/a/b/ migrations/20260101000000_m01_applied.sql')"
+t "subdir: sed -i into sqlc"       deny "$(bdec_at "$sub_api" 'sed -i.bak s/a/b/ internal/db/sqlc/db.go')"
+t "subdir: cp into sqlc"           deny "$(bdec_at "$sub_api" 'cp /tmp/db.go internal/db/sqlc/db.go')"
+t "subdir: cp into the mig dir"    deny "$(bdec_at "$sub_api" 'cp /tmp/20260101000000_m01_applied.sql migrations')"
+t "subdir: tee into ogen"          deny "$(bdec_at "$sub_api" 'echo x | tee internal/api/gen/oas.go')"
+t "subdir: redirect into dead app" deny "$(bdec_at "$repo/apps" 'echo x > landing/index.html')"
+t "subdir: rm the sqlc tree"       deny "$(bdec_at "$sub_api" 'rm -rf internal/db/sqlc/')"
+# An ABSOLUTE destination is the same file by another spelling, and was equally
+# unmatched: the arms are written in repo-relative terms and nothing stripped
+# the root.
+t "absolute: applied migration"    deny "$(bdec_at "$repo" "sed -i.bak s/a/b/ $repo/apps/api/migrations/20260101000000_m01_applied.sql")"
+t "absolute: sqlc tree"            deny "$(bdec_at "$repo" "cp /tmp/db.go $repo/apps/api/internal/db/sqlc/db.go")"
+# DOES NOT OVER-FIRE. A subdirectory cwd must not turn ordinary work red, and
+# these are the shapes that would get the guard switched off.
+t "subdir: new migration"          pass "$(bdec_at "$sub_api" 'cat > migrations/20260813000000_m99_new.sql')"
+t "subdir: ls the mig dir"         pass "$(bdec_at "$sub_api" 'ls migrations/*.sql')"
+t "subdir: sed -n over a glob"     pass "$(bdec_at "$sub_api" 'sed -n 1,5p migrations/*.sql')"
+t "subdir: git log over the dir"   pass "$(bdec_at "$sub_api" 'git log --oneline -- migrations')"
+t "subdir: grep the sqlc tree"     pass "$(bdec_at "$sub_api" 'grep -r Querier internal/db/sqlc/ > /tmp/out')"
+t "subdir: write outside the repo" pass "$(bdec_at "$sub_api" 'cp /tmp/x ../../../elsewhere/x')"
+t "subdir: a same-named sibling"   pass "$(bdec_at "$sub_api" 'cp /tmp/x migrations-notes.txt')"
+t "outside repo cwd: /tmp write"   pass "$(bdec_at /tmp 'cp /tmp/a /tmp/b')"
+# A cwd that is not a directory, and one that is outside any checkout, must not
+# crash the guard or make it answer about a repo it never found. The migrations
+# arm has its own loud refusal for the no-repository case and that is asserted
+# elsewhere; what is asserted here is that an ordinary command still passes.
+t "nonexistent cwd still decides"  pass "$(bdec_at "$tmp/no-such-dir" 'echo hello')"
+
+echo "== bash-guard: a .. or /./ segment is not a different file"
+# Five spellings, each resolving to a protected file, each PERMITTED in silence
+# by the shipped guard. Normalisation is LEXICAL: the destination of a write
+# usually does not exist yet, so realpath/readlink -f would fail or answer about
+# the parent, and resolving a symlink at guard time answers a different question
+# from the one the command asks a moment later.
+t "..  into the migrations dir" deny "$(bdec_at "$repo" 'sed -i.bak s/a/b/ apps/api/../api/migrations/20260101000000_m01_applied.sql')"
+t ".. inside the migrations dir" deny "$(bdec_at "$repo" 'sed -i.bak s/a/b/ apps/api/migrations/../migrations/20260101000000_m01_applied.sql')"
+t ".. into the sqlc tree"       deny "$(bdec_at "$repo" 'cp /tmp/x apps/api/internal/db/../db/sqlc/db.go')"
+t "/./ into the migrations dir" deny "$(bdec_at "$repo" 'sed -i.bak s/a/b/ apps/./api/migrations/20260101000000_m01_applied.sql')"
+t ".. into the dead app"        deny "$(bdec_at "$repo" 'echo x > apps/landing/../landing/index.html')"
+t ".. plus a glob"              deny "$(bdec_at "$repo" 'sed -i.bak s/a/b/ apps/api/../api/migrations/*.sql')"
+t ".. from a subdirectory"      deny "$(bdec_at "$sub_api" 'sed -i.bak s/a/b/ ../api/migrations/20260101000000_m01_applied.sql')"
+t ".. in an absolute path"      deny "$(bdec_at "$repo" "cp /tmp/x $repo/apps/api/../api/internal/db/sqlc/db.go")"
+# DOES NOT OVER-FIRE: a `..` that genuinely leaves the protected tree, and one
+# that leaves the repository altogether, are ordinary.
+t ".. out of the mig dir"       pass "$(bdec_at "$repo" 'cp /tmp/x apps/api/migrations/../notes.txt')"
+t ".. above the repo root"      pass "$(bdec_at "$repo" 'cp /tmp/x ../outside/apps/api/migrations/x.sql')"
+t "a dir literally named .."    pass "$(bdec_at "$repo" 'cp /tmp/x apps/api/migrations-old/../notes.txt')"
+
+echo "== bash-guard: two interpreter in-place writes that named no write call"
+q="'"
+t "python fileinput inplace" deny \
+  "$(bdec_at "$repo" "python3 -c \"import fileinput; [print(l) for l in fileinput.input(${q}apps/api/internal/db/sqlc/db.go${q}, inplace=True)]\"")"
+t "python fileinput inplace=1" deny \
+  "$(bdec_at "$repo" "python3 -c \"import fileinput; [print(l) for l in fileinput.input(${q}apps/api/internal/db/sqlc/db.go${q}, inplace=1)]\"")"
+t "node openSync w truncates" deny \
+  "$(bdec_at "$repo" "node -e \"require(${q}fs${q}).openSync(${q}apps/api/internal/db/sqlc/db.go${q},${q}w${q})\"")"
+t "node openSync a"           deny \
+  "$(bdec_at "$repo" "node -e \"require(${q}fs${q}).openSync(${q}apps/api/internal/db/sqlc/db.go${q},${q}a${q})\"")"
+t "node writeSync after open" deny \
+  "$(bdec_at "$repo" "node -e \"const f=require(${q}fs${q}); const d=f.openSync(${q}apps/api/internal/db/sqlc/db.go${q},${q}w${q}); f.writeSync(d,${q}x${q})\"")"
+# DOES NOT OVER-FIRE: the read forms of the same two calls. Refusing a read is
+# what taught the previous version's users to route around this arm.
+t "python fileinput, no inplace" pass \
+  "$(bdec_at "$repo" "python3 -c \"import fileinput; [print(l) for l in fileinput.input(${q}apps/api/internal/db/sqlc/db.go${q})]\"")"
+t "node openSync r"              pass \
+  "$(bdec_at "$repo" "node -e \"require(${q}fs${q}).openSync(${q}apps/api/internal/db/sqlc/db.go${q},${q}r${q})\"")"
+t "python open() read"           pass \
+  "$(bdec_at "$repo" "python3 -c \"print(open(${q}apps/api/internal/db/sqlc/db.go${q}).read())\"")"
+t "the word fileinput alone"     pass \
+  "$(bdec_at "$repo" 'grep -n fileinput apps/api/internal/db/sqlc/db.go')"
+
+echo "== bash-guard and route-guard REFUSE when jq is missing, never disappear"
+# Measured against the shipped guards before this: with jq off PATH, a write to
+# an applied migration, a glob over the migrations directory and a write into
+# the sqlc tree all returned zero bytes and no stderr. `command -v jq || exit 0`
+# is the whole cause, and a session brief line printed once is not a
+# compensating control for three denies that have vanished.
+#
+# A PATH THIS BLOCK BUILDS, the same idiom as the tr fixture above: linking
+# exactly the binaries the guards need means the absence of jq is decided here
+# and not by whatever the developer has installed.
+nojq="$tmp/no-jq"; mkdir -p "$nojq"
+for b in bash cat git grep sed awk sort tr find head tail date mktemp rm; do
+  bp=$(command -v "$b" 2>/dev/null)
+  [[ "$bp" == /* && -x "$bp" ]] && ln -sf "$bp" "$nojq/$b"
+done
+# The premise, asserted rather than assumed: this PATH really does lack jq.
+# Without it every refusal below could be refusing for some other reason.
+t "fixture: no jq on the stripped PATH" "" "$(PATH="$nojq" command -v jq 2>/dev/null)"
+t "fixture: bash is still there" "$nojq/bash" "$(PATH="$nojq" command -v bash 2>/dev/null)"
+
+nojq_bash() { # nojq_bash <command> -> "<rc>:<bytes of stderr>"
+  local err rc
+  err=$(jq -n --arg c "$repo" --arg x "$1" '{cwd:$c, tool_input:{command:$x}}' \
+        | PATH="$nojq" bash "$BASH_G" 2>&1 >/dev/null); rc=$?
+  printf '%s:%s' "$rc" "$([[ -n "$err" ]] && echo loud || echo silent)"
+}
+nojq_route() { # nojq_route <abs path> -> "<rc>:<loud|silent>"
+  local err rc
+  err=$(jq -n --arg c "$repo" --arg p "$1" '{cwd:$c, tool_input:{file_path:$p}}' \
+        | PATH="$nojq" bash "$ROUTE" 2>&1 >/dev/null); rc=$?
+  printf '%s:%s' "$rc" "$([[ -n "$err" ]] && echo loud || echo silent)"
+}
+# Exit 2 is how a PreToolUse hook blocks. Both halves are asserted: the code
+# alone could be an accident, and stderr alone would still let the tool run.
+t "no jq: bash-guard blocks an applied migration" "2:loud" \
+  "$(nojq_bash 'sed -i.bak s/a/b/ apps/api/migrations/20260101000000_m01_applied.sql')"
+t "no jq: bash-guard blocks a migrations glob"    "2:loud" \
+  "$(nojq_bash 'sed -i.bak s/a/b/ apps/api/migrations/*.sql')"
+t "no jq: bash-guard blocks a write into sqlc"    "2:loud" \
+  "$(nojq_bash 'cp /tmp/db.go apps/api/internal/db/sqlc/db.go')"
+# ...and an ORDINARY command is blocked too. That is the point: the guard cannot
+# read the payload, so it cannot tell one command from another, and answering
+# "allow" would be a decision it has no basis for.
+t "no jq: bash-guard blocks a plain command"      "2:loud" "$(nojq_bash 'ls -la')"
+t "no jq: route-guard blocks the sqlc tree"       "2:loud" \
+  "$(nojq_route "$repo/apps/api/internal/db/sqlc/db.go")"
+t "no jq: route-guard blocks an unrouted file"    "2:loud" "$(nojq_route "$repo/notes.txt")"
+# The remedy has to be in the message, or the refusal is a wall.
+nojq_msg=$(jq -n --arg c "$repo" --arg x 'ls' '{cwd:$c, tool_input:{command:$x}}' \
+           | PATH="$nojq" bash "$BASH_G" 2>&1 >/dev/null)
+tcontains "no jq: bash-guard names the remedy" "brew install jq" "$nojq_msg"
+tcontains "no jq: bash-guard names the cause"  "jq is NOT installed" "$nojq_msg"
+# ...and this suite must go RED rather than SKIP when jq is missing, because a
+# SKIP is the same silence one layer up. Asserted by running the suite's own
+# preamble idiom under the stripped PATH.
+t "no jq: the suite itself refuses" 1 \
+  "$(PATH="$nojq" bash -c 'command -v jq >/dev/null 2>&1 || exit 1'; printf '%s' "$?")"
+tcontains "no jq: the suite says FAIL not SKIP" "FAIL: jq is not installed" \
+  "$(sed -n '/command -v jq/,+2p' "$here/guards_test.sh" | head -3)"
+
+echo "== route-guard-coverage: its own self-test is pinned"
+# The self-test in route-guard-coverage.sh asks the guard three questions whose
+# answers are fixed by the routing table, and refuses to print a rate if any is
+# wrong. Nothing asserted that it existed. Deleting it left this suite fully
+# green and silently restored the exact defect it closed: a guard that reads its
+# payload and exits 0 was then scored
+#   ask 0 (0.0%) / deny 0 (0.0%) / pass 248 (100.0%)
+# and that number is what gets pasted into docs/harness.md as evidence the guard
+# is bearable. This file's subject is unguarded fixes, so its own fix is pinned.
+COV="$here/route-guard-coverage.sh"
+deadguard="$tmp/dead-guard.sh"
+printf '#!/usr/bin/env bash\ncat >/dev/null\nexit 0\n' > "$deadguard"
+chmod +x "$deadguard"
+cov_out=$(cd "$here/../.." && bash "$COV" --since '30 days ago' --guard "$deadguard" 2>&1); cov_rc=$?
+t "a dead guard is not scored"            1 "$cov_rc"
+tcontains "and the self-test names itself" "self-test" "$cov_out"
+tcontains "and it says the guard is not routing" "is not routing" "$cov_out"
+tlacks "and no rate is printed at all"    "route-guard coverage:" "$cov_out"
+# Each of the three questions on its own, so deleting any ONE probe is caught by
+# a named assertion rather than by the other two happening to cover for it.
+# A guard that ONLY denies scores a perfect 0% over-fire; a guard that only asks
+# scores a terrible one. Neither is the shipped guard, and both must be refused.
+alldeny="$tmp/all-deny-guard.sh"
+printf '#!/usr/bin/env bash\ncat >/dev/null\njq -n %s\n' \
+  "'{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:\"x\"}}'" > "$alldeny"
+chmod +x "$alldeny"
+allask="$tmp/all-ask-guard.sh"
+printf '#!/usr/bin/env bash\ncat >/dev/null\njq -n %s\n' \
+  "'{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"ask\",permissionDecisionReason:\"x\"}}'" > "$allask"
+chmod +x "$allask"
+deny_out=$(cd "$here/../.." && bash "$COV" --since '30 days ago' --guard "$alldeny" 2>&1); deny_rc=$?
+ask_out=$(cd "$here/../.." && bash "$COV" --since '30 days ago' --guard "$allask" 2>&1); ask_rc=$?
+t "a deny-everything guard is refused" 1 "$deny_rc"
+tcontains "and the pass probe names it" "zz-coverage-selftest.txt" "$deny_out"
+t "an ask-everything guard is refused"  1 "$ask_rc"
+tcontains "and the deny probe names it" "sqlc/zz_coverage_selftest.go" "$ask_out"
+# DOES NOT OVER-FIRE: the SHIPPED guard passes its own self-test and a rate is
+# printed. Without this the four assertions above are satisfied by a self-test
+# that refuses everything, which measures nothing and blocks the real script.
+live_out=$(cd "$here/../.." && bash "$COV" --since '30 days ago' 2>&1); live_rc=$?
+t "the shipped guard is scored"        0 "$live_rc"
+tcontains "and a rate is printed"      "route-guard coverage:" "$live_out"
+tlacks "and nothing failed on the way" "FAIL:" "$live_out"
 
 echo ""
 if [[ $failed -eq 0 ]]; then

--- a/scripts/claude/harness-reap.sh
+++ b/scripts/claude/harness-reap.sh
@@ -62,8 +62,12 @@ while [[ $# -gt 0 ]]; do
     --cache-gb) CACHE_GB="${2:-10}"; shift ;;
     --worktrees-only) WORKTREES_ONLY=1 ;;
     # Print the whole comment header, however long it grows. A fixed line range
-    # silently truncates the safety notes the moment someone adds one.
-    -h|--help) awk '!/^#/{exit} {print}' "$0"; exit 0 ;;
+    # silently truncates the safety notes the moment someone adds one. The
+    # `NR==1` arm drops the shebang, which is a comment line to awk and was
+    # therefore printed as the first line of the help text. Same expression as
+    # route-guard-coverage.sh, quickstart-selfhost.sh and init-env.sh; all four
+    # are asserted identical in guards_test.sh.
+    -h|--help) awk 'NR==1 && /^#!/ {next} !/^#/{exit} {print}' "$0"; exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
   shift

--- a/scripts/claude/harness-reap.sh
+++ b/scripts/claude/harness-reap.sh
@@ -339,7 +339,15 @@ else
   # this comparison as 0, which is under every ceiling. Refuse to decide instead,
   # and say so loudly: this counts as a failure, so the script exits 1 and the
   # run cannot be read as "checked, nothing to do".
-  if [[ $kbrc -ne 0 ]] || ! [[ "$kb" =~ ^[0-9]+$ ]]; then
+  # ONE test, not two. This was `[[ $kbrc -ne 0 ]] || ! [[ "$kb" =~ ^[0-9]+$ ]]`,
+  # and the halves were not independent: sizeof() returns non-zero ONLY on the
+  # path where it has already printed `size unknown`, so a non-zero $kbrc always
+  # arrives with a $kb the regex rejects anyway. Deleting the status half alone
+  # changed no outcome and reddened nothing, which is a half nobody can test.
+  # $kbrc is still READ, in the message below, because "exit 1 with a partial
+  # total" and "exit 0 with a unit suffix" are different faults to go and look
+  # at, and the reader needs to know which one happened.
+  if ! [[ "$kb" =~ ^[0-9]+$ ]]; then
     say "  COULD NOT MEASURE the build cache: 'du -sk' gave '$kb' (exit $kbrc)."
     say "  The ceiling check is SKIPPED and nothing was cleaned - a size that was"
     say "  never read is not a size below it. Measure it by hand:"

--- a/scripts/claude/harness-reap.sh
+++ b/scripts/claude/harness-reap.sh
@@ -70,9 +70,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 root=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "not in a git repo" >&2; exit 2; }
-# Never continue on a failed `cd` (SC2164). Everything below - `git worktree
-# remove --force`, `git branch -d`, the rev-parse that picks the base branch,
-# `go clean -cache` - resolves its repository from the CURRENT DIRECTORY, while
+# Never continue on a failed `cd` (SC2164). The three GIT commands below - `git
+# worktree remove --force`, `git branch -d`, and the rev-parse that picks the
+# base branch - resolve their repository from the CURRENT DIRECTORY, while
 # the report line, the `$wt == $root` self-protection check and the ownership
 # test all assume that directory is $root. Unchecked, a failed cd left every
 # one of them running somewhere the script had never reached, and it did not
@@ -80,6 +80,14 @@ root=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "not in a git repo" 
 # code goes on to remove a worktree and print "1 removed" from a location it
 # never verified. A script whose next four commands delete things stops when it
 # cannot reach the place it is about to act on.
+#
+# `go clean -cache` is deliberately NOT in that list, though an earlier version
+# of this comment named it as a fourth. It is not cwd-sensitive at all: it wipes
+# the single machine-wide directory `go env GOCACHE` names, which is the same
+# directory whatever the current one is and whatever repository - if any - the
+# current one belongs to. Listing it here read as though the cd guard covered
+# it. Nothing about cwd covers it; what stands between it and the cache is
+# --apply plus the ceiling check in section 3.
 cd "$root" || {
   echo "cannot enter the repository root '$root' (exit $?). Refusing to run." >&2
   echo "Every action below resolves its repository from the current directory," >&2
@@ -96,7 +104,24 @@ act() { if [[ $APPLY -eq 1 ]]; then say "  DO   $*"; else say "  WOULD $*"; fi; 
 # `du` on a path that has just been removed, or that a worktree record points at
 # after the directory went, prints nothing. Say so rather than print an empty
 # column: a blank size reads as zero, and zero is the one thing it does not mean.
-sizeof() { local s; s=$(du -sh "$1" 2>/dev/null | cut -f1); printf '%s' "${s:-size unknown}"; }
+#
+# It also RETURNS du's status, so a caller that has to decide on the number can
+# tell "0" from "could not measure". The Go build-cache ceiling in section 3 is
+# that caller, and it was the one place in this file where neither this helper
+# nor countof() was used: it read `du -sk "$gocache" | cut -f1` straight into an
+# arithmetic expansion, so a failed du became the empty string, `${kb:-0}` became
+# 0, 0 was below any ceiling, and the section printed "under the ceiling, leaving
+# it" - a measurement that never happened, reported as a measurement.
+#
+# The unit is a parameter so this stays ONE du call site rather than growing a
+# second helper beside it. `-s` always, never a recursive listing.
+sizeof() { # sizeof <path> [du unit flag, default h] -> size on stdout, du's status
+  local out rc
+  out=$(du -s"${2:-h}" "$1" 2>/dev/null); rc=$?
+  if [[ $rc -ne 0 || -z "$out" ]]; then printf 'size unknown'; return 1; fi
+  printf '%s' "${out%%$'\t'*}"
+  return 0
+}
 
 # Count something, or say plainly that it could not be counted. Verbatim the
 # helper from session-brief.sh, and deliberately not a second idiom for the same
@@ -295,21 +320,41 @@ say "== Go build cache and docker volumes skipped (--worktrees-only)"
 else
 say "== Go build cache (ceiling ${CACHE_GB}G; module cache is never touched)"
 gocache=$(go env GOCACHE 2>/dev/null || true)
-if [[ -n "$gocache" && -d "$gocache" ]]; then
-  kb=$(du -sk "$gocache" 2>/dev/null | cut -f1)
-  gb=$(( ${kb:-0} / 1024 / 1024 ))
-  say "  $gocache = $(du -sh "$gocache" 2>/dev/null | cut -f1)"
-  if [[ "$gb" -ge "$CACHE_GB" ]]; then
-    act "go clean -cache   (reclaims ~${gb}G; the next build is slow, nothing is lost)"
-    # Same rule as the worktrees: the note claims the cache was reclaimed, so
-    # it may only be written when the clean actually returned 0.
-    attempt "go clean -cache" go clean -cache && reclaimed_note="${reclaimed_note} build-cache"
+if [[ -z "$gocache" ]]; then
+  say "  'go env GOCACHE' returned nothing - no Go toolchain on PATH, or it failed."
+  say "  The cache was NOT measured and NOT cleaned. This is not 'no cache to clean'."
+  failures=$((failures+1))
+elif [[ ! -d "$gocache" ]]; then
+  say "  $gocache is not a directory - nothing to measure or clean"
+else
+  kb=$(sizeof "$gocache" k); kbrc=$?
+  say "  $gocache = $(sizeof "$gocache")"
+  # A ceiling test is a decision, and a decision needs a number. `du` fails on a
+  # cache being written underneath it, on a permission it cannot cross, on an
+  # unreadable mount - and the empty string it leaves behind used to arrive at
+  # this comparison as 0, which is under every ceiling. Refuse to decide instead,
+  # and say so loudly: this counts as a failure, so the script exits 1 and the
+  # run cannot be read as "checked, nothing to do".
+  if [[ $kbrc -ne 0 ]] || ! [[ "$kb" =~ ^[0-9]+$ ]]; then
+    say "  COULD NOT MEASURE the build cache: 'du -sk' gave '$kb' (exit $kbrc)."
+    say "  The ceiling check is SKIPPED and nothing was cleaned - a size that was"
+    say "  never read is not a size below it. Measure it by hand:"
+    say "    du -sh '$gocache'"
+    failures=$((failures+1))
   else
-    say "  under the ceiling, leaving it"
+    gb=$(( kb / 1024 / 1024 ))
+    if [[ "$gb" -ge "$CACHE_GB" ]]; then
+      act "go clean -cache   (reclaims ~${gb}G; the next build is slow, nothing is lost)"
+      # Same rule as the worktrees: the note claims the cache was reclaimed, so
+      # it may only be written when the clean actually returned 0.
+      attempt "go clean -cache" go clean -cache && reclaimed_note="${reclaimed_note} build-cache"
+    else
+      say "  ${gb}G is under the ${CACHE_GB}G ceiling, leaving it"
+    fi
   fi
 fi
 gomod=$(go env GOMODCACHE 2>/dev/null || true)
-[[ -n "$gomod" && -d "$gomod" ]] && say "  module cache $(du -sh "$gomod" 2>/dev/null | cut -f1) - reported only, never cleaned here"
+[[ -n "$gomod" && -d "$gomod" ]] && say "  module cache $(sizeof "$gomod") - reported only, never cleaned here"
 
 # ---- 4. testcontainer volumes ---------------------------------------------
 say "== docker testcontainer volumes"

--- a/scripts/claude/route-guard-coverage.sh
+++ b/scripts/claude/route-guard-coverage.sh
@@ -54,6 +54,74 @@ guard="${guard_override:-$root/scripts/claude/route-guard.sh}"
 # shipping, so every way of ending up with an empty file list is fatal.
 command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed; the guard fails open and this would report 0%" >&2; exit 1; }
 
+errlog=$(mktemp) || exit 1
+trap 'rm -f "$errlog"' EXIT
+
+# ---- "the guard declined" is not "the guard failed" ------------------------
+# Both arms below used to collapse those two into one, with
+#   ... | bash "$guard" 2>/dev/null | jq -r '... // "pass"'   and   "${d:-pass}"
+# so a guard that crashed, that printed a parse error, or that answered nothing
+# at all was scored as a deliberate PASS on every file - a perfect 0.0% over-fire
+# rate for a guard that is not running, exit 0, in both arms. That number gets
+# pasted into docs/harness.md as evidence that the guard is bearable, which is
+# the decision this script exists to inform, so scoring a dead guard is worse
+# than not measuring at all.
+#
+# Declined  = exit 0 and no output. That is the guard's real "pass" protocol.
+# Failed    = a non-zero exit, or output that carries no permissionDecision.
+#             Fatal, named, and non-zero out of this script.
+guard_decision() { # guard_decision <payload> <label> -> prints a decision, or fails
+  local out rc d
+  out=$(printf '%s' "$1" | bash "$guard" 2>>"$errlog"); rc=$?
+  if (( rc != 0 )); then
+    printf 'FAIL: the guard exited %d on %s. A coverage number measured against a failing guard is not a coverage number.\n' "$rc" "$2" >&2
+    [[ -s "$errlog" ]] && { echo "  last stderr:" >&2; tail -3 "$errlog" >&2; }
+    return 1
+  fi
+  [[ -z "$out" ]] && { printf 'pass'; return 0; }
+  d=$(jq -r '.hookSpecificOutput.permissionDecision // empty' <<<"$out" 2>/dev/null)
+  if [[ -z "$d" ]]; then
+    printf 'FAIL: the guard produced %d bytes on %s that carry no .hookSpecificOutput.permissionDecision:\n' "${#out}" "$2" >&2
+    printf '%s\n' "${out:0:400}" >&2
+    return 1
+  fi
+  printf '%s' "$d"
+}
+
+# ---- is the guard alive at all? --------------------------------------------
+# The check above catches a guard that crashes or babbles. It cannot catch the
+# one that this script was actually measuring - a guard that reads its payload,
+# decides nothing and exits 0, which is indistinguishable from a pass on any
+# single file. So the guard is asked three questions whose answers are fixed by
+# the routing table in CLAUDE.md rather than by any count, before a rate is
+# reported:
+#
+#   a generated tree must deny, a Go control-plane file must ask, and a file on
+#   no routed path must pass.
+#
+# All three, or no number. Two would not be enough: "deny everything" and "ask
+# nothing" are both scored 0% over-fire by a two-question probe. The paths need
+# not exist - the guard walks up to the nearest existing ancestor - so this does
+# not rot when a directory is renamed, and it sends no session_id, so the
+# guard's per-session memory cannot answer for it.
+selftest() {
+  local bad=0 want got
+  probe() { # probe <expected> <repo-relative path>
+    got=$(guard_decision "$(jq -n --arg p "$root/$2" --arg c "$root" '{cwd:$c, tool_input:{file_path:$p}}')" "self-test $2") || return 1
+    [[ "$got" == "$1" ]] && return 0
+    printf 'FAIL: self-test: the guard answered %q for %s, expected %q.\n' "$got" "$2" "$1" >&2
+    return 1
+  }
+  probe deny apps/api/internal/db/sqlc/zz_coverage_selftest.go     || bad=1
+  probe ask  apps/api/internal/zzcoverage/zz_coverage_selftest.go  || bad=1
+  probe pass zz-coverage-selftest.txt                              || bad=1
+  if (( bad )); then
+    echo "FAIL: $guard is not routing. Refusing to report a rate for it - a dead guard measures 0% over-fire, which is the best possible number." >&2
+    return 1
+  fi
+}
+selftest || exit 1
+
 # ---- session simulation ----------------------------------------------------
 # The per-file rate above is stateless, so it measures the guard as if every
 # write were the first one. What a person actually experiences is prompts per
@@ -62,8 +130,8 @@ command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed; the guard fa
 # the closest honest stand-in for "a day's work in one session".
 if [[ "$mode" == sessions ]]; then
   simstate=$(mktemp -d) || exit 1
-  simerr=$(mktemp) || exit 1
-  trap 'rm -rf "$simstate" "$simerr"' EXIT
+  simerr="$errlog"
+  trap 'rm -rf "$simstate"; rm -f "$errlog"' EXIT
   # The guard memoises only inside a directory it can prove is its own, and the
   # proof is a marker file it writes when it creates its default one. A bare
   # `mktemp -d` carries no marker, so the guard refused this directory on every
@@ -88,15 +156,17 @@ if [[ "$mode" == sessions ]]; then
     writes=$((writes+1))
     payload=$(jq -n --arg p "$root/$line" --arg c "$root" --arg s "sim-$lastday" \
                 '{cwd:$c, session_id:$s, tool_input:{file_path:$p}}')
-    dec=$(printf '%s' "$payload" | bash "$guard" 2>>"$simerr" \
-          | jq -r '.hookSpecificOutput.permissionDecision // "pass"' 2>/dev/null)
+    dec=$(guard_decision "$payload" "$line") || exit 1
     if [[ "$dec" == "ask" ]]; then
       prompts=$((prompts+1))
       # settings.json wires PostToolUse to `route-guard.sh --record`, so what
       # records a ruling in a real session is the approved write running. A
       # replay that only calls the PreToolUse arm memoises nothing however valid
       # its state directory is, and measures the stateless guard again.
-      printf '%s' "$payload" | bash "$guard" --record >/dev/null 2>>"$simerr"
+      if ! printf '%s' "$payload" | bash "$guard" --record >/dev/null 2>>"$simerr"; then
+        echo "FAIL: the guard's --record arm failed on $line, so the memoisation this arm reports on is not happening." >&2
+        exit 1
+      fi
     fi
   done < <(git -C "$root" log --since="$since" --date=short --format='D %ad' --name-only -- .)
 
@@ -143,13 +213,15 @@ total=${#files[@]}
 ask=0; deny=0; passn=0
 declare -a asked=()
 for f in "${files[@]}"; do
-  d=$(jq -n --arg p "$root/$f" --arg c "$root" '{cwd:$c, tool_input:{file_path:$p}}' \
-      | bash "$guard" 2>/dev/null \
-      | jq -r '.hookSpecificOutput.permissionDecision // "pass"' 2>/dev/null)
-  case "${d:-pass}" in
+  d=$(guard_decision "$(jq -n --arg p "$root/$f" --arg c "$root" '{cwd:$c, tool_input:{file_path:$p}}')" "$f") || exit 1
+  case "$d" in
     ask)  ask=$((ask+1));  asked+=("$f") ;;
     deny) deny=$((deny+1)) ;;
-    *)    passn=$((passn+1)) ;;
+    pass) passn=$((passn+1)) ;;
+    # Not `*)`. A decision this script does not know how to score is not a pass:
+    # `allow` would be counted as silence, and a future fourth value would be
+    # counted as whatever the last case happened to be.
+    *)    echo "FAIL: the guard answered '$d' on $f, which this script cannot score." >&2; exit 1 ;;
   esac
 done
 

--- a/scripts/claude/route-guard-coverage.sh
+++ b/scripts/claude/route-guard-coverage.sh
@@ -40,7 +40,11 @@ while [[ $# -gt 0 ]]; do
     # header's length: it spilled four lines of code into the help text, and
     # stopped only because a later comment edit happened to grow the header by
     # exactly the right number of lines. Same form as harness-reap.sh.
-    -h|--help) awk '!/^#/{exit} {print}' "$0"; exit 0 ;;
+    # The `NR==1` arm drops the shebang, which is a comment line to awk and was
+    # therefore printed as the first line of the help text. Same expression as
+    # harness-reap.sh, quickstart-selfhost.sh and init-env.sh; all four are
+    # asserted identical in guards_test.sh.
+    -h|--help) awk 'NR==1 && /^#!/ {next} !/^#/{exit} {print}' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/scripts/claude/route-guard.sh
+++ b/scripts/claude/route-guard.sh
@@ -28,12 +28,18 @@
 # remembered per session, per destination, for WPMGR_ROUTE_GUARD_TTL_MIN
 # minutes, and a session that comes back to the same area later re-asks.
 #
-# FAIL-OPEN, DELIBERATELY, AND ANNOUNCED. If jq is missing this exits 0 and
-# routes nothing, because blocking every edit on a fresh clone of a public repo
-# is a guard that gets switched off within the hour. The compensating control is
-# scripts/claude/session-brief.sh, which prints "route-guard INACTIVE" at the
-# top of every session when jq is absent. Silence is what this project bans;
-# a stated, visible degradation is not silence.
+# FAIL-CLOSED WHEN jq IS MISSING. This used to exit 0 and route nothing, on the
+# argument that blocking every edit on a fresh clone gets the guard switched off
+# within the hour, with the session brief's "route-guard INACTIVE" line as the
+# compensating control. That argument was wrong on its own terms: a write to an
+# applied migration and a write into the sqlc tree - the two things this file
+# DENIES rather than asks about, because neither is a judgement call - both went
+# through with rc=0 and zero bytes of output. A brief line printed once at
+# session start is not a compensating control for a deny that has vanished.
+#
+# So the absence is now the loud outcome: exit 2, which is how a PreToolUse hook
+# blocks, with the remedy on stderr. One `brew install jq` restores it, and
+# scripts/bootstrap.sh installs it.
 #
 # The de-duplication needs a session identity. If neither session_id nor
 # transcript_path is in the payload it does NOT fail open: it asks every time,
@@ -65,7 +71,17 @@ set -uo pipefail
 mode=run
 [[ "${1:-}" == "--record" ]] && mode=record
 
-command -v jq >/dev/null 2>&1 || exit 0
+if ! command -v jq >/dev/null 2>&1; then
+  cat >/dev/null    # drain the payload, so the caller never sees EPIPE
+  echo "route-guard.sh: jq is NOT installed, so this guard cannot read the hook payload
+and cannot decide anything. It refuses rather than disappearing: without jq a
+write to an already-applied migration and a hand-edit of a generated tree - the
+two edits this guard DENIES outright - both succeed with no prompt and no
+record.
+
+Install it and re-run:  brew install jq" >&2
+  exit 2
+fi
 
 input=$(cat)
 

--- a/scripts/claude/route-guard.sh
+++ b/scripts/claude/route-guard.sh
@@ -73,33 +73,6 @@ input=$(cat)
 # agent_id is present only for subagent tool calls.
 [[ -n "$(jq -r '.agent_id // empty' <<<"$input" 2>/dev/null)" ]] && exit 0
 
-path=$(jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' <<<"$input" 2>/dev/null)
-[[ -z "$path" ]] && exit 0
-case "$path" in /*) ;; *) exit 0 ;; esac
-
-# Repo-relative, derived from the FILE, not from cwd. Deriving it from .cwd
-# silently disabled this guard whenever the session was started in a
-# subdirectory: with cwd=apps/api every control-plane .go file passed.
-#
-# Both sides are resolved to physical paths first: `git rev-parse` returns a
-# physical path, so on any machine where the checkout sits under a symlinked
-# prefix (/tmp -> /private/tmp on macOS) a raw string prefix strip fails to
-# match and the guard silently routes nothing.
-# Walk up to the nearest EXISTING ancestor: a Write that creates a file in a
-# directory that does not exist yet is exactly the case a `dirname` check would
-# wave through, and creating a new migration is that case.
-dir=$(dirname "$path")
-anc="$dir"
-while [[ ! -d "$anc" && "$anc" != "/" && -n "$anc" ]]; do anc=$(dirname "$anc"); done
-[[ -d "$anc" ]] || exit 0
-panc=$(cd "$anc" 2>/dev/null && pwd -P) || exit 0
-root=$(git -C "$panc" rev-parse --show-toplevel 2>/dev/null) || exit 0
-root=$(cd "$root" 2>/dev/null && pwd -P) || exit 0
-# Re-express the full path under the physical ancestor.
-ppath="$panc${path#"$anc"}"
-rel="${ppath#"$root"/}"
-[[ "$rel" == "$ppath" ]] && exit 0
-
 emit() { # emit <decision> <reason>
   # The --record arm answers nothing and records nothing here: every caller of
   # emit above the memory block is a deny, and a deny has no ruling to remember.
@@ -114,6 +87,85 @@ emit() { # emit <decision> <reason>
   }'
   exit 0
 }
+
+path=$(jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' <<<"$input" 2>/dev/null)
+[[ -z "$path" ]] && exit 0
+
+# A RELATIVE file_path used to `exit 0` right here, printing nothing, for every
+# path in the routing table: a payload carrying no usable cwd was a silent route
+# around every arm below, including the two hard denies. Driven at
+# apps/api/internal/auth/members_handler.go - backend-architect plus a mandatory
+# security review - it exited 0 with zero bytes, and the generated sqlc tree did
+# the same. bash-guard.sh had already been hardened against exactly this shape
+# in its migration arm; this is the same fix on this side.
+#
+# "Relative" only means anything against a base, so a base is resolved from two
+# independent sources, and when neither answers the guard still does not fall
+# silent - it judges the literal string as if it were repo-relative, which is
+# the only reading under which a routed prefix means anything, and says so.
+resolved=1
+case "$path" in
+  /*) ;;
+  *)
+    base=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+    if [[ -n "$base" && -d "$base" && ! -L "$base" ]]; then
+      base=$(cd "$base" 2>/dev/null && pwd -P) || base=""
+    else
+      base=""
+    fi
+    # Second source: this hook script is committed inside the repository it
+    # guards, so its own directory resolves that checkout even with no cwd at
+    # all. A relative path in a payload with no cwd is repo-relative or it is
+    # nothing.
+    if [[ -z "$base" ]]; then
+      self_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || self_dir=""
+      if [[ -n "$self_dir" ]]; then
+        base=$(git -C "$self_dir" rev-parse --show-toplevel 2>/dev/null) || base=""
+        [[ -n "$base" ]] && { base=$(cd "$base" 2>/dev/null && pwd -P) || base=""; }
+      fi
+    fi
+    if [[ -n "$base" ]]; then
+      path="$base/$path"
+    else
+      # No cwd, and this script is not inside a checkout either. There is no
+      # base, so there is no physical path to resolve - but there is still a
+      # string, and the routing table is a table of string prefixes. Judge it,
+      # and let the arms below answer. Falling through to `exit 0` here is what
+      # produced zero bytes on the sqlc tree.
+      resolved=0
+      rel="$path"
+      root=""
+    fi
+    ;;
+esac
+
+# Repo-relative, derived from the FILE, not from cwd. Deriving it from .cwd
+# silently disabled this guard whenever the session was started in a
+# subdirectory: with cwd=apps/api every control-plane .go file passed.
+#
+# Both sides are resolved to physical paths first: `git rev-parse` returns a
+# physical path, so on any machine where the checkout sits under a symlinked
+# prefix (/tmp -> /private/tmp on macOS) a raw string prefix strip fails to
+# match and the guard silently routes nothing.
+# Walk up to the nearest EXISTING ancestor: a Write that creates a file in a
+# directory that does not exist yet is exactly the case a `dirname` check would
+# wave through, and creating a new migration is that case.
+if (( resolved )); then
+  dir=$(dirname "$path")
+  anc="$dir"
+  while [[ ! -d "$anc" && "$anc" != "/" && -n "$anc" ]]; do anc=$(dirname "$anc"); done
+  # These three exits are for a path that is outside every checkout on this
+  # machine: there is no repository whose routing table could cover it, so
+  # passing is an answer and not a silence.
+  [[ -d "$anc" ]] || exit 0
+  panc=$(cd "$anc" 2>/dev/null && pwd -P) || exit 0
+  root=$(git -C "$panc" rev-parse --show-toplevel 2>/dev/null) || exit 0
+  root=$(cd "$root" 2>/dev/null && pwd -P) || exit 0
+  # Re-express the full path under the physical ancestor.
+  ppath="$panc${path#"$anc"}"
+  rel="${ppath#"$root"/}"
+  [[ "$rel" == "$ppath" ]] && exit 0
+fi
 
 # ---- deny: generated trees ------------------------------------------------
 case "$rel" in
@@ -143,7 +195,10 @@ esac
 # Editing it is a silent no-op that looks like a fix.
 case "$rel" in
   apps/api/migrations/*.sql)
-    if git -C "$root" cat-file -e "HEAD:$rel" 2>/dev/null; then
+    # With no root (the unresolved case above) this question has no answer, so
+    # it is not answered: the file falls through to the database-engineer ask
+    # below rather than to a deny that might be aimed at brand new work.
+    if [[ -n "$root" ]] && git -C "$root" cat-file -e "HEAD:$rel" 2>/dev/null; then
       emit deny "$rel already exists in HEAD, so it has been applied and internal/db/migrate.go will never read it again:
 
     sort.Strings(versions) ... if applied[version] { continue }

--- a/scripts/claude/session-brief.sh
+++ b/scripts/claude/session-brief.sh
@@ -14,9 +14,12 @@
 #    forbidden to touch a worktree that holds work, which is exactly the ones
 #    that accumulate. Discovering this mid-link is the expensive way.
 #
-# F: the guards fail open when jq is missing. Silence is the defect this project
-#    keeps shipping, so the degradation is announced here, every session,
-#    instead.
+# F: the guards REFUSE when jq is missing - they exit 2 rather than exit 0, so
+#    every Edit, Write and Bash call is blocked until it is installed. That is
+#    loud on its own, but it is loud one command too late, so it is announced
+#    here at session start with the one-line fix. This block used to say the
+#    guards were INACTIVE, which was true of the old fail-open behaviour and is
+#    now the opposite of what happens.
 #
 # Never blocks. SessionStart cannot block, and this must stay cheap.
 set -uo pipefail
@@ -41,8 +44,8 @@ echo "## Machine state"
 
 # --- guard health -----------------------------------------------------------
 if ! command -v jq >/dev/null 2>&1; then
-  echo "- route-guard and bash-guard are INACTIVE: jq is not installed. Routing"
-  echo "  and the wait-loop deny are unenforced this session. Fix: install jq."
+  echo "- route-guard and bash-guard REFUSE EVERYTHING: jq is not installed, so both"
+  echo "  exit 2 and every Edit, Write and Bash call is blocked. Fix: brew install jq."
 fi
 
 # The pre-push hook, resolved for THIS checkout. It is committed but inert until

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -74,7 +74,14 @@ log()  { printf '==> %s\n' "$*"; }
 warn() { printf 'WARN: %s\n' "$*" >&2; }
 die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
-cleanup() { [ -n "${GEN_FILE}" ] && rm -f "${GEN_FILE}"; }
+# An EXIT trap's own return value REPLACES the script's exit status, and this
+# one ended on `[ -n "${GEN_FILE}" ]`, which is false on every run that never
+# minted a temp file. So `scripts/init-env.sh --help` exited 1, and so did a
+# clean bootstrap that used an existing generator - a success reported as a
+# failure to anything that checks, which is `set -e` in the caller, the README's
+# one-liner, and quickstart-selfhost.sh. Measured: `--help` exited 1 with the
+# help text fully printed. `return 0` makes the trap say only what it is for.
+cleanup() { [ -n "${GEN_FILE}" ] && rm -f "${GEN_FILE}"; return 0; }
 trap cleanup EXIT
 
 # current_value: prints the current value of KEY in .env (empty if absent/blank).
@@ -206,8 +213,15 @@ for arg in "$@"; do
   case "${arg}" in
     --force) FORCE=1 ;;
     --hostname=*) HOSTNAME_OVERRIDE="${arg#--hostname=}" ;;
+    # Print the whole comment header, however long it grows. The hardcoded
+    # `sed -n '3,31p'` this replaces overran the block by one line and was
+    # ALREADY WRONG when it was read: it printed `set -euo pipefail` to the user
+    # as though it were help text. Same pattern as scripts/claude/harness-reap.sh
+    # and route-guard-coverage.sh; the NR==1 arm drops the shebang, which is a
+    # comment line but not help text.
     -h | --help)
-      sed -n '3,31p' "${BASH_SOURCE[0]}" | sed 's/^#\{0,1\} \{0,1\}//'
+      awk 'NR==1 && /^#!/ {next} !/^#/{exit} {print}' "${BASH_SOURCE[0]}" \
+        | sed 's/^#\{0,1\} \{0,1\}//'
       exit 0
       ;;
     *)

--- a/scripts/quickstart-selfhost.sh
+++ b/scripts/quickstart-selfhost.sh
@@ -63,8 +63,16 @@ for arg in "$@"; do
     --version=*)  WPMGR_VERSION="${arg#--version=}" ;;
     --dir=*)      WORK_DIR="${arg#--dir=}" ;;
     --force)      FORCE=1 ;;
+    # Print the whole comment header, however long it grows. The hardcoded
+    # `sed -n '3,42p'` this replaces stopped two lines short of the end of the
+    # block and was ALREADY WRONG when it was read: of the three lines under
+    # "Host requirements" it printed only the Docker one, dropping curl/wget and
+    # openssl from the help of the README's headline install script. Same
+    # pattern as scripts/claude/harness-reap.sh and route-guard-coverage.sh; the
+    # NR==1 arm drops the shebang, which is a comment line but not help text.
     -h|--help)
-      sed -n '3,42p' "${BASH_SOURCE[0]}" | sed 's/^#\{0,1\} \{0,1\}//'
+      awk 'NR==1 && /^#!/ {next} !/^#/{exit} {print}' "${BASH_SOURCE[0]}" \
+        | sed 's/^#\{0,1\} \{0,1\}//'
       exit 0
       ;;
     *)


### PR DESCRIPTION
An audit of the guards found this repository's signature defect — a check that announces success over
its own errors — in eleven more places after the `rm -rf` incident was closed. Each was reproduced with
an executed command before it was touched, and each fix was then attacked.

## What was silently permitted before this

```
sed -i 's/a/b/' apps/api/migrations/*.sql              PERMIT, 0 bytes   (all committed migrations)
cd apps/api && sed -i … migrations/<applied>.sql       PERMIT, 0 bytes
apps/api/../api/migrations/<applied>.sql               PERMIT, 0 bytes
cd apps/api/internal/db/sqlc && echo x > db.go         PERMIT, 0 bytes
python3 -c "shutil.copy('/tmp/x', '…/sqlc/db.go')"     PERMIT, 0 bytes
node -e "fs.openSync(p,'w')"                           PERMIT, 0 bytes
route-guard with no cwd in the payload                 PERMIT everything, 0 bytes
jq absent                                              BOTH guards silent on every hard deny
```

Seven of those were proved destructive by execution — target file checksum before, run, checksum after.
The interpreter arm was additionally polarity-inverted: it denied *reading* the generated sqlc tree and
permitted *overwriting* it, which is the hand-sync that caused a production 500 here.

## What was reporting success over failure

`route-guard-coverage.sh` scored a completely broken guard at `ask 0 (0.0%) / deny 0 (0.0%) / pass 248
(100.0%)` and exited 0, in both arms — a number that gets pasted into `docs/harness.md` as evidence.
`commit-gate.sh` exited 0 in silence when the agent's only uncommitted file had a name git quotes.
`harness-reap.sh` read a failed `du` as "under the ceiling, leaving it". Two `--help` outputs sliced a
hardcoded line range and dropped real content from the README's install script.

## And assertions that tested nothing

Four assertions in the `route-guard state` block survived deletion of the code they name; two of them
authorise deletes, and an auditor destroyed real file content with a mutated guard while the suite
stayed green. The suite's only two Python assertions both contained the literal `open(`, so a bare
substring match on `open(` would have passed them while shipping the inverted arm.

That defect recurred *inside this work* twice, and both times mutation testing found it rather than
review: one round shipped four new assertions that pinned nothing, the next shipped two. Both are fixed
and both are in the mutation table.

## Approach

`cd` tracking is now one shared `cd_track`, used by the write arms and the push arm alike, rather than
the push arm's private copy plus nothing elsewhere. The suite asserts the same `cd` shapes against both,
so they cannot drift apart silently — a mutation making the tracker guess reddens a push assertion and a
write assertion in the same run.

Where the effective directory genuinely cannot be determined, the last arm **asks**. It does not deny,
because after an unresolvable `cd` every relative path could be inside a protected tree and denying
reddens `cd "$(mktemp -d)" && echo x > out.txt`. It does not stay silent either — silence is the one
outcome removed.

## Proof

```
$ bash scripts/claude/guards_test.sh
guards_test: 950 assertions passed          (main: 419)
```

Every fix was mutated — deleted or inverted — and the suite confirmed to redden naming the right
assertion; the mutation tables are in the commits. The push arm was regression-checked by replaying
every payload the suite covers against the guard before and after:

```
total payloads replayed: 466
push-shaped payloads:    115
(no push decision changed on any shape the suite covers)
```

## Known gaps, stated rather than implied

Which migrations are *applied* is read from `HEAD` starting at the payload's cwd, not the effective
directory, so `cwd=/tmp` plus `cd <repo>/apps/api && sed -i migrations/<applied>.sql` still passes. The
sqlc, generated-tree and dead-app arms are fixed for that case; the applied-migration arm is not.

`bash-guard.sh` matches command text and cannot decide `eval`, `bash -c`, or a path built at run time.
It says so in its own comments now instead of implying coverage it lacks. `.githooks/pre-push` is the
lock; this is the early stop in front of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security guards now fail closed when required tooling is unavailable, preventing unapproved operations.
  * Improved handling of relative paths, directory changes, redirections, migrations, and branch-aware push checks.
  * Commit checks now accurately handle untracked, renamed, and copied files.
  * Cleanup and cache measurement failures now report errors without masking command results.

* **Improvements**
  * Help output is more complete and consistently generated across setup and maintenance scripts.
  * Vocabulary parsing now rejects missing, duplicate, or multi-line banned assignments.
  * Routing and coverage checks now reject invalid or unknown decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->