### PR TITLE
fix(agent): capture wp_mail_failed on sites WPMgr does not route (GH #381 phase 1)

### DIFF
--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -103,6 +103,7 @@ use WPMgr\Agent\Email\Handlers\PostmarkHandler;
 use WPMgr\Agent\Email\Handlers\SendgridHandler;
 use WPMgr\Agent\Email\Handlers\SesHandler;
 use WPMgr\Agent\Email\Handlers\SmtpHandler;
+use WPMgr\Agent\Email\MailFailureCapture;
 use WPMgr\Agent\Email\MailRouter;
 use WPMgr\Agent\Email\ProviderRouter;
 use WPMgr\Agent\Email\SuppressionCache;
@@ -335,6 +336,15 @@ final class Plugin
     private MailRouter $mailRouter;
 
     /**
+     * Unconditional listener on core's own `wp_mail_failed` action (GH #381
+     * phase 1). MailRouter only sees a failure on sites where a WPMgr
+     * provider is configured; this listener registers regardless of
+     * EmailConfig, so a failed send is captured even on sites WPMgr never
+     * routes (core PHPMailer, or a third-party SMTP plugin).
+     */
+    private MailFailureCapture $mailFailureCapture;
+
+    /**
      * Provider-level send dispatcher. Instantiated with all five v1 handlers
      * (smtp/ses/sendgrid/mailgun/postmark) and shared by MailRouter +
      * SendTestEmailCommand.
@@ -503,6 +513,7 @@ final class Plugin
         $this->providerRouter->register(new MailgunHandler());
         $this->providerRouter->register(new PostmarkHandler());
         $this->mailRouter        = new MailRouter($this->providerRouter, $this->settings);
+        $this->mailFailureCapture = new MailFailureCapture($emailLogger);
         $this->emailLogReporter  = new EmailLogReporter($this->settings, $this->signer);
 
         $this->router              = new Router($this->connector, $this->commands());
@@ -1022,6 +1033,11 @@ final class Plugin
         // The filter is non-destructive: when no email config is stored it
         // returns null immediately, leaving the default WP mail path untouched.
         $this->mailRouter->register_hooks();
+
+        // GH #381 phase 1 — unconditional wp_mail_failed listener. Unlike
+        // mailRouter above, this registration is NOT gated behind email
+        // config: it must see failures on sites WPMgr never routes.
+        $this->mailFailureCapture->register_hooks();
 
         // Email log retention pruner — runs daily via wp-cron.
         add_action(EmailLogger::HOOK_PRUNE, [$this, 'pruneEmailLog']);

--- a/apps/agent/includes/email/class-mail-failure-capture.php
+++ b/apps/agent/includes/email/class-mail-failure-capture.php
@@ -23,10 +23,37 @@
  * presence as "already logged by the router path" and returns without
  * writing a second row.
  *
- * Body is never persisted: the $mail array built here carries only `to` and
- * `subject`, never `message`/`body_html`/`body_text`, so EmailLogger::write()
- * has nothing to read into the `body` column regardless of the site's
- * store_body setting.
+ * Consent governs WHAT is written, never WHETHER a row is written. Phase 1
+ * exists specifically to capture failures on sites WPMgr does not route mail
+ * for -- those sites are unconfigured by definition, so EmailConfig::$log_emails
+ * is false on every one of them (it defaults false). Gating the write itself
+ * on log_emails would mean this feature writes nothing on exactly the
+ * population it exists for. Instead:
+ *   - A row is ALWAYS written on a genuine (non-double-logged) failure:
+ *     site, timestamp, provider='wp_mail', status='failed', the error
+ *     string. None of that is personal data, and it is what the alert needs
+ *     to exist at all.
+ *   - The recipient address and subject line are included in that row ONLY
+ *     when EmailConfig::load()->log_emails is true. When it is false, `to`
+ *     and `subject` are written empty/redacted -- never the real values --
+ *     so opting out still means something even though the row itself
+ *     exists.
+ * This is deliberately NOT the same gate ProviderRouter::maybe_log() applies
+ * (that one skips the write entirely); the two differ on purpose and must
+ * not be unified.
+ *
+ * Body is never persisted, unconditionally, regardless of log_emails or
+ * store_body: the $mail array built here carries only `to` and `subject`,
+ * never `message`/`body_html`/`body_text`, so EmailLogger::write() has
+ * nothing to read into the `body` column.
+ *
+ * Defensive input handling: this class exists specifically to capture
+ * failures from mailers WPMgr does not control, so `to`/`subject` in the
+ * error data are validated defensively (never trusted to be well-typed) and
+ * the write itself is wrapped in a try/catch -- an unenumerable malformed
+ * shape from a third-party filter chain must never escape capture() and
+ * fatal the request that triggered the mail send (checkout, password reset,
+ * etc). Dropping the log write is strictly better than a fatal there.
  *
  * @package WPMgr\Agent\Email
  */
@@ -55,7 +82,9 @@ final class MailFailureCapture {
 	 * UNCONDITIONAL: this registration is not gated behind
 	 * EmailConfig::is_configured() or any other config check. That is the
 	 * entire point -- it must fire on sites with no provider configured, so
-	 * WPMgr sees a failure even when it never routed the send.
+	 * WPMgr sees a failure even when it never routed the send. log_emails
+	 * governs what capture() puts IN the row, never whether the row exists;
+	 * see the class docblock.
 	 *
 	 * @return void
 	 */
@@ -90,18 +119,62 @@ final class MailFailureCapture {
 			return;
 		}
 
+		$cfg = EmailConfig::load();
+
 		$error_message = $error->get_error_message();
 		if ( $error_message === '' ) {
 			$error_message = 'wp_mail_failed';
 		}
 
+		// -- Defensive `to` handling -------------------------------------
+		// Core always sends an array of strings, but a third-party filter
+		// further down the wp_mail_failed chain could hand us anything.
+		// An array containing a non-string element (e.g. an object) would
+		// fatal EmailLogger::write()'s implode(); filter those out. A bare
+		// string is passed through as-is (EmailLogger casts it safely). Any
+		// other shape (object, int, etc. as the whole `to` value) falls back
+		// to an empty array rather than risk a fatal on cast.
+		$to_raw = ( is_array( $data ) && isset( $data['to'] ) ) ? $data['to'] : array();
+		if ( is_array( $to_raw ) ) {
+			$to = array_values( array_filter( $to_raw, 'is_string' ) );
+		} elseif ( is_string( $to_raw ) ) {
+			$to = $to_raw;
+		} else {
+			$to = array();
+		}
+
+		// -- Defensive `subject` handling ---------------------------------
+		// (string) on a non-scalar (e.g. an object with no __toString) would
+		// also fatal; only cast when the value is safely castable.
+		$subject_raw = ( is_array( $data ) && isset( $data['subject'] ) ) ? $data['subject'] : '';
+		$subject     = is_scalar( $subject_raw ) ? (string) $subject_raw : '';
+
+		// Consent governs WHAT is written, not WHETHER (see class docblock):
+		// redact the recipient and subject to empty when the site has not
+		// opted into email logging. The row is still written either way, so
+		// the alert exists, but no real recipient address or subject line
+		// leaves the site without log_emails being on.
+		if ( ! $cfg->log_emails ) {
+			$to      = array();
+			$subject = '';
+		}
+
 		// Only `to` and `subject` -- never the message body, under any key,
 		// regardless of the site's store_body setting (see class docblock).
 		$mail = array(
-			'to'      => ( is_array( $data ) && isset( $data['to'] ) ) ? $data['to'] : array(),
-			'subject' => ( is_array( $data ) && isset( $data['subject'] ) ) ? (string) $data['subject'] : '',
+			'to'      => $to,
+			'subject' => $subject,
 		);
 
-		$this->logger->write( $mail, 'wp_mail', 'failed', '', $error_message, '', 0, EmailConfig::load(), '' );
+		// Belt-and-suspenders: a malformed shape this validation didn't
+		// anticipate must still never escape capture() and fatal the
+		// request that triggered the mail send. Dropping the log write is
+		// strictly better than a WSOD on checkout / password reset / etc.
+		try {
+			$this->logger->write( $mail, 'wp_mail', 'failed', '', $error_message, '', 0, $cfg, '' );
+		} catch ( \Throwable $e ) {
+			// Intentionally swallowed -- see comment above.
+			unset( $e );
+		}
 	}
 }

