### PR TITLE
release: 0.61.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.137] - 2026-08-16
+
+### Added
+
+- Monitoring can now be paused on a site, from the site's row menu, from its own page, or in bulk from the sites list (GH #414). A pause takes a reason and, optionally, a resume time, and both are shown wherever the paused state appears, in all three places. Pausing stops uptime probes, uptime alerts, the weekly screenshot fanout, and scheduled vulnerability rescans. It does not stop backups, the WP-Cron kick, connection checks, RUM, or retention, and it never stops anything a person clicks by hand, including an on-demand rescan or update check: pausing stops the schedule, never the operator. Resuming happens by hand, or automatically at the stored resume time if one was set, exactly once either way, and both the pause and the resume are recorded in the audit log.
+
+### Changed
+
+- The monthly report's uptime section is now keyed on whether a pause actually overlapped the reporting period, not on whether the site happens to be paused when the report runs. A period a pause never touched is measured and shown in full, even for a site that is paused today. A period a pause partly covered is shown with a "Partial coverage" note naming the hours that went unmeasured, instead of being presented as a complete month. A period a pause covered in full still names the site and states that monitoring was paused and why, rather than showing an empty section. If the pause history itself cannot be read, the report says coverage is unconfirmed rather than defaulting to a clean bill, so a read failure can no longer look like a fully measured month.
+
 ## [0.61.136] - 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.135**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.136**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -318,15 +318,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.135
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.135
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.135
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.136
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.136
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.136
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.135   # omit to track :latest
+export WPMGR_VERSION=v0.61.136   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,23 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.137",
+    date: "2026-08-16",
+    summary:
+      "Monitoring can now be paused on a site, with a reason and an optional resume time, from the site's row menu, its own page, or in bulk from the sites list. Pausing stops uptime checks, uptime alerts, weekly screenshots and scheduled vulnerability rescans; it never stops backups, connection tracking, or anything you click yourself. The monthly report's uptime section now goes by whether a pause actually overlapped the reporting period, not by whether the site happens to be paused today, so a measured period is no longer discarded and a partly-covered one says so instead of looking complete.",
+    items: [
+      {
+        tag: "Added",
+        text: "Monitoring can now be paused on a site, from the site's row menu, from its own page, or in bulk from the sites list. A pause takes a reason and, optionally, a resume time, and both are shown wherever the paused state appears, in all three places. Pausing stops uptime checks, uptime alerts, the weekly screenshot fanout, and scheduled vulnerability rescans. It does not stop backups, the WP-Cron kick, connection checks, RUM, or retention, and it never stops anything triggered by a click, including an on-demand rescan or update check: pausing stops the schedule, never the operator. Resuming happens by hand, or automatically at the stored resume time if one was set, exactly once either way, and both the pause and the resume are recorded in the audit log.",
+      },
+      {
+        tag: "Changed",
+        text: "The monthly report's uptime section is now keyed on whether a pause actually overlapped the reporting period, not on whether the site happens to be paused when the report runs. A period a pause never touched is measured and shown in full, even for a site that is paused today. A period a pause partly covered is shown with a note naming the hours that went unmeasured, instead of being presented as a complete month. A period a pause covered in full still names the site and states that monitoring was paused and why, rather than showing an empty section. If the pause history itself cannot be read, the report says coverage is unconfirmed rather than defaulting to a clean bill.",
+      },
+    ],
+    featureLinks: [{ label: "Uptime monitoring", href: "/features/uptime-monitoring" }],
+  },
+  {
     version: "0.61.136",
     date: "2026-08-15",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -219,7 +219,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.135   # omit to track :latest
+export WPMGR_VERSION=v0.61.136   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.136
+  version: 0.61.137
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Cuts the 0.61.137 release surfaces for GH #414 (pause monitoring), merged in PR #432. Control plane and dashboard only; the agent plugin is untouched at 0.61.131.

- `CHANGELOG.md`: new `[0.61.137] - 2026-08-16` entry. Added covers pause/resume itself (row menu, site page, bulk from the sites list; reason and optional resume time shown everywhere the state appears; what stops vs. what does not; exactly-once audited resume). Changed covers the monthly report's uptime section moving from live pause state to real window-overlap, including the partial-coverage and coverage-unconfirmed cases.
- `packages/openapi/openapi.yaml`: `info.version` to `0.61.137`.
- Marketing `/changelog` page: new 0.61.137 entry, tagged against Uptime monitoring.
- `README.md` / `docs/install.md`: install pins move from `v0.61.135` to `v0.61.136` (one release behind the new top entry, per the guard's tolerance). All three `v0.61.136` images verified pullable from GHCR with `docker manifest inspect` before the pin moved.

Agent surfaces deliberately unchanged: plugin header, `WPMGR_AGENT_VERSION`, `readme.txt` Stable tag, and the marketing hero badge all still name `0.61.131`.

## Test plan

- [x] `make check-versions-test` — 76 passed, 0 failed
- [x] `make check-versions` — all surfaces consistent, hero badge confirmed at agent 0.61.131
- [x] `git diff main -- apps/agent/` — empty
- [x] `node apps/marketing/scripts/check-copy.mjs` — passed (no em/en dashes, no competitor names)
- [x] Docs vocabulary check (`ci.yml`'s banned-alternation grep over `docs/**.md` and `./*.md`, excluding ADR-055) — no hits
- [ ] Not merged — awaiting review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pause monitoring for individual sites or in bulk, with a reason and optional resume time.
  - Resume monitoring manually or automatically, with pause and resume activity recorded for auditing.
  - Paused monitoring suspends scheduled probes, alerts, screenshots, and vulnerability rescans while preserving essential operations and manual actions.

- **Bug Fixes**
  - Monthly uptime reports now accurately show full, partial, paused, or unconfirmed coverage based on monitoring pauses.

- **Documentation**
  - Updated release notes, installation instructions, and version references for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->