### PR TITLE
fix(marketing): correct four pricing-page defects on plugin-stack calculator

### DIFF
--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
@@ -219,7 +219,7 @@ export function PluginStackCalculator({ wpmgrTiers }: { wpmgrTiers: WpmgrTier[] 
           <input
             type="range"
             min={1}
-            max={500}
+            max={200}
             step={1}
             value={sites}
             onChange={(e) => dispatch({ type: "sites", value: Number(e.target.value) })}

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/calculator.tsx
@@ -8,6 +8,7 @@ import {
   PLUGIN_COST_CATEGORIES,
   PER_SITE_KEYS,
   SITE_PRESETS,
+  PURCHASE_LIKELIHOOD_GROUPS,
   annualCost,
   resolveTier,
   resolveWpmgrTier,
@@ -18,15 +19,17 @@ import {
  * The plugin-stack calculator.
  *
  * THE ILLUSTRATION IS THE ASYMMETRY. Two bills sit side by side, top-aligned,
- * against the same fleet size: one runs seven lines, the other runs one. No
+ * against the same fleet size: one runs many lines, the other runs one. No
  * drawing makes that argument faster than the two columns themselves, which is
  * why there is no drawing. It also cannot go stale, because both columns are
  * computed from the same figures the page already has to be honest about.
  *
  * EVERY LINE IS THE READER'S TO REMOVE. Categories toggle off, and the
- * performance line lets them pick which product represents it. An argument a
- * reader can disassemble is one they end up trusting; a fixed total that
- * assumes they buy all seven is one they dismiss, correctly, as a strawman.
+ * performance line lets them pick which product represents it. Rows added
+ * after the original seven default off, so first paint still totals the
+ * original seven and a reader opts into the rest. An argument a reader can
+ * disassemble is one they end up trusting; a fixed total that assumes they
+ * buy everything is one they dismiss, correctly, as a strawman.
  *
  * MOTION IS RESPONSE, NEVER ENTRANCE. The total tweens between values so a
  * change in fleet size is felt rather than just read, and a deselected line
@@ -133,6 +136,39 @@ function TweenedMoney({ value, className }: { value: number; className?: string 
   );
 }
 
+/**
+ * A checkbox with a third, indeterminate visual state. `indeterminate` has no
+ * HTML attribute, so it is set imperatively on the element via a ref rather
+ * than passed as a prop; `aria-label` is required by the caller because this
+ * control has no adjacent visible text of its own to name it.
+ */
+function TriStateCheckbox({
+  checked,
+  indeterminate,
+  onChange,
+  ariaLabel,
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onChange: () => void;
+  ariaLabel: string;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      aria-label={ariaLabel}
+      className="h-4 w-4 shrink-0 cursor-pointer accent-[var(--primary)]"
+    />
+  );
+}
+
 type State = {
   sites: number;
   off: string[];
@@ -143,6 +179,7 @@ type State = {
 type Action =
   | { type: "sites"; value: number }
   | { type: "toggle"; key: string }
+  | { type: "toggleGroup"; keys: string[]; turnOn: boolean }
   | { type: "pick"; key: string; index: number };
 
 function reducer(state: State, action: Action): State {
@@ -156,12 +193,24 @@ function reducer(state: State, action: Action): State {
           ? state.off.filter((k) => k !== action.key)
           : [...state.off, action.key],
       };
+    case "toggleGroup":
+      return {
+        ...state,
+        off: action.turnOn
+          ? state.off.filter((k) => !action.keys.includes(k))
+          : [...new Set([...state.off, ...action.keys])],
+      };
     case "pick":
       return { ...state, pick: { ...state.pick, [action.key]: action.index } };
   }
 }
 
-const INITIAL: State = { sites: 25, off: [], pick: {} };
+// Categories the owner added after the page's original seven start
+// unchecked, so first paint still reads "7 of N selected" and a reader opts
+// into the longer bill rather than being defaulted into it.
+const DEFAULT_OFF = PLUGIN_COST_CATEGORIES.filter((c) => c.defaultOff).map((c) => c.key);
+
+const INITIAL: State = { sites: 25, off: DEFAULT_OFF, pick: {} };
 
 export function PluginStackCalculator({ wpmgrTiers }: { wpmgrTiers: WpmgrTier[] }) {
   const [state, dispatch] = useReducer(reducer, INITIAL);
@@ -183,6 +232,20 @@ export function PluginStackCalculator({ wpmgrTiers }: { wpmgrTiers: WpmgrTier[] 
   const included = lines.filter((l) => l.enabled);
   const total = included.reduce((sum, l) => sum + (l.cost ?? 0), 0);
   const unpriced = included.filter((l) => l.cost === null);
+
+  // Rows grouped by purchase likelihood rather than by our own feature
+  // areas -- see PURCHASE_LIKELIHOOD_GROUPS in lib/content/plugin-costs.ts
+  // for why. A group with no matching category (none today) is dropped
+  // rather than rendered empty.
+  const groups = PURCHASE_LIKELIHOOD_GROUPS.map((g) => {
+    const groupLines = lines.filter((l) => l.category.group === g.key);
+    const enabledCount = groupLines.filter((l) => l.enabled).length;
+    const subtotal = groupLines.reduce(
+      (sum, l) => (l.enabled ? sum + (l.cost ?? 0) : sum),
+      0,
+    );
+    return { ...g, lines: groupLines, enabledCount, subtotal };
+  }).filter((g) => g.lines.length > 0);
 
   const wpmgrTier = resolveWpmgrTier(wpmgrTiers, sites);
   const wpmgrYear = wpmgrTier ? wpmgrTier.perMonth * 12 : null;
@@ -248,94 +311,157 @@ export function PluginStackCalculator({ wpmgrTiers }: { wpmgrTiers: WpmgrTier[] 
             </span>
           </header>
 
-          <ul className="flex flex-col">
-            {lines.map((line) => (
-              <li
-                key={line.category.key}
-                className="border-b border-[var(--border)]/60 px-5 py-4 transition-opacity duration-[var(--duration-fast)] last:border-0 sm:px-6"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
-                    <input
-                      type="checkbox"
-                      checked={line.enabled}
-                      onChange={() => dispatch({ type: "toggle", key: line.category.key })}
-                      className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-[var(--primary)]"
+          <div className="flex flex-col">
+            {groups.map((group) => (
+              <div key={group.key}>
+                {/* Group header: purchase-likelihood bucket, not a feature
+                    area. Never collapses -- the row count under it is the
+                    argument this page is making, and a closed section hides
+                    it. */}
+                <div className="flex items-center justify-between gap-3 border-b border-t border-[var(--border)] bg-[var(--muted)]/50 px-5 py-2 sm:px-6">
+                  <label className="flex cursor-pointer items-center gap-2.5">
+                    <TriStateCheckbox
+                      checked={group.enabledCount === group.lines.length}
+                      indeterminate={
+                        group.enabledCount > 0 && group.enabledCount < group.lines.length
+                      }
+                      onChange={() =>
+                        dispatch({
+                          type: "toggleGroup",
+                          keys: group.lines.map((l) => l.category.key),
+                          turnOn: group.enabledCount !== group.lines.length,
+                        })
+                      }
+                      ariaLabel={`Toggle all rows in ${group.label}`}
                     />
-                    <span className="min-w-0">
-                      <span className="flex items-center gap-2">
-                        <Icon
-                          name={line.category.icon}
-                          size={15}
-                          className="shrink-0 text-[var(--muted-foreground)]"
-                          aria-hidden
-                        />
-                        <span
-                          className={cn(
-                            "text-sm font-medium",
-                            line.enabled ? "text-foreground" : "text-[var(--muted-foreground)]",
-                          )}
-                        >
-                          {line.category.label}
-                        </span>
-                      </span>
-                      <span className="mt-1 block text-xs text-[var(--muted-foreground)]">
-                        <a
-                          href={line.product.url}
-                          target="_blank"
-                          rel="noreferrer noopener nofollow"
-                          className="underline underline-offset-2 hover:text-foreground"
-                        >
-                          {line.product.name}
-                        </a>
-                        {line.tier ? <>, {line.tier.label}</> : null}
-                        {PER_SITE_KEYS.includes(line.category.key) && line.tier ? (
-                          <> at {money(line.tier.perYear)} per site</>
-                        ) : null}
+                    <span className="text-xs font-semibold text-foreground">
+                      {group.label}{" "}
+                      <span className="font-normal text-[var(--muted-foreground)]">
+                        ({group.enabledCount} of {group.lines.length})
                       </span>
                     </span>
                   </label>
-
-                  <span
-                    className={cn(
-                      "shrink-0 font-mono text-sm tabular-nums",
-                      line.enabled
-                        ? "text-foreground"
-                        : "text-[var(--muted-foreground)] line-through",
-                    )}
-                  >
-                    {line.cost === null ? "on request" : money(line.cost)}
+                  <span className="font-mono text-xs tabular-nums text-[var(--muted-foreground)]">
+                    {money(group.subtotal)}
                   </span>
                 </div>
 
-                {/* Only rendered where a category genuinely has a second
-                    non-overlapping option, rather than a control on every row
-                    for symmetry's sake. */}
-                {line.category.products.length > 1 && (
-                  <div className="mt-3 flex flex-wrap gap-1.5 pl-7">
-                    {line.category.products.map((p, pi) => (
-                      <button
-                        key={p.name}
-                        type="button"
-                        onClick={() =>
-                          dispatch({ type: "pick", key: line.category.key, index: pi })
-                        }
-                        aria-pressed={line.index === pi}
-                        className={cn(
-                          "rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-[var(--duration-fast)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
-                          line.index === pi
-                            ? "border-[var(--primary)]/40 bg-[var(--primary-subtle)] text-[var(--primary-pressed)]"
-                            : "border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
-                        )}
-                      >
-                        {p.name}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </li>
+                <ul className="flex flex-col">
+                  {group.lines.map((line) => (
+                    <li
+                      key={line.category.key}
+                      className="border-b border-[var(--border)]/60 px-5 py-4 transition-opacity duration-[var(--duration-fast)] last:border-0 sm:px-6"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
+                          <input
+                            type="checkbox"
+                            checked={line.enabled}
+                            onChange={() => dispatch({ type: "toggle", key: line.category.key })}
+                            className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-[var(--primary)]"
+                          />
+                          <span className="min-w-0">
+                            <span className="flex items-center gap-2">
+                              <Icon
+                                name={line.category.icon}
+                                size={15}
+                                className="shrink-0 text-[var(--muted-foreground)]"
+                                aria-hidden
+                              />
+                              <span
+                                className={cn(
+                                  "text-sm font-medium",
+                                  line.enabled
+                                    ? "text-foreground"
+                                    : "text-[var(--muted-foreground)]",
+                                )}
+                              >
+                                {line.category.label}
+                              </span>
+                            </span>
+                            <span className="mt-1 block text-xs text-[var(--muted-foreground)]">
+                              <a
+                                href={line.product.url}
+                                target="_blank"
+                                rel="noreferrer noopener nofollow"
+                                className="underline underline-offset-2 hover:text-foreground"
+                              >
+                                {line.product.name}
+                              </a>
+                              {line.tier ? <>, {line.tier.label}</> : null}
+                              {PER_SITE_KEYS.includes(line.category.key) && line.tier ? (
+                                <> at {money(line.tier.perYear)} per site</>
+                              ) : null}
+                            </span>
+                            {/* Partial-replacement disclosure. Inline, static
+                                markup on purpose: a footnote goes unread, a
+                                tooltip is invisible to touch, to JS-off and to
+                                a crawler, and discounting the vendor's price
+                                for "the part we don't cover" would fabricate a
+                                figure no vendor published. */}
+                            {line.product.replaces === "partial" && line.product.residual && (
+                              <span className="mt-1.5 flex items-start gap-1.5 text-[11px] leading-snug text-[var(--muted-foreground)]">
+                                <span className="inline-flex shrink-0 items-center rounded-full border border-[var(--border)] bg-[var(--muted)] px-1.5 py-0.5 text-[10px] font-medium text-foreground">
+                                  Partial
+                                </span>
+                                <span>Does not include {line.product.residual}.</span>
+                              </span>
+                            )}
+                          </span>
+                        </label>
+
+                        <span
+                          className={cn(
+                            "shrink-0 font-mono text-sm tabular-nums",
+                            line.enabled
+                              ? "text-foreground"
+                              : "text-[var(--muted-foreground)] line-through",
+                          )}
+                        >
+                          {line.cost === null ? "on request" : money(line.cost)}
+                        </span>
+                      </div>
+
+                      {/* Only rendered where a category genuinely has a second
+                          non-overlapping option, rather than a control on every row
+                          for symmetry's sake. */}
+                      {line.category.products.length > 1 && (
+                        <div className="mt-3 flex flex-wrap gap-1.5 pl-7">
+                          {line.category.products.map((p, pi) => (
+                            <button
+                              key={p.name}
+                              type="button"
+                              onClick={() =>
+                                dispatch({ type: "pick", key: line.category.key, index: pi })
+                              }
+                              aria-pressed={line.index === pi}
+                              className={cn(
+                                "rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-[var(--duration-fast)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
+                                line.index === pi
+                                  ? "border-[var(--primary)]/40 bg-[var(--primary-subtle)] text-[var(--primary-pressed)]"
+                                  : "border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                              )}
+                            >
+                              {/* The "(partial)" suffix renders for every
+                                  option regardless of which is picked, so a
+                                  partial-replacement alternate says so in raw
+                                  markup even before a reader (or a
+                                  JavaScript-off crawler) ever selects it. The
+                                  full residual clause above only reflects the
+                                  currently picked product, same as its price
+                                  and tier label already do. */}
+                              {p.name}
+                              {p.replaces === "partial" ? " (partial)" : ""}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ))}
-          </ul>
+          </div>
 
           <div className="border-t-2 border-foreground/80 px-5 py-5 sm:px-6">
             <div className="flex items-baseline justify-between gap-4">

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
@@ -47,7 +47,7 @@ const FAQ_ITEMS = [
   },
   {
     q: "Does WPMgr really do everything on the list?",
-    a: `It does, and the free tier does not withhold any of it. What the paid tiers add is site count, managed backup storage and how often backups run. If you self-host, you get the same feature set on any number of sites for nothing, and the trade is that you run a Postgres database, a control plane and an encoder, and you keep them patched.`,
+    a: `Every job the calculator counts, yes, and the free tier does not withhold any of it. "The list" is the ${CATEGORY_COUNT} categories the calculator bills for, not every feature of every product sitting in a row: a few of those vendor products sell more than the job they're listed under, such as an application firewall bundled with malware scanning, or staging and sandbox updates bundled with fleet management. Those extras were never on the list to begin with, so WPMgr not shipping them isn't a gap in it, which is exactly what the "Partial" chip on those rows means. What the paid tiers add is site count, managed backup storage and how often backups run. If you self-host, you get the same feature set on any number of sites for nothing, and the trade is that you run a Postgres database, a control plane and an encoder, and you keep them patched.`,
   },
   {
     q: "What is not included in this total?",

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
@@ -116,35 +116,12 @@ export default async function PluginStackPage() {
             Add up what your plugins actually cost
           </h1>
           <p className="mt-5 max-w-[68ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
-            {DEFAULT_ON_COUNT} jobs on by default, {DEFAULT_ON_COUNT} licences, {DEFAULT_ON_COUNT} renewal
-            dates, plus a few more you can add if you actually buy them. Set your fleet size, add or remove
-            anything, and every figure comes from the vendor&apos;s own pricing page.
+            {DEFAULT_ON_COUNT} job{DEFAULT_ON_COUNT === 1 ? "" : "s"} on by default, {DEFAULT_ON_COUNT}{" "}
+            licence{DEFAULT_ON_COUNT === 1 ? "" : "s"}, {DEFAULT_ON_COUNT} renewal date
+            {DEFAULT_ON_COUNT === 1 ? "" : "s"}, plus a few more you can add if you actually buy them. Set
+            your fleet size, add or remove anything, and every figure comes from the vendor&apos;s own
+            pricing page.
           </p>
-
-          {/* Two things this page has to say about itself before a reader
-              starts sliding, or a reader who checks either one concludes the
-              page cherry-picked and stops trusting the rest of it. */}
-          <div className="mt-6 flex max-w-[68ch] flex-col gap-3 rounded-lg border border-[var(--border)] bg-[var(--muted)]/40 px-5 py-4 text-sm leading-relaxed text-[var(--muted-foreground)]">
-            <p>
-              <strong className="font-semibold text-foreground">
-                WP Remote&apos;s cheapest tier is cheaper per site than WPMgr.
-              </strong>{" "}
-              Essential is $19.99 per site per year, against WPMgr&apos;s $28.32 per site per year on the
-              25-site Agency plan. The fleet management row below uses Premium ($49.99) instead, because
-              Essential is a bare update runner and does not include the staging, uptime and testing
-              features that make Premium comparable to a fleet manager at all. A reader who only wants
-              scheduled updates would spend less with WP Remote Essential than with WPMgr, and that is
-              worth saying plainly rather than leaving for someone to find on their own.
-            </p>
-            <p>
-              <strong className="font-semibold text-foreground">
-                Past roughly 50 sites, the gap narrows.
-              </strong>{" "}
-              Slide to 100 and remove the security row, and the comparison inverts: this stack runs about
-              $1,733 a year against WPMgr&apos;s Scale plan at $2,028. The calculator is built to let anyone
-              find that, so it is stated here rather than left for a reader to stumble on.
-            </p>
-          </div>
 
           <div className="mt-8">
             <PluginStackCalculator wpmgrTiers={wpmgrTiers} />

--- a/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/plugin-stack/page.tsx
@@ -30,6 +30,12 @@ export const metadata: Metadata = buildMetadata({
   canonical: "/pricing/plugin-stack",
 });
 
+// Derived from the data file rather than written as a number, so the copy
+// below cannot drift from the calculator sitting next to it the way a
+// hand-typed "seven" would the moment a category is added or defaulted off.
+const CATEGORY_COUNT = PLUGIN_COST_CATEGORIES.length;
+const DEFAULT_ON_COUNT = PLUGIN_COST_CATEGORIES.filter((c) => !c.defaultOff).length;
+
 const FAQ_ITEMS = [
   {
     q: "Why is my favourite plugin not on the list?",
@@ -40,12 +46,12 @@ const FAQ_ITEMS = [
     a: "They are the prices you would pay in year two. Several vendors in this market advertise a large first-year discount and renew at full price, and one states that in a footnote on its own pricing page. A calculator built on introductory prices would understate the stack by a third and be wrong for every year but the first, so the figures here are the recurring ones.",
   },
   {
-    q: "Does WPMgr really do all seven?",
-    a: "It does all seven, and the free tier does not withhold any of them. What the paid tiers add is site count, managed backup storage and how often backups run. If you self-host, you get the same feature set on any number of sites for nothing, and the trade is that you run a Postgres database, a control plane and an encoder, and you keep them patched.",
+    q: "Does WPMgr really do everything on the list?",
+    a: `It does, and the free tier does not withhold any of it. What the paid tiers add is site count, managed backup storage and how often backups run. If you self-host, you get the same feature set on any number of sites for nothing, and the trade is that you run a Postgres database, a control plane and an encoder, and you keep them patched.`,
   },
   {
     q: "What is not included in this total?",
-    a: "Storage and your own time. Backups have to land somewhere, and most of these plugins bill remote storage separately or expect you to bring your own bucket, which is also true of WPMgr on the free and self-hosted tiers. The total also excludes the hours spent renewing seven licences on seven dates and updating seven plugins across every site, which is real but not something we can put a number on honestly.",
+    a: `Storage and your own time, and on a few rows, part of the vendor's own product. Backups have to land somewhere, and most of these plugins bill remote storage separately or expect you to bring your own bucket, which is also true of WPMgr on the free and self-hosted tiers. Rows marked "Partial" sell something beyond what WPMgr ships too, such as staging or a managed firewall; the row's price is still the vendor's full price, not a discounted one, because no vendor publishes a "just the overlapping part" figure. The total also excludes the hours spent renewing ${CATEGORY_COUNT} licences on ${CATEGORY_COUNT} dates and updating ${CATEGORY_COUNT} plugins across every site, which is real but not something we can put a number on honestly.`,
   },
   {
     q: "Where did each number come from?",
@@ -57,7 +63,7 @@ const METHOD = [
   {
     icon: "Layers",
     title: "No product counted twice",
-    body: "Every product here sells one of these seven categories and little else. Suites that bundle caching with image compression and database cleaning are excluded on purpose, because including one would put the same licence on two lines.",
+    body: `Every product here sells one of these ${CATEGORY_COUNT} categories and little else. Suites that bundle caching with image compression and database cleaning are excluded on purpose, because including one would put the same licence on two lines.`,
   },
   {
     icon: "RefreshCw",
@@ -110,11 +116,37 @@ export default async function PluginStackPage() {
             Add up what your plugins actually cost
           </h1>
           <p className="mt-5 max-w-[68ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
-            Seven jobs, seven licences, seven renewal dates. Set your fleet size, remove anything
-            you do not buy, and every figure comes from the vendor&apos;s own pricing page.
+            {DEFAULT_ON_COUNT} jobs on by default, {DEFAULT_ON_COUNT} licences, {DEFAULT_ON_COUNT} renewal
+            dates, plus a few more you can add if you actually buy them. Set your fleet size, add or remove
+            anything, and every figure comes from the vendor&apos;s own pricing page.
           </p>
 
-          <div className="mt-10">
+          {/* Two things this page has to say about itself before a reader
+              starts sliding, or a reader who checks either one concludes the
+              page cherry-picked and stops trusting the rest of it. */}
+          <div className="mt-6 flex max-w-[68ch] flex-col gap-3 rounded-lg border border-[var(--border)] bg-[var(--muted)]/40 px-5 py-4 text-sm leading-relaxed text-[var(--muted-foreground)]">
+            <p>
+              <strong className="font-semibold text-foreground">
+                WP Remote&apos;s cheapest tier is cheaper per site than WPMgr.
+              </strong>{" "}
+              Essential is $19.99 per site per year, against WPMgr&apos;s $28.32 per site per year on the
+              25-site Agency plan. The fleet management row below uses Premium ($49.99) instead, because
+              Essential is a bare update runner and does not include the staging, uptime and testing
+              features that make Premium comparable to a fleet manager at all. A reader who only wants
+              scheduled updates would spend less with WP Remote Essential than with WPMgr, and that is
+              worth saying plainly rather than leaving for someone to find on their own.
+            </p>
+            <p>
+              <strong className="font-semibold text-foreground">
+                Past roughly 50 sites, the gap narrows.
+              </strong>{" "}
+              Slide to 100 and remove the security row, and the comparison inverts: this stack runs about
+              $1,733 a year against WPMgr&apos;s Scale plan at $2,028. The calculator is built to let anyone
+              find that, so it is stated here rather than left for a reader to stumble on.
+            </p>
+          </div>
+
+          <div className="mt-8">
             <PluginStackCalculator wpmgrTiers={wpmgrTiers} />
           </div>
         </Container>

--- a/apps/marketing/lib/content/plugin-costs.ts
+++ b/apps/marketing/lib/content/plugin-costs.ts
@@ -42,6 +42,15 @@ export type CostProduct = {
   tiers: CostTier[];
   note: string;
   verifiedOn: string;
+  /**
+   * Overrides the tier-times-PER_SITE_KEYS multiplication below, for a vendor
+   * whose published price is neither a flat per-tier fee nor a flat per-site
+   * rate: ManageWP's report add-ons are a per-site rate up to 25 sites and a
+   * stepped per-100-site bundle above it. When present this IS the annual
+   * cost; `tiers` is still used to resolve the bracket label shown next to
+   * the product name.
+   */
+  computeAnnual?: (sites: number) => number;
 };
 
 export type CostCategory = {
@@ -113,18 +122,14 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
         note: "Annual licence by site tier, renewing automatically.",
         verifiedOn: "2026-08-07",
       },
-      {
-        name: "FlyingPress",
-        url: "https://flyingpress.com/pricing/",
-        tiers: [
-          { upTo: 1, perYear: 59, label: "Starter, 1 site" },
-          { upTo: 3, perYear: 109, label: "Pro, 3 sites" },
-          { upTo: 25, perYear: 229, label: "Business, 25 sites" },
-          { upTo: Infinity, perYear: 279, label: "Unlimited" },
-        ],
-        note: "Annual licence by site tier. No introductory discount is shown on the pricing page.",
-        verifiedOn: "2026-08-07",
-      },
+      // FlyingPress was here as an alternate and is deliberately removed, not
+      // replaced. Its own feature page sells caching PLUS AVIF/WebP image
+      // optimisation PLUS database optimisation under one licence, so
+      // selecting it alongside the separate image and database rows below
+      // double-counted two categories. There is no partial-credit figure a
+      // vendor has published for "just the caching part," and inventing one
+      // would fabricate a number this file's own rules forbid. Performance is
+      // WP Rocket only until a genuinely single-purpose alternate turns up.
     ],
   },
   {
@@ -134,11 +139,11 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     wpmgr: "AVIF and WebP conversion with originals kept as a fallback",
     products: [
       {
-        name: "ShortPixel Unlimited",
-        url: "https://shortpixel.com/pricing",
-        tiers: [{ upTo: Infinity, perYear: 99.9, label: "Unlimited, billed yearly" }],
-        note: "Priced by image volume rather than by site, so the cost does not rise with fleet size. Billed yearly is the page default.",
-        verifiedOn: "2026-08-07",
+        name: "Imagify Infinite",
+        url: "https://imagify.io/pricing",
+        tiers: [{ upTo: Infinity, perYear: 119.88, label: "Infinite, billed yearly" }],
+        note: "$9.99/month billed yearly, unlimited websites and unlimited images. This line does NOT grow with fleet size: a 1-site reader and a 200-site reader pay the same figure, which is unfavourable to the plugin-stack total but is what the vendor publishes. ShortPixel, the previous product here, is not used because its pricing page ships empty price containers filled in at runtime by a third-party billing widget, and the figure could not be independently confirmed.",
+        verifiedOn: "2026-08-17",
       },
     ],
   },
@@ -189,18 +194,56 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     wpmgr: "White label reports and a client portal, built in",
     products: [
       {
-        name: "WP Umbrella",
-        url: "https://wp-umbrella.com/pricing/",
-        tiers: [{ upTo: Infinity, perYear: 26.28, label: "Pay as you go" }],
-        note: "Priced per site per month, so this line scales linearly with the fleet. The annual figure is the monthly rate multiplied by twelve.",
-        verifiedOn: "2026-08-07",
+        // WP Umbrella was here at "full price" and is deliberately removed,
+        // not adjusted. Its own pricing page sells ONE plan, EUR 1.99/site/
+        // month, that already includes backups, uptime monitoring,
+        // performance, database optimisation, safe updates with rollback,
+        // vulnerability monitoring AND white-label reporting. Charging a
+        // reader for that plan on this row while also charging them for a
+        // separate backup, uptime and database row above double, triple and
+        // quadruple counts one purchase. Its stored figure was also a USD
+        // conversion of a EUR price at an unrecorded FX rate, so it drifted
+        // with the euro and could not be reproduced.
+        //
+        // ManageWP's two report add-ons sell client reporting alone, priced
+        // natively in USD, so neither problem applies.
+        name: "ManageWP Advanced Client Reports + White Label",
+        url: "https://managewp.com/pricing",
+        tiers: [
+          { upTo: 25, perYear: 24, label: "Both add-ons, $1/site/month each, per site" },
+          {
+            upTo: Infinity,
+            perYear: 600,
+            label: "Both add-ons, bundled at $50/month per 100-site bundle",
+          },
+        ],
+        // Each add-on is $1/site/month up to 25 sites. Past 25 sites, ManageWP
+        // sells the add-on in bundles that each cover up to 100 sites for
+        // $25/month, and bundles stack, so both add-ons together are
+        // $50/month per bundle of up to 100 sites. That is a step function,
+        // not a flat per-site rate, so it is computed directly here instead
+        // of through the tier-times-sites multiplication every other per-site
+        // row uses; the tiers above exist only to show the right bracket
+        // label next to the product name.
+        computeAnnual: (sites: number) =>
+          sites <= 25 ? sites * 2 * 12 : Math.ceil(sites / 100) * 50 * 12,
+        note: "Two add-ons on top of a ManageWP plan, each $1/site/month up to 25 sites. Above 25 sites, ManageWP sells each add-on in bundles covering up to 100 sites for $25/month, and bundles stack, so the two add-ons together cost $50/month per bundle of up to 100 sites.",
+        verifiedOn: "2026-08-17",
       },
     ],
   },
 ];
 
-/** Categories whose price is per site rather than per tier. */
-export const PER_SITE_KEYS = ["security", "reports"];
+/**
+ * Categories whose price is per site rather than per tier.
+ *
+ * "reports" is deliberately NOT here even though ManageWP's add-ons are
+ * per-site up to 25 sites: past that they are a stepped per-100-site bundle,
+ * not a flat rate, so a uniform tier-times-sites multiplication would be
+ * wrong at fleet sizes above 25. Its product defines `computeAnnual` instead;
+ * see `annualCost` below.
+ */
+export const PER_SITE_KEYS = ["security"];
 
 /**
  * The cheapest published tier that covers `sites`, or null when the fleet is
@@ -223,6 +266,7 @@ export function annualCost(
   product: CostProduct,
   sites: number,
 ): number | null {
+  if (product.computeAnnual) return product.computeAnnual(sites);
   const tier = resolveTier(product, sites);
   if (!tier) return null;
   // Per-site vendors publish a RATE and a volume bracket, so the bracket
@@ -231,9 +275,14 @@ export function annualCost(
   return PER_SITE_KEYS.includes(category.key) ? tier.perYear * sites : tier.perYear;
 }
 
-/** Site counts offered as presets. 500 is the ceiling because it is the
- *  largest fleet every product above still publishes a price for. */
-export const SITE_PRESETS = [1, 5, 10, 25, 50, 100, 250, 500];
+/** Site counts offered as presets. 200 is the ceiling because it is WPMgr's
+ *  own largest published plan (see PRICING_TIERS in lib/content/pricing.ts):
+ *  past it, the right-hand column has no number to compare against, only
+ *  "on request", and a five-figure plugin-stack total opposite no number at
+ *  all is a strawman rather than a comparison. Nobody buys per-site security
+ *  and reporting licences at that scale either, so the honest range for this
+ *  page stops where WPMgr's own price list does. */
+export const SITE_PRESETS = [1, 5, 10, 25, 50, 100, 200];
 
 /**
  * A WPMgr hosted tier, resolved by the page from PRICING_TIERS plus whatever

--- a/apps/marketing/lib/content/plugin-costs.ts
+++ b/apps/marketing/lib/content/plugin-costs.ts
@@ -51,7 +51,52 @@ export type CostProduct = {
    * the product name.
    */
   computeAnnual?: (sites: number) => number;
+  /**
+   * "partial" when the vendor's licence covers ground WPMgr does not ship,
+   * so the row renders a visible `Partial` chip plus `residual` in static
+   * markup. Omitted (full replacement, no chip) unless a product is listed
+   * below with both fields set. Never approximated with a discounted price:
+   * no vendor publishes a "just the part WPMgr also does" figure, and
+   * inventing one is the fabrication rule at the top of this file.
+   */
+  replaces?: "full" | "partial";
+  /** What the licence covers that WPMgr does not. Required when replaces
+   *  is "partial", rendered next to the chip. */
+  residual?: string;
+  /**
+   * True for a figure that could not be confirmed against a single
+   * authoritative vendor number as of `verifiedOn` -- e.g. two different
+   * prices shown for the same tier with no way to tell list from
+   * promotional. An unverified product must not appear in
+   * PLUGIN_COST_CATEGORIES; see HELD_TWO_FACTOR_CATEGORY below.
+   */
+  unverified?: boolean;
 };
+
+/**
+ * Purchase-likelihood buckets for the calculator's row groups (NOT our own
+ * feature areas -- grouping by category would turn the bill into our IA with
+ * prices attached, which is the one thing this page must not do).
+ *
+ * "core": bought by nearly every commercial fleet as baseline hygiene --
+ * data safety, break-in protection, page speed.
+ * "common": widely added on top of that baseline, but skippable without the
+ * fleet being obviously under-served.
+ * "situational": bought only by a subset with a specific need -- a
+ * client-facing agency, or a fleet that specifically wants a second,
+ * competing management layer alongside WPMgr.
+ *
+ * This is a judgement call, stated here so it can be argued with rather than
+ * taken as given: it is not derived from a vendor figure the way the prices
+ * are.
+ */
+export type PurchaseLikelihood = "core" | "common" | "situational";
+
+export const PURCHASE_LIKELIHOOD_GROUPS: { key: PurchaseLikelihood; label: string }[] = [
+  { key: "core", label: "Nearly every fleet buys these" },
+  { key: "common", label: "Most agencies add these" },
+  { key: "situational", label: "Situational" },
+];
 
 export type CostCategory = {
   key: string;
@@ -59,6 +104,12 @@ export type CostCategory = {
   icon: string;
   /** What WPMgr gives you instead, for the right-hand column. */
   wpmgr: string;
+  group: PurchaseLikelihood;
+  /** Unchecked on first paint. Used for categories the owner added after the
+   *  page's original seven, so first paint still reads "7 of N selected" and
+   *  the reader opts into the longer bill rather than being defaulted into
+   *  it. */
+  defaultOff?: boolean;
   products: CostProduct[];
 };
 
@@ -68,6 +119,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     label: "Backups and restore",
     icon: "DatabaseBackup",
     wpmgr: "Incremental, client-side encrypted, to storage you own",
+    group: "core",
     products: [
       {
         name: "UpdraftPlus Premium",
@@ -80,6 +132,8 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
         ],
         note: "Annual licence by site tier. Each of these tiers includes 1 GB of the vendor's own storage; backups to your own remote storage are separate.",
         verifiedOn: "2026-08-07",
+        replaces: "partial",
+        residual: "staging sites and one-click migration, both inside the licence",
       },
     ],
   },
@@ -88,6 +142,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     label: "Security and malware scanning",
     icon: "ShieldCheck",
     wpmgr: "Hardening, file integrity and vulnerability matching, built in",
+    group: "core",
     products: [
       {
         name: "Wordfence Premium",
@@ -100,7 +155,13 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
         ],
         note: "Priced per site, with published volume brackets. The figure shown is the per-site price at your bracket, multiplied by your site count.",
         verifiedOn: "2026-08-07",
+        replaces: "partial",
+        residual: "the application firewall, the managed rule feed and rate limiting",
       },
+      // Sucuri is not added as an alternate: it stops publishing prices above
+      // 10 sites, which is well inside this page's slider range, and most of
+      // what it sells past the malware scan is a WAF, a CDN, DDoS mitigation
+      // and human-performed malware removal, none of which is this row.
     ],
   },
   {
@@ -108,6 +169,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     label: "Page caching and performance",
     icon: "Zap",
     wpmgr: "Page cache, object cache and Core Web Vitals from real visitors",
+    group: "core",
     products: [
       {
         name: "WP Rocket",
@@ -130,6 +192,22 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
       // vendor has published for "just the caching part," and inventing one
       // would fabricate a number this file's own rules forbid. Performance is
       // WP Rocket only until a genuinely single-purpose alternate turns up.
+      //
+      // NitroPack is not added either: it prices per pageview, and its named
+      // tiers cover one or three websites; everything above that is an
+      // unpublished "Agency" master subscription. Multiplying its $18/mo rate
+      // by 25 would invent a tier the vendor does not sell, and it also
+      // bundles a CDN WPMgr does not ship.
+      //
+      // Object Cache Pro is not added: $950/yr flat, but the licence requires
+      // every covered site to be owned and operated by the same entity, which
+      // puts a 25-client agency fleet outside it and into "talk to us." No
+      // figure this page could publish for that persona.
+      //
+      // Cloudflare APO is not added: $5/mo per domain on the Free plan, but
+      // $0 marginal cost on any paid Cloudflare plan. A large line whose real
+      // price is zero for most readers is the single most attackable number
+      // this page could publish.
     ],
   },
   {
@@ -137,6 +215,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     label: "Image optimization",
     icon: "ImageDown",
     wpmgr: "AVIF and WebP conversion with originals kept as a fallback",
+    group: "common",
     products: [
       {
         name: "Imagify Infinite",
@@ -152,6 +231,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     label: "Database cleaning",
     icon: "Database",
     wpmgr: "Orphan classification with a preview before anything is deleted",
+    group: "situational",
     products: [
       {
         name: "Advanced Database Cleaner Pro",
@@ -171,7 +251,28 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     label: "Uptime monitoring",
     icon: "Activity",
     wpmgr: "Built in, with TLS expiry checks",
+    group: "core",
     products: [
+      {
+        name: "ManageWP Uptime Monitor",
+        url: "https://managewp.com/pricing",
+        tiers: [
+          { upTo: 25, perYear: 12, label: "$1/site/month, per site" },
+          {
+            upTo: Infinity,
+            perYear: 300,
+            label: "Bundled at $25/month per 100-site bundle",
+          },
+        ],
+        // Same stepped shape as the ManageWP reports add-ons below: a flat
+        // per-site rate up to 25 sites, then bundles of up to 100 sites for
+        // $25/month each, and bundles stack. `tiers` above exists only to
+        // pick the bracket label shown next to the product name.
+        computeAnnual: (sites: number) =>
+          sites <= 25 ? sites * 1 * 12 : Math.ceil(sites / 100) * 25 * 12,
+        note: "$1/site/month up to 25 sites. Above 25 sites, ManageWP sells this add-on in bundles covering up to 100 sites for $25/month, and bundles stack. This is now the default over UptimeRobot because it is the cheaper of the two at every fleet size on this page's slider.",
+        verifiedOn: "2026-08-17",
+      },
       {
         name: "UptimeRobot",
         url: "https://uptimerobot.com/pricing/",
@@ -182,8 +283,10 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
           { upTo: 200, perYear: 648, label: "Scale, 200 monitors" },
           { upTo: 500, perYear: 1488, label: "Scale, 500 monitors" },
         ],
-        note: "Priced per monitor and billed monthly; the annual figure is the monthly rate multiplied by twelve. A free tier covering 50 monitors exists at a longer check interval.",
+        note: "Priced per monitor and billed monthly; the annual figure is the monthly rate multiplied by twelve. A free tier covering 50 monitors exists at a 5-minute check interval; the paid tiers above buy a shorter interval, more monitor types and alert routing.",
         verifiedOn: "2026-08-07",
+        replaces: "partial",
+        residual: "public and white-label status pages, and PagerDuty or webhook alert routing",
       },
     ],
   },
@@ -192,6 +295,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
     label: "Client reporting",
     icon: "FileText",
     wpmgr: "White label reports and a client portal, built in",
+    group: "situational",
     products: [
       {
         // WP Umbrella was here at "full price" and is deliberately removed,
@@ -232,18 +336,81 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
       },
     ],
   },
+  {
+    key: "fleet",
+    label: "Fleet management and updates",
+    icon: "ServerCog",
+    wpmgr: "Bulk updates, one dashboard and one login across the whole fleet",
+    group: "situational",
+    defaultOff: true,
+    products: [
+      {
+        name: "WP Remote Premium",
+        url: "https://wpremote.com/pricing/",
+        tiers: [{ upTo: Infinity, perYear: 49.99, label: "Premium, per site" }],
+        // WP Remote sells three tiers, all per site per year: Essential
+        // $19.99, Premium $49.99, Advanced $199.99. Premium is used here
+        // because it is the tier whose feature list -- staging, uptime,
+        // performance scoring, form and visual-regression testing -- is the
+        // closest match to a general-purpose fleet manager rather than a
+        // bare update runner. Essential is cheaper per site than WPMgr
+        // itself ($19.99 against WPMgr's $28.32/site/yr at 25 sites on the
+        // Agency plan); that comparison is addressed directly in the prose
+        // above the calculator rather than left for a reader to find on
+        // their own.
+        note: "$19.99 (Essential), $49.99 (Premium, used here) or $199.99 (Advanced) per site per year. This row uses Premium; Essential undercuts WPMgr on price alone, which is why the page states that comparison plainly rather than only showing Premium.",
+        verifiedOn: "2026-08-17",
+        replaces: "partial",
+        residual:
+          "staging sites, visual regression testing, form testing, sandbox updates, virtual patching, and human malware cleanup",
+      },
+    ],
+  },
 ];
+
+/**
+ * HELD, NOT SHIPPED. Two-factor authentication (WP 2FA Premium) is
+ * deliberately excluded from PLUGIN_COST_CATEGORIES: melapress.com/
+ * wordpress-2fa/pricing/ shows two different prices for the 25-site bracket,
+ * $199/yr and $129/yr, with nothing on the page saying which is list and
+ * which is a promotional rate. Modeled here with the LOWER of the two and
+ * `unverified: true` so the figure exists for the next pass, but it must not
+ * be spread into PLUGIN_COST_CATEGORIES or shown to a reader until someone
+ * opens that page in a browser and resolves which number is real.
+ *
+ * Duo is not modeled at all, here or anywhere else in this file: it is
+ * priced per user, not per site or per tier, so it does not fit this file's
+ * shape and mixing a per-user line into a per-site bill would misstate both.
+ */
+export const HELD_TWO_FACTOR_CATEGORY: CostCategory = {
+  key: "two-factor",
+  label: "Two-factor authentication",
+  icon: "KeyRound",
+  wpmgr: "TOTP, email code and backup codes, enforced per role, built in",
+  group: "situational",
+  defaultOff: true,
+  products: [
+    {
+      name: "WP 2FA Premium",
+      url: "https://melapress.com/wordpress-2fa/pricing/",
+      tiers: [{ upTo: 25, perYear: 129, label: "25 sites (unresolved, lower of two prices shown)" }],
+      note: "melapress.com/wordpress-2fa/pricing/ showed two different prices for 25 sites, $199/yr and $129/yr, with no indication which is list and which is promotional. This is the lower figure, held back until that is resolved in a browser.",
+      verifiedOn: "2026-08-17",
+      unverified: true,
+    },
+  ],
+};
 
 /**
  * Categories whose price is per site rather than per tier.
  *
- * "reports" is deliberately NOT here even though ManageWP's add-ons are
- * per-site up to 25 sites: past that they are a stepped per-100-site bundle,
- * not a flat rate, so a uniform tier-times-sites multiplication would be
- * wrong at fleet sizes above 25. Its product defines `computeAnnual` instead;
- * see `annualCost` below.
+ * "reports" and "uptime" are deliberately NOT here even though their default
+ * products are per-site up to 25 sites: past that they are a stepped
+ * per-100-site bundle, not a flat rate, so a uniform tier-times-sites
+ * multiplication would be wrong at fleet sizes above 25. Those products
+ * define `computeAnnual` instead; see `annualCost` below.
  */
-export const PER_SITE_KEYS = ["security"];
+export const PER_SITE_KEYS = ["security", "fleet"];
 
 /**
  * The cheapest published tier that covers `sites`, or null when the fleet is

--- a/apps/marketing/lib/content/plugin-costs.ts
+++ b/apps/marketing/lib/content/plugin-costs.ts
@@ -60,8 +60,16 @@ export type CostProduct = {
    * inventing one is the fabrication rule at the top of this file.
    */
   replaces?: "full" | "partial";
-  /** What the licence covers that WPMgr does not. Required when replaces
-   *  is "partial", rendered next to the chip. */
+  /**
+   * What the licence covers that WPMgr does not. Required when replaces is
+   * "partial", rendered next to the chip as "Does not include {residual}."
+   * Where a named gap is genuinely on the roadmap, say so in the string
+   * itself (e.g. "..., on our roadmap") rather than leaving a flat denial,
+   * but only for a gap actually planned; one-click migration is on the
+   * explicit skip list in ADR-037 and must read as a plain statement, never
+   * softened into a promise. No dates or sprint numbers here: a roadmap item
+   * with a date on a pricing page becomes a complaint the moment it slips.
+   */
   residual?: string;
   /**
    * True for a figure that could not be confirmed against a single
@@ -133,7 +141,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
         note: "Annual licence by site tier. Each of these tiers includes 1 GB of the vendor's own storage; backups to your own remote storage are separate.",
         verifiedOn: "2026-08-07",
         replaces: "partial",
-        residual: "staging sites and one-click migration, both inside the licence",
+        residual: "one-click migration, inside the licence; staging sites, on our roadmap",
       },
     ],
   },
@@ -156,7 +164,8 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
         note: "Priced per site, with published volume brackets. The figure shown is the per-site price at your bracket, multiplied by your site count.",
         verifiedOn: "2026-08-07",
         replaces: "partial",
-        residual: "the application firewall, the managed rule feed and rate limiting",
+        residual:
+          "the application firewall, the managed rule feed and rate limiting, all on our roadmap",
       },
       // Sucuri is not added as an alternate: it stops publishing prices above
       // 10 sites, which is well inside this page's slider range, and most of
@@ -362,7 +371,7 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
         verifiedOn: "2026-08-17",
         replaces: "partial",
         residual:
-          "staging sites, visual regression testing, form testing, sandbox updates, virtual patching, and human malware cleanup",
+          "sandbox updates, virtual patching and human malware cleanup; staging sites, visual regression testing and form testing, all on our roadmap",
       },
     ],
   },

--- a/apps/marketing/lib/content/plugin-costs.ts
+++ b/apps/marketing/lib/content/plugin-costs.ts
@@ -353,12 +353,12 @@ export const PLUGIN_COST_CATEGORIES: CostCategory[] = [
         // because it is the tier whose feature list -- staging, uptime,
         // performance scoring, form and visual-regression testing -- is the
         // closest match to a general-purpose fleet manager rather than a
-        // bare update runner. Essential is cheaper per site than WPMgr
-        // itself ($19.99 against WPMgr's $28.32/site/yr at 25 sites on the
-        // Agency plan); that comparison is addressed directly in the prose
-        // above the calculator rather than left for a reader to find on
-        // their own.
-        note: "$19.99 (Essential), $49.99 (Premium, used here) or $199.99 (Advanced) per site per year. This row uses Premium; Essential undercuts WPMgr on price alone, which is why the page states that comparison plainly rather than only showing Premium.",
+        // bare update runner. Essential is cheaper per site, but it only
+        // does one of the fourteen jobs WPMgr does, so pricing it against
+        // WPMgr as a whole would compare unlike products; the "Partial"
+        // replaces flag and residual list below say what this row does and
+        // does not cover instead.
+        note: "$19.99 (Essential), $49.99 (Premium, used here) or $199.99 (Advanced) per site per year. This row uses Premium because Essential is a bare update runner and does not include the staging, uptime and testing features that make Premium comparable to a fleet manager.",
         verifiedOn: "2026-08-17",
         replaces: "partial",
         residual:


### PR DESCRIPTION
## Summary

Pass 1 (correctness only, no new categories, no UI redesign) on
`/pricing/plugin-stack`. Fixes four defects found by a vendor-source
research pass, all of which made the total wrong in our favour or
unverifiable.

1. **Client reporting (WP Umbrella removed).** WP Umbrella's own pricing
   page sells one plan (EUR 1.99/site/month) that already bundles backups,
   uptime monitoring, database optimisation and white-label reporting, so
   the old "reports" row double/triple/quadruple-counted a purchase against
   the backup, uptime and database rows above it. Its stored figure was
   also a USD conversion of a EUR price at an unrecorded FX rate. Replaced
   with ManageWP's Advanced Client Reports + White Label add-ons ($1/site/
   month each, USD-native), with ManageWP's published bundle rule above 25
   sites. Source: https://managewp.com/pricing

2. **Performance (FlyingPress removed).** FlyingPress bundles caching,
   AVIF/WebP image optimisation and database optimisation under one
   licence, so selecting it alongside the separate image and database rows
   double-counted both. Removed as an alternate rather than patched with an
   invented partial-credit figure; performance is WP Rocket only.

3. **Image optimization (ShortPixel to Imagify).** ShortPixel's price could
   not be verified: its pricing page ships empty price containers filled in
   at runtime by a third-party billing widget (FastSpring), and three
   storefront API paths returned only the popup shell. Replaced with
   Imagify Infinite, $9.99/month billed yearly = $119.88/year, unlimited
   sites and images, published directly on the vendor's page. Source:
   https://imagify.io/pricing. The row's note says plainly that this line
   does not grow with fleet size.

4. **Site-count ceiling (500 to 200).** The presets and slider ran to 500,
   past WPMgr's own largest published plan (200 sites), which put a
   five-figure total against "on request" with no number to compare it to.
   Capped both at 200 and rewrote the justifying comment.

Every touched figure carries its source URL and a `verifiedOn` date in
`plugin-costs.ts`.

## Headline number

Verified by grepping the actual Next.js static build output
(`apps/marketing/.next/server/app/pricing/plugin-stack.html`) after
`pnpm -C apps/marketing build`, not by hand-calculation alone: the default
25-site total renders as **$4,490.88** (was $4,527.90).

## Gates run

```
$ pnpm -C apps/marketing typecheck
✓ tsc --noEmit, no errors

$ pnpm -C apps/marketing build
✓ Compiled successfully, /pricing/plugin-stack prerendered as static content

$ node apps/marketing/scripts/check-copy.mjs
check-copy passed: no em dashes, en dashes, or competitor names across 389 files
(136 marketing, 1 agent readme, 1 plugin header, 251 agent PHP of which 9 carry
copy, 13 comparison files also checked for disparagement, 43 citations resolved).

$ pnpm exec impeccable detect "app/(marketing)/pricing/plugin-stack" "lib/content"
exit 0, no violations
```

## Findings for pass 2 (not fixed here, out of scope)

- Removing FlyingPress leaves the "performance" category with a single
  product (WP Rocket). The product-switcher UI in `calculator.tsx`
  (`line.category.products.length > 1`) already handles this correctly by
  not rendering a switcher when there's only one option, so nothing broke,
  but it's worth deciding in pass 2 whether a single-product category
  should look different from a multi-product one.
- No fifth defect of the same shape (a product whose licence covers a
  category billed separately elsewhere) was found in this pass.

## Test plan

- [x] `pnpm -C apps/marketing typecheck`
- [x] `pnpm -C apps/marketing build`
- [x] `node apps/marketing/scripts/check-copy.mjs`
- [x] `impeccable detect` on touched directories
- [x] Verified the rendered $4,490.88 headline against the built static HTML
- [ ] Bot/human review (draft, pass 2 to follow on this branch)