--- a/apps/agent/includes/email/class-mail-failure-capture.php
+++ b/apps/agent/includes/email/class-mail-failure-capture.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * MailFailureCapture: hooks WordPress core's own `wp_mail_failed` action so a
+ * failed send is logged even on sites WPMgr does not route.
+ *
+ * MailRouter::intercept() (class-mail-router.php) only sees a failure on
+ * sites where EmailConfig::is_configured() is true -- when no provider is
+ * configured it returns null immediately and never touches the send. On a
+ * site sending through core PHPMailer, or through a third-party SMTP plugin
+ * that never defers to WPMgr, that leaves WPMgr blind to every failure. Core
+ * itself fires `wp_mail_failed` with a WP_Error on ANY failed send,
+ * configured or not (wp-includes/pluggable.php), so this class listens there
+ * unconditionally -- independent of EmailConfig -- and is the only path that
+ * covers the unrouted case.
+ *
+ * No-double-log guard: when MailRouter's OWN provider send fails, it already
+ * (a) logs the row itself via ProviderRouter::send() -> EmailLogger::write(),
+ * and (b) fires `wp_mail_failed` itself (see class-mail-router.php,
+ * intercept()) with error_data carrying a `wpmgr_provider_detail` key. That
+ * key is unique to MailRouter's own fire -- core's native wp_mail_failed data
+ * (to, subject, message, headers, attachments, optionally
+ * phpmailer_exception_code) never carries it. So capture() treats that key's
+ * presence as "already logged by the router path" and returns without
+ * writing a second row.
+ *
+ * Body is never persisted: the $mail array built here carries only `to` and
+ * `subject`, never `message`/`body_html`/`body_text`, so EmailLogger::write()
+ * has nothing to read into the `body` column regardless of the site's
+ * store_body setting.
+ *
+ * @package WPMgr\Agent\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Email;
+
+/**
+ * Captures core's wp_mail_failed action for sites WPMgr does not route.
+ */
+final class MailFailureCapture {
+
+	private EmailLogger $logger;
+
+	/**
+	 * @param EmailLogger $logger Local send-event logger.
+	 */
+	public function __construct( EmailLogger $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Register hooks. Called from Plugin::registerHooks().
+	 *
+	 * UNCONDITIONAL: this registration is not gated behind
+	 * EmailConfig::is_configured() or any other config check. That is the
+	 * entire point -- it must fire on sites with no provider configured, so
+	 * WPMgr sees a failure even when it never routed the send.
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- listening on core's own wp_mail_failed hook, not registering a global
+		add_action( 'wp_mail_failed', array( $this, 'capture' ) );
+	}
+
+	/**
+	 * `wp_mail_failed` action handler.
+	 *
+	 * WordPress core always passes a WP_Error, but the hook is typed mixed
+	 * here (and guarded with instanceof) because a badly-behaved third-party
+	 * filter chain could in theory pass something else through; core itself
+	 * never does.
+	 *
+	 * @param mixed $error Expected WP_Error from core or MailRouter.
+	 * @return void
+	 */
+	public function capture( $error ): void {
+		if ( ! ( $error instanceof \WP_Error ) ) {
+			return;
+		}
+
+		$data = $error->get_error_data();
+
+		// MailRouter already logged this failure itself (see class docblock);
+		// the wpmgr_provider_detail key only ever appears on a WP_Error that
+		// MailRouter fired, never on core's own native wp_mail_failed data.
+		// Logging again here would double-count the same send.
+		if ( is_array( $data ) && array_key_exists( 'wpmgr_provider_detail', $data ) ) {
+			return;
+		}
+
+		$error_message = $error->get_error_message();
+		if ( $error_message === '' ) {
+			$error_message = 'wp_mail_failed';
+		}
+
+		// Only `to` and `subject` -- never the message body, under any key,
+		// regardless of the site's store_body setting (see class docblock).
+		$mail = array(
+			'to'      => ( is_array( $data ) && isset( $data['to'] ) ) ? $data['to'] : array(),
+			'subject' => ( is_array( $data ) && isset( $data['subject'] ) ) ? (string) $data['subject'] : '',
+		);
+
+		$this->logger->write( $mail, 'wp_mail', 'failed', '', $error_message, '', 0, EmailConfig::load(), '' );
+	}
+}

