### PR TITLE
fix(email): detect and alert on delivery failures WPMgr does not route (GH #381, #439)

### DIFF
--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -103,6 +103,7 @@ use WPMgr\Agent\Email\Handlers\PostmarkHandler;
 use WPMgr\Agent\Email\Handlers\SendgridHandler;
 use WPMgr\Agent\Email\Handlers\SesHandler;
 use WPMgr\Agent\Email\Handlers\SmtpHandler;
+use WPMgr\Agent\Email\MailFailureCapture;
 use WPMgr\Agent\Email\MailRouter;
 use WPMgr\Agent\Email\ProviderRouter;
 use WPMgr\Agent\Email\SuppressionCache;
@@ -335,6 +336,15 @@ final class Plugin
     private MailRouter $mailRouter;
 
     /**
+     * Unconditional listener on core's own `wp_mail_failed` action (GH #381
+     * phase 1). MailRouter only sees a failure on sites where a WPMgr
+     * provider is configured; this listener registers regardless of
+     * EmailConfig, so a failed send is captured even on sites WPMgr never
+     * routes (core PHPMailer, or a third-party SMTP plugin).
+     */
+    private MailFailureCapture $mailFailureCapture;
+
+    /**
      * Provider-level send dispatcher. Instantiated with all five v1 handlers
      * (smtp/ses/sendgrid/mailgun/postmark) and shared by MailRouter +
      * SendTestEmailCommand.
@@ -503,6 +513,7 @@ final class Plugin
         $this->providerRouter->register(new MailgunHandler());
         $this->providerRouter->register(new PostmarkHandler());
         $this->mailRouter        = new MailRouter($this->providerRouter, $this->settings);
+        $this->mailFailureCapture = new MailFailureCapture($emailLogger);
         $this->emailLogReporter  = new EmailLogReporter($this->settings, $this->signer);
 
         $this->router              = new Router($this->connector, $this->commands());
@@ -1022,6 +1033,11 @@ final class Plugin
         // The filter is non-destructive: when no email config is stored it
         // returns null immediately, leaving the default WP mail path untouched.
         $this->mailRouter->register_hooks();
+
+        // GH #381 phase 1 — unconditional wp_mail_failed listener. Unlike
+        // mailRouter above, this registration is NOT gated behind email
+        // config: it must see failures on sites WPMgr never routes.
+        $this->mailFailureCapture->register_hooks();
 
         // Email log retention pruner — runs daily via wp-cron.
         add_action(EmailLogger::HOOK_PRUNE, [$this, 'pruneEmailLog']);

--- a/apps/agent/includes/email/class-address-parser.php
+++ b/apps/agent/includes/email/class-address-parser.php
@@ -348,9 +348,9 @@ final class AddressParser {
 	}
 
 	/**
-	 * Redact any RFC 5322-shaped email address embedded inside a free-text
-	 * string, replacing each match with a fixed placeholder and leaving the
-	 * surrounding text untouched.
+	 * Redact any email address embedded inside a free-text string, replacing
+	 * each match with a fixed placeholder and leaving the surrounding text
+	 * untouched.
 	 *
 	 * GH #381 phases 1 and 4 (security-reviewer finding): a real
 	 * PHPMailer/SMTP failure message routinely embeds the recipient address
@@ -363,20 +363,96 @@ final class AddressParser {
 	 * this removes only the address-shaped substring and keeps everything
 	 * else.
 	 *
-	 * Deliberately not anchored to a specific known `to` list: a provider
-	 * response can echo back a re-cased/normalised address, or one that was
-	 * never in the `to` array (a bounce target, a Cc/Bcc), so this scans for
-	 * anything address-shaped rather than trusting a caller-supplied
-	 * allow-list of addresses to redact.
+	 * GH #381 phase 2, second review round: a plain ASCII-only regex is
+	 * weakest on exactly the inputs this path emits, because PHPMailer's
+	 * "Invalid address" errors fire BECAUSE the address failed that same
+	 * validation -- a raw IDN domain, a quoted local part, an IP-literal or
+	 * bare-IP domain, a 1-char/numeric TLD, or a non-ASCII local part all
+	 * survived the old regex untouched (the non-ASCII case left a partial
+	 * leak: only the tail from the first ASCII byte on was matched). So this
+	 * is now two stages:
 	 *
-	 * @param string $text Free-text error or provider-response string.
+	 * 1. Remove every address in $known_addresses literally (case-
+	 *    insensitively), plus its percent-encoded and base64-encoded forms,
+	 *    plus a variant tolerant of whitespace/a line break inserted around
+	 *    the '@'. This is a substring match, not a parse, so it catches any
+	 *    format the regex below cannot recognise -- the caller already knows
+	 *    the real recipient list (it is what it is about to blank from
+	 *    `to`), so there is no format the address needs to be "shaped" like.
+	 * 2. Run the Unicode-aware regex net for anything NOT already known: a
+	 *    provider can echo back a re-cased/normalised address, or one that
+	 *    was never in `to` (a bounce target, a Cc/Bcc), so this still scans
+	 *    for anything address-shaped rather than trusting the allow-list
+	 *    alone. Widened from the original ASCII-only class to \p{L}/\p{N} so
+	 *    an unknown non-ASCII local part is removed whole instead of leaving
+	 *    its leading bytes behind.
+	 *
+	 * Deliberately does not attempt to recognise a bare spaced/base64/
+	 * percent-encoded address that is NOT in $known_addresses: real
+	 * PHPMailer/SMTP output never obfuscates an address that way, and a
+	 * regex broad enough to catch it in free text would false-positive on
+	 * ordinary tokens (version strings, hashes) that are not addresses at
+	 * all.
+	 *
+	 * @param string                  $text            Free-text error or provider-response string.
+	 * @param array<int,string|mixed> $known_addresses Raw recipient header values the caller already
+	 *                                                  holds (e.g. the `to` array before it is blanked).
+	 *                                                  Non-string entries are ignored; each entry may
+	 *                                                  itself be a "Name <addr>" form or a bare address.
 	 * @return string
 	 */
-	public static function redact_email_addresses( string $text ): string {
+	public static function redact_email_addresses( string $text, array $known_addresses = array() ): string {
 		if ( $text === '' ) {
 			return $text;
 		}
-		$redacted = preg_replace( '/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/', '[address removed]', $text );
+
+		foreach ( $known_addresses as $entry ) {
+			if ( ! is_string( $entry ) || trim( $entry ) === '' ) {
+				continue;
+			}
+
+			// The raw entry itself (bare address, or an already-unparseable
+			// form such as a raw IDN domain that AddressParser refuses to
+			// parse and passes through untouched) is always a candidate...
+			$candidates = array( trim( $entry ) );
+			// ...and so is every address parse_list() manages to extract
+			// from it (handles "Name <addr>" and comma/semicolon lists).
+			foreach ( self::parse_list( $entry ) as $parsed ) {
+				if ( $parsed['address'] !== '' ) {
+					$candidates[] = $parsed['address'];
+				}
+			}
+
+			foreach ( array_unique( $candidates ) as $addr ) {
+				if ( $addr === '' ) {
+					continue;
+				}
+
+				$text = str_ireplace( $addr, '[address removed]', $text );
+				$text = str_ireplace( rawurlencode( $addr ), '[address removed]', $text );
+				$text = str_replace( base64_encode( $addr ), '[address removed]', $text );
+
+				$at = strpos( $addr, '@' );
+				if ( false === $at ) {
+					continue;
+				}
+				$local  = substr( $addr, 0, $at );
+				$domain = substr( $addr, $at + 1 );
+				if ( $local === '' || $domain === '' ) {
+					continue;
+				}
+				$spaced = preg_replace(
+					'/' . preg_quote( $local, '/' ) . '\s*@\s*' . preg_quote( $domain, '/' ) . '/iu',
+					'[address removed]',
+					$text
+				);
+				if ( null !== $spaced ) {
+					$text = $spaced;
+				}
+			}
+		}
+
+		$redacted = preg_replace( '/[\p{L}\p{N}._%+-]+@[\p{L}\p{N}.-]+\.[\p{L}]{2,}/u', '[address removed]', $text );
 		return $redacted === null ? $text : $redacted;
 	}
 }

--- a/apps/agent/includes/email/class-address-parser.php
+++ b/apps/agent/includes/email/class-address-parser.php
@@ -346,4 +346,37 @@ final class AddressParser {
 	private static function strip_crlf( string $value ): string {
 		return trim( str_replace( array( "\r", "\n" ), '', $value ) );
 	}
+
+	/**
+	 * Redact any RFC 5322-shaped email address embedded inside a free-text
+	 * string, replacing each match with a fixed placeholder and leaving the
+	 * surrounding text untouched.
+	 *
+	 * GH #381 phases 1 and 4 (security-reviewer finding): a real
+	 * PHPMailer/SMTP failure message routinely embeds the recipient address
+	 * verbatim -- e.g. "SMTP Error: The following recipients failed:
+	 * a@x.com: 550 5.1.1 User unknown" -- so emptying the `to` column alone
+	 * does not stop the address leaving the site through the `error` (or
+	 * `response`) column when log_emails is off. A blanket empty-string on
+	 * the whole error would also destroy the one part an operator actually
+	 * needs to diagnose the failure (the "550 5.1.1 User unknown" part), so
+	 * this removes only the address-shaped substring and keeps everything
+	 * else.
+	 *
+	 * Deliberately not anchored to a specific known `to` list: a provider
+	 * response can echo back a re-cased/normalised address, or one that was
+	 * never in the `to` array (a bounce target, a Cc/Bcc), so this scans for
+	 * anything address-shaped rather than trusting a caller-supplied
+	 * allow-list of addresses to redact.
+	 *
+	 * @param string $text Free-text error or provider-response string.
+	 * @return string
+	 */
+	public static function redact_email_addresses( string $text ): string {
+		if ( $text === '' ) {
+			return $text;
+		}
+		$redacted = preg_replace( '/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/', '[address removed]', $text );
+		return $redacted === null ? $text : $redacted;
+	}
 }

--- a/apps/agent/includes/email/class-mail-failure-capture.php
+++ b/apps/agent/includes/email/class-mail-failure-capture.php
@@ -167,10 +167,18 @@ final class MailFailureCapture {
 		// verbatim -- e.g. "Invalid address:  (to): a@x.com" -- so the
 		// address must also be scrubbed out of the error text itself, or it
 		// leaves the site through the `error` column instead.
+		//
+		// FINDING (security review, GH #381 phase 2): a bare address-shaped
+		// regex is not enough either -- pass the real recipient list to
+		// redact_email_addresses() BEFORE it is blanked below, so a
+		// malformed-but-real address (IDN domain, quoted local part,
+		// IP-literal domain, ...) is removed as a literal string rather than
+		// relying on the regex to recognise its shape.
 		if ( ! $cfg->log_emails ) {
-			$to            = array();
-			$subject       = '';
-			$error_message = AddressParser::redact_email_addresses( $error_message );
+			$known_addresses = is_array( $to ) ? $to : array( $to );
+			$to              = array();
+			$subject         = '';
+			$error_message   = AddressParser::redact_email_addresses( $error_message, $known_addresses );
 		}
 
 		// Only `to` and `subject` -- never the message body, under any key,

--- a/apps/agent/includes/email/class-mail-failure-capture.php
+++ b/apps/agent/includes/email/class-mail-failure-capture.php
@@ -31,13 +31,18 @@
  * population it exists for. Instead:
  *   - A row is ALWAYS written on a genuine (non-double-logged) failure:
  *     site, timestamp, provider='wp_mail', status='failed', the error
- *     string. None of that is personal data, and it is what the alert needs
- *     to exist at all.
+ *     string. It is what the alert needs to exist at all.
  *   - The recipient address and subject line are included in that row ONLY
  *     when EmailConfig::load()->log_emails is true. When it is false, `to`
  *     and `subject` are written empty/redacted -- never the real values --
  *     so opting out still means something even though the row itself
- *     exists.
+ *     exists. The error string is ALSO scrubbed of any embedded
+ *     address-shaped substring in that case (AddressParser::redact_email_addresses()):
+ *     a real PHPMailer/SMTP failure routinely echoes the recipient back
+ *     inside the message text itself (e.g. "Invalid address:  (to):
+ *     a@x.com"), so redacting only the `to` column is not sufficient --
+ *     see class-address-parser.php for why this is a substring scrub, not
+ *     a whole-string wipe.
  * This is deliberately NOT the same gate ProviderRouter::maybe_log() applies
  * (that one skips the write entirely); the two differ on purpose and must
  * not be unified.
@@ -154,9 +159,18 @@ final class MailFailureCapture {
 		// opted into email logging. The row is still written either way, so
 		// the alert exists, but no real recipient address or subject line
 		// leaves the site without log_emails being on.
+		//
+		// FINDING A (security review, GH #381 phase 1): emptying `to` and
+		// `subject` is not enough. Core passes PHPMailer's getMessage() (or
+		// the SMTP server's own recipients_failed detail) straight into
+		// $error_message, and that string routinely embeds the address
+		// verbatim -- e.g. "Invalid address:  (to): a@x.com" -- so the
+		// address must also be scrubbed out of the error text itself, or it
+		// leaves the site through the `error` column instead.
 		if ( ! $cfg->log_emails ) {
-			$to      = array();
-			$subject = '';
+			$to            = array();
+			$subject       = '';
+			$error_message = AddressParser::redact_email_addresses( $error_message );
 		}
 
 		// Only `to` and `subject` -- never the message body, under any key,

--- a/apps/agent/includes/email/class-mail-failure-capture.php
+++ b/apps/agent/includes/email/class-mail-failure-capture.php
@@ -23,10 +23,37 @@
  * presence as "already logged by the router path" and returns without
  * writing a second row.
  *
- * Body is never persisted: the $mail array built here carries only `to` and
- * `subject`, never `message`/`body_html`/`body_text`, so EmailLogger::write()
- * has nothing to read into the `body` column regardless of the site's
- * store_body setting.
+ * Consent governs WHAT is written, never WHETHER a row is written. Phase 1
+ * exists specifically to capture failures on sites WPMgr does not route mail
+ * for -- those sites are unconfigured by definition, so EmailConfig::$log_emails
+ * is false on every one of them (it defaults false). Gating the write itself
+ * on log_emails would mean this feature writes nothing on exactly the
+ * population it exists for. Instead:
+ *   - A row is ALWAYS written on a genuine (non-double-logged) failure:
+ *     site, timestamp, provider='wp_mail', status='failed', the error
+ *     string. None of that is personal data, and it is what the alert needs
+ *     to exist at all.
+ *   - The recipient address and subject line are included in that row ONLY
+ *     when EmailConfig::load()->log_emails is true. When it is false, `to`
+ *     and `subject` are written empty/redacted -- never the real values --
+ *     so opting out still means something even though the row itself
+ *     exists.
+ * This is deliberately NOT the same gate ProviderRouter::maybe_log() applies
+ * (that one skips the write entirely); the two differ on purpose and must
+ * not be unified.
+ *
+ * Body is never persisted, unconditionally, regardless of log_emails or
+ * store_body: the $mail array built here carries only `to` and `subject`,
+ * never `message`/`body_html`/`body_text`, so EmailLogger::write() has
+ * nothing to read into the `body` column.
+ *
+ * Defensive input handling: this class exists specifically to capture
+ * failures from mailers WPMgr does not control, so `to`/`subject` in the
+ * error data are validated defensively (never trusted to be well-typed) and
+ * the write itself is wrapped in a try/catch -- an unenumerable malformed
+ * shape from a third-party filter chain must never escape capture() and
+ * fatal the request that triggered the mail send (checkout, password reset,
+ * etc). Dropping the log write is strictly better than a fatal there.
  *
  * @package WPMgr\Agent\Email
  */
@@ -55,7 +82,9 @@ final class MailFailureCapture {
 	 * UNCONDITIONAL: this registration is not gated behind
 	 * EmailConfig::is_configured() or any other config check. That is the
 	 * entire point -- it must fire on sites with no provider configured, so
-	 * WPMgr sees a failure even when it never routed the send.
+	 * WPMgr sees a failure even when it never routed the send. log_emails
+	 * governs what capture() puts IN the row, never whether the row exists;
+	 * see the class docblock.
 	 *
 	 * @return void
 	 */
@@ -90,18 +119,62 @@ final class MailFailureCapture {
 			return;
 		}
 
+		$cfg = EmailConfig::load();
+
 		$error_message = $error->get_error_message();
 		if ( $error_message === '' ) {
 			$error_message = 'wp_mail_failed';
 		}
 
+		// -- Defensive `to` handling -------------------------------------
+		// Core always sends an array of strings, but a third-party filter
+		// further down the wp_mail_failed chain could hand us anything.
+		// An array containing a non-string element (e.g. an object) would
+		// fatal EmailLogger::write()'s implode(); filter those out. A bare
+		// string is passed through as-is (EmailLogger casts it safely). Any
+		// other shape (object, int, etc. as the whole `to` value) falls back
+		// to an empty array rather than risk a fatal on cast.
+		$to_raw = ( is_array( $data ) && isset( $data['to'] ) ) ? $data['to'] : array();
+		if ( is_array( $to_raw ) ) {
+			$to = array_values( array_filter( $to_raw, 'is_string' ) );
+		} elseif ( is_string( $to_raw ) ) {
+			$to = $to_raw;
+		} else {
+			$to = array();
+		}
+
+		// -- Defensive `subject` handling ---------------------------------
+		// (string) on a non-scalar (e.g. an object with no __toString) would
+		// also fatal; only cast when the value is safely castable.
+		$subject_raw = ( is_array( $data ) && isset( $data['subject'] ) ) ? $data['subject'] : '';
+		$subject     = is_scalar( $subject_raw ) ? (string) $subject_raw : '';
+
+		// Consent governs WHAT is written, not WHETHER (see class docblock):
+		// redact the recipient and subject to empty when the site has not
+		// opted into email logging. The row is still written either way, so
+		// the alert exists, but no real recipient address or subject line
+		// leaves the site without log_emails being on.
+		if ( ! $cfg->log_emails ) {
+			$to      = array();
+			$subject = '';
+		}
+
 		// Only `to` and `subject` -- never the message body, under any key,
 		// regardless of the site's store_body setting (see class docblock).
 		$mail = array(
-			'to'      => ( is_array( $data ) && isset( $data['to'] ) ) ? $data['to'] : array(),
-			'subject' => ( is_array( $data ) && isset( $data['subject'] ) ) ? (string) $data['subject'] : '',
+			'to'      => $to,
+			'subject' => $subject,
 		);
 
-		$this->logger->write( $mail, 'wp_mail', 'failed', '', $error_message, '', 0, EmailConfig::load(), '' );
+		// Belt-and-suspenders: a malformed shape this validation didn't
+		// anticipate must still never escape capture() and fatal the
+		// request that triggered the mail send. Dropping the log write is
+		// strictly better than a WSOD on checkout / password reset / etc.
+		try {
+			$this->logger->write( $mail, 'wp_mail', 'failed', '', $error_message, '', 0, $cfg, '' );
+		} catch ( \Throwable $e ) {
+			// Intentionally swallowed -- see comment above.
+			unset( $e );
+		}
 	}
 }

--- a/apps/agent/includes/email/class-mail-failure-capture.php
+++ b/apps/agent/includes/email/class-mail-failure-capture.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * MailFailureCapture: hooks WordPress core's own `wp_mail_failed` action so a
+ * failed send is logged even on sites WPMgr does not route.
+ *
+ * MailRouter::intercept() (class-mail-router.php) only sees a failure on
+ * sites where EmailConfig::is_configured() is true -- when no provider is
+ * configured it returns null immediately and never touches the send. On a
+ * site sending through core PHPMailer, or through a third-party SMTP plugin
+ * that never defers to WPMgr, that leaves WPMgr blind to every failure. Core
+ * itself fires `wp_mail_failed` with a WP_Error on ANY failed send,
+ * configured or not (wp-includes/pluggable.php), so this class listens there
+ * unconditionally -- independent of EmailConfig -- and is the only path that
+ * covers the unrouted case.
+ *
+ * No-double-log guard: when MailRouter's OWN provider send fails, it already
+ * (a) logs the row itself via ProviderRouter::send() -> EmailLogger::write(),
+ * and (b) fires `wp_mail_failed` itself (see class-mail-router.php,
+ * intercept()) with error_data carrying a `wpmgr_provider_detail` key. That
+ * key is unique to MailRouter's own fire -- core's native wp_mail_failed data
+ * (to, subject, message, headers, attachments, optionally
+ * phpmailer_exception_code) never carries it. So capture() treats that key's
+ * presence as "already logged by the router path" and returns without
+ * writing a second row.
+ *
+ * Body is never persisted: the $mail array built here carries only `to` and
+ * `subject`, never `message`/`body_html`/`body_text`, so EmailLogger::write()
+ * has nothing to read into the `body` column regardless of the site's
+ * store_body setting.
+ *
+ * @package WPMgr\Agent\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Email;
+
+/**
+ * Captures core's wp_mail_failed action for sites WPMgr does not route.
+ */
+final class MailFailureCapture {
+
+	private EmailLogger $logger;
+
+	/**
+	 * @param EmailLogger $logger Local send-event logger.
+	 */
+	public function __construct( EmailLogger $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Register hooks. Called from Plugin::registerHooks().
+	 *
+	 * UNCONDITIONAL: this registration is not gated behind
+	 * EmailConfig::is_configured() or any other config check. That is the
+	 * entire point -- it must fire on sites with no provider configured, so
+	 * WPMgr sees a failure even when it never routed the send.
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- listening on core's own wp_mail_failed hook, not registering a global
+		add_action( 'wp_mail_failed', array( $this, 'capture' ) );
+	}
+
+	/**
+	 * `wp_mail_failed` action handler.
+	 *
+	 * WordPress core always passes a WP_Error, but the hook is typed mixed
+	 * here (and guarded with instanceof) because a badly-behaved third-party
+	 * filter chain could in theory pass something else through; core itself
+	 * never does.
+	 *
+	 * @param mixed $error Expected WP_Error from core or MailRouter.
+	 * @return void
+	 */
+	public function capture( $error ): void {
+		if ( ! ( $error instanceof \WP_Error ) ) {
+			return;
+		}
+
+		$data = $error->get_error_data();
+
+		// MailRouter already logged this failure itself (see class docblock);
+		// the wpmgr_provider_detail key only ever appears on a WP_Error that
+		// MailRouter fired, never on core's own native wp_mail_failed data.
+		// Logging again here would double-count the same send.
+		if ( is_array( $data ) && array_key_exists( 'wpmgr_provider_detail', $data ) ) {
+			return;
+		}
+
+		$error_message = $error->get_error_message();
+		if ( $error_message === '' ) {
+			$error_message = 'wp_mail_failed';
+		}
+
+		// Only `to` and `subject` -- never the message body, under any key,
+		// regardless of the site's store_body setting (see class docblock).
+		$mail = array(
+			'to'      => ( is_array( $data ) && isset( $data['to'] ) ) ? $data['to'] : array(),
+			'subject' => ( is_array( $data ) && isset( $data['subject'] ) ) ? (string) $data['subject'] : '',
+		);
+
+		$this->logger->write( $mail, 'wp_mail', 'failed', '', $error_message, '', 0, EmailConfig::load(), '' );
+	}
+}

--- a/apps/agent/includes/email/class-mail-router.php
+++ b/apps/agent/includes/email/class-mail-router.php
@@ -19,6 +19,10 @@
  * The X-WPMgr-Site correlation header is stamped on every outgoing message for
  * the Phase-4 CP webhook fan-out.
  *
+ * wp_mail()'s return value is honest: a provider failure makes wp_mail()
+ * return false (never a lie of true) and fires `wp_mail_failed` with a
+ * WP_Error, same as core would on its own send failure. See intercept().
+ *
  * @package WPMgr\Agent\Email
  */
 
@@ -53,10 +57,14 @@ final class MailRouter {
 	 */
 	public function register_hooks(): void {
 		// pre_wp_mail is the primary interception point (WP 5.7+, our baseline).
-		// Returning a non-null value from this filter short-circuits wp_mail()
-		// entirely. We return the result array on success, true on failure (so WP
-		// does NOT fall through to its own PHPMailer path for a message we already
-		// attempted), and null when email is not configured (leaves WP untouched).
+		// Per wp-includes/pluggable.php, wp_mail() only lets WP's own PHPMailer
+		// path run when this filter returns exactly `null`; ANY other value --
+		// including `false` -- short-circuits and becomes wp_mail()'s own return
+		// value verbatim. So we return the result array on success, false on
+		// failure (still short-circuits, so WP never re-attempts a send we
+		// already made -- but wp_mail() now honestly reports the failure instead
+		// of claiming success), and null when email is not configured (leaves
+		// WP untouched).
 		add_filter( 'pre_wp_mail', array( $this, 'intercept' ), 10, 2 );
 	}
 
@@ -84,10 +92,36 @@ final class MailRouter {
 
 		$result = $this->router->send( $mail, $cfg );
 
-		// Return true (truthy non-null) to short-circuit wp_mail() regardless of
-		// the provider outcome; WP's return value from wp_mail() is a bool and we
-		// have already logged the failure via EmailLogger if it occurred.
-		return $result['ok'] ? $result : true;
+		if ( $result['ok'] ) {
+			// Success: unchanged from before -- the provider result array is a
+			// non-null, truthy value, so it short-circuits wp_mail() and becomes
+			// its return value.
+			return $result;
+		}
+
+		// Failure: `false` still short-circuits wp_mail() (see register_hooks()
+		// above) so WP does NOT fall through to its own PHPMailer for a message
+		// we already attempted -- but wp_mail()'s return value is now the
+		// honest `false` instead of a lie. Fire wp_mail_failed ourselves since
+		// short-circuiting skips WP's own call to it entirely, matching the
+		// WP_Error shape core's own failure paths use (code 'wp_mail_failed',
+		// the failure message, and the mail args minus body/secrets) so
+		// existing listeners on that hook keep working.
+		$error_message = $result['detail'] !== '' ? $result['detail'] : 'WPMgr: mail send failed.';
+
+		$error_data = array(
+			'to'                    => $atts['to'] ?? array(),
+			'subject'               => (string) ( $atts['subject'] ?? '' ),
+			'headers'               => $atts['headers'] ?? array(),
+			'attachments'           => $atts['attachments'] ?? array(),
+			// Provider-side failure detail; never credentials or the message body.
+			'wpmgr_provider_detail' => $error_message,
+		);
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- firing core's own wp_mail_failed hook, not registering a global
+		do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', $error_message, $error_data ) );
+
+		return false;
 	}
 
 	/**

--- a/apps/agent/includes/email/class-mail-router.php
+++ b/apps/agent/includes/email/class-mail-router.php
@@ -23,6 +23,19 @@
  * return false (never a lie of true) and fires `wp_mail_failed` with a
  * WP_Error, same as core would on its own send failure. See intercept().
  *
+ * A SECOND `pre_wp_mail` filter is registered at PHP_INT_MAX (see
+ * reassert_failed_short_circuit()). Filters on this hook run in priority
+ * order and each one receives the PREVIOUS filter's return value, so a
+ * later filter can turn our honest `false` back into `null` -- an ordinary
+ * idiom like `if ( ! $return ) { return null; }` does exactly that, since
+ * `false` and `null` are both falsy. `null` is the ONE value that makes
+ * wp_mail() fall through to its own PHPMailer, so that ordinary idiom would
+ * make WordPress send a message WPMgr already attempted and knows failed --
+ * a silent duplicate delivery. The low-priority filter re-asserts `false`
+ * only when it can prove WPMgr itself attempted and failed THIS dispatch
+ * and the value has been reset to exactly `null`; any other non-null value
+ * means some other plugin has legitimately taken over, and is left alone.
+ *
  * @package WPMgr\Agent\Email
  */
 
@@ -40,6 +53,32 @@ final class MailRouter {
 	private ProviderRouter $router;
 
 	private Settings $settings;
+
+	/**
+	 * LIFO stack, one entry pushed per `pre_wp_mail` dispatch that reaches
+	 * intercept() (i.e. every call: intercept() pushes unconditionally on
+	 * entry), true only when THIS dispatch attempted a send and it failed.
+	 * reassert_failed_short_circuit() pops exactly one entry per dispatch.
+	 * A stack (not a single flag) is required because a `wp_mail_failed`
+	 * listener that itself calls wp_mail() re-enters intercept() BEFORE the
+	 * outer dispatch's own reassert filter has run; nested pre_wp_mail
+	 * dispatches always fully resolve -- both filters -- before an outer one
+	 * resumes, so push/pop stay correctly paired (LIFO) across recursion.
+	 *
+	 * @var array<int,bool>
+	 */
+	private array $attemptFailed = array();
+
+	/**
+	 * True for the duration of OUR OWN do_action( 'wp_mail_failed', ... )
+	 * call inside intercept()'s failure branch. Guards against unbounded
+	 * recursion: a listener on that hook which itself calls wp_mail() (a
+	 * typical failure-alerting plugin) would otherwise re-enter intercept()
+	 * forever whenever the alert send also fails. See intercept().
+	 *
+	 * @var bool
+	 */
+	private bool $firingFailureNotice = false;
 
 	/**
 	 * @param ProviderRouter $router   Resolved provider dispatcher.
@@ -66,6 +105,13 @@ final class MailRouter {
 		// of claiming success), and null when email is not configured (leaves
 		// WP untouched).
 		add_filter( 'pre_wp_mail', array( $this, 'intercept' ), 10, 2 );
+
+		// Second filter, at the lowest possible priority so it runs LAST: a
+		// later filter at ordinary priority can legitimately (if accidentally)
+		// reset our `false` back to `null` -- see the class docblock. This one
+		// re-asserts `false` only when WPMgr itself attempted THIS dispatch and
+		// it failed, and only when the value it now sees is exactly `null`.
+		add_filter( 'pre_wp_mail', array( $this, 'reassert_failed_short_circuit' ), PHP_INT_MAX, 2 );
 	}
 
 	/**
@@ -77,9 +123,33 @@ final class MailRouter {
 	 * @return mixed Null to let WP handle it; a value to short-circuit.
 	 */
 	public function intercept( $return, array $atts ) {
+		// Push a placeholder for THIS dispatch before anything else, so
+		// reassert_failed_short_circuit() -- which always runs after this
+		// method for the same dispatch, even across a recursive wp_mail()
+		// call triggered below -- can pop the matching entry. See the
+		// $attemptFailed docblock for why a stack, not a single flag.
+		$this->attemptFailed[] = false;
+		$stack_index           = array_key_last( $this->attemptFailed );
+
 		// If another filter already short-circuited us, honour it.
 		if ( $return !== null ) {
 			return $return;
+		}
+
+		// REGRESSION E2 guard: refuse a nested send while we are already
+		// inside firing OUR OWN wp_mail_failed for an earlier failure in
+		// this call stack. Without this, a wp_mail_failed listener that
+		// itself calls wp_mail() (a typical failure-alerting plugin)
+		// recurses without bound whenever the alert send also fails --
+		// reproduced by the adversarial review to depth 2001. Reporting an
+		// immediate, un-attempted `false` here is deliberate: it is the only
+		// response that terminates the cycle, because it neither hits the
+		// provider again nor re-fires the hook that caused the recursion.
+		if ( $this->firingFailureNotice ) {
+			$this->attemptFailed[ $stack_index ] = true;
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- gated diagnostic channel (DebugLog only writes under WP_DEBUG_LOG or WPMGR_DEBUG); never fires wp_mail_failed again so this branch cannot itself recurse
+			\WPMgr\Agent\Support\DebugLog::write( 'WPMgr Mail: refused a re-entrant wp_mail() call received while already handling a failed send, to avoid unbounded recursion.' );
+			return false;
 		}
 
 		$cfg = EmailConfig::load();
@@ -105,23 +175,117 @@ final class MailRouter {
 		// honest `false` instead of a lie. Fire wp_mail_failed ourselves since
 		// short-circuiting skips WP's own call to it entirely, matching the
 		// WP_Error shape core's own failure paths use (code 'wp_mail_failed',
-		// the failure message, and the mail args minus body/secrets) so
-		// existing listeners on that hook keep working.
+		// the failure message, and the mail args) so existing listeners on
+		// that hook keep working.
+		$this->attemptFailed[ $stack_index ] = true;
+
 		$error_message = $result['detail'] !== '' ? $result['detail'] : 'WPMgr: mail send failed.';
 
 		$error_data = array(
-			'to'                    => $atts['to'] ?? array(),
-			'subject'               => (string) ( $atts['subject'] ?? '' ),
-			'headers'               => $atts['headers'] ?? array(),
-			'attachments'           => $atts['attachments'] ?? array(),
-			// Provider-side failure detail; never credentials or the message body.
+			'to'          => $atts['to'] ?? array(),
+			'subject'     => (string) ( $atts['subject'] ?? '' ),
+			// Same raw headers a listener would see from core's own native
+			// wp_mail_failed, except the VALUE of a Bcc or an auth/token/
+			// key/secret/password-shaped header NAME is redacted -- see
+			// redact_sensitive_headers(). FINDING C: this hook now fires on
+			// every WPMgr-routed failure, which it never did before GH #439
+			// made a failed send honest, so a header the site set for its
+			// own delivery (a Bcc archive address, a bearer token some site
+			// code adds) would otherwise reach every OTHER plugin subscribed
+			// to this hook on a site where nothing reached them before.
+			'headers'     => $this->redact_sensitive_headers( $mail['headers'] ),
+			'attachments' => $atts['attachments'] ?? array(),
+			// Provider-side failure detail. Never the message body -- $mail
+			// carries body_text/body_html but neither is read here -- and
+			// never a raw credential: this is a provider-defined error
+			// string, not header or body content.
 			'wpmgr_provider_detail' => $error_message,
 		);
 
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- firing core's own wp_mail_failed hook, not registering a global
-		do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', $error_message, $error_data ) );
+		// REGRESSION E1 guard: a listener on wp_mail_failed that throws must
+		// not stop US from producing our own honest return value. Core's own
+		// wp_mail() does not catch anything from this hook, so an uncaught
+		// exception here would otherwise escape wp_mail() itself and fatal
+		// whatever called it (a checkout, a password reset). The finally
+		// block resets the re-entrancy guard even when a listener throws --
+		// without it, one thrown exception would wedge the guard "on" for
+		// the rest of the request and silently break every later send.
+		$this->firingFailureNotice = true;
+		try {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- firing core's own wp_mail_failed hook, not registering a global
+			do_action( 'wp_mail_failed', new \WP_Error( 'wp_mail_failed', $error_message, $error_data ) );
+		} catch ( \Throwable $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- gated diagnostic channel; only writes under WP_DEBUG_LOG or WPMGR_DEBUG
+			\WPMgr\Agent\Support\DebugLog::write( 'WPMgr Mail: a wp_mail_failed listener threw and was caught so the send path still returns: ' . $e->getMessage() );
+		} finally {
+			$this->firingFailureNotice = false;
+		}
 
 		return false;
+	}
+
+	/**
+	 * Second `pre_wp_mail` filter, registered at PHP_INT_MAX (see
+	 * register_hooks()) so it runs after every other registered filter.
+	 *
+	 * Corrects ONLY the case where WPMgr itself attempted THIS dispatch, it
+	 * failed, and a later filter has reset the value to exactly `null` --
+	 * see the class docblock for why that specific reset is dangerous (it is
+	 * the one value that makes wp_mail() fall through to core's own
+	 * PHPMailer, duplicating a send WPMgr already made). Any other non-null
+	 * value means some other plugin has legitimately taken over and is left
+	 * untouched.
+	 *
+	 * @param mixed               $return Filter chain's current value.
+	 * @param array<string,mixed> $atts   wp_mail() arguments array (unused; required by the pre_wp_mail signature).
+	 * @return mixed
+	 */
+	public function reassert_failed_short_circuit( $return, array $atts ) {
+		unset( $atts );
+
+		$failed = array_pop( $this->attemptFailed ) ?? false;
+
+		if ( $failed && $return === null ) {
+			return false;
+		}
+
+		return $return;
+	}
+
+	/**
+	 * Redact the VALUE of a known-sensitive header before it reaches a
+	 * third-party wp_mail_failed listener. The header NAME (and every other
+	 * header) is left exactly as-is, so a diagnostic listener can still see
+	 * what kind of header was present.
+	 *
+	 * "Sensitive" is a closed, name-based check: the literal header `Bcc`
+	 * (its entire purpose is to stay hidden from other recipients, so
+	 * surfacing it to every OTHER plugin on the site is itself a leak), plus
+	 * any header name that looks credential-shaped (auth, token, key,
+	 * secret, or password, case-insensitive) -- e.g. `Authorization` or a
+	 * site-specific `X-Auth-Token`.
+	 *
+	 * @param array<int,string> $header_lines Normalised "Name: value" header lines.
+	 * @return array<int,string>
+	 */
+	private function redact_sensitive_headers( array $header_lines ): array {
+		return array_map(
+			static function ( $line ) {
+				$line = (string) $line;
+				if ( strpos( $line, ':' ) === false ) {
+					return $line;
+				}
+				list( $name, $value ) = explode( ':', $line, 2 );
+				unset( $value );
+				$bare_name = strtolower( trim( $name ) );
+				$is_sensitive = $bare_name === 'bcc' || preg_match( '/auth|token|key|secret|password/i', $bare_name ) === 1;
+				if ( ! $is_sensitive ) {
+					return $line;
+				}
+				return trim( $name ) . ': [redacted]';
+			},
+			$header_lines
+		);
 	}
 
 	/**

--- a/apps/agent/includes/email/class-provider-router.php
+++ b/apps/agent/includes/email/class-provider-router.php
@@ -497,10 +497,17 @@ class ProviderRouter {
 		}
 
 		if ( ! $cfg->log_emails ) {
+			// FINDING (security review, GH #381 phase 2): pass the real
+			// recipient list to redact_email_addresses() BEFORE it is
+			// blanked below, so a malformed-but-real address (IDN domain,
+			// quoted local part, IP-literal domain, ...) is removed as a
+			// literal string rather than relying on the regex net alone to
+			// recognise its shape.
+			$known_addresses = is_array( $mail['to'] ?? null ) ? $mail['to'] : array();
 			$mail['to']      = array();
 			$mail['subject'] = '';
-			$error           = AddressParser::redact_email_addresses( $error );
-			$response        = AddressParser::redact_email_addresses( $response );
+			$error           = AddressParser::redact_email_addresses( $error, $known_addresses );
+			$response        = AddressParser::redact_email_addresses( $response, $known_addresses );
 		}
 
 		$this->logger->write( $mail, $provider, $status, $msg_id, $error, $response, $retries, $cfg, $connection_key );

--- a/apps/agent/includes/email/class-provider-router.php
+++ b/apps/agent/includes/email/class-provider-router.php
@@ -430,7 +430,24 @@ class ProviderRouter {
 	}
 
 	/**
-	 * Write a log row if email logging is enabled.
+	 * Write a log row if email logging is enabled, OR unconditionally when
+	 * the outcome is a failure.
+	 *
+	 * log_emails is a volume-and-retention preference about keeping a
+	 * record of mail that WORKED; it is not a request to be blinded to
+	 * failures. By the time this is called, send() has already DETECTED the
+	 * failure and computed its error string -- discarding that here would
+	 * leave no local row, nothing for the push to ship, and nothing for the
+	 * control plane to alert on, purely because the owner asked for a
+	 * quieter log of successful mail. So the early return only applies when
+	 * BOTH log_emails is off AND the outcome is not a failure ('sent' is the
+	 * only non-failure status this method ever receives; 'failed' and
+	 * 'suppressed' are both incidents and are logged regardless).
+	 *
+	 * This does not touch privacy: store_body is gated independently inside
+	 * EmailLogger::write() and still defaults false there, so turning
+	 * log_emails off still means no message body is ever stored, and a
+	 * successful send is still not recorded at all.
 	 *
 	 * @param array<string,mixed> $mail            Normalised mail payload.
 	 * @param string              $connection_key  Resolved connection key ('default' for primary).
@@ -454,7 +471,8 @@ class ProviderRouter {
 		int $retries,
 		EmailConfig $cfg
 	): void {
-		if ( ! $cfg->log_emails ) {
+		$is_failure = ( 'sent' !== $status );
+		if ( ! $cfg->log_emails && ! $is_failure ) {
 			return;
 		}
 		$this->logger->write( $mail, $provider, $status, $msg_id, $error, $response, $retries, $cfg, $connection_key );

--- a/apps/agent/includes/email/class-provider-router.php
+++ b/apps/agent/includes/email/class-provider-router.php
@@ -431,7 +431,7 @@ class ProviderRouter {
 
 	/**
 	 * Write a log row if email logging is enabled, OR unconditionally when
-	 * the outcome is a failure.
+	 * the outcome is a detected failure.
 	 *
 	 * log_emails is a volume-and-retention preference about keeping a
 	 * record of mail that WORKED; it is not a request to be blinded to
@@ -440,14 +440,34 @@ class ProviderRouter {
 	 * leave no local row, nothing for the push to ship, and nothing for the
 	 * control plane to alert on, purely because the owner asked for a
 	 * quieter log of successful mail. So the early return only applies when
-	 * BOTH log_emails is off AND the outcome is not a failure ('sent' is the
-	 * only non-failure status this method ever receives; 'failed' and
-	 * 'suppressed' are both incidents and are logged regardless).
+	 * BOTH log_emails is off AND the outcome is not a failure.
+	 *
+	 * GH #381 phase 4 (security-reviewer finding, ruling against an earlier
+	 * "WPMgr is the transport, it has already seen the recipient" argument):
+	 * having observed the recipient in flight does not license retaining and
+	 * exporting it. log_emails is the site owner's only control over whether
+	 * mail metadata is written down and shipped to the control plane, and
+	 * this forced write is silent (applied on upgrade, no new consent), so
+	 * it must be symmetric with MailFailureCapture::capture() (phase 1):
+	 * the row is always written on a genuine failure, but `to` and `subject`
+	 * are redacted to empty, and any address-shaped substring embedded in
+	 * the free-text `error`/`response` (a real SMTP/provider failure
+	 * routinely echoes the recipient back, e.g. "550 5.1.1 <a@x.com>:
+	 * Recipient address rejected") is scrubbed via
+	 * AddressParser::redact_email_addresses() -- not blanked entirely, so
+	 * the diagnostic detail ("550 5.1.1 ... rejected") survives. The alert
+	 * only needs "a failure happened on this site", never "to whom".
+	 *
+	 * 'suppressed' is deliberately NOT treated as a failure here: a
+	 * suppression-list hit is routine traffic (WPMgr already knows the
+	 * address is bad; there is nothing new to alert on), not an incident,
+	 * so it follows the ordinary log_emails gate like 'sent' does -- no
+	 * forced write, and so nothing to redact.
 	 *
 	 * This does not touch privacy: store_body is gated independently inside
 	 * EmailLogger::write() and still defaults false there, so turning
 	 * log_emails off still means no message body is ever stored, and a
-	 * successful send is still not recorded at all.
+	 * successful (or suppressed) send is still not recorded at all.
 	 *
 	 * @param array<string,mixed> $mail            Normalised mail payload.
 	 * @param string              $connection_key  Resolved connection key ('default' for primary).
@@ -471,10 +491,18 @@ class ProviderRouter {
 		int $retries,
 		EmailConfig $cfg
 	): void {
-		$is_failure = ( 'sent' !== $status );
+		$is_failure = ( 'failed' === $status );
 		if ( ! $cfg->log_emails && ! $is_failure ) {
 			return;
 		}
+
+		if ( ! $cfg->log_emails ) {
+			$mail['to']      = array();
+			$mail['subject'] = '';
+			$error           = AddressParser::redact_email_addresses( $error );
+			$response        = AddressParser::redact_email_addresses( $response );
+		}
+
 		$this->logger->write( $mail, $provider, $status, $msg_id, $error, $response, $retries, $cfg, $connection_key );
 	}
 }

--- a/apps/agent/includes/email/class-provider-router.php
+++ b/apps/agent/includes/email/class-provider-router.php
@@ -55,6 +55,23 @@ class ProviderRouter {
 	private ?SuppressionCheckerInterface $suppression_cache = null;
 
 	/**
+	 * GH #381 phase 4, round 4: the forced write on the `log_emails=false`
+	 * path is built ALLOWLIST-first. Four independent reviews each found a
+	 * different personal field this path leaked (Cc, Bcc, Reply-To,
+	 * mail_from, the body, attachment names) because the old code took the
+	 * full $mail payload and blanked the fields it remembered. This constant
+	 * is deliberately EMPTY: nothing in the $mail payload is judged safe to
+	 * carry on the forced path, so every key present today (to, from,
+	 * from_name, cc, bcc, reply_to, subject, body_html, body_text,
+	 * attachments, x_site_id, headers, ...) and every key added to that
+	 * payload in the future is excluded by construction in maybe_log(),
+	 * never by whoever remembers to touch this method next.
+	 *
+	 * @var array<int,string>
+	 */
+	private const ALLOWLIST_MAIL_KEYS = array();
+
+	/**
 	 * @param EmailKeystoreInterface          $keystore          Agent keystore (for secret retrieval).
 	 * @param EmailLogger                     $logger            Local send-event logger.
 	 * @param SuppressionCheckerInterface|null $suppression_cache Optional local suppression checker.
@@ -449,14 +466,37 @@ class ProviderRouter {
 	 * mail metadata is written down and shipped to the control plane, and
 	 * this forced write is silent (applied on upgrade, no new consent), so
 	 * it must be symmetric with MailFailureCapture::capture() (phase 1):
-	 * the row is always written on a genuine failure, but `to` and `subject`
-	 * are redacted to empty, and any address-shaped substring embedded in
-	 * the free-text `error`/`response` (a real SMTP/provider failure
-	 * routinely echoes the recipient back, e.g. "550 5.1.1 <a@x.com>:
-	 * Recipient address rejected") is scrubbed via
-	 * AddressParser::redact_email_addresses() -- not blanked entirely, so
-	 * the diagnostic detail ("550 5.1.1 ... rejected") survives. The alert
-	 * only needs "a failure happened on this site", never "to whom".
+	 * the row is always written on a genuine failure, but nothing beyond the
+	 * diagnostic itself is written.
+	 *
+	 * Round 4 (this change): three review bots and two security reviews each
+	 * found a DIFFERENT field this path was still leaking -- Cc, Bcc and
+	 * Reply-To (the routed SMTP path appends rejected values from all three
+	 * into the same error string, and the old code only knew to redact
+	 * `to`), `mail_from` (never blanked), the message body (persisted
+	 * whenever `store_body` was true, which phase 4 made reachable on a row
+	 * that never used to exist), and attachment names. Four rounds of "we
+	 * forgot a field" is a blocklist problem, not a missing-field problem, so
+	 * this branch now builds the row from ALLOWLIST_MAIL_KEYS (see the
+	 * constant's docblock) instead of taking the full $mail payload and
+	 * blanking whichever fields are remembered. Anything not on that list is
+	 * absent from the row by construction, so the next field added to the
+	 * mail payload -- or to EmailLogger::write() -- is excluded by default
+	 * instead of leaking until a fifth reviewer finds it.
+	 *
+	 * Any address-shaped substring embedded in the free-text `error`/
+	 * `response` (a real SMTP/provider failure routinely echoes the
+	 * recipient back, e.g. "550 5.1.1 <a@x.com>: Recipient address
+	 * rejected", and the SMTP handler does the same for a rejected Cc/Bcc/
+	 * Reply-To entry) is scrubbed via AddressParser::redact_email_addresses()
+	 * -- not blanked entirely, so the diagnostic detail ("550 5.1.1 ...
+	 * rejected") survives. The known-address dictionary passed to it now
+	 * covers to/cc/bcc/reply_to/from, not just `to`, so a malformed-but-real
+	 * address in any of those fields (IDN domain, quoted local part, ...) is
+	 * removed as a literal string rather than relying on the regex alone.
+	 * The alert only needs "a failure happened on this site", never "to
+	 * whom", "from whom", "cc'd to whom", "replying to whom", "saying what",
+	 * or "with what attached".
 	 *
 	 * 'suppressed' is deliberately NOT treated as a failure here: a
 	 * suppression-list hit is routine traffic (WPMgr already knows the
@@ -464,10 +504,11 @@ class ProviderRouter {
 	 * so it follows the ordinary log_emails gate like 'sent' does -- no
 	 * forced write, and so nothing to redact.
 	 *
-	 * This does not touch privacy: store_body is gated independently inside
-	 * EmailLogger::write() and still defaults false there, so turning
-	 * log_emails off still means no message body is ever stored, and a
-	 * successful (or suppressed) send is still not recorded at all.
+	 * store_body is FORCED off for this write, regardless of the site's real
+	 * config: that preference was granted for logging the owner explicitly
+	 * asked for (log_emails=true), so it cannot widen a row the owner did
+	 * not ask for. A successful (or suppressed) send is still not recorded
+	 * at all.
 	 *
 	 * @param array<string,mixed> $mail            Normalised mail payload.
 	 * @param string              $connection_key  Resolved connection key ('default' for primary).
@@ -497,17 +538,38 @@ class ProviderRouter {
 		}
 
 		if ( ! $cfg->log_emails ) {
-			// FINDING (security review, GH #381 phase 2): pass the real
-			// recipient list to redact_email_addresses() BEFORE it is
-			// blanked below, so a malformed-but-real address (IDN domain,
-			// quoted local part, IP-literal domain, ...) is removed as a
-			// literal string rather than relying on the regex net alone to
-			// recognise its shape.
-			$known_addresses = is_array( $mail['to'] ?? null ) ? $mail['to'] : array();
-			$mail['to']      = array();
-			$mail['subject'] = '';
-			$error           = AddressParser::redact_email_addresses( $error, $known_addresses );
-			$response        = AddressParser::redact_email_addresses( $response, $known_addresses );
+			// Build the redaction dictionary from every address-shaped field
+			// in the payload -- to, cc, bcc, reply_to, from -- BEFORE the
+			// payload itself is reduced to the allowlist below, so a
+			// malformed-but-real address (IDN domain, quoted local part,
+			// IP-literal domain, ...) in ANY of those fields is removed from
+			// the free-text error/response as a literal string rather than
+			// relying on the regex net alone to recognise its shape.
+			$known_addresses = array();
+			foreach ( array( 'to', 'cc', 'bcc', 'reply_to' ) as $address_field ) {
+				if ( is_array( $mail[ $address_field ] ?? null ) ) {
+					$known_addresses = array_merge( $known_addresses, $mail[ $address_field ] );
+				}
+			}
+			if ( isset( $mail['from'] ) && is_string( $mail['from'] ) && $mail['from'] !== '' ) {
+				$known_addresses[] = $mail['from'];
+			}
+			$error    = AddressParser::redact_email_addresses( $error, $known_addresses );
+			$response = AddressParser::redact_email_addresses( $response, $known_addresses );
+
+			// Allowlist, not blocklist: reduce $mail to ONLY the keys named
+			// in ALLOWLIST_MAIL_KEYS (currently none). Everything else --
+			// to, from, from_name, cc, bcc, reply_to, subject, body_html,
+			// body_text, attachments, and any key added later -- is absent
+			// from the row EmailLogger::write() builds, by construction.
+			$mail = array_intersect_key( $mail, array_flip( self::ALLOWLIST_MAIL_KEYS ) );
+
+			// store_body is an opt-in preference for the logging the owner
+			// explicitly asked for (log_emails=true); it must not widen a
+			// forced row the owner did not ask for. Force it off for this
+			// write only, regardless of the site's real config.
+			$cfg             = clone $cfg;
+			$cfg->store_body = false;
 		}
 
 		$this->logger->write( $mail, $provider, $status, $msg_id, $error, $response, $retries, $cfg, $connection_key );

--- a/apps/agent/includes/email/handlers/class-ses-handler.php
+++ b/apps/agent/includes/email/handlers/class-ses-handler.php
@@ -31,7 +31,7 @@ use WPMgr\Agent\Email\ProviderHandlerInterface;
 final class SesHandler implements ProviderHandlerInterface {
 
 	/** SES endpoint pattern. */
-	private const ENDPOINT = 'https://email.%s.amazonaws.com/';
+	private const ENDPOINT = 'https://email.%s.amazonaws.com/'; // phpcs:ignore PluginCheck.CodeAnalysis.Offloading.OffloadedContent -- not offloaded front-end content; this is the Amazon SES v1 API endpoint used to send outbound email via the site owner's own AWS SigV4-signed credentials. Flagged only because plugin-check 2.1.0's OffloadingSniff now matches "amazonaws.com" unconditionally in any string literal, not just enqueue/markup contexts.
 
 	/** SES service name for SigV4. */
 	private const SERVICE = 'email';

--- a/apps/agent/tests/Email/AddressParserTest.php
+++ b/apps/agent/tests/Email/AddressParserTest.php
@@ -329,4 +329,98 @@ class AddressParserTest extends TestCase
         $this->assertSame('salesianalibri@gmail.com', $parsed['address']);
         $this->assertSame('Andrea Somigli', $parsed['name']);
     }
+
+    // -------------------------------------------------------------------------
+    // GH #381 phase 2 (security review, second round): the bare regex in
+    // redact_email_addresses() only recognises a well-formed ASCII address,
+    // but PHPMailer's own "Invalid address" errors fire BECAUSE the address
+    // failed that exact validation -- so the regex is weakest on precisely
+    // the inputs this code path emits. The remedy is two-stage: remove every
+    // literal known recipient (and its obvious encoded variants) first, then
+    // run the regex as a net for anything not already known. This table is
+    // the reviewer's full leak catalogue plus the forms that already worked;
+    // every row must come out address-free once a matching known address is
+    // supplied, exactly as the two real call sites now supply it.
+    // -------------------------------------------------------------------------
+
+    /** @return array<string,array{0:string,1:string,2:string}> label => [known address, text, needle that must not survive] */
+    public static function redaction_table(): array
+    {
+        return [
+            'raw IDN domain' => ['kunde@münchen.de', 'SMTP Error: recipients failed: kunde@münchen.de: 550 5.1.1 User unknown', 'kunde@münchen.de'],
+            'quoted local part' => ['"john doe"@example.com', 'Invalid address: (to): "john doe"@example.com', '"john doe"@example.com'],
+            'IP-literal domain' => ['admin@[192.168.13.7]', 'Invalid address: (to): admin@[192.168.13.7]', 'admin@[192.168.13.7]'],
+            'bare-IP domain' => ['admin@203.0.113.9', 'Invalid address: (to): admin@203.0.113.9', 'admin@203.0.113.9'],
+            'spaced' => ['alice@example.com', 'Invalid address: (to): alice @ example.com', 'alice @ example.com'],
+            'percent-encoded bare' => ['alice@example.com', 'Invalid address: (to): alice%40example.com', 'alice%40example.com'],
+            'percent-encoded in URL' => ['alice@example.com', 'see https://relay.example/bounce?addr=alice%40example.com', 'alice%40example.com'],
+            'split across line break' => ['alice@example.com', "Invalid address: (to): alice@\nexample.com", "alice@\nexample.com"],
+            'base64' => ['alice@example.com', 'raw recipient: YWxpY2VAZXhhbXBsZS5jb20=', 'YWxpY2VAZXhhbXBsZS5jb20='],
+            '1-char TLD' => ['x@y.c', 'Invalid address: (to): x@y.c', 'x@y.c'],
+            'numeric TLD' => ['admin@example.12345', 'Invalid address: (to): admin@example.12345', 'admin@example.12345'],
+            'non-ASCII local part' => ['jösef@example.com', 'Invalid address: (to): jösef@example.com', 'jösef@example.com'],
+            // Forms that already redacted correctly before this fix -- must stay fixed.
+            'punycode' => ['user@xn--mnchen-3ya.de', 'Invalid address: (to): user@xn--mnchen-3ya.de', 'user@xn--mnchen-3ya.de'],
+            'angle-bracket' => ['a@x.com', 'Invalid address:  (to): Name <a@x.com>', 'a@x.com'],
+            'uppercase' => ['A@X.COM', 'Invalid address: (to): A@X.COM', 'A@X.COM'],
+            'trailing dot' => ['a@x.com.', 'Invalid address: (to): a@x.com.', 'a@x.com.'],
+        ];
+    }
+
+    /**
+     * @dataProvider redaction_table
+     */
+    public function test_redact_email_addresses_removes_every_leaking_shape_given_the_known_address(string $known, string $text, string $needle): void
+    {
+        $redacted = AddressParser::redact_email_addresses($text, [$known]);
+
+        $this->assertStringNotContainsString($needle, $redacted, "'{$needle}' must not survive redaction when it is a known recipient.");
+    }
+
+    /**
+     * The reviewer's own end-to-end proof case, pinned permanently and
+     * independent of the data provider above.
+     */
+    public function test_redact_email_addresses_removes_the_reviewers_idn_proof_case(): void
+    {
+        $text = 'SMTP Error: The following recipients failed: kunde@münchen.de: 550 5.1.1 User unknown';
+
+        $redacted = AddressParser::redact_email_addresses($text, ['kunde@münchen.de']);
+
+        $this->assertStringNotContainsString('kunde@münchen.de', $redacted);
+        $this->assertStringContainsString('550 5.1.1 User unknown', $redacted, 'Diagnostic detail must survive redaction.');
+    }
+
+    /**
+     * Over-fire control: diagnostic detail that is NOT address-shaped must
+     * come through completely unchanged, known-address list or not.
+     */
+    public function test_redact_email_addresses_preserves_diagnostic_detail(): void
+    {
+        $cases = [
+            '550 5.1.1 User unknown',
+            'connect to mail.example.com:587 failed after 3 tries',
+            'Postfix 3.7.4 error 4.4.1 timeout',
+        ];
+
+        foreach ($cases as $text) {
+            $this->assertSame($text, AddressParser::redact_email_addresses($text, ['unrelated@example.com']));
+        }
+    }
+
+    /**
+     * No catastrophic backtracking: a 40,000-char pathological input must
+     * redact in a small fraction of a second, matching the reviewer's own
+     * 0.0001s measurement on the same shape of input.
+     */
+    public function test_redact_email_addresses_has_no_catastrophic_backtracking(): void
+    {
+        $pathological = str_repeat('a', 40000) . '@' . str_repeat('b.', 20000) . 'com';
+
+        $start = microtime(true);
+        AddressParser::redact_email_addresses($pathological, ['known@example.com']);
+        $elapsed = microtime(true) - $start;
+
+        $this->assertLessThan(1.0, $elapsed, "Redaction took {$elapsed}s on a 40,000-char pathological input -- possible catastrophic backtracking.");
+    }
 }

--- a/apps/agent/tests/Email/EmailLogFailureBypassTest.php
+++ b/apps/agent/tests/Email/EmailLogFailureBypassTest.php
@@ -325,6 +325,97 @@ class EmailLogFailureBypassTest extends TestCase
     }
 
     /**
+     * Security review, GH #381 phase 2 (second round): the reviewer's exact
+     * end-to-end proof, on the routed (phase 4) path. kunde@münchen.de is a
+     * raw IDN domain that AddressParser::parse_one() refuses to parse, so
+     * the old ASCII-only regex left it verbatim in `error`. maybe_log() must
+     * now pass the real `to` to redact_email_addresses() so it is removed as
+     * a literal string. Pinned permanently.
+     */
+    public function test_failed_row_redacts_the_reviewers_idn_proof_case(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'SMTP Error: The following recipients failed: kunde@münchen.de: 550 5.1.1 User unknown',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail            = $this->base_mail();
+        $mail['to']      = ['kunde@münchen.de'];
+        $result          = $router->send($mail, $cfg, true);
+
+        $this->assertFalse($result['ok']);
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringNotContainsString('kunde@münchen.de', $row['error'], 'The IDN address embedded in the error text must not survive when log_emails is off.');
+        $this->assertStringContainsString('550 5.1.1 User unknown', $row['error'], 'Redaction must not destroy the diagnostic detail an operator needs -- only the address.');
+
+        $json = (string) json_encode($row);
+        $this->assertStringNotContainsString('kunde@münchen.de', $json, 'Recipient must not appear anywhere in the row when log_emails is off.');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Data-provider over the full GH #381 phase-2 leak catalogue on the
+     * phase-4 routed path -- same catalogue as
+     * MailFailureCaptureTest::addressLeakTable(), proven independently here
+     * because maybe_log() reads the recipient off `$mail['to']`, not the
+     * WP_Error `to` key phase 1 uses.
+     *
+     * @dataProvider addressLeakTable
+     */
+    public function test_failed_row_redacts_every_leaking_address_shape(string $address, string $errorTemplate): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg          = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $errorMessage = sprintf($errorTemplate, $address);
+        $handler      = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => $errorMessage,
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail       = $this->base_mail();
+        $mail['to'] = [$address];
+        $router->send($mail, $cfg, true);
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringNotContainsString($address, $row['error'], "'{$address}' must not survive redaction.");
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /** @return array<string,array{0:string,1:string}> label => [address, error sprintf template with one %s] */
+    public static function addressLeakTable(): array
+    {
+        return [
+            'raw IDN domain' => ['kunde@münchen.de', 'Invalid address: (to): %s'],
+            'quoted local part' => ['"john doe"@example.com', 'Invalid address: (to): %s'],
+            'IP-literal domain' => ['admin@[192.168.13.7]', 'Invalid address: (to): %s'],
+            'bare-IP domain' => ['admin@203.0.113.9', 'Invalid address: (to): %s'],
+            '1-char TLD' => ['x@y.c', 'Invalid address: (to): %s'],
+            'numeric TLD' => ['admin@example.12345', 'Invalid address: (to): %s'],
+            'non-ASCII local part' => ['jösef@example.com', 'Invalid address: (to): %s'],
+        ];
+    }
+
+    /**
      * Ruling on the 'suppressed' status (security-reviewer finding B,
      * open question): maybe_log()'s failure gate used to be
      * `'sent' !== $status`, so a routine suppression-list hit was force-

--- a/apps/agent/tests/Email/EmailLogFailureBypassTest.php
+++ b/apps/agent/tests/Email/EmailLogFailureBypassTest.php
@@ -455,4 +455,293 @@ class EmailLogFailureBypassTest extends TestCase
 
         unset($GLOBALS['wpdb']);
     }
+
+    /**
+     * Round 4 (three review bots + two security reviews, each finding a
+     * DIFFERENT leaking field on this same forced-write path): Cc, Bcc,
+     * Reply-To, mail_from, the body (when store_body is true), and
+     * attachment names. Rather than pin four more named-column assertions
+     * (a blocklist test has the exact same blind spot as the blocklist code
+     * it is proving), this iterates every key of the ACTUAL inserted row
+     * against a small allowlist of columns known to carry no personal data.
+     * Anything else must be empty -- so a fifth field added to the mail
+     * payload or to EmailLogger::write() tomorrow, without anyone touching
+     * this test, still fails it instead of shipping.
+     */
+    private const NON_PERSONAL_COLUMNS = [
+        'message_id', 'provider', 'status', 'response', 'error',
+        'retries', 'resent_count', 'connection_key', 'created_at',
+    ];
+
+    public function test_forced_row_excludes_every_field_outside_the_allowlist(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        // store_body TRUE on purpose: proves the allowlist wins even when
+        // the site's own preference would otherwise permit a body column.
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => true]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'SMTP Error: The following recipients failed: cc@example.com, bcc@example.com: 550 5.1.1 User unknown',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail                 = $this->base_mail();
+        $mail['cc']           = ['cc@example.com'];
+        $mail['bcc']          = ['bcc@example.com'];
+        $mail['reply_to']     = ['reply@example.com'];
+        $mail['attachments']  = [['name' => 'invoice.pdf', 'size_bytes' => 100]];
+        $router->send($mail, $cfg, true);
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+
+        foreach ($row as $column => $value) {
+            if (in_array($column, self::NON_PERSONAL_COLUMNS, true)) {
+                continue;
+            }
+            $this->assertTrue(
+                $value === '' || $value === null || $value === 0,
+                "Column '{$column}' must be empty on the forced (log_emails=false) path; got: " . var_export($value, true)
+            );
+        }
+    }
+
+    /**
+     * RED today: a rejected Cc address survives in `error` because
+     * maybe_log() only ever built its redaction dictionary from `to`. Uses a
+     * malformed-but-real (bare-IP domain) address, matching
+     * addressLeakTable() above, because a plain ASCII address is already
+     * caught by AddressParser::redact_email_addresses()'s unconditional
+     * generic regex pass -- that pass is what would mask this exact gap if
+     * the test used an ordinary address instead.
+     */
+    public function test_rejected_cc_address_is_redacted_from_error(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'no valid recipient address (rejected: admin@203.0.113.9)',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail       = $this->base_mail();
+        $mail['cc'] = ['admin@203.0.113.9'];
+        $router->send($mail, $cfg, true);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringNotContainsString('admin@203.0.113.9', $row['error'], 'A rejected Cc address must not survive in the error text.');
+        $this->assertStringNotContainsString('admin@203.0.113.9', (string) json_encode($row));
+    }
+
+    /** RED today: a rejected Bcc address survives in `error` because maybe_log() only ever built its redaction dictionary from `to`. Same malformed-address rationale as the Cc case above. */
+    public function test_rejected_bcc_address_is_redacted_from_error(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'no valid recipient address (rejected: admin@[192.168.13.7])',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail        = $this->base_mail();
+        $mail['bcc'] = ['admin@[192.168.13.7]'];
+        $router->send($mail, $cfg, true);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringNotContainsString('admin@[192.168.13.7]', $row['error'], 'A rejected Bcc address must not survive in the error text.');
+        $this->assertStringNotContainsString('admin@[192.168.13.7]', (string) json_encode($row));
+    }
+
+    /** RED today: a rejected Reply-To address survives in `error` because maybe_log() only ever built its redaction dictionary from `to`. Same malformed-address rationale as the Cc case above. */
+    public function test_rejected_reply_to_address_is_redacted_from_error(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'no valid recipient address (rejected: "john doe"@example.com)',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail             = $this->base_mail();
+        $mail['reply_to'] = ['"john doe"@example.com'];
+        $router->send($mail, $cfg, true);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringNotContainsString('"john doe"@example.com', $row['error'], 'A rejected Reply-To address must not survive in the error text.');
+        $this->assertStringNotContainsString('"john doe"@example.com', (string) json_encode($row));
+    }
+
+    /** RED today: mail_from column carries the real sender address regardless of log_emails. */
+    public function test_sender_mail_from_is_not_persisted(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok' => false, 'message_id' => '', 'error' => 'boom', 'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail         = $this->base_mail();
+        $mail['from'] = 'sender-victim@example.com';
+        $router->send($mail, $cfg, true);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('', $row['mail_from'], 'mail_from must be empty on the forced path.');
+        $this->assertStringNotContainsString('sender-victim@example.com', (string) json_encode($row));
+    }
+
+    /** RED today: store_body=true persists the real message body into a row the owner never asked for. */
+    public function test_body_is_excluded_when_store_body_is_true(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => true]);
+        $handler = $this->make_handler('smtp', [
+            'ok' => false, 'message_id' => '', 'error' => 'boom', 'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $router->send($this->base_mail(), $cfg, true);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame(0, $row['body_stored'], 'body_stored must be forced to 0 on the forced path, regardless of store_body.');
+        $this->assertNull($row['body'], 'body must be NULL on the forced path, regardless of store_body.');
+        $this->assertStringNotContainsString('SECRET-BODY-TEXT', (string) json_encode($row));
+    }
+
+    /** RED today: attachment names are persisted regardless of log_emails. */
+    public function test_attachment_name_is_not_persisted(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok' => false, 'message_id' => '', 'error' => 'boom', 'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail                = $this->base_mail();
+        $mail['attachments'] = [['name' => 'confidential-invoice.pdf', 'size_bytes' => 4096]];
+        $router->send($mail, $cfg, true);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertNull($row['attachments'], 'attachments must be NULL on the forced path.');
+        $this->assertStringNotContainsString('confidential-invoice.pdf', (string) json_encode($row));
+    }
+
+    /**
+     * Diagnostics survive: redaction removes only the address-shaped
+     * substring, never the SMTP/provider detail an operator needs to act on.
+     *
+     * @dataProvider diagnosticSurvivesTable
+     */
+    public function test_diagnostic_detail_survives_redaction(string $errorMessage, string $mustSurvive): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok' => false, 'message_id' => '', 'error' => $errorMessage, 'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $router->send($this->base_mail(), $cfg, true);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringContainsString($mustSurvive, $row['error']);
+    }
+
+    /** @return array<string,array{0:string,1:string}> label => [error message, substring that must survive] */
+    public static function diagnosticSurvivesTable(): array
+    {
+        return [
+            'user unknown' => [
+                'SMTP Error: The following recipients failed: to@example.com: 550 5.1.1 User unknown',
+                '550 5.1.1 User unknown',
+            ],
+            'connect timeout, no address at all' => [
+                'connect to mail.example.com:587 failed after 3 tries',
+                'connect to mail.example.com:587 failed after 3 tries',
+            ],
+        ];
+    }
+
+    /**
+     * Over-fire control, round 4: with log_emails TRUE, Cc, Bcc, Reply-To,
+     * mail_from, the body and the attachment name are ALL present and
+     * unchanged -- the allowlist applies only to the forced path; the
+     * opt-in path this fix leaves untouched still means real data.
+     */
+    public function test_log_emails_true_still_includes_every_field_the_allowlist_would_strip(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => true, 'store_body' => true]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'SMTP Error: The following recipients failed: cc@example.com, bcc@example.com: 550 5.1.1 User unknown',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $mail                = $this->base_mail();
+        $mail['cc']          = ['cc@example.com'];
+        $mail['bcc']         = ['bcc@example.com'];
+        $mail['reply_to']    = ['reply@example.com'];
+        $mail['attachments'] = [['name' => 'invoice.pdf', 'size_bytes' => 100]];
+        $router->send($mail, $cfg, true);
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringContainsString('cc@example.com', $row['error']);
+        $this->assertSame('Sender <a@example.com>', $row['mail_from']);
+        $this->assertSame(1, $row['body_stored']);
+        $this->assertSame('SECRET-BODY-TEXT', $row['body']);
+        $this->assertNotNull($row['attachments']);
+        $this->assertStringContainsString('invoice.pdf', (string) $row['attachments']);
+    }
 }

