### PR TITLE
feat(web): surface failure-detection coverage on Notifications page (GH #381 phase 3/5)

### DIFF
--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -139,6 +139,22 @@ WHERE s.tenant_id = $1
   AND s.connection_state <> 'archived'
 ORDER BY s.name;
 
+-- name: ListConnectedSiteAgentVersions :many
+-- Tenant-scoped agent_version per site, restricted to connection_state =
+-- 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+-- here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+-- degraded/pending/disconnected/archived): a site whose agent is not actively
+-- connected cannot report a delivery failure regardless of its version, so it
+-- is excluded from both the coverage numerator and denominator rather than
+-- counted as a gap.
+-- Version comparison happens in Go (internal/wpversion.Compare), matching
+-- ListSitesAgentVersions's convention: this query returns only the raw
+-- per-site fact.
+SELECT agent_version
+FROM sites
+WHERE tenant_id = $1
+  AND connection_state = 'connected';
+
 -- name: ListClientNamesForSites :many
 -- Returns the client id + name for sites that have a client_id set (m63).
 -- Used to enrich the sites-list DTO with client_name in a single batched join.

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -46926,8 +46926,10 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 		e.Bool(s.InstanceMailerConfigured)
 	}
 	{
-		e.FieldStart("failure_detection")
-		s.FailureDetection.Encode(e)
+		if s.FailureDetection.Set {
+			e.FieldStart("failure_detection")
+			s.FailureDetection.Encode(e)
+		}
 	}
 	{
 		if s.TenantID.Set {
@@ -47113,8 +47115,8 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"instance_mailer_configured\"")
 			}
 		case "failure_detection":
