### PR TITLE
fix(perf): show the real 28d distribution, not one derived from the rating word

### DIFF
--- a/apps/api/internal/perf/rum_fleet_verdict_test.go
+++ b/apps/api/internal/perf/rum_fleet_verdict_test.go
@@ -319,3 +319,102 @@ func TestRumFleet_worstOffendersEnrichmentIsSingleBulkCall(t *testing.T) {
 		t.Errorf("ListSitesMeta called %d times, want exactly 1 (bulk lookup, not N+1)", calls)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// GH #391 — worst_offenders rows must carry the REAL distribution of the
+// metric that produced OverallRating, not a fabricated split keyed on the
+// rating word.
+// ---------------------------------------------------------------------------
+
+// TestRumFleet_worstOffenderDistribution_matchesWorstMetric is the GH #391
+// regression test: a site with a good LCP but a poor INP must return INP's
+// own bucket distribution and "inp" as DistributionMetric — not LCP's, even
+// though LCP data is also present on the row (LCPP75 is populated). LCP's
+// samples are ALL "good" (100/0/0) and INP's are ALL "poor" (0/0/100), so the
+// two distributions cannot be confused for one another by accident.
+func TestRumFleet_worstOffenderDistribution_matchesWorstMetric(t *testing.T) {
+	siteA := uuid.New()
+
+	// Bucket 0 ([0,200)) interpolates to p75≈150ms/milli — "good" for LCP
+	// (<=2500) and would also read "good" for INP (<=200) were it INP's data.
+	goodCounts := fleetInt32Counts(0, 50)
+	// Bucket 4 lower bound is 500, already >= INP's poor threshold (500), so
+	// this is wholly "poor" for INP regardless of within-bucket interpolation.
+	poorINPCounts := fleetInt32Counts(4, 40)
+
+	rollups := []rum.HourlyRollup{
+		{RollupKey: rum.RollupKey{SiteID: siteA, Metric: "lcp"}, SampleCount: 50, BucketCounts: goodCounts, MaxValue: 190},
+		{RollupKey: rum.RollupKey{SiteID: siteA, Metric: "inp"}, SampleCount: 40, BucketCounts: poorINPCounts, MaxValue: 590},
+	}
+
+	h := newFleetRumHandler([]uuid.UUID{siteA}, rollups)
+	resp := callRumFleet(t, h)
+
+	off := findOffender(resp, siteA)
+	if off == nil {
+		t.Fatalf("expected site A (good LCP, poor INP) in worst_offenders, got none")
+	}
+	if off.OverallRating != "poor" {
+		t.Fatalf("overall_rating = %q, want %q (worst of lcp=good/inp=poor)", off.OverallRating, "poor")
+	}
+	if off.DistributionMetric != "inp" {
+		t.Fatalf("distribution_metric = %q, want %q (INP is the worst-rated metric, not LCP)", off.DistributionMetric, "inp")
+	}
+	if off.DistributionSuppressed {
+		t.Fatalf("distribution_suppressed = true, want false (INP has 40 samples, floor is 30)")
+	}
+	if off.Distribution == nil {
+		t.Fatalf("distribution is nil, want a populated good/needs_improvement/poor split")
+	}
+	if off.Distribution.PoorPct != 100 || off.Distribution.GoodPct != 0 {
+		t.Errorf("distribution = %+v, want 100%% poor / 0%% good (all 40 INP samples are in the poor band, matching INP's own data — LCP's data is 100%% good and must not leak in)", off.Distribution)
+	}
+	if off.DistributionSampleCount != 40 {
+		t.Errorf("distribution_sample_count = %d, want 40 (INP's own sample count, not LCP+INP's combined %d)", off.DistributionSampleCount, off.SampleCount)
+	}
+	if off.DistributionSampleFloor != 30 {
+		t.Errorf("distribution_sample_floor = %d, want 30 (the global minSampleCount default)", off.DistributionSampleFloor)
+	}
+}
+
+// TestOffenderDistribution_belowFloor_isSuppressed verifies offenderDistribution
+// — the gate rum_fleet's worst-offender loop uses to decide whether a row's
+// bar is trustworthy — marks a metric below the sample floor as suppressed
+// with a nil distribution, rather than folding a low-confidence bucket count
+// into a bar the operator would read as measurement (GH #391). Exercised
+// directly (not through the HTTP handler): a row only reaches worst_offenders
+// once its worst metric has already cleared this same floor (see
+// DistributionSuppressed's doc comment on fleetRumWorstOffender), so this
+// state is not reachable via callRumFleet today — this proves the mechanism
+// that guards it stays correct in isolation, e.g. if that upstream gate is
+// ever loosened.
+func TestOffenderDistribution_belowFloor_isSuppressed(t *testing.T) {
+	counts := fleetInt32CountsAsInt64(0, 29) // 29 < floor of 30
+	dist, suppressed := offenderDistribution("lcp", counts, 29, 30)
+	if !suppressed {
+		t.Fatalf("suppressed = false, want true (29 samples < floor of 30)")
+	}
+	if dist != nil {
+		t.Fatalf("distribution = %+v, want nil when suppressed", dist)
+	}
+
+	// Sanity check the non-suppressed side too, so a change that always
+	// returns suppressed=true would also be caught.
+	dist, suppressed = offenderDistribution("lcp", counts, 30, 30)
+	if suppressed {
+		t.Fatalf("suppressed = true, want false (30 samples meets floor of 30)")
+	}
+	if dist == nil {
+		t.Fatalf("distribution is nil, want a populated split (sample count meets the floor)")
+	}
+}
+
+// fleetInt32CountsAsInt64 builds a NumBuckets int64 slice (the shape
+// offenderDistribution/foldBucketsIntoDistribution take directly, vs.
+// fleetInt32Counts' int32 rollup-wire shape) with a single bucket holding the
+// full sample count.
+func fleetInt32CountsAsInt64(idx int, count int64) []int64 {
+	c := make([]int64, rum.NumBuckets)
+	c[idx] = count
+	return c
+}

--- a/apps/api/internal/perf/rum_results_handler.go
+++ b/apps/api/internal/perf/rum_results_handler.go
@@ -489,6 +489,14 @@ type fleetPerMetric struct {
 
 // fleetRumWorstOffender is a site with poor CWV p75 ratings.
 // JSON field names are pinned to the frontend FleetRumOffender contract.
+//
+// GH #391 — the dashboard's per-row distribution bar used to be fabricated: a
+// fixed good/NI/poor split keyed only on OverallRating's word, with no
+// reference to actual sample data (never derivable to "good" in practice,
+// since a site only reaches worst_offenders at all when its worst band is
+// poor or needs-improvement). Distribution* below instead folds the SAME
+// bucket histogram that decided OverallRating, for the metric that actually
+// produced it, so the bar explains the rating sitting beside it.
 type fleetRumWorstOffender struct {
 	SiteID        uuid.UUID `json:"site_id"`
 	Name          string    `json:"name"`
@@ -498,6 +506,47 @@ type fleetRumWorstOffender struct {
 	CLSP75        *float64  `json:"cls_p75"`
 	OverallRating string    `json:"overall_rating"`
 	SampleCount   int64     `json:"sample_count"`
+
+	// DistributionMetric names which metric ("lcp", "inp", or "cls") produced
+	// OverallRating — worstOfThree's tie-break order (lcp, then inp, then
+	// cls; the first metric at max severity wins) is deterministic, so this
+	// never flips between refreshes for a tied row. The frontend labels the
+	// bar with this name instead of the misleading "Overall".
+	DistributionMetric string `json:"distribution_metric"`
+	// Distribution is DistributionMetric's good/needs-improvement/poor split,
+	// folded from the same bucket histogram InterpolateP75FromCounts used for
+	// that metric's p75 — nil when DistributionSuppressed is true.
+	Distribution *RumDistribution `json:"distribution,omitempty"`
+	// DistributionSuppressed is true when DistributionMetric's own sample
+	// count is below DistributionSampleFloor: the frontend must render
+	// "insufficient samples" for this row's bar rather than a confident
+	// split, exactly as the per-site summary endpoint already does for
+	// RumMetricSummary.Suppressed. In the current worst_offenders selection
+	// this metric always already cleared the floor (worstOfThree only
+	// returns a rated metric — see siteVerdict construction above — once its
+	// sample count clears minSampleCount), so this is defence-in-depth
+	// against that gate ever changing rather than a state reachable today;
+	// see the offenderDistribution doc comment.
+	DistributionSuppressed bool `json:"distribution_suppressed"`
+	// DistributionSampleCount is DistributionMetric's own sample count (NOT
+	// the LCP+INP+CLS sum SampleCount above).
+	DistributionSampleCount int64 `json:"distribution_sample_count"`
+	// DistributionSampleFloor is the threshold DistributionSampleCount was
+	// compared against. This is the GLOBAL default (the package-level
+	// minSampleCount const, currently 30) — the same floor that already
+	// gates every rating in this fleet aggregation (siteVerdict.*Rating,
+	// fleetPassPct) — and deliberately NOT the site's own configured
+	// site_perf_config.min_sample_count that the per-site summary endpoint
+	// (rumSummary, RumSummaryDTO.MinSampleCount) honours. rumFleet collapses
+	// many sites' rollups in one pass and loads no per-site config; sending a
+	// per-site floor here while every other rating in the same response used
+	// the global one would let a row's bar disagree with its own rating word
+	// on the exact question of whether there was "enough data" — a more
+	// confusing failure than naming the floor honestly as global. Loading
+	// per-site config for this field is a legitimate follow-up (bounded to
+	// the <=10 capped offenders, same pattern as the Name/URL enrichment
+	// below) if the two floors ever need to diverge.
+	DistributionSampleFloor int64 `json:"distribution_sample_floor"`
 }
 
 // fleetRumTrendPoint is one day's fleet-level p75 values for the three
@@ -549,17 +598,40 @@ func ratingRank(rating string) int {
 }
 
 // worstOfThree returns the most severe of the (already-normalized) lcp/inp/cls
-// ratings, ignoring any that are "" (unrated). Returns "" if none are rated.
-func worstOfThree(lcp, inp, cls string) string {
-	worst := ""
+// ratings, ignoring any that are "" (unrated), together with the name of the
+// metric that produced it ("lcp", "inp", or "cls"). Ties are broken by
+// iteration order below (lcp, inp, cls): the FIRST metric at the max severity
+// wins, deterministically — a row whose bar changed metric between refreshes
+// on a tie would be worse than no bar (GH #391). Returns ("", "") if none are
+// rated.
+func worstOfThree(lcp, inp, cls string) (rating string, metric string) {
+	type candidate struct {
+		rating string
+		metric string
+	}
+	worst := candidate{}
 	worstRank := -1
-	for _, r := range [3]string{lcp, inp, cls} {
-		if rank := ratingRank(r); rank > worstRank {
+	for _, cand := range [3]candidate{{lcp, "lcp"}, {inp, "inp"}, {cls, "cls"}} {
+		if rank := ratingRank(cand.rating); rank > worstRank {
 			worstRank = rank
-			worst = r
+			worst = cand
 		}
 	}
-	return worst
+	return worst.rating, worst.metric
+}
+
+// offenderDistribution folds metric's bucket histogram into a RumDistribution
+// for a worst-offender row, or marks it suppressed when sampleCount is below
+// floor. Factored out of rumFleet so the suppression gate is one
+// independently-testable place instead of being inlined at the call site —
+// see the DistributionSuppressed doc on fleetRumWorstOffender for why this
+// gate cannot currently fire for a row that already made the offenders list,
+// and is kept anyway as defence-in-depth.
+func offenderDistribution(metric string, counts []int64, sampleCount, floor int64) (dist *RumDistribution, suppressed bool) {
+	if sampleCount < floor {
+		return nil, true
+	}
+	return foldBucketsIntoDistribution(metric, counts), false
 }
 
 // rumFleet handles GET /api/v1/perf/rum/fleet.
@@ -809,19 +881,37 @@ func (h *Handler) rumFleet(c *gin.Context) {
 	// OverallRating is the worst band among whichever metrics are rated.
 	worstOffenders := make([]fleetRumWorstOffender, 0, len(siteVerdicts))
 	for siteID, sv := range siteVerdicts {
-		worst := worstOfThree(sv.lcpRating, sv.inpRating, sv.clsRating)
+		worst, worstMetric := worstOfThree(sv.lcpRating, sv.inpRating, sv.clsRating)
 		if worst != "poor" && worst != "needs-improvement" {
 			continue
 		}
+
+		// Distribution of the metric that produced `worst` (GH #391): pull the
+		// SAME per-(site,metric) bucket accumulator that fed siteVerdicts above
+		// (siteAcc, built in the rollup loop earlier in this function) — no new
+		// query, the histogram is already in memory.
+		var dist *RumDistribution
+		var distSamples int64
+		distSuppressed := true
+		if acc, ok := siteAcc[siteMetricKey{siteID: siteID, metric: worstMetric}]; ok {
+			distSamples = acc.sampleCount
+			dist, distSuppressed = offenderDistribution(worstMetric, acc.counts, acc.sampleCount, int64(minSampleCount))
+		}
+
 		worstOffenders = append(worstOffenders, fleetRumWorstOffender{
-			SiteID:        siteID,
-			Name:          "", // enriched below, after sort+cap (GH #202); left empty here by design
-			URL:           "",
-			LCPP75:        sv.lcpP75,
-			INPP75:        sv.inpP75,
-			CLSP75:        sv.clsP75,
-			OverallRating: worst,
-			SampleCount:   sv.lcpSamples + sv.inpSamples + sv.clsSamples,
+			SiteID:                  siteID,
+			Name:                    "", // enriched below, after sort+cap (GH #202); left empty here by design
+			URL:                     "",
+			LCPP75:                  sv.lcpP75,
+			INPP75:                  sv.inpP75,
+			CLSP75:                  sv.clsP75,
+			OverallRating:           worst,
+			SampleCount:             sv.lcpSamples + sv.inpSamples + sv.clsSamples,
+			DistributionMetric:      worstMetric,
+			Distribution:            dist,
+			DistributionSuppressed:  distSuppressed,
+			DistributionSampleCount: distSamples,
+			DistributionSampleFloor: int64(minSampleCount),
 		})
 	}
 	sort.Slice(worstOffenders, func(i, j int) bool {

--- a/apps/api/internal/perf/rum_results_handler.go
+++ b/apps/api/internal/perf/rum_results_handler.go
@@ -532,8 +532,8 @@ type fleetRumWorstOffender struct {
 	// the LCP+INP+CLS sum SampleCount above).
 	DistributionSampleCount int64 `json:"distribution_sample_count"`
 	// DistributionSampleFloor is the threshold DistributionSampleCount was
-	// compared against. This is the GLOBAL default (the package-level
-	// minSampleCount const, currently 30) — the same floor that already
+	// compared against. This is the GLOBAL default (the minSampleCount const
+	// local to rumFleet) — the same floor that already
 	// gates every rating in this fleet aggregation (siteVerdict.*Rating,
 	// fleetPassPct) — and deliberately NOT the site's own configured
 	// site_perf_config.min_sample_count that the per-site summary endpoint

--- a/apps/api/internal/perf/rum_results_handler.go
+++ b/apps/api/internal/perf/rum_results_handler.go
@@ -886,32 +886,22 @@ func (h *Handler) rumFleet(c *gin.Context) {
 			continue
 		}
 
-		// Distribution of the metric that produced `worst` (GH #391): pull the
-		// SAME per-(site,metric) bucket accumulator that fed siteVerdicts above
-		// (siteAcc, built in the rollup loop earlier in this function) — no new
-		// query, the histogram is already in memory.
-		var dist *RumDistribution
-		var distSamples int64
-		distSuppressed := true
-		if acc, ok := siteAcc[siteMetricKey{siteID: siteID, metric: worstMetric}]; ok {
-			distSamples = acc.sampleCount
-			dist, distSuppressed = offenderDistribution(worstMetric, acc.counts, acc.sampleCount, int64(minSampleCount))
-		}
-
+		// DistributionMetric only names which metric produced `worst`; the
+		// histogram fold itself (GH #391) happens below, after sort+cap,
+		// alongside the Name/URL enrichment — same reason: bounded to <=10
+		// rows instead of running once per qualifying site.
 		worstOffenders = append(worstOffenders, fleetRumWorstOffender{
-			SiteID:                  siteID,
-			Name:                    "", // enriched below, after sort+cap (GH #202); left empty here by design
-			URL:                     "",
-			LCPP75:                  sv.lcpP75,
-			INPP75:                  sv.inpP75,
-			CLSP75:                  sv.clsP75,
-			OverallRating:           worst,
-			SampleCount:             sv.lcpSamples + sv.inpSamples + sv.clsSamples,
-			DistributionMetric:      worstMetric,
-			Distribution:            dist,
-			DistributionSuppressed:  distSuppressed,
-			DistributionSampleCount: distSamples,
-			DistributionSampleFloor: int64(minSampleCount),
+			SiteID:             siteID,
+			Name:               "", // enriched below, after sort+cap (GH #202); left empty here by design
+			URL:                "",
+			LCPP75:             sv.lcpP75,
+			INPP75:             sv.inpP75,
+			CLSP75:             sv.clsP75,
+			OverallRating:      worst,
+			SampleCount:        sv.lcpSamples + sv.inpSamples + sv.clsSamples,
+			DistributionMetric: worstMetric,
+			// Distribution / DistributionSuppressed / DistributionSampleCount /
+			// DistributionSampleFloor are filled in below, after sort+cap.
 		})
 	}
 	sort.Slice(worstOffenders, func(i, j int) bool {
@@ -935,9 +925,27 @@ func (h *Handler) rumFleet(c *gin.Context) {
 	}
 
 	// Enrich the (already-capped, <=10) offenders with a display name/url
-	// (GH #202). Deliberately done AFTER sort+cap so this never scales with
-	// the number of reporting sites — one bulk lookup, not an N+1 per site.
+	// (GH #202) and with their offender distribution (GH #391). Deliberately
+	// done AFTER sort+cap so neither scales with the number of reporting
+	// sites — one bulk name/url lookup, and at most ten histogram folds,
+	// not one per qualifying site.
 	if len(worstOffenders) > 0 {
+		for i := range worstOffenders {
+			wo := &worstOffenders[i]
+			wo.DistributionSampleFloor = int64(minSampleCount)
+			// Pull the SAME per-(site,metric) bucket accumulator that fed
+			// siteVerdicts above (siteAcc, built in the rollup loop earlier
+			// in this function) — no new query, the histogram is already in
+			// memory.
+			acc, ok := siteAcc[siteMetricKey{siteID: wo.SiteID, metric: wo.DistributionMetric}]
+			if !ok {
+				wo.DistributionSuppressed = true
+				continue
+			}
+			wo.DistributionSampleCount = acc.sampleCount
+			wo.Distribution, wo.DistributionSuppressed = offenderDistribution(wo.DistributionMetric, acc.counts, acc.sampleCount, int64(minSampleCount))
+		}
+
 		if metas, merr := h.svc.ListSitesMeta(c.Request.Context(), p.TenantID); merr == nil {
 			metaByID := make(map[uuid.UUID]SiteMeta, len(metas))
 			for _, m := range metas {

--- a/apps/api/internal/perf/rum_worst_of_three_test.go
+++ b/apps/api/internal/perf/rum_worst_of_three_test.go
@@ -1,0 +1,126 @@
+package perf
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/rum"
+)
+
+// ---------------------------------------------------------------------------
+// GH #391 — worstOfThree's tie-break order (lcp, then inp, then cls; first
+// metric at max severity wins) must be pinned. A reviewer reversed the order
+// once and the rest of the suite stayed green, because none of it exercised a
+// genuine tie: with only three metrics and three bands, two sites out of
+// three routinely land two metrics in the same band, so an unstable tie-break
+// would flicker the distribution bar between refreshes — precisely the
+// confusion #391 was filed about. See the worstOfThree doc comment.
+// ---------------------------------------------------------------------------
+
+// TestWorstOfThree_tieBreakOrder pins the order directly against the helper.
+// Reversing the iteration order in worstOfThree (lcp, inp, cls) flips every
+// one of these.
+func TestWorstOfThree_tieBreakOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		lcp, inp, cls string
+		wantRating    string
+		wantMetric    string
+	}{
+		{
+			name:       "lcp and inp both worst (poor), cls good: lcp wins",
+			lcp:        "poor",
+			inp:        "poor",
+			cls:        "good",
+			wantRating: "poor",
+			wantMetric: "lcp",
+		},
+		{
+			name:       "inp and cls both worst (poor), lcp better: inp wins",
+			lcp:        "needs-improvement",
+			inp:        "poor",
+			cls:        "poor",
+			wantRating: "poor",
+			wantMetric: "inp",
+		},
+		{
+			name:       "all three tied at the same band: lcp wins",
+			lcp:        "poor",
+			inp:        "poor",
+			cls:        "poor",
+			wantRating: "poor",
+			wantMetric: "lcp",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRating, gotMetric := worstOfThree(tt.lcp, tt.inp, tt.cls)
+			if gotRating != tt.wantRating || gotMetric != tt.wantMetric {
+				t.Errorf("worstOfThree(%q, %q, %q) = (%q, %q), want (%q, %q)",
+					tt.lcp, tt.inp, tt.cls, gotRating, gotMetric, tt.wantRating, tt.wantMetric)
+			}
+		})
+	}
+}
+
+// TestRumFleet_tieBreak_distributionMatchesWinningMetric drives the tie
+// through the real handler path (not just the worstOfThree helper) and
+// verifies the winner is the metric whose DISTRIBUTION is actually returned,
+// not merely the one named in distribution_metric. LCP and INP are both
+// rated "poor" (a genuine tie), so worstOfThree must pick lcp — and the
+// histogram folded into the response must be LCP's own (100% poor, 0% good),
+// not INP's (which is deliberately built with a different split: 20% good /
+// 80% poor) so the two cannot be confused for one another by accident.
+func TestRumFleet_tieBreak_distributionMatchesWinningMetric(t *testing.T) {
+	siteA := uuid.New()
+
+	// LCP: wholly poor. Bucket 17 lower bound (4500ms) is already > LCP's
+	// poor threshold (4000), so this is 100% poor regardless of
+	// within-bucket interpolation.
+	lcpPoorCounts := fleetInt32Counts(17, 50)
+
+	// INP: also rated "poor" at p75 (tied with LCP), but built from a
+	// DIFFERENT distribution so a swapped-source bug is visible: 10 samples
+	// in bucket 0 ([0,200), wholly good for INP's <=200 threshold) plus 40
+	// samples in bucket 4 (lower bound 500, wholly poor for INP's >=500
+	// threshold). p75 (the 38th of 50 samples) falls among the 40 poor
+	// samples, so INP's rating is "poor" — tied with LCP — but its folded
+	// distribution is 20% good / 80% poor, nothing like LCP's 100% poor.
+	inpCounts := make([]int32, rum.NumBuckets)
+	inpCounts[0] = 10
+	inpCounts[4] = 40
+
+	rollups := []rum.HourlyRollup{
+		{RollupKey: rum.RollupKey{SiteID: siteA, Metric: "lcp"}, SampleCount: 50, BucketCounts: lcpPoorCounts, MaxValue: 4900},
+		{RollupKey: rum.RollupKey{SiteID: siteA, Metric: "inp"}, SampleCount: 50, BucketCounts: inpCounts, MaxValue: 590},
+	}
+
+	h := newFleetRumHandler([]uuid.UUID{siteA}, rollups)
+	resp := callRumFleet(t, h)
+
+	off := findOffender(resp, siteA)
+	if off == nil {
+		t.Fatalf("expected site A (lcp=poor, inp=poor tie) in worst_offenders, got none")
+	}
+	if off.OverallRating != "poor" {
+		t.Fatalf("overall_rating = %q, want %q (both lcp and inp are poor)", off.OverallRating, "poor")
+	}
+	if off.DistributionMetric != "lcp" {
+		t.Fatalf("distribution_metric = %q, want %q (tie-break: lcp wins over inp)", off.DistributionMetric, "lcp")
+	}
+	if off.Distribution == nil {
+		t.Fatalf("distribution is nil, want a populated split")
+	}
+	// This is the load-bearing assertion: the bar must carry LCP's own
+	// histogram (100% poor), not INP's (20% good / 80% poor) even though
+	// both are named-eligible via the tie. A bug that names "lcp" correctly
+	// but sources the histogram from the wrong accumulator would pass the
+	// DistributionMetric check above and fail only here.
+	if off.Distribution.PoorPct != 100 || off.Distribution.GoodPct != 0 {
+		t.Errorf("distribution = %+v, want 100%% poor / 0%% good (LCP's own data) — INP's data (20%% good / 80%% poor) must not leak in on the tie", off.Distribution)
+	}
+	if off.DistributionSampleCount != 50 {
+		t.Errorf("distribution_sample_count = %d, want 50 (LCP's own sample count)", off.DistributionSampleCount)
+	}
+}

--- a/apps/web/src/features/fleet/fleet-types.ts
+++ b/apps/web/src/features/fleet/fleet-types.ts
@@ -2,6 +2,8 @@
 // Performance). These are hand-rolled to match the pinned API contract; the
 // endpoints are NOT in the generated @wpmgr/api SDK yet.
 
+import type { RumDistribution } from "@/features/perf/types";
+
 // ---------------------------------------------------------------------------
 // Uptime
 // ---------------------------------------------------------------------------
@@ -180,6 +182,22 @@ export interface FleetRumOffender {
   cls_p75: number | null;
   overall_rating: "good" | "needs-improvement" | "poor";
   sample_count: number;
+  /**
+   * Which of lcp/inp/cls produced `overall_rating` (worstOfThree's
+   * deterministic lcp -> inp -> cls tie-break; see rum_results_handler.go).
+   * The distribution below is THIS metric's own good/NI/poor split, not an
+   * average across all three (different units, different thresholds, and
+   * the rollups are per-metric histograms with no cross-metric join key).
+   */
+  distribution_metric: "lcp" | "inp" | "cls" | "";
+  /** distribution_metric's own good/needs-improvement/poor split. Absent when distribution_suppressed is true. */
+  distribution?: RumDistribution;
+  /** True when distribution_sample_count is below distribution_sample_floor: render "insufficient samples", not a bar. */
+  distribution_suppressed: boolean;
+  /** distribution_metric's own sample count (NOT the lcp+inp+cls sum in sample_count above). */
+  distribution_sample_count: number;
+  /** The floor distribution_sample_count was compared against (fleet aggregation's global minSampleCount). */
+  distribution_sample_floor: number;
 }
 
 export interface FleetRumTrendPoint {

--- a/apps/web/src/features/perf/optimize/RumDistributionBar.test.tsx
+++ b/apps/web/src/features/perf/optimize/RumDistributionBar.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { RumDistributionBar } from "./RumDistributionBar";
+
+// GH #391 follow-up — RumDistributionBar had zero direct test coverage before
+// this file (only exercised indirectly through
+// routes/_authed/-performance.distribution.test.tsx, which covers the
+// worst-offenders table's opt-in `showMetricLabel` usage).
+//
+// FleetRumPanel.tsx has no test file of its own (`find apps/web/src -iname
+// "*FleetRumPanel*"` under a *.test.* filter returns nothing), and
+// portal-month-glance.tsx does not call this component at all — it renders a
+// distinct `PortalDistributionRow` (see that file's header comment). So the
+// worst-offenders table's opt-in flag can't be regression-tested against
+// FleetRumPanel's real usage by running FleetRumPanel's own suite; there
+// isn't one. This file instead pins FleetRumPanel's exact call shape (no
+// `showMetricLabel`) directly against the shared component, so a future
+// change to the default can't silently add a visible label to FleetRumPanel's
+// cards without a test going red here.
+
+describe("RumDistributionBar — default (opt-out) rendering, FleetRumPanel's call shape", () => {
+  it("renders no visible metric-label text when showMetricLabel is omitted", () => {
+    renderWithProviders(
+      <RumDistributionBar
+        metricLabel="LCP"
+        distribution={{
+          good: 60,
+          needs_improvement: 30,
+          poor: 10,
+          good_pct: 60,
+          needs_improvement_pct: 30,
+          poor_pct: 10,
+        }}
+        suppressed={false}
+      />,
+    );
+
+    // The bar itself still carries the metric name for assistive tech...
+    expect(
+      screen.getByRole("img", { name: /^LCP distribution:/ }),
+    ).toBeInTheDocument();
+
+    // ...but nothing sighted-only reads "LCP" — FleetRumPanel's CoreMetricCard
+    // already prints the metric name as its own heading, so a second, visible
+    // "LCP" here would be a duplicate this change must not introduce.
+    expect(screen.queryByText("LCP")).not.toBeInTheDocument();
+  });
+
+  it("renders the plain 'Insufficient samples' fallback with no metric prefix when showMetricLabel is omitted", () => {
+    renderWithProviders(
+      <RumDistributionBar
+        metricLabel="CLS"
+        distribution={undefined}
+        suppressed
+        sampleCount={12}
+        minSampleCount={30}
+      />,
+    );
+
+    // FleetRumPanel never actually reaches this branch in production (its
+    // suppressed slices short-circuit before rendering RumDistributionBar at
+    // all — see CoreMetricCard), but the prop contract still needs to hold:
+    // opt-out means opt-out.
+    expect(
+      screen.getByText(/^Insufficient samples \(12 of 30\)$/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^CLS:/)).not.toBeInTheDocument();
+  });
+
+  it("showMetricLabel=true (the worst-offenders table's opt-in) DOES add a visible label — proves the flag actually does something", () => {
+    renderWithProviders(
+      <RumDistributionBar
+        metricLabel="INP"
+        distribution={{
+          good: 60,
+          needs_improvement: 30,
+          poor: 10,
+          good_pct: 60,
+          needs_improvement_pct: 30,
+          poor_pct: 10,
+        }}
+        showMetricLabel
+      />,
+    );
+    expect(screen.getByText("INP")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/perf/optimize/RumDistributionBar.tsx
+++ b/apps/web/src/features/perf/optimize/RumDistributionBar.tsx
@@ -11,6 +11,10 @@
 // When distribution is absent (the slice is suppressed or has no data), the
 // component renders nothing — the caller is responsible for rendering the
 // existing "insufficient samples" card instead of invoking this bar.
+//
+// `metricLabel` always reaches assistive tech (aria-label / title). It only
+// reaches sighted users when a caller opts in with `showMetricLabel` — see
+// that prop's doc comment for why this is opt-in rather than the default.
 
 import { AlertCircle } from "lucide-react";
 import type { RumDistribution } from "../types";
@@ -71,6 +75,19 @@ export interface RumDistributionBarProps {
   sampleCount?: number;
   /** Required minimum count — used in the suppressed fallback copy. */
   minSampleCount?: number;
+  /**
+   * Render `metricLabel` as a VISIBLE label next to the bar (and in the
+   * suppressed fallback), not just inside the accessible name / title.
+   *
+   * Opt-in: FleetRumPanel's callers each sit inside a card/row that already
+   * names the metric on screen (the CoreMetricCard heading, the "Additional
+   * metrics" row label), so turning this on there would duplicate it and
+   * change their existing rendered output. The worst-offenders table
+   * (performance.tsx) has no other on-screen home for the metric name — three
+   * rows can show three different bars for three different metrics with
+   * nothing else distinguishing them — so it sets this to true (GH #391).
+   */
+  showMetricLabel?: boolean;
 }
 
 export function RumDistributionBar({
@@ -79,6 +96,7 @@ export function RumDistributionBar({
   suppressed,
   sampleCount,
   minSampleCount,
+  showMetricLabel,
 }: RumDistributionBarProps) {
   // If suppressed or no distribution present, render the inline fallback that
   // mirrors the CoreMetricCard suppressed copy. This prevents an empty/0 bar.
@@ -90,6 +108,11 @@ export function RumDistributionBar({
           title={`${metricLabel}: insufficient samples`}
         >
           <AlertCircle aria-hidden="true" className="size-3 shrink-0" />
+          {showMetricLabel ? (
+            <span className="font-semibold text-[var(--color-foreground)]">
+              {metricLabel}:
+            </span>
+          ) : null}
           Insufficient samples
           {sampleCount !== undefined && minSampleCount !== undefined
             ? ` (${String(sampleCount)} of ${String(minSampleCount)})`
@@ -112,37 +135,47 @@ export function RumDistributionBar({
 
   return (
     <div className="mt-2 w-full">
-      {/* Stacked bar */}
-      <div
-        role="img"
-        aria-label={ariaLabel}
-        title={ariaLabel}
-        className="flex h-4 w-full overflow-hidden rounded-full"
-        style={{ minHeight: "1rem" }}
-      >
-        {segments.map((seg) => {
-          if (seg.pct <= 0) return null;
-          return (
-            <div
-              key={seg.key}
-              className={`relative flex items-center justify-center ${seg.bgClass}`}
-              style={{
-                width: `${String(seg.pct)}%`,
-                minWidth:
-                  seg.pct > 0 ? `${String(MIN_SEGMENT_PX)}px` : undefined,
-              }}
-            >
-              {seg.pct >= LABEL_HIDE_BELOW_PCT ? (
-                <span
-                  className={`select-none text-[10px] font-semibold leading-none tabular-nums ${seg.textClass}`}
-                  aria-hidden="true"
-                >
-                  {String(seg.pct)}%
-                </span>
-              ) : null}
-            </div>
-          );
-        })}
+      {/* Metric label (opt-in) + stacked bar, one row so no extra height */}
+      <div className="flex items-center gap-1.5">
+        {showMetricLabel ? (
+          <span
+            aria-hidden="true"
+            className="shrink-0 whitespace-nowrap text-[9px] font-semibold uppercase tracking-wide text-[var(--color-muted-foreground)]"
+          >
+            {metricLabel}
+          </span>
+        ) : null}
+        <div
+          role="img"
+          aria-label={ariaLabel}
+          title={ariaLabel}
+          className="flex h-4 min-w-0 flex-1 overflow-hidden rounded-full"
+          style={{ minHeight: "1rem" }}
+        >
+          {segments.map((seg) => {
+            if (seg.pct <= 0) return null;
+            return (
+              <div
+                key={seg.key}
+                className={`relative flex items-center justify-center ${seg.bgClass}`}
+                style={{
+                  width: `${String(seg.pct)}%`,
+                  minWidth:
+                    seg.pct > 0 ? `${String(MIN_SEGMENT_PX)}px` : undefined,
+                }}
+              >
+                {seg.pct >= LABEL_HIDE_BELOW_PCT ? (
+                  <span
+                    className={`select-none text-[10px] font-semibold leading-none tabular-nums ${seg.textClass}`}
+                    aria-hidden="true"
+                  >
+                    {String(seg.pct)}%
+                  </span>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       {/* Legend row */}

--- a/apps/web/src/routes/_authed/-performance.distribution.test.tsx
+++ b/apps/web/src/routes/_authed/-performance.distribution.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { FleetTable } from "@/features/fleet/FleetTable";
+import type { FleetRumOffender } from "@/features/fleet/fleet-types";
+
+import { buildSiteColumns } from "./performance";
+
+// GH #391 — the worst-offenders "distribution" cell used to fabricate its
+// bar from nothing but `overall_rating`'s one-word band (a hardcoded
+// 75/40/10-style split keyed on the rating string, never on real sample
+// data): every row sharing a rating rendered the IDENTICAL bar, labelled
+// "Overall" even though no such derivable distribution exists (rollups are
+// per-metric histograms with no cross-metric join key — see the design
+// note in the route's own worklog). Before this file, none of the 132 test
+// files under apps/web/src (`find apps/web/src -name "*.test.*" | wc -l`)
+// referenced RumDistributionBar or worst_offenders, so this defect had zero
+// coverage.
+//
+// This file renders the real `buildSiteColumns` cell defs through the real
+// `FleetTable` (not a mock) — the same code path production uses — so a
+// regression that reintroduces the fabrication is caught at the render
+// layer, not just typechecked.
+
+function buildOffender(overrides: Partial<FleetRumOffender>): FleetRumOffender {
+  return {
+    site_id: "site-1",
+    name: "example.com",
+    url: "https://example.com",
+    lcp_p75: 4200,
+    inp_p75: 180,
+    cls_p75: 0.05,
+    overall_rating: "needs-improvement",
+    sample_count: 200,
+    distribution_metric: "lcp",
+    distribution: {
+      good: 5,
+      needs_improvement: 80,
+      poor: 15,
+      good_pct: 5,
+      needs_improvement_pct: 80,
+      poor_pct: 15,
+    },
+    distribution_suppressed: false,
+    distribution_sample_count: 100,
+    distribution_sample_floor: 30,
+    ...overrides,
+  };
+}
+
+describe("performance.tsx worst-offenders distribution cell (GH #391)", () => {
+  it("renders DIFFERENT bars for two rows sharing the SAME overall_rating but different real per-metric distributions", () => {
+    // Both rows are "needs-improvement" — the exact case the fabricated
+    // ternary could not distinguish (it read only overall_rating and always
+    // produced good=40/ni=45/poor=15 for this band, regardless of the site).
+    const lcpDriven = buildOffender({
+      site_id: "site-lcp",
+      name: "lcp-site.example",
+      overall_rating: "needs-improvement",
+      distribution_metric: "lcp",
+      distribution: {
+        good: 5,
+        needs_improvement: 80,
+        poor: 15,
+        good_pct: 5,
+        needs_improvement_pct: 80,
+        poor_pct: 15,
+      },
+    });
+    const inpDriven = buildOffender({
+      site_id: "site-inp",
+      name: "inp-site.example",
+      overall_rating: "needs-improvement",
+      distribution_metric: "inp",
+      distribution: {
+        good: 60,
+        needs_improvement: 30,
+        poor: 10,
+        good_pct: 60,
+        needs_improvement_pct: 30,
+        poor_pct: 10,
+      },
+    });
+
+    const columns = buildSiteColumns(28, vi.fn());
+    renderWithProviders(
+      <FleetTable<FleetRumOffender>
+        data={[lcpDriven, inpDriven]}
+        columns={columns}
+        ariaLabel="Sites"
+      />,
+    );
+
+    // Real, DIFFERENT numbers for each row — this is the regression the
+    // fabricated ternary would have failed: it could only ever emit
+    // 40% good, 45% needs improvement, 15% poor for a needs-improvement row.
+    expect(
+      screen.getByRole("img", {
+        name: "LCP distribution: 5% good, 80% needs improvement, 15% poor.",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", {
+        name: "INP distribution: 60% good, 30% needs improvement, 10% poor.",
+      }),
+    ).toBeInTheDocument();
+
+    // The fabricated split for "needs-improvement" never appears anywhere.
+    expect(
+      screen.queryByText(/40% good, 45% needs improvement, 15% poor/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the insufficient-samples affordance, not a confident bar, for a row below the sample floor", () => {
+    const suppressed = buildOffender({
+      site_id: "site-suppressed",
+      name: "low-traffic.example",
+      overall_rating: "poor",
+      distribution_metric: "cls",
+      distribution: undefined,
+      distribution_suppressed: true,
+      distribution_sample_count: 12,
+      distribution_sample_floor: 30,
+    });
+
+    const columns = buildSiteColumns(28, vi.fn());
+    renderWithProviders(
+      <FleetTable<FleetRumOffender>
+        data={[suppressed]}
+        columns={columns}
+        ariaLabel="Sites"
+      />,
+    );
+
+    expect(
+      screen.getByText(/Insufficient samples \(12 of 30\)/),
+    ).toBeInTheDocument();
+
+    // No stacked-bar role="img" for this row — the suppressed branch never
+    // reaches buildSegments/the percentage bar.
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("labels the bar with the metric that actually drove overall_rating, never the fabricated 'Overall'", () => {
+    const clsDriven = buildOffender({
+      site_id: "site-cls",
+      name: "cls-site.example",
+      overall_rating: "poor",
+      distribution_metric: "cls",
+      distribution: {
+        good: 0,
+        needs_improvement: 10,
+        poor: 90,
+        good_pct: 0,
+        needs_improvement_pct: 10,
+        poor_pct: 90,
+      },
+    });
+
+    const columns = buildSiteColumns(28, vi.fn());
+    renderWithProviders(
+      <FleetTable<FleetRumOffender>
+        data={[clsDriven]}
+        columns={columns}
+        ariaLabel="Sites"
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: /^CLS distribution:/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Overall distribution:/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: /^Overall/ })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/_authed/-performance.distribution.test.tsx
+++ b/apps/web/src/routes/_authed/-performance.distribution.test.tsx
@@ -107,8 +107,12 @@ describe("performance.tsx worst-offenders distribution cell (GH #391)", () => {
     ).toBeInTheDocument();
 
     // The fabricated split for "needs-improvement" never appears anywhere.
+    // This text lives only inside the bar's `title` attribute (and its
+    // identical aria-label) — `queryByText` searches rendered text content
+    // and can never see an attribute, so it must be `queryByTitle` here, not
+    // `queryByText`, or this assertion passes no matter what the code does.
     expect(
-      screen.queryByText(/40% good, 45% needs improvement, 15% poor/),
+      screen.queryByTitle(/40% good, 45% needs improvement, 15% poor/),
     ).not.toBeInTheDocument();
   });
 
@@ -170,7 +174,12 @@ describe("performance.tsx worst-offenders distribution cell (GH #391)", () => {
     expect(
       screen.getByRole("img", { name: /^CLS distribution:/ }),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/^Overall distribution:/)).not.toBeInTheDocument();
+    // Same defect as above: "Overall distribution:" (the old fabricated
+    // label) lives only in the `title` attribute, never in text content, so
+    // this must query the attribute directly rather than `queryByText`.
+    expect(
+      screen.queryByTitle(/^Overall distribution:/),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("img", { name: /^Overall/ })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/_authed/-performance.distribution.test.tsx
+++ b/apps/web/src/routes/_authed/-performance.distribution.test.tsx
@@ -13,9 +13,10 @@ import { buildSiteColumns } from "./performance";
 // data): every row sharing a rating rendered the IDENTICAL bar, labelled
 // "Overall" even though no such derivable distribution exists (rollups are
 // per-metric histograms with no cross-metric join key — see the design
-// note in the route's own worklog). Before this file, none of the 132 test
-// files under apps/web/src (`find apps/web/src -name "*.test.*" | wc -l`)
-// referenced RumDistributionBar or worst_offenders, so this defect had zero
+// note in the route's own worklog). Before this file, no test under
+// apps/web/src referenced RumDistributionBar or worst_offenders (verify with
+// `git grep -l 'RumDistributionBar\|worst_offenders' -- apps/web/src
+// '*.test.*'` against the commit before this one), so this defect had zero
 // coverage.
 //
 // This file renders the real `buildSiteColumns` cell defs through the real

--- a/apps/web/src/routes/_authed/performance.tsx
+++ b/apps/web/src/routes/_authed/performance.tsx
@@ -396,6 +396,7 @@ export function buildSiteColumns(
             suppressed={o.distribution_suppressed}
             sampleCount={o.distribution_sample_count}
             minSampleCount={o.distribution_sample_floor}
+            showMetricLabel
           />
         );
       },

--- a/apps/web/src/routes/_authed/performance.tsx
+++ b/apps/web/src/routes/_authed/performance.tsx
@@ -290,7 +290,11 @@ function HeadlineStrip({
 // All-sites CWV table columns
 // ---------------------------------------------------------------------------
 
-function buildSiteColumns(
+// Exported for -performance.distribution.test.tsx, which renders these
+// columns through the real FleetTable to cover the worst-offenders
+// distribution cell (GH #391) — otherwise untested (see that file's header
+// comment).
+export function buildSiteColumns(
   windowDays: number,
   onRowClick: (row: FleetRumOffender) => void,
 ): ColumnDef<FleetRumOffender>[] {
@@ -382,25 +386,37 @@ function buildSiteColumns(
       enableSorting: false,
       meta: { width: "20%" },
       cell: ({ row }) => {
-        const r = row.original.overall_rating;
-        const goodPct = r === "good" ? 75 : r === "needs-improvement" ? 40 : 10;
-        const poorPct = r === "poor" ? 60 : r === "needs-improvement" ? 15 : 5;
-        const dist = {
-          good: 0, needs_improvement: 0, poor: 0,
-          good_pct: goodPct,
-          needs_improvement_pct: 100 - goodPct - poorPct,
-          poor_pct: poorPct,
-        };
+        const o = row.original;
+        const metricLabel =
+          DISTRIBUTION_METRIC_LABELS[o.distribution_metric] || "Rating";
         return (
           <RumDistributionBar
-            metricLabel="Overall"
-            distribution={dist}
+            metricLabel={metricLabel}
+            distribution={o.distribution}
+            suppressed={o.distribution_suppressed}
+            sampleCount={o.distribution_sample_count}
+            minSampleCount={o.distribution_sample_floor}
           />
         );
       },
     },
   ];
 }
+
+// Labels the distribution bar with the metric that actually produced
+// overall_rating (worstOfThree's lcp -> inp -> cls tie-break; see
+// rum_results_handler.go) instead of the fabricated "Overall" this column
+// used to claim. "" only occurs for a row whose winning metric is unrated,
+// which worst_offenders never emits (GH #391).
+const DISTRIBUTION_METRIC_LABELS: Record<
+  FleetRumOffender["distribution_metric"],
+  string
+> = {
+  lcp: "LCP",
+  inp: "INP",
+  cls: "CLS",
+  "": "Rating",
+};
 
 // ---------------------------------------------------------------------------
 // Fleet CWV trend chart (28-day)


### PR DESCRIPTION
Closes #391 once deployed and verified.

## What was wrong

The "28d distribution" column on the performance tab was fabricated. The cell read one field, the row's
rating word, and picked percentages from a lookup:

```js
const goodPct = r === "good" ? 75 : r === "needs-improvement" ? 40 : 10;
const poorPct = r === "poor" ? 60 : r === "needs-improvement" ? 15 : 5;
```

Three possible outputs, ever:

```
good               75 20  5
needs-improvement  40 45 15     <- the reporter's screenshot, on all seven rows
poor               10 30 60
```

The table is fed `worst_offenders`, and the server drops any site whose worst band is neither poor nor
needs-improvement, so the `good` branch has never rendered in production. The entire column had **two
possible pictures** across every tenant, window and site. Seven identical rows meant seven sites rated
needs-improvement, which is ordinary.

It shipped as an acknowledged placeholder in `0494d2b` (2026-06-15) under a comment reading
*"Approximate distribution from the overall rating and p75 values ... a visual hint"*, and `bcbb927`
removed that comment the same day while keeping the arithmetic. It has been live about two months.

The numbers were asserted as fact on three surfaces: inside each bar segment, in a visible legend row,
and in `title` + `aria-label` reading *"Overall distribution: 40% good, 45% needs improvement, 15%
poor."* Fabricated figures were being read out to screen readers as measurement.

## What it does now

The row shows the real histogram of **the metric that produced its rating**, labelled with that
metric's name. `overall_rating` is already `worstOfThree(lcp, inp, cls)`, so the driving metric was
known and simply discarded.

No new query, no migration, no sqlc or OpenAPI regeneration. `rumFleet` already accumulates the full
CrUX bucket histogram per `{siteID, metric}` in the same function, and `foldBucketsIntoDistribution`
already folds exactly that into good/NI/poor with Hamilton largest-remainder rounding so the three
percentages sum to 100. The data had been in memory the whole time.

The label is visible, not only in the accessible name. An earlier revision of this branch passed the
metric only to `aria-label` and `title`, which meant a screen reader heard "CLS distribution" while
anyone looking at the screen saw an unlabelled bar and could not tell which of three metrics it
measured. It now renders inline beside the bar at zero extra row height, opt-in so the other
`RumDistributionBar` callers are untouched.

**Insufficient samples are honoured**, which was the reporter's second request. That affordance already
existed — the component renders *"Insufficient samples (N of M)"* — but this cell passed none of the
three props and passed a never-undefined object, so the fallback was structurally unreachable from it.

## The design decision

"28d distribution" for a **site** has no single meaning: LCP, INP and CLS have different thresholds and
different sample counts. Two alternatives were rejected and are recorded so nobody re-derives them:

- **Averaging the three** — different units, different thresholds, and sample counts that triple-count
  pageviews while silently weighting whichever metric has the most beacons.
- **A true "share of pageviews good on all three"** — which is what the old `metricLabel="Overall"`
  implied, and is **not derivable from stored data**: the rollups are per-metric histograms with no key
  back to individual pageviews. That label promised something the product cannot compute.

Ties are deterministic, lcp then inp then cls, and now tested: a row whose bar changed metric between
refreshes would be worse than no bar.

## The sample floor, stated rather than implied

The fleet path sends its own global `minSampleCount`, not the site's configured `min_sample_count`. The
field is named `distribution_sample_floor` and both the Go doc and the TS type say **global**
explicitly. The reason is that the same constant already gates every rating in this response, so a row
only reaches `worst_offenders` once its worst metric cleared it; sending a different per-site floor for
the bar alone would let a row's bar disagree with its own rating word about whether there was enough
data. Loading per-site config is noted in the doc comment as a legitimate follow-up.

## Proof

```
$ pnpm -C apps/web test
Test Files  134 passed (134)
     Tests  1599 passed (1599)

$ CGO_ENABLED=1 go test ./internal/perf/...
ok  github.com/mosamlife/wpmgr/apps/api/internal/perf  0.750s

$ grep -c 'goodPct\|poorPct' apps/web/src/routes/_authed/performance.tsx
0
```

Every new assertion was shown to fail before it passed. Two rows sharing a rating but holding different
histograms render different bars — the case the fabrication could never distinguish, and the one the
reporter effectively filed. Reversing the tie-break order reddens four tests naming the exact mismatch.

**Two assertions in the first revision could not fail** and were repaired: they used `queryByText`
against strings that exist only inside `aria-label` and `title` attributes, so `.not.toBeInTheDocument()`
passed whatever rendered. They were the two meant to prove the fabrication and the "Overall" label were
gone, and they proved neither. Now `queryByTitle`, and both were driven red against the pre-fix shape
before going green. The other six in that file were audited and can fail.

Before this branch, none of the 132 web test files referenced `RumDistributionBar` or `worst_offenders`.

## Not done

`make test-integration` was not run. This adds no query, no schema change and no RLS surface — it folds
in-memory buckets already gathered under an existing tenant-scoped read — but that is a judgement, not
a run result.

Deploy order matters: **api before web**. If web ships first the new fields are absent, `distribution`
is undefined, and the column renders blank rather than wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected worst-offender performance distributions to use data from the metric driving the overall rating.
  - Added deterministic tie-breaking when multiple metrics share the same rating.
  - Suppressed distributions when sample counts are below the required threshold.
  - Updated performance views to display accurate distributions, sample information, and metric labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->