--- a/apps/agent/tests/Email/EmailLogFailureBypassTest.php
+++ b/apps/agent/tests/Email/EmailLogFailureBypassTest.php
@@ -27,6 +27,7 @@ use WPMgr\Agent\Email\EmailConfig;
 use WPMgr\Agent\Email\EmailLogger;
 use WPMgr\Agent\Email\ProviderHandlerInterface;
 use WPMgr\Agent\Email\ProviderRouter;
+use WPMgr\Agent\Email\SuppressionCheckerInterface;
 
 /**
  * @covers \WPMgr\Agent\Email\ProviderRouter
@@ -239,6 +240,128 @@ class EmailLogFailureBypassTest extends TestCase
 
         $this->assertCount(1, $fakeWpdbFail->rows, 'a failed send must still be logged when log_emails is on');
         $this->assertSame('failed', $fakeWpdbFail->rows[0]['status']);
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Security-reviewer finding B (GH #381 phase 4): maybe_log()'s forced
+     * write for a detected failure carried the real `to`/`subject`
+     * regardless of log_emails, and the free-text `error` from a real
+     * provider routinely embeds the recipient address too (matching
+     * MailFailureCaptureTest's phase-1 fixture and the reviewer's proof
+     * case). RED before the fix: mail_to/subject were never redacted on
+     * this path at all, and `error` was written verbatim.
+     *
+     * Also proves the redaction line: the address-shaped substring is
+     * removed from `error`, but the diagnostic detail ("550 5.1.1 ...
+     * rejected") survives -- a blanket empty error string would be a
+     * regression in its own right (see class-provider-router.php's
+     * maybe_log() docblock).
+     */
+    public function test_failed_row_redacts_recipient_subject_and_embedded_address_in_error_when_log_emails_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'SMTP Error: The following recipients failed: to@example.com: 550 5.1.1 User unknown',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $result = $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertFalse($result['ok']);
+        $this->assertCount(1, $fakeWpdb->rows);
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('', $row['mail_to'], 'Recipient must be redacted when log_emails is off.');
+        $this->assertSame('', $row['subject'], 'Subject must be redacted when log_emails is off.');
+        $this->assertStringNotContainsString('to@example.com', $row['error'], 'The address embedded in the error text must not survive when log_emails is off.');
+        $this->assertStringContainsString('550 5.1.1 User unknown', $row['error'], 'Redaction must not destroy the diagnostic detail an operator needs -- only the address.');
+
+        $json = (string) json_encode($row);
+        $this->assertStringNotContainsString('to@example.com', $json, 'Recipient must not appear anywhere in the row when log_emails is off.');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Over-fire control for finding B: with log_emails=true, the forced
+     * write on failure carries the REAL recipient, subject, and the
+     * unredacted error text (including any embedded address) -- the opt-in
+     * still has to mean something, on this path exactly as on phase 1's.
+     */
+    public function test_failed_row_carries_real_recipient_subject_and_error_when_log_emails_is_true(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => true, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'SMTP Error: The following recipients failed: to@example.com: 550 5.1.1 User unknown',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringContainsString('to@example.com', $row['mail_to'], 'Opting in to log_emails must actually surface the real recipient.');
+        $this->assertSame('Test', $row['subject']);
+        $this->assertStringContainsString('to@example.com', $row['error'], 'Opting in to log_emails must not redact the error text either.');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Ruling on the 'suppressed' status (security-reviewer finding B,
+     * open question): maybe_log()'s failure gate used to be
+     * `'sent' !== $status`, so a routine suppression-list hit was force-
+     * logged with the real recipient too, exactly like a genuine failure.
+     *
+     * A suppression hit is not an incident -- WPMgr already knows the
+     * address is bad; there is nothing new here for the control-plane
+     * alert to act on, unlike a freshly DETECTED SMTP/provider failure.
+     * So 'suppressed' now follows the ordinary log_emails gate, the same
+     * as 'sent': no forced write, and so nothing to redact. When log_emails
+     * is on, a suppressed send is still logged (unchanged; see
+     * ProviderRouterSuppressionTest::test_suppressed_send_writes_log_row_with_suppressed_status).
+     */
+    public function test_suppressed_send_is_not_logged_when_log_emails_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+
+        $cache = $this->createMock(SuppressionCheckerInterface::class);
+        $cache->method('is_suppressed')->willReturn(true);
+
+        $handler = $this->make_handler('smtp', [
+            'ok' => true, 'message_id' => 'unused', 'error' => '', 'provider_response' => '',
+        ]);
+        $handler->expects($this->never())->method('send');
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger(), $cache);
+        $router->register($handler);
+
+        $result = $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('recipient suppressed', $result['detail']);
+        $this->assertCount(0, $fakeWpdb->rows, 'A routine suppression-list hit is not an incident and must not force a row when log_emails is off.');
+
         unset($GLOBALS['wpdb']);
     }
 }