--- a/apps/agent/includes/email/class-mail-router.php
+++ b/apps/agent/includes/email/class-mail-router.php
@@ -19,6 +19,10 @@
  * The X-WPMgr-Site correlation header is stamped on every outgoing message for
  * the Phase-4 CP webhook fan-out.
  *
+ * wp_mail()'s return value is honest: a provider failure makes wp_mail()
+ * return false (never a lie of true) and fires `wp_mail_failed` with a
+ * WP_Error, same as core would on its own send failure. See intercept().
+ *
  * @package WPMgr\Agent\Email
  */
 
@@ -53,10 +57,14 @@ final class MailRouter {
 	 */
 	public function register_hooks(): void {
 		// pre_wp_mail is the primary interception point (WP 5.7+, our baseline).
-		// Returning a non-null value from this filter short-circuits wp_mail()
-		// entirely. We return the result array on success, true on failure (so WP
-		// does NOT fall through to its own PHPMailer path for a message we already
-		// attempted), and null when email is not configured (leaves WP untouched).
+		// Per wp-includes/pluggable.php, wp_mail() only lets WP's own PHPMailer
+		// path run when this filter returns exactly `null`; ANY other value --
+		// including `false` -- short-circuits and becomes wp_mail()'s own return
+		// value verbatim. So we return the result array on success, false on
+		// failure (still short-circuits, so WP never re-attempts a send we
+		// already made -- but wp_mail() now honestly reports the failure instead
+		// of claiming success), and null when email is not configured (leaves
+		// WP untouched).
 		add_filter( 'pre_wp_mail', array( $this, 'intercept' ), 10, 2 );
 	}
 
@@ -84,10 +92,36 @@ final class MailRouter {
 
 		$result = $this->router->send( $mail, $cfg );
 
-		// Return true (truthy non-null) to short-circuit wp_mail() regardless of
-		// the provider outcome; WP's return value from wp_mail() is a bool and we
-		// have already logged the failure via EmailLogger if it occurred.
-		return $result['ok'] ? $result : true;
+		if ( $result['ok'] ) {
+			// Success: unchanged from before -- the provider result array is a
+			// non-null, truthy value, so it short-circuits wp_mail() and becomes
+			// its return value.
+			return $result;
+		}
+
+		// Failure: `false` still short-circuits wp_mail() (see register_hooks()
+		// above) so WP does NOT fall through to its own PHPMailer for a message
+		// we already attempted -- but wp_mail()'s return value is now the
+		// honest `false` instead of a lie. Fire wp_mail_failed ourselves since
+		// short-circuiting skips WP's own call to it entirely, matching the
+		// WP_Error shape core's own failure paths use (code 'wp_mail_failed',
+		// the failure message, and the mail args minus body/secrets) so
+		// existing listeners on that hook keep working.
+		$error_message = $result['detail'] !== '' ? $result['detail'] : 'WPMgr: mail send failed.';
+
+		$error_data = array(
+			'to'                    => $atts['to'] ?? array(),
+			'subject'               => (string) ( $atts['subject'] ?? '' ),
+			'headers'               => $atts['headers'] ?? array(),
+			'attachments'           => $atts['attachments'] ?? array(),
+			// Provider-side failure detail; never credentials or the message body.
+			'wpmgr_provider_detail' => $error_message,
+		);
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- firing core's own wp_mail_failed hook, not registering a global
+		do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', $error_message, $error_data ) );
+
+		return false;
 	}
 
 	/**

--- a/apps/agent/tests/Email/MailFailureCaptureTest.php
+++ b/apps/agent/tests/Email/MailFailureCaptureTest.php
@@ -8,6 +8,14 @@
  * plugin was invisible to WPMgr. MailFailureCapture closes that gap by
  * listening on wp_mail_failed unconditionally, independent of EmailConfig.
  *
+ * Consent (log_emails) governs WHAT MailFailureCapture::capture() writes,
+ * never WHETHER it writes: a row always exists for a genuine failure (that
+ * is the alert), but the recipient address and subject line are included
+ * only when the site has opted into email logging -- otherwise they are
+ * redacted to empty. See class-mail-failure-capture.php's docblock for the
+ * full reasoning (security-reviewer finding + owner ruling on the initial
+ * commit).
+ *
  * @package WPMgr\Agent\Tests\Email
  */
 
@@ -57,8 +65,11 @@ class MailFailureCaptureTest extends TestCase
 
         Functions\when('current_time')->justReturn('2026-08-17 00:00:00');
 
-        // EmailConfig::load() -> get_option(OPTION); default to an empty
-        // array so the decoded config is unconfigured (provider === '').
+        // EmailConfig::load() -> get_option(OPTION). Default to an empty
+        // array: unconfigured (provider === '') AND log_emails === false --
+        // the real default shape on a site that never touched email
+        // settings, i.e. this feature's entire target population. Tests
+        // that need log_emails=true override this per-test.
         Functions\when('get_option')->justReturn([]);
     }
 
