### PR TITLE
fix(web): PausedBadge text illegible in dark mode (GH #414)

### DIFF
--- a/apps/web/src/features/sites/site-badges.test.tsx
+++ b/apps/web/src/features/sites/site-badges.test.tsx
@@ -72,6 +72,35 @@ describe("PausedBadge", () => {
   });
 });
 
+describe("PausedBadge - legible in dark mode (GH #414)", () => {
+  // GH #414, reported with screenshots: on the site card and the site detail
+  // page the badge rendered as an amber outline with text so dark it was
+  // invisible against the dark surface (one screenshot showed a completely
+  // empty pill). This is a repeat of GH #322's defect shape in
+  // AgentColumnFleetNote (agent-column-header.tsx:186-199): the badge has no
+  // warning FILL, only a border, so its text sits on the ordinary card/row
+  // surface. --warning-foreground is the text colour for content sitting ON a
+  // --warning background, so it is near-black in both themes and its dark
+  // override is darker still (L 20% light, L 15% dark). The right token for
+  // warning-tinted text on an ordinary surface is --warning-subtle-fg, which
+  // inverts properly (L 38% light, L 86% dark).
+  //
+  // Asserting the token rather than a rendered colour is deliberate: jsdom
+  // does not resolve CSS custom properties, so a computed-style assertion
+  // here would pass against either token and prove nothing.
+  it("uses the surface-text warning token, not the on-warning-background one", () => {
+    renderWithProviders(
+      <PausedBadge
+        site={buildSite({ monitoring_paused_at: new Date().toISOString() })}
+      />,
+    );
+    const badge = screen.getByText("Monitoring paused").closest("[title]");
+    expect(badge?.className).toContain("text-warning-subtle-fg");
+    // The token that made it invisible must not come back.
+    expect(badge?.className).not.toContain("text-warning-foreground");
+  });
+});
+
 describe("UptimeBadge", () => {
   it("shows a confident Up while monitoring is active", () => {
     renderWithProviders(<UptimeBadge site={buildSite({ up: true })} />);

--- a/apps/web/src/features/sites/site-badges.tsx
+++ b/apps/web/src/features/sites/site-badges.tsx
@@ -62,7 +62,15 @@ export function PausedBadge({
       title={view.title}
       aria-label={view.title}
       className={cn(
-        "gap-1 border-warning/40 text-warning-foreground",
+        // warning-SUBTLE-FG, not warning-foreground (GH #414, a repeat of
+        // GH #322 — see agent-column-header.tsx:186-199 for the full
+        // reasoning). This badge has no warning fill, only a border, so its
+        // text sits on the ordinary card/row surface. --warning-foreground is
+        // the text colour for content sitting ON a --warning background: it
+        // is near-black in both themes and darker still in dark mode, which
+        // is why the pill read as empty. --warning-subtle-fg is the token for
+        // warning-tinted text on an ordinary surface and inverts properly.
+        "gap-1 border-warning/40 text-warning-subtle-fg",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- GH #414: `PausedBadge` ("Monitoring paused") used `text-warning-foreground` on a bordered-only badge, so the text sat on the ordinary card surface instead of a warning fill. That token is near-black in both themes and darker still in dark mode, which is why the pill read as empty in the reporter's screenshots.
- Switched to `text-warning-subtle-fg`, the token for warning-tinted text on an ordinary surface, which inverts correctly per theme.
- This is a repeat of GH #322's identical defect in `AgentColumnFleetNote`; pinned with a token assertion in the same style as that precedent's test (`agent-column-header.test.tsx:437-461`), since jsdom does not resolve CSS custom properties and a computed-style assertion would pass against either token.
- Swept the other GH #414 surfaces (`pause-monitoring-dialog.tsx`, `site-row-actions.tsx`, `sites-table.tsx`, `site-card.tsx`, the paused state on `sites/$siteId.tsx`): `sites-table.tsx` already correctly pairs `bg-warning-subtle` with `text-warning-subtle-fg`; the rest carry no warning token at all. `site-badges.tsx` was the only instance of the bug.

## Verification
- `grep -rn "text-warning-foreground\b" apps/web/src` → only hit is the new test's own negative assertion (`not.toContain("text-warning-foreground")`), no production usage remains.
- New test reverted to `text-warning-foreground` → RED (`numFailedTests:1`, `numPassedTests:6`); restored → GREEN (`numPassedTests:7`).
- WCAG contrast computed from the actual oklch tokens: new token vs. dark card/background/muted → 11.1-12.65:1 (badge text is `text-xs`/12px, AA requires 4.5:1). Old token on the same surfaces → 1.0-1.14:1, matching the reported invisibility.

## Test plan
- [x] `pnpm -C apps/web typecheck` - clean
- [x] `pnpm -C apps/web lint` - 0 errors, 9 pre-existing warnings unrelated to this change
- [x] `pnpm -C apps/web test` - 1679/1679 passed
- [x] `impeccable detect` on the touched file - clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the paused status badge’s text color in dark mode for better readability and visual consistency.

* **Tests**
  * Added regression coverage to ensure the paused badge uses the correct dark-mode styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->