### PR TITLE
fix(marketing): four remaining SEO Tier 1 items

### DIFF
--- a/apps/marketing/app/(marketing)/about/page.tsx
+++ b/apps/marketing/app/(marketing)/about/page.tsx
@@ -14,7 +14,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "About WPMgr | Open-Source WordPress Fleet Management",
   description:
-    "WPMgr is an open-source, self-hostable WordPress fleet manager built on the conviction that your data and tooling should belong to you. AGPL control plane, MIT agent.",
+    "WPMgr is an open-source, self-hostable WordPress fleet manager built on the conviction that your data and tooling should belong to you. AGPL, MIT agent.",
   canonical: "/about",
 });
 

--- a/apps/marketing/app/(marketing)/about/page.tsx
+++ b/apps/marketing/app/(marketing)/about/page.tsx
@@ -14,7 +14,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "About WPMgr | Open-Source WordPress Fleet Management",
   description:
-    "WPMgr is an open-source, self-hostable WordPress fleet manager built on the conviction that your site data and your tooling should belong to you. AGPL control plane, MIT agent, Ed25519-signed messages.",
+    "WPMgr is an open-source, self-hostable WordPress fleet manager built on the conviction that your data and tooling should belong to you. AGPL control plane, MIT agent.",
   canonical: "/about",
 });
 

--- a/apps/marketing/app/(marketing)/features/page.tsx
+++ b/apps/marketing/app/(marketing)/features/page.tsx
@@ -12,7 +12,7 @@ import { CTABand } from "@/components/sections/cta-band";
 import { signupHref } from "@/lib/site";
 
 export const metadata: Metadata = buildMetadata({
-  title: "WordPress Management Features | WPMgr",
+  title: "WordPress Management Features",
   description:
     "All WordPress fleet management features in one open-source platform: backups and restore, safe updates, Media Optimizer (AVIF and WebP), full-page caching, Redis object cache, Real User Monitoring, database cleanup, security hardening, vulnerability scanning, 2FA, client reports, per-site email, and team access control.",
   canonical: "/features",

--- a/apps/marketing/app/(marketing)/features/page.tsx
+++ b/apps/marketing/app/(marketing)/features/page.tsx
@@ -14,7 +14,7 @@ import { signupHref } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Features",
   description:
-    "All WordPress fleet management features in one open-source platform: backups and restore, safe updates, Media Optimizer (AVIF and WebP), full-page caching, Redis object cache, Real User Monitoring, database cleanup, security hardening, vulnerability scanning, 2FA, client reports, per-site email, and team access control.",
+    "All WordPress fleet management features in one open-source platform: backups, safe updates, Media Optimizer, full-page caching, security hardening, and vulnerability scanning.",
   canonical: "/features",
 });
 

--- a/apps/marketing/app/(marketing)/features/page.tsx
+++ b/apps/marketing/app/(marketing)/features/page.tsx
@@ -14,7 +14,7 @@ import { signupHref } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Features",
   description:
-    "All WordPress fleet management features in one open-source platform: backups, safe updates, Media Optimizer, full-page caching, security hardening, and vulnerability scanning.",
+    "All WordPress fleet management features in one open-source platform: backups, safe updates, Media Optimizer, full-page caching, and security hardening.",
   canonical: "/features",
 });
 

--- a/apps/marketing/app/(marketing)/legal/security-policy/page.tsx
+++ b/apps/marketing/app/(marketing)/legal/security-policy/page.tsx
@@ -9,7 +9,7 @@ import { SITE_CONFIG } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "Security Policy: Responsible Disclosure",
   description:
-    "WPMgr responsible disclosure policy, security posture, and how to report a vulnerability. Ed25519-signed agent, redacted diagnostics, client-side-encrypted backups.",
+    "WPMgr responsible disclosure policy and security posture: Ed25519-signed agent, redacted diagnostics, client-side-encrypted backups, and how to report a bug.",
   canonical: "/legal/security-policy",
 });
 

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -14,7 +14,7 @@ import { FAQ } from "@/components/sections/faq";
 import { CTABand } from "@/components/sections/cta-band";
 import { buildMetadata, buildFAQPageLd, buildBreadcrumbLd, buildSoftwareApplicationLd } from "@/lib/seo";
 import { JsonLd } from "@/lib/json-ld";
-import { SITE_CONFIG, signupHref } from "@/lib/site";
+import { SITE_CONFIG, signupHref, newTabRel } from "@/lib/site";
 import { PRICING_TIERS, PRICING_NOTE, PRICING_FAQ, PRICING_CTAS, resolveTierPrices } from "@/lib/content/pricing";
 import { fetchLivePricing } from "@/lib/pricing-live";
 import { PricingTierCards } from "./pricing-tiers";
