### PR TITLE
release: 0.61.136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.136] - 2026-08-15
+
+### Fixed
+
+- The "28d distribution" bar on the performance tab's worst-offenders table did not show a site's real data. The cell read only the row's rating word and looked up a fixed set of percentages for it: every site rated needs-improvement showed 40% good, 45% needs-improvement, 15% poor, and every site rated poor showed 10% good, 30% needs-improvement, 60% poor, regardless of that site's actual numbers. The table only lists sites rated poor or needs-improvement, so those two pictures were the only ones the column ever produced, across every site and every time window. The sample count shown beside the bar was real, which made a fabricated bar look measured. It shipped as an acknowledged placeholder on 2026-06-15, and the code comment recording that was deleted the same day while the placeholder itself stayed; it was live for about two months. If you drew a conclusion about a specific site from that bar during that time, the picture it showed did not reflect that site. Nothing was stored wrongly, no other number in the product was affected, and no action is required beyond upgrading.
+- The bar now shows the real histogram for whichever metric, LCP, INP or CLS, produced the row's rating, built from data the product was already gathering. It shows "Insufficient samples" instead of a bar when a site does not have enough of that metric's data to be meaningful.
+
+### Changed
+
+- The distribution bar now names the metric it is showing rather than being labelled "Overall". A site's LCP, INP and CLS distributions have no single combined meaning, and "Overall" implied a share of pageviews good on all three, a figure this product does not compute.
+
 ## [0.61.135] - 2026-08-14
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.134**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.135**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -318,15 +318,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.134
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.134
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.134
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.135
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.135
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.135
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.134   # omit to track :latest
+export WPMGR_VERSION=v0.61.135   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,27 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.136",
+    date: "2026-08-15",
+    summary:
+      "The \"28d distribution\" bar on the performance tab's worst-offenders table has been showing a picture derived from a site's rating word, not its real data, for about two months. It now shows the real histogram for whichever metric produced the rating, labelled with that metric's name, and shows \"Insufficient samples\" when there is not enough data to be meaningful. If you drew a conclusion about a specific site from that bar since mid-June, the picture it showed did not reflect that site. Nothing was stored wrongly, no other number in the product was affected, and no action is required beyond upgrading.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The \"28d distribution\" bar on the performance tab did not show a site's real data. It read only the row's rating word and looked up one of two fixed pictures: every site rated needs-improvement showed 40% good, 45% needs-improvement, 15% poor, and every site rated poor showed 10% good, 30% needs-improvement, 60% poor, whatever that site's real numbers were. The table only lists sites rated poor or needs-improvement, so those two pictures were the only ones the column ever produced. The sample count shown beside the bar was real, which made the fabricated bar look measured. It shipped as an acknowledged placeholder in mid-June, the code comment recording that was removed the same day while the placeholder itself stayed, and it was live for about two months. If you drew a conclusion about a specific site from that bar in that time, the picture it showed did not reflect that site. Nothing was stored wrongly, no other number in the product was affected, and no action is required beyond upgrading.",
+      },
+      {
+        tag: "Fixed",
+        text: "The bar now shows the real histogram for whichever metric, LCP, INP or CLS, produced the row's rating, built from data already being gathered. It shows \"Insufficient samples\" instead of a bar when a site does not have enough of that metric's data to be meaningful.",
+      },
+      {
+        tag: "Changed",
+        text: "The distribution bar now names the metric it is showing rather than being labelled \"Overall\". A site's LCP, INP and CLS distributions have no single combined meaning, and \"Overall\" implied a share of pageviews good on all three, a figure this product does not compute.",
+      },
+    ],
+    featureLinks: [{ label: "Real User Monitoring", href: "/features/real-user-monitoring" }],
+  },
+  {
     version: "0.61.135",
     date: "2026-08-14",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -219,7 +219,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.134   # omit to track :latest
+export WPMGR_VERSION=v0.61.135   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.135
+  version: 0.61.136
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Cuts the 0.61.136 release surfaces. Control plane only, closing GH #391 via PR
#426: the "28d distribution" bar on the performance tab's worst-offenders
table showed a picture derived from the row's rating word through a two-way
lookup, not the site's real data. It has been live for about two months. If
you drew a conclusion about a specific site from that bar in that time, the
picture it showed did not reflect that site. Nothing was stored wrongly, no
other number in the product was affected, and no action is required beyond
upgrading. The agent plugin is untouched; its version does not move.

## Files

- `CHANGELOG.md`: new `[0.61.136] - 2026-08-15` entry (Fixed + Changed).
- `packages/openapi/openapi.yaml`: `info.version` to 0.61.136.
- `apps/marketing/app/(marketing)/changelog/page.tsx`: matching entry for a
  site owner, tagged Real User Monitoring.
- `README.md`, `docs/install.md`: install pins v0.61.134 to v0.61.135 (one
  release behind the new top entry, within the guard's tolerance). All three
  v0.61.135 images confirmed pullable from GHCR with `docker manifest inspect`
  before the pin moved.

Agent surfaces deliberately unchanged, all three still 0.61.131: plugin
header, `WPMGR_AGENT_VERSION`, readme.txt Stable tag, and the marketing hero
badge.

## Verification

```
$ make check-versions-test
76 passed, 0 failed

$ make check-versions
OK: packages/openapi/openapi.yaml info.version matches the top CHANGELOG.md entry (0.61.136).
OK: the marketing changelog's newest entry (0.61.136): 0 releases behind 0.61.136, tolerance 5.
OK: the marketing hero badge names agent 0.61.131, matching apps/agent/wpmgr-agent.php.
OK: the agent version triple agrees (0.61.131).
OK: .github/workflows/release.yml lets the agent zip carry its own source version.
OK: the install instructions (0.61.135): 1 release behind 0.61.136, tolerance 1.
OK: every required install pin is present, inside its marked region, and names v0.61.135.
OK: swept the tree: 5 concrete version mentions outside CHANGELOG.md, all within 1 release of 0.61.136.
Version surfaces are consistent.

$ node apps/marketing/scripts/check-copy.mjs
check-copy passed: no em dashes, en dashes, or competitor names across 388 files.
```

Docs vocabulary check (verbatim from ci.yml), proven to fire: planted a
banned term in a scratch docs/ file, it matched; removed the file, it went
clean. The real tree matches clean with no output.

Nothing in this branch is deployed. Merge, tag, deploy and verify against the
running system remain to be done after this merges.

https://github.com/mosamlife/wpmgr/pull/425 was the previous cut (0.61.135),
same shape.