@@ -95,13 +106,92 @@ class MailFailureCaptureTest extends TestCase
     }
 
     /**
-     * RED/GREEN case: core's own wp_mail_failed fires on an UNCONFIGURED
-     * site (no WPMgr provider set) and must produce exactly one 'failed' row.
-     * The send body ('message' in core's error data) must never appear in
-     * any persisted column, under any key, regardless of store_body.
+     * Required test 1 (owner-specified): on an unrouted site with
+     * log_emails=false (the real default), a wp_mail_failed fire must still
+     * write a row -- status='failed', provider='wp_mail', error non-empty --
+     * so the alert exists, but the row must contain NEITHER the recipient
+     * address NOR the subject line in any column.
      */
-    public function test_wp_mail_failed_writes_a_failed_row_when_no_provider_is_configured(): void
+    public function test_row_is_written_but_redacted_when_log_emails_is_disabled(): void
     {
+        Functions\when('get_option')->justReturn([]); // log_emails=false, provider=''
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
+            'to'      => ['a@x.com'],
+            'subject' => 'Order #12',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows, 'A row must always be written for a genuine failure, even with log_emails off.');
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('wp_mail', $row['provider']);
+        $this->assertNotSame('', $row['error']);
+
+        $json = (string) json_encode($row);
+        $this->assertStringNotContainsString('a@x.com', $json, 'Recipient must not appear anywhere in the row when log_emails is off.');
+        $this->assertStringNotContainsString('Order #12', $json, 'Subject must not appear anywhere in the row when log_emails is off.');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Required test 2 (owner-specified): on an unrouted site with
+     * log_emails=true, the row DOES carry the real recipient and subject --
+     * the opt-in has to still mean something.
+     */
+    public function test_row_carries_real_recipient_and_subject_when_log_emails_is_enabled(): void
+    {
+        Functions\when('get_option')->justReturn(['log_emails' => true]);
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
+            'to'      => ['a@x.com'],
+            'subject' => 'Order #12',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('wp_mail', $row['provider']);
+        $this->assertStringContainsString('a@x.com', $row['mail_to'], 'Opting in to log_emails must actually surface the real recipient.');
+        $this->assertSame('Order #12', $row['subject']);
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Required test 3 (owner-specified): with store_body=true (in addition
+     * to cases 1/2 above), the message body is still excluded from every
+     * column, regardless of log_emails or store_body. capture() never sets
+     * body_html/body_text on the $mail payload it builds, so
+     * EmailLogger::write() has nothing to read into the body column no
+     * matter what store_body says.
+     *
+     * Note on `body_stored`: that column reflects the SITE's store_body
+     * setting, not whether any body content was actually captured --
+     * EmailLogger::write() sets it from $cfg->store_body unconditionally
+     * inside its `if ( $cfg->store_body )` branch (class-email-logger.php:75-76),
+     * regardless of whether $mail carries body_html/body_text. So
+     * body_stored=1 here is expected and NOT a leak; the actual property
+     * under test is that the `body` column itself, and every other column,
+     * never contains the raw message text.
+     */
+    public function test_body_is_never_persisted_when_store_body_is_enabled(): void
+    {
+        Functions\when('get_option')->justReturn(['log_emails' => true, 'store_body' => true]);
+
         $fakeWpdb        = $this->fakeWpdb();
         $GLOBALS['wpdb'] = $fakeWpdb;
 
@@ -114,19 +204,47 @@ class MailFailureCaptureTest extends TestCase
             'message' => 'SECRET-BODY',
         ]));
 
