### PR TITLE
fix(email): set the failure-detection version gate to 0.61.139

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.139] - 2026-08-17
+
+### Added
+
+- Email delivery failure detection now also listens to WordPress's own mail-failure signal, so a site is covered even when it sends through its own SMTP setup instead of through WPMgr (GH #381). Previously WPMgr could only see a failure on mail it routed itself, while the Notifications page promised detection generally; a site sending through its own SMTP configuration could have per-failure alerts turned on and never receive one. The Notifications page now states how many connected sites can actually report a failure, and says so plainly when none can, rather than promising coverage it cannot deliver.
+- A detected failure is now recorded even on a site that has email logging turned off. That preference controls whether successful sends are kept for review; a failure is an incident, not a record of mail that worked, so it is written regardless. The recipient, subject, sender and message body are withheld from the record unless the site has opted into email logging; only the fact that a failure happened is kept.
+
+### Fixed
+
+- `wp_mail()` reported success on a failed send: the filter WPMgr uses to route outgoing mail returned a truthy value on a provider failure, so any caller, a contact form, a password reset, a WooCommerce order email, was told the message went out when nothing was delivered, and WordPress's own mail-failure hook never fired (GH #439). `wp_mail()` now returns false on a failed send and fires that hook itself with the same error shape WordPress's own failure paths use, omitting the message body and any secrets. Forms and flows that check the return value of `wp_mail()` will start surfacing delivery failures they were previously hiding; that is the intent of this fix, not a new fault introduced by it.
+
 ## [0.61.138] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.137**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.138**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -318,15 +318,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.137
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.137
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.137
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.138
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.138
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.138
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.137   # omit to track :latest
+export WPMGR_VERSION=v0.61.138   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, security, performance, updates, site management
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.61.131
+Stable tag: 0.61.139
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -276,6 +276,11 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.31.1. This project ships frequently and not every intermediate patch release is listed here. Full history: https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md
 