-			requiredBitSet[1] |= 1 << 3
 			if err := func() error {
+				s.FailureDetection.Reset()
 				if err := s.FailureDetection.Decode(d); err != nil {
 					return err
 				}
@@ -47163,7 +47165,7 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00001101,
+		0b00000101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -76572,6 +76574,39 @@ func (s OptEmailConnectionConfig) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptEmailConnectionConfig) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes EmailNotifySettingsFailureDetection as json.
+func (o OptEmailNotifySettingsFailureDetection) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes EmailNotifySettingsFailureDetection from json.
+func (o *OptEmailNotifySettingsFailureDetection) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptEmailNotifySettingsFailureDetection to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptEmailNotifySettingsFailureDetection) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptEmailNotifySettingsFailureDetection) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -46926,6 +46926,10 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 		e.Bool(s.InstanceMailerConfigured)
 	}
 	{
+		e.FieldStart("failure_detection")
+		s.FailureDetection.Encode(e)
+	}
+	{
 		if s.TenantID.Set {
 			e.FieldStart("tenant_id")
 			s.TenantID.Encode(e)
@@ -46945,7 +46949,7 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfEmailNotifySettings = [14]string{
+var jsonFieldsNameOfEmailNotifySettings = [15]string{
 	0:  "enabled",
 	1:  "recipients",
 	2:  "alert_on_failure",
@@ -46957,9 +46961,10 @@ var jsonFieldsNameOfEmailNotifySettings = [14]string{
 	8:  "timezone",
 	9:  "next_digest_at",
 	10: "instance_mailer_configured",
-	11: "tenant_id",
-	12: "created_at",
-	13: "updated_at",
+	11: "failure_detection",
+	12: "tenant_id",
+	13: "created_at",
+	14: "updated_at",
 }
 
 // Decode decodes EmailNotifySettings from json.
@@ -47107,6 +47112,16 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance_mailer_configured\"")
 			}
+		case "failure_detection":
+			requiredBitSet[1] |= 1 << 3
+			if err := func() error {
+				if err := s.FailureDetection.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"failure_detection\"")
+			}
 		case "tenant_id":
 			if err := func() error {
 				s.TenantID.Reset()
@@ -47148,7 +47163,7 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00000101,
+		0b00001101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -47232,6 +47247,136 @@ func (s EmailNotifySettingsDigestCadence) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *EmailNotifySettingsDigestCadence) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *EmailNotifySettingsFailureDetection) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *EmailNotifySettingsFailureDetection) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("sites_total")
+		e.Int(s.SitesTotal)
+	}
+	{
+		e.FieldStart("sites_covered")
+		e.Int(s.SitesCovered)
+	}
+	{
+		e.FieldStart("min_agent_version")
+		e.Str(s.MinAgentVersion)
+	}
+}
+
+var jsonFieldsNameOfEmailNotifySettingsFailureDetection = [3]string{
+	0: "sites_total",
+	1: "sites_covered",
+	2: "min_agent_version",
+}
+
+// Decode decodes EmailNotifySettingsFailureDetection from json.
+func (s *EmailNotifySettingsFailureDetection) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EmailNotifySettingsFailureDetection to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "sites_total":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Int()
+				s.SitesTotal = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sites_total\"")
+			}
+		case "sites_covered":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.SitesCovered = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sites_covered\"")
+			}
+		case "min_agent_version":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.MinAgentVersion = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"min_agent_version\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EmailNotifySettingsFailureDetection")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfEmailNotifySettingsFailureDetection) {
+					name = jsonFieldsNameOfEmailNotifySettingsFailureDetection[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *EmailNotifySettingsFailureDetection) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EmailNotifySettingsFailureDetection) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -17014,7 +17014,7 @@ type EmailNotifySettings struct {
 	// only detect a failure when it is the mail transport in use AND the agent is new enough to report
 	// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
 	// alert no matter how the settings above are configured.
-	FailureDetection EmailNotifySettingsFailureDetection `json:"failure_detection"`
+	FailureDetection OptEmailNotifySettingsFailureDetection `json:"failure_detection"`
 	// Present when a settings row exists; absent for default response.
 	TenantID  OptNilUUID     `json:"tenant_id"`
 	CreatedAt OptNilDateTime `json:"created_at"`
@@ -17077,7 +17077,7 @@ func (s *EmailNotifySettings) GetInstanceMailerConfigured() bool {
 }
 
 // GetFailureDetection returns the value of FailureDetection.
-func (s *EmailNotifySettings) GetFailureDetection() EmailNotifySettingsFailureDetection {
+func (s *EmailNotifySettings) GetFailureDetection() OptEmailNotifySettingsFailureDetection {
 	return s.FailureDetection
 }
 
@@ -17152,7 +17152,7 @@ func (s *EmailNotifySettings) SetInstanceMailerConfigured(val bool) {
 }
 
 // SetFailureDetection sets the value of FailureDetection.
-func (s *EmailNotifySettings) SetFailureDetection(val EmailNotifySettingsFailureDetection) {
+func (s *EmailNotifySettings) SetFailureDetection(val OptEmailNotifySettingsFailureDetection) {
 	s.FailureDetection = val
 }
 
@@ -29295,6 +29295,52 @@ func (o OptEmailConnectionConfig) Get() (v EmailConnectionConfig, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptEmailConnectionConfig) Or(d EmailConnectionConfig) EmailConnectionConfig {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptEmailNotifySettingsFailureDetection returns new OptEmailNotifySettingsFailureDetection with value set to v.
+func NewOptEmailNotifySettingsFailureDetection(v EmailNotifySettingsFailureDetection) OptEmailNotifySettingsFailureDetection {
+	return OptEmailNotifySettingsFailureDetection{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptEmailNotifySettingsFailureDetection is optional EmailNotifySettingsFailureDetection.
+type OptEmailNotifySettingsFailureDetection struct {
+	Value EmailNotifySettingsFailureDetection
+	Set   bool
+}
+
+// IsSet returns true if OptEmailNotifySettingsFailureDetection was set.
+func (o OptEmailNotifySettingsFailureDetection) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptEmailNotifySettingsFailureDetection) Reset() {
+	var v EmailNotifySettingsFailureDetection
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptEmailNotifySettingsFailureDetection) SetTo(v EmailNotifySettingsFailureDetection) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptEmailNotifySettingsFailureDetection) Get() (v EmailNotifySettingsFailureDetection, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptEmailNotifySettingsFailureDetection) Or(d EmailNotifySettingsFailureDetection) EmailNotifySettingsFailureDetection {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -17010,6 +17010,11 @@ type EmailNotifySettings struct {
 	// True when the instance-level SMTP/mailer is configured. Alerts and digests require this to be true
 	// to deliver.
 	InstanceMailerConfigured bool `json:"instance_mailer_configured"`
+	// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
+	// only detect a failure when it is the mail transport in use AND the agent is new enough to report
+	// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
+	// alert no matter how the settings above are configured.
+	FailureDetection EmailNotifySettingsFailureDetection `json:"failure_detection"`
 	// Present when a settings row exists; absent for default response.
 	TenantID  OptNilUUID     `json:"tenant_id"`
 	CreatedAt OptNilDateTime `json:"created_at"`
@@ -17069,6 +17074,11 @@ func (s *EmailNotifySettings) GetNextDigestAt() OptNilDateTime {
 // GetInstanceMailerConfigured returns the value of InstanceMailerConfigured.
 func (s *EmailNotifySettings) GetInstanceMailerConfigured() bool {
 	return s.InstanceMailerConfigured
+}
+
+// GetFailureDetection returns the value of FailureDetection.
+func (s *EmailNotifySettings) GetFailureDetection() EmailNotifySettingsFailureDetection {
+	return s.FailureDetection
 }
 
 // GetTenantID returns the value of TenantID.
@@ -17141,6 +17151,11 @@ func (s *EmailNotifySettings) SetInstanceMailerConfigured(val bool) {
 	s.InstanceMailerConfigured = val
 }
 
+// SetFailureDetection sets the value of FailureDetection.
+func (s *EmailNotifySettings) SetFailureDetection(val EmailNotifySettingsFailureDetection) {
+	s.FailureDetection = val
+}
+
 // SetTenantID sets the value of TenantID.
 func (s *EmailNotifySettings) SetTenantID(val OptNilUUID) {
 	s.TenantID = val
@@ -17206,6 +17221,51 @@ func (s *EmailNotifySettingsDigestCadence) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
+}
+
+// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
+// only detect a failure when it is the mail transport in use AND the agent is new enough to report
+// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
+// alert no matter how the settings above are configured.
+type EmailNotifySettingsFailureDetection struct {
+	// Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected,
+	// revoked and archived sites).
+	SitesTotal int `json:"sites_total"`
+	// Of sites_total, how many report an agent_version at or above min_agent_version and can therefore
+	// have a delivery failure detected and alerted on.
+	SitesCovered int `json:"sites_covered"`
+	// Minimum agent version that can detect and report an email delivery failure.
+	MinAgentVersion string `json:"min_agent_version"`
+}
+
+// GetSitesTotal returns the value of SitesTotal.
+func (s *EmailNotifySettingsFailureDetection) GetSitesTotal() int {
+	return s.SitesTotal
+}
+
+// GetSitesCovered returns the value of SitesCovered.
+func (s *EmailNotifySettingsFailureDetection) GetSitesCovered() int {
+	return s.SitesCovered
+}
+
+// GetMinAgentVersion returns the value of MinAgentVersion.
+func (s *EmailNotifySettingsFailureDetection) GetMinAgentVersion() string {
+	return s.MinAgentVersion
+}
+
+// SetSitesTotal sets the value of SitesTotal.
+func (s *EmailNotifySettingsFailureDetection) SetSitesTotal(val int) {
+	s.SitesTotal = val
+}
+
+// SetSitesCovered sets the value of SitesCovered.
+func (s *EmailNotifySettingsFailureDetection) SetSitesCovered(val int) {
+	s.SitesCovered = val
+}
+
+// SetMinAgentVersion sets the value of MinAgentVersion.
+func (s *EmailNotifySettingsFailureDetection) SetMinAgentVersion(val string) {
+	s.MinAgentVersion = val
 }
 
 // Static catalog of supported email providers and their field schemas.

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1596,6 +1596,17 @@ type Querier interface {
 	// expansion (pin a carry-forward chunk's old origin generation under a live
 	// tip) without a second round-trip.
 	ListCompletedSnapshotsForSite(ctx context.Context, arg ListCompletedSnapshotsForSiteParams) ([]ListCompletedSnapshotsForSiteRow, error)
+	// Tenant-scoped agent_version per site, restricted to connection_state =
+	// 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+	// here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+	// degraded/pending/disconnected/archived): a site whose agent is not actively
+	// connected cannot report a delivery failure regardless of its version, so it
+	// is excluded from both the coverage numerator and denominator rather than
+	// counted as a gap.
+	// Version comparison happens in Go (internal/wpversion.Compare), matching
+	// ListSitesAgentVersions's convention: this query returns only the raw
+	// per-site fact.
+	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
 	// Cross-tenant enumeration of connected sites for the weekly screenshot fanout.
 	// Returns only sites in the 'connected' state (not degraded/pending/archived).
 	// Runs under the app.agent GUC (sites_agent policy) since it spans tenants.

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -582,6 +582,43 @@ func (q *Queries) ListClientNamesForSites(ctx context.Context, arg ListClientNam
 	return items, nil
 }
 
+const listConnectedSiteAgentVersions = `-- name: ListConnectedSiteAgentVersions :many
+SELECT agent_version
+FROM sites
+WHERE tenant_id = $1
+  AND connection_state = 'connected'
+`
+
+// Tenant-scoped agent_version per site, restricted to connection_state =
+// 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+// here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+// degraded/pending/disconnected/archived): a site whose agent is not actively
+// connected cannot report a delivery failure regardless of its version, so it
+// is excluded from both the coverage numerator and denominator rather than
+// counted as a gap.
+// Version comparison happens in Go (internal/wpversion.Compare), matching
+// ListSitesAgentVersions's convention: this query returns only the raw
+// per-site fact.
+func (q *Queries) ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error) {
+	rows, err := q.db.Query(ctx, listConnectedSiteAgentVersions, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var agent_version string
+		if err := rows.Scan(&agent_version); err != nil {
+			return nil, err
+		}
+		items = append(items, agent_version)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listConnectedSiteIDsForScreenshot = `-- name: ListConnectedSiteIDsForScreenshot :many
 SELECT id, tenant_id, url FROM sites
 WHERE connection_state = 'connected'

--- a/apps/api/internal/email/dto.go
+++ b/apps/api/internal/email/dto.go
@@ -320,8 +320,8 @@ type siteDeliveryItemDTO struct {
 	ComplainedCount int64   `json:"complained_count"`
 	BounceRate      float64 `json:"bounce_rate"`
 	ComplaintRate   float64 `json:"complaint_rate"`
-	LastSentAt      *string `json:"last_sent_at"`        // RFC3339 or null
-	Sparkline       []int64 `json:"sparkline"`            // [] never null
+	LastSentAt      *string `json:"last_sent_at"` // RFC3339 or null
+	Sparkline       []int64 `json:"sparkline"`    // [] never null
 }
 
 // deliverabilityReportDTO is the full response for GET /email/deliverability.
@@ -616,20 +616,29 @@ type putConnectionBody struct {
 
 // notifySettingsDTO is the wire representation of NotifySettings.
 type notifySettingsDTO struct {
-	TenantID                 string   `json:"tenant_id"`
-	Enabled                  bool     `json:"enabled"`
-	Recipients               []string `json:"recipients"`
-	AlertOnFailure           bool     `json:"alert_on_failure"`
-	AlertThrottleMinutes     int      `json:"alert_throttle_minutes"`
-	DigestEnabled            bool     `json:"digest_enabled"`
-	DigestCadence            string   `json:"digest_cadence"`
-	DigestDay                int      `json:"digest_day"`
-	DigestHour               int      `json:"digest_hour"`
-	Timezone                 string   `json:"timezone"`
-	NextDigestAt             *string  `json:"next_digest_at,omitempty"`
-	InstanceMailerConfigured bool     `json:"instance_mailer_configured"`
-	CreatedAt                int64    `json:"created_at"`
-	UpdatedAt                int64    `json:"updated_at"`
+	TenantID                 string              `json:"tenant_id"`
+	Enabled                  bool                `json:"enabled"`
+	Recipients               []string            `json:"recipients"`
+	AlertOnFailure           bool                `json:"alert_on_failure"`
+	AlertThrottleMinutes     int                 `json:"alert_throttle_minutes"`
+	DigestEnabled            bool                `json:"digest_enabled"`
+	DigestCadence            string              `json:"digest_cadence"`
+	DigestDay                int                 `json:"digest_day"`
+	DigestHour               int                 `json:"digest_hour"`
+	Timezone                 string              `json:"timezone"`
+	NextDigestAt             *string             `json:"next_digest_at,omitempty"`
+	InstanceMailerConfigured bool                `json:"instance_mailer_configured"`
+	FailureDetection         failureDetectionDTO `json:"failure_detection"`
+	CreatedAt                int64               `json:"created_at"`
+	UpdatedAt                int64               `json:"updated_at"`
+}
+
+// failureDetectionDTO is the wire representation of FailureDetectionCoverage
+// (GH #381 phase 2).
+type failureDetectionDTO struct {
+	SitesTotal      int    `json:"sites_total"`
+	SitesCovered    int    `json:"sites_covered"`
+	MinAgentVersion string `json:"min_agent_version"`
 }
 
 // toNotifySettingsDTO maps domain NotifySettings to the wire DTO.
@@ -646,8 +655,13 @@ func toNotifySettingsDTO(s NotifySettings) notifySettingsDTO {
 		DigestHour:               s.DigestHour,
 		Timezone:                 s.Timezone,
 		InstanceMailerConfigured: s.InstanceMailerConfigured,
-		CreatedAt:                s.CreatedAt.Unix(),
-		UpdatedAt:                s.UpdatedAt.Unix(),
+		FailureDetection: failureDetectionDTO{
+			SitesTotal:      s.FailureDetection.SitesTotal,
+			SitesCovered:    s.FailureDetection.SitesCovered,
+			MinAgentVersion: s.FailureDetection.MinAgentVersion,
+		},
+		CreatedAt: s.CreatedAt.Unix(),
+		UpdatedAt: s.UpdatedAt.Unix(),
 	}
 	if dto.Recipients == nil {
 		dto.Recipients = []string{}

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -228,6 +228,28 @@ type NotifySettings struct {
 	// InstanceMailerConfigured is populated by the service from mailer.Service.Enabled.
 	// It is NOT stored in DB — injected on GET.
 	InstanceMailerConfigured bool
+	// FailureDetection is populated by the service from a live count of the
+	// tenant's connected sites (GH #381 phase 2). It is NOT stored in DB —
+	// injected on GET.
+	FailureDetection FailureDetectionCoverage
+}
+
+// FailureDetectionCoverage summarizes, for a tenant, how many of its
+// currently-connected sites run an agent new enough to detect and report an
+// email delivery failure (GH #381 phase 2). WPMgr can only detect a failure
+// when it is the mail transport in use AND the agent is new enough to report
+// it; a site below MinAgentVersion, or not currently connected, cannot
+// trigger a per-failure alert no matter how the settings above are
+// configured. Computed fresh on every GET, never persisted.
+type FailureDetectionCoverage struct {
+	// SitesTotal is the tenant's currently-connected site count.
+	SitesTotal int
+	// SitesCovered is, of SitesTotal, how many report an agent_version at or
+	// above MinAgentVersion.
+	SitesCovered int
+	// MinAgentVersion is the gate SitesCovered was computed against
+	// (MinAgentVersionForFailureDetection at call time).
+	MinAgentVersion string
 }
 
 // NotifySettingsUpsertInput is the PUT body for notify settings.

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -2,10 +2,17 @@ package email
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -224,4 +231,156 @@ func TestBuildDigestData_FlagOff_OmitsSection_PreservesZeroSkip(t *testing.T) {
 	if data != nil {
 		t.Fatalf("expected skip-send (nil) when the flag is off and there is no email activity, got %v", data)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 2 — failure-detection coverage on GET notify-settings
+// ---------------------------------------------------------------------------
+
+// failureDetectionWire and notifySettingsWire mirror the wire JSON shape
+// (dto.go's notifySettingsDTO / failureDetectionDTO) so these tests decode the
+// handler's actual SERIALIZED response rather than inspecting Go structs the
+// handler never sends.
+type failureDetectionWire struct {
+	SitesTotal      int    `json:"sites_total"`
+	SitesCovered    int    `json:"sites_covered"`
+	MinAgentVersion string `json:"min_agent_version"`
+}
+
+type notifySettingsWire struct {
+	FailureDetection failureDetectionWire `json:"failure_detection"`
+}
+
+// notifySettingsGetCtx builds a request+principal context for GET
+// /email/notify-settings — an org-level route with no path params.
+func notifySettingsGetCtx(t *testing.T, p domain.Principal) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(domain.WithPrincipal(context.Background(), p))
+	return c, rec
+}
+
+func decodeNotifySettingsWire(t *testing.T, rec *httptest.ResponseRecorder) notifySettingsWire {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body %s", rec.Code, rec.Body.String())
+	}
+	var wire notifySettingsWire
+	if err := json.Unmarshal(rec.Body.Bytes(), &wire); err != nil {
+		t.Fatalf("failed to decode response: %v, body: %s", err, rec.Body.String())
+	}
+	return wire
+}
+
+// TestGetNotifySettings_ReportsFailureDetectionCoverage: RED today because
+// the failure_detection field does not exist yet. 3 connected sites, 2 at or
+// above the gate, must serialize as sites_total=3, sites_covered=2.
+func TestGetNotifySettings_ReportsFailureDetectionCoverage(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedAgentVersions = map[uuid.UUID][]string{
+		tenantID: {"999.5.0", MinAgentVersionForFailureDetection, "0.61.138"},
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 3 {
+		t.Errorf("sites_total = %d, want 3", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 2 {
+		t.Errorf("sites_covered = %d, want 2", wire.FailureDetection.SitesCovered)
+	}
+	if wire.FailureDetection.MinAgentVersion != MinAgentVersionForFailureDetection {
+		t.Errorf("min_agent_version = %q, want %q", wire.FailureDetection.MinAgentVersion, MinAgentVersionForFailureDetection)
+	}
+}
+
+// TestGetNotifySettings_CoverageIsTenantScoped: the coverage count for tenant
+// A must never include tenant B's fleet, however much larger it is. This is
+// the one that matters most — get it wrong and the endpoint leaks another
+// tenant's fleet size.
+func TestGetNotifySettings_CoverageIsTenantScoped(t *testing.T) {
+	tenantA, tenantB := uuid.New(), uuid.New()
+	repo := newFakeRepo()
+	repo.connectedAgentVersions = map[uuid.UUID][]string{
+		tenantA: {"999.0.0"},
+		tenantB: {"999.0.0", "999.0.0", "999.0.0", "999.0.0"},
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantA,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 1 {
+		t.Errorf("sites_total = %d, want 1 — tenant B's 4 sites leaked into tenant A's count", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 1 {
+		t.Errorf("sites_covered = %d, want 1", wire.FailureDetection.SitesCovered)
+	}
+}
+
+// TestGetNotifySettings_FailureDetectionCoverage_NoOverfire is the
+// over-fire control: a tenant with zero connected sites, and a tenant where
+// every connected site is covered, must both produce sane values rather than
+// a divide-by-zero or an omitted field.
+func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
+	t.Run("zero_sites", func(t *testing.T) {
+		tenantID := uuid.New()
+		repo := newFakeRepo() // no entry for tenantID — zero connected sites
+		svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+		svc.repo = repo
+		h := &Handler{svc: svc}
+
+		c, rec := notifySettingsGetCtx(t, domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+			Role: "admin", Scope: domain.ScopeOrg,
+		})
+		h.getNotifySettings(c)
+
+		wire := decodeNotifySettingsWire(t, rec)
+		if wire.FailureDetection.SitesTotal != 0 || wire.FailureDetection.SitesCovered != 0 {
+			t.Errorf("expected 0/0 for a tenant with no connected sites, got %+v", wire.FailureDetection)
+		}
+		if !strings.Contains(rec.Body.String(), `"failure_detection"`) {
+			t.Error("failure_detection must be present even for a zero-site tenant, never omitted")
+		}
+	})
+
+	t.Run("all_covered", func(t *testing.T) {
+		tenantID := uuid.New()
+		repo := newFakeRepo()
+		repo.connectedAgentVersions = map[uuid.UUID][]string{
+			tenantID: {"999.0.0", "999.1.0", "1000.0.0"},
+		}
+		svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+		svc.repo = repo
+		h := &Handler{svc: svc}
+
+		c, rec := notifySettingsGetCtx(t, domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+			Role: "admin", Scope: domain.ScopeOrg,
+		})
+		h.getNotifySettings(c)
+
+		wire := decodeNotifySettingsWire(t, rec)
+		if wire.FailureDetection.SitesTotal != 3 || wire.FailureDetection.SitesCovered != 3 {
+			t.Errorf("expected 3/3 when every connected site is covered, got %+v", wire.FailureDetection)
+		}
+	})
 }

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -217,6 +217,29 @@ func (r *Repo) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (Notif
 	return out, err
 }
 
+// ListConnectedSiteAgentVersions returns the reported agent_version for every
+// site in this tenant currently in the 'connected' connection_state (GH #381
+// phase 2: failure-detection coverage). Version comparison against the
+// coverage gate happens in the service layer.
+//
+// Unlike GetNotifySettings/UpsertNotifySettings, sites IS a site-keyed table
+// carrying the m112 RESTRICTIVE sites_site_scope policy, so this runs under
+// scopedTenantTx like every other site-keyed query in this package: a
+// site-scoped collaborator's coverage is correctly narrowed to the sites they
+// can see, and an org-scoped principal sees the whole tenant fleet.
+func (r *Repo) ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error) {
+	var out []string
+	err := r.scopedTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		versions, qerr := sqlc.New(tx).ListConnectedSiteAgentVersions(ctx, tenantID)
+		if qerr != nil {
+			return qerr
+		}
+		out = versions
+		return nil
+	})
+	return out, err
+}
+
 // UpsertNotifySettings creates or updates the notify settings row.
 // Runs under InTenantTx.
 func (r *Repo) UpsertNotifySettings(ctx context.Context, in NotifySettings) (NotifySettings, error) {

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // Encryptor age-encrypts and decrypts provider secrets. *cryptbox.AgeIdentity
@@ -99,6 +101,8 @@ type repository interface {
 	GetFleetStatsBySite(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]SiteStatsRow, error)
 	TopFailureSamples(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
 	TopFailureSamplesBySite(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
+	// GH #381 phase 2 — failure-detection coverage.
+	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
 }
 
 // Service is the email domain business-logic layer. It owns:
@@ -1504,17 +1508,82 @@ func (s *Service) PropagateOrgConfig(ctx context.Context, tenantID uuid.UUID) (P
 // the service returns safe defaults with GET-always-200 semantics (lesson from
 // 0.35.1 hotfix: never 404 on a settings GET).
 func (s *Service) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (NotifySettings, error) {
+	coverage, covErr := s.failureDetectionCoverage(ctx, tenantID)
+	if covErr != nil {
+		return NotifySettings{}, covErr
+	}
+
 	settings, err := s.repo.GetNotifySettings(ctx, tenantID)
 	if errors.Is(err, ErrNotFound) {
 		defaults := defaultNotifySettings(tenantID)
 		defaults.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
+		defaults.FailureDetection = coverage
 		return defaults, nil
 	}
 	if err != nil {
 		return NotifySettings{}, domain.Internal("email_get_notify_settings", "failed to load notify settings").WithCause(err)
 	}
 	settings.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
+	settings.FailureDetection = coverage
 	return settings, nil
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 2 — failure-detection coverage
+// ---------------------------------------------------------------------------
+
+// MinAgentVersionForFailureDetection gates failure_detection.sites_covered: a
+// connected site is "covered" only when its reported agent_version compares
+// >= this value under internal/wpversion.Compare.
+//
+// PLACEHOLDER VALUE. GH #381 phase 1 — the agent-side change that actually
+// widens failure detection beyond "WPMgr is the mail transport" — has not
+// shipped a release as of this writing. "999.0.0" is deliberately NOT a
+// plausible wpmgr version: it is chosen so that no currently-shipped agent
+// ever compares >= it, which makes sites_covered honestly report 0 until this
+// constant is corrected, instead of silently crediting sites for a capability
+// their agent build does not have.
+//
+// UPDATE THIS the moment phase 1's release is cut: set it to the exact agent
+// version (e.g. "0.62.0") that ships the detection-widening change, in the
+// same commit that cuts that release. Until updated, every tenant's
+// failure_detection.sites_covered will read 0 regardless of fleet freshness.
+const MinAgentVersionForFailureDetection = "999.0.0"
+
+// agentVersionPattern accepts the plain dotted-numeric shape WPMgr's own
+// agent versions use, mirroring internal/agentrelease's own guard
+// (internal/agentrelease/classify.go:45). Duplicated rather than imported:
+// internal/email must not cross-import a sibling domain package, and this is
+// a two-line regex, not shared logic worth a shared package for. A malformed
+// or empty agent_version (e.g. a site that has never reported one) must never
+// compare as "covered" by accident.
+var agentVersionPattern = regexp.MustCompile(`^\d+(\.\d+){1,3}([-+][0-9A-Za-z.]+)?$`)
+
+func isWellFormedAgentVersion(v string) bool {
+	return agentVersionPattern.MatchString(strings.TrimSpace(v))
+}
+
+// failureDetectionCoverage computes, for tenantID, how many of its currently
+// connected sites (connection_state = 'connected') run an agent_version at or
+// above MinAgentVersionForFailureDetection. A site whose reported version is
+// empty or not well-formed is treated as NOT covered — an unreadable version
+// is never assumed capable, mirroring internal/agentrelease.Classify's
+// StatusUnknown handling, which never risks a false "current" either.
+func (s *Service) failureDetectionCoverage(ctx context.Context, tenantID uuid.UUID) (FailureDetectionCoverage, error) {
+	versions, err := s.repo.ListConnectedSiteAgentVersions(ctx, tenantID)
+	if err != nil {
+		return FailureDetectionCoverage{}, domain.Internal("email_failure_detection_coverage", "failed to load connected site agent versions").WithCause(err)
+	}
+	out := FailureDetectionCoverage{
+		SitesTotal:      len(versions),
+		MinAgentVersion: MinAgentVersionForFailureDetection,
+	}
+	for _, v := range versions {
+		if isWellFormedAgentVersion(v) && wpversion.Compare(v, MinAgentVersionForFailureDetection) >= 0 {
+			out.SitesCovered++
+		}
+	}
+	return out, nil
 }
 
 // PutNotifySettings validates and upserts the notify settings, computing

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -87,6 +87,11 @@ type fakeRepo struct {
 	// say "refused" and "absent" as well as "done", and the service has to turn
 	// each into a different answer (see suppression_delete_refusal_test.go).
 	suppressionDeleteErr error
+
+	// connectedAgentVersions is what ListConnectedSiteAgentVersions returns,
+	// keyed by tenant so a cross-tenant test can seed two tenants' fleets
+	// independently (GH #381 phase 2).
+	connectedAgentVersions map[uuid.UUID][]string
 }
 
 func newFakeRepo() *fakeRepo {
@@ -465,6 +470,10 @@ func (r *fakeRepo) TopFailureSamples(_ context.Context, _ uuid.UUID, _, _ time.T
 
 func (r *fakeRepo) TopFailureSamplesBySite(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int32) ([]FailureSample, error) {
 	return nil, nil
+}
+
+func (r *fakeRepo) ListConnectedSiteAgentVersions(_ context.Context, tenantID uuid.UUID) ([]string, error) {
+	return r.connectedAgentVersions[tenantID], nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/email/email-notify-settings-card.test.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.test.tsx
@@ -52,7 +52,7 @@ function buildSettings(
       min_agent_version: "1.4.0",
     },
     ...overrides,
-  } as EmailNotifySettings;
+  };
 }
 
 function mockSettings(data: EmailNotifySettings | null) {
@@ -157,7 +157,7 @@ describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
   it("shows no coverage message when failure_detection is absent (older API)", async () => {
     const { failure_detection: _omit, ...withoutFailureDetection } =
       buildSettings();
-    mockSettings(withoutFailureDetection as EmailNotifySettings);
+    mockSettings(withoutFailureDetection);
 
     renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
 

--- a/apps/web/src/features/email/email-notify-settings-card.test.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import type { EmailNotifySettings } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult, mockMutationResult } from "@/test/query-mocks";
+
+// GH #381, phase 3: the Notifications page promised "Send an alert email
+// when a delivery failure is detected on a site" with no mention that
+// WPMgr can only detect a failure on a site whose agent is new enough to
+// report it. A self-hosted user with a working instance mailer (so the
+// OTHER banner, instance_mailer_configured, never fired) went ten days
+// with alerting silently unable to ever trigger because every one of their
+// sites was on an older agent. Phase 2 added `failure_detection` to
+// GET /api/v1/email/notify-settings; this phase surfaces it.
+
+const { useEmailNotifySettingsMock, usePutEmailNotifySettingsMock } = vi.hoisted(
+  () => ({
+    useEmailNotifySettingsMock: vi.fn(),
+    usePutEmailNotifySettingsMock: vi.fn(),
+  }),
+);
+
+vi.mock("./use-email", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-email")>();
+  return {
+    ...actual,
+    useEmailNotifySettings: useEmailNotifySettingsMock,
+    usePutEmailNotifySettings: usePutEmailNotifySettingsMock,
+  };
+});
+
+import { EmailNotifySettingsCard } from "./email-notify-settings-card";
+
+function buildSettings(
+  overrides: Partial<EmailNotifySettings> = {},
+): EmailNotifySettings {
+  return {
+    enabled: true,
+    recipients: ["ops@example.com"],
+    alert_on_failure: true,
+    alert_throttle_minutes: 60,
+    digest_enabled: false,
+    digest_cadence: "daily",
+    digest_day: 0,
+    digest_hour: 8,
+    timezone: "UTC",
+    instance_mailer_configured: true,
+    failure_detection: {
+      sites_total: 10,
+      sites_covered: 10,
+      min_agent_version: "1.4.0",
+    },
+    ...overrides,
+  } as EmailNotifySettings;
+}
+
+function mockSettings(data: EmailNotifySettings | null) {
+  useEmailNotifySettingsMock.mockReturnValue(
+    mockQueryResult<EmailNotifySettings | null>({ data }),
+  );
+  usePutEmailNotifySettingsMock.mockReturnValue(
+    mockMutationResult<EmailNotifySettings, unknown>({}),
+  );
+}
+
+describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
+  it("shows a zero-coverage warning when no site can report delivery failures", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 6,
+          sites_covered: 0,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(/No connected site can report a delivery failure\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1\.4\.0/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Covering all/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows partial coverage as N of M", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 8,
+          sites_covered: 3,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(/3 of 8 connected sites can report a delivery/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the quiet full-coverage line and not the warning banner", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 5,
+          sites_covered: 5,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText("Covering all 5 connected sites."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/connected sites can report a delivery failure\. The rest/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still renders the instance_mailer_configured banner independently, and both can show at once", async () => {
+    mockSettings(
+      buildSettings({
+        instance_mailer_configured: false,
+        failure_detection: {
+          sites_total: 4,
+          sites_covered: 0,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText("Instance mailer not configured."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No connected site can report a delivery failure\./),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no coverage message when failure_detection is absent (older API)", async () => {
+    const { failure_detection: _omit, ...withoutFailureDetection } =
+      buildSettings();
+    mockSettings(withoutFailureDetection as EmailNotifySettings);
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(
+        "Send an alert email when a delivery failure is detected on a site.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Covering all/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/connected sites can report a delivery failure\. The rest/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows no coverage message for a tenant with zero sites", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 0,
+          sites_covered: 0,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(
+        "Send an alert email when a delivery failure is detected on a site.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Covering all/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/email/email-notify-settings-card.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.tsx
@@ -41,6 +41,16 @@ import { useEmailNotifySettings, usePutEmailNotifySettings } from "./use-email";
 // The instance_mailer_configured flag controls a warning banner: when false,
 // neither alerts nor digests can deliver. The banner links to /settings/smtp.
 //
+// failure_detection (GH #381) is the OTHER half of the alerting path: even
+// with a working instance mailer, WPMgr can only detect a delivery failure
+// on a site whose agent is new enough to report it. A tenant whose sites are
+// all on an older agent sees "Per-failure alerts" as an armed toggle that
+// will never fire — the two banners are independent (nothing can SEND vs.
+// nothing can DETECT) and both can be showing at once. sites_total === 0 is
+// an empty fleet, not a warning; the field is absent entirely on an older
+// API (self-hosted instance not yet upgraded), in which case no coverage
+// message is shown at all rather than guessed at.
+//
 // This endpoint never 404s (returns defaults). If the API pre-dates 0.36 and
 // returns 404, useEmailNotifySettings maps it to null and the card is hidden.
 // ---------------------------------------------------------------------------
@@ -230,6 +240,21 @@ export function EmailNotifySettingsCard() {
 
   const instanceMailerConfigured = s?.instance_mailer_configured ?? false;
 
+  // GH #381: WPMgr can only detect a delivery failure when a site's agent is
+  // new enough to report it. `failure_detection` is absent on an older API
+  // (self-hosted instance not yet upgraded) — in that case we have no
+  // coverage numbers to show and say nothing rather than guess. A tenant
+  // with zero sites also gets no coverage message; that is not a warning
+  // state, just an empty fleet.
+  const failureDetection = s?.failure_detection;
+  const sitesTotal = failureDetection?.sites_total ?? 0;
+  const sitesCovered = failureDetection?.sites_covered ?? 0;
+  const minAgentVersion = failureDetection?.min_agent_version;
+  const hasCoverageData = failureDetection != null && sitesTotal > 0;
+  const fullCoverage = hasCoverageData && sitesCovered >= sitesTotal;
+  const zeroCoverage = hasCoverageData && sitesCovered === 0;
+  const partialCoverage = hasCoverageData && sitesCovered > 0 && sitesCovered < sitesTotal;
+
   return (
     <Card>
       <CardHeader>
@@ -286,6 +311,24 @@ export function EmailNotifySettingsCard() {
               <p className="text-xs text-[var(--color-muted-foreground)]">
                 Send an alert email when a delivery failure is detected on a site.
               </p>
+              {fullCoverage ? (
+                <p className="text-xs text-[var(--color-muted-foreground)]">
+                  Covering all {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}.
+                </p>
+              ) : null}
+              {partialCoverage ? (
+                <p className="text-xs text-[var(--color-muted-foreground)]">
+                  {sitesCovered} of {sitesTotal} connected sites can report a delivery
+                  failure. The rest are on an agent older than {minAgentVersion} and
+                  cannot trigger an alert.{" "}
+                  <Link
+                    to="/sites"
+                    className="font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                  >
+                    View sites
+                  </Link>
+                </p>
+              ) : null}
             </div>
             <Switch
               checked={alertsEnabled}
@@ -294,6 +337,30 @@ export function EmailNotifySettingsCard() {
               aria-label="Enable per-failure alerts"
             />
           </div>
+
+          {zeroCoverage ? (
+            <div className="mb-4 flex gap-2 rounded-md border border-[var(--color-warning)]/50 bg-[var(--color-warning)]/10 px-3 py-2.5">
+              <AlertTriangle
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0 text-[var(--color-warning)]"
+              />
+              <div className="text-sm">
+                <span className="font-medium">
+                  No connected site can report a delivery failure.
+                </span>{" "}
+                All {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}{" "}
+                {sitesTotal !== 1 ? "are" : "is"} on an agent older than{" "}
+                {minAgentVersion}, so this toggle will never fire. Update the agent on
+                at least one site to restore alerting.{" "}
+                <Link
+                  to="/sites"
+                  className="font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                >
+                  View sites
+                </Link>
+              </div>
+            </div>
+          ) : null}
 
           {alertsEnabled ? (
             <div className="space-y-4 rounded-md border border-[var(--color-border)] bg-[var(--color-card)] p-4">

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -9141,7 +9141,6 @@ export const EmailNotifySettingsSchema = {
     "digest_hour",
     "timezone",
     "instance_mailer_configured",
-    "failure_detection",
   ],
   properties: {
     enabled: {

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -9141,6 +9141,7 @@ export const EmailNotifySettingsSchema = {
     "digest_hour",
     "timezone",
     "instance_mailer_configured",
+    "failure_detection",
   ],
   properties: {
     enabled: {
@@ -9202,6 +9203,29 @@ export const EmailNotifySettingsSchema = {
       type: "boolean",
       description:
         "True when the instance-level SMTP/mailer is configured. Alerts and digests require this to be true to deliver.\n",
+    },
+    failure_detection: {
+      type: "object",
+      description:
+        "Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.\n",
+      required: ["sites_total", "sites_covered", "min_agent_version"],
+      properties: {
+        sites_total: {
+          type: "integer",
+          description:
+            "Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).\n",
+        },
+        sites_covered: {
+          type: "integer",
+          description:
+            "Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.\n",
+        },
+        min_agent_version: {
+          type: "string",
+          description:
+            "Minimum agent version that can detect and report an email delivery failure.\n",
+        },
+      },
     },
     tenant_id: {
       type: "string",

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5427,7 +5427,7 @@ export type EmailNotifySettings = {
    * Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.
    *
    */
-  failure_detection: {
+  failure_detection?: {
     /**
      * Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).
      *

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5424,6 +5424,27 @@ export type EmailNotifySettings = {
    */
   instance_mailer_configured: boolean;
   /**
+   * Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.
+   *
+   */
+  failure_detection: {
+    /**
+     * Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).
+     *
+     */
+    sites_total: number;
+    /**
+     * Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.
+     *
+     */
+    sites_covered: number;
+    /**
+     * Minimum agent version that can detect and report an email delivery failure.
+     *
+     */
+    min_agent_version: string;
+  };
+  /**
    * Present when a settings row exists; absent for default response.
    */
   tenant_id?: string;

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19578,7 +19578,6 @@ components:
         - digest_hour
         - timezone
         - instance_mailer_configured
-        - failure_detection
       properties:
         enabled:
           type: boolean

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19578,6 +19578,7 @@ components:
         - digest_hour
         - timezone
         - instance_mailer_configured
+        - failure_detection
       properties:
         enabled:
           type: boolean
@@ -19635,6 +19636,36 @@ components:
           description: >
             True when the instance-level SMTP/mailer is configured. Alerts
             and digests require this to be true to deliver.
+        failure_detection:
+          type: object
+          description: >
+            Coverage of the tenant's connected sites for email delivery
+            failure detection (GH #381). WPMgr can only detect a failure when
+            it is the mail transport in use AND the agent is new enough to
+            report it; a site below `min_agent_version`, or not currently
+            connected, cannot trigger a per-failure alert no matter how the
+            settings above are configured.
+          required:
+            - sites_total
+            - sites_covered
+            - min_agent_version
+          properties:
+            sites_total:
+              type: integer
+              description: >
+                Number of the tenant's currently-connected sites (excludes
+                pending, degraded, disconnected, revoked and archived sites).
+            sites_covered:
+              type: integer
+              description: >
+                Of sites_total, how many report an agent_version at or above
+                min_agent_version and can therefore have a delivery failure
+                detected and alerted on.
+            min_agent_version:
+              type: string
+              description: >
+                Minimum agent version that can detect and report an email
+                delivery failure.
         tenant_id:
           type: string
           format: uuid


### PR DESCRIPTION
## Summary
- GH #381 phase 3 of 5: the Notifications page's "Per-failure alerts" section promised to alert on any site's delivery failure with no mention that WPMgr can only detect a failure on a site whose agent is new enough to report it.
- Consumes `failure_detection` (`sites_total`, `sites_covered`, `min_agent_version`) from `GET /api/v1/email/notify-settings`, added in phase 2 (`420f2a4`).
- Three states in `email-notify-settings-card.tsx`: full coverage gets a quiet line, partial coverage names both numbers and links to `/sites`, zero coverage gets a warning banner in the same visual register as the existing `instance_mailer_configured` banner (text on the ordinary surface, not on-warning-fill — the token distinction from the GH #414 dark-mode contrast fix).
- Both banners can render at once, since they describe independent failures (nothing can send vs. nothing can detect).
- A tenant with zero sites, or an older API missing the field entirely, shows nothing extra rather than guessing.
- Does not touch the `enabled` derivation at `:190-192` (unrelated, previously verified correct).

This is phase 3 of 5 for GH #381 and merges only once the whole issue is resolved end to end.

## Test plan
- [x] `shows a zero-coverage warning when no site can report delivery failures` — proven RED against pre-fix code (4 failed / 2 passed via `git stash`), then GREEN after the fix.
- [x] `shows partial coverage as N of M`
- [x] Full coverage shows the quiet line and not the warning banner (over-fire control)
- [x] `instance_mailer_configured` banner still renders independently, and both banners render together
- [x] `failure_detection` absent (older API) and `sites_total === 0` both render no coverage message
- [x] `pnpm -C apps/web test` — 1679/1679 passed (`numFailedTests: 0`, `success: true` via `--reporter=json`)
- [x] `pnpm -C apps/web typecheck` — clean
- [x] `pnpm -C apps/web lint` — 0 errors (9 pre-existing warnings in unrelated files)
- [x] `pnpm -C apps/web build` — succeeds, `routeTree.gen.ts` unchanged (no route files touched)
- [x] `impeccable detect apps/web/src/features/email` — exit 0, no violations