### PR TITLE
fix(agent): log a detected email failure even when log_emails is off (GH #381 phase 4)

### DIFF
--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -103,6 +103,7 @@ use WPMgr\Agent\Email\Handlers\PostmarkHandler;
 use WPMgr\Agent\Email\Handlers\SendgridHandler;
 use WPMgr\Agent\Email\Handlers\SesHandler;
 use WPMgr\Agent\Email\Handlers\SmtpHandler;
+use WPMgr\Agent\Email\MailFailureCapture;
 use WPMgr\Agent\Email\MailRouter;
 use WPMgr\Agent\Email\ProviderRouter;
 use WPMgr\Agent\Email\SuppressionCache;
@@ -335,6 +336,15 @@ final class Plugin
     private MailRouter $mailRouter;
 
     /**
+     * Unconditional listener on core's own `wp_mail_failed` action (GH #381
+     * phase 1). MailRouter only sees a failure on sites where a WPMgr
+     * provider is configured; this listener registers regardless of
+     * EmailConfig, so a failed send is captured even on sites WPMgr never
+     * routes (core PHPMailer, or a third-party SMTP plugin).
+     */
+    private MailFailureCapture $mailFailureCapture;
+
+    /**
      * Provider-level send dispatcher. Instantiated with all five v1 handlers
      * (smtp/ses/sendgrid/mailgun/postmark) and shared by MailRouter +
      * SendTestEmailCommand.
@@ -503,6 +513,7 @@ final class Plugin
         $this->providerRouter->register(new MailgunHandler());
         $this->providerRouter->register(new PostmarkHandler());
         $this->mailRouter        = new MailRouter($this->providerRouter, $this->settings);
+        $this->mailFailureCapture = new MailFailureCapture($emailLogger);
         $this->emailLogReporter  = new EmailLogReporter($this->settings, $this->signer);
 
         $this->router              = new Router($this->connector, $this->commands());
@@ -1022,6 +1033,11 @@ final class Plugin
         // The filter is non-destructive: when no email config is stored it
         // returns null immediately, leaving the default WP mail path untouched.
         $this->mailRouter->register_hooks();
+
+        // GH #381 phase 1 — unconditional wp_mail_failed listener. Unlike
+        // mailRouter above, this registration is NOT gated behind email
+        // config: it must see failures on sites WPMgr never routes.
+        $this->mailFailureCapture->register_hooks();
 
         // Email log retention pruner — runs daily via wp-cron.
         add_action(EmailLogger::HOOK_PRUNE, [$this, 'pruneEmailLog']);

--- a/apps/agent/includes/email/class-mail-failure-capture.php
+++ b/apps/agent/includes/email/class-mail-failure-capture.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * MailFailureCapture: hooks WordPress core's own `wp_mail_failed` action so a
+ * failed send is logged even on sites WPMgr does not route.
+ *
+ * MailRouter::intercept() (class-mail-router.php) only sees a failure on
+ * sites where EmailConfig::is_configured() is true -- when no provider is
+ * configured it returns null immediately and never touches the send. On a
+ * site sending through core PHPMailer, or through a third-party SMTP plugin
+ * that never defers to WPMgr, that leaves WPMgr blind to every failure. Core
+ * itself fires `wp_mail_failed` with a WP_Error on ANY failed send,
+ * configured or not (wp-includes/pluggable.php), so this class listens there
+ * unconditionally -- independent of EmailConfig -- and is the only path that
+ * covers the unrouted case.
+ *
+ * No-double-log guard: when MailRouter's OWN provider send fails, it already
+ * (a) logs the row itself via ProviderRouter::send() -> EmailLogger::write(),
+ * and (b) fires `wp_mail_failed` itself (see class-mail-router.php,
+ * intercept()) with error_data carrying a `wpmgr_provider_detail` key. That
+ * key is unique to MailRouter's own fire -- core's native wp_mail_failed data
+ * (to, subject, message, headers, attachments, optionally
+ * phpmailer_exception_code) never carries it. So capture() treats that key's
+ * presence as "already logged by the router path" and returns without
+ * writing a second row.
+ *
+ * Body is never persisted: the $mail array built here carries only `to` and
+ * `subject`, never `message`/`body_html`/`body_text`, so EmailLogger::write()
+ * has nothing to read into the `body` column regardless of the site's
+ * store_body setting.
+ *
+ * @package WPMgr\Agent\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Email;
+
+/**
+ * Captures core's wp_mail_failed action for sites WPMgr does not route.
+ */
+final class MailFailureCapture {
+
+	private EmailLogger $logger;
+
+	/**
+	 * @param EmailLogger $logger Local send-event logger.
+	 */
+	public function __construct( EmailLogger $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Register hooks. Called from Plugin::registerHooks().
+	 *
+	 * UNCONDITIONAL: this registration is not gated behind
+	 * EmailConfig::is_configured() or any other config check. That is the
+	 * entire point -- it must fire on sites with no provider configured, so
+	 * WPMgr sees a failure even when it never routed the send.
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- listening on core's own wp_mail_failed hook, not registering a global
+		add_action( 'wp_mail_failed', array( $this, 'capture' ) );
+	}
+
+	/**
+	 * `wp_mail_failed` action handler.
+	 *
+	 * WordPress core always passes a WP_Error, but the hook is typed mixed
+	 * here (and guarded with instanceof) because a badly-behaved third-party
+	 * filter chain could in theory pass something else through; core itself
+	 * never does.
+	 *
+	 * @param mixed $error Expected WP_Error from core or MailRouter.
+	 * @return void
+	 */
+	public function capture( $error ): void {
+		if ( ! ( $error instanceof \WP_Error ) ) {
+			return;
+		}
+
+		$data = $error->get_error_data();
+
+		// MailRouter already logged this failure itself (see class docblock);
+		// the wpmgr_provider_detail key only ever appears on a WP_Error that
+		// MailRouter fired, never on core's own native wp_mail_failed data.
+		// Logging again here would double-count the same send.
+		if ( is_array( $data ) && array_key_exists( 'wpmgr_provider_detail', $data ) ) {
+			return;
+		}
+
+		$error_message = $error->get_error_message();
+		if ( $error_message === '' ) {
+			$error_message = 'wp_mail_failed';
+		}
+
+		// Only `to` and `subject` -- never the message body, under any key,
+		// regardless of the site's store_body setting (see class docblock).
+		$mail = array(
+			'to'      => ( is_array( $data ) && isset( $data['to'] ) ) ? $data['to'] : array(),
+			'subject' => ( is_array( $data ) && isset( $data['subject'] ) ) ? (string) $data['subject'] : '',
+		);
+
+		$this->logger->write( $mail, 'wp_mail', 'failed', '', $error_message, '', 0, EmailConfig::load(), '' );
+	}
+}

--- a/apps/agent/includes/email/class-mail-router.php
+++ b/apps/agent/includes/email/class-mail-router.php
@@ -19,6 +19,10 @@
  * The X-WPMgr-Site correlation header is stamped on every outgoing message for
  * the Phase-4 CP webhook fan-out.
  *
+ * wp_mail()'s return value is honest: a provider failure makes wp_mail()
+ * return false (never a lie of true) and fires `wp_mail_failed` with a
+ * WP_Error, same as core would on its own send failure. See intercept().
+ *
  * @package WPMgr\Agent\Email
  */
 
@@ -53,10 +57,14 @@ final class MailRouter {
 	 */
 	public function register_hooks(): void {
 		// pre_wp_mail is the primary interception point (WP 5.7+, our baseline).
-		// Returning a non-null value from this filter short-circuits wp_mail()
-		// entirely. We return the result array on success, true on failure (so WP
-		// does NOT fall through to its own PHPMailer path for a message we already
-		// attempted), and null when email is not configured (leaves WP untouched).
+		// Per wp-includes/pluggable.php, wp_mail() only lets WP's own PHPMailer
+		// path run when this filter returns exactly `null`; ANY other value --
+		// including `false` -- short-circuits and becomes wp_mail()'s own return
+		// value verbatim. So we return the result array on success, false on
+		// failure (still short-circuits, so WP never re-attempts a send we
+		// already made -- but wp_mail() now honestly reports the failure instead
+		// of claiming success), and null when email is not configured (leaves
+		// WP untouched).
 		add_filter( 'pre_wp_mail', array( $this, 'intercept' ), 10, 2 );
 	}
 
@@ -84,10 +92,36 @@ final class MailRouter {
 
 		$result = $this->router->send( $mail, $cfg );
 
-		// Return true (truthy non-null) to short-circuit wp_mail() regardless of
-		// the provider outcome; WP's return value from wp_mail() is a bool and we
-		// have already logged the failure via EmailLogger if it occurred.
-		return $result['ok'] ? $result : true;
+		if ( $result['ok'] ) {
+			// Success: unchanged from before -- the provider result array is a
+			// non-null, truthy value, so it short-circuits wp_mail() and becomes
+			// its return value.
+			return $result;
+		}
+
+		// Failure: `false` still short-circuits wp_mail() (see register_hooks()
+		// above) so WP does NOT fall through to its own PHPMailer for a message
+		// we already attempted -- but wp_mail()'s return value is now the
+		// honest `false` instead of a lie. Fire wp_mail_failed ourselves since
+		// short-circuiting skips WP's own call to it entirely, matching the
+		// WP_Error shape core's own failure paths use (code 'wp_mail_failed',
+		// the failure message, and the mail args minus body/secrets) so
+		// existing listeners on that hook keep working.
+		$error_message = $result['detail'] !== '' ? $result['detail'] : 'WPMgr: mail send failed.';
+
+		$error_data = array(
+			'to'                    => $atts['to'] ?? array(),
+			'subject'               => (string) ( $atts['subject'] ?? '' ),
+			'headers'               => $atts['headers'] ?? array(),
+			'attachments'           => $atts['attachments'] ?? array(),
+			// Provider-side failure detail; never credentials or the message body.
+			'wpmgr_provider_detail' => $error_message,
+		);
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- firing core's own wp_mail_failed hook, not registering a global
+		do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', $error_message, $error_data ) );
+
+		return false;
 	}
 
 	/**

--- a/apps/agent/includes/email/class-provider-router.php
+++ b/apps/agent/includes/email/class-provider-router.php
@@ -430,7 +430,24 @@ class ProviderRouter {
 	}
 
 	/**
-	 * Write a log row if email logging is enabled.
+	 * Write a log row if email logging is enabled, OR unconditionally when
+	 * the outcome is a failure.
+	 *
+	 * log_emails is a volume-and-retention preference about keeping a
+	 * record of mail that WORKED; it is not a request to be blinded to
+	 * failures. By the time this is called, send() has already DETECTED the
+	 * failure and computed its error string -- discarding that here would
+	 * leave no local row, nothing for the push to ship, and nothing for the
+	 * control plane to alert on, purely because the owner asked for a
+	 * quieter log of successful mail. So the early return only applies when
+	 * BOTH log_emails is off AND the outcome is not a failure ('sent' is the
+	 * only non-failure status this method ever receives; 'failed' and
+	 * 'suppressed' are both incidents and are logged regardless).
+	 *
+	 * This does not touch privacy: store_body is gated independently inside
+	 * EmailLogger::write() and still defaults false there, so turning
+	 * log_emails off still means no message body is ever stored, and a
+	 * successful send is still not recorded at all.
 	 *
 	 * @param array<string,mixed> $mail            Normalised mail payload.
 	 * @param string              $connection_key  Resolved connection key ('default' for primary).
@@ -454,7 +471,8 @@ class ProviderRouter {
 		int $retries,
 		EmailConfig $cfg
 	): void {
-		if ( ! $cfg->log_emails ) {
+		$is_failure = ( 'sent' !== $status );
+		if ( ! $cfg->log_emails && ! $is_failure ) {
 			return;
 		}
 		$this->logger->write( $mail, $provider, $status, $msg_id, $error, $response, $retries, $cfg, $connection_key );

--- a/apps/agent/tests/Email/EmailLogFailureBypassTest.php
+++ b/apps/agent/tests/Email/EmailLogFailureBypassTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * EmailLogFailureBypassTest — GH #381 phase 4: ProviderRouter::maybe_log()
+ * discarded a DETECTED failure whenever the site owner had turned log_emails
+ * off, silently defeating phase 1's failure alerting for that tenant.
+ *
+ * log_emails is a volume-and-retention preference about keeping a record of
+ * mail that WORKED. A failure is an incident, not a record of routine
+ * traffic; someone asking for a quieter log did not ask to be blinded to
+ * failures. store_body is an independent gate (EmailLogger::write()) that
+ * controls whether ANY row -- success or failure -- carries the message
+ * body, and it is untouched by this change: turning log_emails off must
+ * still mean no bodies are ever stored, and must still mean a SUCCESSFUL
+ * send is not recorded at all.
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WPMgr\Agent\Email\EmailConfig;
+use WPMgr\Agent\Email\EmailLogger;
+use WPMgr\Agent\Email\ProviderHandlerInterface;
+use WPMgr\Agent\Email\ProviderRouter;
+
+/**
+ * @covers \WPMgr\Agent\Email\ProviderRouter
+ */
+class EmailLogFailureBypassTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+        Functions\when('current_time')->justReturn('2026-08-17 00:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /** @param array{ok:bool,message_id:string,error:string,provider_response:string} $result */
+    private function make_handler(string $provider, array $result): ProviderHandlerInterface
+    {
+        $handler = $this->createMock(ProviderHandlerInterface::class);
+        $handler->method('provider')->willReturn($provider);
+        $handler->method('send')->willReturn($result);
+        return $handler;
+    }
+
+    /** @return array<string,mixed> */
+    private function base_mail(): array
+    {
+        return [
+            'to'          => ['to@example.com'],
+            'cc'          => [],
+            'bcc'         => [],
+            'reply_to'    => [],
+            'from'        => 'a@example.com',
+            'from_name'   => 'Sender',
+            'subject'     => 'Test',
+            'body_text'   => 'SECRET-BODY-TEXT',
+            'body_html'   => '',
+            'charset'     => 'UTF-8',
+            'headers'     => [],
+            'attachments' => [],
+            'return_path' => false,
+            'x_site_id'   => 'site-123',
+        ];
+    }
+
+    /**
+     * Minimal fake $wpdb: records every insert() call's $data array so a
+     * test can assert row count and shape without a real database. Same
+     * pattern as MailFailureCaptureTest::fakeWpdb().
+     */
+    private function fakeWpdb(): object
+    {
+        return new class () {
+            public string $prefix = 'wp_';
+
+            /** @var array<int,array<string,mixed>> */
+            public array $rows = [];
+
+            public int $insert_id = 0;
+
+            /** @param array<string,mixed> $data */
+            public function insert(string $table, array $data, array $formats): bool
+            {
+                $this->rows[] = $data;
+                $this->insert_id++;
+                return true;
+            }
+        };
+    }
+
+    /**
+     * RED today: maybe_log() returns early on `! $cfg->log_emails` before
+     * ever looking at the outcome, so a DETECTED failure (ok:false, an error
+     * string already computed by send()) produces zero rows -- nothing for
+     * the push to ship, nothing for the control plane to alert on.
+     */
+    public function test_failed_send_is_logged_even_when_log_emails_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'smtp connect() failed: Connection refused',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $result = $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertFalse($result['ok']);
+        $this->assertCount(1, $fakeWpdb->rows, 'a detected failure must be logged even when log_emails is off');
+        $this->assertSame('failed', $fakeWpdb->rows[0]['status']);
+        $this->assertSame('smtp connect() failed: Connection refused', $fakeWpdb->rows[0]['error']);
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * The important control: this must be GREEN both BEFORE and AFTER the
+     * fix. It guards the bypass from quietly becoming "ignore the
+     * preference entirely" -- a successful send is exactly the record a
+     * user who turned log_emails off asked NOT to keep.
+     */
+    public function test_successful_send_is_still_not_logged_when_log_emails_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => true,
+            'message_id'        => 'smtp-ok-1',
+            'error'             => '',
+            'provider_response' => '250 OK',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $result = $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertTrue($result['ok']);
+        $this->assertCount(0, $fakeWpdb->rows, 'a successful send must not be recorded when log_emails is off');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Privacy gate: store_body stays independently false regardless of the
+     * newly-widened failure path. Prove the raw message body never reaches
+     * any column of the failure row this fix now writes.
+     */
+    public function test_failed_row_carries_no_message_body_when_store_body_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'smtp connect() failed: Connection refused',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame(0, $row['body_stored'], 'body_stored must be 0 when store_body is false, even on the newly-widened failure path');
+        $this->assertNull($row['body'], 'body column must be NULL when store_body is false');
+        $this->assertStringNotContainsString('SECRET-BODY-TEXT', (string) json_encode($row));
+        foreach ($row as $column => $value) {
+            $this->assertNotSame('SECRET-BODY-TEXT', $value, "Column '{$column}' must never carry the raw message body when store_body is false.");
+        }
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Over-fire control: with log_emails TRUE, behaviour is completely
+     * unchanged for both success and failure -- this path was never gated
+     * by the outcome before, and must not become gated by it now.
+     */
+    public function test_log_emails_true_behaviour_is_unchanged_for_success_and_failure(): void
+    {
+        $cfg = new EmailConfig(['provider' => 'smtp', 'log_emails' => true, 'store_body' => false]);
+
+        // Success leg.
+        $fakeWpdbOk        = $this->fakeWpdb();
+        $GLOBALS['wpdb']   = $fakeWpdbOk;
+        $okHandler         = $this->make_handler('smtp', [
+            'ok'                => true,
+            'message_id'        => 'smtp-ok-2',
+            'error'             => '',
+            'provider_response' => '250 OK',
+        ]);
+        $okRouter = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $okRouter->register($okHandler);
+        $okRouter->send($this->base_mail(), $cfg, true);
+
+        $this->assertCount(1, $fakeWpdbOk->rows, 'a successful send must still be logged when log_emails is on');
+        $this->assertSame('sent', $fakeWpdbOk->rows[0]['status']);
+        unset($GLOBALS['wpdb']);
+
+        // Failure leg.
+        $fakeWpdbFail      = $this->fakeWpdb();
+        $GLOBALS['wpdb']   = $fakeWpdbFail;
+        $failHandler       = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'boom',
+            'provider_response' => '',
+        ]);
+        $failRouter = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $failRouter->register($failHandler);
+        $failRouter->send($this->base_mail(), $cfg, true);
+
+        $this->assertCount(1, $fakeWpdbFail->rows, 'a failed send must still be logged when log_emails is on');
+        $this->assertSame('failed', $fakeWpdbFail->rows[0]['status']);
+        unset($GLOBALS['wpdb']);
+    }
+}

