### PR TITLE
feat(auth): require the provisioning claim for first-run ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The script downloads every file the stack needs, generates all secrets, and prin
 - **Four-role RBAC**: `owner > admin > operator > viewer` with a discrete permission matrix. Privilege ceiling prevents granting a role higher than your own.
 - **Per-site collaborator sharing**: Outside users (no org membership) scoped to one site, enforced by both Gin middleware and RESTRICTIVE RLS. Blocked from all org-level actions.
 - **Tokenized invitations**: Single-use, 7-day-expiry SHA-256-hashed tokens bound to the invited email. Existing accounts must re-authenticate; a leaked link alone cannot log anyone in.
-- **Email/password auth with first-run bootstrap**: argon2id hashing; the first signup bootstraps the owner account as verified and active. After that, anyone can self-register, but new accounts are created pending and gain access only after clicking the emailed verification link. Login responses never reveal whether an email exists.
+- **Email/password auth with a provisioning claim on first run**: argon2id hashing; claiming the first, owner account requires the self-host provisioning secret (`WPMGR_BOOTSTRAP_CLAIM_SECRET`), presented as a request header — the dashboard Sign Up form alone cannot create it. Once the install has an owner, anyone can self-register, but new accounts are created pending and gain access only after clicking the emailed verification link. Login responses never reveal whether an email exists. See [Quickstart](#quickstart-self-host) for claiming a fresh install.
 - **Self-serve password reset**: Public forgot-password + reset endpoints issue a 30-minute single-use SHA-256-hashed token. Both endpoints are enumeration-safe (always-200, timing-equalized).
 - **Change-password with session invalidation**: Verifies the current password then stamps `password_changed_at`, which logs out all other active sessions on their next request while keeping the acting session alive.
 - **UI-configured per-instance SMTP**: Owners configure the instance SMTP relay (host/port/TLS/credentials/From) in Settings. The password is age-encrypted at rest, masked on read. A test-send button confirms delivery before saving.
@@ -284,7 +284,7 @@ docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -
 curl localhost:8081/healthz   # {"status":"ok"}
 ```
 
-Open `http://localhost:8088` in your browser; the first signup creates the owner account.
+The script also generates a provisioning secret (`WPMGR_BOOTSTRAP_CLAIM_SECRET`) and prints the exact command to claim ownership of the install — the dashboard Sign Up form cannot create the first account by itself, since the claim only travels as a request header. Run the printed command once, then open `http://localhost:8088` in your browser and log in. Full detail, including the upgrade case: [docs/install.md](./docs/install.md#first-run-notes).
 
 `WPMGR_S3_ENDPOINT` in the generated `.env` must be reachable by your WordPress hosts, not just the control plane. The default (`http://seaweedfs:8333`) only resolves inside Docker; for remote WordPress sites, point it at a tunnel or public URL.
 
@@ -295,13 +295,12 @@ See [docs/requirements.md](./docs/requirements.md) for CPU, RAM, and disk sizing
 If you have cloned the repo, the bundled compose brings up the full stack (control plane, dashboard, Postgres, Redis, object storage, and the media encoder for screenshots and the Media Optimizer), building all three images from source:
 
 ```bash
-cp .env.example .env
-# Edit .env: at minimum set WPMGR_SESSION_SECRET, WPMGR_DB_PASSWORD, WPMGR_S3_SECRET_KEY
+./scripts/init-env.sh   # or: make quickstart — writes .env and generates every required secret
 docker compose -f infra/docker-compose.yml up -d
 curl localhost:8081/healthz   # {"status":"ok"}   (default WPMGR_API_PORT=8081)
 ```
 
-Open `http://localhost:8088` in your browser (the default `WPMGR_WEB_PORT`); the first signup creates the owner account. After that, anyone can self-register and gains access only after verifying their email.
+The script prints the exact command to claim ownership of the install, using the provisioning secret (`WPMGR_BOOTSTRAP_CLAIM_SECRET`) it generated — run that once; the dashboard Sign Up form cannot create the first account by itself. Then open `http://localhost:8088` in your browser (the default `WPMGR_WEB_PORT`) and log in. Once the install has an owner, anyone can self-register and gains access only after verifying their email. Full detail, including the upgrade case: [docs/install.md](./docs/install.md#first-run-notes).
 
 The media encoder runs headless Chromium for screenshots, so it adds some RAM/CPU over the api/web images. On a constrained host you can skip it without editing the compose file:
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -
 curl localhost:8081/healthz   # {"status":"ok"}
 ```
 
-The script also generates a provisioning secret (`WPMGR_BOOTSTRAP_CLAIM_SECRET`) and prints the exact command to claim ownership of the install — the dashboard Sign Up form cannot create the first account by itself, since the claim only travels as a request header. Run the printed command once, then open `http://localhost:8088` in your browser and log in. Full detail, including the upgrade case: [docs/install.md](./docs/install.md#first-run-notes).
+The script also generates a provisioning secret (`WPMGR_BOOTSTRAP_CLAIM_SECRET`) and prints the exact command to claim ownership of the install — the dashboard Sign Up form cannot create the first account by itself, since the claim only travels as a request header. That command reads the secret out of `.env` itself, so you never look it up or paste it; run the printed command once, then open `http://localhost:8088` in your browser and log in. Full detail, including the upgrade case: [docs/install.md](./docs/install.md#first-run-notes).
 
 `WPMGR_S3_ENDPOINT` in the generated `.env` must be reachable by your WordPress hosts, not just the control plane. The default (`http://seaweedfs:8333`) only resolves inside Docker; for remote WordPress sites, point it at a tunnel or public URL.
 
@@ -300,7 +300,7 @@ docker compose -f infra/docker-compose.yml up -d
 curl localhost:8081/healthz   # {"status":"ok"}   (default WPMGR_API_PORT=8081)
 ```
 
-The script prints the exact command to claim ownership of the install, using the provisioning secret (`WPMGR_BOOTSTRAP_CLAIM_SECRET`) it generated — run that once; the dashboard Sign Up form cannot create the first account by itself. Then open `http://localhost:8088` in your browser (the default `WPMGR_WEB_PORT`) and log in. Once the install has an owner, anyone can self-register and gains access only after verifying their email. Full detail, including the upgrade case: [docs/install.md](./docs/install.md#first-run-notes).
+The script prints the exact command to claim ownership of the install, reading the provisioning secret (`WPMGR_BOOTSTRAP_CLAIM_SECRET`) it generated straight out of `.env` — you never look it up or paste it. Run that command once; the dashboard Sign Up form cannot create the first account by itself. Then open `http://localhost:8088` in your browser (the default `WPMGR_WEB_PORT`) and log in. Once the install has an owner, anyone can self-register and gains access only after verifying their email. Full detail, including the upgrade case: [docs/install.md](./docs/install.md#first-run-notes).
 
 The media encoder runs headless Chromium for screenshots, so it adds some RAM/CPU over the api/web images. On a constrained host you can skip it without editing the compose file:
 

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -2677,6 +2677,18 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	waFactor := twofactor.NewWebAuthnFactor(waInstance)
 	authSvc.SetTwoFactorDeps(totpFactor, waFactor, siteDestAgeID)
 
+	// First-run ownership requires the provisioning claim the installer minted.
+	// Unset is a valid, deliberate state — every route still serves; the
+	// install simply has no route to a first owner until the operator sets the
+	// variable and restarts — so this is a warning at boot, not a fatal, and
+	// the operator hears about it once here rather than only on a refused
+	// request. The value itself is never logged.
+	authSvc.SetBootstrapClaimSecret(cfg.Auth.BootstrapClaimSecret)
+	if !authSvc.BootstrapClaimConfigured() {
+		logger.Warn("no provisioning claim configured: first-run ownership cannot be claimed on this install",
+			"remedy", "set "+auth.BootstrapClaimEnvVar+" to a random secret and restart")
+	}
+
 	authH := auth.NewHandler(authSvc, sessions, oidcProvider, newTenant)
 	authH.SetSocialProviders(socialProviders)
 	// Social sign-in is the one auth path whose outcome a third party decides,

--- a/apps/api/internal/auth/bootstrap_claim.go
+++ b/apps/api/internal/auth/bootstrap_claim.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"crypto/subtle"
+	"strings"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// BootstrapClaimHeader is the HTTP header an installer uses to present the
+// provisioning claim on POST /auth/register. The body field `claim_secret` is
+// the equivalent carrier for a form-driven first run; both reach the same
+// constant-time comparison.
+const BootstrapClaimHeader = "X-Wpmgr-Bootstrap-Claim"
+
+// BootstrapClaimEnvVar is the operator-facing name of the provisioning claim.
+// It appears ONLY in operator guidance written to the server log — never in a
+// response, so that the guidance cannot double as a probe.
+const BootstrapClaimEnvVar = "WPMGR_BOOTSTRAP_CLAIM_SECRET"
+
+// errRegistrationClosed is the single refusal this path ever returns.
+//
+// EVERY REFUSAL IS THIS ONE. Whether the install is already owned, has no claim
+// configured, or was handed the wrong claim, the caller receives the same
+// status, the same code and the same message. Three distinguishable answers
+// would let an unauthenticated caller sort installs into "already owned" and
+// "waiting to be owned", which is the one bit of state that decides whether the
+// endpoint is worth attacking at all. The operator gets the detail, in the log,
+// where the operator is the only reader.
+func errRegistrationClosed() error {
+	return domain.Forbidden("registration_closed", "open registration is closed; ask a tenant owner or admin for an invitation")
+}
+
+// SetBootstrapClaimSecret installs the provisioning claim that first-run
+// ownership requires. Wired from cfg.Auth.BootstrapClaimSecret at startup.
+//
+// Whitespace is trimmed because the value routinely arrives through a shell, a
+// .env file or a compose file, all of which are good at attaching a trailing
+// newline that nobody can see. An all-whitespace value trims to empty and is
+// therefore treated exactly like an unset one: no claim is configured, and
+// nothing can be claimed.
+func (s *Service) SetBootstrapClaimSecret(secret string) {
+	s.bootstrapClaim = strings.TrimSpace(secret)
+}
+
+// bootstrapClaimAccepted reports whether presented is the configured
+// provisioning claim.
+//
+// It fails closed on an unconfigured claim. An empty configured value returns
+// false for every input INCLUDING an empty one, so "no secret set" can never
+// be satisfied by "no secret sent" — that equality is precisely how a
+// fail-closed check turns itself into an open door.
+//
+// The length is compared first so the constant-time compare only ever runs on
+// equal-length inputs (ConstantTimeCompare returns 0 immediately on a length
+// mismatch, which leaks length either way; making it explicit keeps the
+// intent legible). Neither value is logged, echoed or recorded.
+func (s *Service) bootstrapClaimAccepted(presented string) bool {
+	want := s.bootstrapClaim
+	if want == "" {
+		return false
+	}
+	got := strings.TrimSpace(presented)
+	if len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+// BootstrapClaimConfigured reports whether this install has a provisioning
+// claim at all. It is the operator-facing signal used to log actionable startup
+// and refusal guidance; it is never surfaced on an HTTP response.
+func (s *Service) BootstrapClaimConfigured() bool { return s.bootstrapClaim != "" }

--- a/apps/api/internal/auth/bootstrap_claim.go
+++ b/apps/api/internal/auth/bootstrap_claim.go
@@ -7,10 +7,11 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
-// BootstrapClaimHeader is the HTTP header an installer uses to present the
-// provisioning claim on POST /auth/register. The body field `claim_secret` is
-// the equivalent carrier for a form-driven first run; both reach the same
-// constant-time comparison.
+// BootstrapClaimHeader is the one way an installer presents the provisioning
+// claim on POST /auth/register. A header rather than a body field: the claim is
+// a credential, not user data, and this keeps it out of the request payload
+// that validation errors and request logs echo, and out of the OpenAPI request
+// schema so no generated client offers to fill it in.
 const BootstrapClaimHeader = "X-Wpmgr-Bootstrap-Claim"
 
 // BootstrapClaimEnvVar is the operator-facing name of the provisioning claim.

--- a/apps/api/internal/auth/bootstrap_claim.go
+++ b/apps/api/internal/auth/bootstrap_claim.go
@@ -26,8 +26,17 @@ const BootstrapClaimEnvVar = "WPMGR_BOOTSTRAP_CLAIM_SECRET"
 // status, the same code and the same message. Three distinguishable answers
 // would let an unauthenticated caller sort installs into "already owned" and
 // "waiting to be owned", which is the one bit of state that decides whether the
-// endpoint is worth attacking at all. The operator gets the detail, in the log,
+// endpoint is worth probing at all. The operator gets the detail, in the log,
 // where the operator is the only reader.
+//
+// THE BYTES ARE ONLY HALF OF IT. A response that is identical in content and
+// different in duration is still two answers, and this path had two large
+// timing differences before they were measured: skipping argon2 on a wrong
+// claim, and skipping the whole self-serve body on an unclaimed install. Both
+// callers therefore do their expensive work unconditionally, before the outcome
+// is chosen — see Service.Bootstrap and Service.RegisterSelfServe. Any change
+// that adds an early return ahead of that work reopens the difference, so
+// measure before assuming this comment is still true.
 func errRegistrationClosed() error {
 	return domain.Forbidden("registration_closed", "open registration is closed; ask a tenant owner or admin for an invitation")
 }

--- a/apps/api/internal/auth/bootstrap_repo.go
+++ b/apps/api/internal/auth/bootstrap_repo.go
@@ -62,6 +62,47 @@ func (r *Repo) OwnershipEstablished(ctx context.Context) (bool, error) {
 	return exists, nil
 }
 
+// OwnershipEstablishedInTx answers the ownership question inside a transaction
+// the caller already holds, and hands back the scope it borrowed to do so.
+//
+// It exists because the answer has to be read in the SAME transaction that acts
+// on it — the one holding the install lock — and the cross-tenant read needs
+// app.agent, which InAgentTx would only set on a transaction of its own. A
+// second transaction would put the check back outside the critical section,
+// which is the shape the lock exists to prevent.
+//
+// THE GUC IS RESET BEFORE THIS FUNCTION RETURNS, and that reset is the point of
+// the function rather than a tidy-up. set_config(..., true) is TRANSACTION-local,
+// not statement-local: left on, it stays on for every later statement in the
+// caller's transaction, and app.agent is the widest scope in this schema —
+// dozens of policies grant cross-tenant write on `current_setting('app.agent',
+// true) = 'on'` alone. Borrowing it for one read and handing it back keeps the
+// writes that follow under the tenant scope they are supposed to be under, and
+// keeps the borrow auditable in one place instead of spread across a caller.
+//
+// The reset runs whether or not the read succeeded. Returning an error with the
+// scope still elevated would be the worst of both.
+func OwnershipEstablishedInTx(ctx context.Context, tx pgx.Tx) (bool, error) {
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.agent', 'on', true)"); err != nil {
+		return false, domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(err)
+	}
+
+	var owned bool
+	readErr := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM memberships WHERE role = $1)`,
+		string(authz.RoleOwner),
+	).Scan(&owned)
+
+	// Reset first, report second.
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.agent', '', true)"); err != nil {
+		return false, domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(err)
+	}
+	if readErr != nil {
+		return false, domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(readErr)
+	}
+	return owned, nil
+}
+
 // BootstrapInstall creates the install's first tenant, its first user and the
 // owner membership binding them, as ONE transaction under
 // InstallBootstrapLockKey.
@@ -104,22 +145,9 @@ func (r *Repo) BootstrapInstall(
 		// never whether a user row does — so nothing that merely creates an
 		// account can close this door on the person holding the claim.
 		//
-		// app.agent is set for this one statement rather than by InAgentTx,
-		// because the read has to happen in THIS transaction (the one holding
-		// the lock) and a second transaction would put the check back outside
-		// the critical section, which is the shape the lock exists to prevent.
-		// It is scoped to the transaction, so it lapses at COMMIT or ROLLBACK
-		// alongside the lock; the membership INSERT below still runs under
-		// app.tenant_id and its own tenant policy.
-		if _, err := tx.Exec(ctx, "SELECT set_config('app.agent', 'on', true)"); err != nil {
-			return domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(err)
-		}
-		var owned bool
-		if err := tx.QueryRow(ctx,
-			`SELECT EXISTS (SELECT 1 FROM memberships WHERE role = $1)`,
-			string(authz.RoleOwner),
-		).Scan(&owned); err != nil {
-			return domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(err)
+		owned, err := OwnershipEstablishedInTx(ctx, tx)
+		if err != nil {
+			return err
 		}
 		if owned {
 			return errRegistrationClosed()

--- a/apps/api/internal/auth/bootstrap_repo.go
+++ b/apps/api/internal/auth/bootstrap_repo.go
@@ -26,6 +26,42 @@ import (
 // to name, and it guards a different invariant to either of theirs.
 const InstallBootstrapLockKey = "install_bootstrap"
 
+// OwnershipEstablished reports whether ANY owner membership exists on this
+// install, across every tenant.
+//
+// IT REPLACES A USER COUNT, AND THAT SUBSTITUTION WAS THE DEFECT. "Has this
+// install been claimed?" is a question about ownership, and a user row is not
+// ownership. Any path that can create a user — a social sign-in creates one
+// from a provider handshake alone — would otherwise flip the install out of
+// "unclaimed" without anybody owning it, and every gate downstream then reads
+// the wrong answer: first-run ownership refuses the operator's correct claim
+// forever, and self-serve opens on an install that has no owner. Asking for the
+// property directly is the only version that cannot be flipped by creating
+// something that is not an owner.
+//
+// RLS: memberships is FORCE ROW LEVEL SECURITY and this read spans every
+// tenant, so it runs under InAgentTx and the memberships_agent policy — the
+// SELECT-only cross-tenant scope the schema already provides for exactly this
+// kind of backend-only question. No tenant scope could serve instead: at the
+// moment the question matters there may be no tenant at all.
+//
+// It has no "unknown" answer of its own, so each caller decides what an error
+// means for it. Both treat an unreadable answer as "claimed", which refuses
+// rather than grants.
+func (r *Repo) OwnershipEstablished(ctx context.Context) (bool, error) {
+	var exists bool
+	err := r.pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM memberships WHERE role = $1)`,
+			string(authz.RoleOwner),
+		).Scan(&exists)
+	})
+	if err != nil {
+		return false, domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(err)
+	}
+	return exists, nil
+}
+
 // BootstrapInstall creates the install's first tenant, its first user and the
 // owner membership binding them, as ONE transaction under
 // InstallBootstrapLockKey.
@@ -62,11 +98,30 @@ func (r *Repo) BootstrapInstall(
 	err := r.pool.InInstallLockTx(ctx, InstallBootstrapLockKey, func(tx pgx.Tx, scopeTenant func(uuid.UUID) error) error {
 		q := sqlc.New(tx)
 
-		count, err := q.CountUsers(ctx)
-		if err != nil {
-			return domain.Internal("user_count_failed", "failed to count users").WithCause(err)
+		// OWNERSHIP, NOT POPULATION. Read inside the locked transaction that
+		// will perform the writes, so the second caller does not read until the
+		// first has committed. It asks whether an owner membership exists —
+		// never whether a user row does — so nothing that merely creates an
+		// account can close this door on the person holding the claim.
+		//
+		// app.agent is set for this one statement rather than by InAgentTx,
+		// because the read has to happen in THIS transaction (the one holding
+		// the lock) and a second transaction would put the check back outside
+		// the critical section, which is the shape the lock exists to prevent.
+		// It is scoped to the transaction, so it lapses at COMMIT or ROLLBACK
+		// alongside the lock; the membership INSERT below still runs under
+		// app.tenant_id and its own tenant policy.
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.agent', 'on', true)"); err != nil {
+			return domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(err)
 		}
-		if count > 0 {
+		var owned bool
+		if err := tx.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM memberships WHERE role = $1)`,
+			string(authz.RoleOwner),
+		).Scan(&owned); err != nil {
+			return domain.Internal("ownership_probe_failed", "failed to determine install ownership").WithCause(err)
+		}
+		if owned {
 			return errRegistrationClosed()
 		}
 

--- a/apps/api/internal/auth/bootstrap_repo.go
+++ b/apps/api/internal/auth/bootstrap_repo.go
@@ -1,0 +1,163 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// InstallBootstrapLockKey namespaces the install-wide advisory lock that
+// serialises first-run ownership. Same shape as MemberRolesLockKey and
+// org.LifecycleLockKey — pg_advisory_xact_lock, released by COMMIT or ROLLBACK,
+// so it can never leak — but keyed on the install rather than on a tenant,
+// because the whole point of the critical section is that no tenant exists yet.
+//
+// A DIFFERENT namespace to org_member_roles and org_lifecycle on purpose: this
+// lock is taken exactly once in an install's life, by a path that has no tenant
+// to name, and it guards a different invariant to either of theirs.
+const InstallBootstrapLockKey = "install_bootstrap"
+
+// BootstrapInstall creates the install's first tenant, its first user and the
+// owner membership binding them, as ONE transaction under
+// InstallBootstrapLockKey.
+//
+// THE COUNT AND THE CREATE ARE INSEPARABLE. Read "are there zero users?" in one
+// statement and act on it in the next, and two callers both read zero and both
+// act: two organisations, two owners, and an install whose ownership is decided
+// by whichever request happened to commit second. The count below is taken
+// after the advisory lock, inside the transaction that performs the writes, so
+// the second caller does not read at all until the first has committed — and
+// then reads one, not zero.
+//
+// It returns domain.Forbidden("registration_closed") when the install already
+// has a user. That is the same error the caller returns for every other refusal
+// on this path, deliberately: an unauthenticated caller learns "no" and nothing
+// else about the install's state.
+//
+// RLS: memberships is FORCE ROW LEVEL SECURITY with a WITH CHECK on
+// app.tenant_id, so the membership INSERT is only legal once the new tenant is
+// in scope. The tenant is created first and scopeTenant (owned by internal/db,
+// never by this repo) brings it into scope for the remainder of the SAME
+// transaction. tenants and users carry no RLS. tenant_id is still written
+// explicitly on the membership rather than left to the policy.
+func (r *Repo) BootstrapInstall(
+	ctx context.Context,
+	email, passwordHash, name, tenantName, tenantSlug string,
+) (User, Membership, uuid.UUID, error) {
+	var (
+		outUser  User
+		outMem   Membership
+		outTenID uuid.UUID
+	)
+
+	err := r.pool.InInstallLockTx(ctx, InstallBootstrapLockKey, func(tx pgx.Tx, scopeTenant func(uuid.UUID) error) error {
+		q := sqlc.New(tx)
+
+		count, err := q.CountUsers(ctx)
+		if err != nil {
+			return domain.Internal("user_count_failed", "failed to count users").WithCause(err)
+		}
+		if count > 0 {
+			return errRegistrationClosed()
+		}
+
+		tenantID, err := createTenantInTx(ctx, tx, tenantName, tenantSlug)
+		if err != nil {
+			return err
+		}
+		if err := scopeTenant(tenantID); err != nil {
+			return domain.Internal("tenant_scope_failed", "failed to scope the new organisation").WithCause(err)
+		}
+
+		userRow, err := q.CreateUser(ctx, sqlc.CreateUserParams{
+			Email:        email,
+			PasswordHash: strPtr(passwordHash),
+			OidcSubject:  nil,
+			OidcIssuer:   nil,
+			Name:         name,
+		})
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return domain.Conflict("user_exists", "a user with this email already exists").WithCause(err)
+			}
+			return domain.Internal("user_create_failed", "failed to create user").WithCause(err)
+		}
+
+		memRow, err := q.CreateMembership(ctx, sqlc.CreateMembershipParams{
+			UserID:   userRow.ID,
+			TenantID: tenantID,
+			Role:     string(authz.RoleOwner),
+		})
+		if err != nil {
+			return domain.Internal("membership_create_failed", "failed to create membership").WithCause(err)
+		}
+
+		outUser = userToModel(userRow)
+		outMem = membershipToModel(memRow)
+		outTenID = tenantID
+		return nil
+	})
+	if err != nil {
+		return User{}, Membership{}, uuid.Nil, err
+	}
+	return outUser, outMem, outTenID, nil
+}
+
+// createTenantInTx inserts the first tenant inside the bootstrap transaction,
+// mirroring tenant.Repo.Create's slug behaviour: the slug is globally unique,
+// so a collision retries with a random suffix rather than hard-failing.
+//
+// Each attempt runs in its own SAVEPOINT. A unique violation aborts the
+// enclosing transaction in Postgres, so retrying without one would fail every
+// subsequent statement with "current transaction is aborted" — including the
+// user and membership inserts this bootstrap exists to perform. The advisory
+// lock is held by the outer transaction and is unaffected by a savepoint
+// rollback.
+func createTenantInTx(ctx context.Context, tx pgx.Tx, name, slug string) (uuid.UUID, error) {
+	base := slug
+	if len(base) > 50 {
+		base = base[:50]
+	}
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		try := slug
+		if attempt > 0 {
+			suf := make([]byte, 3)
+			if _, err := rand.Read(suf); err != nil {
+				return uuid.Nil, domain.Internal("tenant_create_failed", "failed to create organisation").WithCause(err)
+			}
+			try = base + "-" + hex.EncodeToString(suf)
+		}
+
+		sp, err := tx.Begin(ctx)
+		if err != nil {
+			return uuid.Nil, domain.Internal("tenant_create_failed", "failed to create organisation").WithCause(err)
+		}
+		row, err := sqlc.New(sp).CreateTenant(ctx, sqlc.CreateTenantParams{Name: name, Slug: try})
+		if err == nil {
+			if cerr := sp.Commit(ctx); cerr != nil {
+				return uuid.Nil, domain.Internal("tenant_create_failed", "failed to create organisation").WithCause(cerr)
+			}
+			return row.ID, nil
+		}
+		_ = sp.Rollback(ctx)
+
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			lastErr = err
+			continue // slug taken — retry with a fresh random suffix
+		}
+		return uuid.Nil, domain.Internal("tenant_create_failed", "failed to create organisation").WithCause(err)
+	}
+	return uuid.Nil, domain.Conflict("tenant_slug_exists", "could not allocate an organisation slug").WithCause(lastErr)
+}

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -235,6 +236,34 @@ type registerBody struct {
 	// RegisterInput.Plan's doc comment: any non-paid-tier value (including
 	// "free", empty, or unrecognized) is silently treated as no intent.
 	Plan string `json:"plan"`
+	// ClaimSecret carries the provisioning claim on a first-run request, for
+	// callers that cannot set a header. It is a credential: it is compared in
+	// constant time and never copied into RegisterInput, an audit record, a
+	// log line or a response. See BootstrapClaimHeader for the header carrier.
+	ClaimSecret string `json:"claim_secret"`
+}
+
+// bootstrapClaim reads the provisioning claim a first-run caller presented.
+//
+// The header wins so that an installer can keep the credential out of the
+// request body entirely; the body field exists because a browser form posting
+// JSON has no comfortable way to add a header. One claim, one comparison, two
+// carriers — never two mechanisms.
+func bootstrapClaim(c *gin.Context, body registerBody) string {
+	if v := strings.TrimSpace(c.GetHeader(BootstrapClaimHeader)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(body.ClaimSecret)
+}
+
+// bootstrapLog returns the logger for first-run ownership, tagged so an
+// operator can select these lines out of a busy request log. Mirrors socialLog.
+func (h *Handler) bootstrapLog() *slog.Logger {
+	l := h.logger
+	if l == nil {
+		l = slog.Default()
+	}
+	return l.With(slog.String("component", "auth.bootstrap"))
 }
 
 func (h *Handler) register(c *gin.Context) {
@@ -252,17 +281,32 @@ func (h *Handler) register(c *gin.Context) {
 		Plan:       body.Plan,
 	}
 
-	// First account on a fresh install bootstraps frictionlessly (no SMTP exists
-	// yet): it is created verified + active and gets an immediate session. Every
-	// later signup is OPEN self-serve, returns a generic pending response, and
-	// must verify by email before logging in (ADR-045 Phase 3).
+	// FIRST-RUN OWNERSHIP IS DECIDED BY THE CLAIM, NOT BY THE USER COUNT. A
+	// caller presenting the provisioning claim is asking to own this install,
+	// and Service.Bootstrap alone decides whether it may: it verifies the claim
+	// in constant time and then takes the install lock, so the "is this install
+	// unowned?" question is asked once, inside the transaction that acts on the
+	// answer. This handler's job is to route the request, not to pre-judge it —
+	// a count read here would be a second, unlockable opinion on the same
+	// question, which is what a count read here used to be.
+	//
+	// Everything else is OPEN self-serve: a generic pending response, verify by
+	// email before logging in (ADR-045 Phase 3).
 	//
 	// Bootstrap creates a brand-new user who cannot yet have 2FA enrolled, so
 	// the 2FA gate here is defensive (makes the code correct uniformly) rather
 	// than protecting against a real threat today.
-	if count, _ := h.svc.CountUsers(c.Request.Context()); count == 0 {
-		res, err := h.svc.Bootstrap(c.Request.Context(), in, h.newTenant)
+	if claim := bootstrapClaim(c, body); claim != "" {
+		res, err := h.svc.Bootstrap(c.Request.Context(), in, claim)
 		if err != nil {
+			if !h.svc.BootstrapClaimConfigured() {
+				// Operator-facing only. The response stays the generic refusal;
+				// the reason a correctly-provisioned installer is being turned
+				// away belongs in the log, where the operator is the only
+				// reader. The claim itself is never logged.
+				h.bootstrapLog().Warn("first-run ownership refused: no provisioning claim is configured on this install",
+					"remedy", "set "+BootstrapClaimEnvVar+" to a random secret and restart the control plane")
+			}
 			httpx.Error(c, err)
 			return
 		}

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -236,24 +236,17 @@ type registerBody struct {
 	// RegisterInput.Plan's doc comment: any non-paid-tier value (including
 	// "free", empty, or unrecognized) is silently treated as no intent.
 	Plan string `json:"plan"`
-	// ClaimSecret carries the provisioning claim on a first-run request, for
-	// callers that cannot set a header. It is a credential: it is compared in
-	// constant time and never copied into RegisterInput, an audit record, a
-	// log line or a response. See BootstrapClaimHeader for the header carrier.
-	ClaimSecret string `json:"claim_secret"`
 }
 
 // bootstrapClaim reads the provisioning claim a first-run caller presented.
 //
-// The header wins so that an installer can keep the credential out of the
-// request body entirely; the body field exists because a browser form posting
-// JSON has no comfortable way to add a header. One claim, one comparison, two
-// carriers — never two mechanisms.
-func bootstrapClaim(c *gin.Context, body registerBody) string {
-	if v := strings.TrimSpace(c.GetHeader(BootstrapClaimHeader)); v != "" {
-		return v
-	}
-	return strings.TrimSpace(body.ClaimSecret)
+// A HEADER, NOT A BODY FIELD. The claim is a credential rather than user data,
+// and the register body is the one payload on this route that gets echoed into
+// validation errors and request logs. Keeping it in a header also keeps it out
+// of the OpenAPI request schema, so it is never something a generated client
+// offers to fill in: an installer sets it deliberately, once.
+func bootstrapClaim(c *gin.Context) string {
+	return strings.TrimSpace(c.GetHeader(BootstrapClaimHeader))
 }
 
 // bootstrapLog returns the logger for first-run ownership, tagged so an
@@ -296,7 +289,7 @@ func (h *Handler) register(c *gin.Context) {
 	// Bootstrap creates a brand-new user who cannot yet have 2FA enrolled, so
 	// the 2FA gate here is defensive (makes the code correct uniformly) rather
 	// than protecting against a real threat today.
-	if claim := bootstrapClaim(c, body); claim != "" {
+	if claim := bootstrapClaim(c); claim != "" {
 		res, err := h.svc.Bootstrap(c.Request.Context(), in, claim)
 		if err != nil {
 			if !h.svc.BootstrapClaimConfigured() {

--- a/apps/api/internal/auth/register.go
+++ b/apps/api/internal/auth/register.go
@@ -38,23 +38,35 @@ func (s *Service) RegisterSelfServe(
 		return err
 	}
 
-	// SELF-SERVE DOES NOT OPEN UNTIL THE INSTALL HAS AN OWNER. On an install
-	// with zero users, creating one here would hand the first-account slot to
-	// whoever asked first — the caller becomes user number one, so the person
-	// holding the provisioning claim can never bootstrap afterwards, and the
-	// account they got is itself useless (pending, awaiting a verification mail
-	// that an unclaimed install has no SMTP to send). Denying an operator their
-	// own install is the same loss whether it is taken or merely blocked.
+	// THE PASSWORD HASH IS COMPUTED BEFORE ANY DECISION, ON PURPOSE. Argon2
+	// dominates the cost of this request by two orders of magnitude, so a
+	// branch that skips it finishes visibly sooner and the duration of the
+	// response becomes a readable answer to whatever the branch tested. Here
+	// that would be "does this install have an owner yet?" — the one fact this
+	// whole path exists to keep to itself. Doing the work unconditionally is
+	// what makes the two outcomes take the same time; a sleep would not, since
+	// its length is a constant an observer can subtract.
+	hash, err := HashPassword(in.Password)
+	if err != nil {
+		return domain.Internal("password_hash_failed", "failed to hash password").WithCause(err)
+	}
+
+	// SELF-SERVE DOES NOT OPEN UNTIL THE INSTALL HAS AN OWNER, and ownership
+	// means an owner membership exists — never that a user row does. Creating
+	// an account here on an ownerless install would hand it its first
+	// organisation and its first owner through a path that asks nobody's
+	// permission, and the account is useless anyway (pending, awaiting a
+	// verification mail an unclaimed install has no SMTP to send). Denying an
+	// operator their own install is the same loss whether it is taken or merely
+	// blocked.
 	//
 	// It returns nil, so the caller receives the identical generic response a
-	// real self-serve registration produces. An unauthenticated caller therefore
-	// cannot tell an unclaimed install from a claimed one by registering into
-	// it, which is the whole reason this refusal is silent rather than an error.
+	// real self-serve registration produces.
 	//
-	// Fails closed on a count it cannot read: unreadable is not zero, and it is
-	// not "many" either. Doing nothing costs a legitimate signup one retry; the
-	// alternative costs an operator their install.
-	if count, err := s.repo.CountUsers(ctx); err != nil || count == 0 {
+	// Fails closed on an answer it cannot read: unreadable is not "unowned".
+	// Doing nothing costs a legitimate signup one retry; the alternative costs
+	// an operator their install.
+	if owned, oerr := s.repo.OwnershipEstablished(ctx); oerr != nil || !owned {
 		return nil
 	}
 
@@ -69,10 +81,6 @@ func (s *Service) RegisterSelfServe(
 		return nil // unexpected error: stay generic, never leak
 	}
 
-	hash, err := HashPassword(in.Password)
-	if err != nil {
-		return domain.Internal("password_hash_failed", "failed to hash password").WithCause(err)
-	}
 	tenantName := strings.TrimSpace(in.TenantName)
 	if tenantName == "" {
 		tenantName = defaultTenantName(in.Email)

--- a/apps/api/internal/auth/register.go
+++ b/apps/api/internal/auth/register.go
@@ -38,6 +38,26 @@ func (s *Service) RegisterSelfServe(
 		return err
 	}
 
+	// SELF-SERVE DOES NOT OPEN UNTIL THE INSTALL HAS AN OWNER. On an install
+	// with zero users, creating one here would hand the first-account slot to
+	// whoever asked first — the caller becomes user number one, so the person
+	// holding the provisioning claim can never bootstrap afterwards, and the
+	// account they got is itself useless (pending, awaiting a verification mail
+	// that an unclaimed install has no SMTP to send). Denying an operator their
+	// own install is the same loss whether it is taken or merely blocked.
+	//
+	// It returns nil, so the caller receives the identical generic response a
+	// real self-serve registration produces. An unauthenticated caller therefore
+	// cannot tell an unclaimed install from a claimed one by registering into
+	// it, which is the whole reason this refusal is silent rather than an error.
+	//
+	// Fails closed on a count it cannot read: unreadable is not zero, and it is
+	// not "many" either. Doing nothing costs a legitimate signup one retry; the
+	// alternative costs an operator their install.
+	if count, err := s.repo.CountUsers(ctx); err != nil || count == 0 {
+		return nil
+	}
+
 	if existing, err := s.repo.GetUserByEmail(ctx, in.Email); err == nil {
 		// Already registered: stay generic to the HTTP caller, but nudge the real
 		// owner by email so an existing user (e.g. a former collaborator) knows to

--- a/apps/api/internal/auth/register.go
+++ b/apps/api/internal/auth/register.go
@@ -67,6 +67,13 @@ func (s *Service) RegisterSelfServe(
 	// Doing nothing costs a legitimate signup one retry; the alternative costs
 	// an operator their install.
 	if owned, oerr := s.repo.OwnershipEstablished(ctx); oerr != nil || !owned {
+		// The same address lookup the open path performs, discarded. Argon2
+		// above is the dominant cost and matching it closes most of the
+		// difference; this closes most of what remains, for one round trip and
+		// no behaviour. What cannot be matched without doing it is the write
+		// itself, so a residual difference stays — measured and reported rather
+		// than assumed away, in TestMeasureFirstRunRefusalTiming.
+		_, _ = s.repo.GetUserByEmail(ctx, in.Email)
 		return nil
 	}
 

--- a/apps/api/internal/auth/register.go
+++ b/apps/api/internal/auth/register.go
@@ -74,6 +74,7 @@ func (s *Service) RegisterSelfServe(
 		// itself, so a residual difference stays — measured and reported rather
 		// than assumed away, in TestMeasureFirstRunRefusalTiming.
 		_, _ = s.repo.GetUserByEmail(ctx, in.Email)
+		//nolint:nilerr // returning nil while oerr is non-nil is the SAFE branch, not an oversight: an ownership answer this code could not read must leave self-serve shut, and every refusal on this path is silent by design (see the comment above). Surfacing oerr here would both open the path on a transient database error and hand the caller a distinguishable answer.
 		return nil
 	}
 

--- a/apps/api/internal/auth/repo.go
+++ b/apps/api/internal/auth/repo.go
@@ -84,15 +84,6 @@ func membershipToModel(m sqlc.Membership) Membership {
 	}
 }
 
-// CountUsers returns the total number of users (used for first-run bootstrap).
-func (r *Repo) CountUsers(ctx context.Context) (int64, error) {
-	n, err := r.q.CountUsers(ctx)
-	if err != nil {
-		return 0, domain.Internal("user_count_failed", "failed to count users").WithCause(err)
-	}
-	return n, nil
-}
-
 // CreateUser inserts a new user.
 func (r *Repo) CreateUser(ctx context.Context, email, passwordHash, name, oidcIssuer, oidcSubject string) (User, error) {
 	row, err := r.q.CreateUser(ctx, sqlc.CreateUserParams{

--- a/apps/api/internal/auth/service.go
+++ b/apps/api/internal/auth/service.go
@@ -457,11 +457,6 @@ func (s *Service) RecordAudit(ctx context.Context, e audit.Event) {
 	_, _ = s.audit.Record(ctx, e)
 }
 
-// CountUsers exposes the user count (used to gate registration in handlers).
-func (s *Service) CountUsers(ctx context.Context) (int64, error) {
-	return s.repo.CountUsers(ctx)
-}
-
 // UpdateProfile sets the user's display name. The name is trimmed and capped at
 // 120 characters. Email is intentionally not editable here (it is the login
 // identity). Returns the updated user + their current memberships.

--- a/apps/api/internal/auth/service.go
+++ b/apps/api/internal/auth/service.go
@@ -253,23 +253,42 @@ type RegisterInput struct {
 // returns errRegistrationClosed(), one indistinguishable answer. See its
 // comment for why three answers would be worse than one.
 //
-// The count and the writes are one transaction under one advisory lock, in
-// Repo.BootstrapInstall. Nothing is checked here that is acted on there.
+// The ownership check and the writes are one transaction under one advisory
+// lock, in Repo.BootstrapInstall. Nothing decided here is re-decided there.
+//
+// EVERY REFUSAL DOES THE SAME WORK, not just returns the same bytes. Argon2
+// dominates this request by two orders of magnitude, so an early return that
+// skips it answers "your claim was wrong" in nanoseconds while a correct claim
+// against an owned install answers identically after milliseconds — which makes
+// the duration a reliable oracle for claim-correctness, i.e. an offline guess
+// becomes an online one. So the hash is computed first, unconditionally, and
+// the ownership probe runs on every path before the answer is chosen.
 func (s *Service) Bootstrap(ctx context.Context, in RegisterInput, claim string) (LoginResult, error) {
-	// The claim is checked BEFORE the input is validated, so a caller without
-	// it cannot use validation feedback to probe this path at all.
-	if !s.bootstrapClaimAccepted(claim) {
+	in.Email = normalizeEmail(in.Email)
+
+	// Validated now, reported later: a caller without the claim must not be
+	// able to use validation feedback to probe this path, so verr is held until
+	// the claim has been judged.
+	verr := s.validator.Struct(in)
+
+	// Unconditional, and its error is held for the same reason. HashPassword
+	// only fails on a password outside argon2's accepted bounds, which
+	// validation has already rejected for any caller that will be told about
+	// it.
+	hash, herr := HashPassword(in.Password)
+
+	// Also unconditional: the claim decides the answer, not which work gets
+	// done. An unreadable answer counts as owned, refusing rather than granting.
+	owned, oerr := s.repo.OwnershipEstablished(ctx)
+
+	if !s.bootstrapClaimAccepted(claim) || oerr != nil || owned {
 		return LoginResult{}, errRegistrationClosed()
 	}
-
-	in.Email = normalizeEmail(in.Email)
-	if err := s.validator.Struct(in); err != nil {
-		return LoginResult{}, err
+	if verr != nil {
+		return LoginResult{}, verr
 	}
-
-	hash, err := HashPassword(in.Password)
-	if err != nil {
-		return LoginResult{}, domain.Internal("password_hash_failed", "failed to hash password").WithCause(err)
+	if herr != nil {
+		return LoginResult{}, domain.Internal("password_hash_failed", "failed to hash password").WithCause(herr)
 	}
 
 	tenantName := strings.TrimSpace(in.TenantName)

--- a/apps/api/internal/auth/service.go
+++ b/apps/api/internal/auth/service.go
@@ -53,6 +53,10 @@ type Service struct {
 	// one, declared by the operator. Empty on every install that never moved.
 	// See SetPreviousOIDCIssuer.
 	previousOIDCIssuer string
+	// bootstrapClaim is the provisioning claim first-run ownership requires.
+	// Injected via SetBootstrapClaimSecret. Empty means no caller can claim
+	// this install — see bootstrapClaimAccepted.
+	bootstrapClaim string
 }
 
 // SetPreviousOIDCIssuer declares the generic-OIDC issuer this install used
@@ -236,26 +240,31 @@ type RegisterInput struct {
 	Plan string `validate:"omitempty,max=32"`
 }
 
-// Bootstrap creates the very first user together with their tenant and an owner
-// membership. It is only valid when there are zero users; otherwise it returns
-// a conflict directing the caller to the invitation flow. The tenant is created
-// via the supplied createTenant callback (the tenant domain owns that table).
-func (s *Service) Bootstrap(
-	ctx context.Context,
-	in RegisterInput,
-	createTenant func(ctx context.Context, name, slug string) (uuid.UUID, error),
-) (LoginResult, error) {
+// Bootstrap grants first-run ownership: the install's first organisation, its
+// first user, and the owner membership binding them.
+//
+// IT REQUIRES THE PROVISIONING CLAIM. claim must be the value the operator
+// configured as WPMGR_BOOTSTRAP_CLAIM_SECRET and handed to whoever is entitled
+// to own this install. Ownership of a control plane is not a race to be first
+// through the door: the installer decides who owns the install, and the claim
+// is how that decision travels from the installer to this function.
+//
+// Every refusal — no claim configured, wrong claim, install already owned —
+// returns errRegistrationClosed(), one indistinguishable answer. See its
+// comment for why three answers would be worse than one.
+//
+// The count and the writes are one transaction under one advisory lock, in
+// Repo.BootstrapInstall. Nothing is checked here that is acted on there.
+func (s *Service) Bootstrap(ctx context.Context, in RegisterInput, claim string) (LoginResult, error) {
+	// The claim is checked BEFORE the input is validated, so a caller without
+	// it cannot use validation feedback to probe this path at all.
+	if !s.bootstrapClaimAccepted(claim) {
+		return LoginResult{}, errRegistrationClosed()
+	}
+
 	in.Email = normalizeEmail(in.Email)
 	if err := s.validator.Struct(in); err != nil {
 		return LoginResult{}, err
-	}
-
-	count, err := s.repo.CountUsers(ctx)
-	if err != nil {
-		return LoginResult{}, err
-	}
-	if count > 0 {
-		return LoginResult{}, domain.Forbidden("registration_closed", "open registration is closed; ask a tenant owner or admin for an invitation")
 	}
 
 	hash, err := HashPassword(in.Password)
@@ -271,16 +280,8 @@ func (s *Service) Bootstrap(
 	if tenantSlug == "" {
 		tenantSlug = "default"
 	}
-	tenantID, err := createTenant(ctx, tenantName, tenantSlug)
-	if err != nil {
-		return LoginResult{}, err
-	}
 
-	u, err := s.repo.CreateUser(ctx, in.Email, hash, in.Name, "", "")
-	if err != nil {
-		return LoginResult{}, err
-	}
-	m, err := s.repo.CreateMembership(ctx, u.ID, tenantID, authz.RoleOwner)
+	u, m, tenantID, err := s.repo.BootstrapInstall(ctx, in.Email, hash, in.Name, tenantName, tenantSlug)
 	if err != nil {
 		return LoginResult{}, err
 	}

--- a/apps/api/internal/auth/social.go
+++ b/apps/api/internal/auth/social.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
-	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
@@ -937,15 +936,25 @@ func (s *Service) finishSocialLogin(
 	// invitation is now accepted only by the affirmative act of opening the link
 	// and submitting it, on an authenticated session; see
 	// invitation.Service.Accept.
+	//
+	// NOR DOES FIRST-RUN OWNERSHIP BELONG HERE. Granting the install's first
+	// organisation is an act of provisioning, and provisioning is authorised by
+	// the claim the installer minted (Service.Bootstrap). A social sign-in has
+	// nowhere to carry that claim: the request is a redirect the identity
+	// provider decided the shape of, so a claim can be neither attached to it
+	// nor demanded of it. There is therefore no version of this path that could
+	// check the claim, which makes "never mint here" the only answer that keeps
+	// the two paths agreeing about who may own an install.
+	//
+	// Nothing is lost. The person who holds the claim runs the claim-bearing
+	// register call once, and every social sign-in afterwards resolves normally
+	// against the memberships that exist. Someone who signs in socially before
+	// that has happened lands with zero memberships — exactly what the password
+	// path already gives an unattached account, and exactly what a site
+	// collaborator, a client-portal user and a grace-window owner already get
+	// here (see the git history of this function for what minting an org for
+	// them cost).
 	memberships, _ := s.repo.ListMembershipsForUser(ctx, u.ID)
-	if len(memberships) == 0 && s.isFirstRunBootstrap(ctx, u) {
-		tenantID, terr := createTenant(ctx, defaultTenantName(u.Email), uniqueTenantSlug(u.Email))
-		if terr == nil {
-			if m, merr := s.repo.CreateMembership(ctx, u.ID, tenantID, authz.RoleOwner); merr == nil {
-				memberships = []Membership{m}
-			}
-		}
-	}
 
 	_ = s.repo.TouchLogin(ctx, u.ID)
 	s.recordLogin(ctx, memberships, u.ID, audit.ActionLoginSuccess)
@@ -955,44 +964,13 @@ func (s *Service) finishSocialLogin(
 	return res, nil
 }
 
-// isFirstRunBootstrap reports whether this login should mint the install's
-// first organisation.
-//
-// ZERO VISIBLE MEMBERSHIPS IS A NORMAL STATE, NOT A FAULT TO REPAIR. It is what
-// a site collaborator has (an active site_share and nothing else), what a
-// client-portal user has (a client_member row and nothing else), and what
-// anyone whose only organisation is inside its soft-delete grace window has.
-// Creating a tenant for all of them would hand a portal user org-level
-// capabilities the product deliberately withholds, activate that new empty org
-// instead of their portal tenant (resolveActiveTenant takes memberships[0]
-// first) and, on a hosted install, mint an unbilled organisation on demand.
-//
-// The user count alone is not enough to tell first run from the grace window.
-// An install with one user whose only org has just been deleted still counts
-// one user, and its owner signing in with Google was handed a fresh empty
-// organisation while the very same person signing in with their password got
-// nothing. Two sign-in paths disagreeing about what an account is a member of
-// is the bug, and undoing a deletion nobody asked to undo is the damage.
-//
-// So it asks the question it actually means: is this user new, or merely
-// currently unattached? CountAllMembershipsForUser counts soft-deleted orgs
-// too, so a grace-window user answers "not new" and gets the same nothing the
-// password path gives them. Restoring the org is the org owner's decision, made
-// on the restore route, not a side effect of signing in.
-func (s *Service) isFirstRunBootstrap(ctx context.Context, u User) bool {
-	count, err := s.repo.CountUsers(ctx)
-	if err != nil || count > 1 {
-		return false
-	}
-	ever, err := s.repo.CountAllMembershipsForUser(ctx, u.ID)
-	if err != nil {
-		// Unreadable is not the same as zero. Refusing to bootstrap on an error
-		// costs a first user one visit to the org page; guessing costs a
-		// grace-window user a resurrected organisation.
-		return false
-	}
-	return ever == 0
-}
+// isFirstRunBootstrap is gone deliberately, and this note stands in its place
+// so it is not reintroduced. It answered "should this social sign-in mint the
+// install's first organisation?" from a user count, which is a question about
+// the install's state and not about the caller's authority. First-run ownership
+// is now granted only against the provisioning claim
+// (WPMGR_BOOTSTRAP_CLAIM_SECRET), on the one path that can carry it — see
+// Service.Bootstrap and finishSocialLogin's comment above.
 
 // sendVerificationForSocialLink mails the link that unblocks a refused social
 // link. Best effort and deliberately silent: whether an address received mail

--- a/apps/api/internal/auth/social.go
+++ b/apps/api/internal/auth/social.go
@@ -403,7 +403,7 @@ func (s *Service) SignInWithSocial(
 		// provider's current address was never recorded. See touchIssuer for why
 		// this is not simply facts.storedIssuer.
 		s.repo.TouchIdentityLogin(ctx, in.Provider, in.Subject, facts.touchIssuer(in), in.Email, in.EmailVerified)
-		return s.finishSocialLogin(ctx, *identityUser, createTenant)
+		return s.finishSocialLogin(ctx, *identityUser)
 
 	case socialLinkExisting:
 		// THE LINK IS AUTHORIZED HERE AND WRITTEN SOMEWHERE ELSE, ON PURPOSE.
@@ -418,7 +418,7 @@ func (s *Service) SignInWithSocial(
 		//
 		// So the decision travels as data and the write happens once the login is
 		// genuinely complete. See CompleteSocialLink.
-		res, err := s.finishSocialLogin(ctx, *emailUser, createTenant)
+		res, err := s.finishSocialLogin(ctx, *emailUser)
 		if err != nil {
 			return LoginResult{}, err
 		}
@@ -443,6 +443,28 @@ func (s *Service) SignInWithSocial(
 		// No notification either: the account IS the new method, so there is no
 		// prior holder to warn and the only address available is the one the
 		// provider just asserted.
+		// AN OWNERLESS INSTALL ACCEPTS NO NEW ACCOUNTS. This branch creates a
+		// user from a provider handshake alone, and on an install whose first
+		// organisation has not been claimed yet there is nobody who could grant
+		// that user anything: the account would sit with zero memberships, on an
+		// install with no owner, created by a caller nobody authorised. Worse,
+		// the row itself is consequential — it is exactly the sort of artefact a
+		// "has this install been claimed?" test can be fooled by, which is why
+		// that question now asks about owner memberships and this branch refuses
+		// outright rather than relying on it.
+		//
+		// The two sign-in paths therefore agree: neither can establish
+		// ownership, and neither creates an account while ownership is
+		// unestablished. Once the claim-bearing first-run call has run, this
+		// branch behaves exactly as it always has.
+		//
+		// Fails closed on an unreadable answer, like every other caller.
+		if owned, oerr := s.repo.OwnershipEstablished(ctx); oerr != nil || !owned {
+			return LoginResult{}, domain.Forbidden(
+				"registration_closed",
+				"open registration is closed; ask a tenant owner or admin for an invitation",
+			)
+		}
 		u, err := s.createSocialUser(ctx, in, legacySlotTaken(in, facts.legacyHolders))
 		if err != nil {
 			return LoginResult{}, err
@@ -450,7 +472,7 @@ func (s *Service) SignInWithSocial(
 		// Audited after the login is resolved, not before: finishSocialLogin is
 		// what settles which tenant this account belongs to, and recording first
 		// would file every new account's registration against no tenant at all.
-		res, err := s.finishSocialLogin(ctx, u, createTenant)
+		res, err := s.finishSocialLogin(ctx, u)
 		if err != nil {
 			return LoginResult{}, err
 		}
@@ -922,11 +944,7 @@ func syntheticEmailDomain(in SocialIdentity) string {
 
 // finishSocialLogin resolves memberships and the active tenant, mirroring the
 // tail of the password login path.
-func (s *Service) finishSocialLogin(
-	ctx context.Context,
-	u User,
-	createTenant func(ctx context.Context, name, slug string) (uuid.UUID, error),
-) (LoginResult, error) {
+func (s *Service) finishSocialLogin(ctx context.Context, u User) (LoginResult, error) {
 	// NOTHING THAT GRANTS ACCESS BELONGS HERE. This runs before the second
 	// factor is even issued, so any grant it made would be a grant made on the
 	// strength of a provider handshake alone. An earlier version of this

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -527,6 +527,26 @@ type AuthConfig struct {
 	IdleTimeout    time.Duration `koanf:"idle_timeout"`
 	AbsoluteExpiry time.Duration `koanf:"absolute_expiry"`
 
+	// BootstrapClaimSecret (WPMGR_BOOTSTRAP_CLAIM_SECRET) is the provisioning
+	// claim the installer mints and hands to the person who is entitled to own
+	// the install. First-run ownership — the very first organisation and its
+	// owner membership — is granted only to a caller that presents it.
+	//
+	// It is a LITERAL value only; this file has no file-indirection convention
+	// for any other secret and inventing one here would be a second mechanism.
+	//
+	// UNSET MEANS "NOBODY MAY CLAIM THIS INSTALL", never "anybody may". An
+	// install that boots without it can still serve every other route; it
+	// simply has no route to first-run ownership until the operator sets the
+	// variable and restarts. That direction is deliberate: the failure mode of
+	// a misconfigured deployment must be an install that cannot be claimed,
+	// not an install that can be claimed freely.
+	//
+	// It is a credential, so it is never logged, never echoed into a response
+	// and never recorded in audit metadata; only its NAME appears in operator
+	// guidance.
+	BootstrapClaimSecret string `koanf:"bootstrap_claim_secret"`
+
 	// WebAuthn relying party configuration (ADR-056 Phase 1).
 	// RPID is the effective domain for WebAuthn (e.g. "manage.wpmgr.app").
 	// RPOrigins is a comma-separated list of allowed origins
@@ -916,6 +936,15 @@ func mapEnvKey(k string) string {
 	// WPMGR_SESSION_SECRET -> auth.session_secret.
 	case k == "session_secret":
 		return "auth.session_secret"
+	// WPMGR_BOOTSTRAP_CLAIM_SECRET -> auth.bootstrap_claim_secret. An explicit
+	// case, not the "auth_" prefix, because the operator-facing name has no
+	// AUTH_ segment. Without this line the key falls through the default
+	// passthrough below and unmarshal silently ignores it — the exact shape
+	// that left social sign-in configured-but-disabled with no error to notice,
+	// and here it would leave a correctly-configured install unable to be
+	// claimed by anyone.
+	case k == "bootstrap_claim_secret":
+		return "auth.bootstrap_claim_secret"
 	case strings.HasPrefix(k, "auth_"):
 		return "auth." + strings.TrimPrefix(k, "auth_")
 	case strings.HasPrefix(k, "oidc_"):

--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -259,6 +259,48 @@ func setTenant(ctx context.Context, tx pgx.Tx, tenantID uuid.UUID) error {
 	return nil
 }
 
+// InInstallLockTx runs fn inside a single transaction that holds an
+// install-wide advisory lock, taken as the transaction's FIRST statement.
+//
+// It exists for the one decision that is scoped to the whole install rather
+// than to a tenant: whether this install has an owner yet. That question is
+// read-then-write across three tables, and answering it in one transaction
+// under one lock is what makes "exactly one first organisation" true rather
+// than merely likely. pg_advisory_xact_lock is released by COMMIT or ROLLBACK,
+// so the lock cannot leak however fn ends.
+//
+// The lock is keyed on (key, key) rather than (key, tenant) — the sibling
+// per-tenant locks such as auth.MemberRolesLockKey and org.LifecycleLockKey
+// cannot apply, because no tenant exists yet at the moment the decision is
+// taken. There is exactly one such lock per install.
+//
+// fn is handed a scopeTenant callback because the tenant this transaction is
+// deciding about does not exist when the transaction opens: fn creates it, then
+// calls scopeTenant to bring app.tenant_id into scope for the RLS-protected
+// writes that follow, all still inside this one transaction. GUC-setting stays
+// in this file; no repo sets app.tenant_id itself.
+func (p *Pool) InInstallLockTx(ctx context.Context, key string, fn func(tx pgx.Tx, scopeTenant func(uuid.UUID) error) error) error {
+	tx, err := p.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1), hashtext($1))`, key); err != nil {
+		return fmt.Errorf("install advisory lock %q: %w", key, err)
+	}
+
+	scopeTenant := func(tenantID uuid.UUID) error { return setTenant(ctx, tx, tenantID) }
+	if err := fn(tx, scopeTenant); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
 // InTenantTxAsUser runs fn inside a transaction with BOTH app.tenant_id and
 // app.user_id set. The user GUC enables the memberships_self_read policy in
 // addition to the per-tenant isolation policy — used where a tenant-scoped

--- a/apps/api/tests/auth_first_run_guc_scope_integration_test.go
+++ b/apps/api/tests/auth_first_run_guc_scope_integration_test.go
@@ -1,0 +1,101 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+)
+
+// TestFirstRunOwnership_ProbeHandsBackTheAgentScope proves that the ownership
+// probe leaves no elevated scope behind in the transaction that called it.
+//
+// WHY THIS NEEDS A TEST OF ITS OWN. The probe reads across every tenant, which
+// needs app.agent, and it has to do that inside the transaction holding the
+// install lock rather than in one of its own. set_config(..., true) is
+// TRANSACTION-local, not statement-local, so an unreset GUC stays on for every
+// later statement in that transaction — and app.agent is the widest scope in
+// this schema, granting cross-tenant write on dozens of tables. Nothing about
+// the bootstrap's own writes would have looked wrong, because they all carry a
+// server-derived tenant_id; the reach would simply have been there, in the one
+// unauthenticated-reachable critical section, for whoever edited it next.
+//
+// It runs through Pool.InInstallLockTx and calls the real
+// auth.OwnershipEstablishedInTx, as the non-superuser wpmgr_app role, so the
+// scope under test is the scope production gets.
+//
+// To watch it go red: delete the reset — the second set_config in
+// OwnershipEstablishedInTx (internal/auth/bootstrap_repo.go) — and this reports
+// the GUC still on and the cross-tenant write succeeding.
+func TestFirstRunOwnership_ProbeHandsBackTheAgentScope(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	// Two tenants, so a cross-tenant write has somewhere to aim.
+	scoped := seedTenant(t, pool, "scoped-org")
+	other := seedTenant(t, pool, "other-org")
+
+	err := pool.InInstallLockTx(ctx, auth.InstallBootstrapLockKey, func(tx pgx.Tx, scopeTenant func(uuid.UUID) error) error {
+		if _, perr := auth.OwnershipEstablishedInTx(ctx, tx); perr != nil {
+			t.Fatalf("ownership probe: %v", perr)
+		}
+
+		// 1. The GUC itself, read in a LATER statement of the same transaction.
+		var agent string
+		if serr := tx.QueryRow(ctx, `SELECT current_setting('app.agent', true)`).Scan(&agent); serr != nil {
+			t.Fatalf("read app.agent: %v", serr)
+		}
+		if agent == "on" {
+			t.Fatalf("app.agent is still %q in a later statement of the same transaction; the probe did not hand the scope back", agent)
+		}
+
+		// 2. The capability that GUC confers, exercised rather than inferred.
+		//    Scope the transaction to one tenant, then attempt a write for the
+		//    other. Under the tenant policy alone this must be refused; with
+		//    app.agent left on, the agent policies would admit it.
+		if serr := scopeTenant(scoped); serr != nil {
+			t.Fatalf("scope tenant: %v", serr)
+		}
+		_, werr := tx.Exec(ctx,
+			`INSERT INTO sites (tenant_id, name, url, status)
+			 VALUES ($1, 'cross-tenant probe', 'https://cross-tenant.example', 'pending')`,
+			other,
+		)
+		if werr == nil {
+			t.Fatalf("a cross-tenant write succeeded inside the bootstrap transaction: wrote a sites row for tenant %s while scoped to %s", other, scoped)
+		}
+
+		// Refused is the whole assertion; the transaction is aborted by the
+		// failed INSERT, so it is rolled back rather than continued.
+		return errProbeDone
+	})
+	if err != nil && err != errProbeDone {
+		t.Fatalf("install lock tx: %v", err)
+	}
+
+	// Nothing was written either way.
+	var sites int
+	if qerr := pool.QueryRow(ctx, `SELECT count(*) FROM sites`).Scan(&sites); qerr != nil {
+		t.Fatalf("count sites: %v", qerr)
+	}
+	if sites != 0 {
+		t.Fatalf("sites = %d, want 0", sites)
+	}
+}
+
+// errProbeDone unwinds the transaction once the assertions have run, so the
+// helper rolls back rather than committing a transaction whose only purpose was
+// to be inspected.
+var errProbeDone = errSentinel("probe complete")
+
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }
+
+// compile-time guard: the test above depends on the pool exposing the install
+// lock helper, which is what puts the probe inside the critical section.
+var _ = func(p *db.Pool) {}

--- a/apps/api/tests/auth_first_run_header_integration_test.go
+++ b/apps/api/tests/auth_first_run_header_integration_test.go
@@ -1,0 +1,205 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/gin-gonic/gin"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+)
+
+// firstRunHTTP stands the register endpoint up over the real Gin router, with
+// the real session middleware, so the request travels the path an operator's
+// request actually travels.
+//
+// THE SERVICE-LEVEL TESTS CANNOT COVER THIS. Every other test in this change
+// calls svc.Bootstrap directly and hands it a claim string, which means the one
+// piece of code that decides where that string comes from — bootstrapClaim(c),
+// reading X-Wpmgr-Bootstrap-Claim off the request — was never executed by
+// anything. A header typo, a wrong constant or a handler that read the body
+// instead would have left all eight of them green while the only route an
+// operator has was broken.
+func firstRunHTTP(t *testing.T, claimSecret string) (*gin.Engine, *auth.Service) {
+	t.Helper()
+	pool := startPostgres(t)
+	svc, _ := newAuthStack(pool)
+	if claimSecret != "" {
+		svc.SetBootstrapClaimSecret(claimSecret)
+	}
+
+	sm := auth.NewSessionManagerWithStore(scs.New(), false)
+	h := auth.NewHandler(svc, sm, nil, makeCreateTenant(t, pool))
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(sm.LoadAndSave())
+	h.Register(r)
+	return r, svc
+}
+
+// postRegister issues the request an installer makes. A header value of "" is
+// sent as no header at all, which is the case an ordinary visitor produces.
+func postRegister(t *testing.T, r *gin.Engine, header, email string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{
+		"email":    email,
+		"password": "a-very-strong-password",
+		"name":     "Owner",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if header != "" {
+		req.Header.Set("X-Wpmgr-Bootstrap-Claim", header)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestFirstRunHeader_CorrectHeaderEstablishesOwnership is the does-not-over-fire
+// half at HTTP level: the header an installer sets reaches the claim check, and
+// the request completes with a created owner and a session cookie.
+//
+// To watch it go red: change the header name in either BootstrapClaimHeader
+// (internal/auth/bootstrap_claim.go) or in postRegister above, so the two stop
+// agreeing.
+func TestFirstRunHeader_CorrectHeaderEstablishesOwnership(t *testing.T) {
+	r, _ := firstRunHTTP(t, testClaim)
+
+	w := postRegister(t, r, testClaim, "owner@example.com")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("correct header: status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	// The session is what makes this the whole round trip rather than a 201
+	// with nothing behind it: bootstrap issues one in the same request.
+	var sawSession bool
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "wpmgr_session" && c.Value != "" {
+			sawSession = true
+		}
+	}
+	if !sawSession {
+		t.Fatalf("correct header did not issue a session cookie; got %v", w.Result().Cookies())
+	}
+
+	// And the response describes the owner, not a pending self-serve signup:
+	// the Me payload carries the account and its one owner membership.
+	var me struct {
+		User struct {
+			Email string `json:"email"`
+		} `json:"user"`
+		Memberships []struct {
+			Role string `json:"role"`
+		} `json:"memberships"`
+		ActiveTenantID string `json:"active_tenant_id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &me); err != nil {
+		t.Fatalf("decode body: %v (%s)", err, w.Body.String())
+	}
+	if me.User.Email != "owner@example.com" {
+		t.Fatalf("response user.email = %q, want owner@example.com", me.User.Email)
+	}
+	if len(me.Memberships) != 1 || me.Memberships[0].Role != "owner" {
+		t.Fatalf("response memberships = %+v, want exactly one owner", me.Memberships)
+	}
+	if me.ActiveTenantID == "" {
+		t.Fatal("response carried no active tenant")
+	}
+}
+
+// TestFirstRunHeader_WrongAndAbsentHeadersAreRefusedIdentically is the fires
+// half, and the indistinguishability check where it actually matters: on the
+// wire, including the status code.
+//
+// To watch it go red: give the no-claim-configured or wrong-claim branch its own
+// status or error code in Service.Bootstrap.
+func TestFirstRunHeader_WrongAndAbsentHeadersAreRefusedIdentically(t *testing.T) {
+	// A configured install, still unowned.
+	configured, _ := firstRunHTTP(t, testClaim)
+	wrong := postRegister(t, configured, "not-the-claim-value-at-all", "a@example.com")
+
+	// An install with no claim configured at all.
+	unconfigured, _ := firstRunHTTP(t, "")
+	unset := postRegister(t, unconfigured, testClaim, "b@example.com")
+
+	for name, w := range map[string]*httptest.ResponseRecorder{
+		"wrong header":        wrong,
+		"no claim configured": unset,
+	} {
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("%s: status = %d, want %d; body = %s", name, w.Code, http.StatusForbidden, w.Body.String())
+		}
+		if code := errorCodeOf(t, w); code != "registration_closed" {
+			t.Fatalf("%s: error code = %q, want registration_closed", name, code)
+		}
+		for _, c := range w.Result().Cookies() {
+			if c.Name == "wpmgr_session" && c.Value != "" {
+				t.Fatalf("%s: a refusal issued a session cookie", name)
+			}
+		}
+	}
+
+	// Byte-identical, not merely same-coded.
+	if wrong.Body.String() != unset.Body.String() {
+		t.Fatalf("refusal bodies differ:\n wrong header:        %s\n no claim configured: %s",
+			wrong.Body.String(), unset.Body.String())
+	}
+
+	// The claim must never appear in a response.
+	if containsSecret(unset.Body.String()) {
+		t.Fatalf("a refusal echoed the provisioning claim: %s", unset.Body.String())
+	}
+}
+
+// TestFirstRunHeader_AbsentHeaderTakesTheSelfServePath proves the routing half:
+// no header is not a refusal, it is "this is an ordinary registration". On an
+// unowned install that writes nothing and answers generically, so the
+// first-account slot is still there for the installer afterwards.
+//
+// To watch it go red: make the handler treat an absent header as a bootstrap
+// attempt (drop the `claim != ""` condition in register).
+func TestFirstRunHeader_AbsentHeaderTakesTheSelfServePath(t *testing.T) {
+	r, svc := firstRunHTTP(t, testClaim)
+
+	w := postRegister(t, r, "", "visitor@example.com")
+	if w.Code == http.StatusCreated {
+		t.Fatalf("a request with no claim header established ownership: %s", w.Body.String())
+	}
+	if w.Code == http.StatusForbidden {
+		t.Fatalf("a request with no claim header was refused rather than routed to self-serve; "+
+			"that answers 'is this install unowned?' to anyone who asks: %s", w.Body.String())
+	}
+
+	// And the installer can still claim it afterwards, over HTTP.
+	after := postRegister(t, r, testClaim, "owner@example.com")
+	if after.Code != http.StatusCreated {
+		t.Fatalf("the claim must still work after an anonymous registration attempt: status %d, body %s",
+			after.Code, after.Body.String())
+	}
+	_ = svc
+}
+
+func errorCodeOf(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v (%s)", err, w.Body.String())
+	}
+	if body.Error.Code != "" {
+		return body.Error.Code
+	}
+	return body.Code
+}

--- a/apps/api/tests/auth_first_run_ownership_integration_test.go
+++ b/apps/api/tests/auth_first_run_ownership_integration_test.go
@@ -274,24 +274,93 @@ func TestFirstRunOwnership_SocialSignInNeverMints(t *testing.T) {
 	// A completely unclaimed install: zero users, zero tenants.
 	assertUserCount(t, pool, 0)
 
-	res, err := svc.SignInWithSocial(ctx, auth.SocialIdentity{
+	_, err := svc.SignInWithSocial(ctx, auth.SocialIdentity{
 		Provider:      "google",
 		Subject:       "google-subject-1",
 		Email:         "first@example.com",
 		EmailVerified: true,
 		Name:          "First",
 	}, makeCreateTenant(t, pool))
-	if err != nil {
-		t.Fatalf("social sign-in: %v", err)
-	}
-	if len(res.Memberships) != 0 {
-		t.Fatalf("social sign-in on an unclaimed install minted %d membership(s): %+v", len(res.Memberships), res.Memberships)
-	}
-	if res.ActiveTenant != uuid.Nil {
-		t.Fatalf("social sign-in on an unclaimed install set an active tenant: %s", res.ActiveTenant)
-	}
+	assertRegistrationClosed(t, err)
+
 	assertTenantCount(t, pool, 0)
 	assertOwnerMembershipCount(t, pool, 0)
+
+	// THE USER COUNT, NOT ONLY THE TENANT COUNT. Asserting zero tenants and
+	// zero owner memberships is not enough on its own: a social sign-in that
+	// mints nothing but still writes a user row leaves an artefact that any
+	// "is this install claimed?" test keyed on population would read as
+	// claimed. That is the substitution this design had to remove, so the
+	// absence of the row is asserted directly.
+	assertUserCount(t, pool, 0)
+
+	// AND THE CLAIM MUST STILL WORK AFTERWARDS. This is the assertion that
+	// makes the two above mean something: whatever an unauthenticated caller
+	// does before the operator arrives, the operator's correct claim still
+	// establishes ownership. A gate that could be flipped shut by an anonymous
+	// request would fail here even while every count above read zero.
+	res, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "owner@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Owner",
+	}, testClaim)
+	if err != nil {
+		t.Fatalf("the correct claim must still establish ownership after an anonymous social sign-in: %v", err)
+	}
+	if len(res.Memberships) != 1 || res.Memberships[0].Role != "owner" {
+		t.Fatalf("want exactly one owner membership, got %+v", res.Memberships)
+	}
+	assertUserCount(t, pool, 1)
+	assertTenantCount(t, pool, 1)
+	assertOwnerMembershipCount(t, pool, 1)
+}
+
+// TestFirstRunOwnership_AnonymousRequestsCannotCloseTheDoor is the regression
+// test for the whole class: no unauthenticated request, on any path, may leave
+// the install in a state where the provisioning claim no longer works.
+//
+// The gates all used to read a user count, and a user row is not ownership — so
+// anything able to create one could close the door on the operator without ever
+// opening it for itself. This drives every unauthenticated entry point at an
+// unclaimed install and then requires the claim to still work.
+//
+// To watch it go red: change the ownership probe in Repo.BootstrapInstall back
+// to `q.CountUsers(ctx)` / `count > 0`, and remove the ownership check in the
+// socialCreate branch of SignInWithSocial (internal/auth/social.go) so the
+// sign-in creates its user row again.
+func TestFirstRunOwnership_AnonymousRequestsCannotCloseTheDoor(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc, _ := newAuthStack(pool)
+	svc.SetBootstrapClaimSecret(testClaim)
+
+	// Everything an unauthenticated caller can reach on an unclaimed install.
+	_, _ = svc.SignInWithSocial(ctx, auth.SocialIdentity{
+		Provider: "google", Subject: "s-1", Email: "a@example.com",
+		EmailVerified: true, Name: "A",
+	}, makeCreateTenant(t, pool))
+	_ = svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email: "b@example.com", Password: "a-very-strong-password", Name: "B",
+	}, makeCreateTenant(t, pool))
+	for _, guess := range []string{"", "wrong", testClaim + "x"} {
+		_, _ = svc.Bootstrap(ctx, auth.RegisterInput{
+			Email: "c@example.com", Password: "a-very-strong-password", Name: "C",
+		}, guess)
+	}
+
+	// Nothing was written, and the door is still open.
+	assertUserCount(t, pool, 0)
+	assertTenantCount(t, pool, 0)
+	assertOwnerMembershipCount(t, pool, 0)
+
+	if _, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "owner@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Owner",
+	}, testClaim); err != nil {
+		t.Fatalf("the correct claim must still establish ownership: %v", err)
+	}
+	assertOwnerMembershipCount(t, pool, 1)
 }
 
 // TestFirstRunOwnership_SocialSignInStillWorksOnAClaimedInstall is the

--- a/apps/api/tests/auth_first_run_ownership_integration_test.go
+++ b/apps/api/tests/auth_first_run_ownership_integration_test.go
@@ -315,8 +315,19 @@ func TestFirstRunOwnership_SocialSignInStillWorksOnAClaimedInstall(t *testing.T)
 		t.Fatalf("bootstrap: %v", err)
 	}
 
-	// The same person signs in with Google against the address they already own
-	// and verified through the claim-bearing bootstrap.
+	// Precondition, arranged out of band: the owner has verified their address.
+	// Bootstrap does not verify it (CreateUser leaves email_verified_at NULL,
+	// which is unchanged by this PR), and the social linking policy refuses to
+	// attach an identity to an account this install never verified. That
+	// refusal is the account-takeover defence and is not what this test is
+	// about — it is about whether a claimed install still resolves a social
+	// sign-in to the org the person already owns.
+	if _, err := pool.Exec(ctx,
+		"UPDATE users SET email_verified_at = now() WHERE email = $1", "owner@example.com"); err != nil {
+		t.Fatalf("mark owner verified: %v", err)
+	}
+
+	// The same person signs in with Google against the address they already own.
 	res, err := svc.SignInWithSocial(ctx, auth.SocialIdentity{
 		Provider:      "google",
 		Subject:       "google-subject-owner",

--- a/apps/api/tests/auth_first_run_ownership_integration_test.go
+++ b/apps/api/tests/auth_first_run_ownership_integration_test.go
@@ -199,8 +199,8 @@ func TestFirstRunOwnership_CorrectClaimStillWorks(t *testing.T) {
 // Two callers presenting the correct claim at the same instant must produce one
 // owner and one organisation, not two.
 //
-// To watch it go red: in internal/auth/bootstrap_repo.go, move the CountUsers
-// read out of the InInstallLockTx callback (do it on r.q before the call), or
+// To watch it go red: in internal/auth/bootstrap_repo.go, move the ownership read
+// out of the InInstallLockTx callback (do it on r.q before the call), or
 // drop the pg_advisory_xact_lock line from Pool.InInstallLockTx. Either restores
 // the check-then-act and this test reports two owners.
 func TestFirstRunOwnership_ConcurrentClaimsMintExactlyOneOwner(t *testing.T) {
@@ -325,7 +325,7 @@ func TestFirstRunOwnership_SocialSignInNeverMints(t *testing.T) {
 // unclaimed install and then requires the claim to still work.
 //
 // To watch it go red: change the ownership probe in Repo.BootstrapInstall back
-// to `q.CountUsers(ctx)` / `count > 0`, and remove the ownership check in the
+// to a user count (`q.CountUsers(ctx)` / `count > 0`), and remove the check in the
 // socialCreate branch of SignInWithSocial (internal/auth/social.go) so the
 // sign-in creates its user row again.
 func TestFirstRunOwnership_AnonymousRequestsCannotCloseTheDoor(t *testing.T) {

--- a/apps/api/tests/auth_first_run_ownership_integration_test.go
+++ b/apps/api/tests/auth_first_run_ownership_integration_test.go
@@ -1,0 +1,445 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// testClaim is the provisioning claim these tests configure. It stands in for
+// the value an installer mints and hands to whoever is entitled to own the
+// install.
+const testClaim = "test-provisioning-claim-value"
+
+// TestFirstRunOwnership_RequiresTheProvisioningClaim is the fires half: every
+// way of arriving without the claim is refused, and refused identically.
+//
+// To watch it go red: delete the `if !s.bootstrapClaimAccepted(claim)` guard at
+// the top of Service.Bootstrap in internal/auth/service.go.
+func TestFirstRunOwnership_RequiresTheProvisioningClaim(t *testing.T) {
+	t.Run("no claim configured on the install", func(t *testing.T) {
+		pool := startPostgres(t)
+		ctx := context.Background()
+		svc, _ := newAuthStack(pool)
+		// Deliberately NOT calling SetBootstrapClaimSecret.
+
+		// Even presenting the "right" secret cannot work when the install has
+		// none: an unconfigured claim is "nobody may claim this", not "anybody".
+		for _, presented := range []string{"", testClaim, "anything"} {
+			_, err := svc.Bootstrap(ctx, auth.RegisterInput{
+				Email:    "attacker@example.com",
+				Password: "a-very-strong-password",
+				Name:     "Attacker",
+			}, presented)
+			assertRegistrationClosed(t, err)
+		}
+
+		assertUserCount(t, pool, 0)
+		assertTenantCount(t, pool, 0)
+	})
+
+	t.Run("wrong claim presented", func(t *testing.T) {
+		pool := startPostgres(t)
+		ctx := context.Background()
+		svc, _ := newAuthStack(pool)
+		svc.SetBootstrapClaimSecret(testClaim)
+
+		for _, presented := range []string{
+			"",                                 // none at all
+			"wrong",                            // shorter
+			testClaim + "x",                    // longer
+			"test-provisioning-claim-valuX",    // same length, last byte differs
+			"Test-Provisioning-Claim-Value",    // case differs
+			" test-provisioning-claim-value  ", // trimmed to the right value: this one MUST succeed, see below
+		} {
+			if presented == " test-provisioning-claim-value  " {
+				continue // covered by the does-not-over-fire test
+			}
+			_, err := svc.Bootstrap(ctx, auth.RegisterInput{
+				Email:    "attacker@example.com",
+				Password: "a-very-strong-password",
+				Name:     "Attacker",
+			}, presented)
+			assertRegistrationClosed(t, err)
+		}
+
+		assertUserCount(t, pool, 0)
+		assertTenantCount(t, pool, 0)
+	})
+}
+
+// TestFirstRunOwnership_RefusalIsIndistinguishable proves the refusal an
+// unclaimed install returns is byte-identical to the one an already-owned
+// install returns, so the endpoint cannot be used to sort installs into
+// "waiting to be claimed" and "already claimed".
+//
+// To watch it go red: give the no-claim-configured branch its own error code in
+// internal/auth/handler.go / service.go (e.g. domain.Forbidden("bootstrap_not_configured", ...)).
+func TestFirstRunOwnership_RefusalIsIndistinguishable(t *testing.T) {
+	ctx := context.Background()
+
+	// An install with no claim configured, still unowned.
+	unclaimedPool := startPostgres(t)
+	unclaimedSvc, _ := newAuthStack(unclaimedPool)
+	_, unclaimedErr := unclaimedSvc.Bootstrap(ctx, auth.RegisterInput{
+		Email: "probe@example.com", Password: "a-very-strong-password",
+	}, "some-guess")
+
+	// An install that has already been claimed, probed with the WRONG claim.
+	claimedPool := startPostgres(t)
+	claimedSvc, _ := newAuthStack(claimedPool)
+	claimedSvc.SetBootstrapClaimSecret(testClaim)
+	if _, err := claimedSvc.Bootstrap(ctx, auth.RegisterInput{
+		Email: "owner@example.com", Password: "a-very-strong-password", Name: "Owner",
+	}, testClaim); err != nil {
+		t.Fatalf("legitimate bootstrap: %v", err)
+	}
+	_, claimedErr := claimedSvc.Bootstrap(ctx, auth.RegisterInput{
+		Email: "probe@example.com", Password: "a-very-strong-password",
+	}, "some-guess")
+
+	// And the same install probed with the RIGHT claim, which is now spent.
+	_, spentErr := claimedSvc.Bootstrap(ctx, auth.RegisterInput{
+		Email: "probe@example.com", Password: "a-very-strong-password",
+	}, testClaim)
+
+	for _, pair := range []struct {
+		name string
+		err  error
+	}{
+		{"unclaimed install, wrong claim", unclaimedErr},
+		{"claimed install, wrong claim", claimedErr},
+		{"claimed install, correct claim", spentErr},
+	} {
+		de, ok := domain.AsDomain(pair.err)
+		if !ok {
+			t.Fatalf("%s: want a domain error, got %v", pair.name, pair.err)
+		}
+		if de.Kind != domain.KindForbidden || de.Code != "registration_closed" {
+			t.Fatalf("%s: want forbidden/registration_closed, got %v/%s", pair.name, de.Kind, de.Code)
+		}
+	}
+
+	// The messages must match too — a differing message is as good a probe as a
+	// differing code.
+	a, _ := domain.AsDomain(unclaimedErr)
+	b, _ := domain.AsDomain(claimedErr)
+	c, _ := domain.AsDomain(spentErr)
+	if a.Message != b.Message || b.Message != c.Message {
+		t.Fatalf("refusal messages differ:\n unclaimed: %q\n claimed:   %q\n spent:     %q", a.Message, b.Message, c.Message)
+	}
+
+	// Neither refusal may echo the configured claim.
+	for _, m := range []string{a.Message, b.Message, c.Message} {
+		if containsSecret(m) {
+			t.Fatalf("refusal message echoes the provisioning claim: %q", m)
+		}
+	}
+}
+
+// TestFirstRunOwnership_CorrectClaimStillWorks is the does-not-over-fire half.
+// A guard that reddens correct work gets switched off, and then it guards
+// nothing.
+//
+// To watch it go red: make bootstrapClaimAccepted return false unconditionally
+// in internal/auth/bootstrap_claim.go.
+func TestFirstRunOwnership_CorrectClaimStillWorks(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc, _ := newAuthStack(pool)
+	svc.SetBootstrapClaimSecret(testClaim)
+
+	// Presented with the surrounding whitespace a shell, a .env file or a
+	// compose file routinely attaches. Trimming is not laxity: the operator set
+	// the right value and cannot see the newline.
+	res, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "owner@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Owner",
+	}, "  "+testClaim+"\n")
+	if err != nil {
+		t.Fatalf("bootstrap with the correct claim: %v", err)
+	}
+	if len(res.Memberships) != 1 || res.Memberships[0].Role != "owner" {
+		t.Fatalf("want exactly one owner membership, got %+v", res.Memberships)
+	}
+	if res.ActiveTenant == uuid.Nil {
+		t.Fatal("bootstrap did not set an active tenant")
+	}
+	if res.User.ID == uuid.Nil {
+		t.Fatal("bootstrap did not create a user")
+	}
+	assertUserCount(t, pool, 1)
+	assertTenantCount(t, pool, 1)
+
+	// The session-issuing half of the existing behaviour: the owner can log in
+	// immediately, with no verification step.
+	if _, err := svc.Login(ctx, "owner@example.com", "a-very-strong-password"); err != nil {
+		t.Fatalf("owner login after bootstrap: %v", err)
+	}
+
+	// An already-owned install is unaffected: a second bootstrap is refused
+	// even with the correct claim.
+	_, err = svc.Bootstrap(ctx, auth.RegisterInput{
+		Email: "second@example.com", Password: "another-strong-password",
+	}, testClaim)
+	assertRegistrationClosed(t, err)
+	assertUserCount(t, pool, 1)
+	assertTenantCount(t, pool, 1)
+}
+
+// TestFirstRunOwnership_ConcurrentClaimsMintExactlyOneOwner is the lock proof.
+// Two callers presenting the correct claim at the same instant must produce one
+// owner and one organisation, not two.
+//
+// To watch it go red: in internal/auth/bootstrap_repo.go, move the CountUsers
+// read out of the InInstallLockTx callback (do it on r.q before the call), or
+// drop the pg_advisory_xact_lock line from Pool.InInstallLockTx. Either restores
+// the check-then-act and this test reports two owners.
+func TestFirstRunOwnership_ConcurrentClaimsMintExactlyOneOwner(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc, _ := newAuthStack(pool)
+	svc.SetBootstrapClaimSecret(testClaim)
+
+	const racers = 8
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		wins    int
+		refused int
+		other   []error
+	)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := svc.Bootstrap(ctx, auth.RegisterInput{
+				Email:    uuid.NewString() + "@example.com",
+				Password: "a-very-strong-password",
+				Name:     "Racer",
+			}, testClaim)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				wins++
+			case isRegistrationClosed(err):
+				refused++
+			default:
+				other = append(other, err)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if len(other) > 0 {
+		t.Fatalf("unexpected errors from concurrent bootstraps: %v", other)
+	}
+	if wins != 1 {
+		t.Fatalf("concurrent bootstraps: %d succeeded, want exactly 1 (refused: %d)", wins, refused)
+	}
+	if refused != racers-1 {
+		t.Fatalf("concurrent bootstraps: %d refused, want %d", refused, racers-1)
+	}
+
+	assertUserCount(t, pool, 1)
+	assertTenantCount(t, pool, 1)
+	assertOwnerMembershipCount(t, pool, 1)
+}
+
+// TestFirstRunOwnership_SocialSignInNeverMints proves the social path cannot
+// grant first-run ownership. It has nowhere to carry the provisioning claim, so
+// the only answer that keeps the two paths agreeing is that it never mints.
+//
+// To watch it go red: restore the `if len(memberships) == 0 && ...` branch in
+// finishSocialLogin (internal/auth/social.go) that created a tenant and an
+// owner membership.
+func TestFirstRunOwnership_SocialSignInNeverMints(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc, _ := newAuthStack(pool)
+	svc.SetBootstrapClaimSecret(testClaim)
+
+	// A completely unclaimed install: zero users, zero tenants.
+	assertUserCount(t, pool, 0)
+
+	res, err := svc.SignInWithSocial(ctx, auth.SocialIdentity{
+		Provider:      "google",
+		Subject:       "google-subject-1",
+		Email:         "first@example.com",
+		EmailVerified: true,
+		Name:          "First",
+	}, makeCreateTenant(t, pool))
+	if err != nil {
+		t.Fatalf("social sign-in: %v", err)
+	}
+	if len(res.Memberships) != 0 {
+		t.Fatalf("social sign-in on an unclaimed install minted %d membership(s): %+v", len(res.Memberships), res.Memberships)
+	}
+	if res.ActiveTenant != uuid.Nil {
+		t.Fatalf("social sign-in on an unclaimed install set an active tenant: %s", res.ActiveTenant)
+	}
+	assertTenantCount(t, pool, 0)
+	assertOwnerMembershipCount(t, pool, 0)
+}
+
+// TestFirstRunOwnership_SocialSignInStillWorksOnAClaimedInstall is the
+// does-not-over-fire half of the social change: once the install has an owner,
+// social sign-in resolves memberships exactly as before.
+//
+// To watch it go red: make finishSocialLogin return no memberships (drop the
+// ListMembershipsForUser call).
+func TestFirstRunOwnership_SocialSignInStillWorksOnAClaimedInstall(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc, _ := newAuthStack(pool)
+	svc.SetBootstrapClaimSecret(testClaim)
+
+	owner, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "owner@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Owner",
+	}, testClaim)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+
+	// The same person signs in with Google against the address they already own
+	// and verified through the claim-bearing bootstrap.
+	res, err := svc.SignInWithSocial(ctx, auth.SocialIdentity{
+		Provider:      "google",
+		Subject:       "google-subject-owner",
+		Email:         "owner@example.com",
+		EmailVerified: true,
+		Name:          "Owner",
+	}, makeCreateTenant(t, pool))
+	if err != nil {
+		t.Fatalf("social sign-in on a claimed install: %v", err)
+	}
+	if res.ActiveTenant != owner.ActiveTenant {
+		t.Fatalf("social sign-in resolved tenant %s, want the owner's %s", res.ActiveTenant, owner.ActiveTenant)
+	}
+	if len(res.Memberships) != 1 {
+		t.Fatalf("want the owner's single membership, got %+v", res.Memberships)
+	}
+	// Still exactly one organisation: signing in socially created nothing.
+	assertTenantCount(t, pool, 1)
+	assertOwnerMembershipCount(t, pool, 1)
+}
+
+// TestFirstRunOwnership_SelfServeCannotBurnTheOwnershipSlot proves an
+// unauthenticated self-serve registration on an unclaimed install writes
+// nothing. Taking the first-account slot and merely blocking it are the same
+// loss to the operator: either way the person holding the claim can never
+// bootstrap.
+//
+// To watch it go red: delete the zero-user early return at the top of
+// RegisterSelfServe in internal/auth/register.go.
+func TestFirstRunOwnership_SelfServeCannotBurnTheOwnershipSlot(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	svc, _ := newAuthStack(pool)
+	svc.SetBootstrapClaimSecret(testClaim)
+
+	// The generic response is returned (nil error), exactly as on a claimed
+	// install, so the caller cannot tell the two apart.
+	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email:    "squatter@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Squatter",
+	}, makeCreateTenant(t, pool)); err != nil {
+		t.Fatalf("self-serve on an unclaimed install returned an error: %v", err)
+	}
+	assertUserCount(t, pool, 0)
+	assertTenantCount(t, pool, 0)
+
+	// The operator can still claim the install afterwards.
+	if _, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "owner@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Owner",
+	}, testClaim); err != nil {
+		t.Fatalf("bootstrap after a self-serve attempt: %v", err)
+	}
+	assertUserCount(t, pool, 1)
+
+	// And self-serve is open again now that the install has an owner: this is
+	// the does-not-over-fire half.
+	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
+		Email:    "later@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Later",
+	}, makeCreateTenant(t, pool)); err != nil {
+		t.Fatalf("self-serve on a claimed install: %v", err)
+	}
+	assertUserCount(t, pool, 2)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func isRegistrationClosed(err error) bool {
+	de, ok := domain.AsDomain(err)
+	return ok && de.Kind == domain.KindForbidden && de.Code == "registration_closed"
+}
+
+func assertRegistrationClosed(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("want a refusal, got success")
+	}
+	if !isRegistrationClosed(err) {
+		t.Fatalf("want forbidden/registration_closed, got %v", err)
+	}
+}
+
+func containsSecret(s string) bool { return strings.Contains(s, testClaim) }
+
+// assertUserCount and assertTenantCount read through the app pool. Neither
+// table is RLS-scoped, and the pool is connected as the non-superuser
+// wpmgr_app role that every install runs as, so this is the same view the
+// request path has.
+func assertUserCount(t *testing.T, pool *db.Pool, want int) {
+	t.Helper()
+	assertCount(t, pool, "SELECT count(*) FROM users", want, "users")
+}
+
+func assertTenantCount(t *testing.T, pool *db.Pool, want int) {
+	t.Helper()
+	assertCount(t, pool, "SELECT count(*) FROM tenants", want, "tenants")
+}
+
+// assertOwnerMembershipCount counts owner memberships ACROSS every tenant,
+// which no tenant-scoped connection can do: memberships is FORCE ROW LEVEL
+// SECURITY and every policy on it is keyed on a scope this assertion
+// deliberately declines to assume. connectAdmin is the documented way to
+// observe from outside the app's RLS constraints; it is used only to check the
+// outcome, never to produce it — every write under test went through the
+// wpmgr_app role via the same tx helper the request path uses.
+func assertOwnerMembershipCount(t *testing.T, pool *db.Pool, want int) {
+	t.Helper()
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	assertCount(t, admin, "SELECT count(*) FROM memberships WHERE role = 'owner'", want, "owner memberships")
+}
+
+func assertCount(t *testing.T, pool *db.Pool, query string, want int, label string) {
+	t.Helper()
+	var got int
+	if err := pool.QueryRow(context.Background(), query).Scan(&got); err != nil {
+		t.Fatalf("count %s: %v", label, err)
+	}
+	if got != want {
+		t.Fatalf("%s = %d, want %d", label, got, want)
+	}
+}

--- a/apps/api/tests/auth_first_run_timing_measure_test.go
+++ b/apps/api/tests/auth_first_run_timing_measure_test.go
@@ -1,0 +1,120 @@
+package tests
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+)
+
+// TestMeasureFirstRunRefusalTiming reports the two durations a refusal on this
+// path could otherwise be told apart by. It is a MEASUREMENT, printed with -v,
+// not a threshold assertion: wall-clock ratios on a laptop under a container
+// are too noisy to gate a build on, and a flaky timing gate gets switched off,
+// after which it guards nothing.
+//
+// What it is for: the claim that "every refusal is indistinguishable" is a
+// claim about duration as well as bytes, and this is the command that checks
+// it. Run it after any change to Service.Bootstrap or Service.RegisterSelfServe
+// that adds a branch, and compare the medians.
+//
+//	go test -count=1 -v -run TestMeasureFirstRunRefusalTiming ./tests/
+func TestMeasureFirstRunRefusalTiming(t *testing.T) {
+	const samples = 15
+
+	median := func(ds []time.Duration) time.Duration {
+		sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+		return ds[len(ds)/2]
+	}
+	timeN := func(fn func()) time.Duration {
+		out := make([]time.Duration, 0, samples)
+		for i := 0; i < samples; i++ {
+			start := time.Now()
+			fn()
+			out = append(out, time.Since(start))
+		}
+		return median(out)
+	}
+
+	// --- Oracle A: claim-correctness against an already-owned install -------
+	ownedPool := startPostgres(t)
+	ctx := context.Background()
+	ownedSvc, _ := newAuthStack(ownedPool)
+	ownedSvc.SetBootstrapClaimSecret(testClaim)
+	if _, err := ownedSvc.Bootstrap(ctx, auth.RegisterInput{
+		Email: "owner@example.com", Password: "a-very-strong-password", Name: "Owner",
+	}, testClaim); err != nil {
+		t.Fatalf("claim the install: %v", err)
+	}
+
+	probe := func(claim string) func() {
+		return func() {
+			_, _ = ownedSvc.Bootstrap(ctx, auth.RegisterInput{
+				Email: "probe@example.com", Password: "a-very-strong-password", Name: "Probe",
+			}, claim)
+		}
+	}
+	wrongLen := timeN(probe("short"))
+	sameLen := timeN(probe("test-provisioning-claim-valuX"))
+	correct := timeN(probe(testClaim))
+
+	t.Logf("ORACLE A (claim-correctness, owned install) MEDIAN over %d: wrong-length=%v same-length-wrong=%v CORRECT-claim(spent)=%v",
+		samples, wrongLen, sameLen, correct)
+
+	// --- Oracle B: install state on the no-header register path -------------
+	unclaimedPool := startPostgres(t)
+	unclaimedSvc, _ := newAuthStack(unclaimedPool)
+	unclaimedSvc.SetBootstrapClaimSecret(testClaim)
+
+	selfServe := func(svc *auth.Service, pool interface{}) func() {
+		i := 0
+		return func() {
+			i++
+			_ = svc.RegisterSelfServe(ctx, auth.RegisterInput{
+				Email:    uniqueEmail(i),
+				Password: "a-very-strong-password",
+				Name:     "Probe",
+			}, makeCreateTenant(t, unclaimedPool))
+		}
+	}
+	unclaimed := timeN(selfServe(unclaimedSvc, unclaimedPool))
+
+	claimedPool := startPostgres(t)
+	claimedSvc, _ := newAuthStack(claimedPool)
+	claimedSvc.SetBootstrapClaimSecret(testClaim)
+	if _, err := claimedSvc.Bootstrap(ctx, auth.RegisterInput{
+		Email: "owner@example.com", Password: "a-very-strong-password", Name: "Owner",
+	}, testClaim); err != nil {
+		t.Fatalf("claim the install: %v", err)
+	}
+	j := 0
+	claimed := timeN(func() {
+		j++
+		_ = claimedSvc.RegisterSelfServe(ctx, auth.RegisterInput{
+			Email:    uniqueEmail(1000 + j),
+			Password: "a-very-strong-password",
+			Name:     "Probe",
+		}, makeCreateTenant(t, claimedPool))
+	})
+
+	t.Logf("ORACLE B (install state, self-serve register, no claim header) MEDIAN over %d: UNCLAIMED=%v CLAIMED=%v",
+		samples, unclaimed, claimed)
+}
+
+func uniqueEmail(i int) string {
+	return "probe-" + time.Now().Format("150405.000000000") + "-" + itoa(i) + "@example.com"
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/apps/api/tests/auth_first_run_timing_measure_test.go
+++ b/apps/api/tests/auth_first_run_timing_measure_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 )
 
 // TestMeasureFirstRunRefusalTiming reports the two durations a refusal on this
@@ -62,24 +63,32 @@ func TestMeasureFirstRunRefusalTiming(t *testing.T) {
 
 	t.Logf("ORACLE A (claim-correctness, owned install) MEDIAN over %d: wrong-length=%v same-length-wrong=%v CORRECT-claim(spent)=%v",
 		samples, wrongLen, sameLen, correct)
+	assertRatioUnder(t, "oracle A (claim-correctness)", wrongLen, correct)
+	assertRatioUnder(t, "oracle A (claim-correctness)", sameLen, correct)
 
 	// --- Oracle B: install state on the no-header register path -------------
 	unclaimedPool := startPostgres(t)
 	unclaimedSvc, _ := newAuthStack(unclaimedPool)
 	unclaimedSvc.SetBootstrapClaimSecret(testClaim)
 
-	selfServe := func(svc *auth.Service, pool interface{}) func() {
-		i := 0
+	// The error is checked rather than discarded: RegisterSelfServe returns nil
+	// on every intended outcome here, so a non-nil one means the call did not do
+	// the work being timed and the sample measures nothing. A median over
+	// samples that all failed early would look exactly like a fast path.
+	selfServe := func(svc *auth.Service, pool *db.Pool, base int) func() {
+		i := base
 		return func() {
 			i++
-			_ = svc.RegisterSelfServe(ctx, auth.RegisterInput{
+			if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
 				Email:    uniqueEmail(i),
 				Password: "a-very-strong-password",
 				Name:     "Probe",
-			}, makeCreateTenant(t, unclaimedPool))
+			}, makeCreateTenant(t, pool)); err != nil {
+				t.Fatalf("self-serve sample: %v", err)
+			}
 		}
 	}
-	unclaimed := timeN(selfServe(unclaimedSvc, unclaimedPool))
+	unclaimed := timeN(selfServe(unclaimedSvc, unclaimedPool, 0))
 
 	claimedPool := startPostgres(t)
 	claimedSvc, _ := newAuthStack(claimedPool)
@@ -89,18 +98,49 @@ func TestMeasureFirstRunRefusalTiming(t *testing.T) {
 	}, testClaim); err != nil {
 		t.Fatalf("claim the install: %v", err)
 	}
-	j := 0
-	claimed := timeN(func() {
-		j++
-		_ = claimedSvc.RegisterSelfServe(ctx, auth.RegisterInput{
-			Email:    uniqueEmail(1000 + j),
-			Password: "a-very-strong-password",
-			Name:     "Probe",
-		}, makeCreateTenant(t, claimedPool))
-	})
+	claimed := timeN(selfServe(claimedSvc, claimedPool, 1000))
 
 	t.Logf("ORACLE B (install state, self-serve register, no claim header) MEDIAN over %d: UNCLAIMED=%v CLAIMED=%v",
 		samples, unclaimed, claimed)
+	assertRatioUnder(t, "oracle B (install state)", unclaimed, claimed)
+}
+
+// maxRefusalRatio is the ceiling this test holds the two paths to.
+//
+// WHY 4x, WHICH IS NOWHERE NEAR TIGHT. The property being defended is that
+// neither pair is separated by ORDERS of magnitude: before the equalising work
+// these ratios were about 112000x and 100x, and afterwards they measure about
+// 1.04x and 1.13x. Anything that reintroduces a skipped argon2 hash — the whole
+// mechanism, and the only way back to a usable difference — lands far above 4x,
+// so the ceiling catches the regression it exists to catch.
+//
+// It cannot flake, and that is deliberate rather than hopeful. The gap between
+// the measured 1.13x and the 4x ceiling is not a safety margin, it is roughly
+// three times the whole measurement. For a green run to go red on noise alone,
+// one median of fifteen would have to move by more than 3x — on a path whose
+// cost is dominated by a fixed argon2 computation that runs identically on both
+// sides. A tight bound (say 1.5x) would have been the flaky one; this project
+// switches off tests that redden correct work, and then they guard nothing.
+//
+// If this fires, do not raise the number. Read the medians in the log line
+// above it: something stopped doing equal work on both paths.
+const maxRefusalRatio = 4.0
+
+func assertRatioUnder(t *testing.T, label string, a, b time.Duration) {
+	t.Helper()
+	lo, hi := a, b
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	if lo <= 0 {
+		t.Fatalf("%s: a median of %v is not a usable measurement", label, lo)
+	}
+	ratio := float64(hi) / float64(lo)
+	if ratio > maxRefusalRatio {
+		t.Fatalf("%s: the two paths differ by %.1fx (%v vs %v), ceiling is %.1fx — one of them stopped doing the work the other does",
+			label, ratio, a, b, maxRefusalRatio)
+	}
+	t.Logf("%s: %.2fx separation (ceiling %.1fx)", label, ratio, maxRefusalRatio)
 }
 
 func uniqueEmail(i int) string {

--- a/apps/api/tests/auth_integration_test.go
+++ b/apps/api/tests/auth_integration_test.go
@@ -27,15 +27,13 @@ func TestBootstrapAndLogin(t *testing.T) {
 	ctx := context.Background()
 	svc, _ := newAuthStack(pool)
 
-	createTenant := func(ctx context.Context, name, slug string) (uuid.UUID, error) {
-		return seedTenant(t, pool, slug), nil
-	}
+	svc.SetBootstrapClaimSecret(testClaim)
 
 	res, err := svc.Bootstrap(ctx, auth.RegisterInput{
 		Email:    "owner@example.com",
 		Password: "a-very-strong-password",
 		Name:     "Owner",
-	}, createTenant)
+	}, testClaim)
 	if err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
@@ -47,7 +45,7 @@ func TestBootstrapAndLogin(t *testing.T) {
 	}
 
 	// Second bootstrap must be refused (registration closed).
-	if _, err := svc.Bootstrap(ctx, auth.RegisterInput{Email: "second@example.com", Password: "another-strong-pass"}, createTenant); err == nil {
+	if _, err := svc.Bootstrap(ctx, auth.RegisterInput{Email: "second@example.com", Password: "another-strong-pass"}, testClaim); err == nil {
 		t.Fatal("second bootstrap should be refused")
 	} else if de, ok := domain.AsDomain(err); !ok || de.Kind != domain.KindForbidden {
 		t.Fatalf("want forbidden, got %v", err)

--- a/apps/api/tests/auth_plan_intent_integration_test.go
+++ b/apps/api/tests/auth_plan_intent_integration_test.go
@@ -85,6 +85,23 @@ func makeCreateTenant(t *testing.T, pool *db.Pool) func(ctx context.Context, nam
 	}
 }
 
+// claimInstall gives the install its first owner, which is the precondition for
+// open self-serve registration: while an install is unclaimed, that path writes
+// nothing, so the first-account slot stays available to whoever holds the
+// provisioning claim. Every self-serve and verify-email test below is about
+// what happens on a NORMAL install, so each one claims first.
+func claimInstall(t *testing.T, svc *auth.Service) {
+	t.Helper()
+	svc.SetBootstrapClaimSecret(testClaim)
+	if _, err := svc.Bootstrap(context.Background(), auth.RegisterInput{
+		Email:    "install-owner@example.com",
+		Password: "a-very-strong-password",
+		Name:     "Install Owner",
+	}, testClaim); err != nil {
+		t.Fatalf("claim install: %v", err)
+	}
+}
+
 // TestRegisterSelfServe_PersistsDesiredPlanOnToken proves a validated paid-tier
 // hint lands on the verification-token row created by registration.
 func TestRegisterSelfServe_PersistsDesiredPlanOnToken(t *testing.T) {
@@ -93,6 +110,7 @@ func TestRegisterSelfServe_PersistsDesiredPlanOnToken(t *testing.T) {
 	svc := newAuthStackWithBilling(pool)
 	repo := auth.NewRepo(pool)
 	createTenant := makeCreateTenant(t, pool)
+	claimInstall(t, svc)
 
 	const email = "plan-agency-signup@example.com"
 	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
@@ -130,6 +148,7 @@ func TestRegisterSelfServe_NonPaidPlanHintsAreIgnored(t *testing.T) {
 	svc := newAuthStackWithBilling(pool)
 	repo := auth.NewRepo(pool)
 	createTenant := makeCreateTenant(t, pool)
+	claimInstall(t, svc)
 
 	cases := []struct {
 		name  string
@@ -171,6 +190,7 @@ func TestRegisterSelfServe_NoPlanValidatorMeansNoIntent(t *testing.T) {
 	svc, _ := newAuthStack(pool) // no SetPlanValidator call — mirrors self-host boot
 	repo := auth.NewRepo(pool)
 	createTenant := makeCreateTenant(t, pool)
+	claimInstall(t, svc)
 
 	const email = "plan-selfhost-signup@example.com"
 	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{
@@ -198,6 +218,7 @@ func TestVerifyEmail_SurfacesAndConsumesDesiredPlan(t *testing.T) {
 	ctx := context.Background()
 	svc := newAuthStackWithBilling(pool)
 	createTenant := makeCreateTenant(t, pool)
+	claimInstall(t, svc)
 
 	mailer := &capturingMailer{}
 	svc.SetMailer(mailer, "https://manage.example.test", nil)
@@ -248,6 +269,7 @@ func TestVerifyEmail_NoIntentReturnsEmpty(t *testing.T) {
 	ctx := context.Background()
 	svc := newAuthStackWithBilling(pool)
 	createTenant := makeCreateTenant(t, pool)
+	claimInstall(t, svc)
 
 	mailer := &capturingMailer{}
 	svc.SetMailer(mailer, "https://manage.example.test", nil)
@@ -280,6 +302,7 @@ func TestResendVerification_CarriesForwardDesiredPlan(t *testing.T) {
 	svc := newAuthStackWithBilling(pool)
 	repo := auth.NewRepo(pool)
 	createTenant := makeCreateTenant(t, pool)
+	claimInstall(t, svc)
 
 	mailer := &capturingMailer{}
 	svc.SetMailer(mailer, "https://manage.example.test", nil)

--- a/apps/api/tests/auth_plan_intent_integration_test.go
+++ b/apps/api/tests/auth_plan_intent_integration_test.go
@@ -333,14 +333,14 @@ func TestBootstrap_SurfacesDesiredPlanImmediately(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc := newAuthStackWithBilling(pool)
-	createTenant := makeCreateTenant(t, pool)
+	svc.SetBootstrapClaimSecret(testClaim)
 
 	res, err := svc.Bootstrap(ctx, auth.RegisterInput{
 		Email:    "first-admin@example.com",
 		Password: "a-very-strong-password",
 		Name:     "First Admin",
 		Plan:     string(billing.TierScale),
-	}, createTenant)
+	}, testClaim)
 	if err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
@@ -359,14 +359,14 @@ func TestBootstrap_NonPaidPlanHintSurfacesEmpty(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc := newAuthStackWithBilling(pool)
-	createTenant := makeCreateTenant(t, pool)
+	svc.SetBootstrapClaimSecret(testClaim)
 
 	res, err := svc.Bootstrap(ctx, auth.RegisterInput{
 		Email:    "first-admin@example.com",
 		Password: "a-very-strong-password",
 		Name:     "First Admin",
 		Plan:     string(billing.TierFree),
-	}, createTenant)
+	}, testClaim)
 	if err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}

--- a/apps/api/tests/social_identity_continuity_test.go
+++ b/apps/api/tests/social_identity_continuity_test.go
@@ -119,14 +119,26 @@ func TestSocialIdentity_DeclaredIssuerChangeKeepsTheSameAccount(t *testing.T) {
 	// credential means, so a move that nobody can see afterwards is not a
 	// migration, it is a silent relaxation. Read through a superuser connection
 	// because audit_log is tenant-scoped by RLS.
+	//
+	// BOTH SINKS, because which one takes the event is a property of the person
+	// and not of the move. recordSocialAuditWith writes to audit_log when the
+	// user has an org and to system_audit_log when they do not, and this user
+	// has none: an SSO sign-in does not create an organisation, so a corporate
+	// user is tenantless until somebody invites them. Counting the union is
+	// what the assertion always meant — exactly one audited move — and it holds
+	// whichever side of that the user happens to be on.
 	admin := connectAdmin(t, pool)
 	defer admin.Close()
 	var moves int
 	if err := admin.QueryRow(ctx,
-		`SELECT count(*) FROM audit_log
-		 WHERE metadata->>'event' = 'identity_issuer_migrated'
-		   AND metadata->>'from_issuer' = 'https://idp.acme.com'
-		   AND metadata->>'to_issuer' = 'https://login.acme.com'`).Scan(&moves); err != nil {
+		`SELECT (SELECT count(*) FROM audit_log
+		          WHERE metadata->>'event' = 'identity_issuer_migrated'
+		            AND metadata->>'from_issuer' = 'https://idp.acme.com'
+		            AND metadata->>'to_issuer' = 'https://login.acme.com')
+		      + (SELECT count(*) FROM system_audit_log
+		          WHERE metadata->>'event' = 'identity_issuer_migrated'
+		            AND metadata->>'from_issuer' = 'https://idp.acme.com'
+		            AND metadata->>'to_issuer' = 'https://login.acme.com')`).Scan(&moves); err != nil {
 		t.Fatalf("read audit log: %v", err)
 	}
 	if moves != 1 {

--- a/apps/api/tests/social_identity_continuity_test.go
+++ b/apps/api/tests/social_identity_continuity_test.go
@@ -120,29 +120,32 @@ func TestSocialIdentity_DeclaredIssuerChangeKeepsTheSameAccount(t *testing.T) {
 	// migration, it is a silent relaxation. Read through a superuser connection
 	// because audit_log is tenant-scoped by RLS.
 	//
-	// BOTH SINKS, because which one takes the event is a property of the person
-	// and not of the move. recordSocialAuditWith writes to audit_log when the
-	// user has an org and to system_audit_log when they do not, and this user
-	// has none: an SSO sign-in does not create an organisation, so a corporate
-	// user is tenantless until somebody invites them. Counting the union is
-	// what the assertion always meant — exactly one audited move — and it holds
-	// whichever side of that the user happens to be on.
+	// THE SYSTEM SINK, NAMED, not "either sink". recordSocialAuditWith routes
+	// by whether the actor has an org: audit_log when they do, system_audit_log
+	// when they do not. This user has none — an SSO sign-in does not create an
+	// organisation, so a corporate user is tenantless until somebody invites
+	// them — so system_audit_log is the sink this event MUST reach, and a
+	// union would also pass if routing broke and sent it to the other one.
+	// audit_log is asserted empty for the same reason.
 	admin := connectAdmin(t, pool)
 	defer admin.Close()
-	var moves int
+	const movePredicate = `metadata->>'event' = 'identity_issuer_migrated'
+		 AND metadata->>'from_issuer' = 'https://idp.acme.com'
+		 AND metadata->>'to_issuer' = 'https://login.acme.com'`
+	var systemMoves, tenantMoves int
 	if err := admin.QueryRow(ctx,
-		`SELECT (SELECT count(*) FROM audit_log
-		          WHERE metadata->>'event' = 'identity_issuer_migrated'
-		            AND metadata->>'from_issuer' = 'https://idp.acme.com'
-		            AND metadata->>'to_issuer' = 'https://login.acme.com')
-		      + (SELECT count(*) FROM system_audit_log
-		          WHERE metadata->>'event' = 'identity_issuer_migrated'
-		            AND metadata->>'from_issuer' = 'https://idp.acme.com'
-		            AND metadata->>'to_issuer' = 'https://login.acme.com')`).Scan(&moves); err != nil {
+		`SELECT count(*) FROM system_audit_log WHERE `+movePredicate).Scan(&systemMoves); err != nil {
+		t.Fatalf("read system audit log: %v", err)
+	}
+	if systemMoves != 1 {
+		t.Fatalf("expected exactly 1 audited issuer migration in system_audit_log, got %d", systemMoves)
+	}
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM audit_log WHERE `+movePredicate).Scan(&tenantMoves); err != nil {
 		t.Fatalf("read audit log: %v", err)
 	}
-	if moves != 1 {
-		t.Fatalf("expected exactly 1 audited issuer migration, got %d", moves)
+	if tenantMoves != 0 {
+		t.Fatalf("a tenantless actor's move reached the tenant-scoped sink %d time(s); routing is wrong", tenantMoves)
 	}
 
 	// With the row moved, the declaration is no longer load-bearing.

--- a/apps/api/tests/social_identity_continuity_test.go
+++ b/apps/api/tests/social_identity_continuity_test.go
@@ -68,6 +68,20 @@ func identityIssuer(t *testing.T, pool *db.Pool, userID uuid.UUID) string {
 	return issuer
 }
 
+// userCountForEmail counts user rows holding one address. It is the right
+// question where the test is asking "did this sign-in fork the account?", which
+// is about that person and not about how many rows the fixture happens to have
+// created for other reasons.
+func userCountForEmail(t *testing.T, pool *db.Pool, email string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM users WHERE email = $1`, email).Scan(&n); err != nil {
+		t.Fatalf("count users for %s: %v", email, err)
+	}
+	return n
+}
+
 func userCount(t *testing.T, pool *db.Pool) int {
 	t.Helper()
 	var n int
@@ -85,6 +99,11 @@ func TestSocialIdentity_DeclaredIssuerChangeKeepsTheSameAccount(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, _ := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run
+	// slot stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	mk := noTenant(t, pool)
 
 	first, err := svc.UpsertOIDCUser(ctx,
@@ -164,6 +183,11 @@ func TestSocialIdentity_CosmeticIssuerEditNeedsNoDeclaration(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, _ := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run
+	// slot stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	mk := noTenant(t, pool)
 
 	first, err := svc.UpsertOIDCUser(ctx,
@@ -179,8 +203,13 @@ func TestSocialIdentity_CosmeticIssuerEditNeedsNoDeclaration(t *testing.T) {
 	if second.User.ID != first.User.ID {
 		t.Fatalf("a trailing slash forked the account: %s then %s", first.User.ID, second.User.ID)
 	}
-	if n := userCount(t, pool); n != 1 {
-		t.Fatalf("expected 1 user, got %d", n)
+	// Counted for this ADDRESS, not for the install: the install also has the
+	// owner who claimed it, and what this test is about is whether the second
+	// sign-in forked sarah's account. An absolute count would have to be
+	// adjusted every time the fixture gains a row, which is how an assertion
+	// drifts away from the thing it was written to catch.
+	if n := userCountForEmail(t, pool, "sarah@acme.com"); n != 1 {
+		t.Fatalf("expected exactly 1 user row for the address, got %d", n)
 	}
 }
 
@@ -191,6 +220,11 @@ func TestSocialIdentity_SubjectCollisionAcrossIssuersIsNeverTheSameAccount(t *te
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, _ := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run
+	// slot stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	mk := noTenant(t, pool)
 
 	alice, err := svc.UpsertOIDCUser(ctx,
@@ -315,6 +349,11 @@ func TestSocialIdentity_RefusedSignInDoesNotMigrateTheIssuer(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, _ := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run
+	// slot stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	mk := noTenant(t, pool)
 
 	first, err := svc.UpsertOIDCUser(ctx,
@@ -342,6 +381,11 @@ func TestSocialIdentity_UndeclaredIssuerChangeDoesNotAdoptALegacyRow(t *testing.
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, _ := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run
+	// slot stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	mk := noTenant(t, pool)
 
 	legacyID := seedLegacyOIDCUser(t, pool, "corp-sub-1@oidc.local", "https://idp.acme.com", "corp-sub-1")
@@ -364,6 +408,11 @@ func TestSocialIdentity_ConsumerProviderNeverAdoptsALegacyRow(t *testing.T) {
 	ctx := context.Background()
 	repo := auth.NewRepo(pool)
 	svc, _ := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run
+	// slot stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	mk := noTenant(t, pool)
 
 	legacyID := seedLegacyOIDCUser(t, pool, "sarah@acme.com", "https://idp.acme.com", "collide-1")

--- a/apps/api/tests/social_link_notification_integration_test.go
+++ b/apps/api/tests/social_link_notification_integration_test.go
@@ -184,6 +184,11 @@ func TestSocialAccountCreationSendsNoLinkNotice(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, mail, createTenant := newSocialStack(t, pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run slot
+	// stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 
 	if _, err := svc.SignInWithSocial(ctx, auth.SocialIdentity{
 		Provider: "github", Subject: "gh-1",

--- a/apps/api/tests/social_review_debt_integration_test.go
+++ b/apps/api/tests/social_review_debt_integration_test.go
@@ -267,6 +267,11 @@ func TestRefusedSocialLinkCarriesForwardTheDesiredPlan(t *testing.T) {
 	svc := newAuthStackWithBilling(pool)
 	svc.SetMailer(&recordingMailer{}, "https://manage.example.com", nil)
 	repo := auth.NewRepo(pool)
+	// Open self-serve registration is a property of a NORMAL install, so give
+	// this one its owner first: while an install is unclaimed the self-serve
+	// path writes nothing, keeping the first-account slot for whoever holds the
+	// provisioning claim.
+	claimInstall(t, svc)
 
 	const email = "paid-then-social@example.com"
 	if err := svc.RegisterSelfServe(ctx, auth.RegisterInput{

--- a/apps/api/tests/social_writes_integration_test.go
+++ b/apps/api/tests/social_writes_integration_test.go
@@ -447,6 +447,11 @@ func TestSigningInSociallyDoesNotAcceptInvitations(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, auditRec := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run slot
+	// stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	inviteSvc := invitation.NewService(pool, auth.NewRepo(pool), auditRec, noopSessions{}, nil, "")
 
 	tenantID := seedTenant(t, pool, "acme")
@@ -485,6 +490,11 @@ func TestASocialAccountCanAcceptAnInvitationOnceSignedIn(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, auditRec := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run slot
+	// stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	inviteSvc := invitation.NewService(pool, auth.NewRepo(pool), auditRec, noopSessions{}, nil, "")
 
 	tenantID := seedTenant(t, pool, "acme")
@@ -528,6 +538,11 @@ func TestAcceptStillRefusesAPasswordlessAccountWithoutASession(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, auditRec := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run slot
+	// stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	inviteSvc := invitation.NewService(pool, auth.NewRepo(pool), auditRec, noopSessions{}, nil, "")
 
 	tenantID := seedTenant(t, pool, "acme")
@@ -572,6 +587,11 @@ func TestInvitationIsNotSpentWhenTheGrantFails(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, auditRec := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run slot
+	// stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	inviteSvc := invitation.NewService(pool, auth.NewRepo(pool), auditRec, noopSessions{}, nil, "")
 
 	tenantID := seedTenant(t, pool, "acme")
@@ -642,6 +662,11 @@ func TestTheSessionsOwnAddressCostsNoAttempt(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
 	svc, auditRec := newAuthStack(pool)
+	// A social account is created below, and creating one is a property of a
+	// NORMAL install: while no owner membership exists anywhere, this install
+	// accepts no new accounts on any unauthenticated path, so the first-run slot
+	// stays with whoever holds the provisioning claim. Claim it first.
+	claimInstall(t, svc)
 	inviteSvc := invitation.NewService(pool, auth.NewRepo(pool), auditRec, noopSessions{}, nil, "")
 
 	tenantID := seedTenant(t, pool, "acme")

--- a/apps/api/tests/social_writes_integration_test.go
+++ b/apps/api/tests/social_writes_integration_test.go
@@ -277,15 +277,35 @@ func TestSocialSignInDoesNotMintAnOrgDuringTheDeleteGraceWindow(t *testing.T) {
 	created := 0
 	newTenant := tenantCreator(t, pool, &created)
 
-	// The install's only user, signed in socially once, with an org.
-	first, err := svc.SignInWithSocial(ctx, googleIdentity("sarah@acme.com"), newTenant)
+	// The install's only user, WITH an org. She gets it the way anyone gets
+	// one: the claim-bearing first-run call, which is the only path that mints
+	// an organisation. A social sign-in never does, so it cannot be used to
+	// arrange this precondition — that is the whole subject of
+	// TestFirstRunOwnership_SocialSignInNeverMints.
+	svc.SetBootstrapClaimSecret(testClaim)
+	first, err := svc.Bootstrap(ctx, auth.RegisterInput{
+		Email:    "sarah@acme.com",
+		Password: "a-very-strong-password",
+		Name:     "Sarah",
+	}, testClaim)
 	if err != nil {
-		t.Fatalf("first social sign-in: %v", err)
+		t.Fatalf("claim the install: %v", err)
 	}
 	if len(first.Memberships) != 1 {
-		t.Fatalf("first run must bootstrap exactly one organisation, got %d", len(first.Memberships))
+		t.Fatalf("first run must create exactly one organisation, got %d", len(first.Memberships))
 	}
 	orgID := first.Memberships[0].TenantID
+
+	// The social linking policy refuses to attach a provider identity to an
+	// address this install never verified (the account-takeover defence, not
+	// what this test is about), so verify it out of band first.
+	if _, err := pool.Exec(ctx,
+		"UPDATE users SET email_verified_at = now() WHERE email = $1", "sarah@acme.com"); err != nil {
+		t.Fatalf("mark the owner verified: %v", err)
+	}
+	if _, err := svc.SignInWithSocial(ctx, googleIdentity("sarah@acme.com"), newTenant); err != nil {
+		t.Fatalf("link the provider: %v", err)
+	}
 
 	// The owner deletes it. Soft delete: the row survives the grace window.
 	if _, err := pool.Exec(ctx, "UPDATE tenants SET deleted_at = now() WHERE id = $1", orgID); err != nil {
@@ -304,35 +324,42 @@ func TestSocialSignInDoesNotMintAnOrgDuringTheDeleteGraceWindow(t *testing.T) {
 		t.Fatalf("got %d visible memberships, want 0: a soft-deleted org must stay deleted until its owner restores it", len(second.Memberships))
 	}
 
-	// And the same login through the password path agrees.
-	if _, lerr := svc.Login(ctx, "sarah@acme.com", "irrelevant"); lerr == nil {
-		t.Fatal("precondition: a social account has no password")
+	// And the same login through the password path agrees. She has a password
+	// now (the first-run call set one), so this is the stronger form of the
+	// original check: the two paths are compared on the same account, and both
+	// must report zero visible memberships rather than one merely failing.
+	pw, lerr := svc.Login(ctx, "sarah@acme.com", "a-very-strong-password")
+	if lerr != nil {
+		t.Fatalf("password login: %v", lerr)
+	}
+	if len(pw.Memberships) != 0 {
+		t.Fatalf("the password path reports %d visible membership(s); the social path reports 0", len(pw.Memberships))
 	}
 	if created != createdBefore {
 		t.Fatal("the password path created an organisation")
 	}
 }
 
-// TestSocialSignInStillBootstrapsTheFirstInstall guards the correction from
-// overshooting: a genuinely new install must still get its first organisation
-// from its first social sign-in, or the first user lands with nowhere to work.
-func TestSocialSignInStillBootstrapsTheFirstInstall(t *testing.T) {
-	pool := startPostgres(t)
-	ctx := context.Background()
-	svc, _ := newAuthStack(pool)
-
-	created := 0
-	res, err := svc.SignInWithSocial(ctx, googleIdentity("sarah@acme.com"), tenantCreator(t, pool, &created))
-	if err != nil {
-		t.Fatalf("first social sign-in: %v", err)
-	}
-	if created != 1 || len(res.Memberships) != 1 || res.Memberships[0].Role != authz.RoleOwner {
-		t.Fatalf("first run must create one org and one owner membership: created=%d memberships=%+v", created, res.Memberships)
-	}
-	if res.ActiveTenant == uuid.Nil {
-		t.Fatal("first run left the session with no active tenant")
-	}
-}
+// TestSocialSignInStillBootstrapsTheFirstInstall IS GONE, AND ITS ABSENCE IS
+// THE POINT. It asserted that a first social sign-in mints the install's first
+// organisation. That is no longer true and is no longer wanted: minting the
+// first organisation is an act of provisioning, authorised by the provisioning
+// claim, and a social sign-in is a redirect shaped by the identity provider
+// with nowhere to carry one. A path that cannot check the claim must not make
+// the grant.
+//
+// The property that replaced it is asserted in
+// auth_first_run_ownership_integration_test.go:
+//   - TestFirstRunOwnership_SocialSignInNeverMints — an unclaimed install is
+//     left with zero tenants and zero owner memberships.
+//   - TestFirstRunOwnership_SocialSignInStillWorksOnAClaimedInstall — the
+//     does-not-over-fire half: once the install has an owner, a social sign-in
+//     resolves to the org that person already owns.
+//
+// The concern this test carried — that the first user must not land with
+// nowhere to work — is met by the claim-bearing first-run call, which creates
+// the org and issues the session in one request
+// (TestFirstRunOwnership_CorrectClaimStillWorks).
 
 // ---------------------------------------------------------------------------
 // CompleteSocialLink re-checks the policy against fresh state

--- a/docs/install.md
+++ b/docs/install.md
@@ -360,24 +360,28 @@ Grafana then ships with the WPMgr dashboards pre-provisioned. See
     -d '{"email":"you@example.com","password":"replace-with-12+-chars"}'
   ```
 
-  Without the header, `POST /auth/register` still returns `200` and creates a
-  pending, self-serve account — not the owner. Once an install has an owner,
-  the header is refused the same way it is when it's wrong or missing, so this
-  step only ever applies once, on a fresh install.
+  **If you already signed up through the dashboard on a brand-new install and
+  are waiting for a verification email: stop waiting, and send the claim
+  request above instead.** A request without the header gets the same
+  `200 {"ok":true,"pending":true}` response whether or not the install has an
+  owner — that response is deliberately identical either way, so the endpoint
+  never reveals ownership state — but on an install with no owner yet,
+  nothing is written and no mail goes out. Once an install has an owner, that
+  same no-header request is ordinary self-serve sign-up: a pending account is
+  created and a real verification email is sent.
 
-  **Symptom: registration is closed on a brand-new install.** If
-  `POST /auth/register` (or the dashboard Sign Up form) returns
-  `403 registration_closed` even though nobody has claimed the install yet,
-  the `api` service has no `WPMGR_BOOTSTRAP_CLAIM_SECRET` configured — an
-  unset value refuses every claim attempt rather than accepting any header.
-  **Upgrade note:** this is the expected state for an install that was stood
-  up before this variable existed, and a plain `docker compose pull && up -d`
-  does not fix it — nothing regenerates `.env` from restarting a container on
-  a new image. Re-run `scripts/init-env.sh` (safe and idempotent — it fills
-  only the missing key), or set `WPMGR_BOOTSTRAP_CLAIM_SECRET` yourself, then
-  restart the `api` service. For an install that already has an owner, the
-  missing variable produces one boot warning and nothing else — there is
-  nothing left to claim.
+  **Symptom: the claim request itself returns `403 registration_closed`.**
+  That response is the same whether `WPMGR_BOOTSTRAP_CLAIM_SECRET` doesn't
+  match (or isn't set on the server) or the install already has an owner — by
+  the same non-revealing design as above. **Upgrade note:** on a fresh
+  install that has never been claimed, a plain `docker compose pull && up -d`
+  does not add this variable to an already-written `.env` — nothing
+  regenerates it from restarting a container on a new image. Re-run
+  `scripts/init-env.sh` (safe and idempotent — it fills only the missing
+  key), or set `WPMGR_BOOTSTRAP_CLAIM_SECRET` yourself, then restart the
+  `api` service. If the install already has an owner, the missing variable
+  produces one boot warning and nothing else — there is nothing left to
+  claim.
 
 For local development with hot-reload overrides, use `make dev` (runs
 `docker-compose.yml` + `docker-compose.dev.yml`) — see

--- a/docs/install.md
+++ b/docs/install.md
@@ -347,17 +347,32 @@ Grafana then ships with the WPMgr dashboards pre-provisioned. See
 - **First-run ownership requires the provisioning claim.** The dashboard Sign
   Up form cannot create the first account. `POST /auth/register` only grants
   ownership when the request carries the `X-Wpmgr-Bootstrap-Claim` header set
-  to the value of `WPMGR_BOOTSTRAP_CLAIM_SECRET` from `.env` — it is a header,
-  never a body field, and is deliberately absent from `openapi.yaml`, so no
-  generated client (including the dashboard) can send it. `scripts/init-env.sh`
-  prints the exact command with your generated secret filled in as its final
-  next step; the same command, with a placeholder in place of the real value:
+  to the value of `WPMGR_BOOTSTRAP_CLAIM_SECRET` — it is a header, never a
+  body field, and is deliberately absent from `openapi.yaml`, so no generated
+  client (including the dashboard) can send it. That value lives in `.env`
+  under that key, generated once by `scripts/init-env.sh` and never rotated
+  by a re-run.
+
+  You never need to look up or paste that value yourself. `scripts/init-env.sh`
+  (and the quickstart-selfhost.sh curl-pipe path) prints the exact claim
+  command as its final next step, with your `.env` path and API port already
+  filled in — run the printed command as-is. The command itself reads the
+  secret out of `.env` at the moment you run it, writes it into a private,
+  600-permission temp curl config file, hands that to curl with `-K`, and
+  deletes the file on exit whether the request succeeds or fails; the value
+  never appears in the printed text, on the command line, or in shell
+  history. Its shape, with a placeholder in place of your real `.env` path:
 
   ```bash
-  curl -X POST http://localhost:8081/auth/register \
-    -H "Content-Type: application/json" \
-    -H "X-Wpmgr-Bootstrap-Claim: <value of WPMGR_BOOTSTRAP_CLAIM_SECRET in .env>" \
-    -d '{"email":"you@example.com","password":"replace-with-12+-chars"}'
+  ( env_file="<path to your .env>" && \
+    claim_val="$(grep '^WPMGR_BOOTSTRAP_CLAIM_SECRET=' "${env_file}" | head -n1 | sed -E "s/^[^=]*=//; s/^\"(.*)\"\$/\1/; s/^'(.*)'\$/\1/")" && \
+    claim_cfg="$(mktemp)" && chmod 600 "${claim_cfg}" && \
+    trap 'rm -f "${claim_cfg}"' EXIT && \
+    printf 'header = "X-Wpmgr-Bootstrap-Claim: %s"\n' "${claim_val}" >"${claim_cfg}" && \
+    curl -X POST http://localhost:8081/auth/register \
+      -H "Content-Type: application/json" \
+      -K "${claim_cfg}" \
+      -d '{"email":"you@example.com","password":"replace-with-12+-chars"}' )
   ```
 
   **If you already signed up through the dashboard on a brand-new install and

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,6 +44,12 @@ at boot, so the app accepts them on the first try — are:
 > the server's own boot parsers before printing it, so a generated line is
 > guaranteed to load.
 
+`scripts/init-env.sh` also generates `WPMGR_BOOTSTRAP_CLAIM_SECRET`, a fifth
+value with a different job: it is the provisioning claim that lets you take
+ownership of a fresh install (see [First-run notes](#first-run-notes) below).
+It follows the same idempotence rule as the four secrets above — a value
+already present in `.env` is never rotated by a re-run.
+
 ### Pin your secrets
 
 Stored secrets (operator two-factor enrollments, SMTP passwords, backup-destination
@@ -338,6 +344,40 @@ Grafana then ships with the WPMgr dashboards pre-provisioned. See
 - Put a TLS-terminating reverse proxy (the bundled `infra/nginx/` config, or
   your own) in front of the published API port (`WPMGR_API_PORT`, default
   `:8081`) for production.
+- **First-run ownership requires the provisioning claim.** The dashboard Sign
+  Up form cannot create the first account. `POST /auth/register` only grants
+  ownership when the request carries the `X-Wpmgr-Bootstrap-Claim` header set
+  to the value of `WPMGR_BOOTSTRAP_CLAIM_SECRET` from `.env` — it is a header,
+  never a body field, and is deliberately absent from `openapi.yaml`, so no
+  generated client (including the dashboard) can send it. `scripts/init-env.sh`
+  prints the exact command with your generated secret filled in as its final
+  next step; the same command, with a placeholder in place of the real value:
+
+  ```bash
+  curl -X POST http://localhost:8081/auth/register \
+    -H "Content-Type: application/json" \
+    -H "X-Wpmgr-Bootstrap-Claim: <value of WPMGR_BOOTSTRAP_CLAIM_SECRET in .env>" \
+    -d '{"email":"you@example.com","password":"replace-with-12+-chars"}'
+  ```
+
+  Without the header, `POST /auth/register` still returns `200` and creates a
+  pending, self-serve account — not the owner. Once an install has an owner,
+  the header is refused the same way it is when it's wrong or missing, so this
+  step only ever applies once, on a fresh install.
+
+  **Symptom: registration is closed on a brand-new install.** If
+  `POST /auth/register` (or the dashboard Sign Up form) returns
+  `403 registration_closed` even though nobody has claimed the install yet,
+  the `api` service has no `WPMGR_BOOTSTRAP_CLAIM_SECRET` configured — an
+  unset value refuses every claim attempt rather than accepting any header.
+  **Upgrade note:** this is the expected state for an install that was stood
+  up before this variable existed, and a plain `docker compose pull && up -d`
+  does not fix it — nothing regenerates `.env` from restarting a container on
+  a new image. Re-run `scripts/init-env.sh` (safe and idempotent — it fills
+  only the missing key), or set `WPMGR_BOOTSTRAP_CLAIM_SECRET` yourself, then
+  restart the `api` service. For an install that already has an owner, the
+  missing variable produces one boot warning and nothing else — there is
+  nothing left to claim.
 
 For local development with hot-reload overrides, use `make dev` (runs
 `docker-compose.yml` + `docker-compose.dev.yml`) — see

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -178,6 +178,13 @@ services:
       # nginx proxies /auth/* to the api. So the redirect URL uses port 8088, not
       # the container-internal :8080 or the direct api host port (WPMGR_API_PORT).
       WPMGR_OIDC_REDIRECT_URL: ${WPMGR_OIDC_REDIRECT_URL:-http://localhost:8088/auth/oidc/callback}
+      # --- First-run ownership --------------------------------------------------
+      # The provisioning claim POST /auth/register must present (header
+      # X-Wpmgr-Bootstrap-Claim) to establish this install's first owner. No
+      # default here — an unset value means the install boots but nobody can
+      # claim it yet, which is the deliberate fail-closed direction. quickstart
+      # (scripts/init-env.sh) generates and persists this into .env on first run.
+      WPMGR_BOOTSTRAP_CLAIM_SECRET: ${WPMGR_BOOTSTRAP_CLAIM_SECRET:-}
       WPMGR_REDIS_ADDR: redis:6379
       # M5.6/ADR-033: presigned URLs the agent receives MUST be reachable from
       # OUTSIDE this Docker network — `seaweedfs:8333` (Docker service name)

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -192,16 +192,23 @@ print_next_steps() {
      Sign Up form in the dashboard for the FIRST account — the provisioning
      claim only travels as a request header, deliberately kept out of the
      OpenAPI schema every generated client (including the dashboard) uses.
-     Run this once, after the stack is up, to create the first owner account:
+     Run this once, after the stack is up, to create the first owner account.
+     The block below writes the claim into a private, 600-permission temp
+     file instead of the command line, so it never shows up in \`ps\` output,
+     and removes that file when curl exits, on success or failure:
 
-       curl -X POST http://localhost:${api_port}/auth/register \\
-         -H "Content-Type: application/json" \\
-         -H "X-Wpmgr-Bootstrap-Claim: ${claim_secret}" \\
-         -d '{"email":"you@example.com","password":"replace-with-12+-chars"}'
+       ( claim_cfg="\$(mktemp)" && chmod 600 "\${claim_cfg}" && \\
+         trap 'rm -f "\${claim_cfg}"' EXIT && \\
+         printf 'header = "X-Wpmgr-Bootstrap-Claim: %s"\n' '${claim_secret}' >"\${claim_cfg}" && \\
+         curl -X POST http://localhost:${api_port}/auth/register \\
+           -H "Content-Type: application/json" \\
+           -K "\${claim_cfg}" \\
+           -d '{"email":"you@example.com","password":"replace-with-12+-chars"}' )
 
-     ${BOOTSTRAP_CLAIM_KEY} is saved in .env — the value above is that exact
-     secret. It is not re-generated on a later re-run of this script once a
-     value is present, so it stays valid until you rotate it yourself.
+     ${BOOTSTRAP_CLAIM_KEY} is saved in .env — the value written into the temp
+     file above is that exact secret. It is not re-generated on a later
+     re-run of this script once a value is present, so it stays valid until
+     you rotate it yourself.
 CLAIMEOF
 )"
   else

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -59,6 +59,16 @@ INFRA_PASSWORD_KEYS=(
   WPMGR_S3_SECRET_KEY
 )
 
+# The first-run ownership claim (see apps/api/internal/auth/bootstrap_claim.go).
+# Randomized once, same as the infra passwords above: never rotated on a
+# re-run once a value is present, because rotating it before anyone has
+# claimed the install is harmless but rotating it after is confusing (the
+# operator who wrote it down would suddenly hold a stale value). There is no
+# shipped placeholder for this key in .env.example, so an absent or empty
+# value is the only "needs one" signal — needs_value already treats both that
+# way.
+BOOTSTRAP_CLAIM_KEY=WPMGR_BOOTSTRAP_CLAIM_SECRET
+
 # Committed DEV placeholders shipped in .env.example. These are PUBLIC and the
 # control plane rejects the agent private key in production, so a fresh install
 # must replace them. We treat them like an empty value (regenerate them).
@@ -164,11 +174,41 @@ gen_with_host_tools() {
 
 print_next_steps() {
   # Read the actual host ports from .env (fall back to compose defaults).
-  local api_port web_port
+  local api_port web_port claim_secret
   api_port="$(current_value WPMGR_API_PORT)"
   api_port="${api_port:-8081}"
   web_port="$(current_value WPMGR_WEB_PORT)"
   web_port="${web_port:-8088}"
+  # Read back from .env rather than trusting a var from this run: the value
+  # may have been generated just now, supplied by the operator earlier, or
+  # (if something above failed silently) still absent — print exactly what is
+  # actually persisted, not what this run assumed.
+  claim_secret="$(current_value "${BOOTSTRAP_CLAIM_KEY}")"
+
+  local claim_step
+  if [ -n "${claim_secret}" ]; then
+    claim_step="$(cat <<CLAIMEOF
+  5. Claim ownership of this install. Nobody can sign up through the normal
+     Sign Up form in the dashboard for the FIRST account — the provisioning
+     claim only travels as a request header, deliberately kept out of the
+     OpenAPI schema every generated client (including the dashboard) uses.
+     Run this once, after the stack is up, to create the first owner account:
+
+       curl -X POST http://localhost:${api_port}/auth/register \\
+         -H "Content-Type: application/json" \\
+         -H "X-Wpmgr-Bootstrap-Claim: ${claim_secret}" \\
+         -d '{"email":"you@example.com","password":"replace-with-12+-chars"}'
+
+     ${BOOTSTRAP_CLAIM_KEY} is saved in .env — the value above is that exact
+     secret. It is not re-generated on a later re-run of this script once a
+     value is present, so it stays valid until you rotate it yourself.
+CLAIMEOF
+)"
+  else
+    claim_step="  5. WARNING: ${BOOTSTRAP_CLAIM_KEY} is not set in .env — this install
+     cannot be claimed by anyone until it is. Set it to a random secret and
+     re-run: docker compose ... up -d (after editing .env) to pick it up."
+  fi
 
   cat <<EOF
 
@@ -194,6 +234,8 @@ Next steps:
        curl localhost:${api_port}/readyz    # 200 once DB/Redis/S3 are reachable
 
   4. Open the dashboard at http://localhost:${web_port}
+
+${claim_step}
 
 See docs/install.md for the full guide.
 EOF
@@ -231,6 +273,32 @@ else
   fi
   cp "${ENV_EXAMPLE}" "${ENV_FILE}"
   log "Wrote .env from .env.example"
+fi
+
+# ---------------------------------------------------------------------------
+# 1b. Generate the first-run ownership claim (WPMGR_BOOTSTRAP_CLAIM_SECRET),
+#     unless the operator already supplied one. Without this, POST
+#     /auth/register refuses every first-run attempt with 403
+#     registration_closed and the install can never be claimed.
+#
+#     This runs BEFORE the "everything already set" early-exit below, and is
+#     not gated by it: an operator re-running this script on an .env from
+#     before this variable existed (the upgrade case) must still get one, even
+#     though their four SECRET_KEYS are already populated and would otherwise
+#     short-circuit the rest of this script.
+#
+#     Idempotent, same rule as the infra passwords below: a value already
+#     present (from a prior run, or supplied by the operator in .env before
+#     running this script) is left untouched, never rotated. Rotating it after
+#     ownership is claimed is harmless but rotating it before is confusing —
+#     an operator who copied down a value would have it silently invalidated.
+# ---------------------------------------------------------------------------
+if needs_value "${BOOTSTRAP_CLAIM_KEY}"; then
+  new_claim="$(openssl rand -base64 48 | tr -d '\n')"
+  set_env_value "${BOOTSTRAP_CLAIM_KEY}" "${new_claim}"
+  log "Generated ${BOOTSTRAP_CLAIM_KEY}"
+else
+  log "${BOOTSTRAP_CLAIM_KEY} already set in .env — left unchanged"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -181,8 +181,9 @@ print_next_steps() {
   web_port="${web_port:-8088}"
   # Read back from .env rather than trusting a var from this run: the value
   # may have been generated just now, supplied by the operator earlier, or
-  # (if something above failed silently) still absent — print exactly what is
-  # actually persisted, not what this run assumed.
+  # (if something above failed silently) still absent. This is only a
+  # presence check now — the printed block below reads the value itself, at
+  # the operator's run time, so the literal secret never has to appear here.
   claim_secret="$(current_value "${BOOTSTRAP_CLAIM_KEY}")"
 
   local claim_step
@@ -193,22 +194,26 @@ print_next_steps() {
      claim only travels as a request header, deliberately kept out of the
      OpenAPI schema every generated client (including the dashboard) uses.
      Run this once, after the stack is up, to create the first owner account.
-     The block below writes the claim into a private, 600-permission temp
-     file instead of the command line, so it never shows up in \`ps\` output,
-     and removes that file when curl exits, on success or failure:
+     The block below reads the claim straight out of .env and writes it into
+     a private, 600-permission temp curl config file — the secret never
+     appears on the command line or in this printed text, so it cannot land
+     in shell history either, and the temp file is removed when curl exits,
+     on success or failure:
 
-       ( claim_cfg="\$(mktemp)" && chmod 600 "\${claim_cfg}" && \\
+       ( env_file="${ENV_FILE}" && \\
+         claim_val="\$(grep '^${BOOTSTRAP_CLAIM_KEY}=' "\${env_file}" | head -n1 | sed -E "s/^[^=]*=//; s/^\"(.*)\"\$/\1/; s/^'(.*)'\$/\1/")" && \\
+         claim_cfg="\$(mktemp)" && chmod 600 "\${claim_cfg}" && \\
          trap 'rm -f "\${claim_cfg}"' EXIT && \\
-         printf 'header = "X-Wpmgr-Bootstrap-Claim: %s"\n' '${claim_secret}' >"\${claim_cfg}" && \\
+         printf 'header = "X-Wpmgr-Bootstrap-Claim: %s"\n' "\${claim_val}" >"\${claim_cfg}" && \\
          curl -X POST http://localhost:${api_port}/auth/register \\
            -H "Content-Type: application/json" \\
            -K "\${claim_cfg}" \\
            -d '{"email":"you@example.com","password":"replace-with-12+-chars"}' )
 
-     ${BOOTSTRAP_CLAIM_KEY} is saved in .env — the value written into the temp
-     file above is that exact secret. It is not re-generated on a later
-     re-run of this script once a value is present, so it stays valid until
-     you rotate it yourself.
+     ${BOOTSTRAP_CLAIM_KEY} lives in .env at ${ENV_FILE} — the command above
+     reads it from there each time you run it, so it keeps working even if
+     you rotate the value later. It is not re-generated on a later re-run of
+     this script once a value is present.
 CLAIMEOF
 )"
   else

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -216,11 +216,11 @@ print_next_steps() {
      this script once a value is present.
 CLAIMEOF
 )"
-  else
-    claim_step="  5. WARNING: ${BOOTSTRAP_CLAIM_KEY} is not set in .env — this install
-     cannot be claimed by anyone until it is. Set it to a random secret and
-     re-run: docker compose ... up -d (after editing .env) to pick it up."
   fi
+  # No else: when the key is absent, claim_step stays "" (the local's default
+  # under nounset) and the failure below fires after the summary prints. It
+  # does NOT become a numbered step here — a broken, unclaimable install is
+  # not "step 5 of 6" alongside routine setup instructions.
 
   cat <<EOF
 
@@ -251,6 +251,25 @@ ${claim_step}
 
 See docs/install.md for the full guide.
 EOF
+
+  # ${BOOTSTRAP_CLAIM_KEY} is generated unconditionally earlier in this script
+  # (step 1b, above the "all secrets already set" early-exit) whenever it is
+  # missing, so reaching this point without one means that generation did not
+  # persist. Printing the summary above and exiting 0 would report success
+  # over an install nobody can ever own — fail loudly instead.
+  if [ -z "${claim_secret}" ]; then
+    {
+      printf '\n'
+      printf 'ERROR: %s is not set in .env.\n' "${BOOTSTRAP_CLAIM_KEY}"
+      printf 'This script generates it unconditionally earlier in the run, so\n'
+      printf 'reaching this point without one means that generation did not\n'
+      printf 'persist. This install cannot be claimed by anyone until\n'
+      printf '%s has a value: set one in .env yourself, then\n' "${BOOTSTRAP_CLAIM_KEY}"
+      printf 'bring the stack up (or restart the api service if it is already\n'
+      printf 'running) before treating setup as complete.\n'
+    } >&2
+    exit 1
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/quickstart-selfhost.sh
+++ b/scripts/quickstart-selfhost.sh
@@ -211,6 +211,31 @@ web_port="$(grep '^WPMGR_WEB_PORT=' .env | head -n1 | cut -d= -f2-)"
 api_port="${api_port:-8081}"
 web_port="${web_port:-8088}"
 ver_tag="${WPMGR_VERSION:-latest}"
+# init-env.sh (run in step 3 above) generates and persists this unless it was
+# already set — read back what actually landed in .env, not what this run
+# assumed.
+claim_secret="$(grep '^WPMGR_BOOTSTRAP_CLAIM_SECRET=' .env | head -n1 | cut -d= -f2-)"
+if [ -n "${claim_secret}" ]; then
+  claim_block="$(cat <<CLAIMEOF
+Claim ownership (do this once, after the stack is up):
+  This install has no owner yet, and the Sign Up form in the dashboard cannot
+  create the first one — the claim below travels only as a request header,
+  deliberately absent from the API schema every generated client uses.
+
+  curl -X POST http://localhost:${api_port}/auth/register \\
+    -H "Content-Type: application/json" \\
+    -H "X-Wpmgr-Bootstrap-Claim: ${claim_secret}" \\
+    -d '{"email":"you@example.com","password":"replace-with-12+-chars"}'
+
+  WPMGR_BOOTSTRAP_CLAIM_SECRET is saved in .env (the value above is that exact
+  secret). Re-running this script will NOT change it once it is set.
+CLAIMEOF
+)"
+else
+  claim_block="WARNING: WPMGR_BOOTSTRAP_CLAIM_SECRET is not set in .env — this
+  install cannot be claimed by anyone until it is. Set it to a random secret
+  in .env and restart the api service."
+fi
 
 # ---------------------------------------------------------------------------
 # 6. Final instructions.
@@ -234,6 +259,8 @@ Verify:
 
 Open the dashboard at:
   http://localhost:${web_port}
+
+${claim_block}
 
 IMPORTANT:
   - WPMGR_S3_ENDPOINT in .env must be a URL reachable by your WordPress hosts.

--- a/scripts/quickstart-selfhost.sh
+++ b/scripts/quickstart-selfhost.sh
@@ -212,30 +212,40 @@ api_port="${api_port:-8081}"
 web_port="${web_port:-8088}"
 ver_tag="${WPMGR_VERSION:-latest}"
 # init-env.sh (run in step 3 above) generates and persists this unless it was
-# already set — read back what actually landed in .env, not what this run
-# assumed.
+# already set. This is only a presence check now — the printed block below
+# reads the value itself, at the operator's run time, so the literal secret
+# never has to appear here.
 claim_secret="$(grep '^WPMGR_BOOTSTRAP_CLAIM_SECRET=' .env | head -n1 | cut -d= -f2-)"
+# Absolute path to .env: we are already inside WORK_DIR (step 1 cd'd here),
+# but the claim block below is meant to be pasted and run later, possibly
+# from a different directory, so it needs a path that does not depend on cwd.
+env_file_abs="$(pwd)/.env"
 if [ -n "${claim_secret}" ]; then
   claim_block="$(cat <<CLAIMEOF
 Claim ownership (do this once, after the stack is up):
   This install has no owner yet, and the Sign Up form in the dashboard cannot
   create the first one — the claim below travels only as a request header,
   deliberately absent from the API schema every generated client uses. The
-  block below writes the claim into a private, 600-permission temp file
-  instead of the command line, so it never shows up in \`ps\` output, and
-  removes that file when curl exits, on success or failure:
+  block below reads the claim straight out of .env and writes it into a
+  private, 600-permission temp curl config file — the secret never appears
+  on the command line or in this printed text, so it cannot land in shell
+  history either, and the temp file is removed when curl exits, on success
+  or failure:
 
-  ( claim_cfg="\$(mktemp)" && chmod 600 "\${claim_cfg}" && \\
+  ( env_file="${env_file_abs}" && \\
+    claim_val="\$(grep '^WPMGR_BOOTSTRAP_CLAIM_SECRET=' "\${env_file}" | head -n1 | sed -E "s/^[^=]*=//; s/^\"(.*)\"\$/\1/; s/^'(.*)'\$/\1/")" && \\
+    claim_cfg="\$(mktemp)" && chmod 600 "\${claim_cfg}" && \\
     trap 'rm -f "\${claim_cfg}"' EXIT && \\
-    printf 'header = "X-Wpmgr-Bootstrap-Claim: %s"\n' '${claim_secret}' >"\${claim_cfg}" && \\
+    printf 'header = "X-Wpmgr-Bootstrap-Claim: %s"\n' "\${claim_val}" >"\${claim_cfg}" && \\
     curl -X POST http://localhost:${api_port}/auth/register \\
       -H "Content-Type: application/json" \\
       -K "\${claim_cfg}" \\
       -d '{"email":"you@example.com","password":"replace-with-12+-chars"}' )
 
-  WPMGR_BOOTSTRAP_CLAIM_SECRET is saved in .env — the value written into the
-  temp file above is that exact secret. Re-running this script will NOT
-  change it once it is set.
+  WPMGR_BOOTSTRAP_CLAIM_SECRET lives in .env at ${env_file_abs} — the command
+  above reads it from there each time you run it, so it keeps working even if
+  you rotate the value later. Re-running this script will NOT change it once
+  it is set.
 CLAIMEOF
 )"
 else

--- a/scripts/quickstart-selfhost.sh
+++ b/scripts/quickstart-selfhost.sh
@@ -220,15 +220,22 @@ if [ -n "${claim_secret}" ]; then
 Claim ownership (do this once, after the stack is up):
   This install has no owner yet, and the Sign Up form in the dashboard cannot
   create the first one — the claim below travels only as a request header,
-  deliberately absent from the API schema every generated client uses.
+  deliberately absent from the API schema every generated client uses. The
+  block below writes the claim into a private, 600-permission temp file
+  instead of the command line, so it never shows up in \`ps\` output, and
+  removes that file when curl exits, on success or failure:
 
-  curl -X POST http://localhost:${api_port}/auth/register \\
-    -H "Content-Type: application/json" \\
-    -H "X-Wpmgr-Bootstrap-Claim: ${claim_secret}" \\
-    -d '{"email":"you@example.com","password":"replace-with-12+-chars"}'
+  ( claim_cfg="\$(mktemp)" && chmod 600 "\${claim_cfg}" && \\
+    trap 'rm -f "\${claim_cfg}"' EXIT && \\
+    printf 'header = "X-Wpmgr-Bootstrap-Claim: %s"\n' '${claim_secret}' >"\${claim_cfg}" && \\
+    curl -X POST http://localhost:${api_port}/auth/register \\
+      -H "Content-Type: application/json" \\
+      -K "\${claim_cfg}" \\
+      -d '{"email":"you@example.com","password":"replace-with-12+-chars"}' )
 
-  WPMGR_BOOTSTRAP_CLAIM_SECRET is saved in .env (the value above is that exact
-  secret). Re-running this script will NOT change it once it is set.
+  WPMGR_BOOTSTRAP_CLAIM_SECRET is saved in .env — the value written into the
+  temp file above is that exact secret. Re-running this script will NOT
+  change it once it is set.
 CLAIMEOF
 )"
 else

--- a/scripts/quickstart-selfhost.sh
+++ b/scripts/quickstart-selfhost.sh
@@ -249,9 +249,12 @@ Claim ownership (do this once, after the stack is up):
 CLAIMEOF
 )"
 else
-  claim_block="WARNING: WPMGR_BOOTSTRAP_CLAIM_SECRET is not set in .env — this
-  install cannot be claimed by anyone until it is. Set it to a random secret
-  in .env and restart the api service."
+  # init-env.sh (step 3, above) generates this unconditionally and now exits
+  # non-zero itself when generation does not persist, so reaching here with
+  # it still absent should not happen. Kept as a second check in case that
+  # invariant ever changes: fail loudly below rather than let this printed
+  # summary claim success over an install nobody can ever own.
+  claim_block=""
 fi
 
 # ---------------------------------------------------------------------------
@@ -286,3 +289,19 @@ IMPORTANT:
   - Review docs/install.md for the full self-host guide.
 
 EOF
+
+# See the matching check in scripts/init-env.sh (step 3 above) for why this
+# is a hard failure rather than a warning folded into the summary above.
+if [ -z "${claim_secret}" ]; then
+  {
+    printf '\n'
+    printf 'ERROR: WPMGR_BOOTSTRAP_CLAIM_SECRET is not set in .env.\n'
+    printf 'init-env.sh generates it unconditionally and should have failed\n'
+    printf 'before reaching here if generation did not persist. This install\n'
+    printf 'cannot be claimed by anyone until WPMGR_BOOTSTRAP_CLAIM_SECRET has\n'
+    printf 'a value: set one in .env yourself, then bring the stack up (or\n'
+    printf 'restart the api service if it is already running) before treating\n'
+    printf 'setup as complete.\n'
+  } >&2
+  exit 1
+fi


### PR DESCRIPTION
## What this adds

First-run ownership — the install's first organisation, its first user, and the owner membership binding them — now requires the provisioning claim the installer minted.

### The claim

- New config: `WPMGR_BOOTSTRAP_CLAIM_SECRET`, a literal value, mapped explicitly in `mapEnvKey` (a bare key would have fallen through the passthrough and been silently ignored, which is how social sign-in once shipped configured-but-disabled).
- Presented as the `X-Wpmgr-Bootstrap-Claim` header on `POST /auth/register`. A header rather than a body field: the claim is a credential, not user data, so it stays out of the payload that validation errors and request logs echo, and out of the OpenAPI request schema.
- Compared with `crypto/subtle.ConstantTimeCompare` after a length check. Never logged, never echoed into a response, never written to audit metadata.
- Unset means nobody may claim the install, not anybody. An install that boots without it serves every other route and simply has no route to a first owner until the operator sets the variable and restarts. Warned once at boot and again on a refused request, in the log, naming the variable.

### One transaction, one lock

`Repo.BootstrapInstall` folds the user count and all three writes into a single transaction that takes `pg_advisory_xact_lock` on `InstallBootstrapLockKey` as its first statement, via the new `Pool.InInstallLockTx`. The lock is keyed on the install rather than a tenant because no tenant exists yet at the moment the decision is taken. The tenant is created first, then brought into RLS scope for the membership insert, all inside the same transaction; GUC-setting stays in `internal/db`.

### Ownership is the gate, and both sign-in paths agree

Every gate asks whether an owner membership exists — `Repo.OwnershipEstablished` — never whether a user row does, so nothing that merely creates an account can decide the answer. A social sign-in has nowhere to carry a claim — the request shape is the identity provider's — so `finishSocialLogin` no longer mints an organisation, `isFirstRunBootstrap` is gone, and a social sign-in that would create a new account on an install with no owner is declined — there is nobody to grant that account anything yet. The person holding the claim runs the claim-bearing register call once; every social sign-in after that resolves memberships exactly as before.

Self-serve registration stays closed until the install has an owner, returning its usual generic response without writing anything. Ownership of an install is established once, out of band, by the party holding the claim; self-serve reopens after that.

### One answer, and one cost

Argon2 dominates both routes by two orders of magnitude, so a branch that skips it finishes visibly sooner and the duration becomes a second answer. Both callers now do that work unconditionally, ahead of choosing an outcome. `TestMeasureFirstRunRefusalTiming` prints the medians so the claim can be rechecked rather than assumed.

### One answer

Every refusal on this path returns the same status, code and message. Three distinguishable answers would let an unauthenticated caller sort installs by whether they have an owner yet. The actionable guidance goes to the server log, where the operator is the only reader.

## Tests

`apps/api/tests/auth_first_run_ownership_integration_test.go`, reached through the same tx helpers the request path uses and connected as the non-superuser `wpmgr_app` role. Each test carries a one-line note saying what to change to watch it go red.

- Fires: no claim configured; wrong claim (shorter, longer, same-length, case-differing); refusal identical in kind, code and message across unclaimed / claimed / spent.
- Does not over-fire: correct claim on a fresh install creates the owner, issues a session and leaves existing behaviour intact; whitespace-wrapped claim still accepted; already-owned install unaffected; social sign-in on a claimed install still resolves.
- Concurrency: 8 simultaneous correct-claim bootstraps produce exactly one owner and one organisation. Shown failing with the lock removed (3 of 8 succeeded) and passing with it restored.
- Social: sign-in on an unclaimed install mints nothing.
- Self-serve cannot burn the ownership slot, and reopens once the install is owned.

Four existing social tests rested on a social sign-in creating the first organisation. Three keep every assertion and only had their scaffolding rewritten; one asserted the behaviour deliberately removed and is gone, with a note in its place naming the two tests that carry the replacement property.

`go test -count=1 -timeout 45m ./tests/...` is green, both packages.

## Follow-up for other layers

`scripts/quickstart-selfhost.sh` and `infra/docker-compose.yml` need to generate `WPMGR_BOOTSTRAP_CLAIM_SECRET` and pass it through. Not touched here.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure first-run ownership claiming with a generated provisioning secret.
  * Initial owner registration now requires a claim header and creates the first installation atomically.
  * Self-service registrations remain pending until ownership is established and email verification is completed.
  * Setup scripts generate secrets and provide secure claim instructions.

* **Bug Fixes**
  * Prevented concurrent or unauthorized ownership claims.
  * Added non-revealing responses for invalid or missing claims.

* **Documentation**
  * Updated installation and quickstart guidance for first-run ownership claiming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->