### PR TITLE
build: move the Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -187,7 +187,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: apps/api/go.sum
 
       # The tests build their containers with testcontainers-go talking to the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: apps/api/go.sum
 
       # Build the api module on its own (workspace disabled) so it does not
@@ -326,9 +326,22 @@ jobs:
       - name: Version surface guard (openapi, changelog page, badge, agent, install pins)
         run: scripts/check-version-surfaces.sh
 
+      # Which Go toolchain compiles the shipped binaries. This job pinned
+      # go-version 1.26.5 while infra/Dockerfile.api built FROM golang:1.26, a
+      # floating tag — so the govulncheck below cleared a toolchain that was not
+      # necessarily the one in the image. Nothing detected that; the only way to
+      # learn the deployed toolchain was `go version -m` on a binary pulled out
+      # of the published image. Self-test first, same as above: a regressed
+      # guard is the more useful failure to read.
+      - name: Go toolchain guard self-test
+        run: scripts/check-go-toolchain_test.sh
+
+      - name: Go toolchain guard (workflow pins vs container base images)
+        run: scripts/check-go-toolchain.sh
+
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: apps/api/go.sum
 
       # govulncheck does call-graph reachability analysis, so it only fails on

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,18 @@ check-versions: ## Check every version-naming surface (docs, marketing, agent)
 check-versions-test: ## Run the version surface guard's regression suite
 	scripts/check-version-surfaces_test.sh
 
+# Which Go toolchain compiles the shipped binaries. CI pinned 1.26.5 while
+# infra/Dockerfile.api built FROM golang:1.26 (floating), so the tested
+# toolchain and the shipped one could differ and nothing noticed. This is the
+# check that makes them unable to disagree.
+.PHONY: check-go-toolchain
+check-go-toolchain: ## Check every Go toolchain pin (workflows, Dockerfiles) agrees
+	scripts/check-go-toolchain.sh
+
+.PHONY: check-go-toolchain-test
+check-go-toolchain-test: ## Run the Go toolchain guard's regression suite
+	scripts/check-go-toolchain_test.sh
+
 # ---- Agent harness (.claude) ------------------------------------------------
 # The harness is build-gating logic, so it lives in tested scripts, not in prose
 # and not in a YAML block scalar. `harness-check` is what ci.yml runs.

--- a/infra/Dockerfile.api
+++ b/infra/Dockerfile.api
@@ -12,7 +12,7 @@
 # this stage. BUILDPLATFORM/TARGETOS/TARGETARCH are injected by BuildKit;
 # when building without --platform (e.g. prod Cloud Build on amd64) they
 # all default to the host, so the amd64-only path is unchanged.
-FROM --platform=$BUILDPLATFORM golang:1.26 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS build
 
 # TARGETOS / TARGETARCH are populated by BuildKit to match the target
 # platform being built (e.g. linux/arm64). CGO_ENABLED=0 means pure Go

--- a/infra/Dockerfile.media-encoder
+++ b/infra/Dockerfile.media-encoder
@@ -7,7 +7,7 @@
 # native codec libs (libaom/dav1d/etc.), so it builds with CGO_ENABLED=1 against
 # a glibc base. The main API NEVER imports the encoder — these are two distinct
 # images by design.
-FROM golang:1.26 AS build
+FROM golang:1.26.6 AS build
 
 # CGO ON. linux/amd64 (lilliput ships prebuilt static codec libs for it).
 ENV CGO_ENABLED=1 \
@@ -68,7 +68,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # debian:trixie-slim ships glibc 2.41 + libstdc++ from GCC 14 (identical ABI
 # to distroless/cc-debian13), so the lilliput CGO requirement is still met.
 #
-# CRITICAL: stay on Debian 13 "trixie" to match golang:1.26 (also trixie).
+# CRITICAL: stay on Debian 13 "trixie" to match golang:1.26.6 (also trixie).
 # The binary requires GLIBC_2.38+ and GLIBCXX_3.4.32+; a debian12 runtime
 # dies at startup before it can bind $PORT.
 #

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
   # Mounts the api module so edits are picked up on container restart.
   api:
     build: !reset null
