### PR TITLE
ci(plugincheck): pin the gate, fix false-positive offloading flag

### DIFF
--- a/apps/agent/includes/email/handlers/class-ses-handler.php
+++ b/apps/agent/includes/email/handlers/class-ses-handler.php
@@ -31,7 +31,7 @@ use WPMgr\Agent\Email\ProviderHandlerInterface;
 final class SesHandler implements ProviderHandlerInterface {
 
 	/** SES endpoint pattern. */
-	private const ENDPOINT = 'https://email.%s.amazonaws.com/';
+	private const ENDPOINT = 'https://email.%s.amazonaws.com/'; // phpcs:ignore PluginCheck.CodeAnalysis.Offloading.OffloadedContent -- not offloaded front-end content; this is the Amazon SES v1 API endpoint used to send outbound email via the site owner's own AWS SigV4-signed credentials. Flagged only because plugin-check 2.1.0's OffloadingSniff now matches "amazonaws.com" unconditionally in any string literal, not just enqueue/markup contexts.
 
 	/** SES service name for SigV4. */
 	private const SERVICE = 'email';

--- a/tools/plugincheck/docker-compose.yml
+++ b/tools/plugincheck/docker-compose.yml
@@ -1,8 +1,16 @@
 # Throwaway WordPress + WP-CLI harness for the AUTHORITATIVE `wp plugin check`.
 # Driven by ../../tools/plugincheck/run.sh (via `make agent-plugincheck`).
+#
+# Images are pinned by digest, not floating tag, so this gate cannot redden a
+# PR on zero code change because upstream repushed `mariadb:11` or
+# `wordpress:cli-php8.3`. To bump deliberately:
+#   docker pull mariadb:11 && docker inspect --format='{{index .RepoDigests 0}}' mariadb:11
+#   docker pull wordpress:cli-php8.3 && docker inspect --format='{{index .RepoDigests 0}}' wordpress:cli-php8.3
+# then paste the new sha256 below and run `make agent-plugincheck` to confirm
+# it still passes before committing the bump.
 services:
   db:
-    image: mariadb:11
+    image: mariadb@sha256:d9f7eb2637296652f24b484afd5d246f759f49f5babcadc6a9e344c9acb75fbf # mariadb:11, pinned 2026-08-17
     environment:
       MARIADB_ROOT_PASSWORD: wp
       MARIADB_DATABASE: wp
@@ -12,7 +20,7 @@ services:
       timeout: 5s
       retries: 40
   wpcli:
-    image: wordpress:cli-php8.3
+    image: wordpress@sha256:2b5e9d4d3e51909dca1aaa4732e9f5e5bf0377c2114dbd8ff39f060bff202586 # wordpress:cli-php8.3, pinned 2026-08-17
     depends_on:
       db:
         condition: service_healthy

--- a/tools/plugincheck/run.sh
+++ b/tools/plugincheck/run.sh
@@ -46,7 +46,13 @@ WP core download --force
 WP config create --dbname=wp --dbuser=root --dbpass=wp --dbhost=db --force
 WP core install --url=http://localhost --title=pc \
   --admin_user=admin --admin_password=admin --admin_email=a@b.test --skip-email
-WP plugin install plugin-check --activate
+# Pinned: an unpinned install pulls whatever plugin-check released today, so a
+# gate on unchanged code can redden a PR because the linter's opinion changed,
+# not because the plugin did. That happened on 2026-08-17 when 2.1.0 shipped a
+# new sniff rule with zero agent code change in between. To bump deliberately,
+# change the version below, run `make agent-plugincheck` locally, and read the
+# diff in ERROR rows before committing.
+WP plugin install plugin-check --version=2.1.0 --activate
 WP plugin install /tmp/plugin.zip --force
 
 echo "==================== wp plugin check: $SLUG ===================="


### PR DESCRIPTION
## Summary

`.github/workflows/plugincheck.yml` went red on PR #440 and #442 with zero
agent code change. Root cause: `tools/plugincheck/run.sh` ran
`wp plugin install plugin-check --activate`, unpinned, so every gate run
installed whatever WordPress.org's plugin-check plugin currently ships.
plugin-check `2.1.0` (published 2026-08-16, confirmed via the
`WordPress/plugin-check` GitHub tags) added a new unconditional first-pass
check to `OffloadingSniff` that regex-matches every PHP string literal
against a list of "known offloading services" — a list that includes a bare,
unscoped `amazonaws\.com`. Diffing the sniff source between tags `2.0.0` and
`2.1.0` confirms this check did not exist before 2.1.0. It flagged
`apps/agent/includes/email/handlers/class-ses-handler.php:34`, the Amazon SES
v1 API endpoint constant, last touched in commit `3f8e576` (release 0.35.0).

**Finding, decided on the merits:** false positive, not a real wp.org policy
issue. That line is not offloaded front-end content (images/js/css served
from a remote CDN instead of bundled with the plugin, which is what this
sniff and the wp.org guideline it enforces exist to catch) — it's an outbound
API call to the site owner's own AWS SES account. Two sibling entries in the
same known-services list already carry negative-lookbehind carve-outs for
their own API subdomains (`(?<!api\.)cloudflare\.com`,
`(?<!fonts\.)gstatic\.com`), showing upstream recognizes the API-vs-CDN-asset
distinction for other providers but hasn't extended it to `amazonaws.com`,
which is used for both S3/CloudFront asset hosting and unrelated pure-API
services (SES, SQS, DynamoDB, Lambda).

## What changed

- `tools/plugincheck/run.sh`: pin `wp plugin install plugin-check` to
  `--version=2.1.0` (the current release; not rolled back — 2.1.0's other
  behavior is fine, only this one line needed handling), with a comment on
  how to bump it deliberately.
- `tools/plugincheck/docker-compose.yml`: pin `mariadb:11` and
  `wordpress:cli-php8.3` by digest, with a comment on how to re-resolve and
  bump them.
- `apps/agent/includes/email/handlers/class-ses-handler.php`: narrowest
  possible fix — a single-line `// phpcs:ignore
  PluginCheck.CodeAnalysis.Offloading.OffloadedContent` on line 34 only, with
  an inline comment stating why. The `Offloading` category is untouched
  everywhere else; no blanket exclude-pattern was added.

## Test plan

- [x] Built the wp.org zip and ran `make agent-plugincheck` locally
      (plugin-check 2.1.0, pinned images) against the fixed tree: **0
      errors**, only pre-existing WARNING rows unrelated to this change.
- [x] Planted a genuine offloading violation (a CDN script URL string in a
      scratch file under `apps/agent/includes/`) and reran the gate: it went
      **red**, one `ERROR` row on
      `PluginCheck.CodeAnalysis.Offloading.OffloadedContent`, `run.sh` exit
      code `1`. Proves the `Offloading` category still fires.
- [x] Removed the scratch file, reran the gate: back to **green**, exit code
      `0`, 0 errors. Proves the fix isn't a blanket disable.