-        $this->assertCount(1, $fakeWpdb->rows, 'Exactly one failed row must be written for an unrouted core mail_failed.');
-
+        $this->assertCount(1, $fakeWpdb->rows);
         $row = $fakeWpdb->rows[0];
-        $this->assertSame('failed', $row['status']);
-        $this->assertSame('wp_mail', $row['provider']);
-        $this->assertNotSame('', $row['error']);
-
-        // Security-relevant assertion: the raw message body must appear in
-        // NO field of the persisted row.
+        $this->assertNotSame('SECRET-BODY', $row['body'], "The 'body' column must never carry the raw message text.");
         $this->assertStringNotContainsString('SECRET-BODY', (string) json_encode($row));
-        foreach ($row as $column => $value) {
-            $this->assertNotSame('SECRET-BODY', $value, "Column '{$column}' must never carry the raw message body.");
-        }
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Required test 4 / security-reviewer finding B: a malformed `to`
+     * (an array containing a non-string element) must not throw an uncaught
+     * Error out of the wp_mail_failed hook. Without validation,
+     * EmailLogger::write()'s implode(', ', $to_raw) fatals on a non-string
+     * element (e.g. an object with no __toString) -- and since
+     * wp_mail_failed fires from inside core's wp_mail() catch block, an
+     * uncaught Error here WSODs whatever request triggered the mail send
+     * (checkout, password reset, etc). capture() filters non-string
+     * elements out before they can reach implode().
+     */
+    public function test_capture_does_not_fatal_on_non_string_to_element(): void
+    {
+        Functions\when('get_option')->justReturn(['log_emails' => true]);
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        $malformedRecipient = new class () {
+            // Deliberately no __toString(): (string) cast or implode() on
+            // this object fatals with an uncaught Error.
+        };
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'malformed to element', [
+            'to'      => ['good@example.com', $malformedRecipient],
+            'subject' => 'S',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows, 'A malformed to-element must not prevent the well-formed recipient from being logged.');
+        $this->assertStringContainsString('good@example.com', $fakeWpdb->rows[0]['mail_to']);
 
         unset($GLOBALS['wpdb']);
     }
@@ -144,7 +262,9 @@ class MailFailureCaptureTest extends TestCase
      * when that marker is present. It does not exercise
      * ProviderRouter::send()'s own separate EmailLogger::write() call (the
      * "first" log write in "logged once not twice") -- that call happens on
