### PR TITLE
build: pin the Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -187,7 +187,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: apps/api/go.sum
 
       # The tests build their containers with testcontainers-go talking to the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: apps/api/go.sum
 
       # Build the api module on its own (workspace disabled) so it does not
@@ -328,7 +328,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: apps/api/go.sum
 
       # govulncheck does call-graph reachability analysis, so it only fails on

--- a/infra/Dockerfile.api
+++ b/infra/Dockerfile.api
@@ -12,7 +12,7 @@
 # this stage. BUILDPLATFORM/TARGETOS/TARGETARCH are injected by BuildKit;
 # when building without --platform (e.g. prod Cloud Build on amd64) they
 # all default to the host, so the amd64-only path is unchanged.
-FROM --platform=$BUILDPLATFORM golang:1.26 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS build
 
 # TARGETOS / TARGETARCH are populated by BuildKit to match the target
 # platform being built (e.g. linux/arm64). CGO_ENABLED=0 means pure Go

--- a/infra/Dockerfile.media-encoder
+++ b/infra/Dockerfile.media-encoder
@@ -7,7 +7,7 @@
 # native codec libs (libaom/dav1d/etc.), so it builds with CGO_ENABLED=1 against
 # a glibc base. The main API NEVER imports the encoder — these are two distinct
 # images by design.
-FROM golang:1.26 AS build
+FROM golang:1.26.6 AS build
 
 # CGO ON. linux/amd64 (lilliput ships prebuilt static codec libs for it).
 ENV CGO_ENABLED=1 \
@@ -68,7 +68,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # debian:trixie-slim ships glibc 2.41 + libstdc++ from GCC 14 (identical ABI
 # to distroless/cc-debian13), so the lilliput CGO requirement is still met.
 #
-# CRITICAL: stay on Debian 13 "trixie" to match golang:1.26 (also trixie).
+# CRITICAL: stay on Debian 13 "trixie" to match golang:1.26.6 (also trixie).
 # The binary requires GLIBC_2.38+ and GLIBCXX_3.4.32+; a debian12 runtime
 # dies at startup before it can bind $PORT.
 #

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
   # Mounts the api module so edits are picked up on container restart.
   api:
     build: !reset null
-    image: golang:1.26
+    image: golang:1.26.6
     working_dir: /src/apps/api
     environment:
       GOWORK: "off"


### PR DESCRIPTION
`main` is red with no code change. Commit `500b445d` was green at 19:03 and failed at 04:08 the next
morning, because `govulncheck` reads a live advisory database. This is the failure mode
`.claude/rules/ci-and-build-logic.md` already names: *"it can redden main with zero code change and a
green PR can fail on merge. Fix the dependency. Never tag a red commit."*

Seven vulnerabilities, all Go standard library, every one `Found in: …@go1.26.5` / `Fixed in: …@go1.26.6`.
Reachable here through `blobstore.Store.EnsureBucket` → `s3.Client.HeadBucket` (`encoding/xml`),
`pgxpool.Pool.Close` (`encoding/asn1`), and `http.Client.Do` (`golang.org/x/net/idna`). Recursion-depth
and input-validation class, not remote code execution.

## The whole change

Three `go-version` pins and three container declarations. Nothing else; no file is added.

```
 .github/workflows/api-integration.yml  go-version: "1.26.5" -> "1.26.6"
 .github/workflows/ci.yml               go-version: "1.26.5" -> "1.26.6"   (x2)
 infra/Dockerfile.api                   golang:1.26 -> golang:1.26.6
 infra/Dockerfile.media-encoder         golang:1.26 -> golang:1.26.6  (+ the Debian comment beside it)
 infra/docker-compose.dev.yml           golang:1.26 -> golang:1.26.6
 5 files changed, 7 insertions(+), 7 deletions(-)
```

The Dockerfiles get an **exact** pin because CI pinned `1.26.5` exactly while they floated on
`golang:1.26`. Those can differ in either direction and nothing notices, so CI could pass on a compiler
the shipped image never used. That tag has since moved on its own — `docker run --rm golang:1.26 go
version` now prints `go1.26.6` — so the image's compiler changed with nobody deciding it. An exact pin
makes the shipped toolchain a declared fact.

`apps/api/go.mod` stays at `go 1.26.3`. That is the language floor for anyone building from source, not
the compiler that ships; raising it per patch release pushes a floor onto consumers for no security gain.

## Verified

```
$ GOTOOLCHAIN=go1.26.6 govulncheck ./cmd/wpmgr/...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
GOVULNCHECK_EXIT=0

$ grep -rn '1\.26\.5' --exclude-dir=.git --exclude-dir=node_modules .
(no output, exit 1)
```

`go build ./...` and `go vet ./...` both exit 0 under `CGO_ENABLED=1` — a whole-tree build needs CGO on,
since `internal/media/encoder/lilliput.go` is `//go:build cgo` and `CGO_ENABLED=0` fails on
`undefined: encoder.NewLilliputEncoder`. Pre-existing and by design; the api image builds with CGO off
and only that package is affected.

The Debian comment beside the media-encoder pin was checked rather than assumed:
`docker run --rm golang:1.26.6 sh -c '. /etc/os-release; echo $PRETTY_NAME'` prints
`Debian GNU/Linux 13 (trixie)`, matching the `debian:trixie-slim` runtime stage.

Residual: 6 advisories in required modules that this code does not call. Unchanged by this bump, and
`govulncheck` exits 0 on them.

## What this does not do

**It does not fix production.** The deployed binary is still `go1.26.5`, read out of the published image
rather than inferred:

```
$ docker cp <container>:/usr/local/bin/wpmgr ./wpmgr && go version -m ./wpmgr
./wpmgr: go1.26.5
```

Closing that needs a rebuild and redeploy, and the GHCR images self-hosters pull carry the same
toolchain. That is a release, not a merge. `media-encoder` ships first when they go out.

It also does not repair the failure mode, only this instance of it: `govulncheck` reads the live feed on
every run, so a green PR here can still redden on merge if a new advisory lands tomorrow.

## Deliberately not included

An earlier version of this change added `scripts/check-go-toolchain.sh` to assert the declarations stay
in step. It is dropped, and it earned that. Replacing the Go base image with `alpine` in all three
container declarations left it reporting `check-go-toolchain: OK`, exit 0 — its emptiness check counted
globally, so surviving workflow pins masked the total absence of the container half. And with a version
repeated inside a trailing comment, greedy anchoring made it report agreement on `1.26.5`, a version
present in no declaration in that tree. A tool for catching wrong version numbers, reporting one that
did not exist.

Both were fixable and both were fixed on a branch. Neither is the reason for dropping it. The reason is
that exact pins make the toolchain a declared fact and `govulncheck` already catches the consequence —
it is what caught this, unprompted. See #423.

## Finding, reported not fixed

`infra/Dockerfile.web:12` and `infra/Dockerfile.marketing:10`/`:65` float on `node:22-alpine`, and
`infra/Dockerfile.web:39` on `nginx:1.27-alpine`. Same shape as `golang:1.26`. The nginx one is the
sharper of them, since it floats a patch series on the process terminating public traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Go toolchain to version 1.26.6 across continuous integration, API integration, development, and container build environments.
  - Standardized development and production build environments on the newer Go patch release.
  - Updated related compatibility documentation to reflect the exact compiler version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->