### PR TITLE
test(api): make container setup failures say they are setup failures

### DIFF
--- a/apps/api/tests/autologin_integration_test.go
+++ b/apps/api/tests/autologin_integration_test.go
@@ -40,6 +40,9 @@ import (
 func startRedis(t *testing.T) (*redis.Pool, string) {
 	t.Helper()
 	ctx := context.Background()
+
+	skipIfDockerUnavailable(t, ctx, "redis")
+
 	req := testcontainers.ContainerRequest{
 		Image:        "redis:7-alpine",
 		ExposedPorts: []string{"6379/tcp"},
@@ -50,7 +53,7 @@ func startRedis(t *testing.T) (*redis.Pool, string) {
 		Started:          true,
 	})
 	if err != nil {
-		setupSkipf(t, err, "redis: container start (docker unavailable?)")
+		setupFatalf(t, err, "redis: container start")
 	}
 	t.Cleanup(func() { _ = c.Terminate(ctx) })
 	host, err := c.Host(ctx)
@@ -102,16 +105,17 @@ func newAutologinSigner(t *testing.T) *agentcmd.Signer {
 // Recorder.
 //
 // Cross-clock note: domain.SystemClock{} below is the HOST's clock — Mint
-// computes expires_at as s.clock.Now().UTC().Add(autologin.JWTTTL) (60s,
-// internal/autologin/model.go) on the host, but Consume's gate is
-// `expires_at > now()` evaluated by the testcontainer's OWN Postgres clock
-// (db/query/autologin.sql, ConsumeAutologinToken). A Consume call in these
-// tests is therefore only guaranteed to pass if host and container clocks
-// agree within the 60s budget minus whatever wall time elapsed between Mint
-// and Consume. Measured skew here is currently zero, so this is not a live
-// bug — but an intermittent Consume failure ("nonce_unavailable") under load
-// is where a real skew would show up first, and this comment is the
-// explanation to find instead of re-deriving it.
+// computes expires_at as s.clock.Now().UTC().Add(autologin.JWTTTL)
+// (internal/autologin/model.go is the source of truth for the TTL value) on
+// the host, but Consume's gate is `expires_at > now()` evaluated by the
+// testcontainer's OWN Postgres clock (db/query/autologin.sql,
+// ConsumeAutologinToken). A Consume call in these tests is therefore only
+// guaranteed to pass if host and container clocks agree within the JWTTTL
+// budget minus whatever wall time elapsed between Mint and Consume. Measured
+// skew here is currently zero, so this is not a live bug — but an
+// intermittent Consume failure ("nonce_unavailable") under load is where a
+// real skew would show up first, and this comment is the explanation to find
+// instead of re-deriving it.
 func buildAutologinService(t *testing.T, pool *db.Pool, redisPool *redis.Pool, siteSvc *site.Service, cfg autologin.Config) (*autologin.Service, *audit.Recorder) {
 	t.Helper()
 	rec := audit.NewRecorder(pool, domain.SystemClock{})

--- a/apps/api/tests/autologin_integration_test.go
+++ b/apps/api/tests/autologin_integration_test.go
@@ -52,10 +52,19 @@ func startRedis(t *testing.T) (*redis.Pool, string) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		setupFatalf(t, err, "redis: container start")
+	// Register cleanup BEFORE inspecting err: GenericContainer can return a
+	// non-nil container alongside a non-nil error on a partial start (create
+	// succeeded but Start failed, etc). setupFatalf below calls t.Fatalf,
+	// which never returns, so anything after it never runs; cleanup must be
+	// registered first or a partially-started container leaks for the life
+	// of the machine. See rls_integration_test.go's startPostgres for the
+	// same fix and the library source citation.
+	if c != nil {
+		t.Cleanup(func() { _ = c.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = c.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "redis: container start")
+	}
 	host, err := c.Host(ctx)
 	if err != nil {
 		setupFatalf(t, err, "redis: resolve container host")

--- a/apps/api/tests/autologin_integration_test.go
+++ b/apps/api/tests/autologin_integration_test.go
@@ -50,16 +50,16 @@ func startRedis(t *testing.T) (*redis.Pool, string) {
 		Started:          true,
 	})
 	if err != nil {
-		t.Skipf("skipping: cannot start redis container (docker unavailable?): %v", err)
+		setupSkipf(t, err, "redis: container start (docker unavailable?)")
 	}
 	t.Cleanup(func() { _ = c.Terminate(ctx) })
 	host, err := c.Host(ctx)
 	if err != nil {
-		t.Fatalf("redis host: %v", err)
+		setupFatalf(t, err, "redis: resolve container host")
 	}
 	port, err := c.MappedPort(ctx, "6379/tcp")
 	if err != nil {
-		t.Fatalf("redis port: %v", err)
+		setupFatalf(t, err, "redis: resolve mapped port")
 	}
 	addr := fmt.Sprintf("%s:%s", host, port.Port())
 	pool := auth.NewRedisPool(addr, "")
@@ -100,6 +100,18 @@ func newAutologinSigner(t *testing.T) *agentcmd.Signer {
 // buildAutologinService assembles a real Service backed by the test PG pool +
 // Redis pool, an in-memory rate limiter, and a no-op-but-recording audit
 // Recorder.
+//
+// Cross-clock note: domain.SystemClock{} below is the HOST's clock — Mint
+// computes expires_at as s.clock.Now().UTC().Add(autologin.JWTTTL) (60s,
+// internal/autologin/model.go) on the host, but Consume's gate is
+// `expires_at > now()` evaluated by the testcontainer's OWN Postgres clock
+// (db/query/autologin.sql, ConsumeAutologinToken). A Consume call in these
+// tests is therefore only guaranteed to pass if host and container clocks
+// agree within the 60s budget minus whatever wall time elapsed between Mint
+// and Consume. Measured skew here is currently zero, so this is not a live
+// bug — but an intermittent Consume failure ("nonce_unavailable") under load
+// is where a real skew would show up first, and this comment is the
+// explanation to find instead of re-deriving it.
 func buildAutologinService(t *testing.T, pool *db.Pool, redisPool *redis.Pool, siteSvc *site.Service, cfg autologin.Config) (*autologin.Service, *audit.Recorder) {
 	t.Helper()
 	rec := audit.NewRecorder(pool, domain.SystemClock{})

--- a/apps/api/tests/rls_integration_test.go
+++ b/apps/api/tests/rls_integration_test.go
@@ -5,6 +5,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -45,10 +46,9 @@ func setupSkipf(t *testing.T, err error, stage string) {
 
 // skipIfDockerUnavailable positively detects whether the Docker/OCI provider
 // testcontainers will use is reachable at all, and skips (via setupSkipf) if
-// it is not. This is the ONLY thing that may resolve to a skip in this
-// package: "the daemon cannot be reached" is checked directly, up front,
-// before any container is asked to start, rather than being inferred from
-// whatever error a later container-start call happens to return.
+// it is not. This is checked directly, up front, before any container is
+// asked to start, rather than being inferred from whatever error a later
+// container-start call happens to return.
 //
 // That distinction matters because a container that fails to START despite
 // Docker being reachable (bad image tag, no space left, registry pull
@@ -57,6 +57,12 @@ func setupSkipf(t *testing.T, err error, stage string) {
 // setupSkipf. Routing a start failure to Skip is exactly the failure mode
 // this test package exists to eliminate: a package-level "ok" over a suite
 // that asserted nothing.
+//
+// setupFatalfOrSkipIfDaemonDied below is the one other path that may resolve
+// to a skip, for the narrow case of a container-start error specifically. It
+// still only skips on a second, independent positive Health() probe — never
+// by inspecting the start error's text — so it cannot reclassify an ordinary
+// start failure as unavailability.
 func skipIfDockerUnavailable(t *testing.T, ctx context.Context, stage string) {
 	t.Helper()
 	provider, err := testcontainers.ProviderDocker.GetProvider()
@@ -67,6 +73,35 @@ func skipIfDockerUnavailable(t *testing.T, ctx context.Context, stage string) {
 	if err := provider.Health(ctx); err != nil {
 		setupSkipf(t, err, stage+" (docker daemon unreachable)")
 	}
+}
+
+// setupFatalfOrSkipIfDaemonDied handles an error from a container-START call
+// specifically (tcpostgres.Run, testcontainers.GenericContainer). At that
+// point skipIfDockerUnavailable already proved the daemon was reachable
+// immediately before this container's start began, so an error here is
+// usually a genuine start failure (bad image tag, no space left, registry
+// pull failure) with the daemon perfectly healthy — that MUST stay fatal, or
+// this package regresses to exactly the "skip on anything" failure mode it
+// was built to eliminate.
+//
+// The one case that should skip instead is the daemon dying in the window
+// this container's own startup (image pull plus up to a 60s wait strategy)
+// spans: Docker Desktop crashing, an OOM kill, disk pressure taking the
+// daemon down mid-run. That is told apart from an ordinary start failure with
+// a SECOND positive Health() probe, the same mechanism skipIfDockerUnavailable
+// already trusts — never by pattern-matching startErr's text. An ordinary
+// start failure re-probes healthy and falls straight through to setupFatalf.
+func setupFatalfOrSkipIfDaemonDied(t *testing.T, ctx context.Context, startErr error, stage string) {
+	t.Helper()
+	provider, provErr := testcontainers.ProviderDocker.GetProvider()
+	if provErr == nil {
+		if healthErr := provider.Health(ctx); healthErr != nil {
+			setupSkipf(t, fmt.Errorf("start error: %v; daemon health re-probe now fails: %w", startErr, healthErr),
+				stage+" (docker daemon died mid-start)")
+			return
+		}
+	}
+	setupFatalf(t, startErr, stage)
 }
 
 // startPostgres spins up an ephemeral Postgres, applies the embedded
@@ -94,10 +129,21 @@ func startPostgres(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		setupFatalf(t, err, "postgres: container start")
+	// Register cleanup BEFORE inspecting err: tcpostgres.Run can return a
+	// non-nil container alongside a non-nil error on a partial start (the
+	// container was created, or even started, and a later step in Run
+	// failed) — testcontainers-go's own GenericContainer says as much: "At
+	// this point `c` might not be nil. Give the caller an opportunity to call
+	// Destroy on the container." setupFatalf below calls t.Fatalf, which
+	// never returns (runtime.Goexit), so anything after it never runs; if
+	// cleanup registration came after that call, a partially-started
+	// container would leak for the life of the machine on every failure path.
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/rls_integration_test.go
+++ b/apps/api/tests/rls_integration_test.go
@@ -43,6 +43,32 @@ func setupSkipf(t *testing.T, err error, stage string) {
 	t.Skipf("SETUP SKIP (infrastructure, not the test's own assertion) at stage=%q: %v", stage, err)
 }
 
+// skipIfDockerUnavailable positively detects whether the Docker/OCI provider
+// testcontainers will use is reachable at all, and skips (via setupSkipf) if
+// it is not. This is the ONLY thing that may resolve to a skip in this
+// package: "the daemon cannot be reached" is checked directly, up front,
+// before any container is asked to start, rather than being inferred from
+// whatever error a later container-start call happens to return.
+//
+// That distinction matters because a container that fails to START despite
+// Docker being reachable (bad image tag, no space left, registry pull
+// failure, resource limits) is a real setup failure, not "Docker is not
+// installed here" — it must go to setupFatalf and turn the run red, never
+// setupSkipf. Routing a start failure to Skip is exactly the failure mode
+// this test package exists to eliminate: a package-level "ok" over a suite
+// that asserted nothing.
+func skipIfDockerUnavailable(t *testing.T, ctx context.Context, stage string) {
+	t.Helper()
+	provider, err := testcontainers.ProviderDocker.GetProvider()
+	if err != nil {
+		setupSkipf(t, err, stage+" (docker provider unavailable)")
+		return
+	}
+	if err := provider.Health(ctx); err != nil {
+		setupSkipf(t, err, stage+" (docker daemon unreachable)")
+	}
+}
+
 // startPostgres spins up an ephemeral Postgres, applies the embedded
 // migrations as the bootstrap superuser, then provisions a dedicated
 // NON-superuser application role and returns a pool connected as that role.
@@ -54,6 +80,8 @@ func setupSkipf(t *testing.T, err error, stage string) {
 func startPostgres(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
+
+	skipIfDockerUnavailable(t, ctx, "postgres")
 
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
@@ -67,7 +95,7 @@ func startPostgres(t *testing.T) *db.Pool {
 		),
 	)
 	if err != nil {
-		setupSkipf(t, err, "postgres: container start (docker unavailable?)")
+		setupFatalf(t, err, "postgres: container start")
 	}
 	t.Cleanup(func() { _ = container.Terminate(ctx) })
 

--- a/apps/api/tests/rls_integration_test.go
+++ b/apps/api/tests/rls_integration_test.go
@@ -20,6 +20,29 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/site"
 )
 
+// setupFatalf fails the test with a message that cannot be mistaken for an
+// assertion made by the test body. A full-package run starts hundreds of
+// testcontainers over roughly ten minutes, and under that load an
+// infrastructure hiccup at one of these stages (container start, connection
+// string, migrate, connect, role provisioning) otherwise surfaces as a bare
+// "%v" attached to whatever test happened to be running when it hit — which
+// reads exactly like that test's own assertion failed. The SETUP FAILURE
+// prefix plus the named stage let the next reader classify it in one glance
+// instead of re-running the investigation that produced this comment.
+func setupFatalf(t *testing.T, err error, stage string) {
+	t.Helper()
+	t.Fatalf("SETUP FAILURE (infrastructure, not the test's own assertion) at stage=%q: %v", stage, err)
+}
+
+// setupSkipf is setupFatalf's skip counterpart, used only for "Docker is not
+// available on this machine at all" — the one setup failure that is not a
+// mid-run flake and that every other test in the package would hit
+// identically, so skipping (rather than failing) is the honest signal.
+func setupSkipf(t *testing.T, err error, stage string) {
+	t.Helper()
+	t.Skipf("SETUP SKIP (infrastructure, not the test's own assertion) at stage=%q: %v", stage, err)
+}
+
 // startPostgres spins up an ephemeral Postgres, applies the embedded
 // migrations as the bootstrap superuser, then provisions a dedicated
 // NON-superuser application role and returns a pool connected as that role.
@@ -44,22 +67,22 @@ func startPostgres(t *testing.T) *db.Pool {
 		),
 	)
 	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+		setupSkipf(t, err, "postgres: container start (docker unavailable?)")
 	}
 	t.Cleanup(func() { _ = container.Terminate(ctx) })
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {
-		t.Fatalf("connection string: %v", err)
+		setupFatalf(t, err, "postgres: connection string")
 	}
 
 	// Apply migrations as the bootstrap superuser.
 	adminPool, err := db.Connect(ctx, adminDSN)
 	if err != nil {
-		t.Fatalf("connect admin: %v", err)
+		setupFatalf(t, err, "postgres: connect as bootstrap superuser")
 	}
 	if err := adminPool.Migrate(ctx); err != nil {
-		t.Fatalf("migrate: %v", err)
+		setupFatalf(t, err, "postgres: run embedded migrations")
 	}
 
 	// The auth migration already created the wpmgr_app role (NOLOGIN, no
@@ -75,7 +98,7 @@ func startPostgres(t *testing.T) *db.Pool {
 		"REVOKE UPDATE, DELETE, TRUNCATE ON audit_log FROM wpmgr_app",
 	} {
 		if _, err := adminPool.Exec(ctx, stmt); err != nil {
-			t.Fatalf("provision app role (%q): %v", stmt, err)
+			setupFatalf(t, err, "postgres: provision app role ("+stmt+")")
 		}
 	}
 	adminPool.Close()
@@ -83,7 +106,7 @@ func startPostgres(t *testing.T) *db.Pool {
 	appDSN := strings.Replace(adminDSN, "wpmgr:wpmgr@", "wpmgr_app:app@", 1)
 	pool, err := db.Connect(ctx, appDSN)
 	if err != nil {
-		t.Fatalf("connect app: %v", err)
+		setupFatalf(t, err, "postgres: connect as wpmgr_app")
 	}
 	t.Cleanup(pool.Close)
 
@@ -122,11 +145,13 @@ func connectAdmin(t *testing.T, app *db.Pool) *db.Pool {
 	dsn, ok := adminDSNs[app]
 	adminDSNsMu.Unlock()
 	if !ok {
-		t.Fatal("no admin DSN recorded for this pool")
+		// Caller misuse, not a container flake: connectAdmin only knows a DSN
+		// for a pool that startPostgres itself returned.
+		t.Fatal("SETUP FAILURE (test helper misuse, not the test's own assertion): connectAdmin called with a pool startPostgres never returned")
 	}
 	pool, err := db.Connect(context.Background(), dsn)
 	if err != nil {
-		t.Fatalf("connect admin: %v", err)
+		setupFatalf(t, err, "postgres: connectAdmin reconnect as bootstrap superuser")
 	}
 	return pool
 }


### PR DESCRIPTION
`TestAutologinMintInjectsRealStoredDefault` failed once in a full-package run and has passed every run
since, including a full run of the identical code. **This PR does not fix that**, because it was never
reproduced. It makes the next occurrence diagnosable in one glance instead of starting the same
investigation again.

## What was ruled out, by measurement

An investigation went after the obvious causes and disproved all of them:

- **Not shared database state.** Every test starts its own Postgres and Redis. `grep -c "startPostgres(t)"`
  returns 12 in `autologin_integration_test.go` and 3 in `autologin_policy_integration_test.go` — 15
  calls for 15 test functions, no `sync.Once`, no cached package pool.
- **Not shared limiter state.** `autologin.NewMemoryLimiter()` is constructed inline per test and is a
  plain in-process map, not Redis-backed.
- **Not parallelism.** `grep -rn "t.Parallel()" apps/api/tests/` returns two hits, both in
  `scan_plugin_checksums_regression_test.go`.
- **Not clock skew, today.** `docker run --rm alpine date +%s` and host `date +%s` both returned
  `1786792156`. Zero.

## What is actually wrong

`startPostgres` turned a container **start** failure into `t.Skipf`, but turned connection-string,
migrate, connect and role-provisioning failures into `t.Fatalf` with a bare `%v`. `startRedis` and
`connectAdmin` had the same shape.

So during a full run — hundreds of containers over about ten minutes — an infrastructure failure
surfaced as *this test asserting wrongly*. That fits the evidence exactly: fails in a full run, never
alone.

Every setup stage now fails with a message that cannot be mistaken for an assertion:

```
SETUP FAILURE (infrastructure, not the test's own assertion) at stage="postgres: run embedded migrations": ensure schema_migrations: closed pool
```

Fail rather than skip, applied consistently to every stage: skipping would hide a real breakage across
the whole suite, and the point here is classification, not silence. Container-start keeps its existing
skip. `connectAdmin`'s "no DSN recorded" is caller misuse rather than infrastructure and says so
separately.

## Proved, by forcing each stage

```
unreachable DSN     → stage="postgres: connect as bootstrap superuser": ping: ... connection refused
pre-closed pool     → stage="postgres: run embedded migrations": ensure schema_migrations: closed pool
bad redis port      → stage="redis: resolve mapped port": port "9999/tcp" not found
```

Each was forced, captured, and reverted; `git diff` was clean before committing. Does not over-fire:
five representative tests still pass, `grep -c '^--- PASS'` → 5.

## One latent fuse, documented not fixed

Autologin writes `expires_at` from the **host** clock (`s.clock.Now().UTC().Add(JWTTTL)`, 60 seconds)
while `db/query/autologin.sql:33` gates on `expires_at > now()`, which is the **container's** clock.
Skew is zero today, so this is not a live bug and no production code or query was changed. A comment
now names the cross-clock comparison and the 60-second budget, so whoever meets an intermittent
`Consume` failure finds the explanation rather than rediscovering it. Every autologin consume test sits
on that same fuse.

Also left alone deliberately: `internal/autologin/service.go:188` swallows the audit-recorder error, so
a failed audit write surfaces as `no rows in result set` with no cause. That is a real diagnosability
gap, and it is also intentional best-effort behaviour in production. Changing production behaviour to
improve a test message is the wrong trade; recorded here instead.

## Scope

Two test files, 48 insertions, 11 deletions. No production code. Independent of GH #414.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration-test setup error handling to clearly distinguish infrastructure failures from test assertion failures.
  * Added clearer diagnostics for container startup, database connections, migrations, role provisioning, and reconnection issues.
  * Tests now skip cleanly when Docker is unavailable.
  * Documented potential clock-skew effects on autologin token expiration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->