--- a/apps/agent/tests/Email/EmailLogFailureBypassTest.php
+++ b/apps/agent/tests/Email/EmailLogFailureBypassTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * EmailLogFailureBypassTest — GH #381 phase 4: ProviderRouter::maybe_log()
+ * discarded a DETECTED failure whenever the site owner had turned log_emails
+ * off, silently defeating phase 1's failure alerting for that tenant.
+ *
+ * log_emails is a volume-and-retention preference about keeping a record of
+ * mail that WORKED. A failure is an incident, not a record of routine
+ * traffic; someone asking for a quieter log did not ask to be blinded to
+ * failures. store_body is an independent gate (EmailLogger::write()) that
+ * controls whether ANY row -- success or failure -- carries the message
+ * body, and it is untouched by this change: turning log_emails off must
+ * still mean no bodies are ever stored, and must still mean a SUCCESSFUL
+ * send is not recorded at all.
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WPMgr\Agent\Email\EmailConfig;
+use WPMgr\Agent\Email\EmailLogger;
+use WPMgr\Agent\Email\ProviderHandlerInterface;
+use WPMgr\Agent\Email\ProviderRouter;
+
+/**
+ * @covers \WPMgr\Agent\Email\ProviderRouter
+ */
+class EmailLogFailureBypassTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+        Functions\when('current_time')->justReturn('2026-08-17 00:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /** @param array{ok:bool,message_id:string,error:string,provider_response:string} $result */
+    private function make_handler(string $provider, array $result): ProviderHandlerInterface
+    {
+        $handler = $this->createMock(ProviderHandlerInterface::class);
+        $handler->method('provider')->willReturn($provider);
+        $handler->method('send')->willReturn($result);
+        return $handler;
+    }
+
+    /** @return array<string,mixed> */
+    private function base_mail(): array
+    {
+        return [
+            'to'          => ['to@example.com'],
+            'cc'          => [],
+            'bcc'         => [],
+            'reply_to'    => [],
+            'from'        => 'a@example.com',
+            'from_name'   => 'Sender',
+            'subject'     => 'Test',
+            'body_text'   => 'SECRET-BODY-TEXT',
+            'body_html'   => '',
+            'charset'     => 'UTF-8',
+            'headers'     => [],
+            'attachments' => [],
+            'return_path' => false,
+            'x_site_id'   => 'site-123',
+        ];
+    }
+
+    /**
+     * Minimal fake $wpdb: records every insert() call's $data array so a
+     * test can assert row count and shape without a real database. Same
+     * pattern as MailFailureCaptureTest::fakeWpdb().
+     */
+    private function fakeWpdb(): object
+    {
+        return new class () {
+            public string $prefix = 'wp_';
+
+            /** @var array<int,array<string,mixed>> */
+            public array $rows = [];
+
+            public int $insert_id = 0;
+
+            /** @param array<string,mixed> $data */
+            public function insert(string $table, array $data, array $formats): bool
+            {
+                $this->rows[] = $data;
+                $this->insert_id++;
+                return true;
+            }
+        };
+    }
+
+    /**
+     * RED today: maybe_log() returns early on `! $cfg->log_emails` before
+     * ever looking at the outcome, so a DETECTED failure (ok:false, an error
+     * string already computed by send()) produces zero rows -- nothing for
+     * the push to ship, nothing for the control plane to alert on.
+     */
+    public function test_failed_send_is_logged_even_when_log_emails_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'smtp connect() failed: Connection refused',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $result = $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertFalse($result['ok']);
+        $this->assertCount(1, $fakeWpdb->rows, 'a detected failure must be logged even when log_emails is off');
+        $this->assertSame('failed', $fakeWpdb->rows[0]['status']);
+        $this->assertSame('smtp connect() failed: Connection refused', $fakeWpdb->rows[0]['error']);
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * The important control: this must be GREEN both BEFORE and AFTER the
+     * fix. It guards the bypass from quietly becoming "ignore the
+     * preference entirely" -- a successful send is exactly the record a
+     * user who turned log_emails off asked NOT to keep.
+     */
+    public function test_successful_send_is_still_not_logged_when_log_emails_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => true,
+            'message_id'        => 'smtp-ok-1',
+            'error'             => '',
+            'provider_response' => '250 OK',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $result = $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertTrue($result['ok']);
+        $this->assertCount(0, $fakeWpdb->rows, 'a successful send must not be recorded when log_emails is off');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Privacy gate: store_body stays independently false regardless of the
+     * newly-widened failure path. Prove the raw message body never reaches
+     * any column of the failure row this fix now writes.
+     */
+    public function test_failed_row_carries_no_message_body_when_store_body_is_false(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $cfg     = new EmailConfig(['provider' => 'smtp', 'log_emails' => false, 'store_body' => false]);
+        $handler = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'smtp connect() failed: Connection refused',
+            'provider_response' => '',
+        ]);
+
+        $router = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $router->register($handler);
+
+        $router->send($this->base_mail(), $cfg, true);
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame(0, $row['body_stored'], 'body_stored must be 0 when store_body is false, even on the newly-widened failure path');
+        $this->assertNull($row['body'], 'body column must be NULL when store_body is false');
+        $this->assertStringNotContainsString('SECRET-BODY-TEXT', (string) json_encode($row));
+        foreach ($row as $column => $value) {
+            $this->assertNotSame('SECRET-BODY-TEXT', $value, "Column '{$column}' must never carry the raw message body when store_body is false.");
+        }
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Over-fire control: with log_emails TRUE, behaviour is completely
+     * unchanged for both success and failure -- this path was never gated
+     * by the outcome before, and must not become gated by it now.
+     */
+    public function test_log_emails_true_behaviour_is_unchanged_for_success_and_failure(): void
+    {
+        $cfg = new EmailConfig(['provider' => 'smtp', 'log_emails' => true, 'store_body' => false]);
+
+        // Success leg.
+        $fakeWpdbOk        = $this->fakeWpdb();
+        $GLOBALS['wpdb']   = $fakeWpdbOk;
+        $okHandler         = $this->make_handler('smtp', [
+            'ok'                => true,
+            'message_id'        => 'smtp-ok-2',
+            'error'             => '',
+            'provider_response' => '250 OK',
+        ]);
+        $okRouter = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $okRouter->register($okHandler);
+        $okRouter->send($this->base_mail(), $cfg, true);
+
+        $this->assertCount(1, $fakeWpdbOk->rows, 'a successful send must still be logged when log_emails is on');
+        $this->assertSame('sent', $fakeWpdbOk->rows[0]['status']);
+        unset($GLOBALS['wpdb']);
+
+        // Failure leg.
+        $fakeWpdbFail      = $this->fakeWpdb();
+        $GLOBALS['wpdb']   = $fakeWpdbFail;
+        $failHandler       = $this->make_handler('smtp', [
+            'ok'                => false,
+            'message_id'        => '',
+            'error'             => 'boom',
+            'provider_response' => '',
+        ]);
+        $failRouter = new ProviderRouter(new FakeKeystore(), new EmailLogger());
+        $failRouter->register($failHandler);
+        $failRouter->send($this->base_mail(), $cfg, true);
+
+        $this->assertCount(1, $fakeWpdbFail->rows, 'a failed send must still be logged when log_emails is on');
+        $this->assertSame('failed', $fakeWpdbFail->rows[0]['status']);
+        unset($GLOBALS['wpdb']);
+    }
+}

--- a/apps/agent/tests/Email/MailFailureCaptureTest.php
+++ b/apps/agent/tests/Email/MailFailureCaptureTest.php
@@ -111,6 +111,17 @@ class MailFailureCaptureTest extends TestCase
      * write a row -- status='failed', provider='wp_mail', error non-empty --
      * so the alert exists, but the row must contain NEITHER the recipient
      * address NOR the subject line in any column.
+     *
+     * FINDING A / A2 (security review): the fixture here used to be
+     * 'SMTP connect() failed' -- the one common failure shape that happens
+     * to omit the address, which let the assertion below pass for the wrong
+     * reason (nothing to leak, not "nothing leaked"). A real PHPMailer/SMTP
+     * failure routinely embeds the address verbatim in the message text
+     * (this exact shape is what the reviewer used to prove the defect, and
+     * matches tests/Email/fake-phpmailer.php:138's
+     * 'Invalid address:  (%s): %s'), so this fixture now does too, and the
+     * assertion covers the `error` column explicitly, not just the whole
+     * serialized row.
      */
     public function test_row_is_written_but_redacted_when_log_emails_is_disabled(): void
     {
@@ -122,10 +133,14 @@ class MailFailureCaptureTest extends TestCase
         $capture = new MailFailureCapture(new EmailLogger());
         $capture->register_hooks();
 
-        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
-            'to'      => ['a@x.com'],
-            'subject' => 'Order #12',
-        ]));
+        do_action('wp_mail_failed', new WP_Error(
+            'wp_mail_failed',
+            'SMTP Error: The following recipients failed: a@x.com: 550 5.1.1 User unknown',
+            [
+                'to'      => ['a@x.com'],
+                'subject' => 'Order #12',
+            ]
+        ));
 
         $this->assertCount(1, $fakeWpdb->rows, 'A row must always be written for a genuine failure, even with log_emails off.');
 
@@ -133,6 +148,8 @@ class MailFailureCaptureTest extends TestCase
         $this->assertSame('failed', $row['status']);
         $this->assertSame('wp_mail', $row['provider']);
         $this->assertNotSame('', $row['error']);
+        $this->assertStringNotContainsString('a@x.com', $row['error'], 'The address embedded in the error text must not survive when log_emails is off.');
+        $this->assertStringContainsString('550 5.1.1 User unknown', $row['error'], 'Redaction must not destroy the diagnostic detail an operator needs -- only the address.');
 
         $json = (string) json_encode($row);
         $this->assertStringNotContainsString('a@x.com', $json, 'Recipient must not appear anywhere in the row when log_emails is off.');
@@ -156,10 +173,14 @@ class MailFailureCaptureTest extends TestCase
         $capture = new MailFailureCapture(new EmailLogger());
         $capture->register_hooks();
 
-        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
-            'to'      => ['a@x.com'],
-            'subject' => 'Order #12',
-        ]));
+        do_action('wp_mail_failed', new WP_Error(
+            'wp_mail_failed',
+            'SMTP Error: The following recipients failed: a@x.com: 550 5.1.1 User unknown',
+            [
+                'to'      => ['a@x.com'],
+                'subject' => 'Order #12',
+            ]
+        ));
 
         $this->assertCount(1, $fakeWpdb->rows);
         $row = $fakeWpdb->rows[0];
@@ -167,6 +188,7 @@ class MailFailureCaptureTest extends TestCase
         $this->assertSame('wp_mail', $row['provider']);
         $this->assertStringContainsString('a@x.com', $row['mail_to'], 'Opting in to log_emails must actually surface the real recipient.');
         $this->assertSame('Order #12', $row['subject']);
+        $this->assertStringContainsString('a@x.com', $row['error'], 'Opting in to log_emails must not redact the error text either -- the opt-in means the real data, unmodified.');
 
         unset($GLOBALS['wpdb']);
     }

--- a/apps/agent/tests/Email/MailFailureCaptureTest.php
+++ b/apps/agent/tests/Email/MailFailureCaptureTest.php
@@ -8,6 +8,14 @@
  * plugin was invisible to WPMgr. MailFailureCapture closes that gap by
  * listening on wp_mail_failed unconditionally, independent of EmailConfig.
  *
+ * Consent (log_emails) governs WHAT MailFailureCapture::capture() writes,
+ * never WHETHER it writes: a row always exists for a genuine failure (that
+ * is the alert), but the recipient address and subject line are included
+ * only when the site has opted into email logging -- otherwise they are
+ * redacted to empty. See class-mail-failure-capture.php's docblock for the
+ * full reasoning (security-reviewer finding + owner ruling on the initial
+ * commit).
+ *
  * @package WPMgr\Agent\Tests\Email
  */
 
@@ -57,8 +65,11 @@ class MailFailureCaptureTest extends TestCase
 
         Functions\when('current_time')->justReturn('2026-08-17 00:00:00');
 
-        // EmailConfig::load() -> get_option(OPTION); default to an empty
-        // array so the decoded config is unconfigured (provider === '').
+        // EmailConfig::load() -> get_option(OPTION). Default to an empty
+        // array: unconfigured (provider === '') AND log_emails === false --
+        // the real default shape on a site that never touched email
+        // settings, i.e. this feature's entire target population. Tests
+        // that need log_emails=true override this per-test.
         Functions\when('get_option')->justReturn([]);
     }
 
@@ -95,13 +106,92 @@ class MailFailureCaptureTest extends TestCase
     }
 
     /**
-     * RED/GREEN case: core's own wp_mail_failed fires on an UNCONFIGURED
-     * site (no WPMgr provider set) and must produce exactly one 'failed' row.
-     * The send body ('message' in core's error data) must never appear in
-     * any persisted column, under any key, regardless of store_body.
+     * Required test 1 (owner-specified): on an unrouted site with
+     * log_emails=false (the real default), a wp_mail_failed fire must still
+     * write a row -- status='failed', provider='wp_mail', error non-empty --
+     * so the alert exists, but the row must contain NEITHER the recipient
+     * address NOR the subject line in any column.
      */
-    public function test_wp_mail_failed_writes_a_failed_row_when_no_provider_is_configured(): void
+    public function test_row_is_written_but_redacted_when_log_emails_is_disabled(): void
     {
+        Functions\when('get_option')->justReturn([]); // log_emails=false, provider=''
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
+            'to'      => ['a@x.com'],
+            'subject' => 'Order #12',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows, 'A row must always be written for a genuine failure, even with log_emails off.');
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('wp_mail', $row['provider']);
+        $this->assertNotSame('', $row['error']);
+
+        $json = (string) json_encode($row);
+        $this->assertStringNotContainsString('a@x.com', $json, 'Recipient must not appear anywhere in the row when log_emails is off.');
+        $this->assertStringNotContainsString('Order #12', $json, 'Subject must not appear anywhere in the row when log_emails is off.');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Required test 2 (owner-specified): on an unrouted site with
+     * log_emails=true, the row DOES carry the real recipient and subject --
+     * the opt-in has to still mean something.
+     */
+    public function test_row_carries_real_recipient_and_subject_when_log_emails_is_enabled(): void
+    {
+        Functions\when('get_option')->justReturn(['log_emails' => true]);
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
+            'to'      => ['a@x.com'],
+            'subject' => 'Order #12',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('wp_mail', $row['provider']);
+        $this->assertStringContainsString('a@x.com', $row['mail_to'], 'Opting in to log_emails must actually surface the real recipient.');
+        $this->assertSame('Order #12', $row['subject']);
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Required test 3 (owner-specified): with store_body=true (in addition
+     * to cases 1/2 above), the message body is still excluded from every
+     * column, regardless of log_emails or store_body. capture() never sets
+     * body_html/body_text on the $mail payload it builds, so
+     * EmailLogger::write() has nothing to read into the body column no
+     * matter what store_body says.
+     *
+     * Note on `body_stored`: that column reflects the SITE's store_body
+     * setting, not whether any body content was actually captured --
+     * EmailLogger::write() sets it from $cfg->store_body unconditionally
+     * inside its `if ( $cfg->store_body )` branch (class-email-logger.php:75-76),
+     * regardless of whether $mail carries body_html/body_text. So
+     * body_stored=1 here is expected and NOT a leak; the actual property
+     * under test is that the `body` column itself, and every other column,
+     * never contains the raw message text.
+     */
+    public function test_body_is_never_persisted_when_store_body_is_enabled(): void
+    {
+        Functions\when('get_option')->justReturn(['log_emails' => true, 'store_body' => true]);
+
         $fakeWpdb        = $this->fakeWpdb();
         $GLOBALS['wpdb'] = $fakeWpdb;
 
@@ -114,19 +204,47 @@ class MailFailureCaptureTest extends TestCase
             'message' => 'SECRET-BODY',
         ]));
 
-        $this->assertCount(1, $fakeWpdb->rows, 'Exactly one failed row must be written for an unrouted core mail_failed.');
-
+        $this->assertCount(1, $fakeWpdb->rows);
         $row = $fakeWpdb->rows[0];
-        $this->assertSame('failed', $row['status']);
-        $this->assertSame('wp_mail', $row['provider']);
-        $this->assertNotSame('', $row['error']);
-
-        // Security-relevant assertion: the raw message body must appear in
-        // NO field of the persisted row.
+        $this->assertNotSame('SECRET-BODY', $row['body'], "The 'body' column must never carry the raw message text.");
         $this->assertStringNotContainsString('SECRET-BODY', (string) json_encode($row));
-        foreach ($row as $column => $value) {
-            $this->assertNotSame('SECRET-BODY', $value, "Column '{$column}' must never carry the raw message body.");
-        }
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Required test 4 / security-reviewer finding B: a malformed `to`
+     * (an array containing a non-string element) must not throw an uncaught
+     * Error out of the wp_mail_failed hook. Without validation,
+     * EmailLogger::write()'s implode(', ', $to_raw) fatals on a non-string
+     * element (e.g. an object with no __toString) -- and since
+     * wp_mail_failed fires from inside core's wp_mail() catch block, an
+     * uncaught Error here WSODs whatever request triggered the mail send
+     * (checkout, password reset, etc). capture() filters non-string
+     * elements out before they can reach implode().
+     */
+    public function test_capture_does_not_fatal_on_non_string_to_element(): void
+    {
+        Functions\when('get_option')->justReturn(['log_emails' => true]);
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        $malformedRecipient = new class () {
+            // Deliberately no __toString(): (string) cast or implode() on
+            // this object fatals with an uncaught Error.
+        };
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'malformed to element', [
+            'to'      => ['good@example.com', $malformedRecipient],
+            'subject' => 'S',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows, 'A malformed to-element must not prevent the well-formed recipient from being logged.');
+        $this->assertStringContainsString('good@example.com', $fakeWpdb->rows[0]['mail_to']);
 
         unset($GLOBALS['wpdb']);
     }
@@ -144,7 +262,9 @@ class MailFailureCaptureTest extends TestCase
      * when that marker is present. It does not exercise
      * ProviderRouter::send()'s own separate EmailLogger::write() call (the
      * "first" log write in "logged once not twice") -- that call happens on
-     * a different code path outside this test's scope.
+     * a different code path outside this test's scope. The marker check
+     * runs before EmailConfig is even loaded, so this holds regardless of
+     * log_emails.
      */
     public function test_router_handled_failure_is_logged_once_not_twice(): void
     {
@@ -176,12 +296,14 @@ class MailFailureCaptureTest extends TestCase
      * core only calls wp_mail_failed on failure, never on a successful send
      * -- so the most meaningful concrete check available here is that
      * capture() is stateless across repeated fires: two INDEPENDENT
-     * unconfigured failures must produce two independent rows, not a single
-     * corrupted/merged entry, proving the listener doesn't leak state or
-     * drop a second in-process failure.
+     * log_emails-enabled failures must produce two independent rows, not a
+     * single corrupted/merged entry, proving the listener doesn't leak
+     * state or drop a second in-process failure.
      */
-    public function test_two_independent_unconfigured_failures_produce_two_independent_rows(): void
+    public function test_two_independent_failures_produce_two_independent_rows(): void
     {
+        Functions\when('get_option')->justReturn(['log_emails' => true]);
+
         $fakeWpdb        = $this->fakeWpdb();
         $GLOBALS['wpdb'] = $fakeWpdb;
 

--- a/apps/agent/tests/Email/MailFailureCaptureTest.php
+++ b/apps/agent/tests/Email/MailFailureCaptureTest.php
@@ -272,6 +272,91 @@ class MailFailureCaptureTest extends TestCase
     }
 
     /**
+     * Security review, GH #381 phase 2 (second round): the reviewer's exact
+     * end-to-end proof. The regex alone left a non-ASCII/IDN address in the
+     * error text (kunde@münchen.de is a raw IDN domain, refused by
+     * AddressParser::parse_one() and so untouched by the old ASCII-only
+     * regex); capture() must now pass the real recipient to
+     * redact_email_addresses() so it is removed as a literal string. Pinned
+     * permanently: this is the reproduction that proved the defect.
+     */
+    public function test_row_redacts_the_reviewers_idn_proof_case(): void
+    {
+        Functions\when('get_option')->justReturn([]); // log_emails=false
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error(
+            'wp_mail_failed',
+            'SMTP Error: The following recipients failed: kunde@münchen.de: 550 5.1.1 User unknown',
+            [
+                'to'      => ['kunde@münchen.de'],
+                'subject' => 'Bestellung #12',
+            ]
+        ));
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringNotContainsString('kunde@münchen.de', $row['error'], 'The IDN address embedded in the error text must not survive when log_emails is off.');
+        $this->assertStringContainsString('550 5.1.1 User unknown', $row['error'], 'Redaction must not destroy the diagnostic detail an operator needs -- only the address.');
+
+        $json = (string) json_encode($row);
+        $this->assertStringNotContainsString('kunde@münchen.de', $json, 'Recipient must not appear anywhere in the row when log_emails is off.');
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Data-provider over the full GH #381 phase-2 leak catalogue on the
+     * phase-1 capture path: every shape the reviewer proved leaks through
+     * the plain regex must be removed once capture() has the real `to` to
+     * anchor on.
+     *
+     * @dataProvider addressLeakTable
+     */
+    public function test_row_redacts_every_leaking_address_shape(string $address, string $errorTemplate): void
+    {
+        Functions\when('get_option')->justReturn([]); // log_emails=false
+
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        $errorMessage = sprintf($errorTemplate, $address);
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', $errorMessage, [
+            'to'      => [$address],
+            'subject' => 'S',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows);
+        $row = $fakeWpdb->rows[0];
+        $this->assertStringNotContainsString($address, $row['error'], "'{$address}' must not survive redaction.");
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /** @return array<string,array{0:string,1:string}> label => [address, error sprintf template with one %s] */
+    public static function addressLeakTable(): array
+    {
+        return [
+            'raw IDN domain' => ['kunde@münchen.de', 'Invalid address: (to): %s'],
+            'quoted local part' => ['"john doe"@example.com', 'Invalid address: (to): %s'],
+            'IP-literal domain' => ['admin@[192.168.13.7]', 'Invalid address: (to): %s'],
+            'bare-IP domain' => ['admin@203.0.113.9', 'Invalid address: (to): %s'],
+            '1-char TLD' => ['x@y.c', 'Invalid address: (to): %s'],
+            'numeric TLD' => ['admin@example.12345', 'Invalid address: (to): %s'],
+            'non-ASCII local part' => ['jösef@example.com', 'Invalid address: (to): %s'],
+        ];
+    }
+
+    /**
      * No-double-log guard: when MailRouter's own provider send fails, it
      * already (a) logs the row itself via ProviderRouter::send() ->
      * EmailLogger::write(), and (b) fires wp_mail_failed itself (post

--- a/apps/agent/tests/Email/MailFailureCaptureTest.php
+++ b/apps/agent/tests/Email/MailFailureCaptureTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * MailFailureCaptureTest — GH #381 phase 1: WordPress core's own
+ * `wp_mail_failed` action fires on ANY failed send (configured or not), but
+ * nothing in this plugin listened for it. MailRouter::intercept()
+ * (class-mail-router.php) only sees a failure when EmailConfig::is_configured()
+ * is true, so a site sending through core PHPMailer or a third-party SMTP
+ * plugin was invisible to WPMgr. MailFailureCapture closes that gap by
+ * listening on wp_mail_failed unconditionally, independent of EmailConfig.
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+use WPMgr\Agent\Email\EmailLogger;
+use WPMgr\Agent\Email\MailFailureCapture;
+
+/**
+ * @covers \WPMgr\Agent\Email\MailFailureCapture
+ */
+class MailFailureCaptureTest extends TestCase
+{
+    /** @var array<string,array<int,callable>> hook name => registered callbacks. */
+    private array $registeredActions = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        $this->registeredActions = [];
+
+        // Brain Monkey's built-in add_action()/do_action() are expectation
+        // trackers, not a working dispatcher: HookExpectationExecutor::execute()
+        // returns null for a hook with no expectation configured, so
+        // do_action() alone never invokes what add_action() registered. These
+        // aliases build a tiny real pub/sub so do_action() genuinely calls
+        // whatever register_hooks() wired -- proving the WIRING, not just
+        // calling capture() directly. Same pattern as
+        // tests/SelfUpdateInRequestApplyTest.php's add_action alias.
+        Functions\when('add_action')->alias(function (string $hook, $callback, int $priority = 10, int $accepted_args = 1): bool {
+            $this->registeredActions[$hook][] = $callback;
+            return true;
+        });
+        Functions\when('do_action')->alias(function (string $hook, ...$args): void {
+            foreach ($this->registeredActions[$hook] ?? [] as $callback) {
+                $callback(...$args);
+            }
+        });
+
+        Functions\when('current_time')->justReturn('2026-08-17 00:00:00');
+
+        // EmailConfig::load() -> get_option(OPTION); default to an empty
+        // array so the decoded config is unconfigured (provider === '').
+        Functions\when('get_option')->justReturn([]);
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * Minimal fake $wpdb: records every insert() call's $data array so a
+     * test can assert row count and shape without a real database. Uses an
+     * array (not a single captured row) because some tests need to count
+     * multiple potential inserts.
+     */
+    private function fakeWpdb(): object
+    {
+        return new class () {
+            public string $prefix = 'wp_';
+
+            /** @var array<int,array<string,mixed>> */
+            public array $rows = [];
+
+            public int $insert_id = 0;
+
+            /** @param array<string,mixed> $data */
+            public function insert(string $table, array $data, array $formats): bool
+            {
+                $this->rows[] = $data;
+                $this->insert_id++;
+                return true;
+            }
+        };
+    }
+
+    /**
+     * RED/GREEN case: core's own wp_mail_failed fires on an UNCONFIGURED
+     * site (no WPMgr provider set) and must produce exactly one 'failed' row.
+     * The send body ('message' in core's error data) must never appear in
+     * any persisted column, under any key, regardless of store_body.
+     */
+    public function test_wp_mail_failed_writes_a_failed_row_when_no_provider_is_configured(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'SMTP connect() failed', [
+            'to'      => ['a@x.com'],
+            'subject' => 'Order #12',
+            'message' => 'SECRET-BODY',
+        ]));
+
+        $this->assertCount(1, $fakeWpdb->rows, 'Exactly one failed row must be written for an unrouted core mail_failed.');
+
+        $row = $fakeWpdb->rows[0];
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('wp_mail', $row['provider']);
+        $this->assertNotSame('', $row['error']);
+
+        // Security-relevant assertion: the raw message body must appear in
+        // NO field of the persisted row.
+        $this->assertStringNotContainsString('SECRET-BODY', (string) json_encode($row));
+        foreach ($row as $column => $value) {
+            $this->assertNotSame('SECRET-BODY', $value, "Column '{$column}' must never carry the raw message body.");
+        }
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * No-double-log guard: when MailRouter's own provider send fails, it
+     * already (a) logs the row itself via ProviderRouter::send() ->
+     * EmailLogger::write(), and (b) fires wp_mail_failed itself (post
+     * cb7737c) with error_data carrying a `wpmgr_provider_detail` marker
+     * that only ever appears on a WP_Error MailRouter fired -- core's own
+     * native wp_mail_failed data never has that key.
+     *
+     * Scoping: this test only proves that MailFailureCapture::capture(),
+     * reached here through the real wp_mail_failed dispatch, adds ZERO rows
+     * when that marker is present. It does not exercise
+     * ProviderRouter::send()'s own separate EmailLogger::write() call (the
+     * "first" log write in "logged once not twice") -- that call happens on
+     * a different code path outside this test's scope.
+     */
+    public function test_router_handled_failure_is_logged_once_not_twice(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'Provider rejected', [
+            'to'                    => ['a@x.com'],
+            'subject'               => 'S',
+            'headers'               => [],
+            'attachments'           => [],
+            'wpmgr_provider_detail' => 'Provider rejected',
+        ]));
+
+        $this->assertCount(
+            0,
+            $fakeWpdb->rows,
+            'MailFailureCapture must add zero rows when the wpmgr_provider_detail marker shows MailRouter already logged this failure.'
+        );
+
+        unset($GLOBALS['wpdb']);
+    }
+
+    /**
+     * Over-fire control. There is no success-path fire to test directly --
+     * core only calls wp_mail_failed on failure, never on a successful send
+     * -- so the most meaningful concrete check available here is that
+     * capture() is stateless across repeated fires: two INDEPENDENT
+     * unconfigured failures must produce two independent rows, not a single
+     * corrupted/merged entry, proving the listener doesn't leak state or
+     * drop a second in-process failure.
+     */
+    public function test_two_independent_unconfigured_failures_produce_two_independent_rows(): void
+    {
+        $fakeWpdb        = $this->fakeWpdb();
+        $GLOBALS['wpdb'] = $fakeWpdb;
+
+        $capture = new MailFailureCapture(new EmailLogger());
+        $capture->register_hooks();
+
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'first failure', [
+            'to'      => ['first@x.com'],
+            'subject' => 'First',
+        ]));
+        do_action('wp_mail_failed', new WP_Error('wp_mail_failed', 'second failure', [
+            'to'      => ['second@x.com'],
+            'subject' => 'Second',
+        ]));
+
+        $this->assertCount(2, $fakeWpdb->rows);
+        $this->assertSame('first failure', $fakeWpdb->rows[0]['error']);
+        $this->assertSame('second failure', $fakeWpdb->rows[1]['error']);
+        $this->assertStringContainsString('first@x.com', $fakeWpdb->rows[0]['mail_to']);
+        $this->assertStringContainsString('second@x.com', $fakeWpdb->rows[1]['mail_to']);
+
+        unset($GLOBALS['wpdb']);
+    }
+}

--- a/apps/agent/tests/Email/MailRouterTest.php
+++ b/apps/agent/tests/Email/MailRouterTest.php
@@ -153,7 +153,10 @@ class MailRouterTest extends TestCase
             'detail'     => 'smtp connect() failed: Connection refused',
         ]);
 