-     * a different code path outside this test's scope.
+     * a different code path outside this test's scope. The marker check
+     * runs before EmailConfig is even loaded, so this holds regardless of
+     * log_emails.
      */
     public function test_router_handled_failure_is_logged_once_not_twice(): void
     {
@@ -176,12 +296,14 @@ class MailFailureCaptureTest extends TestCase
      * core only calls wp_mail_failed on failure, never on a successful send
      * -- so the most meaningful concrete check available here is that
      * capture() is stateless across repeated fires: two INDEPENDENT
-     * unconfigured failures must produce two independent rows, not a single
-     * corrupted/merged entry, proving the listener doesn't leak state or
-     * drop a second in-process failure.
+     * log_emails-enabled failures must produce two independent rows, not a
+     * single corrupted/merged entry, proving the listener doesn't leak
+     * state or drop a second in-process failure.
      */
-    public function test_two_independent_unconfigured_failures_produce_two_independent_rows(): void
+    public function test_two_independent_failures_produce_two_independent_rows(): void
     {
+        Functions\when('get_option')->justReturn(['log_emails' => true]);
+
         $fakeWpdb        = $this->fakeWpdb();
         $GLOBALS['wpdb'] = $fakeWpdb;
 

--- a/apps/agent/tests/Email/MailFailureCaptureTest.php
+++ b/apps/agent/tests/Email/MailFailureCaptureTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * MailFailureCaptureTest — GH #381 phase 1: WordPress core's own
+ * `wp_mail_failed` action fires on ANY failed send (configured or not), but
+ * nothing in this plugin listened for it. MailRouter::intercept()
+ * (class-mail-router.php) only sees a failure when EmailConfig::is_configured()
+ * is true, so a site sending through core PHPMailer or a third-party SMTP
+ * plugin was invisible to WPMgr. MailFailureCapture closes that gap by
+ * listening on wp_mail_failed unconditionally, independent of EmailConfig.
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+use WPMgr\Agent\Email\EmailLogger;
+use WPMgr\Agent\Email\MailFailureCapture;
+
+/**
+ * @covers \WPMgr\Agent\Email\MailFailureCapture
+ */
+class MailFailureCaptureTest extends TestCase
+{
+    /** @var array<string,array<int,callable>> hook name => registered callbacks. */
+    private array $registeredActions = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->registeredActions = [];
+
+        // Brain Monkey's built-in add_action()/do_action() are expectation
+        // trackers, not a working dispatcher: HookExpectationExecutor::execute()
+        // returns null for a hook with no expectation configured, so
+        // do_action() alone never invokes what add_action() registered. These
+        // aliases build a tiny real pub/sub so do_action() genuinely calls
+        // whatever register_hooks() wired -- proving the WIRING, not just
+        // calling capture() directly. Same pattern as
+        // tests/SelfUpdateInRequestApplyTest.php's add_action alias.
+        Functions\when('add_action')->alias(function (string $hook, $callback, int $priority = 10, int $accepted_args = 1): bool {
+            $this->registeredActions[$hook][] = $callback;
+            return true;
+        });
+        Functions\when('do_action')->alias(function (string $hook, ...$args): void {
+            foreach ($this->registeredActions[$hook] ?? [] as $callback) {
+                $callback(...$args);
+            }
+        });
+
+        Functions\when('current_time')->justReturn('2026-08-17 00:00:00');
+
+        // EmailConfig::load() -> get_option(OPTION); default to an empty
+        // array so the decoded config is unconfigured (provider === '').
+        Functions\when('get_option')->justReturn([]);
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Minimal fake $wpdb: records every insert() call's $data array so a
+     * test can assert row count and shape without a real database. Uses an
+     * array (not a single captured row) because some tests need to count
+     * multiple potential inserts.
+     */
+    private function fakeWpdb(): object
+    {
+        return new class () {
+            public string $prefix = 'wp_';
+
+            /** @var array<int,array<string,mixed>> */
+            public array $rows = [];
+
+            public int $insert_id = 0;
+
+            /** @param array<string,mixed> $data */
+            public function insert(string $table, array $data, array $formats): bool
+            {
+                $this->rows[] = $data;
+                $this->insert_id++;
+                return true;
+            }
+        };
+    }
+
+    /**
+     * RED/GREEN case: core's own wp_mail_failed fires on an UNCONFIGURED
+     * site (no WPMgr provider set) and must produce exactly one 'failed' row.
+     * The send body ('message' in core's error data) must never appear in
+     * any persisted column, under any key, regardless of store_body.
+     */
+    public function test_wp_mail_failed_writes_a_failed_row_when_no_provider_is_configured(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
+            'to'      => ['a@x.com'],
+            'subject' => 'Order #12',
+            'message' => 'SECRET-BODY',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows, 'Exactly one failed row must be written for an unrouted core mail_failed.');
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('wp_mail', $row['provider']);
+        $this->assertNotSame('', $row['error']);
+
+        // Security-relevant assertion: the raw message body must appear in
+        // NO field of the persisted row.
+        $this->assertStringNotContainsString('SECRET-BODY', (string) json_encode($row));
+        foreach ($row as $column => $value) {
+            $this->assertNotSame('SECRET-BODY', $value, "Column '{$column}' must never carry the raw message body.");
+        }
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * No-double-log guard: when MailRouter's own provider send fails, it
+     * already (a) logs the row itself via ProviderRouter::send() ->
+     * EmailLogger::write(), and (b) fires wp_mail_failed itself (post
+     * cb7737c) with error_data carrying a `wpmgr_provider_detail` marker
+     * that only ever appears on a WP_Error MailRouter fired -- core's own
+     * native wp_mail_failed data never has that key.
+     *
+     * Scoping: this test only proves that MailFailureCapture::capture(),
+     * reached here through the real wp_mail_failed dispatch, adds ZERO rows
+     * when that marker is present. It does not exercise
+     * ProviderRouter::send()'s own separate EmailLogger::write() call (the
+     * "first" log write in "logged once not twice") -- that call happens on
+     * a different code path outside this test's scope.
+     */
+    public function test_router_handled_failure_is_logged_once_not_twice(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'Provider rejected', [
+            'to'                    => ['a@x.com'],
+            'subject'               => 'S',
+            'headers'               => [],
+            'attachments'           => [],
+            'wpmgr_provider_detail' => 'Provider rejected',
+        ]));
+
+        $this->assertCount(
+            0,
+            $fakeWpdb->rows,
+            'MailFailureCapture must add zero rows when the wpmgr_provider_detail marker shows MailRouter already logged this failure.'
+        );
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Over-fire control. There is no success-path fire to test directly --
+     * core only calls wp_mail_failed on failure, never on a successful send
+     * -- so the most meaningful concrete check available here is that
+     * capture() is stateless across repeated fires: two INDEPENDENT
+     * unconfigured failures must produce two independent rows, not a single
+     * corrupted/merged entry, proving the listener doesn't leak state or
+     * drop a second in-process failure.
+     */
+    public function test_two_independent_unconfigured_failures_produce_two_independent_rows(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'first failure', [
+            'to'      => ['first@x.com'],
+            'subject' => 'First',
+        ]));
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'second failure', [
+            'to'      => ['second@x.com'],
+            'subject' => 'Second',
+        ]));
+
+        $this->assertCount(2, $fakeWpdb->rows);
+        $this->assertSame('first failure', $fakeWpdb->rows[0]['error']);
+        $this->assertSame('second failure', $fakeWpdb->rows[1]['error']);
+        $this->assertStringContainsString('first@x.com', $fakeWpdb->rows[0]['mail_to']);
+        $this->assertStringContainsString('second@x.com', $fakeWpdb->rows[1]['mail_to']);
+
+        unset($GLOBALS['wpdb']);
+    }
+}

