### PR TITLE
fix(email): log every maybeAlertFailures exit path with a reason (GH #381 phase 5)

### DIFF
--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -139,6 +139,22 @@ WHERE s.tenant_id = $1
   AND s.connection_state <> 'archived'
 ORDER BY s.name;
 
+-- name: ListConnectedSiteAgentVersions :many
+-- Tenant-scoped agent_version per site, restricted to connection_state =
+-- 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+-- here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+-- degraded/pending/disconnected/archived): a site whose agent is not actively
+-- connected cannot report a delivery failure regardless of its version, so it
+-- is excluded from both the coverage numerator and denominator rather than
+-- counted as a gap.
+-- Version comparison happens in Go (internal/wpversion.Compare), matching
+-- ListSitesAgentVersions's convention: this query returns only the raw
+-- per-site fact.
+SELECT agent_version
+FROM sites
+WHERE tenant_id = $1
+  AND connection_state = 'connected';
+
 -- name: ListClientNamesForSites :many
 -- Returns the client id + name for sites that have a client_id set (m63).
 -- Used to enrich the sites-list DTO with client_name in a single batched join.

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -46926,6 +46926,10 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 		e.Bool(s.InstanceMailerConfigured)
 	}
 	{
+		e.FieldStart("failure_detection")
+		s.FailureDetection.Encode(e)
+	}
+	{
 		if s.TenantID.Set {
 			e.FieldStart("tenant_id")
 			s.TenantID.Encode(e)
@@ -46945,7 +46949,7 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfEmailNotifySettings = [14]string{
+var jsonFieldsNameOfEmailNotifySettings = [15]string{
 	0:  "enabled",
 	1:  "recipients",
 	2:  "alert_on_failure",
@@ -46957,9 +46961,10 @@ var jsonFieldsNameOfEmailNotifySettings = [14]string{
 	8:  "timezone",
 	9:  "next_digest_at",
 	10: "instance_mailer_configured",
-	11: "tenant_id",
-	12: "created_at",
-	13: "updated_at",
+	11: "failure_detection",
+	12: "tenant_id",
+	13: "created_at",
+	14: "updated_at",
 }
 
 // Decode decodes EmailNotifySettings from json.
@@ -47107,6 +47112,16 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance_mailer_configured\"")
 			}
+		case "failure_detection":
+			requiredBitSet[1] |= 1 << 3
+			if err := func() error {
+				if err := s.FailureDetection.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"failure_detection\"")
+			}
 		case "tenant_id":
 			if err := func() error {
 				s.TenantID.Reset()
@@ -47148,7 +47163,7 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00000101,
+		0b00001101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -47232,6 +47247,136 @@ func (s EmailNotifySettingsDigestCadence) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *EmailNotifySettingsDigestCadence) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *EmailNotifySettingsFailureDetection) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *EmailNotifySettingsFailureDetection) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("sites_total")
+		e.Int(s.SitesTotal)
+	}
+	{
+		e.FieldStart("sites_covered")
+		e.Int(s.SitesCovered)
+	}
+	{
+		e.FieldStart("min_agent_version")
+		e.Str(s.MinAgentVersion)
+	}
+}
+
+var jsonFieldsNameOfEmailNotifySettingsFailureDetection = [3]string{
+	0: "sites_total",
+	1: "sites_covered",
+	2: "min_agent_version",
+}
+
+// Decode decodes EmailNotifySettingsFailureDetection from json.
+func (s *EmailNotifySettingsFailureDetection) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EmailNotifySettingsFailureDetection to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "sites_total":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Int()
+				s.SitesTotal = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sites_total\"")
+			}
+		case "sites_covered":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.SitesCovered = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sites_covered\"")
+			}
+		case "min_agent_version":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.MinAgentVersion = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"min_agent_version\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EmailNotifySettingsFailureDetection")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfEmailNotifySettingsFailureDetection) {
+					name = jsonFieldsNameOfEmailNotifySettingsFailureDetection[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *EmailNotifySettingsFailureDetection) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EmailNotifySettingsFailureDetection) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -17010,6 +17010,11 @@ type EmailNotifySettings struct {
 	// True when the instance-level SMTP/mailer is configured. Alerts and digests require this to be true
 	// to deliver.
 	InstanceMailerConfigured bool `json:"instance_mailer_configured"`
+	// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
+	// only detect a failure when it is the mail transport in use AND the agent is new enough to report
+	// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
+	// alert no matter how the settings above are configured.
+	FailureDetection EmailNotifySettingsFailureDetection `json:"failure_detection"`
 	// Present when a settings row exists; absent for default response.
 	TenantID  OptNilUUID     `json:"tenant_id"`
 	CreatedAt OptNilDateTime `json:"created_at"`
@@ -17069,6 +17074,11 @@ func (s *EmailNotifySettings) GetNextDigestAt() OptNilDateTime {
 // GetInstanceMailerConfigured returns the value of InstanceMailerConfigured.
 func (s *EmailNotifySettings) GetInstanceMailerConfigured() bool {
 	return s.InstanceMailerConfigured
+}
+
+// GetFailureDetection returns the value of FailureDetection.
+func (s *EmailNotifySettings) GetFailureDetection() EmailNotifySettingsFailureDetection {
+	return s.FailureDetection
 }
 
 // GetTenantID returns the value of TenantID.
@@ -17141,6 +17151,11 @@ func (s *EmailNotifySettings) SetInstanceMailerConfigured(val bool) {
 	s.InstanceMailerConfigured = val
 }
 
+// SetFailureDetection sets the value of FailureDetection.
+func (s *EmailNotifySettings) SetFailureDetection(val EmailNotifySettingsFailureDetection) {
+	s.FailureDetection = val
+}
+
 // SetTenantID sets the value of TenantID.
 func (s *EmailNotifySettings) SetTenantID(val OptNilUUID) {
 	s.TenantID = val
@@ -17206,6 +17221,51 @@ func (s *EmailNotifySettingsDigestCadence) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
+}
+
+// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
+// only detect a failure when it is the mail transport in use AND the agent is new enough to report
+// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
+// alert no matter how the settings above are configured.
+type EmailNotifySettingsFailureDetection struct {
+	// Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected,
+	// revoked and archived sites).
+	SitesTotal int `json:"sites_total"`
+	// Of sites_total, how many report an agent_version at or above min_agent_version and can therefore
+	// have a delivery failure detected and alerted on.
+	SitesCovered int `json:"sites_covered"`
+	// Minimum agent version that can detect and report an email delivery failure.
+	MinAgentVersion string `json:"min_agent_version"`
+}
+
+// GetSitesTotal returns the value of SitesTotal.
+func (s *EmailNotifySettingsFailureDetection) GetSitesTotal() int {
+	return s.SitesTotal
+}
+
+// GetSitesCovered returns the value of SitesCovered.
+func (s *EmailNotifySettingsFailureDetection) GetSitesCovered() int {
+	return s.SitesCovered
+}
+
+// GetMinAgentVersion returns the value of MinAgentVersion.
+func (s *EmailNotifySettingsFailureDetection) GetMinAgentVersion() string {
+	return s.MinAgentVersion
+}
+
+// SetSitesTotal sets the value of SitesTotal.
+func (s *EmailNotifySettingsFailureDetection) SetSitesTotal(val int) {
+	s.SitesTotal = val
+}
+
+// SetSitesCovered sets the value of SitesCovered.
+func (s *EmailNotifySettingsFailureDetection) SetSitesCovered(val int) {
+	s.SitesCovered = val
+}
+
+// SetMinAgentVersion sets the value of MinAgentVersion.
+func (s *EmailNotifySettingsFailureDetection) SetMinAgentVersion(val string) {
+	s.MinAgentVersion = val
 }
 
 // Static catalog of supported email providers and their field schemas.

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1596,6 +1596,17 @@ type Querier interface {
 	// expansion (pin a carry-forward chunk's old origin generation under a live
 	// tip) without a second round-trip.
 	ListCompletedSnapshotsForSite(ctx context.Context, arg ListCompletedSnapshotsForSiteParams) ([]ListCompletedSnapshotsForSiteRow, error)
+	// Tenant-scoped agent_version per site, restricted to connection_state =
+	// 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+	// here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+	// degraded/pending/disconnected/archived): a site whose agent is not actively
+	// connected cannot report a delivery failure regardless of its version, so it
+	// is excluded from both the coverage numerator and denominator rather than
+	// counted as a gap.
+	// Version comparison happens in Go (internal/wpversion.Compare), matching
+	// ListSitesAgentVersions's convention: this query returns only the raw
+	// per-site fact.
+	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
 	// Cross-tenant enumeration of connected sites for the weekly screenshot fanout.
 	// Returns only sites in the 'connected' state (not degraded/pending/archived).
 	// Runs under the app.agent GUC (sites_agent policy) since it spans tenants.

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -582,6 +582,43 @@ func (q *Queries) ListClientNamesForSites(ctx context.Context, arg ListClientNam
 	return items, nil
 }
 
+const listConnectedSiteAgentVersions = `-- name: ListConnectedSiteAgentVersions :many
+SELECT agent_version
+FROM sites
+WHERE tenant_id = $1
+  AND connection_state = 'connected'
+`
+
+// Tenant-scoped agent_version per site, restricted to connection_state =
+// 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+// here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+// degraded/pending/disconnected/archived): a site whose agent is not actively
+// connected cannot report a delivery failure regardless of its version, so it
+// is excluded from both the coverage numerator and denominator rather than
+// counted as a gap.
+// Version comparison happens in Go (internal/wpversion.Compare), matching
+// ListSitesAgentVersions's convention: this query returns only the raw
+// per-site fact.
+func (q *Queries) ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error) {
+	rows, err := q.db.Query(ctx, listConnectedSiteAgentVersions, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var agent_version string
+		if err := rows.Scan(&agent_version); err != nil {
+			return nil, err
+		}
+		items = append(items, agent_version)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listConnectedSiteIDsForScreenshot = `-- name: ListConnectedSiteIDsForScreenshot :many
 SELECT id, tenant_id, url FROM sites
 WHERE connection_state = 'connected'

--- a/apps/api/internal/email/dto.go
+++ b/apps/api/internal/email/dto.go
@@ -320,8 +320,8 @@ type siteDeliveryItemDTO struct {
 	ComplainedCount int64   `json:"complained_count"`
 	BounceRate      float64 `json:"bounce_rate"`
 	ComplaintRate   float64 `json:"complaint_rate"`
-	LastSentAt      *string `json:"last_sent_at"`        // RFC3339 or null
-	Sparkline       []int64 `json:"sparkline"`            // [] never null
+	LastSentAt      *string `json:"last_sent_at"` // RFC3339 or null
+	Sparkline       []int64 `json:"sparkline"`    // [] never null
 }
 
 // deliverabilityReportDTO is the full response for GET /email/deliverability.
@@ -616,20 +616,29 @@ type putConnectionBody struct {
 
 // notifySettingsDTO is the wire representation of NotifySettings.
 type notifySettingsDTO struct {
-	TenantID                 string   `json:"tenant_id"`
-	Enabled                  bool     `json:"enabled"`
-	Recipients               []string `json:"recipients"`
-	AlertOnFailure           bool     `json:"alert_on_failure"`
-	AlertThrottleMinutes     int      `json:"alert_throttle_minutes"`
-	DigestEnabled            bool     `json:"digest_enabled"`
-	DigestCadence            string   `json:"digest_cadence"`
-	DigestDay                int      `json:"digest_day"`
-	DigestHour               int      `json:"digest_hour"`
-	Timezone                 string   `json:"timezone"`
-	NextDigestAt             *string  `json:"next_digest_at,omitempty"`
-	InstanceMailerConfigured bool     `json:"instance_mailer_configured"`
-	CreatedAt                int64    `json:"created_at"`
-	UpdatedAt                int64    `json:"updated_at"`
+	TenantID                 string              `json:"tenant_id"`
+	Enabled                  bool                `json:"enabled"`
+	Recipients               []string            `json:"recipients"`
+	AlertOnFailure           bool                `json:"alert_on_failure"`
+	AlertThrottleMinutes     int                 `json:"alert_throttle_minutes"`
+	DigestEnabled            bool                `json:"digest_enabled"`
+	DigestCadence            string              `json:"digest_cadence"`
+	DigestDay                int                 `json:"digest_day"`
+	DigestHour               int                 `json:"digest_hour"`
+	Timezone                 string              `json:"timezone"`
+	NextDigestAt             *string             `json:"next_digest_at,omitempty"`
+	InstanceMailerConfigured bool                `json:"instance_mailer_configured"`
+	FailureDetection         failureDetectionDTO `json:"failure_detection"`
+	CreatedAt                int64               `json:"created_at"`
+	UpdatedAt                int64               `json:"updated_at"`
+}
+
+// failureDetectionDTO is the wire representation of FailureDetectionCoverage
+// (GH #381 phase 2).
+type failureDetectionDTO struct {
+	SitesTotal      int    `json:"sites_total"`
+	SitesCovered    int    `json:"sites_covered"`
+	MinAgentVersion string `json:"min_agent_version"`
 }
 
 // toNotifySettingsDTO maps domain NotifySettings to the wire DTO.
@@ -646,8 +655,13 @@ func toNotifySettingsDTO(s NotifySettings) notifySettingsDTO {
 		DigestHour:               s.DigestHour,
 		Timezone:                 s.Timezone,
 		InstanceMailerConfigured: s.InstanceMailerConfigured,
-		CreatedAt:                s.CreatedAt.Unix(),
-		UpdatedAt:                s.UpdatedAt.Unix(),
+		FailureDetection: failureDetectionDTO{
+			SitesTotal:      s.FailureDetection.SitesTotal,
+			SitesCovered:    s.FailureDetection.SitesCovered,
+			MinAgentVersion: s.FailureDetection.MinAgentVersion,
+		},
+		CreatedAt: s.CreatedAt.Unix(),
+		UpdatedAt: s.UpdatedAt.Unix(),
 	}
 	if dto.Recipients == nil {
 		dto.Recipients = []string{}

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -228,6 +228,28 @@ type NotifySettings struct {
 	// InstanceMailerConfigured is populated by the service from mailer.Service.Enabled.
 	// It is NOT stored in DB — injected on GET.
 	InstanceMailerConfigured bool
+	// FailureDetection is populated by the service from a live count of the
+	// tenant's connected sites (GH #381 phase 2). It is NOT stored in DB —
+	// injected on GET.
+	FailureDetection FailureDetectionCoverage
+}
+
+// FailureDetectionCoverage summarizes, for a tenant, how many of its
+// currently-connected sites run an agent new enough to detect and report an
+// email delivery failure (GH #381 phase 2). WPMgr can only detect a failure
+// when it is the mail transport in use AND the agent is new enough to report
+// it; a site below MinAgentVersion, or not currently connected, cannot
+// trigger a per-failure alert no matter how the settings above are
+// configured. Computed fresh on every GET, never persisted.
+type FailureDetectionCoverage struct {
+	// SitesTotal is the tenant's currently-connected site count.
+	SitesTotal int
+	// SitesCovered is, of SitesTotal, how many report an agent_version at or
+	// above MinAgentVersion.
+	SitesCovered int
+	// MinAgentVersion is the gate SitesCovered was computed against
+	// (MinAgentVersionForFailureDetection at call time).
+	MinAgentVersion string
 }
 
 // NotifySettingsUpsertInput is the PUT body for notify settings.

--- a/apps/api/internal/email/notify.go
+++ b/apps/api/internal/email/notify.go
@@ -12,6 +12,7 @@ package email
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -69,6 +70,67 @@ type VulnDigestItem struct {
 // included in a per-failure alert email body.
 const maxAlertFailureSamples = 5
 
+// alertGoroutineTimeout bounds the detached maybeAlertFailures goroutine
+// launched from IngestLogBatch (service.go). It is detached deliberately to
+// keep the ingest path fast, so a stalled downstream call (settings lookup,
+// alert-slot claim, site-ref fetch, mailer enqueue) must not leak the
+// goroutine forever. The work itself is a handful of single-row reads/writes
+// plus one enqueue call, so 30s is generous headroom over the expected case
+// while still bounding the worst case (GH #381 phase 5).
+const alertGoroutineTimeout = 30 * time.Second
+
+// alertDecisionEvent is the single grep-able event name for every decision
+// maybeAlertFailures makes, whether or not it ends in a sent alert (GH #381
+// phase 5). The issue this answers: a user reports no alert email and there
+// is nothing to grep. Every exit path below now logs exactly one record
+// carrying this event name and a `reason` field distinguishing it.
+//
+// NEVER add a recipient address to these fields. The failure_count is enough
+// to diagnose; recipient addresses would land in operator logs and in
+// whatever ships them onward.
+const alertDecisionEvent = "email_alert_decision"
+
+// logAlertDecision emits the single structured record for one exit path of
+// maybeAlertFailures. errAttr may be nil.
+func (s *Service) logAlertDecision(ctx context.Context, level slog.Level, reason string, tenantID, siteID uuid.UUID, failureCount int, errAttr error) {
+	attrs := []slog.Attr{
+		slog.String("reason", reason),
+		slog.String("tenant_id", tenantID.String()),
+		slog.String("site_id", siteID.String()),
+		slog.Int("failure_count", failureCount),
+	}
+	if errAttr != nil {
+		attrs = append(attrs, slog.Any("error", errAttr))
+	}
+	s.log.LogAttrs(ctx, level, alertDecisionEvent, attrs...)
+}
+
+// maybeAlertFailuresAsync is the entry point IngestLogBatch launches with
+// `go`. It owns the goroutine's lifetime end to end: a bounded context so a
+// stalled downstream call cannot leak the goroutine past alertGoroutineTimeout,
+// and a recover() so a panic anywhere below cannot take down the API process
+// serving every other tenant's ingest traffic — there was no recover() here
+// before phase 5, so any panic in this detached goroutine was fatal to the
+// whole binary.
+func (s *Service) maybeAlertFailuresAsync(tenantID, siteID uuid.UUID, failureCount int) {
+	ctx, cancel := context.WithTimeout(context.Background(), alertGoroutineTimeout)
+	defer cancel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			s.log.LogAttrs(ctx, slog.LevelError, alertDecisionEvent,
+				slog.String("reason", "panic"),
+				slog.String("tenant_id", tenantID.String()),
+				slog.String("site_id", siteID.String()),
+				slog.Int("failure_count", failureCount),
+				slog.Any("panic", r),
+			)
+		}
+	}()
+
+	s.maybeAlertFailures(ctx, tenantID, siteID, failureCount)
+}
+
 // maxDigestTopFailures is the maximum number of top-failure samples in digest.
 const maxDigestTopFailures = 5
 
@@ -82,48 +144,61 @@ const maxDigestSites = 20
 // strictly best-effort (the save has already succeeded).
 func (s *Service) maybeAlertFailures(ctx context.Context, tenantID, siteID uuid.UUID, failureCount int) {
 	if s.mailer == nil {
+		s.logAlertDecision(ctx, slog.LevelWarn, "nil_mailer", tenantID, siteID, failureCount, nil)
 		return
 	}
 	if failureCount <= 0 {
+		// Unreachable in production: the sole caller (IngestLogBatch,
+		// service.go) only launches this goroutine when failureCount > 0.
+		// No log line here deliberately — see notify.go's phase-5 finding.
 		return
 	}
 
 	// Accumulate failures into the per-site state row.
 	if err := s.repo.AccumulateAlertFailures(ctx, tenantID, siteID, int64(failureCount)); err != nil {
-		s.log.Warn("email alert: accumulate failures failed",
-			slog.String("tenant_id", tenantID.String()),
-			slog.String("site_id", siteID.String()),
-			slog.Any("error", err),
-		)
+		s.logAlertDecision(ctx, slog.LevelWarn, "accumulate_failed", tenantID, siteID, failureCount, err)
 		return
 	}
 
 	// Try to claim an alert slot (single-statement conditional UPDATE).
 	settings, err := s.repo.GetNotifySettings(ctx, tenantID)
 	if err != nil {
-		// No settings row = use defaults (but don't alert when disabled).
+		if errors.Is(err, ErrNotFound) {
+			// No settings row = use defaults (but don't alert when disabled).
+			s.logAlertDecision(ctx, slog.LevelDebug, "no_settings_row", tenantID, siteID, failureCount, nil)
+		} else {
+			s.logAlertDecision(ctx, slog.LevelWarn, "settings_lookup_error", tenantID, siteID, failureCount, err)
+		}
 		return
 	}
 	if !settings.Enabled || !settings.AlertOnFailure {
+		reason := "disabled"
+		if settings.Enabled {
+			reason = "alert_on_failure_off"
+		}
+		s.logAlertDecision(ctx, slog.LevelDebug, reason, tenantID, siteID, failureCount, nil)
 		return
 	}
 	if len(settings.Recipients) == 0 {
+		s.logAlertDecision(ctx, slog.LevelDebug, "no_recipients", tenantID, siteID, failureCount, nil)
 		return
 	}
 
 	claimedState, claimErr := s.repo.ClaimAlertSlot(ctx, tenantID, siteID, 1, settings.AlertThrottleMinutes)
-	if claimErr != nil || claimedState == nil {
-		// Throttled or no row — skip.
+	if claimErr != nil {
+		s.logAlertDecision(ctx, slog.LevelWarn, "claim_alert_slot_error", tenantID, siteID, failureCount, claimErr)
+		return
+	}
+	if claimedState == nil {
+		// Throttled — not an error, just not our turn yet.
+		s.logAlertDecision(ctx, slog.LevelDebug, "throttled", tenantID, siteID, failureCount, nil)
 		return
 	}
 
 	// Resolve site name/URL for the email.
 	siteRef, refErr := s.repo.GetSiteRef(ctx, tenantID, siteID)
 	if refErr != nil {
-		s.log.Warn("email alert: could not resolve site ref",
-			slog.String("site_id", siteID.String()),
-			slog.Any("error", refErr),
-		)
+		s.logAlertDecision(ctx, slog.LevelWarn, "site_ref_error", tenantID, siteID, failureCount, refErr)
 		return
 	}
 
@@ -164,12 +239,10 @@ func (s *Service) maybeAlertFailures(ctx context.Context, tenantID, siteID uuid.
 	}
 
 	if err := s.mailer.Enqueue(ctx, tenantID, settings.Recipients, "email_failure_alert", data); err != nil {
-		s.log.Warn("email alert: enqueue failed",
-			slog.String("tenant_id", tenantID.String()),
-			slog.String("site_id", siteID.String()),
-			slog.Any("error", err),
-		)
+		s.logAlertDecision(ctx, slog.LevelWarn, "enqueue_failed", tenantID, siteID, failureCount, err)
+		return
 	}
+	s.logAlertDecision(ctx, slog.LevelInfo, "alert_sent", tenantID, siteID, failureCount, nil)
 }
 
 // buildDigestData gathers per-tenant digest data for a given [from, to] window.

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -3,9 +3,12 @@ package email
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -383,4 +386,436 @@ func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
 			t.Errorf("expected 3/3 when every connected site is covered, got %+v", wire.FailureDetection)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 5 — maybeAlertFailures observability: every exit path logs a
+// reason, the detached goroutine is bounded and panic-safe, and recipient
+// addresses never reach a log record.
+// ---------------------------------------------------------------------------
+
+// capturedRecord is a slog.Record flattened for assertions.
+type capturedRecord struct {
+	Level slog.Level
+	Msg   string
+	Attrs map[string]string
+}
+
+// capturingHandler is a minimal slog.Handler that records everything it is
+// given, regardless of level, so a test can assert on Debug records too.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []capturedRecord
+}
+
+func newCapturingHandler() *capturingHandler { return &capturingHandler{} }
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := make(map[string]string, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+	h.mu.Lock()
+	h.records = append(h.records, capturedRecord{Level: r.Level, Msg: r.Message, Attrs: attrs})
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *capturingHandler) Records() []capturedRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]capturedRecord, len(h.records))
+	copy(out, h.records)
+	return out
+}
+
+// String dumps every captured record's message and attribute values, one per
+// line, so a test can grep the WHOLE emitted surface for a value that must
+// never appear (e.g. a recipient address) rather than checking one known key.
+func (h *capturingHandler) String() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var sb strings.Builder
+	for _, r := range h.records {
+		sb.WriteString(r.Msg)
+		sb.WriteString(" ")
+		for k, v := range r.Attrs {
+			sb.WriteString(k)
+			sb.WriteString("=")
+			sb.WriteString(v)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// fakeMailer is a MailerEnqueuer test double that counts calls and can
+// optionally signal a channel per successful call, so a test can wait
+// (bounded) for the detached alert goroutine to finish instead of sleeping.
+type fakeMailer struct {
+	mu             sync.Mutex
+	enqueueErr     error
+	calls          int
+	lastRecipients []string
+	notify         chan struct{}
+}
+
+func (f *fakeMailer) Enqueue(_ context.Context, _ uuid.UUID, recipients []string, _ string, _ map[string]any) error {
+	f.mu.Lock()
+	if f.enqueueErr != nil {
+		f.mu.Unlock()
+		return f.enqueueErr
+	}
+	f.calls++
+	f.lastRecipients = recipients
+	notify := f.notify
+	f.mu.Unlock()
+	if notify != nil {
+		notify <- struct{}{}
+	}
+	return nil
+}
+
+func (f *fakeMailer) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// panicRepo wraps fakeRepo and panics from AccumulateAlertFailures, standing
+// in for a real driver-level panic so TestMaybeAlertFailures_RecoversFromPanic
+// has something genuine for the recover() in maybeAlertFailuresAsync to catch.
+type panicRepo struct {
+	*fakeRepo
+}
+
+func (r *panicRepo) AccumulateAlertFailures(context.Context, uuid.UUID, uuid.UUID, int64) error {
+	panic("simulated repo panic — GH #381 phase 5 regression test")
+}
+
+// TestMaybeAlertFailures_EveryExitPathLogsAReason is table-driven over every
+// documented exit of maybeAlertFailures (notify.go). RED before phase 5: five
+// of these paths (nil_mailer, no_settings_row, disabled, alert_on_failure_off,
+// no_recipients, throttled — six, in fact) emitted nothing at all.
+func TestMaybeAlertFailures_EveryExitPathLogsAReason(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	fullSettings := NotifySettings{
+		Enabled:              true,
+		AlertOnFailure:       true,
+		Recipients:           []string{"ops@example.com"},
+		AlertThrottleMinutes: 60,
+	}
+	claimedState := &AlertState{TenantID: tenantID, SiteID: siteID, FailuresSinceAlert: 3}
+	siteRef := &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	cases := []struct {
+		name       string
+		mailer     bool // false leaves svc.mailer nil
+		mailerErr  error
+		repo       func(r *fakeRepo)
+		wantLevel  slog.Level
+		wantReason string
+	}{
+		{
+			name:       "nil_mailer",
+			mailer:     false,
+			wantLevel:  slog.LevelWarn,
+			wantReason: "nil_mailer",
+		},
+		{
+			name:   "accumulate_failed",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				r.alertAccumulateErr = errors.New("db unavailable")
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "accumulate_failed",
+		},
+		{
+			name:       "no_settings_row",
+			mailer:     true,
+			wantLevel:  slog.LevelDebug,
+			wantReason: "no_settings_row",
+		},
+		{
+			name:   "settings_lookup_error",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				r.alertSettingsErr = errors.New("connection reset")
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "settings_lookup_error",
+		},
+		{
+			name:   "disabled",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				s.Enabled = false
+				r.alertSettings = &s
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "disabled",
+		},
+		{
+			name:   "alert_on_failure_off",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				s.AlertOnFailure = false
+				r.alertSettings = &s
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "alert_on_failure_off",
+		},
+		{
+			name:   "no_recipients",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				s.Recipients = nil
+				r.alertSettings = &s
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "no_recipients",
+		},
+		{
+			name:   "throttled",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				// alertClaimState/alertClaimErr left nil/nil == throttled.
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "throttled",
+		},
+		{
+			name:   "claim_alert_slot_error",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimErr = errors.New("advisory lock timeout")
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "claim_alert_slot_error",
+		},
+		{
+			name:   "site_ref_error",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimState = claimedState
+				// alertSiteRef/alertSiteRefErr left at default == ErrNotFound.
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "site_ref_error",
+		},
+		{
+			name:   "enqueue_failed",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimState = claimedState
+				r.alertSiteRef = siteRef
+			},
+			mailerErr:  errors.New("smtp timeout"),
+			wantLevel:  slog.LevelWarn,
+			wantReason: "enqueue_failed",
+		},
+		{
+			name:   "alert_sent",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimState = claimedState
+				r.alertSiteRef = siteRef
+			},
+			wantLevel:  slog.LevelInfo,
+			wantReason: "alert_sent",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newCapturingHandler()
+			logger := slog.New(handler)
+
+			repo := newFakeRepo()
+			if tc.repo != nil {
+				tc.repo(repo)
+			}
+
+			svc := NewService(&Repo{}, &fakeEncryptor{}, logger)
+			svc.repo = repo
+			if tc.mailer {
+				svc.mailer = &fakeMailer{enqueueErr: tc.mailerErr}
+			}
+
+			svc.maybeAlertFailures(context.Background(), tenantID, siteID, 7)
+
+			var matches []capturedRecord
+			for _, r := range handler.Records() {
+				if r.Msg == alertDecisionEvent {
+					matches = append(matches, r)
+				}
+			}
+			if len(matches) != 1 {
+				t.Fatalf("expected exactly 1 %q record, got %d: %+v", alertDecisionEvent, len(matches), handler.Records())
+			}
+			got := matches[0]
+			if got.Level != tc.wantLevel {
+				t.Errorf("level = %v, want %v", got.Level, tc.wantLevel)
+			}
+			if got.Attrs["reason"] != tc.wantReason {
+				t.Errorf("reason = %q, want %q", got.Attrs["reason"], tc.wantReason)
+			}
+			if got.Attrs["tenant_id"] != tenantID.String() {
+				t.Errorf("tenant_id = %q, want %q", got.Attrs["tenant_id"], tenantID.String())
+			}
+			if got.Attrs["site_id"] != siteID.String() {
+				t.Errorf("site_id = %q, want %q", got.Attrs["site_id"], siteID.String())
+			}
+			if got.Attrs["failure_count"] != "7" {
+				t.Errorf("failure_count = %q, want %q", got.Attrs["failure_count"], "7")
+			}
+		})
+	}
+}
+
+// TestMaybeAlertFailures_RecoversFromPanic proves the detached goroutine
+// survives a panic anywhere in maybeAlertFailures. RED before phase 5: there
+// was no recover() at all, so this crashed the whole test binary — which is
+// itself the proof a panic here would have taken down the live API process.
+func TestMaybeAlertFailures_RecoversFromPanic(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	handler := newCapturingHandler()
+	logger := slog.New(handler)
+
+	svc := NewService(&Repo{}, &fakeEncryptor{}, logger)
+	svc.repo = &panicRepo{fakeRepo: newFakeRepo()}
+	svc.mailer = &fakeMailer{}
+
+	done := make(chan struct{})
+	go func() {
+		svc.maybeAlertFailuresAsync(tenantID, siteID, 3)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// survived — half the proof.
+	case <-time.After(5 * time.Second):
+		t.Fatal("maybeAlertFailuresAsync did not return within 5s — recover() missing or goroutine hung")
+	}
+
+	var found bool
+	for _, r := range handler.Records() {
+		if r.Msg == alertDecisionEvent && r.Level == slog.LevelError && r.Attrs["reason"] == "panic" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an Error record with reason=panic, got %+v", handler.Records())
+	}
+}
+
+// TestMaybeAlertFailures_NeverLogsRecipientAddress is the assertion that
+// matters most: no recipient address may appear in ANY emitted log record,
+// on the success path or the enqueue-failure path. The fixture recipient is
+// a distinctive string so this test would fail the moment someone logs the
+// recipient list instead of just its count.
+func TestMaybeAlertFailures_NeverLogsRecipientAddress(t *testing.T) {
+	const distinctiveRecipient = "definitely-not-logged-9f3ac21b@example.com"
+	tenantID, siteID := uuid.New(), uuid.New()
+	claimedState := &AlertState{TenantID: tenantID, SiteID: siteID, FailuresSinceAlert: 2}
+	siteRef := &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	for _, mailerErr := range []error{nil, errors.New("smtp rejected")} {
+		handler := newCapturingHandler()
+		logger := slog.New(handler)
+
+		repo := newFakeRepo()
+		repo.alertSettings = &NotifySettings{
+			Enabled:              true,
+			AlertOnFailure:       true,
+			Recipients:           []string{distinctiveRecipient},
+			AlertThrottleMinutes: 60,
+		}
+		repo.alertClaimState = claimedState
+		repo.alertSiteRef = siteRef
+
+		svc := NewService(&Repo{}, &fakeEncryptor{}, logger)
+		svc.repo = repo
+		svc.mailer = &fakeMailer{enqueueErr: mailerErr}
+
+		svc.maybeAlertFailures(context.Background(), tenantID, siteID, 4)
+
+		if dump := handler.String(); strings.Contains(dump, distinctiveRecipient) {
+			t.Fatalf("recipient address leaked into a log record (mailerErr=%v):\n%s", mailerErr, dump)
+		}
+	}
+}
+
+// TestIngestLogBatch_FailureAlert_SendsExactlyOnce_IngestStaysAsync is the
+// over-fire control: a batch that SHOULD trigger an alert still sends exactly
+// one, unchanged from pre-phase-5 behaviour, and IngestLogBatch itself
+// returns without waiting on the alert goroutine — phase 5 is logging and
+// robustness only, never a synchronous write on the ingest hot path.
+func TestIngestLogBatch_FailureAlert_SendsExactlyOnce_IngestStaysAsync(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := newFakeRepo()
+	repo.alertSettings = &NotifySettings{
+		Enabled:              true,
+		AlertOnFailure:       true,
+		Recipients:           []string{"ops@example.com"},
+		AlertThrottleMinutes: 60,
+	}
+	repo.alertClaimState = &AlertState{TenantID: tenantID, SiteID: siteID, FailuresSinceAlert: 1}
+	repo.alertSiteRef = &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	mailer := &fakeMailer{notify: make(chan struct{}, 4)}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, slog.New(newCapturingHandler()))
+	svc.repo = repo
+	svc.mailer = mailer
+
+	start := time.Now()
+	result, err := svc.IngestLogBatch(context.Background(), tenantID, siteID, []IngestEntry{
+		{AgentSeq: 1, Status: "failed", Subject: "test failure"},
+	})
+	ingestElapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("IngestLogBatch: unexpected error: %v", err)
+	}
+	if result.AckedThrough != 1 {
+		t.Errorf("AckedThrough = %d, want 1", result.AckedThrough)
+	}
+	// The alert dispatch must not be on the ingest path.
+	if ingestElapsed > time.Second {
+		t.Errorf("IngestLogBatch took %v — the alert path must stay off the ingest hot path", ingestElapsed)
+	}
+
+	select {
+	case <-mailer.notify:
+		// alert dispatched, asynchronously, exactly as before phase 5.
+	case <-time.After(5 * time.Second):
+		t.Fatal("mailer.Enqueue was never called within 5s of a should-alert batch")
+	}
+	// Give an (incorrect) second dispatch a moment to also land before we count.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := mailer.Calls(); got != 1 {
+		t.Errorf("mailer.Enqueue called %d times, want exactly 1", got)
+	}
 }

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -2,10 +2,17 @@ package email
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -224,4 +231,156 @@ func TestBuildDigestData_FlagOff_OmitsSection_PreservesZeroSkip(t *testing.T) {
 	if data != nil {
 		t.Fatalf("expected skip-send (nil) when the flag is off and there is no email activity, got %v", data)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 2 — failure-detection coverage on GET notify-settings
+// ---------------------------------------------------------------------------
+
+// failureDetectionWire and notifySettingsWire mirror the wire JSON shape
+// (dto.go's notifySettingsDTO / failureDetectionDTO) so these tests decode the
+// handler's actual SERIALIZED response rather than inspecting Go structs the
+// handler never sends.
+type failureDetectionWire struct {
+	SitesTotal      int    `json:"sites_total"`
+	SitesCovered    int    `json:"sites_covered"`
+	MinAgentVersion string `json:"min_agent_version"`
+}
+
+type notifySettingsWire struct {
+	FailureDetection failureDetectionWire `json:"failure_detection"`
+}
+
+// notifySettingsGetCtx builds a request+principal context for GET
+// /email/notify-settings — an org-level route with no path params.
+func notifySettingsGetCtx(t *testing.T, p domain.Principal) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(domain.WithPrincipal(context.Background(), p))
+	return c, rec
+}
+
+func decodeNotifySettingsWire(t *testing.T, rec *httptest.ResponseRecorder) notifySettingsWire {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body %s", rec.Code, rec.Body.String())
+	}
+	var wire notifySettingsWire
+	if err := json.Unmarshal(rec.Body.Bytes(), &wire); err != nil {
+		t.Fatalf("failed to decode response: %v, body: %s", err, rec.Body.String())
+	}
+	return wire
+}
+
+// TestGetNotifySettings_ReportsFailureDetectionCoverage: RED today because
+// the failure_detection field does not exist yet. 3 connected sites, 2 at or
+// above the gate, must serialize as sites_total=3, sites_covered=2.
+func TestGetNotifySettings_ReportsFailureDetectionCoverage(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedAgentVersions = map[uuid.UUID][]string{
+		tenantID: {"999.5.0", MinAgentVersionForFailureDetection, "0.61.138"},
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 3 {
+		t.Errorf("sites_total = %d, want 3", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 2 {
+		t.Errorf("sites_covered = %d, want 2", wire.FailureDetection.SitesCovered)
+	}
+	if wire.FailureDetection.MinAgentVersion != MinAgentVersionForFailureDetection {
+		t.Errorf("min_agent_version = %q, want %q", wire.FailureDetection.MinAgentVersion, MinAgentVersionForFailureDetection)
+	}
+}
+
+// TestGetNotifySettings_CoverageIsTenantScoped: the coverage count for tenant
+// A must never include tenant B's fleet, however much larger it is. This is
+// the one that matters most — get it wrong and the endpoint leaks another
+// tenant's fleet size.
+func TestGetNotifySettings_CoverageIsTenantScoped(t *testing.T) {
+	tenantA, tenantB := uuid.New(), uuid.New()
+	repo := newFakeRepo()
+	repo.connectedAgentVersions = map[uuid.UUID][]string{
+		tenantA: {"999.0.0"},
+		tenantB: {"999.0.0", "999.0.0", "999.0.0", "999.0.0"},
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantA,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 1 {
+		t.Errorf("sites_total = %d, want 1 — tenant B's 4 sites leaked into tenant A's count", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 1 {
+		t.Errorf("sites_covered = %d, want 1", wire.FailureDetection.SitesCovered)
+	}
+}
+
+// TestGetNotifySettings_FailureDetectionCoverage_NoOverfire is the
+// over-fire control: a tenant with zero connected sites, and a tenant where
+// every connected site is covered, must both produce sane values rather than
+// a divide-by-zero or an omitted field.
+func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
+	t.Run("zero_sites", func(t *testing.T) {
+		tenantID := uuid.New()
+		repo := newFakeRepo() // no entry for tenantID — zero connected sites
+		svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+		svc.repo = repo
+		h := &Handler{svc: svc}
+
+		c, rec := notifySettingsGetCtx(t, domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+			Role: "admin", Scope: domain.ScopeOrg,
+		})
+		h.getNotifySettings(c)
+
+		wire := decodeNotifySettingsWire(t, rec)
+		if wire.FailureDetection.SitesTotal != 0 || wire.FailureDetection.SitesCovered != 0 {
+			t.Errorf("expected 0/0 for a tenant with no connected sites, got %+v", wire.FailureDetection)
+		}
+		if !strings.Contains(rec.Body.String(), `"failure_detection"`) {
+			t.Error("failure_detection must be present even for a zero-site tenant, never omitted")
+		}
+	})
+
+	t.Run("all_covered", func(t *testing.T) {
+		tenantID := uuid.New()
+		repo := newFakeRepo()
+		repo.connectedAgentVersions = map[uuid.UUID][]string{
+			tenantID: {"999.0.0", "999.1.0", "1000.0.0"},
+		}
+		svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+		svc.repo = repo
+		h := &Handler{svc: svc}
+
+		c, rec := notifySettingsGetCtx(t, domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+			Role: "admin", Scope: domain.ScopeOrg,
+		})
+		h.getNotifySettings(c)
+
+		wire := decodeNotifySettingsWire(t, rec)
+		if wire.FailureDetection.SitesTotal != 3 || wire.FailureDetection.SitesCovered != 3 {
+			t.Errorf("expected 3/3 when every connected site is covered, got %+v", wire.FailureDetection)
+		}
+	})
 }

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -217,6 +217,29 @@ func (r *Repo) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (Notif
 	return out, err
 }
 
+// ListConnectedSiteAgentVersions returns the reported agent_version for every
+// site in this tenant currently in the 'connected' connection_state (GH #381
+// phase 2: failure-detection coverage). Version comparison against the
+// coverage gate happens in the service layer.
+//
+// Unlike GetNotifySettings/UpsertNotifySettings, sites IS a site-keyed table
+// carrying the m112 RESTRICTIVE sites_site_scope policy, so this runs under
+// scopedTenantTx like every other site-keyed query in this package: a
+// site-scoped collaborator's coverage is correctly narrowed to the sites they
+// can see, and an org-scoped principal sees the whole tenant fleet.
+func (r *Repo) ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error) {
+	var out []string
+	err := r.scopedTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		versions, qerr := sqlc.New(tx).ListConnectedSiteAgentVersions(ctx, tenantID)
+		if qerr != nil {
+			return qerr
+		}
+		out = versions
+		return nil
+	})
+	return out, err
+}
+
 // UpsertNotifySettings creates or updates the notify settings row.
 // Runs under InTenantTx.
 func (r *Repo) UpsertNotifySettings(ctx context.Context, in NotifySettings) (NotifySettings, error) {

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -653,7 +653,7 @@ func (s *Service) IngestLogBatch(ctx context.Context, tenantID, siteID uuid.UUID
 		}
 	}
 	if failureCount > 0 {
-		go s.maybeAlertFailures(context.Background(), tenantID, siteID, failureCount)
+		go s.maybeAlertFailuresAsync(tenantID, siteID, failureCount)
 	}
 
 	return IngestResult{AckedThrough: maxSeq}, nil

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // Encryptor age-encrypts and decrypts provider secrets. *cryptbox.AgeIdentity
@@ -99,6 +101,8 @@ type repository interface {
 	GetFleetStatsBySite(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]SiteStatsRow, error)
 	TopFailureSamples(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
 	TopFailureSamplesBySite(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
+	// GH #381 phase 2 — failure-detection coverage.
+	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
 }
 
 // Service is the email domain business-logic layer. It owns:
@@ -1504,17 +1508,82 @@ func (s *Service) PropagateOrgConfig(ctx context.Context, tenantID uuid.UUID) (P
 // the service returns safe defaults with GET-always-200 semantics (lesson from
 // 0.35.1 hotfix: never 404 on a settings GET).
 func (s *Service) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (NotifySettings, error) {
+	coverage, covErr := s.failureDetectionCoverage(ctx, tenantID)
+	if covErr != nil {
+		return NotifySettings{}, covErr
+	}
+
 	settings, err := s.repo.GetNotifySettings(ctx, tenantID)
 	if errors.Is(err, ErrNotFound) {
 		defaults := defaultNotifySettings(tenantID)
 		defaults.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
+		defaults.FailureDetection = coverage
 		return defaults, nil
 	}
 	if err != nil {
 		return NotifySettings{}, domain.Internal("email_get_notify_settings", "failed to load notify settings").WithCause(err)
 	}
 	settings.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
+	settings.FailureDetection = coverage
 	return settings, nil
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 2 — failure-detection coverage
+// ---------------------------------------------------------------------------
+
+// MinAgentVersionForFailureDetection gates failure_detection.sites_covered: a
+// connected site is "covered" only when its reported agent_version compares
+// >= this value under internal/wpversion.Compare.
+//
+// PLACEHOLDER VALUE. GH #381 phase 1 — the agent-side change that actually
+// widens failure detection beyond "WPMgr is the mail transport" — has not
+// shipped a release as of this writing. "999.0.0" is deliberately NOT a
+// plausible wpmgr version: it is chosen so that no currently-shipped agent
+// ever compares >= it, which makes sites_covered honestly report 0 until this
+// constant is corrected, instead of silently crediting sites for a capability
+// their agent build does not have.
+//
+// UPDATE THIS the moment phase 1's release is cut: set it to the exact agent
+// version (e.g. "0.62.0") that ships the detection-widening change, in the
+// same commit that cuts that release. Until updated, every tenant's
+// failure_detection.sites_covered will read 0 regardless of fleet freshness.
+const MinAgentVersionForFailureDetection = "999.0.0"
+
+// agentVersionPattern accepts the plain dotted-numeric shape WPMgr's own
+// agent versions use, mirroring internal/agentrelease's own guard
+// (internal/agentrelease/classify.go:45). Duplicated rather than imported:
+// internal/email must not cross-import a sibling domain package, and this is
+// a two-line regex, not shared logic worth a shared package for. A malformed
+// or empty agent_version (e.g. a site that has never reported one) must never
+// compare as "covered" by accident.
+var agentVersionPattern = regexp.MustCompile(`^\d+(\.\d+){1,3}([-+][0-9A-Za-z.]+)?$`)
+
+func isWellFormedAgentVersion(v string) bool {
+	return agentVersionPattern.MatchString(strings.TrimSpace(v))
+}
+
+// failureDetectionCoverage computes, for tenantID, how many of its currently
+// connected sites (connection_state = 'connected') run an agent_version at or
+// above MinAgentVersionForFailureDetection. A site whose reported version is
+// empty or not well-formed is treated as NOT covered — an unreadable version
+// is never assumed capable, mirroring internal/agentrelease.Classify's
+// StatusUnknown handling, which never risks a false "current" either.
+func (s *Service) failureDetectionCoverage(ctx context.Context, tenantID uuid.UUID) (FailureDetectionCoverage, error) {
+	versions, err := s.repo.ListConnectedSiteAgentVersions(ctx, tenantID)
+	if err != nil {
+		return FailureDetectionCoverage{}, domain.Internal("email_failure_detection_coverage", "failed to load connected site agent versions").WithCause(err)
+	}
+	out := FailureDetectionCoverage{
+		SitesTotal:      len(versions),
+		MinAgentVersion: MinAgentVersionForFailureDetection,
+	}
+	for _, v := range versions {
+		if isWellFormedAgentVersion(v) && wpversion.Compare(v, MinAgentVersionForFailureDetection) >= 0 {
+			out.SitesCovered++
+		}
+	}
+	return out, nil
 }
 
 // PutNotifySettings validates and upserts the notify settings, computing

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -92,6 +92,18 @@ type fakeRepo struct {
 	// keyed by tenant so a cross-tenant test can seed two tenants' fleets
 	// independently (GH #381 phase 2).
 	connectedAgentVersions map[uuid.UUID][]string
+
+	// GH #381 phase 5 — maybeAlertFailures exit-path control knobs. Each is
+	// nil/zero by default, which preserves the pre-phase-5 fake behaviour
+	// (GetNotifySettings -> ErrNotFound, ClaimAlertSlot -> throttled, GetSiteRef
+	// -> ErrNotFound) so every existing test keeps passing unchanged.
+	alertAccumulateErr error
+	alertSettings      *NotifySettings
+	alertSettingsErr   error
+	alertClaimState    *AlertState
+	alertClaimErr      error
+	alertSiteRef       *SiteRef
+	alertSiteRefErr    error
 }
 
 func newFakeRepo() *fakeRepo {
@@ -433,10 +445,22 @@ func (r *fakeRepo) ListEmailInheritingSites(_ context.Context, _ uuid.UUID) ([]I
 }
 
 func (r *fakeRepo) GetSiteRef(_ context.Context, _, _ uuid.UUID) (SiteRef, error) {
+	if r.alertSiteRefErr != nil {
+		return SiteRef{}, r.alertSiteRefErr
+	}
+	if r.alertSiteRef != nil {
+		return *r.alertSiteRef, nil
+	}
 	return SiteRef{}, ErrNotFound
 }
 
 func (r *fakeRepo) GetNotifySettings(_ context.Context, _ uuid.UUID) (NotifySettings, error) {
+	if r.alertSettingsErr != nil {
+		return NotifySettings{}, r.alertSettingsErr
+	}
+	if r.alertSettings != nil {
+		return *r.alertSettings, nil
+	}
 	return NotifySettings{}, ErrNotFound
 }
 
@@ -445,11 +469,14 @@ func (r *fakeRepo) UpsertNotifySettings(_ context.Context, in NotifySettings) (N
 }
 
 func (r *fakeRepo) AccumulateAlertFailures(_ context.Context, _, _ uuid.UUID, _ int64) error {
-	return nil
+	return r.alertAccumulateErr
 }
 
 func (r *fakeRepo) ClaimAlertSlot(_ context.Context, _, _ uuid.UUID, _ int64, _ int) (*AlertState, error) {
-	return nil, nil // throttled
+	if r.alertClaimErr != nil {
+		return nil, r.alertClaimErr
+	}
+	return r.alertClaimState, nil // nil state, nil error == throttled
 }
 
 func (r *fakeRepo) ListDueDigests(_ context.Context, _ int32) ([]NotifySettings, error) {

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -87,6 +87,11 @@ type fakeRepo struct {
 	// say "refused" and "absent" as well as "done", and the service has to turn
 	// each into a different answer (see suppression_delete_refusal_test.go).
 	suppressionDeleteErr error
+
+	// connectedAgentVersions is what ListConnectedSiteAgentVersions returns,
+	// keyed by tenant so a cross-tenant test can seed two tenants' fleets
+	// independently (GH #381 phase 2).
+	connectedAgentVersions map[uuid.UUID][]string
 }
 
 func newFakeRepo() *fakeRepo {
@@ -465,6 +470,10 @@ func (r *fakeRepo) TopFailureSamples(_ context.Context, _ uuid.UUID, _, _ time.T
 
 func (r *fakeRepo) TopFailureSamplesBySite(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int32) ([]FailureSample, error) {
 	return nil, nil
+}
+
+func (r *fakeRepo) ListConnectedSiteAgentVersions(_ context.Context, tenantID uuid.UUID) ([]string, error) {
+	return r.connectedAgentVersions[tenantID], nil
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -9141,6 +9141,7 @@ export const EmailNotifySettingsSchema = {
     "digest_hour",
     "timezone",
     "instance_mailer_configured",
+    "failure_detection",
   ],
   properties: {
     enabled: {
@@ -9202,6 +9203,29 @@ export const EmailNotifySettingsSchema = {
       type: "boolean",
       description:
         "True when the instance-level SMTP/mailer is configured. Alerts and digests require this to be true to deliver.\n",
+    },
+    failure_detection: {
+      type: "object",
+      description:
+        "Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.\n",
+      required: ["sites_total", "sites_covered", "min_agent_version"],
+      properties: {
+        sites_total: {
+          type: "integer",
+          description:
+            "Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).\n",
+        },
+        sites_covered: {
+          type: "integer",
+          description:
+            "Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.\n",
+        },
+        min_agent_version: {
+          type: "string",
+          description:
+            "Minimum agent version that can detect and report an email delivery failure.\n",
+        },
+      },
     },
     tenant_id: {
       type: "string",

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5424,6 +5424,27 @@ export type EmailNotifySettings = {
    */
   instance_mailer_configured: boolean;
   /**
+   * Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.
+   *
+   */
+  failure_detection: {
+    /**
+     * Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).
+     *
+     */
+    sites_total: number;
+    /**
+     * Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.
+     *
+     */
+    sites_covered: number;
+    /**
+     * Minimum agent version that can detect and report an email delivery failure.
+     *
+     */
+    min_agent_version: string;
+  };
+  /**
    * Present when a settings row exists; absent for default response.
    */
   tenant_id?: string;

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19578,6 +19578,7 @@ components:
         - digest_hour
         - timezone
         - instance_mailer_configured
+        - failure_detection
       properties:
         enabled:
           type: boolean
@@ -19635,6 +19636,36 @@ components:
           description: >
             True when the instance-level SMTP/mailer is configured. Alerts
             and digests require this to be true to deliver.
+        failure_detection:
+          type: object
+          description: >
+            Coverage of the tenant's connected sites for email delivery
+            failure detection (GH #381). WPMgr can only detect a failure when
+            it is the mail transport in use AND the agent is new enough to
+            report it; a site below `min_agent_version`, or not currently
+            connected, cannot trigger a per-failure alert no matter how the
+            settings above are configured.
+          required:
+            - sites_total
+            - sites_covered
+            - min_agent_version
+          properties:
+            sites_total:
+              type: integer
+              description: >
+                Number of the tenant's currently-connected sites (excludes
+                pending, degraded, disconnected, revoked and archived sites).
+            sites_covered:
+              type: integer
+              description: >
+                Of sites_total, how many report an agent_version at or above
+                min_agent_version and can therefore have a delivery failure
+                detected and alerted on.
+            min_agent_version:
+              type: string
+              description: >
+                Minimum agent version that can detect and report an email
+                delivery failure.
         tenant_id:
           type: string
           format: uuid


### PR DESCRIPTION
## Summary

Phase 5 of 5 for GH #381: make it possible to find out why an email failure
alert did not fire. Logging and robustness only — no schema change, no API
change, no change to when an alert IS sent.

- Every exit of `maybeAlertFailures` (`apps/api/internal/email/notify.go`)
  now emits exactly one `email_alert_decision` record with a `reason` field:
  `nil_mailer`, `accumulate_failed`, `no_settings_row`,
  `settings_lookup_error`, `disabled`, `alert_on_failure_off`,
  `no_recipients`, `throttled`, `claim_alert_slot_error`, `site_ref_error`,
  `enqueue_failed`, `alert_sent`. Debug for expected steady state, Warn for
  anomalies, one Info on successful send.
- Recipient addresses are never logged — only `failure_count`.
- The detached goroutine launched from `IngestLogBatch` (`service.go`) is now
  wrapped in a 30s timeout (previously a bare `context.Background()` with no
  deadline) and a `recover()` (previously none — a panic here would have
  taken the whole API process down).
- `IngestLogBatch` itself is unchanged: still fire-and-forget, no new
  database write, no behaviour change to when an alert fires.

## Finding

`notify.go`'s `failureCount <= 0` guard (originally lines 87-89) is
unreachable in production: the sole caller, `IngestLogBatch`
(`service.go:655-657` pre-change), only launches the goroutine when
`failureCount > 0`. Left un-instrumented rather than adding a log line for a
branch that cannot fire, per the phase-5 brief.

## Test plan

- [x] `TestMaybeAlertFailures_EveryExitPathLogsAReason` — table-driven over
      all 12 exits, capturing `slog` handler, asserts exactly one record with
      the expected reason/level/tenant_id/site_id/failure_count.
- [x] `TestMaybeAlertFailures_RecoversFromPanic` — panicking fake repo;
      asserts the process survives and an Error record with `reason=panic`
      is emitted.
- [x] `TestMaybeAlertFailures_NeverLogsRecipientAddress` — a distinctive
      recipient string never appears anywhere in the captured log output, on
      both the success and enqueue-failure paths.
- [x] `TestIngestLogBatch_FailureAlert_SendsExactlyOnce_IngestStaysAsync` —
      over-fire control: alert sent exactly once, `IngestLogBatch` itself
      returns in well under a second.
- [x] RED proven before GREEN: reverted to pre-fix `notify.go`/`service.go`,
      ran a standalone proof — silent paths emitted zero log output, and an
      unrecovered panic crashed the test binary — then restored the fix and
      re-ran to green.
- [x] `go build ./...`, `go vet ./...`, `go test ./internal/email/...` clean.
- [x] `gofmt -l` clean on all four touched files.

Not merging yet — this is one phase of five.