-        $router->intercept(null, $this->baseAtts());
+        $atts = $this->baseAtts();
+        $atts['message'] = 'SECRET-MESSAGE-BODY-MUST-NEVER-LEAK';
+
+        $router->intercept(null, $atts);
 
         $wpMailFailedCalls = array_values(array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'));
         $this->assertCount(1, $wpMailFailedCalls, 'wp_mail_failed must fire exactly once on a failed send');
@@ -162,13 +165,318 @@ class MailRouterTest extends TestCase
         $this->assertInstanceOf(WP_Error::class, $error, 'wp_mail_failed must be passed a WP_Error, matching core');
         $this->assertSame('smtp connect() failed: Connection refused', $error->get_error_message());
 
-        // The error data must not carry the message body or any secret --
-        // only what core itself would attach (recipient/subject/headers/
-        // attachments) plus our own provider failure detail.
-        $data = $error->get_error_data();
-        $this->assertArrayNotHasKey('message', $data, 'wp_mail_failed error data must never carry the message body');
+        // FINDING D6: the body must appear in NO field of the error data,
+        // under ANY key -- not merely absent under the literal key
+        // 'message'. The old version of this assertion was
+        // assertArrayNotHasKey('message', $data), which a leak under a
+        // DIFFERENT key (e.g. 'body') sails straight through; the
+        // adversarial review proved exactly that by relocating the leak.
+        // Serialize the whole structure and search for the body text itself
+        // instead of trusting any particular key name to stay empty.
+        $data       = $error->get_error_data();
+        $serialized = (string) json_encode($data);
+        $this->assertStringNotContainsString(
+            'SECRET-MESSAGE-BODY-MUST-NEVER-LEAK',
+            $serialized,
+            'wp_mail_failed error data must never carry the message body, under any key'
+        );
         $this->assertSame('someone@example.com', $data['to']);
         $this->assertSame('Subject', $data['subject']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Adversarial review of GH #439: three HIGH regressions.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Replays a set of registered `pre_wp_mail` filters in the SAME
+     * priority-then-insertion order WP_Hook::apply_filters() uses. Brain
+     * Monkey's built-in add_filter()/apply_filters() are expectation
+     * trackers, not a working dispatcher, so a faithful multi-filter replay
+     * needs a real pub-sub -- same reasoning as MailFailureCaptureTest's
+     * add_action/do_action alias pair. usort() is stable as of PHP 8, which
+     * this plugin already requires (composer.json: "php": ">=8.1"), so
+     * same-priority ties keep registration order exactly like core.
+     *
+     * @param list<array{priority:int,callback:callable}> $filters
+     * @param array<string,mixed>                          $atts
+     * @return mixed
+     */
+    private function dispatchPreWpMail(array $filters, array $atts)
+    {
+        usort($filters, static fn (array $a, array $b): int => $a['priority'] <=> $b['priority']);
+
+        $return = null;
+        foreach ($filters as $filter) {
+            $return = ($filter['callback'])($return, $atts);
+        }
+
+        return $return;
+    }
+
+    /**
+     * Registers the add_filter() alias and returns the list that it will
+     * populate. IMPORTANT: this list must be read AFTER register_hooks()
+     * runs, and by the SAME reference this method returns -- an earlier
+     * version of this helper returned a plain array *by value* before any
+     * filter had been registered, so callers held a permanently-empty copy
+     * while the real registrations landed in this method's own (dead) local
+     * scope. Wrapping it in an object gives callers a live handle instead.
+     *
+     * @return object{filters: list<array{priority:int,callback:callable}>}
+     */
+    private function captureRegisteredPreWpMailFilters(): object
+    {
+        $box = new class () {
+            /** @var list<array{priority:int,callback:callable}> */
+            public array $filters = [];
+        };
+        Functions\when('add_filter')->alias(function (string $hook, $callback, int $priority = 10, int $acceptedArgs = 1) use ($box): bool {
+            if ($hook === 'pre_wp_mail') {
+                $box->filters[] = ['priority' => $priority, 'callback' => $callback];
+            }
+            return true;
+        });
+
+        return $box;
+    }
+
+    /**
+     * REGRESSION A, RED case: a later, ordinary third-party idiom
+     * (`if (!$return) return null;`) resets our honest `false` back to
+     * `null`. Per wp-includes/pluggable.php, only `null` lets wp_mail() fall
+     * through to its own PHPMailer -- so this reproduces core running a
+     * SECOND, duplicate delivery attempt for a message WPMgr already tried
+     * and knows failed. Fails on the current single-filter registration;
+     * must pass once a second, PHP_INT_MAX-priority filter re-asserts the
+     * short-circuit.
+     */
+    public function test_a_later_falsy_testing_filter_does_not_cause_a_duplicate_send(): void
+    {
+        $filters = $this->captureRegisteredPreWpMailFilters();
+
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+        $router->register_hooks();
+
+        // A1 from the adversarial review: an entirely ordinary idiom, at a
+        // later priority than our own primary filter (10).
+        $filters->filters[] = [
+            'priority' => 20,
+            'callback' => static function ($return, array $atts) {
+                if (!$return) {
+                    return null;
+                }
+                return $return;
+            },
+        ];
+
+        $finalReturn = $this->dispatchPreWpMail($filters->filters, $this->baseAtts());
+
+        // Faithful re-implementation of wp_mail()'s own short-circuit
+        // condition and its fallback to core's own PHPMailer.
+        $phpMailerRuns = 0;
+        if (null !== $finalReturn) {
+            $wpMailReturn = $finalReturn;
+        } else {
+            ++$phpMailerRuns;
+            $wpMailReturn = true;
+        }
+
+        $this->assertSame(
+            0,
+            $phpMailerRuns,
+            'a message WPMgr already attempted and knows failed must never be re-sent by core -- this is the duplicate-send regression'
+        );
+        $this->assertFalse($wpMailReturn, "wp_mail()'s return value must stay the honest false, not core's own (successful) second attempt");
+
+        $wpMailFailedCalls = array_values(array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'));
+        $this->assertCount(1, $wpMailFailedCalls, 'the re-assert filter must not cause a second wp_mail_failed fire');
+    }
+
+    /**
+     * REGRESSION A, over-fire control: a completely successful send must
+     * pass through the second filter unchanged, and the second filter must
+     * never itself call do_action.
+     */
+    public function test_a_successful_send_passes_through_the_reassert_filter_unchanged(): void
+    {
+        $filters = $this->captureRegisteredPreWpMailFilters();
+        Functions\when('do_action')->justReturn(null);
+
+        $sendResult = ['ok' => true, 'message_id' => 'abc123', 'detail' => ''];
+        $router     = $this->routerWithSendResult($sendResult);
+        $router->register_hooks();
+
+        $finalReturn = $this->dispatchPreWpMail($filters->filters, $this->baseAtts());
+
+        $this->assertSame($sendResult, $finalReturn, 'a successful send must be completely unchanged by the reassert filter');
+    }
+
+    /**
+     * REGRESSION A, over-fire control: a plugin that legitimately
+     * short-circuits BEFORE WPMgr (an earlier priority) must still win, and
+     * WPMgr must never have attempted a send at all.
+     */
+    public function test_a_plugin_that_short_circuits_before_wpmgr_still_wins(): void
+    {
+        $filters = $this->captureRegisteredPreWpMailFilters();
+
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+        Functions\when('get_option')->justReturn(['provider' => 'smtp']);
+
+        $providerRouter = $this->createMock(ProviderRouter::class);
+        $providerRouter->expects($this->never())->method('send');
+        $settings = new Settings();
+        $router   = new MailRouter($providerRouter, $settings);
+        $router->register_hooks();
+
+        $filters->filters[] = [
+            'priority' => 5,
+            'callback' => static fn ($return, array $atts) => 'other-plugin-handled-it',
+        ];
+
+        $finalReturn = $this->dispatchPreWpMail($filters->filters, $this->baseAtts());
+
+        $this->assertSame('other-plugin-handled-it', $finalReturn, 'a plugin that already short-circuited before WPMgr must still win');
+        $this->assertCount(0, array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'), 'wp_mail_failed must not fire when WPMgr never attempted a send');
+    }
+
+    /**
+     * REGRESSION E1, RED case: a wp_mail_failed listener that throws must
+     * not propagate out of intercept() -- core's own wp_mail() does not
+     * catch anything from this hook, so an uncaught exception here would
+     * escape wp_mail() itself and fatal whatever called it (a checkout, a
+     * password reset). intercept() must still produce its honest `false`.
+     */
+    public function test_a_throwing_wp_mail_failed_listener_does_not_prevent_the_honest_false_return(): void
+    {
+        Functions\when('do_action')->alias(function (string $hook, ...$args): void {
+            if ($hook === 'wp_mail_failed') {
+                throw new \RuntimeException('a badly-behaved listener blew up');
+            }
+        });
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertFalse($result, 'a throwing wp_mail_failed listener must not stop intercept() from returning the honest false');
+    }
+
+    /**
+     * REGRESSION E2, RED case: a wp_mail_failed listener that itself calls
+     * wp_mail() -- exactly what a failure-alerting plugin does -- must not
+     * recurse without bound when the alert send ALSO fails. Reproduced by
+     * the adversarial review to depth 2001. The 50-call ceiling here is an
+     * adversarial safety valve only: the assertion is that the PRODUCTION
+     * guard stops this at a small, fixed depth, not that the valve caught
+     * it.
+     */
+    public function test_a_wp_mail_failed_listener_that_calls_wp_mail_again_does_not_recurse_unboundedly(): void
+    {
+        Functions\when('get_option')->justReturn(['provider' => 'smtp']);
+
+        $providerRouter = $this->createMock(ProviderRouter::class);
+        $providerRouter->method('send')->willReturn([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'provider is completely broken',
+        ]);
+        $settings = new Settings();
+        $router   = new MailRouter($providerRouter, $settings);
+
+        $wpMailCalls = 0;
+        // Faithful re-implementation of wp_mail(): dispatch to intercept()
+        // exactly as pre_wp_mail would, then -- per
+        // wp-includes/pluggable.php -- only run core's own PHPMailer path
+        // when the result is exactly null.
+        $fakeWpMail = function (array $atts) use (&$fakeWpMail, &$wpMailCalls, $router): void {
+            ++$wpMailCalls;
+            if ($wpMailCalls > 50) {
+                throw new \RuntimeException('unbounded recursion: wp_mail() re-entered more than 50 times');
+            }
+            $router->intercept(null, $atts);
+        };
+
+        // A textbook failure-alerting plugin: on wp_mail_failed, send an
+        // alert -- through wp_mail() again. Wired via a real do_action so
+        // the recursive call happens exactly where core triggers it,
+        // synchronously, inside MailRouter's own do_action('wp_mail_failed').
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use ($fakeWpMail): void {
+            if ($hook === 'wp_mail_failed') {
+                $fakeWpMail([
+                    'to'      => 'admin@example.com',
+                    'subject' => 'Mail alert',
+                    'message' => 'a send failed',
+                    'headers' => '',
+                ]);
+            }
+        });
+
+        $fakeWpMail($this->baseAtts());
+
+        $this->assertLessThanOrEqual(2, $wpMailCalls, 'a wp_mail_failed listener that itself calls wp_mail() must not recurse without bound');
+    }
+
+    /**
+     * FINDING C: headers pass through to every third-party wp_mail_failed
+     * listener verbatim today (matching core's own shape), so a Bcc archive
+     * address or a bearer token a site set for its own delivery would reach
+     * every OTHER plugin subscribed to the hook -- on a failure path that
+     * never fired at all before GH #439 made a failed send honest. Known-
+     * sensitive header VALUES are redacted; the header NAME (and every
+     * other header) stays visible for diagnosis.
+     */
+    public function test_error_data_headers_redact_bcc_and_auth_shaped_values_but_keep_others(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'provider rejected the message',
+        ]);
+
+        $atts             = $this->baseAtts();
+        $atts['headers']  = "Content-Type: text/plain\r\n"
+            . "Bcc: secret-archive@internal.example\r\n"
+            . "X-Auth-Token: Bearer abc123\r\n"
+            . 'X-WPMgr-Site: site-123';
+
+        $router->intercept(null, $atts);
+
+        $wpMailFailedCalls = array_values(array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'));
+        $error             = $wpMailFailedCalls[0][1][0];
+        $data              = $error->get_error_data();
+        $serialized        = (string) json_encode($data['headers']);
+
+        $this->assertStringNotContainsString('secret-archive@internal.example', $serialized, 'the Bcc VALUE must be redacted');
+        $this->assertStringNotContainsString('abc123', $serialized, 'the auth token VALUE must be redacted');
+        $this->assertStringContainsString('Bcc', $serialized, 'the header NAME stays visible for diagnosis');
+        $this->assertStringContainsString('X-Auth-Token', $serialized, 'the header NAME stays visible for diagnosis');
+        $this->assertStringContainsString('X-WPMgr-Site: site-123', $serialized, 'a non-sensitive header passes through unchanged');
     }
 
     public function test_successful_send_is_unchanged_and_does_not_fire_wp_mail_failed(): void

--- a/apps/agent/tests/Email/MailRouterTest.php
+++ b/apps/agent/tests/Email/MailRouterTest.php
@@ -223,14 +223,11 @@ class MailRouterTest extends TestCase
      * while the real registrations landed in this method's own (dead) local
      * scope. Wrapping it in an object gives callers a live handle instead.
      *
-     * @return object{filters: list<array{priority:int,callback:callable}>}
+     * @return PreWpMailFilterBox
      */
-    private function captureRegisteredPreWpMailFilters(): object
+    private function captureRegisteredPreWpMailFilters(): PreWpMailFilterBox
     {
-        $box = new class () {
-            /** @var list<array{priority:int,callback:callable}> */
-            public array $filters = [];
-        };
+        $box = new PreWpMailFilterBox();
         Functions\when('add_filter')->alias(function (string $hook, $callback, int $priority = 10, int $acceptedArgs = 1) use ($box): bool {
             if ($hook === 'pre_wp_mail') {
                 $box->filters[] = ['priority' => $priority, 'callback' => $callback];

--- a/apps/agent/tests/Email/MailRouterTest.php
+++ b/apps/agent/tests/Email/MailRouterTest.php
@@ -23,6 +23,7 @@ namespace WPMgr\Agent\Tests\Email;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use WP_Error;
 use WPMgr\Agent\Email\AddressParser;
 use WPMgr\Agent\Email\EmailConfig;
 use WPMgr\Agent\Email\MailRouter;
@@ -58,6 +59,138 @@ class MailRouterTest extends TestCase
         $settings       = new Settings();
 
         return new MailRouter($providerRouter, $settings);
+    }
+
+    /**
+     * Build a MailRouter whose ProviderRouter::send() is stubbed to return a
+     * fixed result, and whose EmailConfig::load() sees a configured provider
+     * (so intercept() does not bail out on the "not configured" early return).
+     *
+     * @param array{ok:bool,message_id:string,detail:string} $sendResult
+     */
+    private function routerWithSendResult(array $sendResult): MailRouter
+    {
+        Functions\when('get_option')->justReturn(['provider' => 'smtp']);
+
+        $providerRouter = $this->createMock(ProviderRouter::class);
+        $providerRouter->method('send')->willReturn($sendResult);
+        $settings = new Settings();
+
+        return new MailRouter($providerRouter, $settings);
+    }
+
+    /** @return array<string,mixed> */
+    private function baseAtts(): array
+    {
+        return [
+            'to'      => 'someone@example.com',
+            'subject' => 'Subject',
+            'message' => 'Body',
+            'headers' => '',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #439: wp_mail() must report the truth, not a hard-coded `true`.
+    //
+    // pre_wp_mail short-circuits wp_mail() and its return value BECOMES
+    // wp_mail()'s return value verbatim (wp-includes/pluggable.php:
+    // `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`). Only `null`
+    // lets WP fall through to its own PHPMailer path; any other value --
+    // including `false` -- still short-circuits. So `false` is both an
+    // honest failure signal AND still prevents WP from re-attempting the
+    // send through its own PHPMailer.
+    // -------------------------------------------------------------------------
+
+    public function test_failed_send_returns_false_not_true(): void
+    {
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame(false, $result, 'A failed send must make wp_mail() return false, not a truthy placeholder');
+    }
+
+    public function test_failed_send_return_value_still_satisfies_cores_own_short_circuit_condition(): void
+    {
+        // This re-states, verbatim, the exact condition wp_mail() itself uses
+        // in wp-includes/pluggable.php to decide whether to run its own
+        // PHPMailer path: `if ( null !== $pre_wp_mail ) { return $pre_wp_mail; }`
+        // A failed send must keep satisfying it -- i.e. never fall back to
+        // `null` -- or WordPress will attempt a second, duplicate delivery.
+        Functions\when('do_action')->justReturn(null);
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'provider rejected the message',
+        ]);
+
+        $preWpMail = $router->intercept(null, $this->baseAtts());
+
+        $coreWouldShortCircuit = ( null !== $preWpMail );
+        $this->assertTrue($coreWouldShortCircuit, 'core must still short-circuit on a failed send, or WP retries the send itself and duplicates the email');
+        $this->assertFalse($preWpMail, 'the short-circuited value must be the honest false, not a placeholder true');
+    }
+
+    public function test_failed_send_fires_wp_mail_failed_exactly_once_with_wp_error(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $router = $this->routerWithSendResult([
+            'ok'         => false,
+            'message_id' => '',
+            'detail'     => 'smtp connect() failed: Connection refused',
+        ]);
+
+        $router->intercept(null, $this->baseAtts());
+
+        $wpMailFailedCalls = array_values(array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed'));
+        $this->assertCount(1, $wpMailFailedCalls, 'wp_mail_failed must fire exactly once on a failed send');
+
+        $error = $wpMailFailedCalls[0][1][0] ?? null;
+        $this->assertInstanceOf(WP_Error::class, $error, 'wp_mail_failed must be passed a WP_Error, matching core');
+        $this->assertSame('smtp connect() failed: Connection refused', $error->get_error_message());
+
+        // The error data must not carry the message body or any secret --
+        // only what core itself would attach (recipient/subject/headers/
+        // attachments) plus our own provider failure detail.
+        $data = $error->get_error_data();
+        $this->assertArrayNotHasKey('message', $data, 'wp_mail_failed error data must never carry the message body');
+        $this->assertSame('someone@example.com', $data['to']);
+        $this->assertSame('Subject', $data['subject']);
+    }
+
+    public function test_successful_send_is_unchanged_and_does_not_fire_wp_mail_failed(): void
+    {
+        /** @var list<array{string,array<mixed>}> */
+        $fired = [];
+        Functions\when('do_action')->alias(function (string $hook, ...$args) use (&$fired): void {
+            $fired[] = [$hook, $args];
+        });
+
+        $sendResult = [
+            'ok'         => true,
+            'message_id' => 'abc123',
+            'detail'     => '',
+        ];
+        $router = $this->routerWithSendResult($sendResult);
+
+        $result = $router->intercept(null, $this->baseAtts());
+
+        $this->assertSame($sendResult, $result, 'a successful send must return the same value as before this fix');
+        $wpMailFailedCalls = array_filter($fired, static fn (array $c) => $c[0] === 'wp_mail_failed');
+        $this->assertCount(0, $wpMailFailedCalls, 'wp_mail_failed must never fire on a successful send');
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/Email/PreWpMailFilterBox.php
+++ b/apps/agent/tests/Email/PreWpMailFilterBox.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * PreWpMailFilterBox: mutable, live handle for the `pre_wp_mail` filter
+ * registrations captured by MailRouterTest::captureRegisteredPreWpMailFilters().
+ *
+ * Extracted out of an inline `new class () {...}` so PHPStan sees a normal,
+ * writable class property across the method boundary. An anonymous class
+ * annotated via the `@return object{filters: ...}` PHPDoc shape is inferred
+ * as a READ-ONLY object shape once it crosses out of the declaring method's
+ * scope, so every caller appending to `->filters` after calling that helper
+ * (`$filters->filters[] = [...]`) trips `assign.propertyReadOnly` even
+ * though the property itself is an ordinary mutable `public array`. A named
+ * class has no such inference gap.
+ *
+ * @package WPMgr\Agent\Tests\Email
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Email;
+
+/**
+ * Live handle for captured `pre_wp_mail` filter registrations.
+ */
+final class PreWpMailFilterBox
+{
+    /** @var list<array{priority:int,callback:callable}> */
+    public array $filters = [];
+}

--- a/apps/api/db/query/site_email.sql
+++ b/apps/api/db/query/site_email.sql
@@ -149,6 +149,45 @@ WHERE tenant_id = @tenant_id
 ORDER BY created_at DESC, id DESC
 LIMIT @row_limit OFFSET @row_offset;
 
+-- name: ListConnectedSiteEmailCoverage :many
+-- GH #381 phase 2 fix: per-connected-site facts needed to compute
+-- failure-detection coverage honestly. A site can report a delivery failure
+-- either because WPMgr is the mail transport in use (routed = true) OR
+-- because its agent_version is new enough to capture an unrouted failure
+-- (compared in Go against MinAgentVersionForFailureDetection). Both raw
+-- facts are returned per site; the OR is applied in Go
+-- (internal/email/service.go failureDetectionCoverage).
+--
+-- routed mirrors the agent's own EmailConfig::is_configured(), which is true
+-- exactly when the stored provider string is non-empty
+-- (apps/agent/includes/email/class-email-config.php): a per-site
+-- site_email_config row, when one exists, governs outright (no fallback to
+-- the org-wide default even if its own provider happens to be empty) --
+-- ONLY the absence of a per-site row falls back to the org-wide default row
+-- (site_id IS NULL). This mirrors GetSiteEmailConfig's documented
+-- ErrNoRows-triggers-fallback contract (site_email.sql, GetSiteEmailConfig /
+-- GetOrgEmailConfig above).
+--
+-- The ::boolean cast is not cosmetic: without it sqlc cannot infer a type for
+-- the bare CASE and generates the column as interface{}, forcing a type
+-- assertion on every caller. Both branches are already non-NULL boolean
+-- (provider is NOT NULL, and COALESCE covers the absent org row), so the cast
+-- only names the type it already has.
+SELECT
+    s.id,
+    s.agent_version,
+    (CASE
+        WHEN sec.id IS NOT NULL THEN sec.provider <> ''
+        ELSE COALESCE(org.provider, '') <> ''
+    END)::boolean AS routed
+FROM sites s
+LEFT JOIN site_email_config sec
+    ON sec.tenant_id = s.tenant_id AND sec.site_id = s.id
+LEFT JOIN site_email_config org
+    ON org.tenant_id = s.tenant_id AND org.site_id IS NULL
+WHERE s.tenant_id = @tenant_id
+  AND s.connection_state = 'connected';
+
 -- name: GetEmailConfigByRouteTokenHash :one
 -- m61: resolve a config row by its webhook_route_token_hash for the public
 -- webhook dispatcher.  Runs under InAgentTx (webhook path, no tenant GUC).

--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -139,6 +139,22 @@ WHERE s.tenant_id = $1
   AND s.connection_state <> 'archived'
 ORDER BY s.name;
 
+-- name: ListConnectedSiteAgentVersions :many
+-- Tenant-scoped agent_version per site, restricted to connection_state =
+-- 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+-- here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+-- degraded/pending/disconnected/archived): a site whose agent is not actively
+-- connected cannot report a delivery failure regardless of its version, so it
+-- is excluded from both the coverage numerator and denominator rather than
+-- counted as a gap.
+-- Version comparison happens in Go (internal/wpversion.Compare), matching
+-- ListSitesAgentVersions's convention: this query returns only the raw
+-- per-site fact.
+SELECT agent_version
+FROM sites
+WHERE tenant_id = $1
+  AND connection_state = 'connected';
+
 -- name: ListClientNamesForSites :many
 -- Returns the client id + name for sites that have a client_id set (m63).
 -- Used to enrich the sites-list DTO with client_name in a single batched join.

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -46926,8 +46926,10 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 		e.Bool(s.InstanceMailerConfigured)
 	}
 	{
-		e.FieldStart("failure_detection")
-		s.FailureDetection.Encode(e)
+		if s.FailureDetection.Set {
+			e.FieldStart("failure_detection")
+			s.FailureDetection.Encode(e)
+		}
 	}
 	{
 		if s.TenantID.Set {
@@ -47113,8 +47115,8 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"instance_mailer_configured\"")
 			}
 		case "failure_detection":
-			requiredBitSet[1] |= 1 << 3
 			if err := func() error {
+				s.FailureDetection.Reset()
 				if err := s.FailureDetection.Decode(d); err != nil {
 					return err
 				}
@@ -47163,7 +47165,7 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00001101,
+		0b00000101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -76572,6 +76574,39 @@ func (s OptEmailConnectionConfig) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptEmailConnectionConfig) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes EmailNotifySettingsFailureDetection as json.
+func (o OptEmailNotifySettingsFailureDetection) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes EmailNotifySettingsFailureDetection from json.
+func (o *OptEmailNotifySettingsFailureDetection) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptEmailNotifySettingsFailureDetection to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptEmailNotifySettingsFailureDetection) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptEmailNotifySettingsFailureDetection) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -47271,15 +47271,20 @@ func (s *EmailNotifySettingsFailureDetection) encodeFields(e *jx.Encoder) {
 		e.Int(s.SitesCovered)
 	}
 	{
-		e.FieldStart("min_agent_version")
-		e.Str(s.MinAgentVersion)
+		e.FieldStart("sites_routed")
+		e.Int(s.SitesRouted)
+	}
+	{
+		e.FieldStart("min_agent_version_unrouted")
+		e.Str(s.MinAgentVersionUnrouted)
 	}
 }
 
-var jsonFieldsNameOfEmailNotifySettingsFailureDetection = [3]string{
+var jsonFieldsNameOfEmailNotifySettingsFailureDetection = [4]string{
 	0: "sites_total",
 	1: "sites_covered",
-	2: "min_agent_version",
+	2: "sites_routed",
+	3: "min_agent_version_unrouted",
 }
 
 // Decode decodes EmailNotifySettingsFailureDetection from json.
@@ -47315,17 +47320,29 @@ func (s *EmailNotifySettingsFailureDetection) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"sites_covered\"")
 			}
-		case "min_agent_version":
+		case "sites_routed":
 			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				v, err := d.Str()
-				s.MinAgentVersion = string(v)
+				v, err := d.Int()
+				s.SitesRouted = int(v)
 				if err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"min_agent_version\"")
+				return errors.Wrap(err, "decode field \"sites_routed\"")
+			}
+		case "min_agent_version_unrouted":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Str()
+				s.MinAgentVersionUnrouted = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"min_agent_version_unrouted\"")
 			}
 		default:
 			return d.Skip()
