### PR TITLE
release: 0.61.139

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.139] - 2026-08-17
+
+### Added
+
+- Email delivery failure detection now also listens to WordPress's own mail-failure signal, so a site is covered even when it sends through its own SMTP setup instead of through WPMgr (GH #381). Previously WPMgr could only see a failure on mail it routed itself, while the Notifications page promised detection generally; a site sending through its own SMTP configuration could have per-failure alerts turned on and never receive one. The Notifications page now states how many connected sites can actually report a failure, and says so plainly when none can, rather than promising coverage it cannot deliver.
+- A detected failure is now recorded even on a site that has email logging turned off. That preference controls whether successful sends are kept for review; a failure is an incident, not a record of mail that worked, so it is written regardless. The recipient, subject, sender and message body are withheld from the record unless the site has opted into email logging; only the fact that a failure happened is kept.
+
+### Fixed
+
+- `wp_mail()` reported success on a failed send: the filter WPMgr uses to route outgoing mail returned a truthy value on a provider failure, so any caller, a contact form, a password reset, a WooCommerce order email, was told the message went out when nothing was delivered, and WordPress's own mail-failure hook never fired (GH #439). `wp_mail()` now returns false on a failed send and fires that hook itself with the same error shape WordPress's own failure paths use, omitting the message body and any secrets. Forms and flows that check the return value of `wp_mail()` will start surfacing delivery failures they were previously hiding; that is the intent of this fix, not a new fault introduced by it.
+
 ## [0.61.138] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.137**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.138**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -318,15 +318,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.137
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.137
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.137
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.138
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.138
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.138
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.137   # omit to track :latest
+export WPMGR_VERSION=v0.61.138   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, security, performance, updates, site management
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.61.131
+Stable tag: 0.61.139
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -276,6 +276,11 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.31.1. This project ships frequently and not every intermediate patch release is listed here. Full history: https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md
 