--- a/apps/agent/tests/Email/MailFailureCaptureTest.php
+++ b/apps/agent/tests/Email/MailFailureCaptureTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * MailFailureCaptureTest — GH #381 phase 1: WordPress core's own
+ * `wp_mail_failed` action fires on ANY failed send (configured or not), but
+ * nothing in this plugin listened for it. MailRouter::intercept()
+ * (class-mail-router.php) only sees a failure when EmailConfig::is_configured()
+ * is true, so a site sending through core PHPMailer or a third-party SMTP
+ * plugin was invisible to WPMgr. MailFailureCapture closes that gap by
+ * listening on wp_mail_failed unconditionally, independent of EmailConfig.
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+use WPMgr\Agent\Email\EmailLogger;
+use WPMgr\Agent\Email\MailFailureCapture;
+
+/**
+ * @covers \WPMgr\Agent\Email\MailFailureCapture
+ */
+class MailFailureCaptureTest extends TestCase
+{
+    /** @var array<string,array<int,callable>> hook name => registered callbacks. */
+    private array $registeredActions = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->registeredActions = [];
+
+        // Brain Monkey's built-in add_action()/do_action() are expectation
+        // trackers, not a working dispatcher: HookExpectationExecutor::execute()
+        // returns null for a hook with no expectation configured, so
+        // do_action() alone never invokes what add_action() registered. These
+        // aliases build a tiny real pub/sub so do_action() genuinely calls
+        // whatever register_hooks() wired -- proving the WIRING, not just
+        // calling capture() directly. Same pattern as
+        // tests/SelfUpdateInRequestApplyTest.php's add_action alias.
+        Functions\when('add_action')->alias(function (string $hook, $callback, int $priority = 10, int $accepted_args = 1): bool {
+            $this->registeredActions[$hook][] = $callback;
+            return true;
+        });
+        Functions\when('do_action')->alias(function (string $hook, ...$args): void {
+            foreach ($this->registeredActions[$hook] ?? [] as $callback) {
+                $callback(...$args);
+            }
+        });
+
+        Functions\when('current_time')->justReturn('2026-08-17 00:00:00');
+
+        // EmailConfig::load() -> get_option(OPTION); default to an empty
+        // array so the decoded config is unconfigured (provider === '').
+        Functions\when('get_option')->justReturn([]);
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Minimal fake $wpdb: records every insert() call's $data array so a
+     * test can assert row count and shape without a real database. Uses an
+     * array (not a single captured row) because some tests need to count
+     * multiple potential inserts.
+     */
+    private function fakeWpdb(): object
+    {
+        return new class () {
+            public string $prefix = 'wp_';
+
+            /** @var array<int,array<string,mixed>> */
+            public array $rows = [];
+
+            public int $insert_id = 0;
+
+            /** @param array<string,mixed> $data */
+            public function insert(string $table, array $data, array $formats): bool
+            {
+                $this->rows[] = $data;
+                $this->insert_id++;
+                return true;
+            }
+        };
+    }
+
+    /**
+     * RED/GREEN case: core's own wp_mail_failed fires on an UNCONFIGURED
+     * site (no WPMgr provider set) and must produce exactly one 'failed' row.
+     * The send body ('message' in core's error data) must never appear in
+     * any persisted column, under any key, regardless of store_body.
+     */
+    public function test_wp_mail_failed_writes_a_failed_row_when_no_provider_is_configured(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
+            'to'      => ['a@x.com'],
+            'subject' => 'Order #12',
+            'message' => 'SECRET-BODY',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows, 'Exactly one failed row must be written for an unrouted core mail_failed.');
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('wp_mail', $row['provider']);
+        $this->assertNotSame('', $row['error']);
+
+        // Security-relevant assertion: the raw message body must appear in
+        // NO field of the persisted row.
+        $this->assertStringNotContainsString('SECRET-BODY', (string) json_encode($row));
+        foreach ($row as $column => $value) {
+            $this->assertNotSame('SECRET-BODY', $value, "Column '{$column}' must never carry the raw message body.");
+        }
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * No-double-log guard: when MailRouter's own provider send fails, it
+     * already (a) logs the row itself via ProviderRouter::send() ->
+     * EmailLogger::write(), and (b) fires wp_mail_failed itself (post
+     * cb7737c) with error_data carrying a `wpmgr_provider_detail` marker
+     * that only ever appears on a WP_Error MailRouter fired -- core's own
+     * native wp_mail_failed data never has that key.
+     *
+     * Scoping: this test only proves that MailFailureCapture::capture(),
+     * reached here through the real wp_mail_failed dispatch, adds ZERO rows
+     * when that marker is present. It does not exercise
+     * ProviderRouter::send()'s own separate EmailLogger::write() call (the
+     * "first" log write in "logged once not twice") -- that call happens on
+     * a different code path outside this test's scope.
+     */
+    public function test_router_handled_failure_is_logged_once_not_twice(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'Provider rejected', [
+            'to'                    => ['a@x.com'],
+            'subject'               => 'S',
+            'headers'               => [],
+            'attachments'           => [],
+            'wpmgr_provider_detail' => 'Provider rejected',
+        ]));
+
+        $this->assertCount(
+            0,
+            $fakeWpdb->rows,
+            'MailFailureCapture must add zero rows when the wpmgr_provider_detail marker shows MailRouter already logged this failure.'
+        );
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Over-fire control. There is no success-path fire to test directly --
+     * core only calls wp_mail_failed on failure, never on a successful send
+     * -- so the most meaningful concrete check available here is that
+     * capture() is stateless across repeated fires: two INDEPENDENT
+     * unconfigured failures must produce two independent rows, not a single
+     * corrupted/merged entry, proving the listener doesn't leak state or
+     * drop a second in-process failure.
+     */
+    public function test_two_independent_unconfigured_failures_produce_two_independent_rows(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'first failure', [
+            'to'      => ['first@x.com'],
+            'subject' => 'First',
+        ]));
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'second failure', [
+            'to'      => ['second@x.com'],
+            'subject' => 'Second',
+        ]));
+
+        $this->assertCount(2, $fakeWpdb->rows);
+        $this->assertSame('first failure', $fakeWpdb->rows[0]['error']);
+        $this->assertSame('second failure', $fakeWpdb->rows[1]['error']);
+        $this->assertStringContainsString('first@x.com', $fakeWpdb->rows[0]['mail_to']);
+        $this->assertStringContainsString('second@x.com', $fakeWpdb->rows[1]['mail_to']);
+
+        unset($GLOBALS['wpdb']);
+    }
+}