@@ -47337,7 +47354,7 @@ func (s *EmailNotifySettingsFailureDetection) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000111,
+		0b00001111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -46926,6 +46926,10 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 		e.Bool(s.InstanceMailerConfigured)
 	}
 	{
+		e.FieldStart("failure_detection")
+		s.FailureDetection.Encode(e)
+	}
+	{
 		if s.TenantID.Set {
 			e.FieldStart("tenant_id")
 			s.TenantID.Encode(e)
@@ -46945,7 +46949,7 @@ func (s *EmailNotifySettings) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfEmailNotifySettings = [14]string{
+var jsonFieldsNameOfEmailNotifySettings = [15]string{
 	0:  "enabled",
 	1:  "recipients",
 	2:  "alert_on_failure",
@@ -46957,9 +46961,10 @@ var jsonFieldsNameOfEmailNotifySettings = [14]string{
 	8:  "timezone",
 	9:  "next_digest_at",
 	10: "instance_mailer_configured",
-	11: "tenant_id",
-	12: "created_at",
-	13: "updated_at",
+	11: "failure_detection",
+	12: "tenant_id",
+	13: "created_at",
+	14: "updated_at",
 }
 
 // Decode decodes EmailNotifySettings from json.
@@ -47107,6 +47112,16 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"instance_mailer_configured\"")
 			}
+		case "failure_detection":
+			requiredBitSet[1] |= 1 << 3
+			if err := func() error {
+				if err := s.FailureDetection.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"failure_detection\"")
+			}
 		case "tenant_id":
 			if err := func() error {
 				s.TenantID.Reset()
@@ -47148,7 +47163,7 @@ func (s *EmailNotifySettings) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b11111111,
-		0b00000101,
+		0b00001101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -47232,6 +47247,136 @@ func (s EmailNotifySettingsDigestCadence) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *EmailNotifySettingsDigestCadence) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *EmailNotifySettingsFailureDetection) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *EmailNotifySettingsFailureDetection) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("sites_total")
+		e.Int(s.SitesTotal)
+	}
+	{
+		e.FieldStart("sites_covered")
+		e.Int(s.SitesCovered)
+	}
+	{
+		e.FieldStart("min_agent_version")
+		e.Str(s.MinAgentVersion)
+	}
+}
+
+var jsonFieldsNameOfEmailNotifySettingsFailureDetection = [3]string{
+	0: "sites_total",
+	1: "sites_covered",
+	2: "min_agent_version",
+}
+
+// Decode decodes EmailNotifySettingsFailureDetection from json.
+func (s *EmailNotifySettingsFailureDetection) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EmailNotifySettingsFailureDetection to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "sites_total":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Int()
+				s.SitesTotal = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sites_total\"")
+			}
+		case "sites_covered":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.SitesCovered = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sites_covered\"")
+			}
+		case "min_agent_version":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.MinAgentVersion = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"min_agent_version\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EmailNotifySettingsFailureDetection")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfEmailNotifySettingsFailureDetection) {
+					name = jsonFieldsNameOfEmailNotifySettingsFailureDetection[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *EmailNotifySettingsFailureDetection) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EmailNotifySettingsFailureDetection) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -17014,7 +17014,7 @@ type EmailNotifySettings struct {
 	// only detect a failure when it is the mail transport in use AND the agent is new enough to report
 	// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
 	// alert no matter how the settings above are configured.
-	FailureDetection EmailNotifySettingsFailureDetection `json:"failure_detection"`
+	FailureDetection OptEmailNotifySettingsFailureDetection `json:"failure_detection"`
 	// Present when a settings row exists; absent for default response.
 	TenantID  OptNilUUID     `json:"tenant_id"`
 	CreatedAt OptNilDateTime `json:"created_at"`
@@ -17077,7 +17077,7 @@ func (s *EmailNotifySettings) GetInstanceMailerConfigured() bool {
 }
 
 // GetFailureDetection returns the value of FailureDetection.
-func (s *EmailNotifySettings) GetFailureDetection() EmailNotifySettingsFailureDetection {
+func (s *EmailNotifySettings) GetFailureDetection() OptEmailNotifySettingsFailureDetection {
 	return s.FailureDetection
 }
 
@@ -17152,7 +17152,7 @@ func (s *EmailNotifySettings) SetInstanceMailerConfigured(val bool) {
 }
 
 // SetFailureDetection sets the value of FailureDetection.
-func (s *EmailNotifySettings) SetFailureDetection(val EmailNotifySettingsFailureDetection) {
+func (s *EmailNotifySettings) SetFailureDetection(val OptEmailNotifySettingsFailureDetection) {
 	s.FailureDetection = val
 }
 
@@ -29295,6 +29295,52 @@ func (o OptEmailConnectionConfig) Get() (v EmailConnectionConfig, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptEmailConnectionConfig) Or(d EmailConnectionConfig) EmailConnectionConfig {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptEmailNotifySettingsFailureDetection returns new OptEmailNotifySettingsFailureDetection with value set to v.
+func NewOptEmailNotifySettingsFailureDetection(v EmailNotifySettingsFailureDetection) OptEmailNotifySettingsFailureDetection {
+	return OptEmailNotifySettingsFailureDetection{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptEmailNotifySettingsFailureDetection is optional EmailNotifySettingsFailureDetection.
+type OptEmailNotifySettingsFailureDetection struct {
+	Value EmailNotifySettingsFailureDetection
+	Set   bool
+}
+
+// IsSet returns true if OptEmailNotifySettingsFailureDetection was set.
+func (o OptEmailNotifySettingsFailureDetection) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptEmailNotifySettingsFailureDetection) Reset() {
+	var v EmailNotifySettingsFailureDetection
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptEmailNotifySettingsFailureDetection) SetTo(v EmailNotifySettingsFailureDetection) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptEmailNotifySettingsFailureDetection) Get() (v EmailNotifySettingsFailureDetection, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptEmailNotifySettingsFailureDetection) Or(d EmailNotifySettingsFailureDetection) EmailNotifySettingsFailureDetection {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -17010,10 +17010,11 @@ type EmailNotifySettings struct {
 	// True when the instance-level SMTP/mailer is configured. Alerts and digests require this to be true
 	// to deliver.
 	InstanceMailerConfigured bool `json:"instance_mailer_configured"`
-	// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
-	// only detect a failure when it is the mail transport in use AND the agent is new enough to report
-	// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
-	// alert no matter how the settings above are configured.
+	// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). A site is
+	// covered when EITHER WPMgr is the mail transport it actively uses (routing does not depend on agent
+	// version) OR its agent is new enough (>= min_agent_version_unrouted) to capture a failure on mail
+	// WPMgr does not route. A site that is neither routed nor on a new enough agent cannot trigger a
+	// per-failure alert no matter how the settings above are configured.
 	FailureDetection OptEmailNotifySettingsFailureDetection `json:"failure_detection"`
 	// Present when a settings row exists; absent for default response.
 	TenantID  OptNilUUID     `json:"tenant_id"`
@@ -17223,19 +17224,26 @@ func (s *EmailNotifySettingsDigestCadence) UnmarshalText(data []byte) error {
 	}
 }
 
-// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
-// only detect a failure when it is the mail transport in use AND the agent is new enough to report
-// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
-// alert no matter how the settings above are configured.
+// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). A site is
+// covered when EITHER WPMgr is the mail transport it actively uses (routing does not depend on agent
+// version) OR its agent is new enough (>= min_agent_version_unrouted) to capture a failure on mail
+// WPMgr does not route. A site that is neither routed nor on a new enough agent cannot trigger a
+// per-failure alert no matter how the settings above are configured.
 type EmailNotifySettingsFailureDetection struct {
 	// Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected,
 	// revoked and archived sites).
 	SitesTotal int `json:"sites_total"`
-	// Of sites_total, how many report an agent_version at or above min_agent_version and can therefore
-	// have a delivery failure detected and alerted on.
+	// Of sites_total, how many can have a delivery failure detected and alerted on — because WPMgr
+	// routes their mail, because their agent_version is at or above min_agent_version_unrouted, or both.
 	SitesCovered int `json:"sites_covered"`
-	// Minimum agent version that can detect and report an email delivery failure.
-	MinAgentVersion string `json:"min_agent_version"`
+	// Of sites_total, how many have WPMgr configured as their active mail transport. These sites are
+	// covered regardless of agent version; this count explains why sites_covered can be high even on a
+	// fleet below min_agent_version_unrouted.
+	SitesRouted int `json:"sites_routed"`
+	// Minimum agent version needed to detect and report a delivery failure ONLY for sites that do NOT
+	// route their mail through WPMgr (sites_total - sites_routed of them). It says nothing about routed
+	// sites, which are covered independent of this value.
+	MinAgentVersionUnrouted string `json:"min_agent_version_unrouted"`
 }
 
 // GetSitesTotal returns the value of SitesTotal.
@@ -17248,9 +17256,14 @@ func (s *EmailNotifySettingsFailureDetection) GetSitesCovered() int {
 	return s.SitesCovered
 }
 
-// GetMinAgentVersion returns the value of MinAgentVersion.
-func (s *EmailNotifySettingsFailureDetection) GetMinAgentVersion() string {
-	return s.MinAgentVersion
+// GetSitesRouted returns the value of SitesRouted.
+func (s *EmailNotifySettingsFailureDetection) GetSitesRouted() int {
+	return s.SitesRouted
+}
+
+// GetMinAgentVersionUnrouted returns the value of MinAgentVersionUnrouted.
+func (s *EmailNotifySettingsFailureDetection) GetMinAgentVersionUnrouted() string {
+	return s.MinAgentVersionUnrouted
 }
 
 // SetSitesTotal sets the value of SitesTotal.
@@ -17263,9 +17276,14 @@ func (s *EmailNotifySettingsFailureDetection) SetSitesCovered(val int) {
 	s.SitesCovered = val
 }
 
-// SetMinAgentVersion sets the value of MinAgentVersion.
-func (s *EmailNotifySettingsFailureDetection) SetMinAgentVersion(val string) {
-	s.MinAgentVersion = val
+// SetSitesRouted sets the value of SitesRouted.
+func (s *EmailNotifySettingsFailureDetection) SetSitesRouted(val int) {
+	s.SitesRouted = val
+}
+
+// SetMinAgentVersionUnrouted sets the value of MinAgentVersionUnrouted.
+func (s *EmailNotifySettingsFailureDetection) SetMinAgentVersionUnrouted(val string) {
+	s.MinAgentVersionUnrouted = val
 }
 
 // Static catalog of supported email providers and their field schemas.

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -17010,6 +17010,11 @@ type EmailNotifySettings struct {
 	// True when the instance-level SMTP/mailer is configured. Alerts and digests require this to be true
 	// to deliver.
 	InstanceMailerConfigured bool `json:"instance_mailer_configured"`
+	// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
+	// only detect a failure when it is the mail transport in use AND the agent is new enough to report
+	// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
+	// alert no matter how the settings above are configured.
+	FailureDetection EmailNotifySettingsFailureDetection `json:"failure_detection"`
 	// Present when a settings row exists; absent for default response.
 	TenantID  OptNilUUID     `json:"tenant_id"`
 	CreatedAt OptNilDateTime `json:"created_at"`
@@ -17069,6 +17074,11 @@ func (s *EmailNotifySettings) GetNextDigestAt() OptNilDateTime {
 // GetInstanceMailerConfigured returns the value of InstanceMailerConfigured.
 func (s *EmailNotifySettings) GetInstanceMailerConfigured() bool {
 	return s.InstanceMailerConfigured
+}
+
+// GetFailureDetection returns the value of FailureDetection.
+func (s *EmailNotifySettings) GetFailureDetection() EmailNotifySettingsFailureDetection {
+	return s.FailureDetection
 }
 
 // GetTenantID returns the value of TenantID.
@@ -17141,6 +17151,11 @@ func (s *EmailNotifySettings) SetInstanceMailerConfigured(val bool) {
 	s.InstanceMailerConfigured = val
 }
 
+// SetFailureDetection sets the value of FailureDetection.
+func (s *EmailNotifySettings) SetFailureDetection(val EmailNotifySettingsFailureDetection) {
+	s.FailureDetection = val
+}
+
 // SetTenantID sets the value of TenantID.
 func (s *EmailNotifySettings) SetTenantID(val OptNilUUID) {
 	s.TenantID = val
@@ -17206,6 +17221,51 @@ func (s *EmailNotifySettingsDigestCadence) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
+}
+
+// Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can
+// only detect a failure when it is the mail transport in use AND the agent is new enough to report
+// it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure
+// alert no matter how the settings above are configured.
+type EmailNotifySettingsFailureDetection struct {
+	// Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected,
+	// revoked and archived sites).
+	SitesTotal int `json:"sites_total"`
+	// Of sites_total, how many report an agent_version at or above min_agent_version and can therefore
+	// have a delivery failure detected and alerted on.
+	SitesCovered int `json:"sites_covered"`
+	// Minimum agent version that can detect and report an email delivery failure.
+	MinAgentVersion string `json:"min_agent_version"`
+}
+
+// GetSitesTotal returns the value of SitesTotal.
+func (s *EmailNotifySettingsFailureDetection) GetSitesTotal() int {
+	return s.SitesTotal
+}
+
+// GetSitesCovered returns the value of SitesCovered.
+func (s *EmailNotifySettingsFailureDetection) GetSitesCovered() int {
+	return s.SitesCovered
+}
+
+// GetMinAgentVersion returns the value of MinAgentVersion.
+func (s *EmailNotifySettingsFailureDetection) GetMinAgentVersion() string {
+	return s.MinAgentVersion
+}
+
+// SetSitesTotal sets the value of SitesTotal.
+func (s *EmailNotifySettingsFailureDetection) SetSitesTotal(val int) {
+	s.SitesTotal = val
+}
+
+// SetSitesCovered sets the value of SitesCovered.
+func (s *EmailNotifySettingsFailureDetection) SetSitesCovered(val int) {
+	s.SitesCovered = val
+}
+
+// SetMinAgentVersion sets the value of MinAgentVersion.
+func (s *EmailNotifySettingsFailureDetection) SetMinAgentVersion(val string) {
+	s.MinAgentVersion = val
 }
 
 // Static catalog of supported email providers and their field schemas.

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1596,6 +1596,17 @@ type Querier interface {
 	// expansion (pin a carry-forward chunk's old origin generation under a live
 	// tip) without a second round-trip.
 	ListCompletedSnapshotsForSite(ctx context.Context, arg ListCompletedSnapshotsForSiteParams) ([]ListCompletedSnapshotsForSiteRow, error)
+	// Tenant-scoped agent_version per site, restricted to connection_state =
+	// 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+	// here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+	// degraded/pending/disconnected/archived): a site whose agent is not actively
+	// connected cannot report a delivery failure regardless of its version, so it
+	// is excluded from both the coverage numerator and denominator rather than
+	// counted as a gap.
+	// Version comparison happens in Go (internal/wpversion.Compare), matching
+	// ListSitesAgentVersions's convention: this query returns only the raw
+	// per-site fact.
+	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
 	// Cross-tenant enumeration of connected sites for the weekly screenshot fanout.
 	// Returns only sites in the 'connected' state (not degraded/pending/archived).
 	// Runs under the app.agent GUC (sites_agent policy) since it spans tenants.

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -1607,6 +1607,30 @@ type Querier interface {
 	// ListSitesAgentVersions's convention: this query returns only the raw
 	// per-site fact.
 	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
+	// GH #381 phase 2 fix: per-connected-site facts needed to compute
+	// failure-detection coverage honestly. A site can report a delivery failure
+	// either because WPMgr is the mail transport in use (routed = true) OR
+	// because its agent_version is new enough to capture an unrouted failure
+	// (compared in Go against MinAgentVersionForFailureDetection). Both raw
+	// facts are returned per site; the OR is applied in Go
+	// (internal/email/service.go failureDetectionCoverage).
+	//
+	// routed mirrors the agent's own EmailConfig::is_configured(), which is true
+	// exactly when the stored provider string is non-empty
+	// (apps/agent/includes/email/class-email-config.php): a per-site
+	// site_email_config row, when one exists, governs outright (no fallback to
+	// the org-wide default even if its own provider happens to be empty) --
+	// ONLY the absence of a per-site row falls back to the org-wide default row
+	// (site_id IS NULL). This mirrors GetSiteEmailConfig's documented
+	// ErrNoRows-triggers-fallback contract (site_email.sql, GetSiteEmailConfig /
+	// GetOrgEmailConfig above).
+	//
+	// The ::boolean cast is not cosmetic: without it sqlc cannot infer a type for
+	// the bare CASE and generates the column as interface{}, forcing a type
+	// assertion on every caller. Both branches are already non-NULL boolean
+	// (provider is NOT NULL, and COALESCE covers the absent org row), so the cast
+	// only names the type it already has.
+	ListConnectedSiteEmailCoverage(ctx context.Context, tenantID uuid.UUID) ([]ListConnectedSiteEmailCoverageRow, error)
 	// Cross-tenant enumeration of connected sites for the weekly screenshot fanout.
 	// Returns only sites in the 'connected' state (not degraded/pending/archived).
 	// Runs under the app.agent GUC (sites_agent policy) since it spans tenants.

--- a/apps/api/internal/db/sqlc/site_email.sql.go
+++ b/apps/api/internal/db/sqlc/site_email.sql.go
@@ -1365,6 +1365,72 @@ func (q *Queries) IsSuppressed(ctx context.Context, arg IsSuppressedParams) (boo
 	return suppressed, err
 }
 
+const listConnectedSiteEmailCoverage = `-- name: ListConnectedSiteEmailCoverage :many
+SELECT
+    s.id,
+    s.agent_version,
+    (CASE
+        WHEN sec.id IS NOT NULL THEN sec.provider <> ''
+        ELSE COALESCE(org.provider, '') <> ''
+    END)::boolean AS routed
+FROM sites s
+LEFT JOIN site_email_config sec
+    ON sec.tenant_id = s.tenant_id AND sec.site_id = s.id
+LEFT JOIN site_email_config org
+    ON org.tenant_id = s.tenant_id AND org.site_id IS NULL
+WHERE s.tenant_id = $1
+  AND s.connection_state = 'connected'
+`
+
+type ListConnectedSiteEmailCoverageRow struct {
+	ID           uuid.UUID `json:"id"`
+	AgentVersion string    `json:"agent_version"`
+	Routed       bool      `json:"routed"`
+}
+
+// GH #381 phase 2 fix: per-connected-site facts needed to compute
+// failure-detection coverage honestly. A site can report a delivery failure
+// either because WPMgr is the mail transport in use (routed = true) OR
+// because its agent_version is new enough to capture an unrouted failure
+// (compared in Go against MinAgentVersionForFailureDetection). Both raw
+// facts are returned per site; the OR is applied in Go
+// (internal/email/service.go failureDetectionCoverage).
+//
+// routed mirrors the agent's own EmailConfig::is_configured(), which is true
+// exactly when the stored provider string is non-empty
+// (apps/agent/includes/email/class-email-config.php): a per-site
+// site_email_config row, when one exists, governs outright (no fallback to
+// the org-wide default even if its own provider happens to be empty) --
+// ONLY the absence of a per-site row falls back to the org-wide default row
+// (site_id IS NULL). This mirrors GetSiteEmailConfig's documented
+// ErrNoRows-triggers-fallback contract (site_email.sql, GetSiteEmailConfig /
+// GetOrgEmailConfig above).
+//
+// The ::boolean cast is not cosmetic: without it sqlc cannot infer a type for
+// the bare CASE and generates the column as interface{}, forcing a type
+// assertion on every caller. Both branches are already non-NULL boolean
+// (provider is NOT NULL, and COALESCE covers the absent org row), so the cast
+// only names the type it already has.
+func (q *Queries) ListConnectedSiteEmailCoverage(ctx context.Context, tenantID uuid.UUID) ([]ListConnectedSiteEmailCoverageRow, error) {
+	rows, err := q.db.Query(ctx, listConnectedSiteEmailCoverage, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListConnectedSiteEmailCoverageRow
+	for rows.Next() {
+		var i ListConnectedSiteEmailCoverageRow
+		if err := rows.Scan(&i.ID, &i.AgentVersion, &i.Routed); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDueDigests = `-- name: ListDueDigests :many
 
 SELECT tenant_id, enabled, recipients, alert_on_failure, alert_throttle_minutes, digest_enabled, digest_cadence, digest_day, digest_hour, timezone, next_digest_at, created_at, updated_at

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -582,6 +582,43 @@ func (q *Queries) ListClientNamesForSites(ctx context.Context, arg ListClientNam
 	return items, nil
 }
 
+const listConnectedSiteAgentVersions = `-- name: ListConnectedSiteAgentVersions :many
+SELECT agent_version
+FROM sites
+WHERE tenant_id = $1
+  AND connection_state = 'connected'
+`
+
+// Tenant-scoped agent_version per site, restricted to connection_state =
+// 'connected' (GH #381 phase 2: email failure-detection coverage). "Connected"
+// here matches ListConnectedSiteIDsForScreenshot's strict definition (not
+// degraded/pending/disconnected/archived): a site whose agent is not actively
+// connected cannot report a delivery failure regardless of its version, so it
+// is excluded from both the coverage numerator and denominator rather than
+// counted as a gap.
+// Version comparison happens in Go (internal/wpversion.Compare), matching
+// ListSitesAgentVersions's convention: this query returns only the raw
+// per-site fact.
+func (q *Queries) ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error) {
+	rows, err := q.db.Query(ctx, listConnectedSiteAgentVersions, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var agent_version string
+		if err := rows.Scan(&agent_version); err != nil {
+			return nil, err
+		}
+		items = append(items, agent_version)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listConnectedSiteIDsForScreenshot = `-- name: ListConnectedSiteIDsForScreenshot :many
 SELECT id, tenant_id, url FROM sites
 WHERE connection_state = 'connected'

--- a/apps/api/internal/email/dto.go
+++ b/apps/api/internal/email/dto.go
@@ -320,8 +320,8 @@ type siteDeliveryItemDTO struct {
 	ComplainedCount int64   `json:"complained_count"`
 	BounceRate      float64 `json:"bounce_rate"`
 	ComplaintRate   float64 `json:"complaint_rate"`
-	LastSentAt      *string `json:"last_sent_at"`        // RFC3339 or null
-	Sparkline       []int64 `json:"sparkline"`            // [] never null
+	LastSentAt      *string `json:"last_sent_at"` // RFC3339 or null
+	Sparkline       []int64 `json:"sparkline"`    // [] never null
 }
 
 // deliverabilityReportDTO is the full response for GET /email/deliverability.
@@ -616,20 +616,29 @@ type putConnectionBody struct {
 
 // notifySettingsDTO is the wire representation of NotifySettings.
 type notifySettingsDTO struct {
-	TenantID                 string   `json:"tenant_id"`
-	Enabled                  bool     `json:"enabled"`
-	Recipients               []string `json:"recipients"`
-	AlertOnFailure           bool     `json:"alert_on_failure"`
-	AlertThrottleMinutes     int      `json:"alert_throttle_minutes"`
-	DigestEnabled            bool     `json:"digest_enabled"`
-	DigestCadence            string   `json:"digest_cadence"`
-	DigestDay                int      `json:"digest_day"`
-	DigestHour               int      `json:"digest_hour"`
-	Timezone                 string   `json:"timezone"`
-	NextDigestAt             *string  `json:"next_digest_at,omitempty"`
-	InstanceMailerConfigured bool     `json:"instance_mailer_configured"`
-	CreatedAt                int64    `json:"created_at"`
-	UpdatedAt                int64    `json:"updated_at"`
+	TenantID                 string              `json:"tenant_id"`
+	Enabled                  bool                `json:"enabled"`
+	Recipients               []string            `json:"recipients"`
+	AlertOnFailure           bool                `json:"alert_on_failure"`
+	AlertThrottleMinutes     int                 `json:"alert_throttle_minutes"`
+	DigestEnabled            bool                `json:"digest_enabled"`
+	DigestCadence            string              `json:"digest_cadence"`
+	DigestDay                int                 `json:"digest_day"`
+	DigestHour               int                 `json:"digest_hour"`
+	Timezone                 string              `json:"timezone"`
+	NextDigestAt             *string             `json:"next_digest_at,omitempty"`
+	InstanceMailerConfigured bool                `json:"instance_mailer_configured"`
+	FailureDetection         failureDetectionDTO `json:"failure_detection"`
+	CreatedAt                int64               `json:"created_at"`
+	UpdatedAt                int64               `json:"updated_at"`
+}
+
+// failureDetectionDTO is the wire representation of FailureDetectionCoverage
+// (GH #381 phase 2).
+type failureDetectionDTO struct {
+	SitesTotal      int    `json:"sites_total"`
+	SitesCovered    int    `json:"sites_covered"`
+	MinAgentVersion string `json:"min_agent_version"`
 }
 
 // toNotifySettingsDTO maps domain NotifySettings to the wire DTO.
@@ -646,8 +655,13 @@ func toNotifySettingsDTO(s NotifySettings) notifySettingsDTO {
 		DigestHour:               s.DigestHour,
 		Timezone:                 s.Timezone,
 		InstanceMailerConfigured: s.InstanceMailerConfigured,
-		CreatedAt:                s.CreatedAt.Unix(),
-		UpdatedAt:                s.UpdatedAt.Unix(),
+		FailureDetection: failureDetectionDTO{
+			SitesTotal:      s.FailureDetection.SitesTotal,
+			SitesCovered:    s.FailureDetection.SitesCovered,
+			MinAgentVersion: s.FailureDetection.MinAgentVersion,
+		},
+		CreatedAt: s.CreatedAt.Unix(),
+		UpdatedAt: s.UpdatedAt.Unix(),
 	}
 	if dto.Recipients == nil {
 		dto.Recipients = []string{}

--- a/apps/api/internal/email/dto.go
+++ b/apps/api/internal/email/dto.go
@@ -616,21 +616,26 @@ type putConnectionBody struct {
 
 // notifySettingsDTO is the wire representation of NotifySettings.
 type notifySettingsDTO struct {
-	TenantID                 string              `json:"tenant_id"`
-	Enabled                  bool                `json:"enabled"`
-	Recipients               []string            `json:"recipients"`
-	AlertOnFailure           bool                `json:"alert_on_failure"`
-	AlertThrottleMinutes     int                 `json:"alert_throttle_minutes"`
-	DigestEnabled            bool                `json:"digest_enabled"`
-	DigestCadence            string              `json:"digest_cadence"`
-	DigestDay                int                 `json:"digest_day"`
-	DigestHour               int                 `json:"digest_hour"`
-	Timezone                 string              `json:"timezone"`
-	NextDigestAt             *string             `json:"next_digest_at,omitempty"`
-	InstanceMailerConfigured bool                `json:"instance_mailer_configured"`
-	FailureDetection         failureDetectionDTO `json:"failure_detection"`
-	CreatedAt                int64               `json:"created_at"`
-	UpdatedAt                int64               `json:"updated_at"`
+	TenantID                 string   `json:"tenant_id"`
+	Enabled                  bool     `json:"enabled"`
+	Recipients               []string `json:"recipients"`
+	AlertOnFailure           bool     `json:"alert_on_failure"`
+	AlertThrottleMinutes     int      `json:"alert_throttle_minutes"`
+	DigestEnabled            bool     `json:"digest_enabled"`
+	DigestCadence            string   `json:"digest_cadence"`
+	DigestDay                int      `json:"digest_day"`
+	DigestHour               int      `json:"digest_hour"`
+	Timezone                 string   `json:"timezone"`
+	NextDigestAt             *string  `json:"next_digest_at,omitempty"`
+	InstanceMailerConfigured bool     `json:"instance_mailer_configured"`
+	// FailureDetection is a pointer so a coverage-query failure can omit it
+	// entirely (PR #447 bot review finding 2) instead of serializing a false
+	// "sites_covered: 0" — the frontend already treats absence as "unknown",
+	// same shape as the older-API-doesn't-send-it case this field was made
+	// optional for.
+	FailureDetection *failureDetectionDTO `json:"failure_detection,omitempty"`
+	CreatedAt        int64                `json:"created_at"`
+	UpdatedAt        int64                `json:"updated_at"`
 }
 
 // failureDetectionDTO is the wire representation of FailureDetectionCoverage
@@ -658,14 +663,16 @@ func toNotifySettingsDTO(s NotifySettings) notifySettingsDTO {
 		DigestHour:               s.DigestHour,
 		Timezone:                 s.Timezone,
 		InstanceMailerConfigured: s.InstanceMailerConfigured,
-		FailureDetection: failureDetectionDTO{
+		CreatedAt:                s.CreatedAt.Unix(),
+		UpdatedAt:                s.UpdatedAt.Unix(),
+	}
+	if s.FailureDetection != nil {
+		dto.FailureDetection = &failureDetectionDTO{
 			SitesTotal:              s.FailureDetection.SitesTotal,
 			SitesCovered:            s.FailureDetection.SitesCovered,
 			SitesRouted:             s.FailureDetection.SitesRouted,
 			MinAgentVersionUnrouted: s.FailureDetection.MinAgentVersionUnrouted,
-		},
-		CreatedAt: s.CreatedAt.Unix(),
-		UpdatedAt: s.UpdatedAt.Unix(),
+		}
 	}
 	if dto.Recipients == nil {
 		dto.Recipients = []string{}

--- a/apps/api/internal/email/dto.go
+++ b/apps/api/internal/email/dto.go
@@ -634,11 +634,14 @@ type notifySettingsDTO struct {
 }
 
 // failureDetectionDTO is the wire representation of FailureDetectionCoverage
-// (GH #381 phase 2).
+// (GH #381). min_agent_version_unrouted gates ONLY sites that do not route
+// their mail through WPMgr; a routed site is covered regardless of its agent
+// version, and sites_routed says how many of sites_total are in that state.
 type failureDetectionDTO struct {
-	SitesTotal      int    `json:"sites_total"`
-	SitesCovered    int    `json:"sites_covered"`
-	MinAgentVersion string `json:"min_agent_version"`
+	SitesTotal              int    `json:"sites_total"`
+	SitesCovered            int    `json:"sites_covered"`
+	SitesRouted             int    `json:"sites_routed"`
+	MinAgentVersionUnrouted string `json:"min_agent_version_unrouted"`
 }
 
 // toNotifySettingsDTO maps domain NotifySettings to the wire DTO.
@@ -656,9 +659,10 @@ func toNotifySettingsDTO(s NotifySettings) notifySettingsDTO {
 		Timezone:                 s.Timezone,
 		InstanceMailerConfigured: s.InstanceMailerConfigured,
 		FailureDetection: failureDetectionDTO{
-			SitesTotal:      s.FailureDetection.SitesTotal,
-			SitesCovered:    s.FailureDetection.SitesCovered,
-			MinAgentVersion: s.FailureDetection.MinAgentVersion,
+			SitesTotal:              s.FailureDetection.SitesTotal,
+			SitesCovered:            s.FailureDetection.SitesCovered,
+			SitesRouted:             s.FailureDetection.SitesRouted,
+			MinAgentVersionUnrouted: s.FailureDetection.MinAgentVersionUnrouted,
 		},
 		CreatedAt: s.CreatedAt.Unix(),
 		UpdatedAt: s.UpdatedAt.Unix(),

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -235,21 +235,49 @@ type NotifySettings struct {
 }
 
 // FailureDetectionCoverage summarizes, for a tenant, how many of its
-// currently-connected sites run an agent new enough to detect and report an
-// email delivery failure (GH #381 phase 2). WPMgr can only detect a failure
-// when it is the mail transport in use AND the agent is new enough to report
-// it; a site below MinAgentVersion, or not currently connected, cannot
-// trigger a per-failure alert no matter how the settings above are
-// configured. Computed fresh on every GET, never persisted.
+// currently-connected sites can detect and report an email delivery failure
+// (GH #381). A site is covered by EITHER of two independent paths:
+//
+//  1. Routed: WPMgr is the mail transport the site actively uses
+//     (MailRouter::intercept() -> EmailLogger::write() on the agent). This
+//     path predates GH #381 phase 1 entirely, consults no agent-version gate,
+//     and works on any currently-shipped agent.
+//  2. Unrouted-but-new-enough: the site does not route its mail through
+//     WPMgr, but its agent_version is >= MinAgentVersionUnrouted, so it can
+//     still capture and report a failure on mail WPMgr never saw pass
+//     through it (GH #381 phase 1's widening).
+//
+// A site below MinAgentVersionUnrouted that is ALSO not routed cannot trigger
+// a per-failure alert. A site that IS routed is covered regardless of its
+// agent version. Computed fresh on every GET, never persisted.
 type FailureDetectionCoverage struct {
 	// SitesTotal is the tenant's currently-connected site count.
 	SitesTotal int
-	// SitesCovered is, of SitesTotal, how many report an agent_version at or
-	// above MinAgentVersion.
+	// SitesCovered is, of SitesTotal, how many are covered via EITHER path
+	// above (routed OR agent_version >= MinAgentVersionUnrouted).
 	SitesCovered int
-	// MinAgentVersion is the gate SitesCovered was computed against
+	// SitesRouted is, of SitesTotal, how many have WPMgr actively configured
+	// as their mail transport (path 1 above) and are therefore covered
+	// regardless of agent version. Surfaced separately so the interface can
+	// explain a high sites_covered count on a fleet that is otherwise below
+	// MinAgentVersionUnrouted, instead of that number reading as unexplained.
+	SitesRouted int
+	// MinAgentVersionUnrouted is the gate applied to path 2 only (sites NOT
+	// routed through WPMgr). It says nothing about routed sites, which are
+	// covered independent of this value.
 	// (MinAgentVersionForFailureDetection at call time).
-	MinAgentVersion string
+	MinAgentVersionUnrouted string
+}
+
+// ConnectedSiteEmailFact is one connected site's raw facts needed to compute
+// FailureDetectionCoverage, as returned by
+// repository.ListConnectedSiteEmailCoverage. Routed=true short-circuits the
+// coverage predicate regardless of AgentVersion (see FailureDetectionCoverage
+// doc comment); the version-gate comparison in Go only matters when
+// Routed=false.
+type ConnectedSiteEmailFact struct {
+	AgentVersion string
+	Routed       bool
 }
 
 // NotifySettingsUpsertInput is the PUT body for notify settings.

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -228,6 +228,28 @@ type NotifySettings struct {
 	// InstanceMailerConfigured is populated by the service from mailer.Service.Enabled.
 	// It is NOT stored in DB — injected on GET.
 	InstanceMailerConfigured bool
+	// FailureDetection is populated by the service from a live count of the
+	// tenant's connected sites (GH #381 phase 2). It is NOT stored in DB —
+	// injected on GET.
+	FailureDetection FailureDetectionCoverage
+}
+
+// FailureDetectionCoverage summarizes, for a tenant, how many of its
+// currently-connected sites run an agent new enough to detect and report an
+// email delivery failure (GH #381 phase 2). WPMgr can only detect a failure
+// when it is the mail transport in use AND the agent is new enough to report
+// it; a site below MinAgentVersion, or not currently connected, cannot
+// trigger a per-failure alert no matter how the settings above are
+// configured. Computed fresh on every GET, never persisted.
+type FailureDetectionCoverage struct {
+	// SitesTotal is the tenant's currently-connected site count.
+	SitesTotal int
+	// SitesCovered is, of SitesTotal, how many report an agent_version at or
+	// above MinAgentVersion.
+	SitesCovered int
+	// MinAgentVersion is the gate SitesCovered was computed against
+	// (MinAgentVersionForFailureDetection at call time).
+	MinAgentVersion string
 }
 
 // NotifySettingsUpsertInput is the PUT body for notify settings.

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -230,8 +230,11 @@ type NotifySettings struct {
 	InstanceMailerConfigured bool
 	// FailureDetection is populated by the service from a live count of the
 	// tenant's connected sites (GH #381 phase 2). It is NOT stored in DB —
-	// injected on GET.
-	FailureDetection FailureDetectionCoverage
+	// injected on GET. Nil means the coverage query itself failed (PR #447
+	// bot review finding 2): the rest of the settings are still valid and
+	// must still be returned, but the caller must render coverage as ABSENT,
+	// never as a false "sites_covered: 0" built from an error.
+	FailureDetection *FailureDetectionCoverage
 }
 
 // FailureDetectionCoverage summarizes, for a tenant, how many of its

--- a/apps/api/internal/email/notify.go
+++ b/apps/api/internal/email/notify.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/mailer"
 )
@@ -27,7 +28,18 @@ import (
 // with internal/mailer and remains unit-testable with a fake.
 type MailerEnqueuer interface {
 	Enqueue(ctx context.Context, tenantID uuid.UUID, recipients []string, template string, data map[string]any) error
+	// EnqueueTx enqueues within the caller's transaction (transactional
+	// outbox — see maybeAlertFailures/Repo.ClaimAlertSlot). *mailer.Enqueuer
+	// satisfies this via its own EnqueueTx method.
+	EnqueueTx(ctx context.Context, tx pgx.Tx, tenantID uuid.UUID, recipients []string, template string, data map[string]any) error
 }
+
+// errAlertEnqueueFailed marks a ClaimAlertSlot failure that originated in the
+// onClaim callback (the mailer enqueue) rather than in the claim UPDATE
+// itself, so maybeAlertFailures can log the correct reason
+// ("enqueue_failed" vs "claim_alert_slot_error") after the transaction has
+// already rolled back.
+var errAlertEnqueueFailed = errors.New("email alert enqueue failed")
 
 // MailerStatus reports whether the instance mailer is currently configured.
 // *mailer.Service satisfies this interface.
@@ -184,18 +196,11 @@ func (s *Service) maybeAlertFailures(ctx context.Context, tenantID, siteID uuid.
 		return
 	}
 
-	claimedState, claimErr := s.repo.ClaimAlertSlot(ctx, tenantID, siteID, 1, settings.AlertThrottleMinutes)
-	if claimErr != nil {
-		s.logAlertDecision(ctx, slog.LevelWarn, "claim_alert_slot_error", tenantID, siteID, failureCount, claimErr)
-		return
-	}
-	if claimedState == nil {
-		// Throttled — not an error, just not our turn yet.
-		s.logAlertDecision(ctx, slog.LevelDebug, "throttled", tenantID, siteID, failureCount, nil)
-		return
-	}
-
-	// Resolve site name/URL for the email.
+	// Resolve the email content BEFORE claiming the slot — mirrors
+	// internal/vuln's dispatchTenant (fetch everything the send needs first,
+	// THEN claim + enqueue atomically as the last step). This also means a
+	// site-ref lookup failure can never land after the claim has already
+	// committed the failures-since-alert reset.
 	siteRef, refErr := s.repo.GetSiteRef(ctx, tenantID, siteID)
 	if refErr != nil {
 		s.logAlertDecision(ctx, slog.LevelWarn, "site_ref_error", tenantID, siteID, failureCount, refErr)
@@ -215,14 +220,14 @@ func (s *Service) maybeAlertFailures(ctx context.Context, tenantID, siteID uuid.
 		Error    string
 	}
 	dtoSamples := make([]sampleDTO, 0, len(samples))
-	for _, s := range samples {
+	for _, smp := range samples {
 		// Truncate error to 200 chars per spec (never bodies).
-		errStr := s.Error
+		errStr := smp.Error
 		if len(errStr) > 200 {
 			errStr = errStr[:200] + "..."
 		}
 		dtoSamples = append(dtoSamples, sampleDTO{
-			Subject: s.Subject,
+			Subject: smp.Subject,
 			Error:   errStr,
 		})
 	}
@@ -233,13 +238,44 @@ func (s *Service) maybeAlertFailures(ctx context.Context, tenantID, siteID uuid.
 		"SiteName":      siteRef.Name,
 		"SiteURL":       siteRef.URL,
 		"SiteEmailURL":  dashURL,
-		"FailureCount":  int(claimedState.FailuresSinceAlert) + failureCount,
+		"FailureCount":  failureCount,
 		"WindowMinutes": settings.AlertThrottleMinutes,
 		"Samples":       dtoSamples,
 	}
 
-	if err := s.mailer.Enqueue(ctx, tenantID, settings.Recipients, "email_failure_alert", data); err != nil {
-		s.logAlertDecision(ctx, slog.LevelWarn, "enqueue_failed", tenantID, siteID, failureCount, err)
+	// Claim the alert slot and enqueue the email in the SAME transaction
+	// (transactional outbox — see Repo.ClaimAlertSlot). If the enqueue
+	// fails, the whole transaction rolls back: the failures_since_alert
+	// reset and last_alert_at bump revert together with the failed send, so
+	// a genuine enqueue failure can never leave the site silently marked as
+	// recently-alerted (GH #381's original bug, reintroduced by claiming and
+	// enqueueing as two steps that could disagree).
+	//
+	// This still cannot double-send: the claim UPDATE row-locks
+	// email_alert_state for the life of the transaction, so a second,
+	// concurrent tick blocks on that row until this one commits or rolls
+	// back. If it commits, the concurrent tick re-evaluates the throttle
+	// predicate against the now-reset row and finds nothing to claim. If it
+	// rolls back, the row reverts to its pre-claim state and the concurrent
+	// tick is free to claim and send — never both.
+	claimedState, claimErr := s.repo.ClaimAlertSlot(ctx, tenantID, siteID, 1, settings.AlertThrottleMinutes,
+		func(tx pgx.Tx) error {
+			if err := s.mailer.EnqueueTx(ctx, tx, tenantID, settings.Recipients, "email_failure_alert", data); err != nil {
+				return fmt.Errorf("%w: %v", errAlertEnqueueFailed, err)
+			}
+			return nil
+		})
+	if claimErr != nil {
+		reason := "claim_alert_slot_error"
+		if errors.Is(claimErr, errAlertEnqueueFailed) {
+			reason = "enqueue_failed"
+		}
+		s.logAlertDecision(ctx, slog.LevelWarn, reason, tenantID, siteID, failureCount, claimErr)
+		return
+	}
+	if claimedState == nil {
+		// Throttled — not an error, just not our turn yet.
+		s.logAlertDecision(ctx, slog.LevelDebug, "throttled", tenantID, siteID, failureCount, nil)
 		return
 	}
 	s.logAlertDecision(ctx, slog.LevelInfo, "alert_sent", tenantID, siteID, failureCount, nil)

--- a/apps/api/internal/email/notify.go
+++ b/apps/api/internal/email/notify.go
@@ -12,6 +12,7 @@ package email
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -69,6 +70,67 @@ type VulnDigestItem struct {
 // included in a per-failure alert email body.
 const maxAlertFailureSamples = 5
 
+// alertGoroutineTimeout bounds the detached maybeAlertFailures goroutine
+// launched from IngestLogBatch (service.go). It is detached deliberately to
+// keep the ingest path fast, so a stalled downstream call (settings lookup,
+// alert-slot claim, site-ref fetch, mailer enqueue) must not leak the
+// goroutine forever. The work itself is a handful of single-row reads/writes
+// plus one enqueue call, so 30s is generous headroom over the expected case
+// while still bounding the worst case (GH #381 phase 5).
+const alertGoroutineTimeout = 30 * time.Second
+
+// alertDecisionEvent is the single grep-able event name for every decision
+// maybeAlertFailures makes, whether or not it ends in a sent alert (GH #381
+// phase 5). The issue this answers: a user reports no alert email and there
+// is nothing to grep. Every exit path below now logs exactly one record
+// carrying this event name and a `reason` field distinguishing it.
+//
+// NEVER add a recipient address to these fields. The failure_count is enough
+// to diagnose; recipient addresses would land in operator logs and in
+// whatever ships them onward.
+const alertDecisionEvent = "email_alert_decision"
+
+// logAlertDecision emits the single structured record for one exit path of
+// maybeAlertFailures. errAttr may be nil.
+func (s *Service) logAlertDecision(ctx context.Context, level slog.Level, reason string, tenantID, siteID uuid.UUID, failureCount int, errAttr error) {
+	attrs := []slog.Attr{
+		slog.String("reason", reason),
+		slog.String("tenant_id", tenantID.String()),
+		slog.String("site_id", siteID.String()),
+		slog.Int("failure_count", failureCount),
+	}
+	if errAttr != nil {
+		attrs = append(attrs, slog.Any("error", errAttr))
+	}
+	s.log.LogAttrs(ctx, level, alertDecisionEvent, attrs...)
+}
+
+// maybeAlertFailuresAsync is the entry point IngestLogBatch launches with
+// `go`. It owns the goroutine's lifetime end to end: a bounded context so a
+// stalled downstream call cannot leak the goroutine past alertGoroutineTimeout,
+// and a recover() so a panic anywhere below cannot take down the API process
+// serving every other tenant's ingest traffic — there was no recover() here
+// before phase 5, so any panic in this detached goroutine was fatal to the
+// whole binary.
+func (s *Service) maybeAlertFailuresAsync(tenantID, siteID uuid.UUID, failureCount int) {
+	ctx, cancel := context.WithTimeout(context.Background(), alertGoroutineTimeout)
+	defer cancel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			s.log.LogAttrs(ctx, slog.LevelError, alertDecisionEvent,
+				slog.String("reason", "panic"),
+				slog.String("tenant_id", tenantID.String()),
+				slog.String("site_id", siteID.String()),
+				slog.Int("failure_count", failureCount),
+				slog.Any("panic", r),
+			)
+		}
+	}()
+
+	s.maybeAlertFailures(ctx, tenantID, siteID, failureCount)
+}
+
 // maxDigestTopFailures is the maximum number of top-failure samples in digest.
 const maxDigestTopFailures = 5
 
@@ -82,48 +144,61 @@ const maxDigestSites = 20
 // strictly best-effort (the save has already succeeded).
 func (s *Service) maybeAlertFailures(ctx context.Context, tenantID, siteID uuid.UUID, failureCount int) {
 	if s.mailer == nil {
+		s.logAlertDecision(ctx, slog.LevelWarn, "nil_mailer", tenantID, siteID, failureCount, nil)
 		return
 	}
 	if failureCount <= 0 {
+		// Unreachable in production: the sole caller (IngestLogBatch,
+		// service.go) only launches this goroutine when failureCount > 0.
+		// No log line here deliberately — see notify.go's phase-5 finding.
 		return
 	}
 
 	// Accumulate failures into the per-site state row.
 	if err := s.repo.AccumulateAlertFailures(ctx, tenantID, siteID, int64(failureCount)); err != nil {
-		s.log.Warn("email alert: accumulate failures failed",
-			slog.String("tenant_id", tenantID.String()),
-			slog.String("site_id", siteID.String()),
-			slog.Any("error", err),
-		)
+		s.logAlertDecision(ctx, slog.LevelWarn, "accumulate_failed", tenantID, siteID, failureCount, err)
 		return
 	}
 
 	// Try to claim an alert slot (single-statement conditional UPDATE).
 	settings, err := s.repo.GetNotifySettings(ctx, tenantID)
 	if err != nil {
-		// No settings row = use defaults (but don't alert when disabled).
+		if errors.Is(err, ErrNotFound) {
+			// No settings row = use defaults (but don't alert when disabled).
+			s.logAlertDecision(ctx, slog.LevelDebug, "no_settings_row", tenantID, siteID, failureCount, nil)
+		} else {
+			s.logAlertDecision(ctx, slog.LevelWarn, "settings_lookup_error", tenantID, siteID, failureCount, err)
+		}
 		return
 	}
 	if !settings.Enabled || !settings.AlertOnFailure {
+		reason := "disabled"
+		if settings.Enabled {
+			reason = "alert_on_failure_off"
+		}
+		s.logAlertDecision(ctx, slog.LevelDebug, reason, tenantID, siteID, failureCount, nil)
 		return
 	}
 	if len(settings.Recipients) == 0 {
+		s.logAlertDecision(ctx, slog.LevelDebug, "no_recipients", tenantID, siteID, failureCount, nil)
 		return
 	}
 
 	claimedState, claimErr := s.repo.ClaimAlertSlot(ctx, tenantID, siteID, 1, settings.AlertThrottleMinutes)
-	if claimErr != nil || claimedState == nil {
-		// Throttled or no row — skip.
+	if claimErr != nil {
+		s.logAlertDecision(ctx, slog.LevelWarn, "claim_alert_slot_error", tenantID, siteID, failureCount, claimErr)
+		return
+	}
+	if claimedState == nil {
+		// Throttled — not an error, just not our turn yet.
+		s.logAlertDecision(ctx, slog.LevelDebug, "throttled", tenantID, siteID, failureCount, nil)
 		return
 	}
 
 	// Resolve site name/URL for the email.
 	siteRef, refErr := s.repo.GetSiteRef(ctx, tenantID, siteID)
 	if refErr != nil {
-		s.log.Warn("email alert: could not resolve site ref",
-			slog.String("site_id", siteID.String()),
-			slog.Any("error", refErr),
-		)
+		s.logAlertDecision(ctx, slog.LevelWarn, "site_ref_error", tenantID, siteID, failureCount, refErr)
 		return
 	}
 
@@ -164,12 +239,10 @@ func (s *Service) maybeAlertFailures(ctx context.Context, tenantID, siteID uuid.
 	}
 
 	if err := s.mailer.Enqueue(ctx, tenantID, settings.Recipients, "email_failure_alert", data); err != nil {
-		s.log.Warn("email alert: enqueue failed",
-			slog.String("tenant_id", tenantID.String()),
-			slog.String("site_id", siteID.String()),
-			slog.Any("error", err),
-		)
+		s.logAlertDecision(ctx, slog.LevelWarn, "enqueue_failed", tenantID, siteID, failureCount, err)
+		return
 	}
+	s.logAlertDecision(ctx, slog.LevelInfo, "alert_sent", tenantID, siteID, failureCount, nil)
 }
 
 // buildDigestData gathers per-tenant digest data for a given [from, to] window.

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -3,9 +3,12 @@ package email
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -383,4 +386,436 @@ func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
 			t.Errorf("expected 3/3 when every connected site is covered, got %+v", wire.FailureDetection)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 5 — maybeAlertFailures observability: every exit path logs a
+// reason, the detached goroutine is bounded and panic-safe, and recipient
+// addresses never reach a log record.
+// ---------------------------------------------------------------------------
+
+// capturedRecord is a slog.Record flattened for assertions.
+type capturedRecord struct {
+	Level slog.Level
+	Msg   string
+	Attrs map[string]string
+}
+
+// capturingHandler is a minimal slog.Handler that records everything it is
+// given, regardless of level, so a test can assert on Debug records too.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []capturedRecord
+}
+
+func newCapturingHandler() *capturingHandler { return &capturingHandler{} }
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := make(map[string]string, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+	h.mu.Lock()
+	h.records = append(h.records, capturedRecord{Level: r.Level, Msg: r.Message, Attrs: attrs})
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *capturingHandler) Records() []capturedRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]capturedRecord, len(h.records))
+	copy(out, h.records)
+	return out
+}
+
+// String dumps every captured record's message and attribute values, one per
+// line, so a test can grep the WHOLE emitted surface for a value that must
+// never appear (e.g. a recipient address) rather than checking one known key.
+func (h *capturingHandler) String() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var sb strings.Builder
+	for _, r := range h.records {
+		sb.WriteString(r.Msg)
+		sb.WriteString(" ")
+		for k, v := range r.Attrs {
+			sb.WriteString(k)
+			sb.WriteString("=")
+			sb.WriteString(v)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// fakeMailer is a MailerEnqueuer test double that counts calls and can
+// optionally signal a channel per successful call, so a test can wait
+// (bounded) for the detached alert goroutine to finish instead of sleeping.
+type fakeMailer struct {
+	mu             sync.Mutex
+	enqueueErr     error
+	calls          int
+	lastRecipients []string
+	notify         chan struct{}
+}
+
+func (f *fakeMailer) Enqueue(_ context.Context, _ uuid.UUID, recipients []string, _ string, _ map[string]any) error {
+	f.mu.Lock()
+	if f.enqueueErr != nil {
+		f.mu.Unlock()
+		return f.enqueueErr
+	}
+	f.calls++
+	f.lastRecipients = recipients
+	notify := f.notify
+	f.mu.Unlock()
+	if notify != nil {
+		notify <- struct{}{}
+	}
+	return nil
+}
+
+func (f *fakeMailer) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// panicRepo wraps fakeRepo and panics from AccumulateAlertFailures, standing
+// in for a real driver-level panic so TestMaybeAlertFailures_RecoversFromPanic
+// has something genuine for the recover() in maybeAlertFailuresAsync to catch.
+type panicRepo struct {
+	*fakeRepo
+}
+
+func (r *panicRepo) AccumulateAlertFailures(context.Context, uuid.UUID, uuid.UUID, int64) error {
+	panic("simulated repo panic — GH #381 phase 5 regression test")
+}
+
+// TestMaybeAlertFailures_EveryExitPathLogsAReason is table-driven over every
+// documented exit of maybeAlertFailures (notify.go). RED before phase 5: five
+// of these paths (nil_mailer, no_settings_row, disabled, alert_on_failure_off,
+// no_recipients, throttled — six, in fact) emitted nothing at all.
+func TestMaybeAlertFailures_EveryExitPathLogsAReason(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	fullSettings := NotifySettings{
+		Enabled:              true,
+		AlertOnFailure:       true,
+		Recipients:           []string{"ops@example.com"},
+		AlertThrottleMinutes: 60,
+	}
+	claimedState := &AlertState{TenantID: tenantID, SiteID: siteID, FailuresSinceAlert: 3}
+	siteRef := &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	cases := []struct {
+		name       string
+		mailer     bool // false leaves svc.mailer nil
+		mailerErr  error
+		repo       func(r *fakeRepo)
+		wantLevel  slog.Level
+		wantReason string
+	}{
+		{
+			name:       "nil_mailer",
+			mailer:     false,
+			wantLevel:  slog.LevelWarn,
+			wantReason: "nil_mailer",
+		},
+		{
+			name:   "accumulate_failed",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				r.alertAccumulateErr = errors.New("db unavailable")
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "accumulate_failed",
+		},
+		{
+			name:       "no_settings_row",
+			mailer:     true,
+			wantLevel:  slog.LevelDebug,
+			wantReason: "no_settings_row",
+		},
+		{
+			name:   "settings_lookup_error",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				r.alertSettingsErr = errors.New("connection reset")
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "settings_lookup_error",
+		},
+		{
+			name:   "disabled",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				s.Enabled = false
+				r.alertSettings = &s
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "disabled",
+		},
+		{
+			name:   "alert_on_failure_off",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				s.AlertOnFailure = false
+				r.alertSettings = &s
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "alert_on_failure_off",
+		},
+		{
+			name:   "no_recipients",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				s.Recipients = nil
+				r.alertSettings = &s
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "no_recipients",
+		},
+		{
+			name:   "throttled",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				// alertClaimState/alertClaimErr left nil/nil == throttled.
+			},
+			wantLevel:  slog.LevelDebug,
+			wantReason: "throttled",
+		},
+		{
+			name:   "claim_alert_slot_error",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimErr = errors.New("advisory lock timeout")
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "claim_alert_slot_error",
+		},
+		{
+			name:   "site_ref_error",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimState = claimedState
+				// alertSiteRef/alertSiteRefErr left at default == ErrNotFound.
+			},
+			wantLevel:  slog.LevelWarn,
+			wantReason: "site_ref_error",
+		},
+		{
+			name:   "enqueue_failed",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimState = claimedState
+				r.alertSiteRef = siteRef
+			},
+			mailerErr:  errors.New("smtp timeout"),
+			wantLevel:  slog.LevelWarn,
+			wantReason: "enqueue_failed",
+		},
+		{
+			name:   "alert_sent",
+			mailer: true,
+			repo: func(r *fakeRepo) {
+				s := fullSettings
+				r.alertSettings = &s
+				r.alertClaimState = claimedState
+				r.alertSiteRef = siteRef
+			},
+			wantLevel:  slog.LevelInfo,
+			wantReason: "alert_sent",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newCapturingHandler()
+			logger := slog.New(handler)
+
+			repo := newFakeRepo()
+			if tc.repo != nil {
+				tc.repo(repo)
+			}
+
+			svc := NewService(&Repo{}, &fakeEncryptor{}, logger)
+			svc.repo = repo
+			if tc.mailer {
+				svc.mailer = &fakeMailer{enqueueErr: tc.mailerErr}
+			}
+
+			svc.maybeAlertFailures(context.Background(), tenantID, siteID, 7)
+
+			var matches []capturedRecord
+			for _, r := range handler.Records() {
+				if r.Msg == alertDecisionEvent {
+					matches = append(matches, r)
+				}
+			}
+			if len(matches) != 1 {
+				t.Fatalf("expected exactly 1 %q record, got %d: %+v", alertDecisionEvent, len(matches), handler.Records())
+			}
+			got := matches[0]
+			if got.Level != tc.wantLevel {
+				t.Errorf("level = %v, want %v", got.Level, tc.wantLevel)
+			}
+			if got.Attrs["reason"] != tc.wantReason {
+				t.Errorf("reason = %q, want %q", got.Attrs["reason"], tc.wantReason)
+			}
+			if got.Attrs["tenant_id"] != tenantID.String() {
+				t.Errorf("tenant_id = %q, want %q", got.Attrs["tenant_id"], tenantID.String())
+			}
+			if got.Attrs["site_id"] != siteID.String() {
+				t.Errorf("site_id = %q, want %q", got.Attrs["site_id"], siteID.String())
+			}
+			if got.Attrs["failure_count"] != "7" {
+				t.Errorf("failure_count = %q, want %q", got.Attrs["failure_count"], "7")
+			}
+		})
+	}
+}
+
+// TestMaybeAlertFailures_RecoversFromPanic proves the detached goroutine
+// survives a panic anywhere in maybeAlertFailures. RED before phase 5: there
+// was no recover() at all, so this crashed the whole test binary — which is
+// itself the proof a panic here would have taken down the live API process.
+func TestMaybeAlertFailures_RecoversFromPanic(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	handler := newCapturingHandler()
+	logger := slog.New(handler)
+
+	svc := NewService(&Repo{}, &fakeEncryptor{}, logger)
+	svc.repo = &panicRepo{fakeRepo: newFakeRepo()}
+	svc.mailer = &fakeMailer{}
+
+	done := make(chan struct{})
+	go func() {
+		svc.maybeAlertFailuresAsync(tenantID, siteID, 3)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// survived — half the proof.
+	case <-time.After(5 * time.Second):
+		t.Fatal("maybeAlertFailuresAsync did not return within 5s — recover() missing or goroutine hung")
+	}
+
+	var found bool
+	for _, r := range handler.Records() {
+		if r.Msg == alertDecisionEvent && r.Level == slog.LevelError && r.Attrs["reason"] == "panic" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an Error record with reason=panic, got %+v", handler.Records())
+	}
+}
+
+// TestMaybeAlertFailures_NeverLogsRecipientAddress is the assertion that
+// matters most: no recipient address may appear in ANY emitted log record,
+// on the success path or the enqueue-failure path. The fixture recipient is
+// a distinctive string so this test would fail the moment someone logs the
+// recipient list instead of just its count.
+func TestMaybeAlertFailures_NeverLogsRecipientAddress(t *testing.T) {
+	const distinctiveRecipient = "definitely-not-logged-9f3ac21b@example.com"
+	tenantID, siteID := uuid.New(), uuid.New()
+	claimedState := &AlertState{TenantID: tenantID, SiteID: siteID, FailuresSinceAlert: 2}
+	siteRef := &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	for _, mailerErr := range []error{nil, errors.New("smtp rejected")} {
+		handler := newCapturingHandler()
+		logger := slog.New(handler)
+
+		repo := newFakeRepo()
+		repo.alertSettings = &NotifySettings{
+			Enabled:              true,
+			AlertOnFailure:       true,
+			Recipients:           []string{distinctiveRecipient},
+			AlertThrottleMinutes: 60,
+		}
+		repo.alertClaimState = claimedState
+		repo.alertSiteRef = siteRef
+
+		svc := NewService(&Repo{}, &fakeEncryptor{}, logger)
+		svc.repo = repo
+		svc.mailer = &fakeMailer{enqueueErr: mailerErr}
+
+		svc.maybeAlertFailures(context.Background(), tenantID, siteID, 4)
+
+		if dump := handler.String(); strings.Contains(dump, distinctiveRecipient) {
+			t.Fatalf("recipient address leaked into a log record (mailerErr=%v):\n%s", mailerErr, dump)
+		}
+	}
+}
+
+// TestIngestLogBatch_FailureAlert_SendsExactlyOnce_IngestStaysAsync is the
+// over-fire control: a batch that SHOULD trigger an alert still sends exactly
+// one, unchanged from pre-phase-5 behaviour, and IngestLogBatch itself
+// returns without waiting on the alert goroutine — phase 5 is logging and
+// robustness only, never a synchronous write on the ingest hot path.
+func TestIngestLogBatch_FailureAlert_SendsExactlyOnce_IngestStaysAsync(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := newFakeRepo()
+	repo.alertSettings = &NotifySettings{
+		Enabled:              true,
+		AlertOnFailure:       true,
+		Recipients:           []string{"ops@example.com"},
+		AlertThrottleMinutes: 60,
+	}
+	repo.alertClaimState = &AlertState{TenantID: tenantID, SiteID: siteID, FailuresSinceAlert: 1}
+	repo.alertSiteRef = &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	mailer := &fakeMailer{notify: make(chan struct{}, 4)}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, slog.New(newCapturingHandler()))
+	svc.repo = repo
+	svc.mailer = mailer
+
+	start := time.Now()
+	result, err := svc.IngestLogBatch(context.Background(), tenantID, siteID, []IngestEntry{
+		{AgentSeq: 1, Status: "failed", Subject: "test failure"},
+	})
+	ingestElapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("IngestLogBatch: unexpected error: %v", err)
+	}
+	if result.AckedThrough != 1 {
+		t.Errorf("AckedThrough = %d, want 1", result.AckedThrough)
+	}
+	// The alert dispatch must not be on the ingest path.
+	if ingestElapsed > time.Second {
+		t.Errorf("IngestLogBatch took %v — the alert path must stay off the ingest hot path", ingestElapsed)
+	}
+
+	select {
+	case <-mailer.notify:
+		// alert dispatched, asynchronously, exactly as before phase 5.
+	case <-time.After(5 * time.Second):
+		t.Fatal("mailer.Enqueue was never called within 5s of a should-alert batch")
+	}
+	// Give an (incorrect) second dispatch a moment to also land before we count.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := mailer.Calls(); got != 1 {
+		t.Errorf("mailer.Enqueue called %d times, want exactly 1", got)
+	}
 }

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
@@ -279,6 +280,23 @@ type notifySettingsWire struct {
 
 // notifySettingsGetCtx builds a request+principal context for GET
 // /email/notify-settings — an org-level route with no path params.
+//
+// Every test below calls h.getNotifySettings(c) directly instead of going
+// through the real router (qodo flagged this on PR #447 — noting it here so
+// later passes stop re-flagging it). That is deliberate, not a gap: this
+// endpoint has no :siteId, so it carries no authz.RequireSiteAccess gate to
+// bypass, and its own middleware only resolves the principal from context,
+// which notifySettingsGetCtx supplies the same way domain.WithPrincipal does
+// in production. These tests exist to pin the coverage computation's JSON
+// serialization (sites_total/sites_covered/sites_routed, and — PR #447
+// finding 2 — failure_detection's presence/absence on a coverage-query
+// failure), not route wiring or permission enforcement; a router-level test
+// would add HTTP-plumbing noise without exercising anything these don't
+// already cover. Contrast this with the RLS-bypass pattern the project also
+// uses deliberately (a test that skips the Go gate ON PURPOSE to prove the
+// database refuses a write on its own, e.g. the integration suite's tenancy
+// proofs) — that is testing the DB's own enforcement; this is testing this
+// handler's serialization in isolation, a different and narrower claim.
 func notifySettingsGetCtx(t *testing.T, p domain.Principal) (*gin.Context, *httptest.ResponseRecorder) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -414,6 +432,48 @@ func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
 	})
 }
 
+// TestGetNotifySettings_CoverageQueryFails_SettingsStillReturned is PR #447
+// bot review finding 2: the failure-detection coverage query used to be on
+// the critical path of GET /email/notify-settings — a fault in that
+// decorative count took down the WHOLE settings page, including the
+// recipients/toggles a user visits this endpoint to edit. RED before the
+// fix (service.go's GetNotifySettings returned early on covErr): the request
+// failed outright instead of degrading. The response must still be 200, must
+// still carry the real settings, and failure_detection must be ABSENT from
+// the wire — never a false "sites_covered: 0" built from an error, which the
+// frontend would render as "no site can report a delivery failure".
+func TestGetNotifySettings_CoverageQueryFails_SettingsStillReturned(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedSiteFactsErr = errors.New("db: connection reset")
+	repo.alertSettings = &NotifySettings{
+		TenantID:             tenantID,
+		Enabled:              true,
+		Recipients:           []string{"ops@example.com"},
+		AlertOnFailure:       true,
+		AlertThrottleMinutes: 45,
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 even when the coverage query fails, got %d body %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"ops@example.com"`) {
+		t.Errorf("expected the real recipients to still be returned, got body %s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `"failure_detection"`) {
+		t.Errorf("expected failure_detection to be ABSENT on a coverage-query failure, not present (possibly zeroed), got body %s", rec.Body.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GH #381 — coverage predicate corrected: gating sites_covered on
 // agent_version alone told every customer with a fully-working, WPMgr-routed
@@ -497,7 +557,7 @@ func TestGetNotifySettings_MixedFleet_ReportsHonestSplit(t *testing.T) {
 	tenantID := uuid.New()
 	repo := newFakeRepo()
 	facts := append(
-		routedFacts("0.61.136", "0.60.2"), // covered via routing, old agent
+		routedFacts("0.61.136", "0.60.2"),                               // covered via routing, old agent
 		ConnectedSiteEmailFact{AgentVersion: "1000.0.0", Routed: false}, // covered via version
 	)
 	facts = append(facts,
@@ -653,6 +713,15 @@ func (f *fakeMailer) Enqueue(_ context.Context, _ uuid.UUID, recipients []string
 	return nil
 }
 
+// EnqueueTx is the tx-scoped counterpart maybeAlertFailures actually calls
+// (transactional outbox — see Repo.ClaimAlertSlot). The fake ignores tx
+// (fakeRepo's ClaimAlertSlot never has a real one to hand it) and otherwise
+// behaves exactly like Enqueue, so every existing assertion on calls/
+// lastRecipients/notify still holds for the alert path.
+func (f *fakeMailer) EnqueueTx(ctx context.Context, _ pgx.Tx, tenantID uuid.UUID, recipients []string, template string, data map[string]any) error {
+	return f.Enqueue(ctx, tenantID, recipients, template, data)
+}
+
 func (f *fakeMailer) Calls() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -762,6 +831,7 @@ func TestMaybeAlertFailures_EveryExitPathLogsAReason(t *testing.T) {
 			repo: func(r *fakeRepo) {
 				s := fullSettings
 				r.alertSettings = &s
+				r.alertSiteRef = siteRef
 				// alertClaimState/alertClaimErr left nil/nil == throttled.
 			},
 			wantLevel:  slog.LevelDebug,
@@ -773,6 +843,7 @@ func TestMaybeAlertFailures_EveryExitPathLogsAReason(t *testing.T) {
 			repo: func(r *fakeRepo) {
 				s := fullSettings
 				r.alertSettings = &s
+				r.alertSiteRef = siteRef
 				r.alertClaimErr = errors.New("advisory lock timeout")
 			},
 			wantLevel:  slog.LevelWarn,
@@ -987,5 +1058,179 @@ func TestIngestLogBatch_FailureAlert_SendsExactlyOnce_IngestStaysAsync(t *testin
 
 	if got := mailer.Calls(); got != 1 {
 		t.Errorf("mailer.Enqueue called %d times, want exactly 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PR #447 bot review, finding 1 — a failed enqueue must not silence the site.
+//
+// ClaimAlertSlot used to commit last_alert_at/failures_since_alert=0 BEFORE
+// mailer.Enqueue ran. When Enqueue failed, that commit stood: the site was
+// left looking "recently alerted" with nothing actually sent — a genuine
+// failure reaching the admin as silence, then throttling every subsequent
+// attempt too. This is the original GH #381 bug, reintroduced inside its own
+// fix. The repo-level fix (Repo.ClaimAlertSlot, repo.go) now runs the claim
+// UPDATE and the mailer's EnqueueTx insert in ONE transaction, so a failed
+// enqueue rolls the claim back with it.
+//
+// fakeRepo's static alertClaimState/alertClaimErr fixtures can't exercise
+// this — they don't model accumulation or the claim's reset at all. These
+// two tests use stubAlertRepo instead, which models the real
+// email_alert_state row (accumulate, conditional claim-with-reset,
+// rollback-on-callback-error under a lock standing in for Postgres's row
+// lock) closely enough to prove both halves of the contract.
+// ---------------------------------------------------------------------------
+
+// stubAlertRow mirrors one email_alert_state row.
+type stubAlertRow struct {
+	failuresSinceAlert int64
+	lastAlertAt        *time.Time
+}
+
+// stubAlertRepo is a repository double whose ClaimAlertSlot replicates the
+// REAL query's single-statement conditional claim (see
+// db/query/site_email.sql's ClaimAlertSlot) plus the transactional-outbox
+// rollback Repo.ClaimAlertSlot now performs when onClaim fails. Everything
+// else (settings, site ref, samples) delegates to the embedded fakeRepo.
+type stubAlertRepo struct {
+	*fakeRepo
+	mu   sync.Mutex
+	rows map[uuid.UUID]*stubAlertRow // keyed by siteID
+}
+
+func newStubAlertRepo() *stubAlertRepo {
+	return &stubAlertRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]*stubAlertRow{}}
+}
+
+func (r *stubAlertRepo) AccumulateAlertFailures(_ context.Context, _, siteID uuid.UUID, n int64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	row := r.rows[siteID]
+	if row == nil {
+		row = &stubAlertRow{}
+		r.rows[siteID] = row
+	}
+	row.failuresSinceAlert += n
+	return nil
+}
+
+// ClaimAlertSlot holds r.mu for the whole onClaim call — the stand-in for
+// Postgres holding the row lock for the transaction's lifetime — so two
+// concurrent callers serialize exactly like two concurrent ticks racing the
+// same email_alert_state row.
+func (r *stubAlertRepo) ClaimAlertSlot(_ context.Context, _, siteID uuid.UUID, minFailures int64, throttleMinutes int, onClaim func(tx pgx.Tx) error) (*AlertState, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	row := r.rows[siteID]
+	if row == nil {
+		return nil, nil // nothing accumulated yet == throttled/nothing to claim
+	}
+	now := time.Now()
+	throttleWindow := time.Duration(throttleMinutes) * time.Minute
+	throttled := row.failuresSinceAlert < minFailures ||
+		(row.lastAlertAt != nil && now.Sub(*row.lastAlertAt) < throttleWindow)
+	if throttled {
+		return nil, nil
+	}
+
+	// Speculatively apply the UPDATE's effect (matches its RETURNING *).
+	prevFailures, prevLastAlertAt := row.failuresSinceAlert, row.lastAlertAt
+	row.failuresSinceAlert = 0
+	row.lastAlertAt = &now
+
+	if onClaim != nil {
+		if err := onClaim(nil); err != nil {
+			// Roll back — exactly what InAgentTx's real ROLLBACK does when
+			// the mailer's EnqueueTx call fails.
+			row.failuresSinceAlert, row.lastAlertAt = prevFailures, prevLastAlertAt
+			return nil, err
+		}
+	}
+	return &AlertState{SiteID: siteID, FailuresSinceAlert: row.failuresSinceAlert, LastAlertAt: row.lastAlertAt}, nil
+}
+
+// TestMaybeAlertFailures_EnqueueFailure_DoesNotLeaveSiteThrottled is RED
+// before the repo.go fix: the old two-step claim-then-enqueue committed the
+// claim regardless of the enqueue's outcome, so failures_since_alert stayed
+// reset to 0 and last_alert_at stayed stamped after a failed send — the next
+// tick would see the site as already (falsely) alerted and skip it too.
+func TestMaybeAlertFailures_EnqueueFailure_DoesNotLeaveSiteThrottled(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := newStubAlertRepo()
+	repo.alertSettings = &NotifySettings{
+		Enabled:              true,
+		AlertOnFailure:       true,
+		Recipients:           []string{"ops@example.com"},
+		AlertThrottleMinutes: 60,
+	}
+	repo.alertSiteRef = &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	svc := NewService(&Repo{}, &fakeEncryptor{}, slog.New(newCapturingHandler()))
+	svc.repo = repo
+	mailer := &fakeMailer{enqueueErr: errors.New("smtp timeout")}
+	svc.mailer = mailer
+
+	// First tick: 3 failures accumulate, the claim would succeed, but the
+	// enqueue fails.
+	svc.maybeAlertFailures(context.Background(), tenantID, siteID, 3)
+	if got := mailer.Calls(); got != 0 {
+		t.Fatalf("expected 0 sends after a failing enqueue, got %d", got)
+	}
+
+	repo.mu.Lock()
+	row := repo.rows[siteID]
+	repo.mu.Unlock()
+	if row == nil || row.failuresSinceAlert != 3 {
+		t.Fatalf("expected failures_since_alert to still be 3 after a failed enqueue (claim must roll back), got %+v", row)
+	}
+	if row.lastAlertAt != nil {
+		t.Fatalf("expected last_alert_at to remain unset after a failed enqueue (claim must roll back), got %v", *row.lastAlertAt)
+	}
+
+	// Second tick, mailer now works: the site must NOT be throttled by the
+	// first attempt's failure — this is the assertion that matters.
+	mailer.mu.Lock()
+	mailer.enqueueErr = nil
+	mailer.mu.Unlock()
+	svc.maybeAlertFailures(context.Background(), tenantID, siteID, 1)
+	if got := mailer.Calls(); got != 1 {
+		t.Fatalf("expected the next tick to alert successfully (site not throttled by the prior failure), got %d calls", got)
+	}
+}
+
+// TestMaybeAlertFailures_ConcurrentTicks_NeverDoubleSend is the over-fire
+// control for the fix above: combining the claim and the enqueue into one
+// transaction must not let two concurrent ticks both win the claim and both
+// send. The claim UPDATE's row lock (modeled here by holding stubAlertRepo's
+// mutex for onClaim's whole duration) is what still prevents that.
+func TestMaybeAlertFailures_ConcurrentTicks_NeverDoubleSend(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := newStubAlertRepo()
+	repo.alertSettings = &NotifySettings{
+		Enabled:              true,
+		AlertOnFailure:       true,
+		Recipients:           []string{"ops@example.com"},
+		AlertThrottleMinutes: 60,
+	}
+	repo.alertSiteRef = &SiteRef{ID: siteID, Name: "example.com", URL: "https://example.com"}
+
+	svc := NewService(&Repo{}, &fakeEncryptor{}, slog.New(newCapturingHandler()))
+	svc.repo = repo
+	mailer := &fakeMailer{}
+	svc.mailer = mailer
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			svc.maybeAlertFailures(context.Background(), tenantID, siteID, 3)
+		}()
+	}
+	wg.Wait()
+
+	if got := mailer.Calls(); got != 1 {
+		t.Fatalf("expected exactly 1 send from 2 concurrent ticks racing the same claim, got %d", got)
 	}
 }

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -245,9 +245,32 @@ func TestBuildDigestData_FlagOff_OmitsSection_PreservesZeroSkip(t *testing.T) {
 // handler's actual SERIALIZED response rather than inspecting Go structs the
 // handler never sends.
 type failureDetectionWire struct {
-	SitesTotal      int    `json:"sites_total"`
-	SitesCovered    int    `json:"sites_covered"`
-	MinAgentVersion string `json:"min_agent_version"`
+	SitesTotal              int    `json:"sites_total"`
+	SitesCovered            int    `json:"sites_covered"`
+	SitesRouted             int    `json:"sites_routed"`
+	MinAgentVersionUnrouted string `json:"min_agent_version_unrouted"`
+}
+
+// unroutedFacts builds ConnectedSiteEmailFact values for sites that do NOT
+// route their mail through WPMgr, keyed only by their reported agent_version
+// — the shape every pre-existing test in this file assumed before routing
+// was modeled at all.
+func unroutedFacts(versions ...string) []ConnectedSiteEmailFact {
+	out := make([]ConnectedSiteEmailFact, len(versions))
+	for i, v := range versions {
+		out[i] = ConnectedSiteEmailFact{AgentVersion: v, Routed: false}
+	}
+	return out
+}
+
+// routedFacts builds ConnectedSiteEmailFact values for sites whose mail IS
+// actively routed through WPMgr — covered regardless of agent_version.
+func routedFacts(versions ...string) []ConnectedSiteEmailFact {
+	out := make([]ConnectedSiteEmailFact, len(versions))
+	for i, v := range versions {
+		out[i] = ConnectedSiteEmailFact{AgentVersion: v, Routed: true}
+	}
+	return out
 }
 
 type notifySettingsWire struct {
@@ -283,8 +306,8 @@ func decodeNotifySettingsWire(t *testing.T, rec *httptest.ResponseRecorder) noti
 func TestGetNotifySettings_ReportsFailureDetectionCoverage(t *testing.T) {
 	tenantID := uuid.New()
 	repo := newFakeRepo()
-	repo.connectedAgentVersions = map[uuid.UUID][]string{
-		tenantID: {"999.5.0", MinAgentVersionForFailureDetection, "0.61.138"},
+	repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{
+		tenantID: unroutedFacts("999.5.0", MinAgentVersionForFailureDetection, "0.61.138"),
 	}
 	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
 	svc.repo = repo
@@ -303,8 +326,11 @@ func TestGetNotifySettings_ReportsFailureDetectionCoverage(t *testing.T) {
 	if wire.FailureDetection.SitesCovered != 2 {
 		t.Errorf("sites_covered = %d, want 2", wire.FailureDetection.SitesCovered)
 	}
-	if wire.FailureDetection.MinAgentVersion != MinAgentVersionForFailureDetection {
-		t.Errorf("min_agent_version = %q, want %q", wire.FailureDetection.MinAgentVersion, MinAgentVersionForFailureDetection)
+	if wire.FailureDetection.SitesRouted != 0 {
+		t.Errorf("sites_routed = %d, want 0 — none of these sites are routed", wire.FailureDetection.SitesRouted)
+	}
+	if wire.FailureDetection.MinAgentVersionUnrouted != MinAgentVersionForFailureDetection {
+		t.Errorf("min_agent_version_unrouted = %q, want %q", wire.FailureDetection.MinAgentVersionUnrouted, MinAgentVersionForFailureDetection)
 	}
 }
 
@@ -315,9 +341,9 @@ func TestGetNotifySettings_ReportsFailureDetectionCoverage(t *testing.T) {
 func TestGetNotifySettings_CoverageIsTenantScoped(t *testing.T) {
 	tenantA, tenantB := uuid.New(), uuid.New()
 	repo := newFakeRepo()
-	repo.connectedAgentVersions = map[uuid.UUID][]string{
-		tenantA: {"999.0.0"},
-		tenantB: {"999.0.0", "999.0.0", "999.0.0", "999.0.0"},
+	repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{
+		tenantA: unroutedFacts("999.0.0"),
+		tenantB: unroutedFacts("999.0.0", "999.0.0", "999.0.0", "999.0.0"),
 	}
 	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
 	svc.repo = repo
@@ -368,8 +394,8 @@ func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
 	t.Run("all_covered", func(t *testing.T) {
 		tenantID := uuid.New()
 		repo := newFakeRepo()
-		repo.connectedAgentVersions = map[uuid.UUID][]string{
-			tenantID: {"999.0.0", "999.1.0", "1000.0.0"},
+		repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{
+			tenantID: unroutedFacts("999.0.0", "999.1.0", "1000.0.0"),
 		}
 		svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
 		svc.repo = repo
@@ -386,6 +412,150 @@ func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
 			t.Errorf("expected 3/3 when every connected site is covered, got %+v", wire.FailureDetection)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 — coverage predicate corrected: gating sites_covered on
+// agent_version alone told every customer with a fully-working, WPMgr-routed
+// fleet that alerting was broken. A site whose mail WPMgr routes has ALWAYS
+// been able to report a delivery failure (MailRouter::intercept() ->
+// EmailLogger::write(), predates this feature, consults no version gate).
+// Coverage is routed OR new-enough-agent, not agent-version alone.
+// ---------------------------------------------------------------------------
+
+// TestGetNotifySettings_RoutedFleetOnOldAgent_ReportsFullCoverage: every
+// connected site routes its mail through WPMgr but reports an agent_version
+// far below the gate. This must report full coverage. RED before the fix —
+// the old predicate checked agent_version only and reported 0/6.
+func TestGetNotifySettings_RoutedFleetOnOldAgent_ReportsFullCoverage(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{
+		tenantID: routedFacts("0.61.136", "0.61.136", "0.60.2", "0.59.0", "0.58.4", "0.57.1"),
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 6 {
+		t.Errorf("sites_total = %d, want 6", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 6 {
+		t.Errorf("sites_covered = %d, want 6 — every site is routed, so coverage must be full regardless of agent_version", wire.FailureDetection.SitesCovered)
+	}
+	if wire.FailureDetection.SitesRouted != 6 {
+		t.Errorf("sites_routed = %d, want 6", wire.FailureDetection.SitesRouted)
+	}
+}
+
+// TestGetNotifySettings_PlaceholderConstant_RoutedFleetNotFalselyUncovered is
+// the state that actually ships: MinAgentVersionForFailureDetection is still
+// its impossible placeholder ("999.0.0" at time of writing), and every
+// connected site is on a real, shipped, therefore-always-below-placeholder
+// agent version. This reproduces the adversary's exact finding — "No
+// connected site can report a delivery failure" — for a fleet that is, in
+// fact, fully covered because it is routed. Deliberately uses the real
+// exported constant rather than a plausible-looking stand-in, unlike the
+// frontend tests that hard-coded "1.4.0" and never exercised this branch.
+func TestGetNotifySettings_PlaceholderConstant_RoutedFleetNotFalselyUncovered(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{
+		tenantID: routedFacts("0.61.136"),
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.MinAgentVersionUnrouted != MinAgentVersionForFailureDetection {
+		t.Fatalf("test assumes the constant is still %q; it changed to %q — update this test's story, don't just relax the assertion below", MinAgentVersionForFailureDetection, wire.FailureDetection.MinAgentVersionUnrouted)
+	}
+	if wire.FailureDetection.SitesCovered != 1 || wire.FailureDetection.SitesTotal != 1 {
+		t.Errorf("expected 1/1 (full coverage) for a routed site under the placeholder gate, got %+v", wire.FailureDetection)
+	}
+}
+
+// TestGetNotifySettings_MixedFleet_ReportsHonestSplit: a tenant with routed
+// sites on old agents, an unrouted site new enough to be covered anyway, and
+// unrouted sites on old agents that are genuinely NOT covered. The split must
+// be exact, not rounded toward either extreme.
+func TestGetNotifySettings_MixedFleet_ReportsHonestSplit(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	facts := append(
+		routedFacts("0.61.136", "0.60.2"), // covered via routing, old agent
+		ConnectedSiteEmailFact{AgentVersion: "1000.0.0", Routed: false}, // covered via version
+	)
+	facts = append(facts,
+		unroutedFacts("0.61.136", "0.60.2")..., // NOT covered: neither routed nor new enough
+	)
+	repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{tenantID: facts}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 5 {
+		t.Errorf("sites_total = %d, want 5", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 3 {
+		t.Errorf("sites_covered = %d, want 3 (2 routed + 1 new-enough-unrouted)", wire.FailureDetection.SitesCovered)
+	}
+	if wire.FailureDetection.SitesRouted != 2 {
+		t.Errorf("sites_routed = %d, want 2", wire.FailureDetection.SitesRouted)
+	}
+}
+
+// TestGetNotifySettings_NoRoutedSites_OldAgents_ReportsZero: the honest
+// zero-coverage case must still be reachable — nothing routed, nothing new
+// enough. If this ever also reports full coverage, the warning banner has
+// become decoration that can never fire.
+func TestGetNotifySettings_NoRoutedSites_OldAgents_ReportsZero(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{
+		tenantID: unroutedFacts("0.61.136", "0.60.2", "0.59.0"),
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 3 {
+		t.Errorf("sites_total = %d, want 3", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 0 {
+		t.Errorf("sites_covered = %d, want 0 — the warning state must stay reachable", wire.FailureDetection.SitesCovered)
+	}
+	if wire.FailureDetection.SitesRouted != 0 {
+		t.Errorf("sites_routed = %d, want 0", wire.FailureDetection.SitesRouted)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -2,10 +2,17 @@ package email
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -224,4 +231,156 @@ func TestBuildDigestData_FlagOff_OmitsSection_PreservesZeroSkip(t *testing.T) {
 	if data != nil {
 		t.Fatalf("expected skip-send (nil) when the flag is off and there is no email activity, got %v", data)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 2 — failure-detection coverage on GET notify-settings
+// ---------------------------------------------------------------------------
+
+// failureDetectionWire and notifySettingsWire mirror the wire JSON shape
+// (dto.go's notifySettingsDTO / failureDetectionDTO) so these tests decode the
+// handler's actual SERIALIZED response rather than inspecting Go structs the
+// handler never sends.
+type failureDetectionWire struct {
+	SitesTotal      int    `json:"sites_total"`
+	SitesCovered    int    `json:"sites_covered"`
+	MinAgentVersion string `json:"min_agent_version"`
+}
+
+type notifySettingsWire struct {
+	FailureDetection failureDetectionWire `json:"failure_detection"`
+}
+
+// notifySettingsGetCtx builds a request+principal context for GET
+// /email/notify-settings — an org-level route with no path params.
+func notifySettingsGetCtx(t *testing.T, p domain.Principal) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(domain.WithPrincipal(context.Background(), p))
+	return c, rec
+}
+
+func decodeNotifySettingsWire(t *testing.T, rec *httptest.ResponseRecorder) notifySettingsWire {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body %s", rec.Code, rec.Body.String())
+	}
+	var wire notifySettingsWire
+	if err := json.Unmarshal(rec.Body.Bytes(), &wire); err != nil {
+		t.Fatalf("failed to decode response: %v, body: %s", err, rec.Body.String())
+	}
+	return wire
+}
+
+// TestGetNotifySettings_ReportsFailureDetectionCoverage: RED today because
+// the failure_detection field does not exist yet. 3 connected sites, 2 at or
+// above the gate, must serialize as sites_total=3, sites_covered=2.
+func TestGetNotifySettings_ReportsFailureDetectionCoverage(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedAgentVersions = map[uuid.UUID][]string{
+		tenantID: {"999.5.0", MinAgentVersionForFailureDetection, "0.61.138"},
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 3 {
+		t.Errorf("sites_total = %d, want 3", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 2 {
+		t.Errorf("sites_covered = %d, want 2", wire.FailureDetection.SitesCovered)
+	}
+	if wire.FailureDetection.MinAgentVersion != MinAgentVersionForFailureDetection {
+		t.Errorf("min_agent_version = %q, want %q", wire.FailureDetection.MinAgentVersion, MinAgentVersionForFailureDetection)
+	}
+}
+
+// TestGetNotifySettings_CoverageIsTenantScoped: the coverage count for tenant
+// A must never include tenant B's fleet, however much larger it is. This is
+// the one that matters most — get it wrong and the endpoint leaks another
+// tenant's fleet size.
+func TestGetNotifySettings_CoverageIsTenantScoped(t *testing.T) {
+	tenantA, tenantB := uuid.New(), uuid.New()
+	repo := newFakeRepo()
+	repo.connectedAgentVersions = map[uuid.UUID][]string{
+		tenantA: {"999.0.0"},
+		tenantB: {"999.0.0", "999.0.0", "999.0.0", "999.0.0"},
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantA,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesTotal != 1 {
+		t.Errorf("sites_total = %d, want 1 — tenant B's 4 sites leaked into tenant A's count", wire.FailureDetection.SitesTotal)
+	}
+	if wire.FailureDetection.SitesCovered != 1 {
+		t.Errorf("sites_covered = %d, want 1", wire.FailureDetection.SitesCovered)
+	}
+}
+
+// TestGetNotifySettings_FailureDetectionCoverage_NoOverfire is the
+// over-fire control: a tenant with zero connected sites, and a tenant where
+// every connected site is covered, must both produce sane values rather than
+// a divide-by-zero or an omitted field.
+func TestGetNotifySettings_FailureDetectionCoverage_NoOverfire(t *testing.T) {
+	t.Run("zero_sites", func(t *testing.T) {
+		tenantID := uuid.New()
+		repo := newFakeRepo() // no entry for tenantID — zero connected sites
+		svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+		svc.repo = repo
+		h := &Handler{svc: svc}
+
+		c, rec := notifySettingsGetCtx(t, domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+			Role: "admin", Scope: domain.ScopeOrg,
+		})
+		h.getNotifySettings(c)
+
+		wire := decodeNotifySettingsWire(t, rec)
+		if wire.FailureDetection.SitesTotal != 0 || wire.FailureDetection.SitesCovered != 0 {
+			t.Errorf("expected 0/0 for a tenant with no connected sites, got %+v", wire.FailureDetection)
+		}
+		if !strings.Contains(rec.Body.String(), `"failure_detection"`) {
+			t.Error("failure_detection must be present even for a zero-site tenant, never omitted")
+		}
+	})
+
+	t.Run("all_covered", func(t *testing.T) {
+		tenantID := uuid.New()
+		repo := newFakeRepo()
+		repo.connectedAgentVersions = map[uuid.UUID][]string{
+			tenantID: {"999.0.0", "999.1.0", "1000.0.0"},
+		}
+		svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+		svc.repo = repo
+		h := &Handler{svc: svc}
+
+		c, rec := notifySettingsGetCtx(t, domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+			Role: "admin", Scope: domain.ScopeOrg,
+		})
+		h.getNotifySettings(c)
+
+		wire := decodeNotifySettingsWire(t, rec)
+		if wire.FailureDetection.SitesTotal != 3 || wire.FailureDetection.SitesCovered != 3 {
+			t.Errorf("expected 3/3 when every connected site is covered, got %+v", wire.FailureDetection)
+		}
+	})
 }

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -217,6 +217,29 @@ func (r *Repo) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (Notif
 	return out, err
 }
 
+// ListConnectedSiteAgentVersions returns the reported agent_version for every
+// site in this tenant currently in the 'connected' connection_state (GH #381
+// phase 2: failure-detection coverage). Version comparison against the
+// coverage gate happens in the service layer.
+//
+// Unlike GetNotifySettings/UpsertNotifySettings, sites IS a site-keyed table
+// carrying the m112 RESTRICTIVE sites_site_scope policy, so this runs under
+// scopedTenantTx like every other site-keyed query in this package: a
+// site-scoped collaborator's coverage is correctly narrowed to the sites they
+// can see, and an org-scoped principal sees the whole tenant fleet.
+func (r *Repo) ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error) {
+	var out []string
+	err := r.scopedTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		versions, qerr := sqlc.New(tx).ListConnectedSiteAgentVersions(ctx, tenantID)
+		if qerr != nil {
+			return qerr
+		}
+		out = versions
+		return nil
+	})
+	return out, err
+}
+
 // UpsertNotifySettings creates or updates the notify settings row.
 // Runs under InTenantTx.
 func (r *Repo) UpsertNotifySettings(ctx context.Context, in NotifySettings) (NotifySettings, error) {

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -298,10 +298,22 @@ func (r *Repo) AccumulateAlertFailures(ctx context.Context, tenantID, siteID uui
 	})
 }
 
-// ClaimAlertSlot tries to claim an alert slot for a site. Returns the updated
-// AlertState when the claim succeeds, nil when throttled (pgx.ErrNoRows).
-// Runs under InAgentTx.
-func (r *Repo) ClaimAlertSlot(ctx context.Context, tenantID, siteID uuid.UUID, minFailures int64, throttleMinutes int) (*AlertState, error) {
+// ClaimAlertSlot tries to claim an alert slot for a site and, when the claim
+// succeeds, invokes onClaim in the SAME transaction as the claim UPDATE
+// before committing — typically an EnqueueTx call. This is the transactional
+// outbox pattern (mirrors internal/vuln's ClaimUnnotifiedFindings +
+// AlertMailer.EnqueueTx): if onClaim returns an error, the WHOLE transaction
+// rolls back, so the failures_since_alert reset and last_alert_at bump are
+// undone together with the failed send. A genuine enqueue failure therefore
+// never leaves the site silently marked as recently-alerted — the original
+// GH #381 bug, reintroduced by claiming and enqueueing as two independent
+// steps that could disagree.
+//
+// Returns the claimed state (nil = throttled, not an error — pgx.ErrNoRows),
+// or the onClaim error, propagated unwrapped after the rollback. onClaim may
+// be nil (claim with no side effect, e.g. tests exercising the throttle gate
+// alone). Runs under InAgentTx.
+func (r *Repo) ClaimAlertSlot(ctx context.Context, tenantID, siteID uuid.UUID, minFailures int64, throttleMinutes int, onClaim func(tx pgx.Tx) error) (*AlertState, error) {
 	var state *AlertState
 	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
 		row, qerr := sqlc.New(tx).ClaimAlertSlot(ctx, sqlc.ClaimAlertSlotParams{
@@ -325,10 +337,18 @@ func (r *Repo) ClaimAlertSlot(ctx context.Context, tenantID, siteID uuid.UUID, m
 			t := row.LastAlertAt.Time
 			s.LastAlertAt = &t
 		}
+		if onClaim != nil {
+			if cbErr := onClaim(tx); cbErr != nil {
+				return cbErr // rolls back the claim together with the failed side effect
+			}
+		}
 		state = &s
 		return nil
 	})
-	return state, err
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -217,24 +217,31 @@ func (r *Repo) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (Notif
 	return out, err
 }
 
-// ListConnectedSiteAgentVersions returns the reported agent_version for every
-// site in this tenant currently in the 'connected' connection_state (GH #381
-// phase 2: failure-detection coverage). Version comparison against the
-// coverage gate happens in the service layer.
+// ListConnectedSiteEmailCoverage returns, for every site in this tenant
+// currently in the 'connected' connection_state, the two raw facts needed to
+// compute failure-detection coverage (GH #381): its reported agent_version,
+// and whether WPMgr is actively routing its mail (per-site
+// site_email_config.provider, falling back to the org-wide default row when
+// no per-site row exists — mirrors the agent's own
+// EmailConfig::is_configured()). Both the version-gate comparison and the
+// routed-OR-new-enough predicate happen in the service layer.
 //
-// Unlike GetNotifySettings/UpsertNotifySettings, sites IS a site-keyed table
-// carrying the m112 RESTRICTIVE sites_site_scope policy, so this runs under
-// scopedTenantTx like every other site-keyed query in this package: a
-// site-scoped collaborator's coverage is correctly narrowed to the sites they
-// can see, and an org-scoped principal sees the whole tenant fleet.
-func (r *Repo) ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error) {
-	var out []string
+// Unlike GetNotifySettings/UpsertNotifySettings, sites and site_email_config
+// are site-keyed tables carrying the m112 RESTRICTIVE site_scope policies, so
+// this runs under scopedTenantTx like every other site-keyed query in this
+// package: a site-scoped collaborator's coverage is correctly narrowed to the
+// sites they can see, and an org-scoped principal sees the whole tenant
+// fleet.
+func (r *Repo) ListConnectedSiteEmailCoverage(ctx context.Context, tenantID uuid.UUID) ([]ConnectedSiteEmailFact, error) {
+	var out []ConnectedSiteEmailFact
 	err := r.scopedTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
-		versions, qerr := sqlc.New(tx).ListConnectedSiteAgentVersions(ctx, tenantID)
+		rows, qerr := sqlc.New(tx).ListConnectedSiteEmailCoverage(ctx, tenantID)
 		if qerr != nil {
 			return qerr
 		}
-		out = versions
+		for _, row := range rows {
+			out = append(out, ConnectedSiteEmailFact{AgentVersion: row.AgentVersion, Routed: row.Routed})
+		}
 		return nil
 	})
 	return out, err

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
@@ -95,7 +96,7 @@ type repository interface {
 	GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (NotifySettings, error)
 	UpsertNotifySettings(ctx context.Context, in NotifySettings) (NotifySettings, error)
 	AccumulateAlertFailures(ctx context.Context, tenantID, siteID uuid.UUID, n int64) error
-	ClaimAlertSlot(ctx context.Context, tenantID, siteID uuid.UUID, minFailures int64, throttleMinutes int) (*AlertState, error)
+	ClaimAlertSlot(ctx context.Context, tenantID, siteID uuid.UUID, minFailures int64, throttleMinutes int, onClaim func(tx pgx.Tx) error) (*AlertState, error)
 	ListDueDigests(ctx context.Context, limit int32) ([]NotifySettings, error)
 	ClaimAdvanceDigest(ctx context.Context, tenantID uuid.UUID, newNextAt time.Time) (NotifySettings, error)
 	GetFleetStatsBySite(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]SiteStatsRow, error)
@@ -1507,24 +1508,36 @@ func (s *Service) PropagateOrgConfig(ctx context.Context, tenantID uuid.UUID) (P
 // GetNotifySettings returns the org-level notify settings. When no row exists
 // the service returns safe defaults with GET-always-200 semantics (lesson from
 // 0.35.1 hotfix: never 404 on a settings GET).
+//
+// The failure-detection coverage count (GH #381 phase 2) is decorative, not
+// load-bearing: a fault in that query must never take down the settings page
+// a user visits to fix recipients/toggles (PR #447 bot review finding 2). On
+// a coverage-query failure this logs a warning and returns the settings with
+// FailureDetection left nil (omitted on the wire), never a false
+// "sites_covered: 0" built from an error.
 func (s *Service) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (NotifySettings, error) {
 	coverage, covErr := s.failureDetectionCoverage(ctx, tenantID)
 	if covErr != nil {
-		return NotifySettings{}, covErr
+		s.log.Warn("email notify-settings: failure-detection coverage query failed, degrading to settings without coverage",
+			slog.String("tenant_id", tenantID.String()), slog.Any("error", covErr))
 	}
 
 	settings, err := s.repo.GetNotifySettings(ctx, tenantID)
 	if errors.Is(err, ErrNotFound) {
 		defaults := defaultNotifySettings(tenantID)
 		defaults.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
-		defaults.FailureDetection = coverage
+		if covErr == nil {
+			defaults.FailureDetection = &coverage
+		}
 		return defaults, nil
 	}
 	if err != nil {
 		return NotifySettings{}, domain.Internal("email_get_notify_settings", "failed to load notify settings").WithCause(err)
 	}
 	settings.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
-	settings.FailureDetection = coverage
+	if covErr == nil {
+		settings.FailureDetection = &coverage
+	}
 	return settings, nil
 }
 

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -101,8 +101,8 @@ type repository interface {
 	GetFleetStatsBySite(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]SiteStatsRow, error)
 	TopFailureSamples(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
 	TopFailureSamplesBySite(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
-	// GH #381 phase 2 — failure-detection coverage.
-	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
+	// GH #381 — failure-detection coverage.
+	ListConnectedSiteEmailCoverage(ctx context.Context, tenantID uuid.UUID) ([]ConnectedSiteEmailFact, error)
 }
 
 // Service is the email domain business-logic layer. It owns:
@@ -1532,22 +1532,30 @@ func (s *Service) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (No
 // GH #381 phase 2 — failure-detection coverage
 // ---------------------------------------------------------------------------
 
-// MinAgentVersionForFailureDetection gates failure_detection.sites_covered: a
-// connected site is "covered" only when its reported agent_version compares
-// >= this value under internal/wpversion.Compare.
+// MinAgentVersionForFailureDetection gates the UNROUTED half of
+// failure_detection.sites_covered only: a connected site that does not route
+// its mail through WPMgr is "covered" solely when its reported agent_version
+// compares >= this value under internal/wpversion.Compare. A routed site
+// (WPMgr is its active mail transport) is covered regardless of this gate —
+// that capture path (MailRouter::intercept() -> EmailLogger::write()) predates
+// GH #381 entirely and has never depended on agent version. See
+// failureDetectionCoverage below for the full predicate.
 //
-// PLACEHOLDER VALUE. GH #381 phase 1 — the agent-side change that actually
-// widens failure detection beyond "WPMgr is the mail transport" — has not
-// shipped a release as of this writing. "999.0.0" is deliberately NOT a
-// plausible wpmgr version: it is chosen so that no currently-shipped agent
-// ever compares >= it, which makes sites_covered honestly report 0 until this
-// constant is corrected, instead of silently crediting sites for a capability
-// their agent build does not have.
+// PLACEHOLDER VALUE. GH #381 phase 1 — the agent-side change that widens
+// failure detection to sites WPMgr does NOT route — has not shipped a release
+// as of this writing. "999.0.0" is deliberately NOT a plausible wpmgr
+// version: it is chosen so that no currently-shipped agent ever compares >=
+// it, which makes the UNROUTED half of sites_covered honestly report 0 until
+// this constant is corrected, instead of silently crediting sites for a
+// capability their agent build does not have. Because coverage is now
+// routed-OR-version, this placeholder can NEVER make a routed fleet read as
+// uncovered — only the unrouted half stays at 0 until updated.
 //
 // UPDATE THIS the moment phase 1's release is cut: set it to the exact agent
 // version (e.g. "0.62.0") that ships the detection-widening change, in the
-// same commit that cuts that release. Until updated, every tenant's
-// failure_detection.sites_covered will read 0 regardless of fleet freshness.
+// same commit that cuts that release. Until updated, unrouted sites never
+// count toward failure_detection.sites_covered regardless of fleet freshness;
+// routed sites always have.
 const MinAgentVersionForFailureDetection = "999.0.0"
 
 // agentVersionPattern accepts the plain dotted-numeric shape WPMgr's own
@@ -1564,22 +1572,40 @@ func isWellFormedAgentVersion(v string) bool {
 }
 
 // failureDetectionCoverage computes, for tenantID, how many of its currently
-// connected sites (connection_state = 'connected') run an agent_version at or
-// above MinAgentVersionForFailureDetection. A site whose reported version is
-// empty or not well-formed is treated as NOT covered — an unreadable version
-// is never assumed capable, mirroring internal/agentrelease.Classify's
-// StatusUnknown handling, which never risks a false "current" either.
+// connected sites (connection_state = 'connected') can detect and report an
+// email delivery failure. A site is covered when EITHER:
+//
+//   - it is routed: WPMgr is its active mail transport, per
+//     ConnectedSiteEmailFact.Routed (a per-site site_email_config row's
+//     provider, or — absent one — the tenant's org-wide default row's
+//     provider, is non-empty; mirrors the agent's own
+//     EmailConfig::is_configured()). This path is independent of agent
+//     version.
+//   - OR it is unrouted but its agent_version compares >=
+//     MinAgentVersionForFailureDetection. A site whose reported version is
+//     empty or not well-formed is treated as NOT covered by this path — an
+//     unreadable version is never assumed capable, mirroring
+//     internal/agentrelease.Classify's StatusUnknown handling, which never
+//     risks a false "current" either.
+//
+// A routed site is therefore counted as covered even while
+// MinAgentVersionForFailureDetection is still the unreachable placeholder —
+// that gate only ever suppresses the unrouted half.
 func (s *Service) failureDetectionCoverage(ctx context.Context, tenantID uuid.UUID) (FailureDetectionCoverage, error) {
-	versions, err := s.repo.ListConnectedSiteAgentVersions(ctx, tenantID)
+	facts, err := s.repo.ListConnectedSiteEmailCoverage(ctx, tenantID)
 	if err != nil {
-		return FailureDetectionCoverage{}, domain.Internal("email_failure_detection_coverage", "failed to load connected site agent versions").WithCause(err)
+		return FailureDetectionCoverage{}, domain.Internal("email_failure_detection_coverage", "failed to load connected site email coverage facts").WithCause(err)
 	}
 	out := FailureDetectionCoverage{
-		SitesTotal:      len(versions),
-		MinAgentVersion: MinAgentVersionForFailureDetection,
+		SitesTotal:              len(facts),
+		MinAgentVersionUnrouted: MinAgentVersionForFailureDetection,
 	}
-	for _, v := range versions {
-		if isWellFormedAgentVersion(v) && wpversion.Compare(v, MinAgentVersionForFailureDetection) >= 0 {
+	for _, f := range facts {
+		if f.Routed {
+			out.SitesRouted++
+		}
+		versionCovered := isWellFormedAgentVersion(f.AgentVersion) && wpversion.Compare(f.AgentVersion, MinAgentVersionForFailureDetection) >= 0
+		if f.Routed || versionCovered {
 			out.SitesCovered++
 		}
 	}

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -653,7 +653,7 @@ func (s *Service) IngestLogBatch(ctx context.Context, tenantID, siteID uuid.UUID
 		}
 	}
 	if failureCount > 0 {
-		go s.maybeAlertFailures(context.Background(), tenantID, siteID, failureCount)
+		go s.maybeAlertFailuresAsync(tenantID, siteID, failureCount)
 	}
 
 	return IngestResult{AckedThrough: maxSeq}, nil

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // Encryptor age-encrypts and decrypts provider secrets. *cryptbox.AgeIdentity
@@ -99,6 +101,8 @@ type repository interface {
 	GetFleetStatsBySite(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]SiteStatsRow, error)
 	TopFailureSamples(ctx context.Context, tenantID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
 	TopFailureSamplesBySite(ctx context.Context, tenantID, siteID uuid.UUID, from, to time.Time, limit int32) ([]FailureSample, error)
+	// GH #381 phase 2 — failure-detection coverage.
+	ListConnectedSiteAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]string, error)
 }
 
 // Service is the email domain business-logic layer. It owns:
@@ -1504,17 +1508,82 @@ func (s *Service) PropagateOrgConfig(ctx context.Context, tenantID uuid.UUID) (P
 // the service returns safe defaults with GET-always-200 semantics (lesson from
 // 0.35.1 hotfix: never 404 on a settings GET).
 func (s *Service) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (NotifySettings, error) {
+	coverage, covErr := s.failureDetectionCoverage(ctx, tenantID)
+	if covErr != nil {
+		return NotifySettings{}, covErr
+	}
+
 	settings, err := s.repo.GetNotifySettings(ctx, tenantID)
 	if errors.Is(err, ErrNotFound) {
 		defaults := defaultNotifySettings(tenantID)
 		defaults.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
+		defaults.FailureDetection = coverage
 		return defaults, nil
 	}
 	if err != nil {
 		return NotifySettings{}, domain.Internal("email_get_notify_settings", "failed to load notify settings").WithCause(err)
 	}
 	settings.InstanceMailerConfigured = s.mailerIsConfigured(ctx)
+	settings.FailureDetection = coverage
 	return settings, nil
+}
+
+// ---------------------------------------------------------------------------
+// GH #381 phase 2 — failure-detection coverage
+// ---------------------------------------------------------------------------
+
+// MinAgentVersionForFailureDetection gates failure_detection.sites_covered: a
+// connected site is "covered" only when its reported agent_version compares
+// >= this value under internal/wpversion.Compare.
+//
+// PLACEHOLDER VALUE. GH #381 phase 1 — the agent-side change that actually
+// widens failure detection beyond "WPMgr is the mail transport" — has not
+// shipped a release as of this writing. "999.0.0" is deliberately NOT a
+// plausible wpmgr version: it is chosen so that no currently-shipped agent
+// ever compares >= it, which makes sites_covered honestly report 0 until this
+// constant is corrected, instead of silently crediting sites for a capability
+// their agent build does not have.
+//
+// UPDATE THIS the moment phase 1's release is cut: set it to the exact agent
+// version (e.g. "0.62.0") that ships the detection-widening change, in the
+// same commit that cuts that release. Until updated, every tenant's
+// failure_detection.sites_covered will read 0 regardless of fleet freshness.
+const MinAgentVersionForFailureDetection = "999.0.0"
+
+// agentVersionPattern accepts the plain dotted-numeric shape WPMgr's own
+// agent versions use, mirroring internal/agentrelease's own guard
+// (internal/agentrelease/classify.go:45). Duplicated rather than imported:
+// internal/email must not cross-import a sibling domain package, and this is
+// a two-line regex, not shared logic worth a shared package for. A malformed
+// or empty agent_version (e.g. a site that has never reported one) must never
+// compare as "covered" by accident.
+var agentVersionPattern = regexp.MustCompile(`^\d+(\.\d+){1,3}([-+][0-9A-Za-z.]+)?$`)
+
+func isWellFormedAgentVersion(v string) bool {
+	return agentVersionPattern.MatchString(strings.TrimSpace(v))
+}
+
+// failureDetectionCoverage computes, for tenantID, how many of its currently
+// connected sites (connection_state = 'connected') run an agent_version at or
+// above MinAgentVersionForFailureDetection. A site whose reported version is
+// empty or not well-formed is treated as NOT covered — an unreadable version
+// is never assumed capable, mirroring internal/agentrelease.Classify's
+// StatusUnknown handling, which never risks a false "current" either.
+func (s *Service) failureDetectionCoverage(ctx context.Context, tenantID uuid.UUID) (FailureDetectionCoverage, error) {
+	versions, err := s.repo.ListConnectedSiteAgentVersions(ctx, tenantID)
+	if err != nil {
+		return FailureDetectionCoverage{}, domain.Internal("email_failure_detection_coverage", "failed to load connected site agent versions").WithCause(err)
+	}
+	out := FailureDetectionCoverage{
+		SitesTotal:      len(versions),
+		MinAgentVersion: MinAgentVersionForFailureDetection,
+	}
+	for _, v := range versions {
+		if isWellFormedAgentVersion(v) && wpversion.Compare(v, MinAgentVersionForFailureDetection) >= 0 {
+			out.SitesCovered++
+		}
+	}
+	return out, nil
 }
 
 // PutNotifySettings validates and upserts the notify settings, computing

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -92,6 +92,18 @@ type fakeRepo struct {
 	// keyed by tenant so a cross-tenant test can seed two tenants' fleets
 	// independently (GH #381 phase 2).
 	connectedAgentVersions map[uuid.UUID][]string
+
+	// GH #381 phase 5 — maybeAlertFailures exit-path control knobs. Each is
+	// nil/zero by default, which preserves the pre-phase-5 fake behaviour
+	// (GetNotifySettings -> ErrNotFound, ClaimAlertSlot -> throttled, GetSiteRef
+	// -> ErrNotFound) so every existing test keeps passing unchanged.
+	alertAccumulateErr error
+	alertSettings      *NotifySettings
+	alertSettingsErr   error
+	alertClaimState    *AlertState
+	alertClaimErr      error
+	alertSiteRef       *SiteRef
+	alertSiteRefErr    error
 }
 
 func newFakeRepo() *fakeRepo {
@@ -433,10 +445,22 @@ func (r *fakeRepo) ListEmailInheritingSites(_ context.Context, _ uuid.UUID) ([]I
 }
 
 func (r *fakeRepo) GetSiteRef(_ context.Context, _, _ uuid.UUID) (SiteRef, error) {
+	if r.alertSiteRefErr != nil {
+		return SiteRef{}, r.alertSiteRefErr
+	}
+	if r.alertSiteRef != nil {
+		return *r.alertSiteRef, nil
+	}
 	return SiteRef{}, ErrNotFound
 }
 
 func (r *fakeRepo) GetNotifySettings(_ context.Context, _ uuid.UUID) (NotifySettings, error) {
+	if r.alertSettingsErr != nil {
+		return NotifySettings{}, r.alertSettingsErr
+	}
+	if r.alertSettings != nil {
+		return *r.alertSettings, nil
+	}
 	return NotifySettings{}, ErrNotFound
 }
 
@@ -445,11 +469,14 @@ func (r *fakeRepo) UpsertNotifySettings(_ context.Context, in NotifySettings) (N
 }
 
 func (r *fakeRepo) AccumulateAlertFailures(_ context.Context, _, _ uuid.UUID, _ int64) error {
-	return nil
+	return r.alertAccumulateErr
 }
 
 func (r *fakeRepo) ClaimAlertSlot(_ context.Context, _, _ uuid.UUID, _ int64, _ int) (*AlertState, error) {
-	return nil, nil // throttled
+	if r.alertClaimErr != nil {
+		return nil, r.alertClaimErr
+	}
+	return r.alertClaimState, nil // nil state, nil error == throttled
 }
 
 func (r *fakeRepo) ListDueDigests(_ context.Context, _ int32) ([]NotifySettings, error) {

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -87,6 +87,11 @@ type fakeRepo struct {
 	// say "refused" and "absent" as well as "done", and the service has to turn
 	// each into a different answer (see suppression_delete_refusal_test.go).
 	suppressionDeleteErr error
+
+	// connectedAgentVersions is what ListConnectedSiteAgentVersions returns,
+	// keyed by tenant so a cross-tenant test can seed two tenants' fleets
+	// independently (GH #381 phase 2).
+	connectedAgentVersions map[uuid.UUID][]string
 }
 
 func newFakeRepo() *fakeRepo {
@@ -465,6 +470,10 @@ func (r *fakeRepo) TopFailureSamples(_ context.Context, _ uuid.UUID, _, _ time.T
 
 func (r *fakeRepo) TopFailureSamplesBySite(_ context.Context, _, _ uuid.UUID, _, _ time.Time, _ int32) ([]FailureSample, error) {
 	return nil, nil
+}
+
+func (r *fakeRepo) ListConnectedSiteAgentVersions(_ context.Context, tenantID uuid.UUID) ([]string, error) {
+	return r.connectedAgentVersions[tenantID], nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
@@ -93,6 +94,10 @@ type fakeRepo struct {
 	// independently (GH #381). Each fact carries both the agent_version and
 	// whether the site routes its mail through WPMgr.
 	connectedSiteFacts map[uuid.UUID][]ConnectedSiteEmailFact
+	// connectedSiteFactsErr, when set, makes ListConnectedSiteEmailCoverage
+	// fail — PR #447 bot review finding 2: this must degrade GetNotifySettings
+	// to settings-without-coverage, never fail the whole GET.
+	connectedSiteFactsErr error
 
 	// GH #381 phase 5 — maybeAlertFailures exit-path control knobs. Each is
 	// nil/zero by default, which preserves the pre-phase-5 fake behaviour
@@ -473,11 +478,24 @@ func (r *fakeRepo) AccumulateAlertFailures(_ context.Context, _, _ uuid.UUID, _ 
 	return r.alertAccumulateErr
 }
 
-func (r *fakeRepo) ClaimAlertSlot(_ context.Context, _, _ uuid.UUID, _ int64, _ int) (*AlertState, error) {
+// ClaimAlertSlot mirrors the real Repo's transactional-outbox contract: when
+// a claim is configured to succeed (alertClaimState set) it invokes onClaim
+// (the mailer EnqueueTx call), and an onClaim error is propagated as this
+// call's error — exactly like a rolled-back transaction — instead of a
+// claimed state ever being returned alongside a failed send.
+func (r *fakeRepo) ClaimAlertSlot(_ context.Context, _, _ uuid.UUID, _ int64, _ int, onClaim func(tx pgx.Tx) error) (*AlertState, error) {
 	if r.alertClaimErr != nil {
 		return nil, r.alertClaimErr
 	}
-	return r.alertClaimState, nil // nil state, nil error == throttled
+	if r.alertClaimState == nil {
+		return nil, nil // nil state, nil error == throttled
+	}
+	if onClaim != nil {
+		if err := onClaim(nil); err != nil {
+			return nil, err // rolled back
+		}
+	}
+	return r.alertClaimState, nil
 }
 
 func (r *fakeRepo) ListDueDigests(_ context.Context, _ int32) ([]NotifySettings, error) {
@@ -501,6 +519,9 @@ func (r *fakeRepo) TopFailureSamplesBySite(_ context.Context, _, _ uuid.UUID, _,
 }
 
 func (r *fakeRepo) ListConnectedSiteEmailCoverage(_ context.Context, tenantID uuid.UUID) ([]ConnectedSiteEmailFact, error) {
+	if r.connectedSiteFactsErr != nil {
+		return nil, r.connectedSiteFactsErr
+	}
 	return r.connectedSiteFacts[tenantID], nil
 }
 

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -88,10 +88,11 @@ type fakeRepo struct {
 	// each into a different answer (see suppression_delete_refusal_test.go).
 	suppressionDeleteErr error
 
-	// connectedAgentVersions is what ListConnectedSiteAgentVersions returns,
-	// keyed by tenant so a cross-tenant test can seed two tenants' fleets
-	// independently (GH #381 phase 2).
-	connectedAgentVersions map[uuid.UUID][]string
+	// connectedSiteFacts is what ListConnectedSiteEmailCoverage returns, keyed
+	// by tenant so a cross-tenant test can seed two tenants' fleets
+	// independently (GH #381). Each fact carries both the agent_version and
+	// whether the site routes its mail through WPMgr.
+	connectedSiteFacts map[uuid.UUID][]ConnectedSiteEmailFact
 
 	// GH #381 phase 5 — maybeAlertFailures exit-path control knobs. Each is
 	// nil/zero by default, which preserves the pre-phase-5 fake behaviour
@@ -499,8 +500,8 @@ func (r *fakeRepo) TopFailureSamplesBySite(_ context.Context, _, _ uuid.UUID, _,
 	return nil, nil
 }
 
-func (r *fakeRepo) ListConnectedSiteAgentVersions(_ context.Context, tenantID uuid.UUID) ([]string, error) {
-	return r.connectedAgentVersions[tenantID], nil
+func (r *fakeRepo) ListConnectedSiteEmailCoverage(_ context.Context, tenantID uuid.UUID) ([]ConnectedSiteEmailFact, error) {
+	return r.connectedSiteFacts[tenantID], nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/email/email-notify-settings-card.test.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.test.tsx
@@ -52,7 +52,7 @@ function buildSettings(
       min_agent_version: "1.4.0",
     },
     ...overrides,
-  } as EmailNotifySettings;
+  };
 }
 
 function mockSettings(data: EmailNotifySettings | null) {
@@ -157,7 +157,7 @@ describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
   it("shows no coverage message when failure_detection is absent (older API)", async () => {
     const { failure_detection: _omit, ...withoutFailureDetection } =
       buildSettings();
-    mockSettings(withoutFailureDetection as EmailNotifySettings);
+    mockSettings(withoutFailureDetection);
 
     renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
 

--- a/apps/web/src/features/email/email-notify-settings-card.test.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import type { EmailNotifySettings } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult, mockMutationResult } from "@/test/query-mocks";
+
+// GH #381, phase 3: the Notifications page promised "Send an alert email
+// when a delivery failure is detected on a site" with no mention that
+// WPMgr can only detect a failure on a site whose agent is new enough to
+// report it. A self-hosted user with a working instance mailer (so the
+// OTHER banner, instance_mailer_configured, never fired) went ten days
+// with alerting silently unable to ever trigger because every one of their
+// sites was on an older agent. Phase 2 added `failure_detection` to
+// GET /api/v1/email/notify-settings; this phase surfaces it.
+
+const { useEmailNotifySettingsMock, usePutEmailNotifySettingsMock } = vi.hoisted(
+  () => ({
+    useEmailNotifySettingsMock: vi.fn(),
+    usePutEmailNotifySettingsMock: vi.fn(),
+  }),
+);
+
+vi.mock("./use-email", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-email")>();
+  return {
+    ...actual,
+    useEmailNotifySettings: useEmailNotifySettingsMock,
+    usePutEmailNotifySettings: usePutEmailNotifySettingsMock,
+  };
+});
+
+import { EmailNotifySettingsCard } from "./email-notify-settings-card";
+
+function buildSettings(
+  overrides: Partial<EmailNotifySettings> = {},
+): EmailNotifySettings {
+  return {
+    enabled: true,
+    recipients: ["ops@example.com"],
+    alert_on_failure: true,
+    alert_throttle_minutes: 60,
+    digest_enabled: false,
+    digest_cadence: "daily",
+    digest_day: 0,
+    digest_hour: 8,
+    timezone: "UTC",
+    instance_mailer_configured: true,
+    failure_detection: {
+      sites_total: 10,
+      sites_covered: 10,
+      min_agent_version: "1.4.0",
+    },
+    ...overrides,
+  } as EmailNotifySettings;
+}
+
+function mockSettings(data: EmailNotifySettings | null) {
+  useEmailNotifySettingsMock.mockReturnValue(
+    mockQueryResult<EmailNotifySettings | null>({ data }),
+  );
+  usePutEmailNotifySettingsMock.mockReturnValue(
+    mockMutationResult<EmailNotifySettings, unknown>({}),
+  );
+}
+
+describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
+  it("shows a zero-coverage warning when no site can report delivery failures", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 6,
+          sites_covered: 0,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(/No connected site can report a delivery failure\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1\.4\.0/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Covering all/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows partial coverage as N of M", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 8,
+          sites_covered: 3,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(/3 of 8 connected sites can report a delivery/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the quiet full-coverage line and not the warning banner", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 5,
+          sites_covered: 5,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText("Covering all 5 connected sites."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/connected sites can report a delivery failure\. The rest/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still renders the instance_mailer_configured banner independently, and both can show at once", async () => {
+    mockSettings(
+      buildSettings({
+        instance_mailer_configured: false,
+        failure_detection: {
+          sites_total: 4,
+          sites_covered: 0,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText("Instance mailer not configured."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No connected site can report a delivery failure\./),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no coverage message when failure_detection is absent (older API)", async () => {
+    const { failure_detection: _omit, ...withoutFailureDetection } =
+      buildSettings();
+    mockSettings(withoutFailureDetection as EmailNotifySettings);
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(
+        "Send an alert email when a delivery failure is detected on a site.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Covering all/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/connected sites can report a delivery failure\. The rest/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows no coverage message for a tenant with zero sites", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 0,
+          sites_covered: 0,
+          min_agent_version: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(
+        "Send an alert email when a delivery failure is detected on a site.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Covering all/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/email/email-notify-settings-card.test.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.test.tsx
@@ -13,6 +13,16 @@ import { mockQueryResult, mockMutationResult } from "@/test/query-mocks";
 // with alerting silently unable to ever trigger because every one of their
 // sites was on an older agent. Phase 2 added `failure_detection` to
 // GET /api/v1/email/notify-settings; this phase surfaces it.
+//
+// GH #381 phase 2 fix: coverage is routed-OR-new-enough-agent, not
+// agent-version-alone. A site WPMgr actively routes mail through has always
+// been able to report a delivery failure regardless of agent version, so a
+// fully-routed fleet on old agents is fully covered, not 0% covered. The
+// "fully routed, real placeholder version" test below is the regression
+// test for the shipped bug: it asserts the full-coverage state renders for
+// exactly that fleet shape, using the real production placeholder
+// ("999.0.0", MinAgentVersionForFailureDetection in
+// apps/api/internal/email/service.go) rather than a plausible fake.
 
 const { useEmailNotifySettingsMock, usePutEmailNotifySettingsMock } = vi.hoisted(
   () => ({
@@ -49,7 +59,8 @@ function buildSettings(
     failure_detection: {
       sites_total: 10,
       sites_covered: 10,
-      min_agent_version: "1.4.0",
+      sites_routed: 0,
+      min_agent_version_unrouted: "1.4.0",
     },
     ...overrides,
   };
@@ -71,7 +82,8 @@ describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
         failure_detection: {
           sites_total: 6,
           sites_covered: 0,
-          min_agent_version: "1.4.0",
+          sites_routed: 0,
+          min_agent_version_unrouted: "1.4.0",
         },
       }),
     );
@@ -87,13 +99,67 @@ describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows the zero-coverage warning for a genuinely zero-coverage tenant (nothing routed, nothing new enough) — the banner must still be reachable", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 4,
+          sites_covered: 0,
+          sites_routed: 0,
+          min_agent_version_unrouted: "1.4.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(/No connected site can report a delivery failure\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1\.4\.0/)).toBeInTheDocument();
+    expect(screen.queryByText(/Covering all/)).not.toBeInTheDocument();
+  });
+
+  // Regression test for the shipped bug: a fully-routed fleet, all on agents
+  // below the real (unreachable-until-shipped) placeholder version, is fully
+  // covered because routing does not depend on agent version. Before the
+  // GH #381 phase 2 fix, sites_covered was computed from agent_version alone,
+  // so this exact fleet shape reported 0 of N covered and told customers to
+  // update to an impossible version.
+  it("shows full coverage for a fully-routed fleet under the real production placeholder version, not the zero-coverage warning", async () => {
+    mockSettings(
+      buildSettings({
+        failure_detection: {
+          sites_total: 12,
+          sites_covered: 12,
+          sites_routed: 12,
+          min_agent_version_unrouted: "999.0.0",
+        },
+      }),
+    );
+
+    renderWithProviders(<EmailNotifySettingsCard />, { withRouter: true });
+
+    expect(
+      await screen.findByText(/Covering all 12 connected sites/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected site can report a delivery failure\./),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/999\.0\.0/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/connected sites can report a delivery failure \(/),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows partial coverage as N of M", async () => {
     mockSettings(
       buildSettings({
         failure_detection: {
           sites_total: 8,
           sites_covered: 3,
-          min_agent_version: "1.4.0",
+          sites_routed: 0,
+          min_agent_version_unrouted: "1.4.0",
         },
       }),
     );
@@ -114,7 +180,8 @@ describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
         failure_detection: {
           sites_total: 5,
           sites_covered: 5,
-          min_agent_version: "1.4.0",
+          sites_routed: 0,
+          min_agent_version_unrouted: "1.4.0",
         },
       }),
     );
@@ -139,7 +206,8 @@ describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
         failure_detection: {
           sites_total: 4,
           sites_covered: 0,
-          min_agent_version: "1.4.0",
+          sites_routed: 0,
+          min_agent_version_unrouted: "1.4.0",
         },
       }),
     );
@@ -181,7 +249,8 @@ describe("EmailNotifySettingsCard failure-detection coverage (GH #381)", () => {
         failure_detection: {
           sites_total: 0,
           sites_covered: 0,
-          min_agent_version: "1.4.0",
+          sites_routed: 0,
+          min_agent_version_unrouted: "1.4.0",
         },
       }),
     );

--- a/apps/web/src/features/email/email-notify-settings-card.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.tsx
@@ -43,13 +43,19 @@ import { useEmailNotifySettings, usePutEmailNotifySettings } from "./use-email";
 //
 // failure_detection (GH #381) is the OTHER half of the alerting path: even
 // with a working instance mailer, WPMgr can only detect a delivery failure
-// on a site whose agent is new enough to report it. A tenant whose sites are
-// all on an older agent sees "Per-failure alerts" as an armed toggle that
-// will never fire — the two banners are independent (nothing can SEND vs.
-// nothing can DETECT) and both can be showing at once. sites_total === 0 is
-// an empty fleet, not a warning; the field is absent entirely on an older
-// API (self-hosted instance not yet upgraded), in which case no coverage
-// message is shown at all rather than guessed at.
+// on a site that EITHER routes its mail through WPMgr (covered regardless of
+// agent version — that capture path predates this feature and consults no
+// version gate) OR whose agent is new enough to report a failure on mail it
+// does not route (>= min_agent_version_unrouted). sites_routed says how many
+// of the tenant's sites fall into the first bucket, so a high sites_covered
+// count on a fleet of old agents is explained rather than looking wrong.
+// A tenant whose sites are neither routed nor new enough sees "Per-failure
+// alerts" as an armed toggle that will never fire — the two banners are
+// independent (nothing can SEND vs. nothing can DETECT) and both can be
+// showing at once. sites_total === 0 is an empty fleet, not a warning; the
+// field is absent entirely on an older API (self-hosted instance not yet
+// upgraded), in which case no coverage message is shown at all rather than
+// guessed at.
 //
 // This endpoint never 404s (returns defaults). If the API pre-dates 0.36 and
 // returns 404, useEmailNotifySettings maps it to null and the card is hidden.
@@ -240,20 +246,28 @@ export function EmailNotifySettingsCard() {
 
   const instanceMailerConfigured = s?.instance_mailer_configured ?? false;
 
-  // GH #381: WPMgr can only detect a delivery failure when a site's agent is
-  // new enough to report it. `failure_detection` is absent on an older API
-  // (self-hosted instance not yet upgraded) — in that case we have no
-  // coverage numbers to show and say nothing rather than guess. A tenant
+  // GH #381: WPMgr can only detect a delivery failure on a site that is
+  // either routed through WPMgr (any agent version) or new enough to report
+  // a failure on mail it does not route. `failure_detection` is absent on an
+  // older API (self-hosted instance not yet upgraded) — in that case we have
+  // no coverage numbers to show and say nothing rather than guess. A tenant
   // with zero sites also gets no coverage message; that is not a warning
   // state, just an empty fleet.
   const failureDetection = s?.failure_detection;
   const sitesTotal = failureDetection?.sites_total ?? 0;
   const sitesCovered = failureDetection?.sites_covered ?? 0;
-  const minAgentVersion = failureDetection?.min_agent_version;
+  const sitesRouted = failureDetection?.sites_routed ?? 0;
+  const minAgentVersionUnrouted = failureDetection?.min_agent_version_unrouted;
   const hasCoverageData = failureDetection != null && sitesTotal > 0;
   const fullCoverage = hasCoverageData && sitesCovered >= sitesTotal;
   const zeroCoverage = hasCoverageData && sitesCovered === 0;
   const partialCoverage = hasCoverageData && sitesCovered > 0 && sitesCovered < sitesTotal;
+  // Of the sitesTotal - sitesRouted sites that are NOT routed, how many are
+  // still uncovered (i.e. also below min_agent_version_unrouted). Because
+  // coverage is routed OR new-enough, every uncovered site is necessarily
+  // unrouted — sitesTotal - sitesCovered is exactly that unrouted-and-old
+  // count, never larger, so this is safe to state without overclaiming.
+  const uncoveredCount = sitesTotal - sitesCovered;
 
   return (
     <Card>
@@ -313,14 +327,32 @@ export function EmailNotifySettingsCard() {
               </p>
               {fullCoverage ? (
                 <p className="text-xs text-[var(--color-muted-foreground)]">
-                  Covering all {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}.
+                  {sitesRouted >= sitesTotal ? (
+                    <>
+                      Covering all {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}
+                      {" — all of them route mail through WPMgr, so this holds regardless "}
+                      of agent version.
+                    </>
+                  ) : sitesRouted > 0 ? (
+                    <>
+                      Covering all {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}:{" "}
+                      {sitesRouted} via mail routing, the rest by agent version.
+                    </>
+                  ) : (
+                    <>
+                      Covering all {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}.
+                    </>
+                  )}
                 </p>
               ) : null}
               {partialCoverage ? (
                 <p className="text-xs text-[var(--color-muted-foreground)]">
                   {sitesCovered} of {sitesTotal} connected sites can report a delivery
-                  failure. The rest are on an agent older than {minAgentVersion} and
-                  cannot trigger an alert.{" "}
+                  failure{sitesRouted > 0 ? ` (${sitesRouted} via mail routing)` : ""}. The
+                  other {uncoveredCount}{" "}
+                  {uncoveredCount !== 1 ? "aren't routed through WPMgr and are" : "isn't routed through WPMgr and is"}{" "}
+                  on an agent older than {minAgentVersionUnrouted}; updating the agent
+                  restores alerting.{" "}
                   <Link
                     to="/sites"
                     className="font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
@@ -348,10 +380,11 @@ export function EmailNotifySettingsCard() {
                 <span className="font-medium">
                   No connected site can report a delivery failure.
                 </span>{" "}
-                All {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}{" "}
-                {sitesTotal !== 1 ? "are" : "is"} on an agent older than{" "}
-                {minAgentVersion}, so this toggle will never fire. Update the agent on
-                at least one site to restore alerting.{" "}
+                None of your {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}{" "}
+                route{sitesTotal !== 1 ? "" : "s"} mail through WPMgr, and{" "}
+                {sitesTotal !== 1 ? "all are" : "it is"} on an agent older than{" "}
+                {minAgentVersionUnrouted}, so this toggle will never fire. Update the
+                agent on at least one site to restore alerting.{" "}
                 <Link
                   to="/sites"
                   className="font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"

--- a/apps/web/src/features/email/email-notify-settings-card.tsx
+++ b/apps/web/src/features/email/email-notify-settings-card.tsx
@@ -41,6 +41,16 @@ import { useEmailNotifySettings, usePutEmailNotifySettings } from "./use-email";
 // The instance_mailer_configured flag controls a warning banner: when false,
 // neither alerts nor digests can deliver. The banner links to /settings/smtp.
 //
+// failure_detection (GH #381) is the OTHER half of the alerting path: even
+// with a working instance mailer, WPMgr can only detect a delivery failure
+// on a site whose agent is new enough to report it. A tenant whose sites are
+// all on an older agent sees "Per-failure alerts" as an armed toggle that
+// will never fire — the two banners are independent (nothing can SEND vs.
+// nothing can DETECT) and both can be showing at once. sites_total === 0 is
+// an empty fleet, not a warning; the field is absent entirely on an older
+// API (self-hosted instance not yet upgraded), in which case no coverage
+// message is shown at all rather than guessed at.
+//
 // This endpoint never 404s (returns defaults). If the API pre-dates 0.36 and
 // returns 404, useEmailNotifySettings maps it to null and the card is hidden.
 // ---------------------------------------------------------------------------
@@ -230,6 +240,21 @@ export function EmailNotifySettingsCard() {
 
   const instanceMailerConfigured = s?.instance_mailer_configured ?? false;
 
+  // GH #381: WPMgr can only detect a delivery failure when a site's agent is
+  // new enough to report it. `failure_detection` is absent on an older API
+  // (self-hosted instance not yet upgraded) — in that case we have no
+  // coverage numbers to show and say nothing rather than guess. A tenant
+  // with zero sites also gets no coverage message; that is not a warning
+  // state, just an empty fleet.
+  const failureDetection = s?.failure_detection;
+  const sitesTotal = failureDetection?.sites_total ?? 0;
+  const sitesCovered = failureDetection?.sites_covered ?? 0;
+  const minAgentVersion = failureDetection?.min_agent_version;
+  const hasCoverageData = failureDetection != null && sitesTotal > 0;
+  const fullCoverage = hasCoverageData && sitesCovered >= sitesTotal;
+  const zeroCoverage = hasCoverageData && sitesCovered === 0;
+  const partialCoverage = hasCoverageData && sitesCovered > 0 && sitesCovered < sitesTotal;
+
   return (
     <Card>
       <CardHeader>
@@ -286,6 +311,24 @@ export function EmailNotifySettingsCard() {
               <p className="text-xs text-[var(--color-muted-foreground)]">
                 Send an alert email when a delivery failure is detected on a site.
               </p>
+              {fullCoverage ? (
+                <p className="text-xs text-[var(--color-muted-foreground)]">
+                  Covering all {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}.
+                </p>
+              ) : null}
+              {partialCoverage ? (
+                <p className="text-xs text-[var(--color-muted-foreground)]">
+                  {sitesCovered} of {sitesTotal} connected sites can report a delivery
+                  failure. The rest are on an agent older than {minAgentVersion} and
+                  cannot trigger an alert.{" "}
+                  <Link
+                    to="/sites"
+                    className="font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                  >
+                    View sites
+                  </Link>
+                </p>
+              ) : null}
             </div>
             <Switch
               checked={alertsEnabled}
@@ -294,6 +337,30 @@ export function EmailNotifySettingsCard() {
               aria-label="Enable per-failure alerts"
             />
           </div>
+
+          {zeroCoverage ? (
+            <div className="mb-4 flex gap-2 rounded-md border border-[var(--color-warning)]/50 bg-[var(--color-warning)]/10 px-3 py-2.5">
+              <AlertTriangle
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0 text-[var(--color-warning)]"
+              />
+              <div className="text-sm">
+                <span className="font-medium">
+                  No connected site can report a delivery failure.
+                </span>{" "}
+                All {sitesTotal} connected site{sitesTotal !== 1 ? "s" : ""}{" "}
+                {sitesTotal !== 1 ? "are" : "is"} on an agent older than{" "}
+                {minAgentVersion}, so this toggle will never fire. Update the agent on
+                at least one site to restore alerting.{" "}
+                <Link
+                  to="/sites"
+                  className="font-medium text-[var(--color-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                >
+                  View sites
+                </Link>
+              </div>
+            </div>
+          ) : null}
 
           {alertsEnabled ? (
             <div className="space-y-4 rounded-md border border-[var(--color-border)] bg-[var(--color-card)] p-4">

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -9206,8 +9206,13 @@ export const EmailNotifySettingsSchema = {
     failure_detection: {
       type: "object",
       description:
-        "Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.\n",
-      required: ["sites_total", "sites_covered", "min_agent_version"],
+        "Coverage of the tenant's connected sites for email delivery failure detection (GH #381). A site is covered when EITHER WPMgr is the mail transport it actively uses (routing does not depend on agent version) OR its agent is new enough (>= min_agent_version_unrouted) to capture a failure on mail WPMgr does not route. A site that is neither routed nor on a new enough agent cannot trigger a per-failure alert no matter how the settings above are configured.\n",
+      required: [
+        "sites_total",
+        "sites_covered",
+        "sites_routed",
+        "min_agent_version_unrouted",
+      ],
       properties: {
         sites_total: {
           type: "integer",
@@ -9217,12 +9222,17 @@ export const EmailNotifySettingsSchema = {
         sites_covered: {
           type: "integer",
           description:
-            "Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.\n",
+            "Of sites_total, how many can have a delivery failure detected and alerted on — because WPMgr routes their mail, because their agent_version is at or above min_agent_version_unrouted, or both.\n",
         },
-        min_agent_version: {
+        sites_routed: {
+          type: "integer",
+          description:
+            "Of sites_total, how many have WPMgr configured as their active mail transport. These sites are covered regardless of agent version; this count explains why sites_covered can be high even on a fleet below min_agent_version_unrouted.\n",
+        },
+        min_agent_version_unrouted: {
           type: "string",
           description:
-            "Minimum agent version that can detect and report an email delivery failure.\n",
+            "Minimum agent version needed to detect and report a delivery failure ONLY for sites that do NOT route their mail through WPMgr (sites_total - sites_routed of them). It says nothing about routed sites, which are covered independent of this value.\n",
         },
       },
     },

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -9141,7 +9141,6 @@ export const EmailNotifySettingsSchema = {
     "digest_hour",
     "timezone",
     "instance_mailer_configured",
-    "failure_detection",
   ],
   properties: {
     enabled: {

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -9141,6 +9141,7 @@ export const EmailNotifySettingsSchema = {
     "digest_hour",
     "timezone",
     "instance_mailer_configured",
+    "failure_detection",
   ],
   properties: {
     enabled: {
@@ -9202,6 +9203,29 @@ export const EmailNotifySettingsSchema = {
       type: "boolean",
       description:
         "True when the instance-level SMTP/mailer is configured. Alerts and digests require this to be true to deliver.\n",
+    },
+    failure_detection: {
+      type: "object",
+      description:
+        "Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.\n",
+      required: ["sites_total", "sites_covered", "min_agent_version"],
+      properties: {
+        sites_total: {
+          type: "integer",
+          description:
+            "Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).\n",
+        },
+        sites_covered: {
+          type: "integer",
+          description:
+            "Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.\n",
+        },
+        min_agent_version: {
+          type: "string",
+          description:
+            "Minimum agent version that can detect and report an email delivery failure.\n",
+        },
+      },
     },
     tenant_id: {
       type: "string",

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5424,7 +5424,7 @@ export type EmailNotifySettings = {
    */
   instance_mailer_configured: boolean;
   /**
-   * Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.
+   * Coverage of the tenant's connected sites for email delivery failure detection (GH #381). A site is covered when EITHER WPMgr is the mail transport it actively uses (routing does not depend on agent version) OR its agent is new enough (>= min_agent_version_unrouted) to capture a failure on mail WPMgr does not route. A site that is neither routed nor on a new enough agent cannot trigger a per-failure alert no matter how the settings above are configured.
    *
    */
   failure_detection?: {
@@ -5434,15 +5434,20 @@ export type EmailNotifySettings = {
      */
     sites_total: number;
     /**
-     * Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.
+     * Of sites_total, how many can have a delivery failure detected and alerted on — because WPMgr routes their mail, because their agent_version is at or above min_agent_version_unrouted, or both.
      *
      */
     sites_covered: number;
     /**
-     * Minimum agent version that can detect and report an email delivery failure.
+     * Of sites_total, how many have WPMgr configured as their active mail transport. These sites are covered regardless of agent version; this count explains why sites_covered can be high even on a fleet below min_agent_version_unrouted.
      *
      */
-    min_agent_version: string;
+    sites_routed: number;
+    /**
+     * Minimum agent version needed to detect and report a delivery failure ONLY for sites that do NOT route their mail through WPMgr (sites_total - sites_routed of them). It says nothing about routed sites, which are covered independent of this value.
+     *
+     */
+    min_agent_version_unrouted: string;
   };
   /**
    * Present when a settings row exists; absent for default response.

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5427,7 +5427,7 @@ export type EmailNotifySettings = {
    * Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.
    *
    */
-  failure_detection: {
+  failure_detection?: {
     /**
      * Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).
      *

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5424,6 +5424,27 @@ export type EmailNotifySettings = {
    */
   instance_mailer_configured: boolean;
   /**
+   * Coverage of the tenant's connected sites for email delivery failure detection (GH #381). WPMgr can only detect a failure when it is the mail transport in use AND the agent is new enough to report it; a site below `min_agent_version`, or not currently connected, cannot trigger a per-failure alert no matter how the settings above are configured.
+   *
+   */
+  failure_detection: {
+    /**
+     * Number of the tenant's currently-connected sites (excludes pending, degraded, disconnected, revoked and archived sites).
+     *
+     */
+    sites_total: number;
+    /**
+     * Of sites_total, how many report an agent_version at or above min_agent_version and can therefore have a delivery failure detected and alerted on.
+     *
+     */
+    sites_covered: number;
+    /**
+     * Minimum agent version that can detect and report an email delivery failure.
+     *
+     */
+    min_agent_version: string;
+  };
+  /**
    * Present when a settings row exists; absent for default response.
    */
   tenant_id?: string;

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19578,7 +19578,6 @@ components:
         - digest_hour
         - timezone
         - instance_mailer_configured
-        - failure_detection
       properties:
         enabled:
           type: boolean

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19578,6 +19578,7 @@ components:
         - digest_hour
         - timezone
         - instance_mailer_configured
+        - failure_detection
       properties:
         enabled:
           type: boolean
@@ -19635,6 +19636,36 @@ components:
           description: >
             True when the instance-level SMTP/mailer is configured. Alerts
             and digests require this to be true to deliver.
+        failure_detection:
+          type: object
+          description: >
+            Coverage of the tenant's connected sites for email delivery
+            failure detection (GH #381). WPMgr can only detect a failure when
+            it is the mail transport in use AND the agent is new enough to
+            report it; a site below `min_agent_version`, or not currently
+            connected, cannot trigger a per-failure alert no matter how the
+            settings above are configured.
+          required:
+            - sites_total
+            - sites_covered
+            - min_agent_version
+          properties:
+            sites_total:
+              type: integer
+              description: >
+                Number of the tenant's currently-connected sites (excludes
+                pending, degraded, disconnected, revoked and archived sites).
+            sites_covered:
+              type: integer
+              description: >
+                Of sites_total, how many report an agent_version at or above
+                min_agent_version and can therefore have a delivery failure
+                detected and alerted on.
+            min_agent_version:
+              type: string
+              description: >
+                Minimum agent version that can detect and report an email
+                delivery failure.
         tenant_id:
           type: string
           format: uuid

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19639,15 +19639,18 @@ components:
           type: object
           description: >
             Coverage of the tenant's connected sites for email delivery
-            failure detection (GH #381). WPMgr can only detect a failure when
-            it is the mail transport in use AND the agent is new enough to
-            report it; a site below `min_agent_version`, or not currently
-            connected, cannot trigger a per-failure alert no matter how the
+            failure detection (GH #381). A site is covered when EITHER WPMgr
+            is the mail transport it actively uses (routing does not depend on
+            agent version) OR its agent is new enough
+            (>= min_agent_version_unrouted) to capture a failure on mail
+            WPMgr does not route. A site that is neither routed nor on a new
+            enough agent cannot trigger a per-failure alert no matter how the
             settings above are configured.
           required:
             - sites_total
             - sites_covered
-            - min_agent_version
+            - sites_routed
+            - min_agent_version_unrouted
           properties:
             sites_total:
               type: integer
@@ -19657,14 +19660,25 @@ components:
             sites_covered:
               type: integer
               description: >
-                Of sites_total, how many report an agent_version at or above
-                min_agent_version and can therefore have a delivery failure
-                detected and alerted on.
-            min_agent_version:
+                Of sites_total, how many can have a delivery failure detected
+                and alerted on — because WPMgr routes their mail, because
+                their agent_version is at or above
+                min_agent_version_unrouted, or both.
+            sites_routed:
+              type: integer
+              description: >
+                Of sites_total, how many have WPMgr configured as their active
+                mail transport. These sites are covered regardless of agent
+                version; this count explains why sites_covered can be high
+                even on a fleet below min_agent_version_unrouted.
+            min_agent_version_unrouted:
               type: string
               description: >
-                Minimum agent version that can detect and report an email
-                delivery failure.
+                Minimum agent version needed to detect and report a delivery
+                failure ONLY for sites that do NOT route their mail through
+                WPMgr (sites_total - sites_routed of them). It says nothing
+                about routed sites, which are covered independent of this
+                value.
         tenant_id:
           type: string
           format: uuid

--- a/tools/plugincheck/docker-compose.yml
+++ b/tools/plugincheck/docker-compose.yml
@@ -1,8 +1,16 @@
 # Throwaway WordPress + WP-CLI harness for the AUTHORITATIVE `wp plugin check`.
 # Driven by ../../tools/plugincheck/run.sh (via `make agent-plugincheck`).
+#
+# Images are pinned by digest, not floating tag, so this gate cannot redden a
+# PR on zero code change because upstream repushed `mariadb:11` or
+# `wordpress:cli-php8.3`. To bump deliberately:
+#   docker pull mariadb:11 && docker inspect --format='{{index .RepoDigests 0}}' mariadb:11
+#   docker pull wordpress:cli-php8.3 && docker inspect --format='{{index .RepoDigests 0}}' wordpress:cli-php8.3
+# then paste the new sha256 below and run `make agent-plugincheck` to confirm
+# it still passes before committing the bump.
 services:
   db:
-    image: mariadb:11
+    image: mariadb@sha256:d9f7eb2637296652f24b484afd5d246f759f49f5babcadc6a9e344c9acb75fbf # mariadb:11, pinned 2026-08-17
     environment:
       MARIADB_ROOT_PASSWORD: wp
       MARIADB_DATABASE: wp
@@ -12,7 +20,7 @@ services:
       timeout: 5s
       retries: 40
   wpcli:
-    image: wordpress:cli-php8.3
+    image: wordpress@sha256:2b5e9d4d3e51909dca1aaa4732e9f5e5bf0377c2114dbd8ff39f060bff202586 # wordpress:cli-php8.3, pinned 2026-08-17
     depends_on:
       db:
         condition: service_healthy

--- a/tools/plugincheck/run.sh
+++ b/tools/plugincheck/run.sh
@@ -46,7 +46,13 @@ WP core download --force
 WP config create --dbname=wp --dbuser=root --dbpass=wp --dbhost=db --force
 WP core install --url=http://localhost --title=pc \
   --admin_user=admin --admin_password=admin --admin_email=a@b.test --skip-email
-WP plugin install plugin-check --activate
+# Pinned: an unpinned install pulls whatever plugin-check released today, so a
+# gate on unchanged code can redden a PR because the linter's opinion changed,
+# not because the plugin did. That happened on 2026-08-17 when 2.1.0 shipped a
+# new sniff rule with zero agent code change in between. To bump deliberately,
+# change the version below, run `make agent-plugincheck` locally, and read the
+# diff in ERROR rows before committing.
+WP plugin install plugin-check --version=2.1.0 --activate
 WP plugin install /tmp/plugin.zip --force
 
 echo "==================== wp plugin check: $SLUG ===================="


### PR DESCRIPTION
Closes #381. Closes #439.

## What was broken

A self-hosted user configured per-failure email alerts and received nothing for ten days. The alerting path was correct throughout — WPMgr simply could not *see* a site's mail failure unless WPMgr was that site's mail transport. On a site sending through core PHPMailer or a third-party SMTP plugin, no failure was ever detected, so no alert could fire, while the Notifications page promised "Send an alert email when a delivery failure is detected on a site."

Found on the way, and worse for anyone who never enabled alerting at all: `wp_mail()` returned `true` on a failed send. A contact form told its visitor "message sent" when nothing was delivered, and `wp_mail_failed` never fired, so nothing else could catch it either.

## What changed

**Detection.** A new listener captures `wp_mail_failed` unconditionally, so failures on sites WPMgr does not route are recorded and reported. A detected failure is now logged even when the site's email log is switched off — that preference governs keeping a record of mail that worked, and a failure is an incident.

**Honesty.** `wp_mail()` now returns the truth and fires `wp_mail_failed`. The Notifications page states how many sites can actually report a failure instead of promising blanket coverage, and says plainly when none can.

**Privacy.** A failure row records that a failure happened; the recipient and subject are withheld unless the site owner opted into email logging. Addresses are removed from the error and response text as well, since mailer errors routinely embed them.

**Diagnosability.** Every exit of the alert path now logs a reason. The path previously had five exits that emitted nothing at all, which is why this issue produced no diagnostic thread for ten days. The detached goroutine gained a timeout and a panic recovery.

## What still cannot be detected

Stated here because it goes to the reporter too. Mail that never passes through `wp_mail()` — a plugin calling PHPMailer directly, or posting to a vendor API. Third-party mailers that swallow their own errors without raising the failure hook. Anything that fails after the receiving server accepted the message. Sites where the agent is disconnected or WP-Cron never runs.

## Review

Two security passes and two adversarial passes, plus the reviews each phase took as it was built. They blocked this three times: a recipient address surviving in the error column, the same defect on the routed path, and a coverage banner that would have told every customer their alerting was broken on day one. Each fix carries a regression test shown failing before it passes.

The full integration suite passes locally; `ci.yml` does not run that package. The WordPress plugin check is now pinned — it began failing on unchanged code when the checker's offloading rule widened its scope upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic capture and logging for email delivery failures, including failures outside the standard routing flow.
  - Added failure-detection coverage details to notification settings, showing covered, routed, and uncovered connected sites.
  - Added guidance and site links when failure-detection coverage is partial or unavailable.

- **Bug Fixes**
  - Failed email sends now correctly report failure status and avoid duplicate processing.
  - Sensitive email details and message bodies are redacted or excluded when appropriate.
  - Failure alerts are more resilient and no longer disrupt normal requests when processing errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->