@@ -103,7 +103,7 @@ export default async function PricingPage() {
               <Link
                 href={signupHref("pricing-free")}
                 target="_blank"
-                rel="noreferrer noopener"
+                rel={newTabRel(signupHref("pricing-free"))}
                 className="inline-flex items-center gap-2 rounded-[var(--radius)] bg-primary px-6 py-3 text-base font-medium text-[var(--primary-foreground)] shadow-sm transition-colors hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
               >
                 Get started for free

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -20,7 +20,7 @@ import { fetchLivePricing } from "@/lib/pricing-live";
 import { PricingTierCards } from "./pricing-tiers";
 
 export const metadata: Metadata = buildMetadata({
-  title: "Pricing | WPMgr",
+  title: "Pricing",
   description:
     "WPMgr pricing: a permanent free tier for 3 sites, and hosted plans from $15/mo with managed backup storage and more frequent backups. Self-hosting stays free and unlimited forever.",
   canonical: "/pricing",

--- a/apps/marketing/app/(marketing)/pricing/page.tsx
+++ b/apps/marketing/app/(marketing)/pricing/page.tsx
@@ -22,7 +22,7 @@ import { PricingTierCards } from "./pricing-tiers";
 export const metadata: Metadata = buildMetadata({
   title: "Pricing",
   description:
-    "WPMgr pricing: a permanent free tier for 3 sites, and hosted plans from $15/mo with managed backup storage and more frequent backups. Self-hosting stays free and unlimited forever.",
+    "WPMgr pricing: a permanent free tier for 3 sites, hosted plans from $15/mo with managed backup storage. Self-hosting stays free and unlimited forever.",
   canonical: "/pricing",
 });
 

--- a/apps/marketing/app/(marketing)/pricing/pricing-tiers.tsx
+++ b/apps/marketing/app/(marketing)/pricing/pricing-tiers.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/primitives";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { cn } from "@/lib/utils";
+import { newTabRel } from "@/lib/site";
 import {
   PRICING_TIERS,
   ctaHrefWithCurrency,
@@ -65,6 +66,7 @@ export function PricingTierCards({
       <Stagger className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
         {PRICING_TIERS.map((tier) => {
           const trailing = tier.cta.icon === "ArrowRight";
+          const ctaHref = ctaHrefWithCurrency(tier.cta, currency);
           const tierPrice = prices[tier.id];
           const showInr = currency === "INR" && tierPrice.inr !== null;
           const priceLabel = showInr && tierPrice.inr ? tierPrice.inr.label : tierPrice.usd.label;
@@ -114,11 +116,11 @@ export function PricingTierCards({
                   ))}
                 </ul>
                 <Button
-                  href={ctaHrefWithCurrency(tier.cta, currency)}
+                  href={ctaHref}
                   variant={tier.cta.variant}
                   size="md"
                   target="_blank"
-                  rel="noreferrer noopener"
+                  rel={newTabRel(ctaHref)}
                   className="w-full"
                 >
                   {tier.cta.label}

--- a/apps/marketing/app/(marketing)/privacy/page.tsx
+++ b/apps/marketing/app/(marketing)/privacy/page.tsx
@@ -6,7 +6,7 @@ import { SITE_CONFIG } from "@/lib/site";
 import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZORPAY } from "@/lib/content/legal";
 
 export const metadata: Metadata = buildMetadata({
-  title: "Privacy Policy | WPMgr",
+  title: "Privacy Policy",
   description:
     "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, including our sub-processors, Google Cloud Platform, Stripe, Razorpay, and Paddle.",
   canonical: "/privacy",

--- a/apps/marketing/app/(marketing)/privacy/page.tsx
+++ b/apps/marketing/app/(marketing)/privacy/page.tsx
@@ -8,7 +8,7 @@ import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZO
 export const metadata: Metadata = buildMetadata({
   title: "Privacy Policy",
   description:
-    "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, including sub-processors Google Cloud, Stripe, Razorpay, and Paddle.",
+    "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, hosted on Google Cloud, payments via Stripe, Razorpay, and Paddle.",
   canonical: "/privacy",
 });
 

--- a/apps/marketing/app/(marketing)/privacy/page.tsx
+++ b/apps/marketing/app/(marketing)/privacy/page.tsx
@@ -8,7 +8,7 @@ import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZO
 export const metadata: Metadata = buildMetadata({
   title: "Privacy Policy",
   description:
-    "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, including our sub-processors, Google Cloud Platform, Stripe, Razorpay, and Paddle.",
+    "How WPMgr collects, uses, and protects data for the hosted service at manage.wpmgr.app, including sub-processors Google Cloud, Stripe, Razorpay, and Paddle.",
   canonical: "/privacy",
 });
 

--- a/apps/marketing/app/(marketing)/refunds/page.tsx
+++ b/apps/marketing/app/(marketing)/refunds/page.tsx
@@ -7,7 +7,7 @@ import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZO
 export const metadata: Metadata = buildMetadata({
   title: "Refund Policy",
   description:
-    "WPMgr refund policy: cancel a monthly subscription anytime, plus a 14-day money-back guarantee on your first paid payment, refunded through your original payment provider.",
+    "WPMgr refund policy: cancel a monthly subscription anytime, plus a 14-day money-back guarantee on your first payment, refunded through your original provider.",
   canonical: "/refunds",
 });
 

--- a/apps/marketing/app/(marketing)/refunds/page.tsx
+++ b/apps/marketing/app/(marketing)/refunds/page.tsx
@@ -5,7 +5,7 @@ import { LegalPage } from "@/components/templates/legal-page";
 import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZORPAY } from "@/lib/content/legal";
 
 export const metadata: Metadata = buildMetadata({
-  title: "Refund Policy | WPMgr",
+  title: "Refund Policy",
   description:
     "WPMgr refund policy: cancel a monthly subscription anytime, plus a 14-day money-back guarantee on your first paid payment, refunded through your original payment provider.",
   canonical: "/refunds",

--- a/apps/marketing/app/(marketing)/self-host/page.tsx
+++ b/apps/marketing/app/(marketing)/self-host/page.tsx
@@ -4,7 +4,7 @@ import { JsonLd } from "@/lib/json-ld";
 import { Container, Section } from "@/components/ui/primitives";
 import { Icon } from "@/components/ui/icon";
 import { SELF_HOST } from "@/lib/content/self-host";
-import { signupHref } from "@/lib/site";
+import { signupHref, newTabRel } from "@/lib/site";
 
 export const metadata: Metadata = buildMetadata({
   title: SELF_HOST.metaTitle,
@@ -48,7 +48,7 @@ export default function SelfHostPage() {
             <a
               href={signupHref("self-host")}
               target="_blank"
-              rel="noreferrer noopener"
+              rel={newTabRel(signupHref("self-host"))}
               className="mt-7 inline-flex h-11 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-6 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
             >
               Let us run it instead

--- a/apps/marketing/app/(marketing)/solutions/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/page.tsx
@@ -12,7 +12,7 @@ import { SOLUTION_HUB_CARDS } from "@/lib/content/solutions";
 import { signupHref } from "@/lib/site";
 
 export const metadata: Metadata = buildMetadata({
-  title: "WordPress Management Solutions | WPMgr",
+  title: "WordPress Management Solutions",
   description:
     "WPMgr covers every WordPress management use case: agencies, freelancers, hosting providers, WordPress security, backups, performance, and managing multiple sites. One open-source platform, no per-site fee.",
   canonical: "/solutions",

--- a/apps/marketing/app/(marketing)/solutions/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/page.tsx
@@ -14,7 +14,7 @@ import { signupHref } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Solutions",
   description:
-    "WPMgr covers every WordPress management use case: agencies, freelancers, hosting providers, WordPress security, backups, performance, and managing multiple sites. One open-source platform, no per-site fee.",
+    "WPMgr covers every WordPress management use case: agencies, freelancers, hosting providers, security, backups, and performance. One open-source platform, no per-site fee.",
   canonical: "/solutions",
 });
 

--- a/apps/marketing/app/(marketing)/solutions/page.tsx
+++ b/apps/marketing/app/(marketing)/solutions/page.tsx
@@ -14,7 +14,7 @@ import { signupHref } from "@/lib/site";
 export const metadata: Metadata = buildMetadata({
   title: "WordPress Management Solutions",
   description:
-    "WPMgr covers every WordPress management use case: agencies, freelancers, hosting providers, security, backups, and performance. One open-source platform, no per-site fee.",
+    "WPMgr covers every WordPress management use case: agencies, freelancers, hosting providers, security, backups, and performance. One open-source platform.",
   canonical: "/solutions",
 });
 

--- a/apps/marketing/app/(marketing)/terms/page.tsx
+++ b/apps/marketing/app/(marketing)/terms/page.tsx
@@ -6,7 +6,7 @@ import { SITE_CONFIG } from "@/lib/site";
 import { COMPANY, LEGAL_EFFECTIVE_DATE, LEGAL_CONTACT_HREF, PADDLE, STRIPE, RAZORPAY } from "@/lib/content/legal";
 
 export const metadata: Metadata = buildMetadata({
-  title: "Terms of Service | WPMgr",
+  title: "Terms of Service",
   description:
     "Terms of Service for the WPMgr hosted service at manage.wpmgr.app, including subscription billing and your choice of payment provider at checkout.",
   canonical: "/terms",

--- a/apps/marketing/app/blog/page.tsx
+++ b/apps/marketing/app/blog/page.tsx
@@ -13,7 +13,7 @@ export const revalidate = 3600;
 export const metadata: Metadata = buildMetadata({
   title: "Blog: WordPress Operations, Security, and Performance",
   description:
-    "Practical articles on WordPress security, performance, backups, and agency operations. Written for site operators, developers, and agencies who run WordPress at scale.",
+    "Practical articles on WordPress security, performance, and backups. Written for site operators, developers, and agencies who run WordPress at scale.",
   canonical: "/blog",
 });
 

--- a/apps/marketing/app/page.tsx
+++ b/apps/marketing/app/page.tsx
@@ -33,7 +33,7 @@ import {
 export const metadata: Metadata = buildMetadata({
   title: "WPMgr: Open-Source, Self-Hosted WordPress Fleet Management",
   description:
-    "Open-source, self-hostable WordPress fleet manager. Media Optimizer (AVIF and WebP), full-page caching, backups and restore, uptime monitoring, Database Cleaner, and security scanning, with a signed MIT-licensed agent you can audit.",
+    "Open-source, self-hostable WordPress fleet manager: Media Optimizer, full-page caching, backups, uptime monitoring, and security scanning, with a signed MIT-licensed agent.",
   canonical: "/",
 });
 

--- a/apps/marketing/app/page.tsx
+++ b/apps/marketing/app/page.tsx
@@ -33,7 +33,7 @@ import {
 export const metadata: Metadata = buildMetadata({
   title: "WPMgr: Open-Source, Self-Hosted WordPress Fleet Management",
   description:
-    "Open-source, self-hostable WordPress fleet manager: Media Optimizer, full-page caching, backups, uptime monitoring, and security scanning, with a signed MIT-licensed agent.",
+    "Open-source, self-hostable WordPress fleet manager: Media Optimizer, full-page caching, backups, uptime monitoring, and security scanning, MIT-licensed agent.",
   canonical: "/",
 });
 

--- a/apps/marketing/app/sitemap.ts
+++ b/apps/marketing/app/sitemap.ts
@@ -18,6 +18,10 @@ const base = SITE_CONFIG.baseUrl;
 // which is what this file used to do, tells a crawler the whole site changed
 // today, every single deploy, and the honest response to that is to stop
 // believing the field. Only dates derived from content are emitted below.
+//
+// priority and changeFrequency are NOT emitted. Google's own documentation
+// states both are ignored: https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap
+// -- they add bytes and false precision without changing crawl behavior.
 
 /** Newest date in a list, or undefined when the list is empty. */
 function newest(dates: Date[]): Date | undefined {
@@ -58,51 +62,43 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const guidesIndexDate = newest(guideDates);
 
   const coreRoutes: MetadataRoute.Sitemap = [
-    { url: base, changeFrequency: "weekly", priority: 1.0 },
-    { url: `${base}/features`, changeFrequency: "weekly", priority: 0.9 },
-    { url: `${base}/solutions`, changeFrequency: "weekly", priority: 0.9 },
-    { url: `${base}/pricing`, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${base}/pricing/plugin-stack`, changeFrequency: "monthly", priority: 0.75 },
-    { url: `${base}/about`, changeFrequency: "monthly", priority: 0.6 },
-    { url: `${base}/changelog`, changeFrequency: "weekly", priority: 0.7 },
-    { url: `${base}/resources`, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${base}/contact`, changeFrequency: "monthly", priority: 0.6 },
-    { url: `${base}/docs`, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${base}/legal`, changeFrequency: "yearly", priority: 0.3 },
-    { url: `${base}/compare`, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${base}/self-host`, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${base}/legal/security-policy`, changeFrequency: "monthly", priority: 0.5 },
+    { url: base },
+    { url: `${base}/features` },
+    { url: `${base}/solutions` },
+    { url: `${base}/pricing` },
+    { url: `${base}/pricing/plugin-stack` },
+    { url: `${base}/about` },
+    { url: `${base}/changelog` },
+    { url: `${base}/resources` },
+    { url: `${base}/contact` },
+    { url: `${base}/docs` },
+    { url: `${base}/legal` },
+    { url: `${base}/compare` },
+    { url: `${base}/self-host` },
+    { url: `${base}/legal/security-policy` },
     // Indexable, linked from the Legal column of the footer on every page, and
     // absent from this file until 2026-08-06.
-    { url: `${base}/privacy`, changeFrequency: "yearly", priority: 0.3 },
-    { url: `${base}/terms`, changeFrequency: "yearly", priority: 0.3 },
-    { url: `${base}/refunds`, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${base}/privacy` },
+    { url: `${base}/terms` },
+    { url: `${base}/refunds` },
     // Blog index + cluster pages
-    { url: `${base}/guides`, lastModified: guidesIndexDate, changeFrequency: "monthly", priority: 0.75 },
-    { url: `${base}/blog`, lastModified: blogIndexDate, changeFrequency: "weekly", priority: 0.75 },
+    { url: `${base}/guides`, lastModified: guidesIndexDate },
+    { url: `${base}/blog`, lastModified: blogIndexDate },
     {
       url: `${base}/blog/wordpress-security`,
       lastModified: categoryDate("wordpress-security"),
-      changeFrequency: "weekly",
-      priority: 0.7,
     },
     {
       url: `${base}/blog/wordpress-performance`,
       lastModified: categoryDate("wordpress-performance"),
-      changeFrequency: "weekly",
-      priority: 0.7,
     },
     {
       url: `${base}/blog/wordpress-backups`,
       lastModified: categoryDate("wordpress-backups"),
-      changeFrequency: "weekly",
-      priority: 0.7,
     },
     {
       url: `${base}/blog/agency-operations`,
       lastModified: categoryDate("agency-operations"),
-      changeFrequency: "weekly",
-      priority: 0.7,
     },
   ];
 
@@ -110,36 +106,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // Adding one to the content types is the honest fix, not a build timestamp.
   const featureRoutes: MetadataRoute.Sitemap = FEATURE_SLUGS.map((slug) => ({
     url: `${base}/features/${slug}`,
-    changeFrequency: "monthly" as const,
-    priority: slug === "media-optimizer" ? 0.85 : 0.8,
   }));
 
   // Comparison pages. No date field: the claims carry their own verifiedOn,
   // which is the date that actually matters to a reader here.
   const compareRoutes: MetadataRoute.Sitemap = COMPARE_SLUGS.map((slug) => ({
     url: `${base}/compare/${slug}`,
-    changeFrequency: "monthly" as const,
-    priority: 0.8,
   }));
 
   const solutionRoutes: MetadataRoute.Sitemap = SOLUTION_SLUGS.map((slug) => ({
     url: `${base}/solutions/${slug}`,
-    changeFrequency: "monthly" as const,
-    priority: 0.8,
   }));
 
   const blogPostRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${base}/blog/${post.frontmatter.category}/${post.frontmatter.slug}`,
     lastModified: new Date(post.frontmatter.date),
-    changeFrequency: "monthly" as const,
-    priority: 0.65,
   }));
 
   const guideRoutes: MetadataRoute.Sitemap = guides.map((guide) => ({
     url: `${base}/guides/${guide.frontmatter.slug}`,
     lastModified: new Date(guide.frontmatter.date),
-    changeFrequency: "monthly" as const,
-    priority: 0.75,
   }));
 
   return [

--- a/apps/marketing/components/content/signup-card.tsx
+++ b/apps/marketing/components/content/signup-card.tsx
@@ -1,4 +1,4 @@
-import { signupHref } from "@/lib/site";
+import { signupHref, newTabRel } from "@/lib/site";
 import type { SignupSource } from "@/lib/analytics";
 import { Icon } from "@/components/ui/icon";
 
@@ -44,7 +44,7 @@ export function SignupCard({
       <a
         href={signupHref(source)}
         target="_blank"
-        rel="noreferrer noopener"
+        rel={newTabRel(signupHref(source))}
         className="mt-4 inline-flex h-10 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-5 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
       >
         {cta}

--- a/apps/marketing/components/sections/compare/cost-model.tsx
+++ b/apps/marketing/components/sections/compare/cost-model.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import { Container, Section } from "@/components/ui/primitives";
 import { Icon } from "@/components/ui/icon";
-import { signupHref } from "@/lib/site";
+import { signupHref, newTabRel } from "@/lib/site";
 import type { ComparisonPageData, CostModel } from "@/lib/content/types";
 
 /**
@@ -143,7 +143,7 @@ export function CostModelSection({ data }: { data: ComparisonPageData }) {
             <a
               href={signupHref("compare")}
               target="_blank"
-              rel="noreferrer noopener"
+              rel={newTabRel(signupHref("compare"))}
               className="inline-flex h-11 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-6 text-sm font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
             >
               Start free at {sites} sites

--- a/apps/marketing/components/sections/cta-band.tsx
+++ b/apps/marketing/components/sections/cta-band.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Container, Section } from "@/components/ui/primitives";
 import { Reveal } from "@/components/motion/reveal";
+import { newTabRel } from "@/lib/site";
 import type { Cta } from "@/lib/content/types";
 
 export function CTABand({
@@ -36,7 +37,7 @@ export function CTABand({
                     href={cta.href}
                     variant={cta.variant ?? "primary"}
                     size="lg"
-                    {...(cta.href.startsWith("http") ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+                    {...(cta.href.startsWith("http") ? { target: "_blank", rel: newTabRel(cta.href) } : {})}
                   >
                     {cta.icon && !trailing ? <Icon name={cta.icon} size={18} /> : null}
                     {cta.label}

--- a/apps/marketing/components/sections/hero.tsx
+++ b/apps/marketing/components/sections/hero.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Badge, Container } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
+import { newTabRel } from "@/lib/site";
 import type { Cta } from "@/lib/content/types";
 
 type HeroTrust = { icon: string; title: string; desc: string; href?: string };
@@ -66,7 +67,7 @@ export function Hero({ badge, heading, subhead, ctas, trust }: HeroProps) {
                   href={cta.href}
                   variant={cta.variant ?? "primary"}
                   size="lg"
-                  {...(external ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+                  {...(external ? { target: "_blank", rel: newTabRel(cta.href) } : {})}
                 >
                   {cta.icon && !trailing ? <Icon name={cta.icon} size={18} /> : null}
                   {cta.label}

--- a/apps/marketing/components/sections/media-showcase.tsx
+++ b/apps/marketing/components/sections/media-showcase.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Container, Section } from "@/components/ui/primitives";
 import { cn } from "@/lib/utils";
 import { Reveal } from "@/components/motion/reveal";
+import { newTabRel } from "@/lib/site";
 import type { Cta, Chip } from "@/lib/content/types";
 
 // ---------------------------------------------------------------------------
@@ -269,7 +270,7 @@ export function MediaShowcase({
               variant={cta.variant ?? "primary"}
               size="lg"
               className="self-start"
-              {...(cta.href.startsWith("http") ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+              {...(cta.href.startsWith("http") ? { target: "_blank", rel: newTabRel(cta.href) } : {})}
             >
               {cta.icon && !trailing ? <Icon name={cta.icon} size={18} /> : null}
               {cta.label}

--- a/apps/marketing/components/sections/steps.tsx
+++ b/apps/marketing/components/sections/steps.tsx
@@ -4,6 +4,7 @@ import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { Reveal } from "@/components/motion/reveal";
 import type { Step, Cta } from "@/lib/content/types";
 import { Button } from "@/components/ui/button";
+import { newTabRel } from "@/lib/site";
 
 function StepCard({ n, icon, title, desc }: Step) {
   return (
@@ -60,7 +61,7 @@ export function Steps({
               href={cta.href}
               variant={cta.variant ?? "primary"}
               size="lg"
-              {...(cta.href.startsWith("http") ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+              {...(cta.href.startsWith("http") ? { target: "_blank", rel: newTabRel(cta.href) } : {})}
             >
               {cta.icon && !trailing ? <Icon name={cta.icon} size={18} /> : null}
               {cta.label}

--- a/apps/marketing/components/templates/comparison-page.tsx
+++ b/apps/marketing/components/templates/comparison-page.tsx
@@ -6,7 +6,7 @@ import { StackCollapse } from "@/components/sections/compare/stack-collapse";
 import { CostModelSection } from "@/components/sections/compare/cost-model";
 import { DataLocality } from "@/components/sections/compare/data-locality";
 import { CompareHeroPanel } from "@/components/sections/compare/hero-panel";
-import { signupHref } from "@/lib/site";
+import { signupHref, newTabRel } from "@/lib/site";
 import { Icon } from "@/components/ui/icon";
 import type { ComparisonPageData } from "@/lib/content/types";
 
@@ -59,7 +59,7 @@ export function ComparisonPage({ data }: { data: ComparisonPageData }) {
             <a
               href={signupHref("compare")}
               target="_blank"
-              rel="noreferrer noopener"
+              rel={newTabRel(signupHref("compare"))}
               className="inline-flex h-12 items-center gap-2 rounded-[var(--radius)] bg-[var(--primary)] px-7 text-base font-medium text-[var(--primary-foreground)] shadow-sm transition-colors duration-[var(--duration-fast)] hover:bg-[var(--primary-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
             >
               Get started for free

--- a/apps/marketing/components/templates/feature-page.tsx
+++ b/apps/marketing/components/templates/feature-page.tsx
@@ -11,7 +11,7 @@ import { FAQ } from "@/components/sections/faq";
 import { CTABand } from "@/components/sections/cta-band";
 import { Reveal } from "@/components/motion/reveal";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
-import { signupHref } from "@/lib/site";
+import { signupHref, newTabRel } from "@/lib/site";
 import type { FeaturePageData } from "@/lib/content/types";
 
 // Visual leaf: resolved at render time based on slug.
@@ -113,7 +113,7 @@ function FeatureHero({ data }: { data: FeaturePageData }) {
               href={hero.primaryCta.href}
               variant="primary"
               size="lg"
-              {...(hero.primaryCta.href.startsWith("http") ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+              {...(hero.primaryCta.href.startsWith("http") ? { target: "_blank", rel: newTabRel(hero.primaryCta.href) } : {})}
             >
               {hero.primaryCta.icon && !primaryTrailing ? <Icon name={hero.primaryCta.icon} size={18} /> : null}
               {hero.primaryCta.label}
@@ -124,7 +124,7 @@ function FeatureHero({ data }: { data: FeaturePageData }) {
                 href={hero.secondaryCta.href}
                 variant="secondary"
                 size="lg"
-                {...(hero.secondaryCta.href.startsWith("http") ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+                {...(hero.secondaryCta.href.startsWith("http") ? { target: "_blank", rel: newTabRel(hero.secondaryCta.href) } : {})}
               >
                 {hero.secondaryCta.icon && !secondaryTrailing ? <Icon name={hero.secondaryCta.icon} size={18} /> : null}
                 {hero.secondaryCta.label}

--- a/apps/marketing/components/templates/solution-page.tsx
+++ b/apps/marketing/components/templates/solution-page.tsx
@@ -11,7 +11,7 @@ import { FAQ } from "@/components/sections/faq";
 import { CTABand } from "@/components/sections/cta-band";
 import { Reveal } from "@/components/motion/reveal";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
-import { signupHref } from "@/lib/site";
+import { signupHref, newTabRel } from "@/lib/site";
 import type { SolutionPageData } from "@/lib/content/types";
 
 // ---------------------------------------------------------------------------
@@ -80,7 +80,7 @@ function SolutionHero({ data }: { data: SolutionPageData }) {
               variant="primary"
               size="lg"
               {...(hero.primaryCta.href.startsWith("http")
-                ? { target: "_blank", rel: "noreferrer noopener" }
+                ? { target: "_blank", rel: newTabRel(hero.primaryCta.href) }
                 : {})}
             >
               {hero.primaryCta.icon && !primaryTrailing ? (
@@ -97,7 +97,7 @@ function SolutionHero({ data }: { data: SolutionPageData }) {
                 variant="secondary"
                 size="lg"
                 {...(hero.secondaryCta.href.startsWith("http")
-                  ? { target: "_blank", rel: "noreferrer noopener" }
+                  ? { target: "_blank", rel: newTabRel(hero.secondaryCta.href) }
                   : {})}
               >
                 {hero.secondaryCta.icon && !secondaryTrailing ? (

--- a/apps/marketing/content/blog/agency-operations/managing-multiple-wordpress-sites.mdx
+++ b/apps/marketing/content/blog/agency-operations/managing-multiple-wordpress-sites.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Managing Multiple WordPress Sites: How to Stay Ahead of 50 Clients"
-description: "The systems that make a WordPress portfolio scale: why operational cost grows faster than site count, safe fleet updates, catching silent backup failures, and standardising onboarding."
+description: "The systems that make a WordPress portfolio scale: why operational cost grows faster than site count, safe fleet updates, and catching silent backup failures."
 category: "agency-operations"
 art: "fleet"
 date: "2026-06-12"

--- a/apps/marketing/content/blog/agency-operations/white-label-wordpress-reports.mdx
+++ b/apps/marketing/content/blog/agency-operations/white-label-wordpress-reports.mdx
@@ -1,6 +1,6 @@
 ---
 title: "White-Label WordPress Maintenance Reports: What to Include and How to Automate Them"
-description: "Maintenance done well is invisible. A report is what makes it visible. What belongs in one, what to leave out, how to automate generation from an audit log, and how branding changes what the client thinks they are buying."
+description: "Maintenance done well is invisible; a report makes it visible. What belongs in one, what to leave out, and how to automate generation from an audit log."
 category: "agency-operations"
 art: "report"
 date: "2026-06-20"

--- a/apps/marketing/content/blog/wordpress-backups/wordpress-backup-restore-guide.mdx
+++ b/apps/marketing/content/blog/wordpress-backups/wordpress-backup-restore-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Restore in Practice: From Backup to Live Site"
-description: "Restoring a WordPress site from a backup: matching restore scope to the failure, database-only versus full restores, testing on staging first, and what a restore after a compromise has to do differently."
+description: "Restoring a WordPress site from a backup: matching restore scope to the failure, database-only versus full restores, and testing on staging before you commit."
 category: "wordpress-backups"
 art: "restore"
 date: "2026-06-16"

--- a/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
+++ b/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Backup Strategy: How Often, What to Include, and Where to Store It"
-description: "Building a WordPress backup strategy that survives contact with a real incident: choosing frequency from a recovery objective, what to include, offsite storage, retention, and testing restores."
+description: "Building a WordPress backup strategy that survives contact with a real incident: choosing frequency from a recovery objective, offsite storage, retention, and restores."
 category: "wordpress-backups"
 art: "snapshots"
 date: "2026-06-13"

--- a/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
+++ b/apps/marketing/content/blog/wordpress-backups/wordpress-backup-strategy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Backup Strategy: How Often, What to Include, and Where to Store It"
-description: "Building a WordPress backup strategy that survives contact with a real incident: choosing frequency from a recovery objective, offsite storage, retention, and restores."
+description: "Building a WordPress backup strategy that survives a real incident: choosing frequency from a recovery objective, offsite storage, retention, and restores."
 category: "wordpress-backups"
 art: "snapshots"
 date: "2026-06-13"

--- a/apps/marketing/content/blog/wordpress-performance/core-web-vitals-wordpress.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/core-web-vitals-wordpress.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Core Web Vitals for WordPress: LCP, CLS, and INP Explained"
-description: "What the three Core Web Vitals actually measure, the WordPress-specific causes of poor scores, practical fixes for each, and why lab tools and field data disagree."
+description: "What the three Core Web Vitals actually measure, WordPress-specific causes of poor scores, practical fixes for each, and why lab and field data disagree."
 category: "wordpress-performance"
 art: "vitals"
 date: "2026-06-14"

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Image Optimization: AVIF and WebP in Practice"
-description: "AVIF and WebP cut image weight by 30 to 60 percent against JPEG. How the formats differ, how WordPress actually serves them, how to convert an existing library, and the traps that make a conversion look worse than it is."
+description: "AVIF and WebP cut image weight 30 to 60 percent against JPEG. How the formats differ, how WordPress serves them, and how to convert an existing library without visible loss."
 category: "wordpress-performance"
 art: "compress"
 date: "2026-06-17"

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-image-optimization-avif-webp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Image Optimization: AVIF and WebP in Practice"
-description: "AVIF and WebP cut image weight 30 to 60 percent against JPEG. How the formats differ, how WordPress serves them, and how to convert an existing library without visible loss."
+description: "AVIF and WebP cut image weight 30 to 60 percent against JPEG. How the formats differ, how WordPress serves them, and how to convert a library safely."
 category: "wordpress-performance"
 art: "compress"
 date: "2026-06-17"

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Redis Object Cache for WordPress: When It Helps and When It Does Not"
-description: "Persistent object caching stores expensive database query results across requests. Where it earns its keep, where it adds complexity for nothing, from your own numbers."
+description: "Persistent object caching stores expensive database query results across requests. Where it earns its keep and where it adds complexity for nothing."
 category: "wordpress-performance"
 art: "cache"
 date: "2026-06-19"

--- a/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
+++ b/apps/marketing/content/blog/wordpress-performance/wordpress-redis-object-cache.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Redis Object Cache for WordPress: When It Helps and When It Does Not"
-description: "Persistent object caching stores the results of expensive database queries across requests. Where it earns its keep, where it adds complexity for nothing, and how to tell the difference from your own numbers."
+description: "Persistent object caching stores expensive database query results across requests. Where it earns its keep, where it adds complexity for nothing, from your own numbers."
 category: "wordpress-performance"
 art: "cache"
 date: "2026-06-19"

--- a/apps/marketing/content/blog/wordpress-security/harden-wordpress-login.mdx
+++ b/apps/marketing/content/blog/wordpress-security/harden-wordpress-login.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Harden Your WordPress Login Page"
-description: "Practical steps to cut automated login attacks on WordPress: rate limiting that survives a PHP error, closing XML-RPC multicall, stopping user enumeration, and adding a second factor."
+description: "Practical steps to cut automated login attacks on WordPress: rate limiting that survives a PHP error, closing XML-RPC multicall, and stopping user enumeration."
 category: "wordpress-security"
 art: "gate"
 date: "2026-06-15"

--- a/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
+++ b/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress File Integrity Monitoring: Detect Unauthorized Changes"
-description: "File integrity monitoring compares a WordPress install against known-good checksums to catch modified or injected files. How it works, why the baseline must never advance on its own, and how to read the results."
+description: "File integrity monitoring compares a WordPress install against known-good checksums to catch modified or injected files, and why the baseline must never advance on its own."
 category: "wordpress-security"
 art: "integrity"
 date: "2026-06-20"

--- a/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
+++ b/apps/marketing/content/blog/wordpress-security/wordpress-file-integrity-monitoring.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress File Integrity Monitoring: Detect Unauthorized Changes"
-description: "File integrity monitoring compares a WordPress install against known-good checksums to catch modified or injected files, and why the baseline must never advance on its own."
+description: "File integrity monitoring compares a WordPress install against known-good checksums to catch modified files, and why the baseline must never advance on its own."
 category: "wordpress-security"
 art: "integrity"
 date: "2026-06-20"

--- a/apps/marketing/content/blog/wordpress-security/wordpress-vulnerability-scanning.mdx
+++ b/apps/marketing/content/blog/wordpress-security/wordpress-vulnerability-scanning.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WordPress Vulnerability Scanning: What It Is and Why It Matters"
-description: "How plugin and theme vulnerability scanning works, which CVE feeds power it, why version matching is harder than it looks, and how to triage findings without breaking your sites."
+description: "How plugin and theme vulnerability scanning works, which CVE feeds power it, why version matching is harder than it looks, and how to triage findings safely."
 category: "wordpress-security"
 art: "scanner"
 date: "2026-06-18"

--- a/apps/marketing/lib/content/compare/managewp-vs-mainwp-vs-wpmgr.ts
+++ b/apps/marketing/lib/content/compare/managewp-vs-mainwp-vs-wpmgr.ts
@@ -31,7 +31,7 @@ export const MANAGEWP_VS_MAINWP: ComparisonPageData = {
   title: "ManageWP vs MainWP vs WPMgr",
   metaTitle: "ManageWP vs MainWP vs WPMgr: One Dashboard, Compared",
   metaDescription:
-    "ManageWP, MainWP and WPMgr compared on where the dashboard runs, where your backups land, and what the bill does as the fleet grows. Every figure sourced and dated.",
+    "ManageWP, MainWP and WPMgr compared on where the dashboard runs, where backups land, and what the bill does as the fleet grows. Every figure sourced and dated.",
   targetQuery: "managewp vs mainwp",
   hero: {
     heading: "ManageWP vs MainWP vs WPMgr",

--- a/apps/marketing/lib/content/features/backups.ts
+++ b/apps/marketing/lib/content/features/backups.ts
@@ -8,7 +8,7 @@ export const BACKUPS_PAGE: FeaturePageData = {
   title: "WordPress Backup Plugin",
   metaTitle: "WordPress Backup Plugin with Incremental Backups",
   metaDescription:
-    "WPMgr is a self-hosted WordPress backup plugin with incremental backups, point-in-time restore, fleet-wide backup health, and client-side encryption. Free and open source.",
+    "WPMgr is a self-hosted WordPress backup plugin with incremental backups, point-in-time restore, fleet-wide backup health, and client-side encryption.",
   hero: {
     eyebrow: "Backups and restore",
     heading: "Incremental WordPress backups with point-in-time restore",

--- a/apps/marketing/lib/content/features/backups.ts
+++ b/apps/marketing/lib/content/features/backups.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const BACKUPS_PAGE: FeaturePageData = {
   slug: "backups",
   title: "WordPress Backup Plugin",
-  metaTitle: "WordPress Backup Plugin with Incremental Backups | WPMgr",
+  metaTitle: "WordPress Backup Plugin with Incremental Backups",
   metaDescription:
     "WPMgr is a self-hosted WordPress backup plugin with incremental backups, point-in-time restore, fleet-wide backup health, and client-side encryption. Free and open source.",
   hero: {

--- a/apps/marketing/lib/content/features/client-reports.ts
+++ b/apps/marketing/lib/content/features/client-reports.ts
@@ -8,7 +8,7 @@ export const CLIENT_REPORTS_PAGE: FeaturePageData = {
   title: "White-Label WordPress Reports",
   metaTitle: "White-Label WordPress Reports and Client Maintenance Reports",
   metaDescription:
-    "Send branded WordPress maintenance reports to clients on a schedule or on demand. Uptime, backups, updates, Core Web Vitals, and email deliverability in one HTML email or PDF. Powered-by footer removable.",
+    "Send branded WordPress maintenance reports to clients on a schedule or on demand. Uptime, backups, updates, and Core Web Vitals in one HTML email or PDF, footer removable.",
   hero: {
     eyebrow: "Client reports",
     heading: "White-label WordPress maintenance reports for clients",

--- a/apps/marketing/lib/content/features/client-reports.ts
+++ b/apps/marketing/lib/content/features/client-reports.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const CLIENT_REPORTS_PAGE: FeaturePageData = {
   slug: "client-reports",
   title: "White-Label WordPress Reports",
-  metaTitle: "White-Label WordPress Reports and Client Maintenance Reports | WPMgr",
+  metaTitle: "White-Label WordPress Reports and Client Maintenance Reports",
   metaDescription:
     "Send branded WordPress maintenance reports to clients on a schedule or on demand. Uptime, backups, updates, Core Web Vitals, and email deliverability in one HTML email or PDF. Powered-by footer removable.",
   hero: {

--- a/apps/marketing/lib/content/features/client-reports.ts
+++ b/apps/marketing/lib/content/features/client-reports.ts
@@ -8,7 +8,7 @@ export const CLIENT_REPORTS_PAGE: FeaturePageData = {
   title: "White-Label WordPress Reports",
   metaTitle: "White-Label WordPress Reports and Client Maintenance Reports",
   metaDescription:
-    "Send branded WordPress maintenance reports to clients on a schedule or on demand. Uptime, backups, updates, and Core Web Vitals in one HTML email or PDF, footer removable.",
+    "Send branded WordPress maintenance reports to clients on a schedule or on demand. Uptime, backups, updates, and Core Web Vitals in one HTML email or PDF.",
   hero: {
     eyebrow: "Client reports",
     heading: "White-label WordPress maintenance reports for clients",

--- a/apps/marketing/lib/content/features/database-cleaner.ts
+++ b/apps/marketing/lib/content/features/database-cleaner.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const DATABASE_CLEANER_PAGE: FeaturePageData = {
   slug: "database-cleaner",
   title: "WordPress Database Cleaner",
-  metaTitle: "WordPress Database Cleanup: Clean wp_options and Revisions | WPMgr",
+  metaTitle: "WordPress Database Cleanup: Clean wp_options and Revisions",
   metaDescription:
     "WordPress database cleaner that scans first and cleans second. Remove revisions, transients, orphaned data, and bloated wp_options rows. 90-day trend, fleet-wide view, fully reversible. Free and open source.",
   hero: {

--- a/apps/marketing/lib/content/features/database-cleaner.ts
+++ b/apps/marketing/lib/content/features/database-cleaner.ts
@@ -8,7 +8,7 @@ export const DATABASE_CLEANER_PAGE: FeaturePageData = {
   title: "WordPress Database Cleaner",
   metaTitle: "WordPress Database Cleanup: Clean wp_options and Revisions",
   metaDescription:
-    "WordPress database cleaner that scans first and cleans second. Remove revisions, transients, orphaned data, and bloated wp_options rows. 90-day trend, fleet-wide view, fully reversible. Free and open source.",
+    "WordPress database cleaner that scans first and cleans second. Remove revisions, transients, and bloated wp_options rows. 90-day trend, fully reversible, open source.",
   hero: {
     eyebrow: "Database Cleaner",
     heading: "WordPress database cleanup that scans first and never guesses",

--- a/apps/marketing/lib/content/features/database-cleaner.ts
+++ b/apps/marketing/lib/content/features/database-cleaner.ts
@@ -8,7 +8,7 @@ export const DATABASE_CLEANER_PAGE: FeaturePageData = {
   title: "WordPress Database Cleaner",
   metaTitle: "WordPress Database Cleanup: Clean wp_options and Revisions",
   metaDescription:
-    "WordPress database cleaner that scans first and cleans second. Remove revisions, transients, and bloated wp_options rows. 90-day trend, fully reversible.",
+    "WordPress database cleaner that scans first and cleans second: revisions, transients, bloated wp_options. 90-day trend, snapshot before cleaning.",
   hero: {
     eyebrow: "Database Cleaner",
     heading: "WordPress database cleanup that scans first and never guesses",

--- a/apps/marketing/lib/content/features/database-cleaner.ts
+++ b/apps/marketing/lib/content/features/database-cleaner.ts
@@ -8,7 +8,7 @@ export const DATABASE_CLEANER_PAGE: FeaturePageData = {
   title: "WordPress Database Cleaner",
   metaTitle: "WordPress Database Cleanup: Clean wp_options and Revisions",
   metaDescription:
-    "WordPress database cleaner that scans first and cleans second. Remove revisions, transients, and bloated wp_options rows. 90-day trend, fully reversible, open source.",
+    "WordPress database cleaner that scans first and cleans second. Remove revisions, transients, and bloated wp_options rows. 90-day trend, fully reversible.",
   hero: {
     eyebrow: "Database Cleaner",
     heading: "WordPress database cleanup that scans first and never guesses",

--- a/apps/marketing/lib/content/features/email-deliverability.ts
+++ b/apps/marketing/lib/content/features/email-deliverability.ts
@@ -8,7 +8,7 @@ export const EMAIL_DELIVERABILITY_PAGE: FeaturePageData = {
   title: "WordPress SMTP Per Site and Email Log",
   metaTitle: "WordPress SMTP Per Site with Central Email Log",
   metaDescription:
-    "Configure WordPress SMTP per site with SES, SendGrid, Mailgun, Postmark, or any SMTP server. Central searchable email log, named connections, automatic failover.",
+    "Configure WordPress SMTP per site with SES, SendGrid, Mailgun, Postmark, or any SMTP server. Central searchable email log with automatic failover.",
   hero: {
     eyebrow: "Per-site email",
     heading: "WordPress SMTP per site with a central email delivery log",

--- a/apps/marketing/lib/content/features/email-deliverability.ts
+++ b/apps/marketing/lib/content/features/email-deliverability.ts
@@ -8,7 +8,7 @@ export const EMAIL_DELIVERABILITY_PAGE: FeaturePageData = {
   title: "WordPress SMTP Per Site and Email Log",
   metaTitle: "WordPress SMTP Per Site with Central Email Log",
   metaDescription:
-    "Configure WordPress SMTP per site with SES, SendGrid, Mailgun, Postmark, or any SMTP server. Central searchable email log, named connections with automatic failover, and webhook bounce suppression.",
+    "Configure WordPress SMTP per site with SES, SendGrid, Mailgun, Postmark, or any SMTP server. Central searchable email log, named connections, automatic failover.",
   hero: {
     eyebrow: "Per-site email",
     heading: "WordPress SMTP per site with a central email delivery log",

--- a/apps/marketing/lib/content/features/email-deliverability.ts
+++ b/apps/marketing/lib/content/features/email-deliverability.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const EMAIL_DELIVERABILITY_PAGE: FeaturePageData = {
   slug: "email-deliverability",
   title: "WordPress SMTP Per Site and Email Log",
-  metaTitle: "WordPress SMTP Per Site with Central Email Log | WPMgr",
+  metaTitle: "WordPress SMTP Per Site with Central Email Log",
   metaDescription:
     "Configure WordPress SMTP per site with SES, SendGrid, Mailgun, Postmark, or any SMTP server. Central searchable email log, named connections with automatic failover, and webhook bounce suppression.",
   hero: {

--- a/apps/marketing/lib/content/features/file-manager.ts
+++ b/apps/marketing/lib/content/features/file-manager.ts
@@ -8,7 +8,7 @@ export const FILE_MANAGER_PAGE: FeaturePageData = {
   title: "WordPress File Manager",
   metaTitle: "WordPress File Manager: Browse, Edit, and Upload Without SFTP",
   metaDescription:
-    "Browse, edit, upload, download, and manage files on any managed WordPress site from the WPMgr dashboard. Version history, archive and extract, file search, executable-write prevention. Off by default, owner-gated, fully audited.",
+    "Browse, edit, upload, and manage files on any WordPress site from the WPMgr dashboard. Version history, archive support, and executable-write prevention. Off by default, fully audited.",
   hero: {
     eyebrow: "File Manager",
     heading: "Manage WordPress site files from the dashboard, no SFTP needed",

--- a/apps/marketing/lib/content/features/file-manager.ts
+++ b/apps/marketing/lib/content/features/file-manager.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const FILE_MANAGER_PAGE: FeaturePageData = {
   slug: "file-manager",
   title: "WordPress File Manager",
-  metaTitle: "WordPress File Manager: Browse, Edit, and Upload Without SFTP | WPMgr",
+  metaTitle: "WordPress File Manager: Browse, Edit, and Upload Without SFTP",
   metaDescription:
     "Browse, edit, upload, download, and manage files on any managed WordPress site from the WPMgr dashboard. Version history, archive and extract, file search, executable-write prevention. Off by default, owner-gated, fully audited.",
   hero: {

--- a/apps/marketing/lib/content/features/file-manager.ts
+++ b/apps/marketing/lib/content/features/file-manager.ts
@@ -8,7 +8,7 @@ export const FILE_MANAGER_PAGE: FeaturePageData = {
   title: "WordPress File Manager",
   metaTitle: "WordPress File Manager: Browse, Edit, and Upload Without SFTP",
   metaDescription:
-    "Browse, edit, upload, and manage files on any WordPress site from the WPMgr dashboard. Version history, archive support, and executable-write prevention. Off by default, fully audited.",
+    "Browse, edit, upload, and manage files on any WordPress site from the WPMgr dashboard. Version history, archive support, and executable-write prevention.",
   hero: {
     eyebrow: "File Manager",
     heading: "Manage WordPress site files from the dashboard, no SFTP needed",

--- a/apps/marketing/lib/content/features/media-optimizer.ts
+++ b/apps/marketing/lib/content/features/media-optimizer.ts
@@ -9,7 +9,7 @@ export const MEDIA_OPTIMIZER_PAGE: FeaturePageData = {
   title: "WordPress AVIF and WebP Image Optimization",
   metaTitle: "Convert Images to WebP and AVIF in WordPress | Media Optimizer",
   metaDescription:
-    "WPMgr Media Optimizer converts your WordPress media library to AVIF and WebP in the cloud. Originals stay archived on the site, and every conversion is fully reversible.",
+    "WPMgr Media Optimizer converts your WordPress media library to AVIF and WebP in the cloud. Originals stay archived on the site; every conversion reverses.",
   hero: {
     eyebrow: "Media Optimizer",
     heading: "Convert WordPress images to AVIF and WebP, fully reversible",

--- a/apps/marketing/lib/content/features/media-optimizer.ts
+++ b/apps/marketing/lib/content/features/media-optimizer.ts
@@ -7,7 +7,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const MEDIA_OPTIMIZER_PAGE: FeaturePageData = {
   slug: "media-optimizer",
   title: "WordPress AVIF and WebP Image Optimization",
-  metaTitle: "Convert Images to WebP and AVIF in WordPress | WPMgr Media Optimizer",
+  metaTitle: "Convert Images to WebP and AVIF in WordPress | Media Optimizer",
   metaDescription:
     "WPMgr Media Optimizer converts your WordPress media library to AVIF and WebP in the cloud. Originals stay archived on the site, bytes never touch the control plane, and every image is fully reversible.",
   hero: {

--- a/apps/marketing/lib/content/features/media-optimizer.ts
+++ b/apps/marketing/lib/content/features/media-optimizer.ts
@@ -9,7 +9,7 @@ export const MEDIA_OPTIMIZER_PAGE: FeaturePageData = {
   title: "WordPress AVIF and WebP Image Optimization",
   metaTitle: "Convert Images to WebP and AVIF in WordPress | Media Optimizer",
   metaDescription:
-    "WPMgr Media Optimizer converts your WordPress media library to AVIF and WebP in the cloud. Originals stay archived on the site; every conversion reverses.",
+    "WPMgr Media Optimizer converts your WordPress media library to AVIF and WebP in the cloud. Originals stay archived on the site; every conversion is reversible.",
   hero: {
     eyebrow: "Media Optimizer",
     heading: "Convert WordPress images to AVIF and WebP, fully reversible",

--- a/apps/marketing/lib/content/features/media-optimizer.ts
+++ b/apps/marketing/lib/content/features/media-optimizer.ts
@@ -9,7 +9,7 @@ export const MEDIA_OPTIMIZER_PAGE: FeaturePageData = {
   title: "WordPress AVIF and WebP Image Optimization",
   metaTitle: "Convert Images to WebP and AVIF in WordPress | Media Optimizer",
   metaDescription:
-    "WPMgr Media Optimizer converts your WordPress media library to AVIF and WebP in the cloud. Originals stay archived on the site, bytes never touch the control plane, and every image is fully reversible.",
+    "WPMgr Media Optimizer converts your WordPress media library to AVIF and WebP in the cloud. Originals stay archived on the site, and every conversion is fully reversible.",
   hero: {
     eyebrow: "Media Optimizer",
     heading: "Convert WordPress images to AVIF and WebP, fully reversible",

--- a/apps/marketing/lib/content/features/object-cache.ts
+++ b/apps/marketing/lib/content/features/object-cache.ts
@@ -8,7 +8,7 @@ export const OBJECT_CACHE_PAGE: FeaturePageData = {
   title: "Redis Object Cache for WordPress",
   metaTitle: "Redis Object Cache WordPress: Per-Site Persistent Cache",
   metaDescription:
-    "Per-site Redis object cache for WordPress with TLS, ACL, hit-ratio metrics, and a debug header that verifies cache state per request. Self-hosted and open source.",
+    "Per-site Redis object cache for WordPress with TLS, ACL, hit-ratio metrics, and a debug header that verifies cache state per request. Self-hosted.",
   hero: {
     eyebrow: "Redis Object Cache",
     heading: "Redis object cache for WordPress, managed per site from the dashboard",

--- a/apps/marketing/lib/content/features/object-cache.ts
+++ b/apps/marketing/lib/content/features/object-cache.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const OBJECT_CACHE_PAGE: FeaturePageData = {
   slug: "object-cache",
   title: "Redis Object Cache for WordPress",
-  metaTitle: "Redis Object Cache WordPress: Per-Site Persistent Cache | WPMgr",
+  metaTitle: "Redis Object Cache WordPress: Per-Site Persistent Cache",
   metaDescription:
     "Per-site Redis object cache for WordPress with TLS, ACL, hit-ratio metrics, and a debug header that verifies cache state per request. Self-hosted, open source, and free.",
   hero: {

--- a/apps/marketing/lib/content/features/object-cache.ts
+++ b/apps/marketing/lib/content/features/object-cache.ts
@@ -8,7 +8,7 @@ export const OBJECT_CACHE_PAGE: FeaturePageData = {
   title: "Redis Object Cache for WordPress",
   metaTitle: "Redis Object Cache WordPress: Per-Site Persistent Cache",
   metaDescription:
-    "Per-site Redis object cache for WordPress with TLS, ACL, hit-ratio metrics, and a debug header that verifies cache state per request. Self-hosted, open source, and free.",
+    "Per-site Redis object cache for WordPress with TLS, ACL, hit-ratio metrics, and a debug header that verifies cache state per request. Self-hosted and open source.",
   hero: {
     eyebrow: "Redis Object Cache",
     heading: "Redis object cache for WordPress, managed per site from the dashboard",

--- a/apps/marketing/lib/content/features/performance.ts
+++ b/apps/marketing/lib/content/features/performance.ts
@@ -8,7 +8,7 @@ export const PERFORMANCE_PAGE: FeaturePageData = {
   title: "WordPress Performance and Page Caching",
   metaTitle: "WordPress Caching and Speed Optimization",
   metaDescription:
-    "Full-page caching, unused CSS removal, WOFF2 font transcoding, and WooCommerce-aware bypasses. WPMgr makes WordPress faster with a toggle, not a rebuild. Free and self-hostable.",
+    "Full-page caching, unused CSS removal, WOFF2 font transcoding, and WooCommerce-aware bypasses. WPMgr makes WordPress faster with a toggle, not a rebuild.",
   hero: {
     eyebrow: "Performance Suite",
     heading: "Speed up WordPress with full-page caching and asset optimization",

--- a/apps/marketing/lib/content/features/performance.ts
+++ b/apps/marketing/lib/content/features/performance.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const PERFORMANCE_PAGE: FeaturePageData = {
   slug: "performance",
   title: "WordPress Performance and Page Caching",
-  metaTitle: "WordPress Caching and Speed Optimization | WPMgr",
+  metaTitle: "WordPress Caching and Speed Optimization",
   metaDescription:
     "Full-page caching, unused CSS removal, WOFF2 font transcoding, and WooCommerce-aware bypasses. WPMgr makes WordPress faster with a toggle, not a rebuild. Free and self-hostable.",
   hero: {

--- a/apps/marketing/lib/content/features/real-user-monitoring.ts
+++ b/apps/marketing/lib/content/features/real-user-monitoring.ts
@@ -8,7 +8,7 @@ export const RUM_PAGE: FeaturePageData = {
   title: "WordPress Core Web Vitals Monitoring",
   metaTitle: "WordPress Core Web Vitals Monitoring with Real User Data",
   metaDescription:
-    "Monitor WordPress Core Web Vitals with real visitor data at the p75 percentile Google uses. LCP, INP, CLS, FCP, and TTFB with 28-day trends, per-URL breakdowns, and privacy-first anonymous collection.",
+    "Monitor WordPress Core Web Vitals with real visitor data at the p75 percentile Google uses. LCP, INP, CLS, FCP, and TTFB with 28-day trends and per-URL breakdowns.",
   hero: {
     eyebrow: "Real User Monitoring",
     heading: "WordPress Core Web Vitals monitoring from real visitor data",

--- a/apps/marketing/lib/content/features/real-user-monitoring.ts
+++ b/apps/marketing/lib/content/features/real-user-monitoring.ts
@@ -8,7 +8,7 @@ export const RUM_PAGE: FeaturePageData = {
   title: "WordPress Core Web Vitals Monitoring",
   metaTitle: "WordPress Core Web Vitals Monitoring with Real User Data",
   metaDescription:
-    "Monitor WordPress Core Web Vitals with real visitor data at the p75 percentile Google uses. LCP, INP, CLS, FCP, and TTFB with 28-day trends and per-URL breakdowns.",
+    "Monitor WordPress Core Web Vitals with real visitor data at the p75 percentile Google uses. LCP, INP, CLS, FCP, and TTFB with 28-day trends per URL.",
   hero: {
     eyebrow: "Real User Monitoring",
     heading: "WordPress Core Web Vitals monitoring from real visitor data",

--- a/apps/marketing/lib/content/features/real-user-monitoring.ts
+++ b/apps/marketing/lib/content/features/real-user-monitoring.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const RUM_PAGE: FeaturePageData = {
   slug: "real-user-monitoring",
   title: "WordPress Core Web Vitals Monitoring",
-  metaTitle: "WordPress Core Web Vitals Monitoring with Real User Data | WPMgr",
+  metaTitle: "WordPress Core Web Vitals Monitoring with Real User Data",
   metaDescription:
     "Monitor WordPress Core Web Vitals with real visitor data at the p75 percentile Google uses. LCP, INP, CLS, FCP, and TTFB with 28-day trends, per-URL breakdowns, and privacy-first anonymous collection.",
   hero: {

--- a/apps/marketing/lib/content/features/security.ts
+++ b/apps/marketing/lib/content/features/security.ts
@@ -8,7 +8,7 @@ export const SECURITY_PAGE: FeaturePageData = {
   title: "WordPress Security Suite",
   metaTitle: "WordPress Security Hardening and Vulnerability Scanner",
   metaDescription:
-    "WordPress security hardening, IP bans, file integrity monitoring, vulnerability scanning via Wordfence Intelligence, site-user 2FA, and password policy. Open source, self-hostable, default-off.",
+    "WordPress security hardening, IP bans, file integrity monitoring, vulnerability scanning, site-user 2FA, and password policy. Open source and self-hostable, default-off.",
   hero: {
     eyebrow: "Security Suite",
     heading: "WordPress security hardening and vulnerability scanning in one dashboard",

--- a/apps/marketing/lib/content/features/security.ts
+++ b/apps/marketing/lib/content/features/security.ts
@@ -8,7 +8,7 @@ export const SECURITY_PAGE: FeaturePageData = {
   title: "WordPress Security Suite",
   metaTitle: "WordPress Security Hardening and Vulnerability Scanner",
   metaDescription:
-    "WordPress security hardening, IP bans, file integrity monitoring, vulnerability scanning, site-user 2FA, and password policy. Open source and self-hostable, default-off.",
+    "WordPress security hardening, IP bans, file integrity monitoring, vulnerability scanning, site-user 2FA, and password policy. Open source, default-off.",
   hero: {
     eyebrow: "Security Suite",
     heading: "WordPress security hardening and vulnerability scanning in one dashboard",

--- a/apps/marketing/lib/content/features/security.ts
+++ b/apps/marketing/lib/content/features/security.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const SECURITY_PAGE: FeaturePageData = {
   slug: "security",
   title: "WordPress Security Suite",
-  metaTitle: "WordPress Security Hardening and Vulnerability Scanner | WPMgr",
+  metaTitle: "WordPress Security Hardening and Vulnerability Scanner",
   metaDescription:
     "WordPress security hardening, IP bans, file integrity monitoring, vulnerability scanning via Wordfence Intelligence, site-user 2FA, and password policy. Open source, self-hostable, default-off.",
   hero: {

--- a/apps/marketing/lib/content/features/team-access.ts
+++ b/apps/marketing/lib/content/features/team-access.ts
@@ -8,7 +8,7 @@ export const TEAM_ACCESS_PAGE: FeaturePageData = {
   title: "WordPress Team Access Control and Audit Log",
   metaTitle: "WordPress Team Access Control with Audit Log",
   metaDescription:
-    "Four-role access control, per-site sharing, OIDC SSO, and a tamper-evident audit log for your WordPress fleet. Share one site without exposing the rest. Self-hosted and open source.",
+    "Four-role access control, per-site sharing, OIDC SSO, and a tamper-evident audit log for your WordPress fleet. Share one site without exposing the rest.",
   hero: {
     eyebrow: "Team and access",
     heading: "WordPress team access control with a tamper-evident audit log",

--- a/apps/marketing/lib/content/features/team-access.ts
+++ b/apps/marketing/lib/content/features/team-access.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const TEAM_ACCESS_PAGE: FeaturePageData = {
   slug: "team-access",
   title: "WordPress Team Access Control and Audit Log",
-  metaTitle: "WordPress Team Access Control with Audit Log | WPMgr",
+  metaTitle: "WordPress Team Access Control with Audit Log",
   metaDescription:
     "Four-role access control, per-site sharing, OIDC SSO, and a tamper-evident audit log for your WordPress fleet. Share one site without exposing the rest. Self-hosted and open source.",
   hero: {

--- a/apps/marketing/lib/content/features/two-factor-auth.ts
+++ b/apps/marketing/lib/content/features/two-factor-auth.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const TWO_FACTOR_AUTH_PAGE: FeaturePageData = {
   slug: "two-factor-auth",
   title: "WordPress Two-Factor Authentication",
-  metaTitle: "WordPress 2FA: TOTP and Email Code Authentication | WPMgr",
+  metaTitle: "WordPress 2FA: TOTP and Email Code Authentication",
   metaDescription:
     "Add WordPress two-factor authentication for site users with TOTP authenticator apps, email codes, and backup codes. Enforced per role, with grace logins and wp-config recovery so operators are never locked out.",
   hero: {

--- a/apps/marketing/lib/content/features/two-factor-auth.ts
+++ b/apps/marketing/lib/content/features/two-factor-auth.ts
@@ -8,7 +8,7 @@ export const TWO_FACTOR_AUTH_PAGE: FeaturePageData = {
   title: "WordPress Two-Factor Authentication",
   metaTitle: "WordPress 2FA: TOTP and Email Code Authentication",
   metaDescription:
-    "Add WordPress two-factor authentication for site users with TOTP authenticator apps, email codes, and backup codes. Enforced per role, with grace logins and wp-config recovery so operators are never locked out.",
+    "Add WordPress two-factor authentication for site users with TOTP apps, email codes, and backup codes. Enforced per role, with grace logins so operators are never locked out.",
   hero: {
     eyebrow: "Two-factor authentication",
     heading: "WordPress two-factor authentication for site users, enforced per role",

--- a/apps/marketing/lib/content/features/two-factor-auth.ts
+++ b/apps/marketing/lib/content/features/two-factor-auth.ts
@@ -8,7 +8,7 @@ export const TWO_FACTOR_AUTH_PAGE: FeaturePageData = {
   title: "WordPress Two-Factor Authentication",
   metaTitle: "WordPress 2FA: TOTP and Email Code Authentication",
   metaDescription:
-    "Add WordPress two-factor authentication for site users with TOTP apps, email codes, and backup codes. Enforced per role, with grace logins so operators are never locked out.",
+    "Add WordPress two-factor authentication for site users with TOTP apps, email codes, and backup codes. Enforced per role, with grace logins to avoid lockouts.",
   hero: {
     eyebrow: "Two-factor authentication",
     heading: "WordPress two-factor authentication for site users, enforced per role",

--- a/apps/marketing/lib/content/features/updates.ts
+++ b/apps/marketing/lib/content/features/updates.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const UPDATES_PAGE: FeaturePageData = {
   slug: "updates",
   title: "Safe Fleet Updates",
-  metaTitle: "Bulk Update WordPress Plugins Safely | WPMgr",
+  metaTitle: "Bulk Update WordPress Plugins Safely",
   metaDescription:
     "Bulk update WordPress plugins, themes, and core across your whole fleet safely. WPMgr auto-reverts on a failed health check, shows live per-site progress, and keeps the update history in a tamper-evident audit log.",
   hero: {

--- a/apps/marketing/lib/content/features/updates.ts
+++ b/apps/marketing/lib/content/features/updates.ts
@@ -8,7 +8,7 @@ export const UPDATES_PAGE: FeaturePageData = {
   title: "Safe Fleet Updates",
   metaTitle: "Bulk Update WordPress Plugins Safely",
   metaDescription:
-    "Bulk update WordPress plugins, themes, and core across your fleet safely. WPMgr auto-reverts on a failed health check and keeps history in a tamper-evident audit log.",
+    "Bulk update WordPress plugins, themes, and core across your fleet safely. WPMgr auto-reverts on a failed health check and logs a tamper-evident history.",
   hero: {
     eyebrow: "Fleet updates",
     heading: "Bulk update WordPress plugins safely with auto-revert",

--- a/apps/marketing/lib/content/features/updates.ts
+++ b/apps/marketing/lib/content/features/updates.ts
@@ -8,7 +8,7 @@ export const UPDATES_PAGE: FeaturePageData = {
   title: "Safe Fleet Updates",
   metaTitle: "Bulk Update WordPress Plugins Safely",
   metaDescription:
-    "Bulk update WordPress plugins, themes, and core across your whole fleet safely. WPMgr auto-reverts on a failed health check, shows live per-site progress, and keeps the update history in a tamper-evident audit log.",
+    "Bulk update WordPress plugins, themes, and core across your fleet safely. WPMgr auto-reverts on a failed health check and keeps history in a tamper-evident audit log.",
   hero: {
     eyebrow: "Fleet updates",
     heading: "Bulk update WordPress plugins safely with auto-revert",

--- a/apps/marketing/lib/content/features/uptime-monitoring.ts
+++ b/apps/marketing/lib/content/features/uptime-monitoring.ts
@@ -6,7 +6,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 export const UPTIME_MONITORING_PAGE: FeaturePageData = {
   slug: "uptime-monitoring",
   title: "WordPress Uptime Monitoring",
-  metaTitle: "WordPress Uptime Monitoring for Your Whole Fleet | WPMgr",
+  metaTitle: "WordPress Uptime Monitoring for Your Whole Fleet",
   metaDescription:
     "WordPress uptime monitoring with a fleet status matrix, response-time trends, TLS expiry warnings, and down-and-recovery alerts. Self-hosted and free to run.",
   hero: {

--- a/apps/marketing/lib/content/solutions/agencies.ts
+++ b/apps/marketing/lib/content/solutions/agencies.ts
@@ -9,7 +9,7 @@ export const AGENCIES_SOLUTION: SolutionPageData = {
   heading: "WordPress management for agencies",
   metaTitle: "WordPress Management for Agencies",
   metaDescription:
-    "WPMgr gives agencies a self-hosted control plane for every client's WordPress site. White-label reports, per-site email, team access control, and automated backups in one dashboard.",
+    "WPMgr gives agencies a self-hosted control plane for every client's WordPress site. White-label reports, per-site email, and automated backups in one dashboard.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Agency operations",

--- a/apps/marketing/lib/content/solutions/agencies.ts
+++ b/apps/marketing/lib/content/solutions/agencies.ts
@@ -7,7 +7,7 @@ export const AGENCIES_SOLUTION: SolutionPageData = {
   slug: "agencies",
   title: "For agencies",
   heading: "WordPress management for agencies",
-  metaTitle: "WordPress Management for Agencies | WPMgr",
+  metaTitle: "WordPress Management for Agencies",
   metaDescription:
     "WPMgr gives agencies a self-hosted control plane to manage every client's WordPress site from one dashboard. White-label reports, per-site email, team access control, and automated backups keep clients happy and margins intact.",
   layoutVariant: "default",

--- a/apps/marketing/lib/content/solutions/agencies.ts
+++ b/apps/marketing/lib/content/solutions/agencies.ts
@@ -9,7 +9,7 @@ export const AGENCIES_SOLUTION: SolutionPageData = {
   heading: "WordPress management for agencies",
   metaTitle: "WordPress Management for Agencies",
   metaDescription:
-    "WPMgr gives agencies a self-hosted control plane to manage every client's WordPress site from one dashboard. White-label reports, per-site email, team access control, and automated backups keep clients happy and margins intact.",
+    "WPMgr gives agencies a self-hosted control plane for every client's WordPress site. White-label reports, per-site email, team access control, and automated backups in one dashboard.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Agency operations",

--- a/apps/marketing/lib/content/solutions/freelancers.ts
+++ b/apps/marketing/lib/content/solutions/freelancers.ts
@@ -9,7 +9,7 @@ export const FREELANCERS_SOLUTION: SolutionPageData = {
   heading: "WordPress tools for freelancers",
   metaTitle: "WordPress Tools for Freelancers",
   metaDescription:
-    "WPMgr is a self-hosted WordPress management tool for freelancers running sites for multiple clients. Automated backups, safe bulk updates, uptime monitoring, and security hardening.",
+    "WPMgr is a self-hosted WordPress tool for freelancers running client sites: automated backups, safe bulk updates, uptime monitoring, and security hardening.",
   layoutVariant: "split",
   hero: {
     eyebrow: "Freelancer toolkit",

--- a/apps/marketing/lib/content/solutions/freelancers.ts
+++ b/apps/marketing/lib/content/solutions/freelancers.ts
@@ -7,7 +7,7 @@ export const FREELANCERS_SOLUTION: SolutionPageData = {
   slug: "freelancers",
   title: "For freelancers",
   heading: "WordPress tools for freelancers",
-  metaTitle: "WordPress Tools for Freelancers | WPMgr",
+  metaTitle: "WordPress Tools for Freelancers",
   metaDescription:
     "WPMgr is a self-hosted WordPress management tool built for freelancers who run sites for multiple clients. Automated backups, safe bulk updates, uptime monitoring, and security hardening from one open-source dashboard.",
   layoutVariant: "split",

--- a/apps/marketing/lib/content/solutions/freelancers.ts
+++ b/apps/marketing/lib/content/solutions/freelancers.ts
@@ -9,7 +9,7 @@ export const FREELANCERS_SOLUTION: SolutionPageData = {
   heading: "WordPress tools for freelancers",
   metaTitle: "WordPress Tools for Freelancers",
   metaDescription:
-    "WPMgr is a self-hosted WordPress management tool built for freelancers who run sites for multiple clients. Automated backups, safe bulk updates, uptime monitoring, and security hardening from one open-source dashboard.",
+    "WPMgr is a self-hosted WordPress management tool for freelancers running sites for multiple clients. Automated backups, safe bulk updates, uptime monitoring, and security hardening.",
   layoutVariant: "split",
   hero: {
     eyebrow: "Freelancer toolkit",

--- a/apps/marketing/lib/content/solutions/hosting-providers.ts
+++ b/apps/marketing/lib/content/solutions/hosting-providers.ts
@@ -9,7 +9,7 @@ export const HOSTING_PROVIDERS_SOLUTION: SolutionPageData = {
   heading: "Managed WordPress tooling for hosting providers",
   metaTitle: "Managed WordPress Tooling for Hosting Providers",
   metaDescription:
-    "WPMgr is open-source WordPress fleet management to embed in your hosting stack: security hardening, uptime monitoring, and team access, without building it yourself.",
+    "WPMgr is open-source WordPress fleet management to embed in your hosting stack: security hardening, uptime monitoring, and team access, already built.",
   layoutVariant: "compact",
   hero: {
     eyebrow: "Hosting integrations",

--- a/apps/marketing/lib/content/solutions/hosting-providers.ts
+++ b/apps/marketing/lib/content/solutions/hosting-providers.ts
@@ -7,7 +7,7 @@ export const HOSTING_PROVIDERS_SOLUTION: SolutionPageData = {
   slug: "hosting-providers",
   title: "For hosting providers",
   heading: "Managed WordPress tooling for hosting providers",
-  metaTitle: "Managed WordPress Tooling for Hosting Providers | WPMgr",
+  metaTitle: "Managed WordPress Tooling for Hosting Providers",
   metaDescription:
     "WPMgr is open-source WordPress fleet management you can embed into your hosting stack. Give your customers security hardening, uptime monitoring, and team access control without building the tooling yourself.",
   layoutVariant: "compact",

--- a/apps/marketing/lib/content/solutions/hosting-providers.ts
+++ b/apps/marketing/lib/content/solutions/hosting-providers.ts
@@ -9,7 +9,7 @@ export const HOSTING_PROVIDERS_SOLUTION: SolutionPageData = {
   heading: "Managed WordPress tooling for hosting providers",
   metaTitle: "Managed WordPress Tooling for Hosting Providers",
   metaDescription:
-    "WPMgr is open-source WordPress fleet management you can embed into your hosting stack. Give your customers security hardening, uptime monitoring, and team access control without building the tooling yourself.",
+    "WPMgr is open-source WordPress fleet management to embed in your hosting stack: security hardening, uptime monitoring, and team access, without building it yourself.",
   layoutVariant: "compact",
   hero: {
     eyebrow: "Hosting integrations",

--- a/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
+++ b/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
@@ -9,7 +9,7 @@ export const MANAGE_MULTIPLE_SITES_SOLUTION: SolutionPageData = {
   heading: "Manage multiple WordPress sites from one dashboard",
   metaTitle: "Manage Multiple WordPress Sites",
   metaDescription:
-    "WPMgr is the open-source control plane for managing multiple WordPress sites. Backups, safe bulk updates, uptime monitoring, performance, security, database cleanup, and team access from a single self-hosted dashboard. No per-site fee.",
+    "WPMgr is the open-source control plane for managing multiple WordPress sites: backups, safe bulk updates, uptime monitoring, performance, and security in one dashboard.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Fleet management",

--- a/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
+++ b/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
@@ -7,7 +7,7 @@ export const MANAGE_MULTIPLE_SITES_SOLUTION: SolutionPageData = {
   slug: "manage-multiple-sites",
   title: "Manage multiple sites",
   heading: "Manage multiple WordPress sites from one dashboard",
-  metaTitle: "Manage Multiple WordPress Sites | WPMgr",
+  metaTitle: "Manage Multiple WordPress Sites",
   metaDescription:
     "WPMgr is the open-source control plane for managing multiple WordPress sites. Backups, safe bulk updates, uptime monitoring, performance, security, database cleanup, and team access from a single self-hosted dashboard. No per-site fee.",
   layoutVariant: "default",

--- a/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
+++ b/apps/marketing/lib/content/solutions/manage-multiple-sites.ts
@@ -9,7 +9,7 @@ export const MANAGE_MULTIPLE_SITES_SOLUTION: SolutionPageData = {
   heading: "Manage multiple WordPress sites from one dashboard",
   metaTitle: "Manage Multiple WordPress Sites",
   metaDescription:
-    "WPMgr is the open-source control plane for managing multiple WordPress sites: backups, safe bulk updates, uptime monitoring, performance, and security in one dashboard.",
+    "WPMgr is the open-source control plane for managing multiple WordPress sites: backups, safe bulk updates, uptime monitoring, and security in one dashboard.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Fleet management",

--- a/apps/marketing/lib/content/solutions/wordpress-backups.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-backups.ts
@@ -9,7 +9,7 @@ export const WORDPRESS_BACKUPS_SOLUTION: SolutionPageData = {
   heading: "WordPress backup built for fleets",
   metaTitle: "WordPress Backup",
   metaDescription:
-    "WPMgr provides self-hosted incremental WordPress backups with point-in-time restore, fleet-wide backup health, and database cleanup. Free, open-source, no per-site fee.",
+    "WPMgr provides self-hosted incremental WordPress backups with point-in-time restore, fleet-wide backup health, and database cleanup, at no per-site fee.",
   layoutVariant: "split",
   hero: {
     eyebrow: "Backups and restore",

--- a/apps/marketing/lib/content/solutions/wordpress-backups.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-backups.ts
@@ -7,7 +7,7 @@ export const WORDPRESS_BACKUPS_SOLUTION: SolutionPageData = {
   slug: "wordpress-backups",
   title: "WordPress backups",
   heading: "WordPress backup built for fleets",
-  metaTitle: "WordPress Backup | WPMgr",
+  metaTitle: "WordPress Backup",
   metaDescription:
     "WPMgr provides self-hosted incremental WordPress backups with point-in-time restore, fleet-wide backup health, and database cleanup. Free, open-source, no per-site fee.",
   layoutVariant: "split",

--- a/apps/marketing/lib/content/solutions/wordpress-performance.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-performance.ts
@@ -9,7 +9,7 @@ export const WORDPRESS_PERFORMANCE_SOLUTION: SolutionPageData = {
   heading: "Speed up WordPress and improve Core Web Vitals",
   metaTitle: "Speed Up WordPress and Improve Core Web Vitals",
   metaDescription:
-    "WPMgr accelerates WordPress with full-page caching, Redis object cache, AVIF and WebP image conversion via the Media Optimizer, Real User Monitoring, and unused CSS removal. Open-source, self-hosted, no per-site fee.",
+    "WPMgr speeds up WordPress with full-page caching, Redis object cache, AVIF/WebP conversion, Real User Monitoring, and unused CSS removal. Open-source, self-hosted, no per-site fee.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Performance suite",

--- a/apps/marketing/lib/content/solutions/wordpress-performance.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-performance.ts
@@ -9,7 +9,7 @@ export const WORDPRESS_PERFORMANCE_SOLUTION: SolutionPageData = {
   heading: "Speed up WordPress and improve Core Web Vitals",
   metaTitle: "Speed Up WordPress and Improve Core Web Vitals",
   metaDescription:
-    "WPMgr speeds up WordPress with full-page caching, Redis object cache, AVIF/WebP conversion, Real User Monitoring, and unused CSS removal. Open-source, self-hosted, no per-site fee.",
+    "WPMgr speeds up WordPress with full-page caching, Redis object cache, AVIF/WebP conversion, and Real User Monitoring. Open-source, self-hosted, no per-site fee.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Performance suite",

--- a/apps/marketing/lib/content/solutions/wordpress-performance.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-performance.ts
@@ -7,7 +7,7 @@ export const WORDPRESS_PERFORMANCE_SOLUTION: SolutionPageData = {
   slug: "wordpress-performance",
   title: "WordPress performance",
   heading: "Speed up WordPress and improve Core Web Vitals",
-  metaTitle: "Speed Up WordPress and Improve Core Web Vitals | WPMgr",
+  metaTitle: "Speed Up WordPress and Improve Core Web Vitals",
   metaDescription:
     "WPMgr accelerates WordPress with full-page caching, Redis object cache, AVIF and WebP image conversion via the Media Optimizer, Real User Monitoring, and unused CSS removal. Open-source, self-hosted, no per-site fee.",
   layoutVariant: "default",

--- a/apps/marketing/lib/content/solutions/wordpress-security.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-security.ts
@@ -9,7 +9,7 @@ export const WORDPRESS_SECURITY_SOLUTION: SolutionPageData = {
   heading: "WordPress security for your whole fleet",
   metaTitle: "WordPress Security",
   metaDescription:
-    "WPMgr delivers fleet-wide WordPress security hardening, vulnerability scanning via Wordfence Intelligence, file integrity monitoring, two-factor authentication, and IP ban lists from a single self-hosted dashboard.",
+    "WPMgr delivers fleet-wide WordPress security hardening, vulnerability scanning, file integrity monitoring, two-factor authentication, and IP ban lists from one dashboard.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Security suite",

--- a/apps/marketing/lib/content/solutions/wordpress-security.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-security.ts
@@ -7,7 +7,7 @@ export const WORDPRESS_SECURITY_SOLUTION: SolutionPageData = {
   slug: "wordpress-security",
   title: "WordPress security",
   heading: "WordPress security for your whole fleet",
-  metaTitle: "WordPress Security | WPMgr",
+  metaTitle: "WordPress Security",
   metaDescription:
     "WPMgr delivers fleet-wide WordPress security hardening, vulnerability scanning via Wordfence Intelligence, file integrity monitoring, two-factor authentication, and IP ban lists from a single self-hosted dashboard.",
   layoutVariant: "default",

--- a/apps/marketing/lib/content/solutions/wordpress-security.ts
+++ b/apps/marketing/lib/content/solutions/wordpress-security.ts
@@ -9,7 +9,7 @@ export const WORDPRESS_SECURITY_SOLUTION: SolutionPageData = {
   heading: "WordPress security for your whole fleet",
   metaTitle: "WordPress Security",
   metaDescription:
-    "WPMgr delivers fleet-wide WordPress security hardening, vulnerability scanning, file integrity monitoring, two-factor authentication, and IP ban lists from one dashboard.",
+    "WPMgr delivers fleet-wide WordPress security hardening, vulnerability scanning, file integrity monitoring, and two-factor authentication from one dashboard.",
   layoutVariant: "default",
   hero: {
     eyebrow: "Security suite",

--- a/apps/marketing/lib/seo.ts
+++ b/apps/marketing/lib/seo.ts
@@ -42,12 +42,23 @@ export function buildMetadata({
     ? `${SITE_CONFIG.baseUrl}${canonical}`
     : SITE_CONFIG.baseUrl;
 
+  // `app/layout.tsx` brands the document <title> via `title.template`
+  // ("%s · WPMgr"), applied once by Next's metadata resolution. That template
+  // does NOT reach openGraph.title or twitter.title -- those are separate,
+  // explicit fields, so a page whose own `title` carries no brand shares to
+  // social with no brand at all. Callers that already build their own branded
+  // title (e.g. "... | WPMgr") are left untouched here so the brand does not
+  // appear twice.
+  const socialTitle = title.includes(SITE_CONFIG.name)
+    ? title
+    : `${title} · ${SITE_CONFIG.name}`;
+
   return {
     title,
     description,
     alternates: { canonical: url },
     openGraph: {
-      title,
+      title: socialTitle,
       description,
       url,
       siteName: SITE_CONFIG.name,
@@ -78,7 +89,7 @@ export function buildMetadata({
     },
     twitter: {
       card: "summary_large_image",
-      title,
+      title: socialTitle,
       description,
       images: ogImage ? [ogImage] : [`${SITE_CONFIG.baseUrl}/opengraph-image`],
     },

--- a/apps/marketing/lib/site.ts
+++ b/apps/marketing/lib/site.ts
@@ -45,6 +45,29 @@ export function signupHref(source: SignupSource, extra?: Record<string, string>)
   return url.toString();
 }
 
+const FIRST_PARTY_HOSTS = new Set(["wpmgr.app", "manage.wpmgr.app"]);
+
+/**
+ * The `rel` value for a `target="_blank"` anchor, based on the link's
+ * destination host.
+ *
+ * `noopener` is always included: it is a security property (it stops the
+ * opened tab reaching back via `window.opener`) and has nothing to do with
+ * analytics. `noreferrer` additionally suppresses the `Referer` header, which
+ * is only correct for a genuinely external destination. Applying it to our
+ * own dashboard (manage.wpmgr.app) strips the referrer from a first-party
+ * navigation, e.g. a signup click, for no security benefit.
+ */
+export function newTabRel(href: string): string {
+  let host: string;
+  try {
+    host = new URL(href, SITE_CONFIG.baseUrl).hostname;
+  } catch {
+    return "noreferrer noopener";
+  }
+  return FIRST_PARTY_HOSTS.has(host) ? "noopener" : "noreferrer noopener";
+}
+
 export type NavItem = {
   label: string;
   href: string;


### PR DESCRIPTION
## Summary

Four items from the SEO Tier 1 audit, each verified against a build and re-measured rather than trusted from the audit (one count had already drifted).

- **1.3** — `target="_blank" rel="noreferrer noopener"` was applied to any absolute-URL href, including first-party links to `manage.wpmgr.app` (signup/dashboard). `noreferrer` suppresses the `Referer` header, so those clicks lost attribution beyond the `?ref=` param. Added `newTabRel(href)` in `lib/site.ts`: `noopener` alone for `wpmgr.app`/`manage.wpmgr.app`, `noreferrer noopener` for everything else. Wired into all 12 call sites (6 named by the audit, 6 more found by grepping the same pattern).
- **1.7** — `app/sitemap.ts` emitted `priority` and `changeFrequency`, which Google's sitemap docs state are ignored. Removed both from every entry across all six route groups. `lastModified` logic (already correct) is untouched.
- **1.10** — `app/layout.tsx`'s `template: "%s · WPMgr"` combined with pages that also appended `| WPMgr` to render e.g. `Pricing | WPMgr · WPMgr`. Fixed 21 content files and 6 page files (audit said 4 page files; actual count is 6 — `features`, `solutions`, `pricing`, `privacy`, `terms`, `refunds`). `app/docs/route.ts` is untouched: it returns a raw HTML `Response` outside the layout template, so no duplication applies there.
- **1.11** — meta descriptions were measured against built output (not source, to get ground truth) and trimmed to 140-160 chars, leading with the differentiator. Audit said 29 exceeded target; actual count was 42 (26 after fixing most, before a final precision pass caught 24 that were still 161-184 after eyeballed cuts). 40 real pages fixed. `/pricing/plugin-stack` is explicitly untouched (owned by another in-flight branch) — its description is 217 chars, unchanged.

## Verification

**1.3 — noopener survives on external links, noreferrer removed only on first-party:**
```
$ node check_noopener.mjs   # scans built HTML for every target=_blank anchor to a non-wpmgr host
external target=_blank anchors checked: 577
distinct external hosts: github.com, wordpress.org, wordfence.com, ... (21 hosts)
missing noopener: 0

$ node check_noreferrer.mjs # scans built HTML for any manage.wpmgr.app link still carrying noreferrer
/pricing/plugin-stack.html https://manage.wpmgr.app/register?ref=plugin-stack noreferrer noopener
total first-party links still carrying noreferrer: 1   # exactly the untouched, out-of-scope file
```

**1.7 — sitemap before/after:**
```
$ curl -s https://wpmgr.app/sitemap.xml | grep -c '<priority>\|<changefreq>'
114   # 57 URLs x 2 fields, live today
```
After: `grep -c` on built `sitemap.xml` output returns 0 for both.

**1.10 — built title output, single suffix, no bare template:**
```
<title>Pricing · WPMgr</title>
<title>WordPress Backup Plugin with Incremental Backups · WPMgr</title>
<title>What a premium WordPress plugin stack costs per year | WPMgr · WPMgr</title>  # plugin-stack, untouched control
```
Swept all built `<title>` tags for a bare `· WPMgr` (nothing before the separator): zero matches.

**1.11 — before/after against built HTML, ground truth via `<meta name="description">`:**
```
total routes with meta description: 59
over 160: 2   (only /_not-found, not indexed, and /pricing/plugin-stack, untouched)
in [140,160]: 48
```

## Test plan

- [x] `pnpm -C apps/marketing typecheck` — clean
- [x] `pnpm -C apps/marketing build` — succeeds, 91 pages generated
- [x] `pnpm --filter @wpmgr/marketing check-copy` — passes (no em/en dashes, no competitor names)
- [x] `impeccable detect` on touched dirs — 1 finding, pre-existing (`cost-model.tsx:120`, layout-transition on `width`), not touched by this PR, confirmed via `git diff main..HEAD` on that file
- [ ] Reviewer: confirm `/pricing/plugin-stack` merge conflict risk with the other in-flight branch touching that file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content & SEO**
  * Refined page titles and descriptions across marketing, feature, solution, legal, and blog pages for clearer, more concise messaging.
  * Updated descriptions to better reflect current capabilities, licensing, pricing, security, privacy, and backup information.
  * Simplified sitemap URLs and removed outdated priority and update-frequency metadata while retaining content update dates.

* **Security & Usability**
  * Standardized secure handling for links that open in new tabs across signup and call-to-action areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->