### PR TITLE
release: 0.61.138

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.138] - 2026-08-16
+
+### Fixed
+
+- The "Monitoring paused" badge was illegible in dark mode: an amber outline around text you effectively could not read, and on some sites the pill looked completely empty (GH #414). The badge has no warning-colored fill, only a border, so its text always sits on the ordinary card surface, and it was using the color meant for text sitting directly on a solid warning-colored background instead of the color meant for warning-tinted text on an ordinary surface. Measured contrast on the dark surfaces where the badge appears ranged from 1.0:1 to 1.14:1; at the low end the text was rendered in exactly the same color as the surface behind it. It now uses the correct color, and contrast on those same surfaces ranges from 11.1:1 to 12.65:1, well past the 4.5:1 minimum for readable text.
+
 ## [0.61.137] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.136**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.137**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -318,15 +318,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.136
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.136
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.136
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.137
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.137
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.137
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.136   # omit to track :latest
+export WPMGR_VERSION=v0.61.137   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,19 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.138",
+    date: "2026-08-16",
+    summary:
+      "The \"Monitoring paused\" badge was illegible in dark mode, an amber outline around text with almost no contrast against the card behind it, and on some sites the pill looked completely empty. It now renders with normal contrast in both themes.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The \"Monitoring paused\" badge was illegible in dark mode: an amber outline around text you effectively could not read, and on some sites the pill looked completely empty. The badge has no warning-colored fill, only a border, so its text always sits on the ordinary card surface, and it was using the color meant for text sitting directly on a solid warning-colored background instead of the color meant for warning-tinted text on an ordinary surface. Measured contrast on the dark surfaces where the badge appears ranged from 1.0:1 to 1.14:1; at the low end the text was rendered in exactly the same color as the surface behind it. It now uses the correct color, and contrast on those same surfaces ranges from 11.1:1 to 12.65:1, well past the 4.5:1 minimum for readable text.",
+      },
+    ],
+    featureLinks: [{ label: "Uptime monitoring", href: "/features/uptime-monitoring" }],
+  },
+  {
     version: "0.61.137",
     date: "2026-08-16",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -219,7 +219,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.136   # omit to track :latest
+export WPMGR_VERSION=v0.61.137   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.137
+  version: 0.61.138
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

- Cuts the 0.61.138 patch release: dashboard-only fix for PR #435 / GH #414,
  the "Monitoring paused" badge that was illegible in dark mode.
- CHANGELOG.md gains a `[0.61.138] - 2026-08-16` Fixed entry written for a
  user who saw an empty pill, not for a developer reading the diff.
- `packages/openapi/openapi.yaml` `info.version` moves to `0.61.138`.
- Marketing `/changelog` gains the matching entry (79 entries total, recounted
  with `grep -cE '^    version:' 'apps/marketing/app/(marketing)/changelog/page.tsx'`).
- README.md and docs/install.md install pins move from v0.61.136 to v0.61.137
  (one release behind the new top entry, within the guard's tolerance). All
  three v0.61.137 images were confirmed pullable from GHCR via
  `docker manifest inspect` before the pin moved.
- Agent surfaces untouched: `git diff main -- apps/agent/` is empty, and the
  marketing hero badge still names agent 0.61.131.

## Test plan

- [x] `make check-versions-test` — 76 passed, 0 failed
- [x] `make check-versions` — all 8 checks OK
- [x] `node apps/marketing/scripts/check-copy.mjs` — passed, 0 hits
- [x] Docs vocabulary check (verbatim from `ci.yml`) — 0 hits
- [x] `git diff main -- apps/agent/` — empty
- [ ] CI (`ci.yml`) on this PR

Not merging; opened for review per instructions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode contrast for the “Monitoring paused” badge, making its status easier to read.

* **Documentation**
  * Added release notes for version 0.61.138.
  * Updated installation instructions and prebuilt image examples to reference the latest documented release version.
  * Refreshed the public API documentation version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->