-    image: golang:1.26
+    image: golang:1.26.6
     working_dir: /src/apps/api
     environment:
       GOWORK: "off"

--- a/scripts/check-go-toolchain.sh
+++ b/scripts/check-go-toolchain.sh
@@ -92,6 +92,10 @@ if [[ -d "$wf_dir" ]]; then
     rest="${line#*:}"
     lineno="${rest%%:*}"
     text="${rest#*:}"
+    # Comments discuss pins as well as set them — ci.yml's own history note
+    # names the version it moved off. Same trap as the Dockerfile scan below:
+    # test the `#` on the TEXT, not on grep -n's file:line: prefix.
+    [[ "$text" =~ ^[[:space:]]*# ]] && continue
     # go-version: "1.26.6"  |  go-version: 1.26.6  |  go-version: '1.26.6'
     ver="$(printf '%s' "$text" | sed -E "s/.*go-version:[[:space:]]*[\"']?([^\"'[:space:]]+)[\"']?.*/\1/")"
     where="${file#"$ROOT"/}:$lineno"

--- a/scripts/check-go-toolchain.sh
+++ b/scripts/check-go-toolchain.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# scripts/check-go-toolchain.sh
+#
+# Every place in this repo that decides WHICH GO TOOLCHAIN COMPILES A BINARY,
+# checked against every other place.
+#
+# WHY THIS EXISTS. On 2026-08-14 the Security audit job went red on main with
+# zero code change: govulncheck reads a live advisory database, and go1.26.5
+# picked up 7 stdlib advisories overnight. Fixing it surfaced a second, quieter
+# defect: CI pinned `go-version: "1.26.5"` while infra/Dockerfile.api built
+# `FROM golang:1.26`, a floating tag. So CI tested one toolchain and the shipped
+# image was compiled by whatever that tag resolved to at build time. Those can
+# differ in either direction and NOTHING DETECTED IT. The only way anyone
+# learned which toolchain production actually ran was pulling the published
+# image and reading the binary:
+#
+#   docker cp <container>:/usr/local/bin/wpmgr ./wpmgr && go version -m ./wpmgr
+#
+# That is not a check, that is an autopsy. This script is the check.
+#
+# WHY PINNED AND NOT FLOATING. A floating `golang:1.26` gets patch fixes for
+# free, which is the honest argument for it. It also means rebuilding the same
+# git sha twice can produce two different binaries, so "which build is in
+# production" stops being answerable from the repo — and answering that question
+# is a first-class concern here (the version chip exists for it). We pin, and we
+# accept the cost of a bump per patch release, because the mechanism that
+# NOTICES a patch release already exists and is proven: the govulncheck step in
+# ci.yml went red and named `Fixed in: go1.26.6` unprompted. Pinning plus a live
+# advisory feed gets deliberate upgrades AND automatic notification. Floating
+# gets automatic upgrades and no record.
+#
+# Note what that buys and what it does not: govulncheck fires on SECURITY patch
+# releases, not on every patch release. A non-security patch can sit unadopted.
+# That is the accepted cost, and it is the cheap direction to be wrong in.
+#
+# RUN IT (no CI, no install, nothing but a shell):
+#   make check-go-toolchain          or  scripts/check-go-toolchain.sh
+#   make check-go-toolchain-test     or  scripts/check-go-toolchain_test.sh
+#   scripts/check-go-toolchain.sh /path/to/some/other/tree
+#
+# Exit 0 when every declaration agrees. Exit 1 on drift, on a floating tag, and
+# on FINDING NOTHING — a toolchain guard that scans a tree with no declarations
+# in it has not passed, it has failed to look.
+
+set -uo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-go-toolchain.sh [ROOT]
+
+  ROOT  repository root to check (default: the repo this script lives in)
+USAGE
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+ROOT="${1:-}"
+if [[ -z "$ROOT" ]]; then
+  ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "FAIL: root is not a directory: $ROOT" >&2
+  exit 1
+fi
+
+errors=0
+fail() { echo "FAIL: $*" >&2; errors=$((errors + 1)); }
+info() { echo "  $*"; }
+
+# Collected as "version<TAB>where" so every reported version keeps its source.
+decls=""
+add_decl() { decls+="$1"$'\t'"$2"$'\n'; }
+
+# An exact toolchain version: three numeric components, nothing else. Docker
+# variant suffixes (-alpine, -trixie) are stripped before this is applied, so
+# golang:1.26.6-trixie is exact and golang:1.26 is not.
+EXACT_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+echo "Go toolchain declarations under $ROOT"
+
+# ---------------------------------------------------------------------------
+# 1. GitHub Actions: actions/setup-go `go-version:`
+# ---------------------------------------------------------------------------
+wf_dir="$ROOT/.github/workflows"
+if [[ -d "$wf_dir" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    file="${line%%:*}"
+    rest="${line#*:}"
+    lineno="${rest%%:*}"
+    text="${rest#*:}"
+    # go-version: "1.26.6"  |  go-version: 1.26.6  |  go-version: '1.26.6'
+    ver="$(printf '%s' "$text" | sed -E "s/.*go-version:[[:space:]]*[\"']?([^\"'[:space:]]+)[\"']?.*/\1/")"
+    where="${file#"$ROOT"/}:$lineno"
+    if [[ ! "$ver" =~ $EXACT_RE ]]; then
+      fail "$where declares go-version '$ver', which is not an exact X.Y.Z toolchain"
+      continue
+    fi
+    add_decl "$ver" "$where (setup-go)"
+  done < <(grep -rn "go-version:" "$wf_dir" 2>/dev/null)
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Container base images: golang:<tag> in Dockerfiles and compose files
+# ---------------------------------------------------------------------------
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  file="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+  text="${rest#*:}"
+  # Comments mention base images too ("stay on trixie to match golang:1.26.6").
+  # The `#` has to be tested on the TEXT, not on the grep -n output, which is
+  # prefixed with file:line: and so never starts with `#`. Getting this wrong
+  # made this guard's own first run red on a comment.
+  [[ "$text" =~ ^[[:space:]]*# ]] && continue
+  tag="$(printf '%s' "$text" | sed -E 's/.*golang:([A-Za-z0-9._-]+).*/\1/')"
+  where="${file#"$ROOT"/}:$lineno"
+  # Strip a Debian/Alpine variant suffix; keep the version part.
+  ver="$(printf '%s' "$tag" | sed -E 's/-(alpine|bookworm|trixie|bullseye)[0-9.]*$//')"
+  if [[ ! "$ver" =~ $EXACT_RE ]]; then
+    fail "$where uses base image golang:$tag — a floating tag. Pin the exact patch (golang:X.Y.Z)."
+    continue
+  fi
+  add_decl "$ver" "$where (golang:$tag)"
+done < <(grep -rn "golang:" "$ROOT/infra" 2>/dev/null | grep -v '^\s*#')
+
+# ---------------------------------------------------------------------------
+# 3. Report. Finding nothing is a failure, not a pass.
+# ---------------------------------------------------------------------------
+decl_count=$(printf '%s' "$decls" | grep -c . || true)
+
+if [[ "$decl_count" -eq 0 ]]; then
+  echo "FAIL: found no Go toolchain declarations at all under $ROOT." >&2
+  echo "      This guard scans .github/workflows (go-version:) and infra (golang:)." >&2
+  echo "      Zero declarations means the scan is broken or the paths moved," >&2
+  echo "      never that the repo is consistent." >&2
+  exit 1
+fi
+
+printf '%s' "$decls" | while IFS=$'\t' read -r v w; do
+  [[ -z "$v" ]] && continue
+  info "go$v  $w"
+done
+
+echo "  ($decl_count declarations found)"
+
+distinct="$(printf '%s' "$decls" | cut -f1 | sort -u | grep -c . || true)"
+if [[ "$distinct" -gt 1 ]]; then
+  fail "Go toolchain declarations disagree. Distinct versions: $(printf '%s' "$decls" | cut -f1 | sort -u | tr '\n' ' ')"
+  echo "      CI would test one toolchain while the image ships another." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 4. The go.mod LANGUAGE floor must not exceed the toolchain that builds it.
+#    These are deliberately NOT required to be equal: `go 1.26.3` in go.mod is
+#    the minimum language version a consumer needs, not the compiler we ship
+#    with. Raising it in lockstep with every patch release would push a floor
+#    onto everyone building from source for no security gain — the binaries this
+#    repo ships are governed by the pins above, not by the go directive.
+# ---------------------------------------------------------------------------
+gomod="$ROOT/apps/api/go.mod"
+if [[ -f "$gomod" ]]; then
+  floor="$(grep -E '^go [0-9]' "$gomod" | head -1 | awk '{print $2}')"
+  if [[ -z "$floor" ]]; then
+    fail "apps/api/go.mod has no 'go' directive"
+  else
+    toolchain="$(printf '%s' "$decls" | cut -f1 | sort -u | head -1)"
+    lowest="$(printf '%s\n%s\n' "$floor" "$toolchain" | sort -V | head -1)"
+    if [[ "$lowest" != "$floor" ]]; then
+      fail "apps/api/go.mod requires go $floor but the pinned toolchain is $toolchain (floor is above the compiler)"
+    else
+      info "go.mod language floor go$floor <= toolchain go$toolchain (ok; these are not required to be equal)"
+    fi
+  fi
+fi
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "check-go-toolchain: $errors problem(s)" >&2
+  exit 1
+fi
+
+echo "check-go-toolchain: OK"
+exit 0

--- a/scripts/check-go-toolchain_test.sh
+++ b/scripts/check-go-toolchain_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# scripts/check-go-toolchain_test.sh
+#
+# Builds throwaway trees and asserts check-go-toolchain.sh's exit code against
+# each. Half of these cases are FAILURES it must catch; the other half are
+# correct trees it must NOT block. Both halves matter equally: a guard that
+# reddens correct work gets switched off, and then it guards nothing.
+#
+#   scripts/check-go-toolchain_test.sh      (or: make check-go-toolchain-test)
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/check-go-toolchain.sh"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass=0
+fail=0
+
+# make_tree <dir> <ci-version> <docker-tag> <gomod-go>
+make_tree() {
+  local d="$1" civ="$2" dtag="$3" gomodv="$4"
+  mkdir -p "$d/.github/workflows" "$d/infra" "$d/apps/api"
+  if [[ "$civ" != "-" ]]; then
+    {
+      printf 'jobs:\n  build:\n    steps:\n'
+      printf '      - uses: actions/setup-go@v5\n'
+      printf '        with:\n'
+      printf '          go-version: "%s"\n' "$civ"
+    } > "$d/.github/workflows/ci.yml"
+  fi
+  if [[ "$dtag" != "-" ]]; then
+    printf 'FROM golang:%s AS build\n' "$dtag" > "$d/infra/Dockerfile.api"
+  fi
+  if [[ "$gomodv" != "-" ]]; then
+    printf 'module example.com/x\n\ngo %s\n' "$gomodv" > "$d/apps/api/go.mod"
+  fi
+}
+
+# expect <exit-code> <name> <dir>
+expect() {
+  local want="$1" name="$2" dir="$3"
+  local out got
+  out="$("$GUARD" "$dir" 2>&1)"
+  got=$?
+  if [[ "$got" -eq "$want" ]]; then
+    printf 'ok    %s (exit %d)\n' "$name" "$got"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %s: wanted exit %d, got %d\n' "$name" "$want" "$got"
+    printf '%s\n' "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+  fi
+}
+
+# --- MUST FAIL: the defects this guard exists to catch ---------------------
+
+# The exact production defect of 2026-08-14: CI pinned, image floating.
+make_tree "$TMPROOT/floating" "1.26.6" "1.26" "1.26.3"
+expect 1 "floating base image golang:1.26 is caught" "$TMPROOT/floating"
+
+# CI and image both pinned, but to different patches.
+make_tree "$TMPROOT/drift" "1.26.6" "1.26.5" "1.26.3"
+expect 1 "CI 1.26.6 vs image 1.26.5 disagreement is caught" "$TMPROOT/drift"
+
+# A guard that finds nothing must go red, not green.
+mkdir -p "$TMPROOT/empty"
+expect 1 "empty tree (zero declarations) is a failure, not a pass" "$TMPROOT/empty"
+
+# go.mod demanding a language version above the compiler we pin.
+make_tree "$TMPROOT/floor" "1.26.6" "1.26.6" "1.27.0"
+expect 1 "go.mod floor above the pinned toolchain is caught" "$TMPROOT/floor"
+
+# `latest` is floating too.
+make_tree "$TMPROOT/latest" "1.26.6" "latest" "1.26.3"
+expect 1 "golang:latest is caught" "$TMPROOT/latest"
+
+# A nonexistent root is an error, not a silent pass.
+expect 1 "nonexistent root fails loudly" "$TMPROOT/does-not-exist"
+
+# --- MUST PASS: correct trees it must not block ----------------------------
+
+# The state this branch puts the repo in.
+make_tree "$TMPROOT/clean" "1.26.6" "1.26.6" "1.26.3"
+expect 0 "all declarations agree on an exact patch" "$TMPROOT/clean"
+
+# Debian variant suffixes are a base-image choice, not a version disagreement.
+make_tree "$TMPROOT/variant" "1.26.6" "1.26.6-trixie" "1.26.3"
+expect 0 "golang:1.26.6-trixie is exact, not floating" "$TMPROOT/variant"
+
+# The go.mod floor is a language minimum and is NOT required to equal the
+# toolchain. Requiring equality would redden the repo on every patch bump.
+make_tree "$TMPROOT/floorlow" "1.26.6" "1.26.6" "1.25.0"
+expect 0 "go.mod floor well below the toolchain is fine" "$TMPROOT/floorlow"
+
+# A comment naming a base image is prose, not a declaration. This guard's own
+# first run went red here, on infra/Dockerfile.media-encoder's trixie comment.
+make_tree "$TMPROOT/comment" "1.26.6" "1.26.6" "1.26.3"
+printf '# CRITICAL: stay on trixie to match golang:1.26 (also trixie).\n' \
+  >> "$TMPROOT/comment/infra/Dockerfile.api"
+expect 0 "a comment mentioning golang:1.26 does not trip the guard" "$TMPROOT/comment"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/check-go-toolchain_test.sh
+++ b/scripts/check-go-toolchain_test.sh
@@ -101,6 +101,13 @@ printf '# CRITICAL: stay on trixie to match golang:1.26 (also trixie).\n' \
   >> "$TMPROOT/comment/infra/Dockerfile.api"
 expect 0 "a comment mentioning golang:1.26 does not trip the guard" "$TMPROOT/comment"
 
+# A workflow comment naming an old pin is prose too. ci.yml carries exactly
+# such a note about the 1.26.5 it moved off, so this is the live case.
+make_tree "$TMPROOT/wfcomment" "1.26.6" "1.26.6" "1.26.3"
+printf '      # this job pinned go-version: "1.26.5" until the 1.26.6 bump\n' \
+  >> "$TMPROOT/wfcomment/.github/workflows/ci.yml"
+expect 0 "a workflow comment naming an old go-version does not trip the guard" "$TMPROOT/wfcomment"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]] || exit 1
 exit 0


### PR DESCRIPTION
`main` is red with no code change. The same commit `500b445d` was green at 19:03 and failed at 04:08
the next morning, because `govulncheck` reads a live advisory database. `.claude/rules/ci-and-build-logic.md`
already names this: *"it can redden main with zero code change and a green PR can fail on merge. Fix
the dependency. Never tag a red commit."*

Seven vulnerabilities, all standard library, every one `Found in: …@go1.26.5` / `Fixed in: …@go1.26.6`.
Reachable in this codebase through `blobstore.Store.EnsureBucket` to `s3.Client.HeadBucket`
(`encoding/xml`), `pgxpool.Pool.Close` (`encoding/asn1`), and `http.Client.Do` (`golang.org/x/net/idna`).
Recursion-depth and input-validation class, not remote code execution.

## The second defect, which is why this is more than a version bump

CI pinned `go-version: "1.26.5"` exactly while `infra/Dockerfile.api` built `FROM golang:1.26`, a
floating tag. Those can differ in either direction and nothing noticed — CI could pass on a toolchain
the shipped image never used. That floating tag has since moved on its own: `docker run --rm golang:1.26
go version` now prints `go1.26.6`, so the image's compiler changed without anyone deciding it.

Every declaration is now an exact pin, and `scripts/check-go-toolchain.sh` (with a test file, 11 cases)
asserts they are all identical and none floats. Six declarations across `.github/` and `infra/`,
including `infra/docker-compose.dev.yml`, which was a fourth floating tag nobody had listed — a grep
for `1\.26\.[0-9]` structurally cannot see a floating tag, which is how it stayed hidden.

`apps/api/go.mod` deliberately stays at `go 1.26.3`. That is the language floor for anyone building
from source, not the compiler that ships; raising it per patch release pushes a floor onto consumers
for no security gain. The guard asserts floor ≤ toolchain rather than equality.

## Verified

```
$ GOTOOLCHAIN=go1.26.6 govulncheck ./cmd/wpmgr/...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
EXIT=0                       (advisory IDs in output: 0)

$ bash scripts/check-go-toolchain.sh          EXIT=0   (6 declarations found)
$ <revert one Dockerfile to golang:1.26>      EXIT=1
  FAIL: infra/Dockerfile.api:15 uses base image golang:1.26 — a floating tag.
$ <restore>                                   EXIT=0
```

The guard was reverted against the real repository rather than a synthetic fixture, and an empty tree
exits 1 — finding zero declarations is a failure, not a pass. The guard also went red on its own first
run against a genuine bug in itself: it read a comment as a declaration, because the `#` test ran
against `grep -n` output that is prefixed `file:line:` and so never starts with `#`. Both scans had it;
both now have regression cases.

## Not done, stated plainly

**This does not fix production.** The deployed binary is still `go1.26.5` — read out of the published
image, not inferred:

```
$ docker cp <container>:/usr/local/bin/wpmgr ./wpmgr && go version -m ./wpmgr
./wpmgr: go1.26.5
```

Closing it needs a rebuild and redeploy of both layers, and the published GHCR images self-hosters pull
carry the same toolchain. That is a release, not a merge.

`go test ./...` did not complete: 69 packages `ok`, 0 `FAIL`, then it stalled on `apps/api/tests`
spinning testcontainers, and was stopped at a bounded four minutes. `ci.yml` excludes that package by
name, so it does not run there either. Reported incomplete rather than implying coverage.

Residual advisories: 6, in modules required but not called by this code. Unreachable, pre-existing, and
not addressed by this bump.

## Findings, reported not fixed

`infra/Dockerfile.web` and `infra/Dockerfile.marketing` still float on `node:22-alpine` and
`nginx:1.27-alpine`. `node:22` moves minor and patch silently, and the marketing image ships only via
cloudbuild, so `release.yml` never sees it. The new guard is Go-only by design and does not cover them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchains to version 1.26.6 across CI, development containers, and build images.
  * Added automated checks to detect missing, inconsistent, or floating Go toolchain versions.
* **Tests**
  * Added regression coverage for valid and invalid toolchain configurations, including version compatibility checks.
* **Bug Fixes**
  * Improved security checks by enforcing consistency between workflow and container Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->