--- a/apps/agent/tests/Email/MailRouterTest.php
+++ b/apps/agent/tests/Email/MailRouterTest.php
@@ -23,6 +23,7 @@ namespace WPMgr\Agent\Tests\Email;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use WP_Error;
 use WPMgr\Agent\Email\AddressParser;
 use WPMgr\Agent\Email\EmailConfig;
 use WPMgr\Agent\Email\MailRouter;
@@ -58,6 +59,138 @@ class MailRouterTest extends TestCase
         $settings       = new Settings();
 
         return new MailRouter($providerRouter, $settings);
+    }
+
+    /**
+     * Build a MailRouter whose ProviderRouter::send() is stubbed to return a
+     * fixed result, and whose EmailConfig::load() sees a configured provider
+     * (so intercept() does not bail out on the "not configured" early return).
+     *
+     * @param array{ok:bool,message_id:string,detail:string} $sendResult
+     */
+    private function routerWithSendResult(array $sendResult): MailRouter
+    {
+        Functions\when('get_option')->justReturn(['provider' => 'smtp']);
+
+        $providerRouter = $this->createMock(ProviderRouter::class);
+        $providerRouter->method('send')->willReturn($sendResult);
+        $settings = new Settings();
+
+        return new MailRouter($providerRouter, $settings);
+    }
+
+    /** @return array<string,mixed> */
+    private function baseAtts(): array
+    {
+        return [
+            'to'      => 'someone@example.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+            'headers' => '',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #439: wp_mail() must report the truth, not a hard-coded `true`.
+    //
+    // pre_wp_mail short-circuits wp_mail() and its return value BECOMES
+    // wp_mail()'s return value verbatim (wp-includes/pluggable.php:
+    // `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`). Only `null`
+    // lets WP fall through to its own PHPMailer path; any other value --
+    // including `false` -- still short-circuits. So `false` is both an
+    // honest failure signal AND still prevents WP from re-attempting the
+    // send through its own PHPMailer.
+    // -------------------------------------------------------------------------
+
+    public function test_failed_send_returns_false_not_true(): void
+    {
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame(false, $result, 'A failed send must make wp_mail() return false, not a truthy placeholder');
+    }
+
+    public function test_failed_send_return_value_still_satisfies_cores_own_short_circuit_condition(): void
+    {
+        // This re-states, verbatim, the exact condition wp_mail() itself uses
+        // in wp-includes/pluggable.php to decide whether to run its own
+        // PHPMailer path: `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`
+        // A failed send must keep satisfying it -- i.e. never fall back to
+        // `null` -- or WordPress will attempt a second, duplicate delivery.
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'provider rejected the message',
+        ]);
+
+        $preWpMail = $router->intercept(null, $this->baseAtts());
+
+        $coreWouldShortCircuit = ( null !== $preWpMail );
+        $this->assertTrue($coreWouldShortCircuit, 'core must still short-circuit on a failed send, or WP retries the send itself and duplicates the email');
+        $this->assertFalse($preWpMail, 'the short-circuited value must be the honest false, not a placeholder true');
+    }
+
+    public function test_failed_send_fires_wp_mail_failed_exactly_once_with_wp_error(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $router->intercept(null, $this->baseAtts());
+
+        $wpMailFailedCalls = array_values(array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'));
+        $this->assertCount(1, $wpMailFailedCalls, 'wp_mail_failed must fire exactly once on a failed send');
+
+        $error = $wpMailFailedCalls[0][1][0] ?? null;
+        $this->assertInstanceOf(WP_Error::class, $error, 'wp_mail_failed must be passed a WP_Error, matching core');
+        $this->assertSame('smtp connect() failed: Connection refused', $error->get_error_message());
+
+        // The error data must not carry the message body or any secret --
+        // only what core itself would attach (recipient/subject/headers/
+        // attachments) plus our own provider failure detail.
+        $data = $error->get_error_data();
+        $this->assertArrayNotHasKey('message', $data, 'wp_mail_failed error data must never carry the message body');
+        $this->assertSame('someone@example.com', $data['to']);
+        $this->assertSame('Subject', $data['subject']);
+    }
+
+    public function test_successful_send_is_unchanged_and_does_not_fire_wp_mail_failed(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $sendResult = [
+            'ok'         => true,
+            'message_id' => 'abc123',
+            'detail'     => '',
+        ];
+        $router = $this->routerWithSendResult($sendResult);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame($sendResult, $result, 'a successful send must return the same value as before this fix');
+        $wpMailFailedCalls = array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed');
+        $this->assertCount(0, $wpMailFailedCalls, 'wp_mail_failed must never fire on a successful send');
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## What this closes

WPMgr only saw an email-send failure on sites where it routed the send itself (`EmailConfig::is_configured()` true — a WPMgr provider configured). On a site sending through core PHPMailer, or through a third-party SMTP plugin that never defers to WPMgr, `MailRouter::intercept()` (`apps/agent/includes/email/class-mail-router.php:86-89`) returns `null` immediately and WPMgr never sees anything, even though WordPress core fires its own `wp_mail_failed` action with a `WP_Error` on ANY failed send, configured or not (`wp-includes/pluggable.php`). Nothing in the plugin hooked that action.

New `WPMgr\Agent\Email\MailFailureCapture` (`apps/agent/includes/email/class-mail-failure-capture.php`) registers on `wp_mail_failed` **unconditionally** — independent of `EmailConfig` — so a failure is captured on any site, routed or not. Wired into `apps/agent/includes/class-plugin.php` alongside `mailRouter->register_hooks()`, reusing the same `EmailLogger` instance.

## Double-log guard

When `MailRouter::intercept()` handles a *configured* provider's failure, it already (a) logs the row itself via `ProviderRouter::send()` → `EmailLogger::write()`, and (b) as of `cb7737c` fires `wp_mail_failed` itself, with `error_data` carrying a `wpmgr_provider_detail` key. That key is unique to a `WP_Error` MailRouter fires itself — core's own native `wp_mail_failed` data (`to`, `subject`, `message`, `headers`, `attachments`, optionally `phpmailer_exception_code`) never carries it. `MailFailureCapture::capture()` checks `get_error_data()` for that key and returns early when present, so a router-handled failure is never logged twice.

## Consent: redact, don't suppress (post-review fix)

An independent security-reviewer pass on the initial commit (1f2eadc) found the row was written with the REAL recipient address and subject line regardless of `EmailConfig->log_emails`. Since `log_emails` defaults false and Phase 1's entire target population (sites WPMgr does not route mail for) is unconfigured by definition, that meant recipient PII shipped to the control plane within ~5 minutes of any failed `wp_mail()` call on sites that had never opted into email logging — a real, proven blocking defect.

The fix separates **whether** a row is written from **what** it contains:
- A row is **always** written for a genuine (non-double-logged) failure: site, timestamp, `provider='wp_mail'`, `status='failed'`, the error string. None of that is personal data, and it's what the alert needs to exist at all. (An earlier draft of this fix gated the write itself on `log_emails` — that was wrong: it would have made the feature write nothing on exactly the population it exists for, and was reverted before merge.)
- The recipient address and subject line are included in that row **only when `EmailConfig::load()->log_emails` is true**. When it's false, `to` and `subject` are redacted to empty — never the real values — so opting in still means something.
- The message body stays excluded **unconditionally**, regardless of `log_emails` or `store_body` — `capture()` never sets `body_html`/`body_text` on the `$mail` payload, so `EmailLogger::write()` has nothing to read into the `body` column.

This is deliberately **not** the same gate `ProviderRouter::maybe_log()` applies (that one skips the write entirely) — the two differ on purpose and are not unified.

## Defensive input handling (post-review fix)

The same review found that a non-string element in the WP_Error's `to` data (as a badly-behaved third-party `wp_mail_failed` filter could supply) reached `EmailLogger::write()`'s `implode(', ', $to_raw)` uncaught — and since the hook fires from inside core's `wp_mail()` catch block, an uncaught `Error` there WSODs whatever request triggered the mail send (checkout, password reset, etc). `capture()` now filters `to` to string elements only, casts `subject` defensively (`is_scalar()` check before `(string)`), and wraps the `EmailLogger::write()` call in a `try/catch (\Throwable)` as a last-resort guard against any shape this validation didn't anticipate.

## Known coverage limit

If a third-party mailer swallows its own send error internally and never raises `wp_mail_failed`, this phase cannot see that failure. That is a real, already-known gap in this approach, not a bug in this change — WPMgr can only see what core's hook system is told about.

## Test plan

- [x] `composer test` (phpunit) — `tests/Email/MailFailureCaptureTest.php`, 6 tests covering: row-written-but-redacted when `log_emails` is off, row carries real data when `log_emails` is on, body excluded even with `store_body=true`, a malformed `to` element does not fatal, the double-log guard, and two independent failures produce two independent rows. All green.
- [x] `make agent-check` (phpcs) — 0 errors
- [ ] `make agent-plugincheck` — not yet run in this phase; deferred per phase-1 scope. `.github/workflows/plugincheck.yml` runs it automatically on this PR.

This is phase 1 of 5 for GH #381. Not to be merged standalone without CI's `make agent-plugincheck` run.