--- a/apps/agent/tests/Email/MailRouterTest.php
+++ b/apps/agent/tests/Email/MailRouterTest.php
@@ -23,6 +23,7 @@ namespace WPMgr\Agent\Tests\Email;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use WP_Error;
 use WPMgr\Agent\Email\AddressParser;
 use WPMgr\Agent\Email\EmailConfig;
 use WPMgr\Agent\Email\MailRouter;
@@ -58,6 +59,138 @@ class MailRouterTest extends TestCase
         $settings       = new Settings();
 
         return new MailRouter($providerRouter, $settings);
+    }
+
+    /**
+     * Build a MailRouter whose ProviderRouter::send() is stubbed to return a
+     * fixed result, and whose EmailConfig::load() sees a configured provider
+     * (so intercept() does not bail out on the "not configured" early return).
+     *
+     * @param array{ok:bool,message_id:string,detail:string} $sendResult
+     */
+    private function routerWithSendResult(array $sendResult): MailRouter
+    {
+        Functions\when('get_option')->justReturn(['provider' => 'smtp']);
+
+        $providerRouter = $this->createMock(ProviderRouter::class);
+        $providerRouter->method('send')->willReturn($sendResult);
+        $settings = new Settings();
+
+        return new MailRouter($providerRouter, $settings);
+    }
+
+    /** @return array<string,mixed> */
+    private function baseAtts(): array
+    {
+        return [
+            'to'      => 'someone@example.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+            'headers' => '',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #439: wp_mail() must report the truth, not a hard-coded `true`.
+    //
+    // pre_wp_mail short-circuits wp_mail() and its return value BECOMES
+    // wp_mail()'s return value verbatim (wp-includes/pluggable.php:
+    // `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`). Only `null`
+    // lets WP fall through to its own PHPMailer path; any other value --
+    // including `false` -- still short-circuits. So `false` is both an
+    // honest failure signal AND still prevents WP from re-attempting the
+    // send through its own PHPMailer.
+    // -------------------------------------------------------------------------
+
+    public function test_failed_send_returns_false_not_true(): void
+    {
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame(false, $result, 'A failed send must make wp_mail() return false, not a truthy placeholder');
+    }
+
+    public function test_failed_send_return_value_still_satisfies_cores_own_short_circuit_condition(): void
+    {
+        // This re-states, verbatim, the exact condition wp_mail() itself uses
+        // in wp-includes/pluggable.php to decide whether to run its own
+        // PHPMailer path: `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`
+        // A failed send must keep satisfying it -- i.e. never fall back to
+        // `null` -- or WordPress will attempt a second, duplicate delivery.
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'provider rejected the message',
+        ]);
+
+        $preWpMail = $router->intercept(null, $this->baseAtts());
+
+        $coreWouldShortCircuit = ( null !== $preWpMail );
+        $this->assertTrue($coreWouldShortCircuit, 'core must still short-circuit on a failed send, or WP retries the send itself and duplicates the email');
+        $this->assertFalse($preWpMail, 'the short-circuited value must be the honest false, not a placeholder true');
+    }
+
+    public function test_failed_send_fires_wp_mail_failed_exactly_once_with_wp_error(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $router->intercept(null, $this->baseAtts());
+
+        $wpMailFailedCalls = array_values(array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'));
+        $this->assertCount(1, $wpMailFailedCalls, 'wp_mail_failed must fire exactly once on a failed send');
+
+        $error = $wpMailFailedCalls[0][1][0] ?? null;
+        $this->assertInstanceOf(WP_Error::class, $error, 'wp_mail_failed must be passed a WP_Error, matching core');
+        $this->assertSame('smtp connect() failed: Connection refused', $error->get_error_message());
+
+        // The error data must not carry the message body or any secret --
+        // only what core itself would attach (recipient/subject/headers/
+        // attachments) plus our own provider failure detail.
+        $data = $error->get_error_data();
+        $this->assertArrayNotHasKey('message', $data, 'wp_mail_failed error data must never carry the message body');
+        $this->assertSame('someone@example.com', $data['to']);
+        $this->assertSame('Subject', $data['subject']);
+    }
+
+    public function test_successful_send_is_unchanged_and_does_not_fire_wp_mail_failed(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $sendResult = [
+            'ok'         => true,
+            'message_id' => 'abc123',
+            'detail'     => '',
+        ];
+        $router = $this->routerWithSendResult($sendResult);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame($sendResult, $result, 'a successful send must return the same value as before this fix');
+        $wpMailFailedCalls = array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed');
+        $this->assertCount(0, $wpMailFailedCalls, 'wp_mail_failed must never fire on a successful send');
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- GH #381 phase 4 of 5. `ProviderRouter::maybe_log()` discarded an already-DETECTED send failure (`ok:false` + computed error string) whenever the site owner turned `log_emails` off, silently defeating phase 1's failure alerting for that tenant.
- `maybe_log()` now returns early only when `log_emails` is false AND the outcome is not a failure (`status !== 'sent'`). `'failed'` and `'suppressed'` are both incidents and are logged regardless of the preference.
- `store_body` is untouched: it stays independently gated inside `EmailLogger::write()`, defaults false, and still means no message body is ever stored and a successful send is still not recorded when logging is off.

## Blast radius checked
Every `maybe_log()` call site lives inside `ProviderRouter::send()` or `send_via()` — the two provider-send entry points (`grep -n "maybe_log(" apps/agent/includes/email/class-provider-router.php`, 9 call sites, statuses only ever `sent`/`failed`/`suppressed`). No retry, queue, or non-send path reaches it.

## Test plan
- [x] New `apps/agent/tests/Email/EmailLogFailureBypassTest.php`, 4 tests:
  - `test_failed_send_is_logged_even_when_log_emails_is_false` — RED before fix (0 rows), GREEN after.
  - `test_successful_send_is_still_not_logged_when_log_emails_is_false` — green before AND after (the control against widening the bypass into "ignore the preference").
  - `test_failed_row_carries_no_message_body_when_store_body_is_false` — RED before fix (0 rows), GREEN after; proves the privacy gate on the newly-widened path.
  - `test_log_emails_true_behaviour_is_unchanged_for_success_and_failure` — over-fire control.
- [x] `composer test` (phpunit): 3208 tests, 0 failures, 0 errors (`php -d memory_limit=512M vendor/bin/phpunit`; the bare 128M default OOMs on an unrelated pre-existing backup-module test, `SqlInspectorTest`, not touched by this change).
- [x] `make agent-check` (phpcs, `--no-cache`): 0 errors, 0 warnings.
- [ ] `make agent-plugincheck` not run for this phase (test+lint only per phase scope); will run before the phase-5 merge.

One phase of five. Not merging — merges only once the whole GH #381 fix works end to end.