+= 0.61.139 =
+* Added: this site now also reports an email delivery failure detected through WordPress's own mail-failure signal, not only failures on mail this site routes through WPMgr. Sites sending through their own SMTP setup are now covered too.
+* Added: a detected failure is recorded even when this site's email log is turned off. That setting controls whether successful sends are kept for review; a failure is recorded regardless, and the recipient, subject, sender and message body are withheld from the record unless email logging is on.
+* Fixed: `wp_mail()` reported success on a failed send, so a contact form or password reset could tell a visitor the message went out when nothing was delivered. `wp_mail()` now returns false on a failed send and fires WordPress's own mail-failure hook, so plugins and themes that check the result learn the truth.
+
 = 0.61.131 =
 * Fixed: sending email from this site could silently stop working days after it had been set up and used successfully, showing as "SMTP Error: Could not authenticate" (GH #380). Saving, testing or syncing this site's email settings from the dashboard could send an empty password, and the site read that as an instruction to delete the working password it already had. This site no longer deletes a stored password unless the dashboard actually sends a real replacement, and it now refuses an email settings update it cannot make sense of instead of acting on the part it understood. If this site lost its password this way, the dashboard restores it the next time it syncs this site's email settings, with nothing for you to re-enter.
 * Security: a password belonging to your dashboard account is no longer sent to a mail server you choose from this site's own settings page, and a stored password is no longer carried over automatically when you point this site's email at a different mail server, mailbox user or provider.
@@ -416,6 +421,9 @@ The entries below summarize the notable changes since 0.31.1. This project ships
 * New: WOFF2 font transcoding. TTF, OTF and WOFF are converted on the control plane; the flag defaults to off.
 
 == Upgrade Notice ==
+
+= 0.61.139 =
+Email delivery failures are now detected on sites that send through their own SMTP setup, not only sites routed through WPMgr, and a plugin bug that reported a failed send as successful is fixed: wp_mail() now returns false on a failed send. Forms and other flows that check the result of wp_mail() will start correctly reporting failures they previously hid. Safe to update in place.
 
 = 0.61.131 =
 Fixes a bug that could silently delete this site's working SMTP password when its email settings were saved, tested or synced from the dashboard, breaking outgoing email. Update now if this site sends mail through SMTP, SES, SendGrid, Mailgun or Postmark; the dashboard restores the password automatically on its next sync with this site.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.131
+ * Version:           0.61.139
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.131');
+define('WPMGR_AGENT_VERSION', '0.61.139');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/api/internal/email/notify_test.go
+++ b/apps/api/internal/email/notify_test.go
@@ -7,6 +7,10 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // ---------------------------------------------------------------------------
@@ -546,6 +551,106 @@ func TestGetNotifySettings_PlaceholderConstant_RoutedFleetNotFalselyUncovered(t 
 	}
 	if wire.FailureDetection.SitesCovered != 1 || wire.FailureDetection.SitesTotal != 1 {
 		t.Errorf("expected 1/1 (full coverage) for a routed site under the placeholder gate, got %+v", wire.FailureDetection)
+	}
+}
+
+// TestGetNotifySettings_UnroutedFleet_CoveredAtShippingAgentVersion is the
+// RED/GREEN case for the release MinAgentVersionForFailureDetection now
+// belongs to: an unrouted site reporting the real, shipping agent version
+// (0.61.139) must read as covered. This is the failure mode the placeholder
+// existed to make honest and the eventual fix existed to correct — while the
+// constant was still "999.0.0" this reported 0/1, meaning a real fleet on
+// the very release that ships the wp_mail_failed listener would still have
+// been told it could not report a delivery failure.
+func TestGetNotifySettings_UnroutedFleet_CoveredAtShippingAgentVersion(t *testing.T) {
+	tenantID := uuid.New()
+	repo := newFakeRepo()
+	repo.connectedSiteFacts = map[uuid.UUID][]ConnectedSiteEmailFact{
+		tenantID: unroutedFacts("0.61.139"),
+	}
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	h := &Handler{svc: svc}
+
+	c, rec := notifySettingsGetCtx(t, domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	h.getNotifySettings(c)
+
+	wire := decodeNotifySettingsWire(t, rec)
+	if wire.FailureDetection.SitesCovered != 1 || wire.FailureDetection.SitesTotal != 1 {
+		t.Errorf("expected 1/1 (covered) for an unrouted site on the shipping agent version 0.61.139, got %+v — MinAgentVersionForFailureDetection must be <= 0.61.139", wire.FailureDetection)
+	}
+}
+
+// agentVersionDefineRe extracts WPMGR_AGENT_VERSION out of
+// apps/agent/wpmgr-agent.php's PHP source, e.g.
+// `define('WPMGR_AGENT_VERSION', '0.61.139');`.
+var agentVersionDefineRe = regexp.MustCompile(`define\(\s*'WPMGR_AGENT_VERSION',\s*'([0-9]+(?:\.[0-9]+){1,3})'\s*\)`)
+
+// currentShippingAgentVersion reads WPMGR_AGENT_VERSION directly out of
+// apps/agent/wpmgr-agent.php instead of duplicating the version as a second
+// literal in this package — a literal copy would only ever go stale in step
+// with the constant it exists to check, catching nothing independently. The
+// live agent source is the one authoritative place that version is defined.
+func currentShippingAgentVersion(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate the repo root to read apps/agent/wpmgr-agent.php")
+	}
+	// thisFile: apps/api/internal/email/notify_test.go — four levels above
+	// the repo root.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+	pluginFile := filepath.Join(repoRoot, "apps", "agent", "wpmgr-agent.php")
+	data, err := os.ReadFile(pluginFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", pluginFile, err)
+	}
+	m := agentVersionDefineRe.FindSubmatch(data)
+	if m == nil {
+		t.Fatalf("WPMGR_AGENT_VERSION define not found in %s", pluginFile)
+	}
+	return string(m[1])
+}
+
+// TestMinAgentVersionForFailureDetection_NotAheadOfShippingAgent pins
+// MinAgentVersionForFailureDetection against the release it belongs to.
+//
+// "The exact agent release that first shipped the wp_mail_failed listener"
+// is a historical fact, not something derivable from the repo's current
+// state — a future release keeps bumping WPMGR_AGENT_VERSION forever while
+// this floor rightly stays put, so the two are pinned to the SAME literal
+// only in the release that introduces the capability (this one). That fact
+// is: apps/agent/includes/email/class-mail-failure-capture.php was
+// introduced by commit 1f2eadc, present in the 0.61.139 release and absent
+// from the prior 0.61.138 release — `git log 804bb86..db2b1db -- apps/agent`
+// and `git show 804bb86:apps/agent/includes/email/class-mail-failure-capture.php`
+// (no such path) confirm it. That half of this test is therefore a pinned
+// literal, deliberately, with the derivation recorded here instead of
+// resting on memory.
+//
+// What CAN be checked mechanically, every time this runs, without going
+// stale on an unrelated future release: the floor must never be ahead of
+// the agent version apps/agent actually ships. Read live off
+// wpmgr-agent.php, that property holds automatically forever, because
+// shipped agent versions only increase — and its violation is the literal
+// incident this constant guards against (see MinAgentVersionForFailureDetection's
+// own doc comment): set the floor even one patch too high and every
+// unrouted site reads as uncovered again.
+func TestMinAgentVersionForFailureDetection_NotAheadOfShippingAgent(t *testing.T) {
+	const firstVersionWithWpMailFailedListener = "0.61.139"
+
+	if MinAgentVersionForFailureDetection != firstVersionWithWpMailFailedListener {
+		t.Fatalf("MinAgentVersionForFailureDetection = %q, want %q (the release that first shipped the wp_mail_failed listener); if this constant is being deliberately re-gated to a later release, update this pin in the same commit and restate why in the comment above",
+			MinAgentVersionForFailureDetection, firstVersionWithWpMailFailedListener)
+	}
+
+	shipping := currentShippingAgentVersion(t)
+	if wpversion.Compare(MinAgentVersionForFailureDetection, shipping) > 0 {
+		t.Fatalf("MinAgentVersionForFailureDetection (%q) is ahead of the agent version apps/agent actually ships (%q, from wpmgr-agent.php); no currently-shipped agent could ever satisfy the gate, so every unrouted site reads as uncovered",
+			MinAgentVersionForFailureDetection, shipping)
 	}
 }
 

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -1554,22 +1554,27 @@ func (s *Service) GetNotifySettings(ctx context.Context, tenantID uuid.UUID) (No
 // GH #381 entirely and has never depended on agent version. See
 // failureDetectionCoverage below for the full predicate.
 //
-// PLACEHOLDER VALUE. GH #381 phase 1 — the agent-side change that widens
-// failure detection to sites WPMgr does NOT route — has not shipped a release
-// as of this writing. "999.0.0" is deliberately NOT a plausible wpmgr
-// version: it is chosen so that no currently-shipped agent ever compares >=
-// it, which makes the UNROUTED half of sites_covered honestly report 0 until
-// this constant is corrected, instead of silently crediting sites for a
-// capability their agent build does not have. Because coverage is now
-// routed-OR-version, this placeholder can NEVER make a routed fleet read as
-// uncovered — only the unrouted half stays at 0 until updated.
+// GH #381 phase 1 shipped in agent release 0.61.139: the wp_mail_failed
+// listener that lets a site WPMgr does NOT route still report a delivery
+// failure (apps/agent/includes/email/class-mail-failure-capture.php,
+// introduced by commit 1f2eadc, absent from the prior 0.61.138 release —
+// verified via `git log 804bb86..db2b1db -- apps/agent`). 0.61.139 is
+// therefore the correct floor: an unrouted site must report an agent_version
+// at or above it to be credited with the capability its build actually has.
 //
-// UPDATE THIS the moment phase 1's release is cut: set it to the exact agent
-// version (e.g. "0.62.0") that ships the detection-widening change, in the
-// same commit that cuts that release. Until updated, unrouted sites never
-// count toward failure_detection.sites_covered regardless of fleet freshness;
-// routed sites always have.
-const MinAgentVersionForFailureDetection = "999.0.0"
+// Before this was set, it held "999.0.0" — deliberately not a plausible
+// wpmgr version, chosen so no currently-shipped agent could ever compare >=
+// it, so the UNROUTED half of sites_covered honestly reported 0 rather than
+// silently crediting sites for a capability no shipped agent build had yet.
+// Because coverage is routed-OR-version, that placeholder never made a
+// routed fleet read as uncovered — only the unrouted half stayed at 0.
+//
+// If this constant is ever re-gated to a later release (the capability
+// regresses and needs re-fixing, say), bump it in the same commit that cuts
+// that release, and update the pin in
+// TestMinAgentVersionForFailureDetection_NotAheadOfShippingAgent alongside
+// it.
+const MinAgentVersionForFailureDetection = "0.61.139"
 
 // agentVersionPattern accepts the plain dotted-numeric shape WPMgr's own
 // agent versions use, mirroring internal/agentrelease's own guard

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,27 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.139",
+    date: "2026-08-17",
+    summary:
+      "Email delivery failure detection now works on sites that send through their own SMTP setup, not only sites that route mail through WPMgr, and the Notifications page states how many connected sites can actually report a failure. Separately, a WordPress bug where a failed send was reported as successful is fixed, so forms and other flows now learn honestly when mail did not go out.",
+    items: [
+      {
+        tag: "Added",
+        text: "Email delivery failure detection now also listens to WordPress's own mail-failure signal, so a site is covered even when it sends through its own SMTP setup instead of through WPMgr. The Notifications page now states how many connected sites can actually report a failure, and says so plainly when none can, rather than promising coverage it cannot deliver.",
+      },
+      {
+        tag: "Added",
+        text: "A detected failure is now recorded even on a site that has email logging turned off. That preference controls whether successful sends are kept for review; a failure is an incident and is written regardless, though the recipient, subject, sender and message body are withheld unless the site has opted into email logging.",
+      },
+      {
+        tag: "Fixed",
+        text: "wp_mail() reported success on a failed send, so a contact form or password reset could tell a visitor the message went out when nothing was delivered. wp_mail() now returns false on a failed send and fires WordPress's own mail-failure hook, so forms and flows that check the result will start surfacing failures they were previously hiding.",
+      },
+    ],
+    featureLinks: [{ label: "Email deliverability", href: "/features/email-deliverability" }],
+  },
+  {
     version: "0.61.138",
     date: "2026-08-16",
     summary:

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -14,7 +14,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 // on every release: the agent version deliberately does not track the repo
 // release version, so a control-plane-only release leaves this alone and the
 // badge stays true.
-const AGENT_VERSION = "0.61.131";
+const AGENT_VERSION = "0.61.139";
 
 export const HOME_HERO = {
   badge: `v${AGENT_VERSION} / open source`,

--- a/docs/install.md
+++ b/docs/install.md
@@ -219,7 +219,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.137   # omit to track :latest
+export WPMGR_VERSION=v0.61.138   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.138
+  version: 0.61.139
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary
- `MinAgentVersionForFailureDetection` (`apps/api/internal/email/service.go`) moves off its deliberate `"999.0.0"` placeholder to `"0.61.139"`, the agent release that ships the `wp_mail_failed` listener (`apps/agent/includes/email/class-mail-failure-capture.php`, absent from the prior `0.61.138` release — verified via `git log 804bb86..db2b1db -- apps/agent`).
- Coverage is `routed || versionCovered`; this only changes the unrouted half. Routed sites were already covered regardless of this gate.
- Adds `TestGetNotifySettings_UnroutedFleet_CoveredAtShippingAgentVersion` (the real RED/GREEN case for an unrouted site on 0.61.139) and `TestMinAgentVersionForFailureDetection_NotAheadOfShippingAgent` (pins the constant to the release it belongs to, and independently checks — by reading `apps/agent/wpmgr-agent.php` live — that the floor is never ahead of the agent version actually shipping).
- Confirmed `TestGetNotifySettings_PlaceholderConstant_RoutedFleetNotFalselyUncovered` (the routed-fleet regression test) keeps passing in both the RED and GREEN states — it covers the routed half, unaffected by this gate.

## Test plan
- [x] RED: with the constant reverted to `"999.0.0"`, `TestGetNotifySettings_UnroutedFleet_CoveredAtShippingAgentVersion` and `TestMinAgentVersionForFailureDetection_NotAheadOfShippingAgent` fail; `TestGetNotifySettings_PlaceholderConstant_RoutedFleetNotFalselyUncovered` still passes.
- [x] GREEN: with the constant at `"0.61.139"`, all three pass.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/email/...` (all green, 24.5s)
- [x] `gofmt -l` clean on both touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded email-delivery failure detection, including failures from unrouted sites.
  - Notifications now report actual email-monitoring coverage.
  - Failure events are recorded even when successful email logging is disabled, with message details omitted unless logging is enabled.

- **Bug Fixes**
  - Failed routed emails now correctly return a failure result and trigger WordPress’s standard mail-failure notification.

- **Documentation**
  - Updated release notes, installation guidance, version information, and email deliverability documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->