### PR TITLE
fix(agent): wp_mail() reports the truth on a failed send

### DIFF
--- a/apps/agent/includes/email/class-mail-router.php
+++ b/apps/agent/includes/email/class-mail-router.php
@@ -19,6 +19,10 @@
  * The X-WPMgr-Site correlation header is stamped on every outgoing message for
  * the Phase-4 CP webhook fan-out.
  *
+ * wp_mail()'s return value is honest: a provider failure makes wp_mail()
+ * return false (never a lie of true) and fires `wp_mail_failed` with a
+ * WP_Error, same as core would on its own send failure. See intercept().
+ *
  * @package WPMgr\Agent\Email
  */
 
@@ -53,10 +57,14 @@ final class MailRouter {
 	 */
 	public function register_hooks(): void {
 		// pre_wp_mail is the primary interception point (WP 5.7+, our baseline).
-		// Returning a non-null value from this filter short-circuits wp_mail()
-		// entirely. We return the result array on success, true on failure (so WP
-		// does NOT fall through to its own PHPMailer path for a message we already
-		// attempted), and null when email is not configured (leaves WP untouched).
+		// Per wp-includes/pluggable.php, wp_mail() only lets WP's own PHPMailer
+		// path run when this filter returns exactly `null`; ANY other value --
+		// including `false` -- short-circuits and becomes wp_mail()'s own return
+		// value verbatim. So we return the result array on success, false on
+		// failure (still short-circuits, so WP never re-attempts a send we
+		// already made -- but wp_mail() now honestly reports the failure instead
+		// of claiming success), and null when email is not configured (leaves
+		// WP untouched).
 		add_filter( 'pre_wp_mail', array( $this, 'intercept' ), 10, 2 );
 	}
 
@@ -84,10 +92,36 @@ final class MailRouter {
 
 		$result = $this->router->send( $mail, $cfg );
 
-		// Return true (truthy non-null) to short-circuit wp_mail() regardless of
-		// the provider outcome; WP's return value from wp_mail() is a bool and we
-		// have already logged the failure via EmailLogger if it occurred.
-		return $result['ok'] ? $result : true;
+		if ( $result['ok'] ) {
+			// Success: unchanged from before -- the provider result array is a
+			// non-null, truthy value, so it short-circuits wp_mail() and becomes
+			// its return value.
+			return $result;
+		}
+
+		// Failure: `false` still short-circuits wp_mail() (see register_hooks()
+		// above) so WP does NOT fall through to its own PHPMailer for a message
+		// we already attempted -- but wp_mail()'s return value is now the
+		// honest `false` instead of a lie. Fire wp_mail_failed ourselves since
+		// short-circuiting skips WP's own call to it entirely, matching the
+		// WP_Error shape core's own failure paths use (code 'wp_mail_failed',
+		// the failure message, and the mail args minus body/secrets) so
+		// existing listeners on that hook keep working.
+		$error_message = $result['detail'] !== '' ? $result['detail'] : 'WPMgr: mail send failed.';
+
+		$error_data = array(
+			'to'                    => $atts['to'] ?? array(),
+			'subject'               => (string) ( $atts['subject'] ?? '' ),
+			'headers'               => $atts['headers'] ?? array(),
+			'attachments'           => $atts['attachments'] ?? array(),
+			// Provider-side failure detail; never credentials or the message body.
+			'wpmgr_provider_detail' => $error_message,
+		);
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- firing core's own wp_mail_failed hook, not registering a global
+		do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', $error_message, $error_data ) );
+
+		return false;
 	}
 
 	/**

--- a/apps/agent/tests/Email/MailRouterTest.php
+++ b/apps/agent/tests/Email/MailRouterTest.php
@@ -23,6 +23,7 @@ namespace WPMgr\Agent\Tests\Email;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use WP_Error;
 use WPMgr\Agent\Email\AddressParser;
 use WPMgr\Agent\Email\EmailConfig;
 use WPMgr\Agent\Email\MailRouter;
@@ -58,6 +59,138 @@ class MailRouterTest extends TestCase
         $settings       = new Settings();
 
         return new MailRouter($providerRouter, $settings);
+    }
+
+    /**
+     * Build a MailRouter whose ProviderRouter::send() is stubbed to return a
+     * fixed result, and whose EmailConfig::load() sees a configured provider
+     * (so intercept() does not bail out on the "not configured" early return).
+     *
+     * @param array{ok:bool,message_id:string,detail:string} $sendResult
+     */
+    private function routerWithSendResult(array $sendResult): MailRouter
+    {
+        Functions\when('get_option')->justReturn(['provider' => 'smtp']);
+
+        $providerRouter = $this->createMock(ProviderRouter::class);
+        $providerRouter->method('send')->willReturn($sendResult);
+        $settings = new Settings();
+
+        return new MailRouter($providerRouter, $settings);
+    }
+
+    /** @return array<string,mixed> */
+    private function baseAtts(): array
+    {
+        return [
+            'to'      => 'someone@example.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+            'headers' => '',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #439: wp_mail() must report the truth, not a hard-coded `true`.
+    //
+    // pre_wp_mail short-circuits wp_mail() and its return value BECOMES
+    // wp_mail()'s return value verbatim (wp-includes/pluggable.php:
+    // `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`). Only `null`
+    // lets WP fall through to its own PHPMailer path; any other value --
+    // including `false` -- still short-circuits. So `false` is both an
+    // honest failure signal AND still prevents WP from re-attempting the
+    // send through its own PHPMailer.
+    // -------------------------------------------------------------------------
+
+    public function test_failed_send_returns_false_not_true(): void
+    {
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame(false, $result, 'A failed send must make wp_mail() return false, not a truthy placeholder');
+    }
+
+    public function test_failed_send_return_value_still_satisfies_cores_own_short_circuit_condition(): void
+    {
+        // This re-states, verbatim, the exact condition wp_mail() itself uses
+        // in wp-includes/pluggable.php to decide whether to run its own
+        // PHPMailer path: `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`
+        // A failed send must keep satisfying it -- i.e. never fall back to
+        // `null` -- or WordPress will attempt a second, duplicate delivery.
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'provider rejected the message',
+        ]);
+
+        $preWpMail = $router->intercept(null, $this->baseAtts());
+
+        $coreWouldShortCircuit = ( null !== $preWpMail );
+        $this->assertTrue($coreWouldShortCircuit, 'core must still short-circuit on a failed send, or WP retries the send itself and duplicates the email');
+        $this->assertFalse($preWpMail, 'the short-circuited value must be the honest false, not a placeholder true');
+    }
+
+    public function test_failed_send_fires_wp_mail_failed_exactly_once_with_wp_error(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $router->intercept(null, $this->baseAtts());
+
+        $wpMailFailedCalls = array_values(array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'));
+        $this->assertCount(1, $wpMailFailedCalls, 'wp_mail_failed must fire exactly once on a failed send');
+
+        $error = $wpMailFailedCalls[0][1][0] ?? null;
+        $this->assertInstanceOf(WP_Error::class, $error, 'wp_mail_failed must be passed a WP_Error, matching core');
+        $this->assertSame('smtp connect() failed: Connection refused', $error->get_error_message());
+
+        // The error data must not carry the message body or any secret --
+        // only what core itself would attach (recipient/subject/headers/
+        // attachments) plus our own provider failure detail.
+        $data = $error->get_error_data();
+        $this->assertArrayNotHasKey('message', $data, 'wp_mail_failed error data must never carry the message body');
+        $this->assertSame('someone@example.com', $data['to']);
+        $this->assertSame('Subject', $data['subject']);
+    }
+
+    public function test_successful_send_is_unchanged_and_does_not_fire_wp_mail_failed(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $sendResult = [
+            'ok'         => true,
+            'message_id' => 'abc123',
+            'detail'     => '',
+        ];
+        $router = $this->routerWithSendResult($sendResult);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame($sendResult, $result, 'a successful send must return the same value as before this fix');
+        $wpMailFailedCalls = array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed');
+        $this->assertCount(0, $wpMailFailedCalls, 'wp_mail_failed must never fire on a successful send');
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `MailRouter::intercept()` (`apps/agent/includes/email/class-mail-router.php`) short-circuits `wp_mail()` via `pre_wp_mail`. On a provider failure it returned `true`, so `wp_mail()`'s return value — which callers (core, contact forms, checkout, password resets) treat as the send result — reported success on every failed send.
- Verified against WordPress core (`wp-includes/pluggable.php`): `wp_mail()` only falls through to its own PHPMailer path when `pre_wp_mail` returns exactly `null`; any other value, including `false`, still short-circuits. So `false` is both an honest failure signal and still prevents WP from re-attempting the send.
- `wp_mail_failed` never fired on a routed failure (short-circuiting skips WP's own call to it, and the plugin never fired it). Now fired with a `WP_Error` shaped like core's own (`to`, `subject`, `headers`, `attachments`, plus a `wpmgr_provider_detail` string) — never the message body or a secret.
- Successful sends are unchanged: same return value, `wp_mail_failed` does not fire.

## Behaviour change
Sites will start seeing `wp_mail()` return `false` where it previously returned `true` on a provider failure. Forms and flows that were silently swallowing failures will now surface them. That is the intent of this fix, not a regression.

## Out of scope
`log_emails` silently dropping the failure record when disabled (GH #381), being designed separately. `maybe_log()` is untouched.

## Test plan
- [x] `apps/agent/tests/Email/MailRouterTest.php`: new tests proven RED against the pre-fix code (`git stash` of the implementation file only), then GREEN after — pasted in the PR discussion / session log.
  - failed send returns `false`, not `true`
  - failed send still satisfies core's own short-circuit condition (`null !== $pre_wp_mail`), so WP does not re-attempt delivery
  - `wp_mail_failed` fires exactly once with a `WP_Error`, data excludes the message body
  - successful send is byte-for-byte unchanged and does not fire `wp_mail_failed`
- [x] `composer test` (phpunit): 3201 tests, 17027 assertions, 0 failures (7 skipped, pre-existing/unrelated)
- [x] `make agent-check` (phpcs): 8 files, 0 errors
- [ ] `make agent-plugincheck` (Docker `wp plugin check`): not run locally (budget); `.github/workflows/plugincheck.yml` runs it automatically on this PR

Fixes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed email deliveries now correctly report failure while preventing duplicate WordPress retries.
  * Email failure notifications now include sanitized error details and non-sensitive message metadata.
  * Successful email delivery behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->