### PR TITLE
fix(marketing): render FAQ answers in the served HTML (SEO Tier 1.6)

### DIFF
--- a/apps/marketing/components/sections/faq.tsx
+++ b/apps/marketing/components/sections/faq.tsx
@@ -1,24 +1,20 @@
-"use client";
-
-import { useState } from "react";
 import { Icon } from "@/components/ui/icon";
 import { Container, Section, SectionHeading } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
 import { Reveal } from "@/components/motion/reveal";
 import type { FaqItem } from "@/lib/content/types";
 
+// Native <details>/<summary>: the answer is always in the served HTML (a
+// crawler that never executes JS still reads it), collapsed by default, and
+// expand/collapse plus keyboard operation and the expanded a11y state come
+// from the browser for free. No client JS needed for this component.
 function FaqItemRow({ q, a }: FaqItem) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <div className="border-b border-[var(--border)] last:border-0">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        aria-expanded={open}
+    <details className="group border-b border-[var(--border)] last:border-0">
+      <summary
         className={cn(
-          "flex w-full items-center justify-between gap-4 py-4 text-left",
-          "text-base font-medium text-foreground",
+          "flex w-full list-none items-center justify-between gap-4 py-4 text-left",
+          "cursor-pointer text-base font-medium text-foreground [&::-webkit-details-marker]:hidden",
           "transition-colors duration-[var(--duration-fast)] hover:text-[var(--primary)]",
           "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)] rounded-sm",
         )}
@@ -29,14 +25,12 @@ function FaqItemRow({ q, a }: FaqItem) {
           size={18}
           className={cn(
             "shrink-0 text-[var(--muted-foreground)] transition-transform duration-[var(--duration-base)]",
-            open && "rotate-180",
+            "group-open:rotate-180",
           )}
         />
-      </button>
-      {open && (
-        <p className="pb-5 text-sm leading-relaxed text-[var(--muted-foreground)]">{a}</p>
-      )}
-    </div>
+      </summary>
+      <p className="pb-5 text-sm leading-relaxed text-[var(--muted-foreground)]">{a}</p>
+    </details>
   );
 }
 


### PR DESCRIPTION
The FAQ component rendered its answers only after a click, so the text existed
in the React payload and the FAQ structured data but never in the served HTML.

Measured on this branch, not quoted from the audit: 24 pages, 116 answers,
4,676 words flow through this component. A `curl -sA GPTBot` of the live site
finds the answer text only inside `<script>` tags; the same fetch against this
build finds it in a real `<p>` in the body.

That matters because the assistants this content is written for do not execute
JavaScript. It also conflicted with Google's guidance not to mark up content
that is not visible to readers, which we were doing on every one of those pages.

Now a native `<details>`/`<summary>`: always in the HTML, collapsed by default,
with expand and keyboard handling from the browser rather than from us.

Two things found while measuring, neither fixed here:

- `/compare/[slug]` was never affected. Those pages use an always-visible
  definition list, so the audit's page count was slightly high.
- `/refunds` emits FAQ structured data but never renders the FAQ visibly at all.
  Same policy problem, different cause, no accordion to fix.

The JSON-LD and the visible text were checked for disagreement across all 24
pages and match, since each passes the same array to both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved FAQ expand/collapse behavior with native browser controls.
  * Enhanced keyboard interaction and accessibility state handling.
* **Bug Fixes**
  * FAQ items now work reliably without client-side scripting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->