### PR TITLE
build: enable puppeteer for impeccable's pixel-based contrast engine

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,10 +65,11 @@ allowBuilds:
   # `pnpm install`, so this must be answered rather than left.
   core-js: false
   esbuild: true
-  # Puppeteer's postinstall downloads ~100 MB of Chromium. Disabled because
-  # nothing in our pipeline launches a headless browser; impeccable's critique
-  # uses static analysis, not screenshots. Flip to `true` if a future phase
-  # needs a real browser (live preview iteration, visual diffs, etc.).
-  puppeteer: false
+  # Puppeteer's postinstall downloads ~100 MB of Chromium. Enabled: impeccable's
+  # static engine only matches literal Tailwind palette classes and cannot see
+  # a semantic-token contrast bug (e.g. text-warning-foreground on an unfilled
+  # card), so the pixel-based low-contrast/gray-on-color checks in
+  # engines/browser + engines/visual need a real headless browser to run.
+  puppeteer: true
   sharp: true
   vue-demi: false


### PR DESCRIPTION
## Summary
- Flips `allowBuilds.puppeteer` to `true` in `pnpm-workspace.yaml` so impeccable's pixel-based `low-contrast` / `gray-on-color` checks (browser + visual engines) can actually launch Chromium locally, and updates the stale comment.
- Measurement-only change, not wiring into `ci.yml`. Do not merge until the owner decides how (or whether) to wire the URL/visual engine in based on the result below.

## What this was tested against
Reproduced GH #414's invisible-badge bug (`text-warning-foreground` on a border-only, unfilled `PausedBadge` pill, landing on the ordinary card surface) via a temporary local fixture (not part of this diff — built and reverted during measurement), built with `pnpm -C apps/web build`, served statically, scanned with `impeccable detect <url>` in both the fixed and buggy state, dark mode (the app's default `<html class="dark">`).

**Verdict: the pixel-based engine does NOT catch this bug either**, on both the workspace-pinned `impeccable@2.1.9` and the newer `3.6.0` (what `npx impeccable`, the invocation named in `.claude/rules/web-frontend.md`, actually resolves to). All four runs (fixed/buggy × two versions) returned `[]`, confirmed non-silent-failure with a negative connection-refused control.

Root cause in 3.6.0's `checkColors` (`cli/engine/rules/checks.mjs`): `<span>` is in `SAFE_TAGS`, and the escape hatch requires the element's own background alpha > 0.5 (or a gradient). A border-only, unfilled badge has `background-color: transparent`, so it never reaches the contrast-ratio computation at all — exactly the badge shape that shipped this bug.

Also found: flipping this pnpm flag doesn't actually gate `npx impeccable` (the documented invocation) — npx installs its own isolated puppeteer copy independent of the workspace's `allowBuilds` setting. The flag only affects the pinned `apps/web` devDependency (2.1.9), which is missing from the ^2.1.9 semver range that a newer major would need anyway.

## Test plan
- [x] `pnpm install` with the flag on: Chromium confirmed present and launchable (`Chrome/148.0.7778.97`)
- [x] Fixed badge, impeccable 2.1.9: `[]`, exit 0, no stderr (~1.6s)
- [x] Buggy badge, impeccable 2.1.9: `[]`, exit 0, no stderr (~1.6s) — miss
- [x] Fixed badge, impeccable 3.6.0 (npx-resolved): `[]`, exit 0 (~3.0s)
- [x] Buggy badge, impeccable 3.6.0: `[]`, exit 0, no stderr (~4.7s) — miss
- [x] Negative control (bad port): stderr shows `net::ERR_CONNECTION_REFUSED`, but still exits 0 with `[]` — a fails-open shape in impeccable itself worth flagging upstream
- [x] `git diff` on `site-badges.tsx` is empty (fixture toggling was reverted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled Chromium installation for browser-based visual and contrast checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->