+= 0.61.139 =
+* Added: this site now also reports an email delivery failure detected through WordPress's own mail-failure signal, not only failures on mail this site routes through WPMgr. Sites sending through their own SMTP setup are now covered too.
+* Added: a detected failure is recorded even when this site's email log is turned off. That setting controls whether successful sends are kept for review; a failure is recorded regardless, and the recipient, subject, sender and message body are withheld from the record unless email logging is on.
+* Fixed: `wp_mail()` reported success on a failed send, so a contact form or password reset could tell a visitor the message went out when nothing was delivered. `wp_mail()` now returns false on a failed send and fires WordPress's own mail-failure hook, so plugins and themes that check the result learn the truth.
+
 = 0.61.131 =
 * Fixed: sending email from this site could silently stop working days after it had been set up and used successfully, showing as "SMTP Error: Could not authenticate" (GH #380). Saving, testing or syncing this site's email settings from the dashboard could send an empty password, and the site read that as an instruction to delete the working password it already had. This site no longer deletes a stored password unless the dashboard actually sends a real replacement, and it now refuses an email settings update it cannot make sense of instead of acting on the part it understood. If this site lost its password this way, the dashboard restores it the next time it syncs this site's email settings, with nothing for you to re-enter.
 * Security: a password belonging to your dashboard account is no longer sent to a mail server you choose from this site's own settings page, and a stored password is no longer carried over automatically when you point this site's email at a different mail server, mailbox user or provider.
@@ -416,6 +421,9 @@ The entries below summarize the notable changes since 0.31.1. This project ships
 * New: WOFF2 font transcoding. TTF, OTF and WOFF are converted on the control plane; the flag defaults to off.
 
 == Upgrade Notice ==
+
+= 0.61.139 =
+Email delivery failures are now detected on sites that send through their own SMTP setup, not only sites routed through WPMgr, and a plugin bug that reported a failed send as successful is fixed: wp_mail() now returns false on a failed send. Forms and other flows that check the result of wp_mail() will start correctly reporting failures they previously hid. Safe to update in place.
 
 = 0.61.131 =
 Fixes a bug that could silently delete this site's working SMTP password when its email settings were saved, tested or synced from the dashboard, breaking outgoing email. Update now if this site sends mail through SMTP, SES, SendGrid, Mailgun or Postmark; the dashboard restores the password automatically on its next sync with this site.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.131
+ * Version:           0.61.139
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.131');
+define('WPMGR_AGENT_VERSION', '0.61.139');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -53,7 +53,7 @@ const RELEASES: ChangeEntry[] = [
     version: "0.61.139",
     date: "2026-08-17",
     summary:
-      "Email delivery failure detection now works on sites that send through their own SMTP setup, not only sites that route mail through WPMgr, and the Notifications page states how many connected sites can actually report a failure. Separately, a WordPress bug where a failed send was reported as successful is fixed, so forms and other flows now learn honestly when mail did not go out.",
+      "Email delivery failure detection now works on sites that send through their own SMTP setup, not only sites that route mail through WPMgr, and the Notifications page states how many connected sites can actually report a failure. Separately, a bug in WPMgr's own mail routing that reported a failed send as successful is fixed, so forms and other flows now learn honestly when mail did not go out.",
     items: [
       {
         tag: "Added",

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,27 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.139",
+    date: "2026-08-17",
+    summary:
+      "Email delivery failure detection now works on sites that send through their own SMTP setup, not only sites that route mail through WPMgr, and the Notifications page states how many connected sites can actually report a failure. Separately, a WordPress bug where a failed send was reported as successful is fixed, so forms and other flows now learn honestly when mail did not go out.",
+    items: [
+      {
+        tag: "Added",
+        text: "Email delivery failure detection now also listens to WordPress's own mail-failure signal, so a site is covered even when it sends through its own SMTP setup instead of through WPMgr. The Notifications page now states how many connected sites can actually report a failure, and says so plainly when none can, rather than promising coverage it cannot deliver.",
+      },
+      {
+        tag: "Added",
+        text: "A detected failure is now recorded even on a site that has email logging turned off. That preference controls whether successful sends are kept for review; a failure is an incident and is written regardless, though the recipient, subject, sender and message body are withheld unless the site has opted into email logging.",
+      },
+      {
+        tag: "Fixed",
+        text: "wp_mail() reported success on a failed send, so a contact form or password reset could tell a visitor the message went out when nothing was delivered. wp_mail() now returns false on a failed send and fires WordPress's own mail-failure hook, so forms and flows that check the result will start surfacing failures they were previously hiding.",
+      },
+    ],
+    featureLinks: [{ label: "Email deliverability", href: "/features/email-deliverability" }],
+  },
+  {
     version: "0.61.138",
     date: "2026-08-16",
     summary:

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -14,7 +14,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 // on every release: the agent version deliberately does not track the repo
 // release version, so a control-plane-only release leaves this alone and the
 // badge stays true.
-const AGENT_VERSION = "0.61.131";
+const AGENT_VERSION = "0.61.139";
 
 export const HOME_HERO = {
   badge: `v${AGENT_VERSION} / open source`,

--- a/docs/install.md
+++ b/docs/install.md
@@ -219,7 +219,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.137   # omit to track :latest
+export WPMGR_VERSION=v0.61.138   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.138
+  version: 0.61.139
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Cuts GH #381 and GH #439 as an **agent release**. Unlike the previous two releases, `apps/agent/**` changed substantially, so the agent version moves (0.61.131 -> 0.61.139) and the marketing hero badge moves with it, per `scripts/check-version-surfaces.sh`.

What shipped:
- Email delivery failure detection now also listens to WordPress's own `wp_mail_failed` signal, covering sites that send through their own SMTP setup, not only sites WPMgr routes mail for. The Notifications page states how many connected sites can actually report a failure.
- A detected failure is recorded even when a site's email log is off; recipient, subject, sender and body are withheld unless logging is on.
- `wp_mail()` now returns `false` on a failed send instead of falsely reporting success, and fires WordPress's own mail-failure hook itself. This is a user-visible behavior change: forms and flows that check the return value will start surfacing failures they previously hid.

Version surfaces moved:
- `CHANGELOG.md`: new `[0.61.139]` entry.
- `packages/openapi/openapi.yaml`: `info.version` -> 0.61.139.
- `apps/marketing/app/(marketing)/changelog/page.tsx`: new entry, linked to the email-deliverability feature page.
- `apps/marketing/lib/content/home.ts`: `AGENT_VERSION` (hero badge) -> 0.61.139.
- `apps/agent/wpmgr-agent.php`: plugin header `Version` and `WPMGR_AGENT_VERSION` -> 0.61.139.
- `apps/agent/readme.txt`: `Stable tag` -> 0.61.139, plus changelog and upgrade-notice entries.
- `README.md` / `docs/install.md` install pins -> v0.61.138 (the most recent published release; verified pullable in GHCR for wpmgr-api, wpmgr-web and wpmgr-media-encoder via `docker manifest inspect`), within the guard's one-release tolerance of the new 0.61.139 top entry.

## Test plan
- [x] `make check-versions-test` - 76 passed, 0 failed
- [x] `make check-versions` - all surfaces consistent, agent triple agrees at 0.61.139, hero badge matches
- [x] Docs vocabulary check (verbatim from `ci.yml`) - clean
- [x] `node apps/marketing/scripts/check-copy.mjs` - passed, 389 files
- [ ] Owner QA, then deploy, then tag, per this repo's release order

Opened as a **draft**: bot review is a metered resource here and today's limit was already hit.