### PR TITLE
fix(update): make the update-task claim a compare-and-swap

### DIFF
--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -763,6 +763,16 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// instead of relying on the 60s default. See DeriveApplyJobTimeout's doc
 	// comment for the full arithmetic.
 	updateJobTimeout := update.DeriveApplyJobTimeout(cfg.Update.ApplyHTTPTimeout, cfg.Update.HTTPTimeout)
+	// The update-task claim reclaims a task whose worker died, decided purely
+	// by how old the row is. That bound has to stay above this install's
+	// worst-case apply budget (or a second worker claims a task the first is
+	// still applying) and below the reaper's threshold (or the reaper
+	// terminalizes a row the claim still treats as live). Both ends move with
+	// env-settable timeouts, so neither the compiler nor a default-config test
+	// can catch a bad combination — assert it here and refuse to start.
+	if err := update.ValidateClaimTimings(updateJobTimeout); err != nil {
+		return fmt.Errorf("invalid update timing configuration: %w", err)
+	}
 	updateWorker := update.NewWorker(updateRepo, sitesLookup, updateApplyCmd, prober, updateHub, auditRec, logger, cfg.Update.PerTenantParallelism, updateJobTimeout)
 	// #131 follow-up — periodic reaper for update_tasks stuck in pending/running
 	// past staleTaskThreshold (a worker crash mid-task, or a failed enqueue that

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -1,5 +1,14 @@
--- M3 bulk-update queries. Every statement is tenant-scoped both explicitly
--- (tenant_id in the WHERE/VALUES) and by RLS (the app.tenant_id policy).
+-- M3 bulk-update queries. Every statement here is tenant-scoped both
+-- explicitly (tenant_id in the WHERE/VALUES) and by RLS
+-- (update_runs_tenant_isolation / update_tasks_tenant_isolation on
+-- app.tenant_id); update_tasks additionally carries the RESTRICTIVE
+-- update_tasks_site_scope policy the two portal reads depend on.
+--
+-- ONE statement is deliberately outside that, and it is the only one:
+-- ListStaleUpdateTasks sweeps every tenant for the periodic reaper, carries
+-- no tenant_id at all, and is admitted by the update_tasks_agent policy
+-- instead. It repeats that at its own definition. Any OTHER statement in
+-- db/query/updates.sql without a tenant_id is a bug, not a second exception.
 
 -- name: CreateUpdateRun :one
 -- tenant_id is supplied explicitly for defense-in-depth; RLS additionally

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -188,10 +188,21 @@ WHERE id = $1 AND tenant_id = $2;
 -- task would become re-claimable mid-confirmation. Agent rows may be claimed
 -- from 'pending' only.
 --
--- A NULL @stale_after makes the reclaim branch match nothing (NULL comparison),
--- which fails CLOSED: strict pending-only claiming. Safe but conservative —
--- an abandoned row then waits for the reaper instead of a retry. Pass the
--- constant.
+-- @stale_after HAS TWO DEGENERATE VALUES, AND THEY FAIL IN OPPOSITE
+-- DIRECTIONS. A genuine SQL NULL makes the reclaim branch match nothing (NULL
+-- comparison) and fails CLOSED: strict pending-only claiming, safe but
+-- conservative — an abandoned row then waits for the reaper instead of a
+-- retry. A ZERO interval fails OPEN: coalesce(started_at, updated_at) <
+-- now() - '0'::interval is true for every non-agent 'running' row the moment
+-- it is written, so the reclaim branch matches rows a live worker is
+-- mid-dispatch on — the double dispatch this precondition exists to prevent.
+--
+-- ONLY THE SECOND IS REACHABLE FROM GO. durationToInterval (update/repo.go)
+-- builds pgtype.Interval with Valid: true unconditionally, so no caller on
+-- this path can produce a SQL NULL: a zero time.Duration arrives as
+-- interval '0'. Do NOT read the NULL case as what an unset bound gives you —
+-- an unset bound gives you the OPEN one. Pass the derived value
+-- (Worker.claimStaleAfter, from ClaimStaleAfter), never the zero value.
 --
 -- ZERO ROWS MEANS: you did not get the claim, and you must NOT dispatch.
 -- It does not distinguish why, so the caller re-reads the row and decides:

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -256,12 +256,23 @@ RETURNING *;
 -- no reason; the agent's own lock is what serialises the two channels in
 -- both directions.
 --
--- The staleness clause bounds a crashed worker: a row whose command went out
--- longer ago than @hold_max cannot have a live worker behind it (River
--- cancels the job's context at its own job timeout regardless of whether the
--- site answers). Ignoring such a row only makes the gate MORE permissive
--- (lets a sibling dispatch it would otherwise have deferred), never less,
--- which is safe — the agent's own lock is still the backstop either way.
+-- The staleness clause bounds a crashed WORKER, and only that: past @hold_max
+-- no River job for this row can still be waiting on the site, because River
+-- cancels the job's context at its own job timeout whether the site answers or
+-- not. It says nothing about the SITE — cancelling that context ends the
+-- control plane's wait for the HTTP response, it does not stop an apply the
+-- agent has already begun (the same correction MarkUpdateTaskRunning's reclaim
+-- arm carries above). Here that gap is harmless, and for a reason of its own:
+-- ignoring an over-age row only makes the gate MORE permissive (lets a sibling
+-- dispatch it would otherwise have deferred), never less, which is safe — the
+-- agent's own lock is still the backstop either way.
+--
+-- @hold_max is therefore the flat siteWriterHoldMax constant, passed straight
+-- through by worker.go, and NOT the config-derived ClaimStaleAfter the claim
+-- above is given. Neither call site is wrong: see ClaimStaleAfter's doc
+-- comment in update/worker.go, which sets out why over-permissive is safe for
+-- this gate and is precisely the defect for the claim.
+--
 -- coalesce(started_at, updated_at) covers a row observed between
 -- MarkUpdateTaskRunning (which sets both) and any later touch.
 --

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -138,15 +138,36 @@ WHERE id = $1 AND tenant_id = $2;
 --                zero rows and drop that work on the floor, which is a worse
 --                bug than the one being fixed. Bounding it by age is what
 --                separates "my previous attempt died" from "another worker is
---                mid-dispatch right now": River cancels a job's context at its
---                own job timeout whether the site answers or not, so a row
---                older than that bound cannot have a live worker behind it.
---                Callers pass siteWriterHoldMax, the same constant and the
---                same reasoning as SiteHasRunningUpdateTask's @hold_max above
---                (worker.go asserts maxApply < siteWriterHoldMax <
---                staleTaskThreshold, so this window opens strictly after a
---                worker must be dead and strictly before the reaper claims the
---                row). coalesce(started_at, updated_at) mirrors that gate for
+--                mid-dispatch right now", but read the next two paragraphs for
+--                what that separation is and is not worth.
+--
+--                WHAT THE BOUND GUARANTEES: past @stale_after, no CONTROL-PLANE
+--                worker is still inside its apply call for this row. Callers do
+--                not pass a constant; they derive the bound from THIS install's
+--                apply budget — ClaimStaleAfter(applyJobTimeout) =
+--                max(applyJobTimeout + claimStaleMargin, siteWriterHoldMax) in
+--                update/worker.go — and main() refuses to boot on a
+--                configuration where the budget could reach it
+--                (ValidateClaimTimings, asserting applyJobTimeout <
+--                ClaimStaleAfter < staleTaskThreshold). So the reclaim window
+--                opens strictly after River has cancelled the previous job's
+--                context and strictly before the periodic reaper terminalizes
+--                the row.
+--
+--                WHAT IT DOES NOT GUARANTEE: that nothing is still applying ON
+--                THE SITE. Cancelling a River job's context ends the control
+--                plane's WAIT for the HTTP response; it does not reach into
+--                WordPress and stop an apply the agent has already started. The
+--                AGENT's own site-update lock is the authoritative bound on
+--                that, exactly as it is for SiteHasRunningUpdateTask's
+--                @hold_max below. If the bound is ever exceeded in practice the
+--                residual is therefore a duplicate DISPATCH — a second command
+--                for the same item and a second set of audit/event records for
+--                it, which the agent's lock is what serialises — and not a
+--                guaranteed double-apply. Still a real defect, and still worth
+--                bounding; simply not a proof that no work is live.
+--
+--                coalesce(started_at, updated_at) mirrors the gate below for
 --                the same reason.
 --
 -- target_type <> 'agent' on the reclaim branch is NOT an optimisation, and it

--- a/apps/api/db/query/updates.sql
+++ b/apps/api/db/query/updates.sql
@@ -108,9 +108,80 @@ SELECT * FROM update_tasks
 WHERE id = $1 AND tenant_id = $2;
 
 -- name: MarkUpdateTaskRunning :one
+-- Claims a task for dispatch: the compare-and-swap that makes "I am the one
+-- worker talking to this site about this item" true, rather than merely
+-- assumed. Tenant-scoped by id+tenant_id.
+--
+-- WITHOUT the status precondition this was a bare write, and the read that
+-- guards it is not in the same statement: Worker.Work loads the task, returns
+-- early only for TERMINAL statuses, and claims some way further down
+-- (GetTask -> ... -> MarkTaskRunning). Two River jobs for the same task both
+-- observe a non-terminal row in that gap and both proceed, so one item is
+-- applied to one site twice over. The precondition closes the gap the same way
+-- FinishUpdateTask's does: the transition is decided by the row itself, under
+-- its own row lock, not by what the caller read a moment earlier.
+--
+-- TRANSITIONS FROM, deliberately, exactly two states:
+--
+--   'pending'  — the ordinary claim. Also the ONLY state the agent
+--                self-update wave path can present (ClaimAgentWaveTask holds
+--                the run's advisory lock and returns ClaimAlreadyClaimed for
+--                anything not pending before it ever reaches this statement),
+--                and the state deferForBusySite leaves a waiter in
+--                (DeferUpdateTaskToPending writes 'pending' and NULLs
+--                started_at). So a deferred task re-claims normally.
+--
+--   'running', but only if ABANDONED — its command went out longer ago than
+--                @stale_after. 'running' is not terminal, so a River retry of
+--                a job that already claimed re-enters Work and reaches here
+--                with its own row 'running'; a strict = 'pending' would match
+--                zero rows and drop that work on the floor, which is a worse
+--                bug than the one being fixed. Bounding it by age is what
+--                separates "my previous attempt died" from "another worker is
+--                mid-dispatch right now": River cancels a job's context at its
+--                own job timeout whether the site answers or not, so a row
+--                older than that bound cannot have a live worker behind it.
+--                Callers pass siteWriterHoldMax, the same constant and the
+--                same reasoning as SiteHasRunningUpdateTask's @hold_max above
+--                (worker.go asserts maxApply < siteWriterHoldMax <
+--                staleTaskThreshold, so this window opens strictly after a
+--                worker must be dead and strictly before the reaper claims the
+--                row). coalesce(started_at, updated_at) mirrors that gate for
+--                the same reason.
+--
+-- target_type <> 'agent' on the reclaim branch is NOT an optimisation, and it
+-- is the same exclusion SiteHasRunningUpdateTask carries: an agent
+-- self-update task stays 'running' for its whole confirmation window (20m, or
+-- 90m on external cron) with NO live worker behind it by design, because the
+-- apply happens after the ARM response is released. Age is therefore not
+-- evidence of abandonment for an agent row, and without this clause a wave
+-- task would become re-claimable mid-confirmation. Agent rows may be claimed
+-- from 'pending' only.
+--
+-- A NULL @stale_after makes the reclaim branch match nothing (NULL comparison),
+-- which fails CLOSED: strict pending-only claiming. Safe but conservative —
+-- an abandoned row then waits for the reaper instead of a retry. Pass the
+-- constant.
+--
+-- ZERO ROWS MEANS: you did not get the claim, and you must NOT dispatch.
+-- It does not distinguish why, so the caller re-reads the row and decides:
+-- terminal => the outcome is recorded, stop (return nil, as Work already does
+-- for a terminal read); still 'pending' or a FRESH 'running' => another worker
+-- holds it, so give the row up WITHOUT consuming a retry (river.JobSnooze),
+-- because that holder may still die and the row must stay reclaimable. Never
+-- treat zero rows as an error to retry into, and never as permission to
+-- proceed.
 UPDATE update_tasks
 SET status = 'running', started_at = now(), updated_at = now()
-WHERE id = $1 AND tenant_id = $2
+WHERE id = @id AND tenant_id = @tenant_id
+  AND (
+    status = 'pending'
+    OR (
+      status = 'running'
+      AND target_type <> 'agent'
+      AND coalesce(started_at, updated_at) < now() - @stale_after::interval
+    )
+  )
 RETURNING *;
 
 -- name: FinishUpdateTask :one

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -2275,15 +2275,36 @@ type Querier interface {
 	//                zero rows and drop that work on the floor, which is a worse
 	//                bug than the one being fixed. Bounding it by age is what
 	//                separates "my previous attempt died" from "another worker is
-	//                mid-dispatch right now": River cancels a job's context at its
-	//                own job timeout whether the site answers or not, so a row
-	//                older than that bound cannot have a live worker behind it.
-	//                Callers pass siteWriterHoldMax, the same constant and the
-	//                same reasoning as SiteHasRunningUpdateTask's @hold_max above
-	//                (worker.go asserts maxApply < siteWriterHoldMax <
-	//                staleTaskThreshold, so this window opens strictly after a
-	//                worker must be dead and strictly before the reaper claims the
-	//                row). coalesce(started_at, updated_at) mirrors that gate for
+	//                mid-dispatch right now", but read the next two paragraphs for
+	//                what that separation is and is not worth.
+	//
+	//                WHAT THE BOUND GUARANTEES: past @stale_after, no CONTROL-PLANE
+	//                worker is still inside its apply call for this row. Callers do
+	//                not pass a constant; they derive the bound from THIS install's
+	//                apply budget — ClaimStaleAfter(applyJobTimeout) =
+	//                max(applyJobTimeout + claimStaleMargin, siteWriterHoldMax) in
+	//                update/worker.go — and main() refuses to boot on a
+	//                configuration where the budget could reach it
+	//                (ValidateClaimTimings, asserting applyJobTimeout <
+	//                ClaimStaleAfter < staleTaskThreshold). So the reclaim window
+	//                opens strictly after River has cancelled the previous job's
+	//                context and strictly before the periodic reaper terminalizes
+	//                the row.
+	//
+	//                WHAT IT DOES NOT GUARANTEE: that nothing is still applying ON
+	//                THE SITE. Cancelling a River job's context ends the control
+	//                plane's WAIT for the HTTP response; it does not reach into
+	//                WordPress and stop an apply the agent has already started. The
+	//                AGENT's own site-update lock is the authoritative bound on
+	//                that, exactly as it is for SiteHasRunningUpdateTask's
+	//                @hold_max below. If the bound is ever exceeded in practice the
+	//                residual is therefore a duplicate DISPATCH — a second command
+	//                for the same item and a second set of audit/event records for
+	//                it, which the agent's lock is what serialises — and not a
+	//                guaranteed double-apply. Still a real defect, and still worth
+	//                bounding; simply not a proof that no work is live.
+	//
+	//                coalesce(started_at, updated_at) mirrors the gate below for
 	//                the same reason.
 	//
 	// target_type <> 'agent' on the reclaim branch is NOT an optimisation, and it

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -2245,6 +2245,69 @@ type Querier interface {
 	MarkSiteRevoked(ctx context.Context, arg MarkSiteRevokedParams) (Site, error)
 	// Marks a site unreachable. Runs under app.agent GUC (cross-tenant job).
 	MarkSiteUnreachable(ctx context.Context, id uuid.UUID) (int64, error)
+	// Claims a task for dispatch: the compare-and-swap that makes "I am the one
+	// worker talking to this site about this item" true, rather than merely
+	// assumed. Tenant-scoped by id+tenant_id.
+	//
+	// WITHOUT the status precondition this was a bare write, and the read that
+	// guards it is not in the same statement: Worker.Work loads the task, returns
+	// early only for TERMINAL statuses, and claims some way further down
+	// (GetTask -> ... -> MarkTaskRunning). Two River jobs for the same task both
+	// observe a non-terminal row in that gap and both proceed, so one item is
+	// applied to one site twice over. The precondition closes the gap the same way
+	// FinishUpdateTask's does: the transition is decided by the row itself, under
+	// its own row lock, not by what the caller read a moment earlier.
+	//
+	// TRANSITIONS FROM, deliberately, exactly two states:
+	//
+	//   'pending'  — the ordinary claim. Also the ONLY state the agent
+	//                self-update wave path can present (ClaimAgentWaveTask holds
+	//                the run's advisory lock and returns ClaimAlreadyClaimed for
+	//                anything not pending before it ever reaches this statement),
+	//                and the state deferForBusySite leaves a waiter in
+	//                (DeferUpdateTaskToPending writes 'pending' and NULLs
+	//                started_at). So a deferred task re-claims normally.
+	//
+	//   'running', but only if ABANDONED — its command went out longer ago than
+	//                @stale_after. 'running' is not terminal, so a River retry of
+	//                a job that already claimed re-enters Work and reaches here
+	//                with its own row 'running'; a strict = 'pending' would match
+	//                zero rows and drop that work on the floor, which is a worse
+	//                bug than the one being fixed. Bounding it by age is what
+	//                separates "my previous attempt died" from "another worker is
+	//                mid-dispatch right now": River cancels a job's context at its
+	//                own job timeout whether the site answers or not, so a row
+	//                older than that bound cannot have a live worker behind it.
+	//                Callers pass siteWriterHoldMax, the same constant and the
+	//                same reasoning as SiteHasRunningUpdateTask's @hold_max above
+	//                (worker.go asserts maxApply < siteWriterHoldMax <
+	//                staleTaskThreshold, so this window opens strictly after a
+	//                worker must be dead and strictly before the reaper claims the
+	//                row). coalesce(started_at, updated_at) mirrors that gate for
+	//                the same reason.
+	//
+	// target_type <> 'agent' on the reclaim branch is NOT an optimisation, and it
+	// is the same exclusion SiteHasRunningUpdateTask carries: an agent
+	// self-update task stays 'running' for its whole confirmation window (20m, or
+	// 90m on external cron) with NO live worker behind it by design, because the
+	// apply happens after the ARM response is released. Age is therefore not
+	// evidence of abandonment for an agent row, and without this clause a wave
+	// task would become re-claimable mid-confirmation. Agent rows may be claimed
+	// from 'pending' only.
+	//
+	// A NULL @stale_after makes the reclaim branch match nothing (NULL comparison),
+	// which fails CLOSED: strict pending-only claiming. Safe but conservative —
+	// an abandoned row then waits for the reaper instead of a retry. Pass the
+	// constant.
+	//
+	// ZERO ROWS MEANS: you did not get the claim, and you must NOT dispatch.
+	// It does not distinguish why, so the caller re-reads the row and decides:
+	// terminal => the outcome is recorded, stop (return nil, as Work already does
+	// for a terminal read); still 'pending' or a FRESH 'running' => another worker
+	// holds it, so give the row up WITHOUT consuming a retry (river.JobSnooze),
+	// because that holder may still die and the row must stay reclaimable. Never
+	// treat zero rows as an error to retry into, and never as permission to
+	// proceed.
 	MarkUpdateTaskRunning(ctx context.Context, arg MarkUpdateTaskRunningParams) (UpdateTask, error)
 	// Activate + mark verified (used on self-serve activation and trusted bootstrap).
 	MarkUserEmailVerified(ctx context.Context, id uuid.UUID) error

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -447,8 +447,17 @@ type Querier interface {
 	// around them, and rename+merge is the remedy after the fact).
 	CreateTag(ctx context.Context, arg CreateTagParams) (SiteTag, error)
 	CreateTenant(ctx context.Context, arg CreateTenantParams) (Tenant, error)
-	// M3 bulk-update queries. Every statement is tenant-scoped both explicitly
-	// (tenant_id in the WHERE/VALUES) and by RLS (the app.tenant_id policy).
+	// M3 bulk-update queries. Every statement here is tenant-scoped both
+	// explicitly (tenant_id in the WHERE/VALUES) and by RLS
+	// (update_runs_tenant_isolation / update_tasks_tenant_isolation on
+	// app.tenant_id); update_tasks additionally carries the RESTRICTIVE
+	// update_tasks_site_scope policy the two portal reads depend on.
+	//
+	// ONE statement is deliberately outside that, and it is the only one:
+	// ListStaleUpdateTasks sweeps every tenant for the periodic reaper, carries
+	// no tenant_id at all, and is admitted by the update_tasks_agent policy
+	// instead. It repeats that at its own definition. Any OTHER statement in
+	// db/query/updates.sql without a tenant_id is a bug, not a second exception.
 	// tenant_id is supplied explicitly for defense-in-depth; RLS additionally
 	// enforces it matches the current app.tenant_id setting.
 	CreateUpdateRun(ctx context.Context, arg CreateUpdateRunParams) (UpdateRun, error)

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -2325,10 +2325,21 @@ type Querier interface {
 	// task would become re-claimable mid-confirmation. Agent rows may be claimed
 	// from 'pending' only.
 	//
-	// A NULL @stale_after makes the reclaim branch match nothing (NULL comparison),
-	// which fails CLOSED: strict pending-only claiming. Safe but conservative —
-	// an abandoned row then waits for the reaper instead of a retry. Pass the
-	// constant.
+	// @stale_after HAS TWO DEGENERATE VALUES, AND THEY FAIL IN OPPOSITE
+	// DIRECTIONS. A genuine SQL NULL makes the reclaim branch match nothing (NULL
+	// comparison) and fails CLOSED: strict pending-only claiming, safe but
+	// conservative — an abandoned row then waits for the reaper instead of a
+	// retry. A ZERO interval fails OPEN: coalesce(started_at, updated_at) <
+	// now() - '0'::interval is true for every non-agent 'running' row the moment
+	// it is written, so the reclaim branch matches rows a live worker is
+	// mid-dispatch on — the double dispatch this precondition exists to prevent.
+	//
+	// ONLY THE SECOND IS REACHABLE FROM GO. durationToInterval (update/repo.go)
+	// builds pgtype.Interval with Valid: true unconditionally, so no caller on
+	// this path can produce a SQL NULL: a zero time.Duration arrives as
+	// interval '0'. Do NOT read the NULL case as what an unset bound gives you —
+	// an unset bound gives you the OPEN one. Pass the derived value
+	// (Worker.claimStaleAfter, from ClaimStaleAfter), never the zero value.
 	//
 	// ZERO ROWS MEANS: you did not get the claim, and you must NOT dispatch.
 	// It does not distinguish why, so the caller re-reads the row and decides:

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -2564,12 +2564,23 @@ type Querier interface {
 	// no reason; the agent's own lock is what serialises the two channels in
 	// both directions.
 	//
-	// The staleness clause bounds a crashed worker: a row whose command went out
-	// longer ago than @hold_max cannot have a live worker behind it (River
-	// cancels the job's context at its own job timeout regardless of whether the
-	// site answers). Ignoring such a row only makes the gate MORE permissive
-	// (lets a sibling dispatch it would otherwise have deferred), never less,
-	// which is safe — the agent's own lock is still the backstop either way.
+	// The staleness clause bounds a crashed WORKER, and only that: past @hold_max
+	// no River job for this row can still be waiting on the site, because River
+	// cancels the job's context at its own job timeout whether the site answers or
+	// not. It says nothing about the SITE — cancelling that context ends the
+	// control plane's wait for the HTTP response, it does not stop an apply the
+	// agent has already begun (the same correction MarkUpdateTaskRunning's reclaim
+	// arm carries above). Here that gap is harmless, and for a reason of its own:
+	// ignoring an over-age row only makes the gate MORE permissive (lets a sibling
+	// dispatch it would otherwise have deferred), never less, which is safe — the
+	// agent's own lock is still the backstop either way.
+	//
+	// @hold_max is therefore the flat siteWriterHoldMax constant, passed straight
+	// through by worker.go, and NOT the config-derived ClaimStaleAfter the claim
+	// above is given. Neither call site is wrong: see ClaimStaleAfter's doc
+	// comment in update/worker.go, which sets out why over-permissive is safe for
+	// this gate and is precisely the defect for the claim.
+	//
 	// coalesce(started_at, updated_at) covers a row observed between
 	// MarkUpdateTaskRunning (which sets both) and any later touch.
 	//

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -998,10 +998,21 @@ type MarkUpdateTaskRunningParams struct {
 // task would become re-claimable mid-confirmation. Agent rows may be claimed
 // from 'pending' only.
 //
-// A NULL @stale_after makes the reclaim branch match nothing (NULL comparison),
-// which fails CLOSED: strict pending-only claiming. Safe but conservative —
-// an abandoned row then waits for the reaper instead of a retry. Pass the
-// constant.
+// @stale_after HAS TWO DEGENERATE VALUES, AND THEY FAIL IN OPPOSITE
+// DIRECTIONS. A genuine SQL NULL makes the reclaim branch match nothing (NULL
+// comparison) and fails CLOSED: strict pending-only claiming, safe but
+// conservative — an abandoned row then waits for the reaper instead of a
+// retry. A ZERO interval fails OPEN: coalesce(started_at, updated_at) <
+// now() - '0'::interval is true for every non-agent 'running' row the moment
+// it is written, so the reclaim branch matches rows a live worker is
+// mid-dispatch on — the double dispatch this precondition exists to prevent.
+//
+// ONLY THE SECOND IS REACHABLE FROM GO. durationToInterval (update/repo.go)
+// builds pgtype.Interval with Valid: true unconditionally, so no caller on
+// this path can produce a SQL NULL: a zero time.Duration arrives as
+// interval '0'. Do NOT read the NULL case as what an unset bound gives you —
+// an unset bound gives you the OPEN one. Pass the derived value
+// (Worker.claimStaleAfter, from ClaimStaleAfter), never the zero value.
 //
 // ZERO ROWS MEANS: you did not get the claim, and you must NOT dispatch.
 // It does not distinguish why, so the caller re-reads the row and decides:

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -901,16 +901,88 @@ const markUpdateTaskRunning = `-- name: MarkUpdateTaskRunning :one
 UPDATE update_tasks
 SET status = 'running', started_at = now(), updated_at = now()
 WHERE id = $1 AND tenant_id = $2
+  AND (
+    status = 'pending'
+    OR (
+      status = 'running'
+      AND target_type <> 'agent'
+      AND coalesce(started_at, updated_at) < now() - $3::interval
+    )
+  )
 RETURNING id, run_id, tenant_id, site_id, target_type, target_slug, desired_version, from_version, to_version, status, detail, error, started_at, finished_at, created_at, updated_at
 `
 
 type MarkUpdateTaskRunningParams struct {
-	ID       uuid.UUID `json:"id"`
-	TenantID uuid.UUID `json:"tenant_id"`
+	ID         uuid.UUID       `json:"id"`
+	TenantID   uuid.UUID       `json:"tenant_id"`
+	StaleAfter pgtype.Interval `json:"stale_after"`
 }
 
+// Claims a task for dispatch: the compare-and-swap that makes "I am the one
+// worker talking to this site about this item" true, rather than merely
+// assumed. Tenant-scoped by id+tenant_id.
+//
+// WITHOUT the status precondition this was a bare write, and the read that
+// guards it is not in the same statement: Worker.Work loads the task, returns
+// early only for TERMINAL statuses, and claims some way further down
+// (GetTask -> ... -> MarkTaskRunning). Two River jobs for the same task both
+// observe a non-terminal row in that gap and both proceed, so one item is
+// applied to one site twice over. The precondition closes the gap the same way
+// FinishUpdateTask's does: the transition is decided by the row itself, under
+// its own row lock, not by what the caller read a moment earlier.
+//
+// TRANSITIONS FROM, deliberately, exactly two states:
+//
+//	'pending'  — the ordinary claim. Also the ONLY state the agent
+//	             self-update wave path can present (ClaimAgentWaveTask holds
+//	             the run's advisory lock and returns ClaimAlreadyClaimed for
+//	             anything not pending before it ever reaches this statement),
+//	             and the state deferForBusySite leaves a waiter in
+//	             (DeferUpdateTaskToPending writes 'pending' and NULLs
+//	             started_at). So a deferred task re-claims normally.
+//
+//	'running', but only if ABANDONED — its command went out longer ago than
+//	             @stale_after. 'running' is not terminal, so a River retry of
+//	             a job that already claimed re-enters Work and reaches here
+//	             with its own row 'running'; a strict = 'pending' would match
+//	             zero rows and drop that work on the floor, which is a worse
+//	             bug than the one being fixed. Bounding it by age is what
+//	             separates "my previous attempt died" from "another worker is
+//	             mid-dispatch right now": River cancels a job's context at its
+//	             own job timeout whether the site answers or not, so a row
+//	             older than that bound cannot have a live worker behind it.
+//	             Callers pass siteWriterHoldMax, the same constant and the
+//	             same reasoning as SiteHasRunningUpdateTask's @hold_max above
+//	             (worker.go asserts maxApply < siteWriterHoldMax <
+//	             staleTaskThreshold, so this window opens strictly after a
+//	             worker must be dead and strictly before the reaper claims the
+//	             row). coalesce(started_at, updated_at) mirrors that gate for
+//	             the same reason.
+//
+// target_type <> 'agent' on the reclaim branch is NOT an optimisation, and it
+// is the same exclusion SiteHasRunningUpdateTask carries: an agent
+// self-update task stays 'running' for its whole confirmation window (20m, or
+// 90m on external cron) with NO live worker behind it by design, because the
+// apply happens after the ARM response is released. Age is therefore not
+// evidence of abandonment for an agent row, and without this clause a wave
+// task would become re-claimable mid-confirmation. Agent rows may be claimed
+// from 'pending' only.
+//
+// A NULL @stale_after makes the reclaim branch match nothing (NULL comparison),
+// which fails CLOSED: strict pending-only claiming. Safe but conservative —
+// an abandoned row then waits for the reaper instead of a retry. Pass the
+// constant.
+//
+// ZERO ROWS MEANS: you did not get the claim, and you must NOT dispatch.
+// It does not distinguish why, so the caller re-reads the row and decides:
+// terminal => the outcome is recorded, stop (return nil, as Work already does
+// for a terminal read); still 'pending' or a FRESH 'running' => another worker
+// holds it, so give the row up WITHOUT consuming a retry (river.JobSnooze),
+// because that holder may still die and the row must stay reclaimable. Never
+// treat zero rows as an error to retry into, and never as permission to
+// proceed.
 func (q *Queries) MarkUpdateTaskRunning(ctx context.Context, arg MarkUpdateTaskRunningParams) (UpdateTask, error) {
-	row := q.db.QueryRow(ctx, markUpdateTaskRunning, arg.ID, arg.TenantID)
+	row := q.db.QueryRow(ctx, markUpdateTaskRunning, arg.ID, arg.TenantID, arg.StaleAfter)
 	var i UpdateTask
 	err := row.Scan(
 		&i.ID,

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -121,8 +121,17 @@ type CreateUpdateRunParams struct {
 	ScheduledAt pgtype.Timestamptz `json:"scheduled_at"`
 }
 
-// M3 bulk-update queries. Every statement is tenant-scoped both explicitly
-// (tenant_id in the WHERE/VALUES) and by RLS (the app.tenant_id policy).
+// M3 bulk-update queries. Every statement here is tenant-scoped both
+// explicitly (tenant_id in the WHERE/VALUES) and by RLS
+// (update_runs_tenant_isolation / update_tasks_tenant_isolation on
+// app.tenant_id); update_tasks additionally carries the RESTRICTIVE
+// update_tasks_site_scope policy the two portal reads depend on.
+//
+// ONE statement is deliberately outside that, and it is the only one:
+// ListStaleUpdateTasks sweeps every tenant for the periodic reaper, carries
+// no tenant_id at all, and is admitted by the update_tasks_agent policy
+// instead. It repeats that at its own definition. Any OTHER statement in
+// db/query/updates.sql without a tenant_id is a bug, not a second exception.
 // tenant_id is supplied explicitly for defense-in-depth; RLS additionally
 // enforces it matches the current app.tenant_id setting.
 func (q *Queries) CreateUpdateRun(ctx context.Context, arg CreateUpdateRunParams) (UpdateRun, error) {

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -948,15 +948,36 @@ type MarkUpdateTaskRunningParams struct {
 //	             zero rows and drop that work on the floor, which is a worse
 //	             bug than the one being fixed. Bounding it by age is what
 //	             separates "my previous attempt died" from "another worker is
-//	             mid-dispatch right now": River cancels a job's context at its
-//	             own job timeout whether the site answers or not, so a row
-//	             older than that bound cannot have a live worker behind it.
-//	             Callers pass siteWriterHoldMax, the same constant and the
-//	             same reasoning as SiteHasRunningUpdateTask's @hold_max above
-//	             (worker.go asserts maxApply < siteWriterHoldMax <
-//	             staleTaskThreshold, so this window opens strictly after a
-//	             worker must be dead and strictly before the reaper claims the
-//	             row). coalesce(started_at, updated_at) mirrors that gate for
+//	             mid-dispatch right now", but read the next two paragraphs for
+//	             what that separation is and is not worth.
+//
+//	             WHAT THE BOUND GUARANTEES: past @stale_after, no CONTROL-PLANE
+//	             worker is still inside its apply call for this row. Callers do
+//	             not pass a constant; they derive the bound from THIS install's
+//	             apply budget — ClaimStaleAfter(applyJobTimeout) =
+//	             max(applyJobTimeout + claimStaleMargin, siteWriterHoldMax) in
+//	             update/worker.go — and main() refuses to boot on a
+//	             configuration where the budget could reach it
+//	             (ValidateClaimTimings, asserting applyJobTimeout <
+//	             ClaimStaleAfter < staleTaskThreshold). So the reclaim window
+//	             opens strictly after River has cancelled the previous job's
+//	             context and strictly before the periodic reaper terminalizes
+//	             the row.
+//
+//	             WHAT IT DOES NOT GUARANTEE: that nothing is still applying ON
+//	             THE SITE. Cancelling a River job's context ends the control
+//	             plane's WAIT for the HTTP response; it does not reach into
+//	             WordPress and stop an apply the agent has already started. The
+//	             AGENT's own site-update lock is the authoritative bound on
+//	             that, exactly as it is for SiteHasRunningUpdateTask's
+//	             @hold_max below. If the bound is ever exceeded in practice the
+//	             residual is therefore a duplicate DISPATCH — a second command
+//	             for the same item and a second set of audit/event records for
+//	             it, which the agent's lock is what serialises — and not a
+//	             guaranteed double-apply. Still a real defect, and still worth
+//	             bounding; simply not a proof that no work is live.
+//
+//	             coalesce(started_at, updated_at) mirrors the gate below for
 //	             the same reason.
 //
 // target_type <> 'agent' on the reclaim branch is NOT an optimisation, and it

--- a/apps/api/internal/db/sqlc/updates.sql.go
+++ b/apps/api/internal/db/sqlc/updates.sql.go
@@ -1100,12 +1100,23 @@ type SiteHasRunningUpdateTaskParams struct {
 // no reason; the agent's own lock is what serialises the two channels in
 // both directions.
 //
-// The staleness clause bounds a crashed worker: a row whose command went out
-// longer ago than @hold_max cannot have a live worker behind it (River
-// cancels the job's context at its own job timeout regardless of whether the
-// site answers). Ignoring such a row only makes the gate MORE permissive
-// (lets a sibling dispatch it would otherwise have deferred), never less,
-// which is safe — the agent's own lock is still the backstop either way.
+// The staleness clause bounds a crashed WORKER, and only that: past @hold_max
+// no River job for this row can still be waiting on the site, because River
+// cancels the job's context at its own job timeout whether the site answers or
+// not. It says nothing about the SITE — cancelling that context ends the
+// control plane's wait for the HTTP response, it does not stop an apply the
+// agent has already begun (the same correction MarkUpdateTaskRunning's reclaim
+// arm carries above). Here that gap is harmless, and for a reason of its own:
+// ignoring an over-age row only makes the gate MORE permissive (lets a sibling
+// dispatch it would otherwise have deferred), never less, which is safe — the
+// agent's own lock is still the backstop either way.
+//
+// @hold_max is therefore the flat siteWriterHoldMax constant, passed straight
+// through by worker.go, and NOT the config-derived ClaimStaleAfter the claim
+// above is given. Neither call site is wrong: see ClaimStaleAfter's doc
+// comment in update/worker.go, which sets out why over-permissive is safe for
+// this gate and is precisely the defect for the claim.
+//
 // coalesce(started_at, updated_at) covers a row observed between
 // MarkUpdateTaskRunning (which sets both) and any later touch.
 //

--- a/apps/api/internal/update/agent_repo.go
+++ b/apps/api/internal/update/agent_repo.go
@@ -210,7 +210,12 @@ func (r *pgRepo) ClaimAgentWaveTask(ctx context.Context, tenantID, runID, taskID
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return domain.NotFound("update_task_not_found", "update task not found")
+				// Same statement, same condition, same answer as
+				// pgRepo.MarkTaskRunning: zero rows means the claim was not
+				// granted, NOT that the row is missing. Unreachable here (see
+				// above), but two callers of one statement must not disagree
+				// about what its zero-row case means.
+				return ErrTaskNotClaimed
 			}
 			return domain.Internal("update_task_run_failed", "failed to mark task running").WithCause(err)
 		}

--- a/apps/api/internal/update/agent_repo.go
+++ b/apps/api/internal/update/agent_repo.go
@@ -195,7 +195,19 @@ func (r *pgRepo) ClaimAgentWaveTask(ctx context.Context, tenantID, runID, taskID
 			return nil
 		}
 
-		row, err := q.MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{ID: taskID, TenantID: tenantID})
+		// staleAfter is passed for uniformity with the plugin/theme/core claim
+		// (worker.go), but the reclaim branch it enables is UNREACHABLE from
+		// here, twice over: the CAS excludes target_type = 'agent' outright,
+		// and the me.Status != TaskPending check above has already returned
+		// ClaimAlreadyClaimed for anything not pending, while holding the
+		// run's advisory lock. So this statement can only ever match on the
+		// 'pending' arm, exactly as it did before the precondition existed,
+		// and the ErrNoRows branch below stays unreachable in practice.
+		row, err := q.MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{
+			ID:         taskID,
+			TenantID:   tenantID,
+			StaleAfter: durationToInterval(siteWriterHoldMax),
+		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return domain.NotFound("update_task_not_found", "update task not found")

--- a/apps/api/internal/update/claim_cas_test.go
+++ b/apps/api/internal/update/claim_cas_test.go
@@ -189,17 +189,27 @@ func TestValidateClaimTimings_FiresAndDoesNotOverFire(t *testing.T) {
 	}
 }
 
-// TestYieldContendedClaim_IsWallClockBounded is the F2 regression. Every other
-// waiting path in this worker is bounded by siteBusyMaxWait from CreatedAt and
-// terminalizes as TaskSkipped; before this, the contended-claim path was the
-// only one that could snooze forever, and its unreadable-row branch did so
-// with nothing but a Warn — no error, no attempt consumed, no terminal state.
+// TestYieldContendedClaim_PastBound_IsLoudAndNeverWrites pins BOTH halves of
+// the contended path's wall-clock bound.
 //
-// RED: drop the busyBoundExceeded check from yieldContendedClaim and both
-// subtests snooze instead of terminalizing.
-func TestYieldContendedClaim_IsWallClockBounded(t *testing.T) {
+// It must be bounded: before the bound existed, a contended claim could snooze
+// forever with no error, no attempt consumed and no terminal state, and the
+// unreadable-row branch could do it on nothing but a Warn.
+//
+// It must ALSO never write. The first attempt at the bound terminalized the
+// task as TaskSkipped from the pre-claim snapshot. FinishUpdateTask accepts
+// 'pending' and 'running' alike, so that skip lands on the row the WINNER is
+// actively dispatching, the winner's real result is then rejected as
+// ErrTaskNotOpen, and the permanent record says "nothing was sent to the site"
+// about a site that was updated. A worker that never got the claim has no
+// outcome to record.
+//
+// RED: restore the terminalizing form (w.finish(..., TaskSkipped, ...) ahead of
+// the re-read) and both subtests fail on the write assertions.
+func TestYieldContendedClaim_PastBound_IsLoudAndNeverWrites(t *testing.T) {
 	cases := map[string]func(*probeFakeRepo){
-		"row still held": func(r *probeFakeRepo) {
+		// The winner holds the row and is mid-dispatch right now.
+		"row held by the winner": func(r *probeFakeRepo) {
 			held := claimTestTask()
 			held.Status = TaskRunning
 			r.getTask = func(uuid.UUID, uuid.UUID) (Task, error) { return held, nil }
@@ -223,20 +233,89 @@ func TestYieldContendedClaim_IsWallClockBounded(t *testing.T) {
 			err := w.yieldContendedClaim(context.Background(), TaskArgs{
 				TenantID: task.TenantID, RunID: task.RunID, TaskID: task.ID,
 			}, task)
-			if err != nil {
-				t.Fatalf("a task past its wall-clock bound must terminalize, not snooze; got %v", err)
+
+			// Loud: an error, which consumes an attempt and eventually
+			// dead-letters. Not nil (silently dropped) and not a snooze
+			// (invisible forever).
+			if err == nil {
+				t.Fatal("a task past its wall-clock bound must fail loudly, got nil")
 			}
-			if len(repo.finished) != 1 {
-				t.Fatalf("expected exactly one terminal write, got %+v", repo.finished)
+			if _, ok := asSnooze(err); ok {
+				t.Fatalf("past the bound this must stop snoozing, got %v", err)
 			}
-			if got := repo.finished[0].Status; got != TaskSkipped {
-				t.Fatalf("status = %q, want %q: this worker never got the claim, so nothing was sent to the site",
-					got, TaskSkipped)
+			// And never a write of any kind.
+			if len(repo.finished) != 0 {
+				t.Fatalf("a worker that never got the claim must never record an outcome; "+
+					"this would overwrite the winner's live row and report the update as not attempted, got %+v",
+					repo.finished)
 			}
 			if cmd.updateCalls != 0 {
 				t.Fatalf("a task that never won the claim must never dispatch, got %d", cmd.updateCalls)
 			}
 		})
+	}
+}
+
+// TestContendedClaim_LoserNeverOverwritesTheWinnersOutcome is the race stated
+// end to end, on one shared row, past siteBusyMaxWait: a winner that claims and
+// finishes, and a loser that is refused. What must be recorded is the WINNER's
+// result. The loser writing its own verdict is the defect, and it is worse than
+// a lost update: the site IS changed and the record says it was not.
+//
+// RED: restore the terminalizing form and the recorded status is "skipped".
+func TestContendedClaim_LoserNeverOverwritesTheWinnersOutcome(t *testing.T) {
+	task := claimTestTask()
+	task.CreatedAt = time.Now().Add(-siteBusyMaxWait - time.Minute) // past the bound
+	repo := claimRepo(task)
+
+	// One shared row both workers act on.
+	row := task
+	var claimed bool
+	repo.getTask = func(uuid.UUID, uuid.UUID) (Task, error) { return row, nil }
+	repo.markRunning = func(_, _ uuid.UUID, _ time.Duration) (Task, error) {
+		if claimed {
+			return Task{}, ErrTaskNotClaimed // the loser
+		}
+		claimed = true
+		row.Status = TaskRunning // the winner now holds it
+		return row, nil
+	}
+	// FinishTask on this fake mirrors FinishUpdateTask's precondition: it
+	// writes while the row is OPEN (pending|running) and refuses afterwards.
+	// That precondition is exactly why the loser must not call it at all.
+	repo.finishTask = func(in FinishTaskInput) (Task, error) {
+		if terminal(row.Status) {
+			return row, ErrTaskNotOpen
+		}
+		row.Status = in.Status
+		row.Detail = in.Detail
+		return row, nil
+	}
+
+	w, _ := claimTestWorker(repo, task)
+	args := TaskArgs{TenantID: task.TenantID, RunID: task.RunID, TaskID: task.ID}
+
+	// The winner claims.
+	if _, err := repo.MarkTaskRunning(context.Background(), task.TenantID, task.ID, w.claimStaleAfter); err != nil {
+		t.Fatalf("the winner must get the claim: %v", err)
+	}
+	// The loser is refused and yields.
+	loserErr := w.yieldContendedClaim(context.Background(), args, task)
+	// The winner then records its real outcome.
+	winnerErr := w.finish(context.Background(), row, TaskSucceeded, "1.9.9", "2.0.0", "updated", "")
+
+	if winnerErr != nil {
+		t.Fatalf("the winner's outcome must be recordable after the loser yields, got %v", winnerErr)
+	}
+	if row.Status != TaskSucceeded {
+		t.Fatalf("recorded status = %q, want %q: the loser overwrote the winner's live row, "+
+			"so the site was updated while the record says it was not", row.Status, TaskSucceeded)
+	}
+	if strings.Contains(row.Detail, "Nothing was sent to the site") {
+		t.Fatalf("the record claims nothing was sent to the site, but the winner updated it: %q", row.Detail)
+	}
+	if loserErr == nil {
+		t.Fatal("past the bound the loser must still fail loudly rather than return nil")
 	}
 }
 

--- a/apps/api/internal/update/claim_cas_test.go
+++ b/apps/api/internal/update/claim_cas_test.go
@@ -116,7 +116,9 @@ func TestClaim_PassesRealStaleAfter(t *testing.T) {
 		t.Fatalf("Work: %v", err)
 	}
 	if repo.markStaleAfter != w.claimStaleAfter {
-		t.Fatalf("the claim must pass the worker's own derived staleness bound, got %v want %v (a zero duration is a NULL interval, which silently disables abandoned-task reclaim)",
+		t.Fatalf("the claim must pass the worker's own derived staleness bound, got %v want %v "+
+			"(a flat constant stops exceeding the apply budget once apply_http_timeout is raised, "+
+			"and a non-positive bound would make every running row instantly reclaimable)",
 			repo.markStaleAfter, w.claimStaleAfter)
 	}
 	if repo.markStaleAfter <= 0 {

--- a/apps/api/internal/update/claim_cas_test.go
+++ b/apps/api/internal/update/claim_cas_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,9 +104,151 @@ func TestClaim_PassesRealStaleAfter(t *testing.T) {
 	if err := runClaimWork(t, w, task); err != nil {
 		t.Fatalf("Work: %v", err)
 	}
-	if repo.markStaleAfter != siteWriterHoldMax {
-		t.Fatalf("the claim must pass the real staleness bound, got %v want %v (a zero duration is a NULL interval, which silently disables abandoned-task reclaim)",
-			repo.markStaleAfter, siteWriterHoldMax)
+	if repo.markStaleAfter != w.claimStaleAfter {
+		t.Fatalf("the claim must pass the worker's own derived staleness bound, got %v want %v (a zero duration is a NULL interval, which silently disables abandoned-task reclaim)",
+			repo.markStaleAfter, w.claimStaleAfter)
+	}
+	if repo.markStaleAfter <= 0 {
+		t.Fatal("the claim's staleness bound must be positive")
+	}
+}
+
+// TestClaimStaleAfter_TracksTheConfiguredApplyBudget is the F1 regression. The
+// bound the claim uses must EXCEED this install's worst-case apply budget, or
+// a second worker reclaims a row whose holder is still applying and both
+// dispatch. That budget is config-driven (DeriveApplyJobTimeout over
+// cfg.Update.ApplyHTTPTimeout and cfg.Update.HTTPTimeout, both env-settable),
+// so a fixed constant stops exceeding it once the timeout is raised. The
+// existing ordering test pins the DEFAULT configuration only; this one sweeps
+// configurations a real operator can set.
+//
+// RED: make ClaimStaleAfter return the constant siteWriterHoldMax again, and
+// every row from 10m upward fails.
+func TestClaimStaleAfter_TracksTheConfiguredApplyBudget(t *testing.T) {
+	// applyHTTPTimeout values an operator can set via
+	// WPMGR_UPDATE_APPLY_HTTP_TIMEOUT, spanning the default and well past the
+	// point the old constant stopped covering the budget.
+	for _, applyHTTP := range []time.Duration{
+		1 * time.Minute, 8 * time.Minute, 14 * time.Minute, 20 * time.Minute, 30 * time.Minute,
+	} {
+		budget := DeriveApplyJobTimeout(applyHTTP, 30*time.Second)
+		bound := ClaimStaleAfter(budget)
+		if bound <= budget {
+			t.Errorf("apply_http_timeout=%v: claim bound %v must exceed the apply budget %v, "+
+				"or a worker reclaims a task another worker is still applying", applyHTTP, bound, budget)
+		}
+	}
+}
+
+// TestValidateClaimTimings_FiresAndDoesNotOverFire covers the boot assertion
+// both ways: it must refuse a configuration that puts the claim bound at or
+// past the reaper threshold, and it must NOT refuse configurations an operator
+// can legitimately run. A boot check that reddens valid config gets deleted,
+// and then it guards nothing.
+//
+// RED: return nil unconditionally from ValidateClaimTimings and the invalid
+// rows fail; clamp the bound below staleTaskThreshold and the valid rows fail.
+func TestValidateClaimTimings_FiresAndDoesNotOverFire(t *testing.T) {
+	// Valid: the default, and everything up to the point the bound would
+	// reach the reaper threshold.
+	for _, applyHTTP := range []time.Duration{
+		0, 1 * time.Minute, 8 * time.Minute, 20 * time.Minute,
+	} {
+		budget := DeriveApplyJobTimeout(applyHTTP, 30*time.Second)
+		if err := ValidateClaimTimings(budget); err != nil {
+			t.Errorf("apply_http_timeout=%v is a legitimate configuration and must boot, got %v", applyHTTP, err)
+		}
+	}
+	// Invalid: the bound would land at or past staleTaskThreshold, so the
+	// reaper could terminalize a row the claim still treats as live.
+	for _, applyHTTP := range []time.Duration{40 * time.Minute, 90 * time.Minute} {
+		budget := DeriveApplyJobTimeout(applyHTTP, 30*time.Second)
+		err := ValidateClaimTimings(budget)
+		if err == nil {
+			t.Errorf("apply_http_timeout=%v pushes the claim bound to %v, at or past the reaper threshold %v: boot must fail",
+				applyHTTP, ClaimStaleAfter(budget), staleTaskThreshold)
+			continue
+		}
+		// The operator who raised the timeout has to be able to act on this.
+		if !strings.Contains(err.Error(), "apply_http_timeout") {
+			t.Errorf("the boot failure must name the knob to change, got %q", err)
+		}
+	}
+}
+
+// TestYieldContendedClaim_IsWallClockBounded is the F2 regression. Every other
+// waiting path in this worker is bounded by siteBusyMaxWait from CreatedAt and
+// terminalizes as TaskSkipped; before this, the contended-claim path was the
+// only one that could snooze forever, and its unreadable-row branch did so
+// with nothing but a Warn — no error, no attempt consumed, no terminal state.
+//
+// RED: drop the busyBoundExceeded check from yieldContendedClaim and both
+// subtests snooze instead of terminalizing.
+func TestYieldContendedClaim_IsWallClockBounded(t *testing.T) {
+	cases := map[string]func(*probeFakeRepo){
+		"row still held": func(r *probeFakeRepo) {
+			held := claimTestTask()
+			held.Status = TaskRunning
+			r.getTask = func(uuid.UUID, uuid.UUID) (Task, error) { return held, nil }
+		},
+		// The branch that was genuinely unbounded: the re-read itself fails,
+		// so the bound must not depend on it.
+		"row unreadable": func(r *probeFakeRepo) {
+			r.getTask = func(uuid.UUID, uuid.UUID) (Task, error) {
+				return Task{}, errors.New("connection reset")
+			}
+		},
+	}
+	for name, wire := range cases {
+		t.Run(name, func(t *testing.T) {
+			task := claimTestTask()
+			task.CreatedAt = time.Now().Add(-siteBusyMaxWait - time.Minute)
+			repo := claimRepo(task)
+			wire(repo)
+			w, cmd := claimTestWorker(repo, task)
+
+			err := w.yieldContendedClaim(context.Background(), TaskArgs{
+				TenantID: task.TenantID, RunID: task.RunID, TaskID: task.ID,
+			}, task)
+			if err != nil {
+				t.Fatalf("a task past its wall-clock bound must terminalize, not snooze; got %v", err)
+			}
+			if len(repo.finished) != 1 {
+				t.Fatalf("expected exactly one terminal write, got %+v", repo.finished)
+			}
+			if got := repo.finished[0].Status; got != TaskSkipped {
+				t.Fatalf("status = %q, want %q: this worker never got the claim, so nothing was sent to the site",
+					got, TaskSkipped)
+			}
+			if cmd.updateCalls != 0 {
+				t.Fatalf("a task that never won the claim must never dispatch, got %d", cmd.updateCalls)
+			}
+		})
+	}
+}
+
+// TestYieldContendedClaim_WithinBoundStillSnoozes is the does-not-over-fire
+// companion: the bound must not terminalize an ordinary contended task that
+// has only been waiting a moment.
+//
+// RED: drop the `bound != ""` condition so the check always terminalizes.
+func TestYieldContendedClaim_WithinBoundStillSnoozes(t *testing.T) {
+	task := claimTestTask()
+	task.CreatedAt = time.Now() // nowhere near siteBusyMaxWait
+	repo := claimRepo(task)
+	held := task
+	held.Status = TaskRunning
+	repo.getTask = func(uuid.UUID, uuid.UUID) (Task, error) { return held, nil }
+	w, _ := claimTestWorker(repo, task)
+
+	err := w.yieldContendedClaim(context.Background(), TaskArgs{
+		TenantID: task.TenantID, RunID: task.RunID, TaskID: task.ID,
+	}, task)
+	if _, ok := asSnooze(err); !ok {
+		t.Fatalf("a freshly contended task must still snooze, got %v (%T)", err, err)
+	}
+	if len(repo.finished) != 0 {
+		t.Fatalf("a task within its bound must not be terminalized, got %+v", repo.finished)
 	}
 }
 

--- a/apps/api/internal/update/claim_cas_test.go
+++ b/apps/api/internal/update/claim_cas_test.go
@@ -29,7 +29,18 @@ func claimTestWorker(repo *probeFakeRepo, task Task) (*Worker, *recordingCommand
 	sites := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{
 		task.SiteID: {ID: task.SiteID, URL: "https://example.test", Name: "example", Enrolled: true},
 	}}
-	w := NewWorker(repo, sites, cmd, &scriptedProber{script: []probeStep{healthyStep()}}, nil /* hub */, nil /* audit */, nil, 5, 0)
+	// A NON-DEFAULT job timeout, deliberately. Constructing with 0 puts
+	// claimStaleAfter on its siteWriterHoldMax floor, and then asserting that
+	// the call site passes w.claimStaleAfter cannot tell the derived bound
+	// apart from the flat constant — the F1 defect could be reintroduced at
+	// the call site with nothing going red. This value makes the two differ
+	// (apply budget 25m52s -> bound 31m52s, against a 20m floor), so the
+	// assertion binds the seam and not just the arithmetic.
+	jobTimeout := DeriveApplyJobTimeout(20*time.Minute, 30*time.Second)
+	w := NewWorker(repo, sites, cmd, &scriptedProber{script: []probeStep{healthyStep()}}, nil /* hub */, nil /* audit */, nil, 5, jobTimeout)
+	if w.claimStaleAfter == siteWriterHoldMax {
+		panic("claim test fixture must construct a worker whose derived bound differs from the gate constant")
+	}
 	// Deterministic snooze: the jittered production backoff would make the
 	// assertions below flaky about the duration.
 	w.busyBackoff = func(Task) time.Duration { return 7 * time.Second }
@@ -290,20 +301,30 @@ func TestClaim_Reclaimed_AbandonedTaskDispatches(t *testing.T) {
 	// A row whose command went out well past the point a live worker could
 	// still be behind it: River has long since cancelled that job's context.
 	task.Status = TaskRunning
-	age := siteWriterHoldMax + 5*time.Minute
 
 	repo := claimRepo(task)
+	w, cmd := claimTestWorker(repo, task)
+	// Age the row relative to the worker's OWN derived bound, not a constant,
+	// so this test keeps meaning what it says under any configuration.
+	age := w.claimStaleAfter + 5*time.Minute
 	repo.markRunning = func(_, _ uuid.UUID, staleAfter time.Duration) (Task, error) {
-		// Mirrors the CAS: the 'running' arm matches only when the row is
-		// older than staleAfter. A NULL/zero interval matches nothing.
-		if staleAfter <= 0 || age <= staleAfter {
+		// Mirrors the real statement's 'running' arm:
+		// coalesce(started_at, updated_at) < now() - staleAfter.
+		//
+		// Note what a NON-POSITIVE bound does here — it matches EVERYTHING,
+		// because durationToInterval yields interval '0' and never NULL. That
+		// is the fail-OPEN direction. An earlier version of this fake encoded
+		// `staleAfter <= 0` as "matches nothing", which modelled the opposite
+		// of the real statement in the direction that hides the danger.
+		// pgRepo.MarkTaskRunning refuses a non-positive bound outright, so
+		// production cannot reach this, but the double must not lie about it.
+		if age <= staleAfter {
 			return Task{}, ErrTaskNotClaimed
 		}
 		running := task
 		running.Status = TaskRunning
 		return running, nil
 	}
-	w, cmd := claimTestWorker(repo, task)
 
 	if err := runClaimWork(t, w, task); err != nil {
 		t.Fatalf("an abandoned task must be reclaimed and dispatched, got %v", err)

--- a/apps/api/internal/update/claim_cas_test.go
+++ b/apps/api/internal/update/claim_cas_test.go
@@ -1,0 +1,298 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// These tests cover the CALLER half of the update-task claim compare-and-swap
+// (MarkUpdateTaskRunning in db/query/updates.sql). The SQL half is pinned by
+// tests/update_task_claim_cas_test.go against a real database; what is pinned
+// here is what Worker.Work does with each of the CAS's two outcomes, because
+// the failure mode this change exists to close is a caller that compiles fine
+// and silently does the wrong thing with them.
+
+// claimTestWorker wires a Worker with the minimum needed to drive Work as far
+// as the claim: a site the lookup can resolve, a commander that records
+// whether anything was ever dispatched, and a repo whose hooks the caller sets.
+func claimTestWorker(repo *probeFakeRepo, task Task) (*Worker, *recordingCommander) {
+	cmd := &recordingCommander{}
+	sites := &fakeSiteLookup{sites: map[uuid.UUID]SiteInfo{
+		task.SiteID: {ID: task.SiteID, URL: "https://example.test", Name: "example", Enrolled: true},
+	}}
+	w := NewWorker(repo, sites, cmd, &scriptedProber{script: []probeStep{healthyStep()}}, nil /* hub */, nil /* audit */, nil, 5, 0)
+	// Deterministic snooze: the jittered production backoff would make the
+	// assertions below flaky about the duration.
+	w.busyBackoff = func(Task) time.Duration { return 7 * time.Second }
+	return w, cmd
+}
+
+// recordingCommander records every dispatch. A dispatch that must not happen
+// is proved by updateCalls staying 0; the responses are shaped so a dispatch
+// that DOES happen completes cleanly rather than dragging the test into the
+// rollback ladder.
+type recordingCommander struct {
+	updateCalls int
+}
+
+func (c *recordingCommander) Update(_ context.Context, _ uuid.UUID, _ string, req agentcmd.UpdateRequest) (agentcmd.UpdateResponse, error) {
+	c.updateCalls++
+	item := req.Items[0]
+	return agentcmd.UpdateResponse{OK: true, Results: []agentcmd.ItemResult{{
+		Type: item.Type, Slug: item.Slug, Status: agentcmd.ItemSucceeded, ToVersion: item.Version,
+	}}}, nil
+}
+
+func (c *recordingCommander) Rollback(context.Context, uuid.UUID, string, agentcmd.RollbackRequest) (agentcmd.RollbackResponse, error) {
+	panic("no rollback expected in a claim test")
+}
+
+// claimTestTask is a plain non-agent task in the state Work expects to find it
+// in when a job starts: pending, nothing dispatched yet.
+func claimTestTask() Task {
+	t := testTask()
+	t.Status = TaskPending
+	return t
+}
+
+// claimRepo returns a probeFakeRepo wired to let Work reach the claim: the row
+// reads back as `task`, no other task is running for the tenant, and the run
+// is already running so ensureRunRunning is a no-op.
+func claimRepo(task Task) *probeFakeRepo {
+	return &probeFakeRepo{
+		getTask:      func(uuid.UUID, uuid.UUID) (Task, error) { return task, nil },
+		countRunning: func(uuid.UUID) (int64, error) { return 0, nil },
+		getRun:       func(uuid.UUID, uuid.UUID) (Run, error) { return Run{Status: RunRunning}, nil },
+	}
+}
+
+func runClaimWork(t *testing.T, w *Worker, task Task) error {
+	t.Helper()
+	return w.Work(context.Background(), &river.Job[TaskArgs]{
+		Args: TaskArgs{TenantID: task.TenantID, RunID: task.RunID, TaskID: task.ID},
+	})
+}
+
+// TestClaim_PassesRealStaleAfter is the regression test for the defect this
+// change closes. Both call sites used keyed struct literals, so when the
+// generated params struct grew StaleAfter they kept compiling while sending a
+// zero pgtype.Interval — SQL NULL — which makes the CAS's reclaim branch match
+// nothing. Nothing errored and nothing logged; the feature was simply inert.
+// Assert on the VALUE the worker hands the repo, not merely that the claim
+// succeeded, because a zero value succeeds too.
+//
+// RED: revert worker.go's call to MarkTaskRunning(ctx, a.TenantID, a.TaskID, 0).
+func TestClaim_PassesRealStaleAfter(t *testing.T) {
+	task := claimTestTask()
+	repo := claimRepo(task)
+	repo.markRunning = func(_, _ uuid.UUID, _ time.Duration) (Task, error) {
+		running := task
+		running.Status = TaskRunning
+		return running, nil
+	}
+	w, _ := claimTestWorker(repo, task)
+
+	if err := runClaimWork(t, w, task); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if repo.markStaleAfter != siteWriterHoldMax {
+		t.Fatalf("the claim must pass the real staleness bound, got %v want %v (a zero duration is a NULL interval, which silently disables abandoned-task reclaim)",
+			repo.markStaleAfter, siteWriterHoldMax)
+	}
+}
+
+// TestClaim_Succeeds_Dispatches is the does-not-over-fire case: an ordinary
+// uncontended claim must still go all the way through to a dispatch. A guard
+// that blocks correct work gets switched off, and then it guards nothing.
+//
+// RED: make yieldContendedClaim run unconditionally (drop the errors.Is check
+// in Work) and the dispatch never happens.
+func TestClaim_Succeeds_Dispatches(t *testing.T) {
+	task := claimTestTask()
+	repo := claimRepo(task)
+	repo.markRunning = func(_, _ uuid.UUID, _ time.Duration) (Task, error) {
+		running := task
+		running.Status = TaskRunning
+		return running, nil
+	}
+	w, cmd := claimTestWorker(repo, task)
+
+	if err := runClaimWork(t, w, task); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if cmd.updateCalls != 1 {
+		t.Fatalf("a successful claim must dispatch exactly once, got %d", cmd.updateCalls)
+	}
+}
+
+// TestClaim_Reclaimed_AbandonedTaskDispatches is the behaviour that is INERT
+// today: a row left 'running' by a worker that died is re-claimable once it
+// ages past siteWriterHoldMax, and the retrying job must dispatch rather than
+// give up. The repo hook here stands in for the SQL reclaim arm (proved
+// against a real DB in tests/update_task_claim_cas_test.go): it grants the
+// claim only when handed a staleAfter that would actually match the row.
+//
+// RED: pass 0 (or any duration greater than the row's age) at the call site
+// and the hook refuses, so the task snoozes forever instead of dispatching.
+func TestClaim_Reclaimed_AbandonedTaskDispatches(t *testing.T) {
+	task := claimTestTask()
+	// A row whose command went out well past the point a live worker could
+	// still be behind it: River has long since cancelled that job's context.
+	task.Status = TaskRunning
+	age := siteWriterHoldMax + 5*time.Minute
+
+	repo := claimRepo(task)
+	repo.markRunning = func(_, _ uuid.UUID, staleAfter time.Duration) (Task, error) {
+		// Mirrors the CAS: the 'running' arm matches only when the row is
+		// older than staleAfter. A NULL/zero interval matches nothing.
+		if staleAfter <= 0 || age <= staleAfter {
+			return Task{}, ErrTaskNotClaimed
+		}
+		running := task
+		running.Status = TaskRunning
+		return running, nil
+	}
+	w, cmd := claimTestWorker(repo, task)
+
+	if err := runClaimWork(t, w, task); err != nil {
+		t.Fatalf("an abandoned task must be reclaimed and dispatched, got %v", err)
+	}
+	if cmd.updateCalls != 1 {
+		t.Fatalf("the reclaiming worker must dispatch exactly once, got %d", cmd.updateCalls)
+	}
+}
+
+// TestClaim_Contended_SnoozesWithoutDispatching is the fires case. A losing
+// claimant must snooze: not an error (that spends a retry attempt and
+// eventually dead-letters work that never failed), not nil (that drops the
+// task while its row stays pending forever, holding the in-flight dedup slot),
+// and above all not domain.NotFound, which is what this path reported before
+// and which sends an operator hunting for a row that is still there.
+//
+// RED: return the error instead of snoozing in yieldContendedClaim, or restore
+// the pgx.ErrNoRows -> domain.NotFound mapping in repo.go.
+func TestClaim_Contended_SnoozesWithoutDispatching(t *testing.T) {
+	task := claimTestTask()
+	repo := claimRepo(task)
+	repo.markRunning = func(_, _ uuid.UUID, _ time.Duration) (Task, error) {
+		return Task{}, ErrTaskNotClaimed
+	}
+	// The re-read sees the row alive and held by the winner.
+	held := task
+	held.Status = TaskRunning
+	repo.getTask = func(uuid.UUID, uuid.UUID) (Task, error) { return held, nil }
+
+	w, cmd := claimTestWorker(repo, task)
+	err := runClaimWork(t, w, task)
+
+	snooze, ok := asSnooze(err)
+	if !ok {
+		t.Fatalf("a losing claimant must snooze without consuming a retry attempt, got %v (%T)", err, err)
+	}
+	if snooze.Duration != 7*time.Second {
+		t.Fatalf("snooze duration = %v, want the configured backoff 7s", snooze.Duration)
+	}
+	if cmd.updateCalls != 0 {
+		t.Fatalf("a losing claimant must never dispatch, got %d dispatches", cmd.updateCalls)
+	}
+	if len(repo.finished) != 0 {
+		t.Fatalf("a losing claimant must not terminalize the winner's task, got %+v", repo.finished)
+	}
+	// The re-read is the whole mechanism: Work's opening read plus
+	// yieldContendedClaim's.
+	if repo.getTaskCalls != 2 {
+		t.Fatalf("the contended branch must re-read the row before deciding, got %d GetTask calls", repo.getTaskCalls)
+	}
+}
+
+// TestClaim_Contended_TerminalRowStops proves the other half of the re-read:
+// when the winner already recorded a terminal outcome, there is nothing left
+// to do and snoozing would loop on a finished row. Return nil.
+//
+// RED: drop the terminal(current.Status) branch and this snoozes instead.
+func TestClaim_Contended_TerminalRowStops(t *testing.T) {
+	for _, status := range []string{TaskSucceeded, TaskFailed, TaskRolledBack, TaskSkipped, TaskCancelled} {
+		t.Run(status, func(t *testing.T) {
+			task := claimTestTask()
+			repo := claimRepo(task)
+			repo.markRunning = func(_, _ uuid.UUID, _ time.Duration) (Task, error) {
+				return Task{}, ErrTaskNotClaimed
+			}
+			// First read: still open, so Work proceeds to the claim. Second
+			// read (the re-read): the winner has finished it.
+			repo.getTask = func(uuid.UUID, uuid.UUID) (Task, error) {
+				if repo.getTaskCalls > 1 {
+					done := task
+					done.Status = status
+					return done, nil
+				}
+				return task, nil
+			}
+			w, cmd := claimTestWorker(repo, task)
+
+			if err := runClaimWork(t, w, task); err != nil {
+				t.Fatalf("a task the winner already finished must stop cleanly, got %v", err)
+			}
+			if cmd.updateCalls != 0 {
+				t.Fatalf("a terminal task must never be dispatched, got %d", cmd.updateCalls)
+			}
+			if len(repo.finished) != 0 {
+				t.Fatalf("a terminal task must not be re-terminalized, got %+v", repo.finished)
+			}
+		})
+	}
+}
+
+// TestClaim_Contended_UnreadableRowSnoozes covers the branch where the re-read
+// itself fails: terminal and contended are indistinguishable, so take the safe
+// reading (someone may hold it) and snooze rather than spend a retry attempt
+// on a control-plane DB hiccup.
+//
+// RED: return the GetTask error and this fails on the snooze assertion.
+func TestClaim_Contended_UnreadableRowSnoozes(t *testing.T) {
+	task := claimTestTask()
+	repo := claimRepo(task)
+	repo.markRunning = func(_, _ uuid.UUID, _ time.Duration) (Task, error) {
+		return Task{}, ErrTaskNotClaimed
+	}
+	boom := errors.New("connection reset")
+	repo.getTask = func(uuid.UUID, uuid.UUID) (Task, error) {
+		if repo.getTaskCalls > 1 {
+			return Task{}, boom
+		}
+		return task, nil
+	}
+	w, cmd := claimTestWorker(repo, task)
+
+	err := runClaimWork(t, w, task)
+	if _, ok := asSnooze(err); !ok {
+		t.Fatalf("an unreadable row after a refused claim must snooze, got %v (%T)", err, err)
+	}
+	if cmd.updateCalls != 0 {
+		t.Fatalf("a worker that did not get the claim must never dispatch, got %d", cmd.updateCalls)
+	}
+}
+
+// TestErrTaskNotClaimed_IsNotNotFoundOrNotOpen pins the three-way distinction
+// the callers branch on. ErrTaskNotClaimed carries NO verdict about the task;
+// conflating it with ErrTaskNotOpen would make a losing claimant return nil
+// and drop live work, and the domain.NotFound it used to be reported an absent
+// row that is in fact present and held.
+//
+// RED: define ErrTaskNotClaimed = ErrTaskNotOpen.
+func TestErrTaskNotClaimed_IsNotNotFoundOrNotOpen(t *testing.T) {
+	if errors.Is(ErrTaskNotClaimed, ErrTaskNotOpen) || errors.Is(ErrTaskNotOpen, ErrTaskNotClaimed) {
+		t.Fatal("ErrTaskNotClaimed (no verdict; another worker holds the row) must stay distinct from ErrTaskNotOpen (a terminal outcome is recorded)")
+	}
+	if _, ok := domain.AsDomain(ErrTaskNotClaimed); ok {
+		t.Fatal("ErrTaskNotClaimed must not be a domain error: reporting the losing claimant as NotFound sends operators hunting for a row that still exists")
+	}
+}

--- a/apps/api/internal/update/claim_cas_test.go
+++ b/apps/api/internal/update/claim_cas_test.go
@@ -172,6 +172,26 @@ func TestValidateClaimTimings_FiresAndDoesNotOverFire(t *testing.T) {
 			t.Errorf("apply_http_timeout=%v is a legitimate configuration and must boot, got %v", applyHTTP, err)
 		}
 	}
+	// The TRANSITION itself, derived from the constants rather than guessed.
+	// The loops above bracket it at 20m valid and 40m invalid, and the real
+	// boundary sits between them; a change to claimStaleMargin,
+	// probeRetryDelays or agentVerifyTimeout moves it anywhere inside that gap
+	// with both loops still green. Pin the edge instead: the largest budget
+	// that still boots, and the smallest that must not.
+	//
+	// RED: change claimStaleMargin without re-deriving, and these two fail
+	// while every fixed-value row above keeps passing.
+	lastValid := staleTaskThreshold - claimStaleMargin - time.Second
+	if err := ValidateClaimTimings(lastValid); err != nil {
+		t.Errorf("an apply budget of %v leaves the bound just under the reaper threshold %v and must boot, got %v",
+			lastValid, staleTaskThreshold, err)
+	}
+	firstInvalid := staleTaskThreshold - claimStaleMargin
+	if err := ValidateClaimTimings(firstInvalid); err == nil {
+		t.Errorf("an apply budget of %v puts the bound exactly at the reaper threshold %v and must be refused",
+			firstInvalid, staleTaskThreshold)
+	}
+
 	// Invalid: the bound would land at or past staleTaskThreshold, so the
 	// reaper could terminalize a row the claim still treats as live.
 	for _, applyHTTP := range []time.Duration{40 * time.Minute, 90 * time.Minute} {

--- a/apps/api/internal/update/handler_test.go
+++ b/apps/api/internal/update/handler_test.go
@@ -53,7 +53,7 @@ func (f *fakeRepo) GetTask(context.Context, uuid.UUID, uuid.UUID) (Task, error) 
 	panic("not used")
 }
 
-func (f *fakeRepo) MarkTaskRunning(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
+func (f *fakeRepo) MarkTaskRunning(context.Context, uuid.UUID, uuid.UUID, time.Duration) (Task, error) {
 	panic("not used")
 }
 

--- a/apps/api/internal/update/repo.go
+++ b/apps/api/internal/update/repo.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -58,10 +59,16 @@ type Repo interface {
 	// to 'running' only from 'pending', or from an ABANDONED 'running' (a
 	// non-agent row whose command went out longer ago than staleAfter). It
 	// returns ErrTaskNotClaimed, never domain.NotFound, when it matches no row.
-	// staleAfter is the same staleness bound the per-site gate uses
-	// (siteWriterHoldMax); passing a zero duration would be a NULL interval,
-	// which fails closed to strict pending-only claiming and silently disables
-	// reclaim of a row a dead worker left behind.
+	//
+	// staleAfter must be POSITIVE and is refused otherwise. It is NOT the
+	// per-site gate's siteWriterHoldMax: the gate and the claim hold
+	// deliberately separate values with opposite safe directions (see
+	// ClaimStaleAfter). Production callers pass the worker's own derived
+	// Worker.claimStaleAfter.
+	//
+	// A zero duration is NOT a NULL interval and does NOT fail closed. It is
+	// interval '0', which makes every non-agent 'running' row instantly
+	// reclaimable — the fail-OPEN direction. Hence the refusal.
 	MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID, staleAfter time.Duration) (Task, error)
 	// FinishTask records a terminal state for a task that is still OPEN
 	// (pending|running). A task that already reached a terminal state is
@@ -343,14 +350,28 @@ func (r *pgRepo) GetTask(ctx context.Context, tenantID, taskID uuid.UUID) (Task,
 }
 
 func (r *pgRepo) MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID, staleAfter time.Duration) (Task, error) {
+	// A non-positive bound is refused HERE, before the statement runs, which
+	// is the only place that makes the failure unreachable by construction
+	// rather than by convention.
+	//
+	// durationToInterval always sets Valid: true, so a zero Duration is not a
+	// SQL NULL — it is interval '0', and
+	// `coalesce(started_at, updated_at) < now() - '0'::interval` is true for
+	// every non-agent 'running' row the instant it is written. That reopens
+	// the double-dispatch race this whole path exists to close: it fails OPEN,
+	// not closed. Refusing beats documenting, because the next caller reads
+	// the signature, not this comment.
+	if staleAfter <= 0 {
+		return Task{}, domain.Internal("update_task_claim_bound_invalid",
+			"failed to mark task running").WithCause(
+			fmt.Errorf("claim staleness bound must be positive, got %v: a non-positive bound "+
+				"makes every running row instantly reclaimable", staleAfter))
+	}
 	var out Task
 	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		row, err := sqlc.New(tx).MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{
-			ID:       taskID,
-			TenantID: tenantID,
-			// A zero Duration would marshal to a NULL interval and quietly
-			// disable the reclaim branch while still compiling and still
-			// succeeding on the ordinary path — pass the real bound.
+			ID:         taskID,
+			TenantID:   tenantID,
 			StaleAfter: durationToInterval(staleAfter),
 		})
 		if err != nil {
@@ -547,6 +568,12 @@ func (r *pgRepo) DeferTaskToPending(ctx context.Context, in DeferTaskInput) (Tas
 // durationToInterval converts a time.Duration to a pgtype.Interval suitable
 // for an @threshold::interval parameter (pgtype.Interval stores microseconds
 // in the Microseconds field).
+//
+// Valid is ALWAYS true, so this never produces SQL NULL. A zero Duration
+// becomes interval '0', not NULL — which for a `now() - $bound` staleness
+// comparison means "everything is stale" rather than "nothing matches".
+// Callers whose bound must be positive check it themselves before calling;
+// see pgRepo.MarkTaskRunning.
 func durationToInterval(d time.Duration) pgtype.Interval {
 	return pgtype.Interval{Microseconds: d.Microseconds(), Valid: true}
 }

--- a/apps/api/internal/update/repo.go
+++ b/apps/api/internal/update/repo.go
@@ -24,6 +24,21 @@ import (
 // stands and the job is done. See Worker.finish.
 var ErrTaskNotOpen = errors.New("update task is not open")
 
+// ErrTaskNotClaimed reports that MarkTaskRunning's compare-and-swap matched no
+// row: the caller did NOT get the claim and must not dispatch. It is
+// deliberately distinct from domain.NotFound, which this path used to return
+// for the same condition — the row is virtually always still there, held by
+// another worker, and reporting "update task not found" sends an operator
+// hunting for a deleted row that exists. It is also distinct from
+// ErrTaskNotOpen: that one means a TERMINAL outcome is already recorded and
+// the job is done, whereas this one carries no verdict at all. Zero rows does
+// not say why (see MarkUpdateTaskRunning in db/query/updates.sql), so the
+// caller re-reads the row and decides: terminal => stop; otherwise another
+// worker holds it => give the row up WITHOUT consuming a retry attempt
+// (river.JobSnooze), because that holder may still die and the row must stay
+// reclaimable. See Worker.yieldContendedClaim.
+var ErrTaskNotClaimed = errors.New("update task was not claimed")
+
 // Repo is the tenant-scoped persistence interface for update runs/tasks. Every
 // method runs inside a tenant-scoped transaction so RLS enforces isolation even
 // if a query omitted its tenant filter.
@@ -39,7 +54,15 @@ type Repo interface {
 	ListTasks(ctx context.Context, tenantID, runID uuid.UUID) ([]Task, error)
 	GetTask(ctx context.Context, tenantID, taskID uuid.UUID) (Task, error)
 
-	MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID) (Task, error)
+	// MarkTaskRunning is the claim: a compare-and-swap that transitions a task
+	// to 'running' only from 'pending', or from an ABANDONED 'running' (a
+	// non-agent row whose command went out longer ago than staleAfter). It
+	// returns ErrTaskNotClaimed, never domain.NotFound, when it matches no row.
+	// staleAfter is the same staleness bound the per-site gate uses
+	// (siteWriterHoldMax); passing a zero duration would be a NULL interval,
+	// which fails closed to strict pending-only claiming and silently disables
+	// reclaim of a row a dead worker left behind.
+	MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID, staleAfter time.Duration) (Task, error)
 	// FinishTask records a terminal state for a task that is still OPEN
 	// (pending|running). A task that already reached a terminal state is
 	// returned unchanged alongside ErrTaskNotOpen: its recorded outcome wins.
@@ -319,13 +342,22 @@ func (r *pgRepo) GetTask(ctx context.Context, tenantID, taskID uuid.UUID) (Task,
 	return out, err
 }
 
-func (r *pgRepo) MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID) (Task, error) {
+func (r *pgRepo) MarkTaskRunning(ctx context.Context, tenantID, taskID uuid.UUID, staleAfter time.Duration) (Task, error) {
 	var out Task
 	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
-		row, err := sqlc.New(tx).MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{ID: taskID, TenantID: tenantID})
+		row, err := sqlc.New(tx).MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{
+			ID:       taskID,
+			TenantID: tenantID,
+			// A zero Duration would marshal to a NULL interval and quietly
+			// disable the reclaim branch while still compiling and still
+			// succeeding on the ordinary path — pass the real bound.
+			StaleAfter: durationToInterval(staleAfter),
+		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return domain.NotFound("update_task_not_found", "update task not found")
+				// The CAS matched nothing. NOT NotFound: the row is almost
+				// certainly present and held by someone else.
+				return ErrTaskNotClaimed
 			}
 			return domain.Internal("update_task_run_failed", "failed to mark task running").WithCause(err)
 		}

--- a/apps/api/internal/update/service_test.go
+++ b/apps/api/internal/update/service_test.go
@@ -161,7 +161,7 @@ func (f *fakeCreateRepo) ListTasks(_ context.Context, tenantID, runID uuid.UUID)
 func (f *fakeCreateRepo) GetTask(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
 	panic("not used")
 }
-func (f *fakeCreateRepo) MarkTaskRunning(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
+func (f *fakeCreateRepo) MarkTaskRunning(context.Context, uuid.UUID, uuid.UUID, time.Duration) (Task, error) {
 	panic("not used")
 }
 func (f *fakeCreateRepo) FinishTask(context.Context, FinishTaskInput) (Task, error) {

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -95,6 +95,11 @@ type Worker struct {
 	hub    *Hub
 	audit  *audit.Recorder
 	logger *slog.Logger
+	// claimStaleAfter is the staleness bound handed to the claim CAS,
+	// derived from this worker's own configured job timeout at construction
+	// (see ClaimStaleAfter). A field, not a constant, because the budget it
+	// must exceed is config-driven.
+	claimStaleAfter time.Duration
 	// perTenantLimit bounds concurrent running tasks per tenant as a
 	// belt-and-suspenders guard alongside the per-tenant queue sharding. When the
 	// limit is reached the job snoozes and retries shortly.
@@ -163,7 +168,7 @@ func NewWorker(repo Repo, sites SiteLookup, cmd Commander, prober HealthProber, 
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Worker{repo: repo, sites: sites, cmd: cmd, prober: prober, hub: hub, audit: rec, logger: logger, perTenantLimit: perTenantLimit, jobTimeout: jobTimeout}
+	return &Worker{repo: repo, sites: sites, cmd: cmd, prober: prober, hub: hub, audit: rec, logger: logger, perTenantLimit: perTenantLimit, jobTimeout: jobTimeout, claimStaleAfter: ClaimStaleAfter(jobTimeout)}
 }
 
 // Timeout overrides River's default per-job context deadline (60s) for the
@@ -319,11 +324,11 @@ func (w *Worker) Work(ctx context.Context, job *river.Job[TaskArgs]) error {
 	// The claim. Everything above this line is a read; from here on this
 	// worker asserts it is the one talking to this site about this item, and
 	// the assertion is decided by the row itself under its own row lock, not
-	// by the GetTask above. siteWriterHoldMax is the same bound the per-site
-	// gate uses: a 'running' row older than that cannot have a live worker
-	// behind it, so this worker reclaims it rather than leaving it for the
-	// reaper 25 minutes later.
-	running, err := w.repo.MarkTaskRunning(ctx, a.TenantID, a.TaskID, siteWriterHoldMax)
+	// by the GetTask above. The bound is derived from this worker's own
+	// configured apply budget (see ClaimStaleAfter), NOT shared with the
+	// per-site gate above: for the gate an over-age row is safe to ignore,
+	// for the claim an over-short bound is exactly the double-dispatch defect.
+	running, err := w.repo.MarkTaskRunning(ctx, a.TenantID, a.TaskID, w.claimStaleAfter)
 	if errors.Is(err, ErrTaskNotClaimed) {
 		return w.yieldContendedClaim(ctx, a, task)
 	}
@@ -387,6 +392,81 @@ func (w *Worker) refuseAgentSelfUpdate(ctx context.Context, task Task) error {
 // which is safe: the agent's own site-update lock is the authoritative bound
 // in every case, this gate is only a round-trip optimisation.
 const siteWriterHoldMax = 20 * time.Minute
+
+// claimStaleMargin is the headroom the CLAIM's staleness bound keeps over the
+// worst-case apply job budget, covering scheduling delay and clock skew
+// between the control plane and Postgres.
+const claimStaleMargin = 6 * time.Minute
+
+// ClaimStaleAfter is the staleness bound the update-task claim
+// (MarkUpdateTaskRunning's reclaim arm) is given, derived from THIS install's
+// configured apply job budget rather than fixed.
+//
+// It is deliberately NOT siteWriterHoldMax, even though the two are equal on
+// default configuration. They are different judgements that happen to agree
+// today, and the reasoning does not transfer between them:
+//
+//   - For the per-site GATE (SiteHasRunningUpdateTask), being over-permissive
+//     is SAFE. Ignoring an over-age row only lets a sibling send a command the
+//     gate would otherwise have deferred, and the agent's own site-update lock
+//     is the authoritative bound. See siteWriterHoldMax's own comment.
+//   - For the CLAIM, being over-permissive is THE DEFECT. A bound shorter than
+//     the time a worker can legitimately still be applying lets a second
+//     worker claim a row whose holder is alive, and both dispatch. The claim
+//     therefore has to track the apply budget; a constant cannot.
+//
+// The apply budget is config-driven (DeriveApplyJobTimeout over
+// cfg.Update.ApplyHTTPTimeout and cfg.Update.HTTPTimeout, both env-settable),
+// so a constant 20m silently stops exceeding it once ApplyHTTPTimeout is
+// raised past ~14m. Deriving from the same number that produced the job
+// timeout keeps the relationship true at any configuration.
+//
+// The siteWriterHoldMax floor keeps the historical value on default
+// configuration (13m52s + 6m = 19m52s rounds up to 20m) so this is not also a
+// silent retune of production behaviour, and makes the bound monotone in the
+// apply budget.
+//
+// applyJobTimeout of 0 means "no derived budget; River's own default applies"
+// (see DeriveApplyJobTimeout), which the floor covers.
+//
+// ValidateClaimTimings must hold for the result; call it at boot.
+func ClaimStaleAfter(applyJobTimeout time.Duration) time.Duration {
+	if bound := applyJobTimeout + claimStaleMargin; bound > siteWriterHoldMax {
+		return bound
+	}
+	return siteWriterHoldMax
+}
+
+// ValidateClaimTimings reports whether the claim's staleness bound still sits
+// in the window it must occupy for this install's configuration:
+//
+//	applyJobTimeout  <  ClaimStaleAfter(applyJobTimeout)  <  staleTaskThreshold
+//
+// The left inequality is what stops a second worker reclaiming a row whose
+// holder is still legitimately applying. The right one keeps the periodic
+// reaper from terminalizing a row the claim would still treat as live, which
+// would let the reaper and a retrying worker act on one task at once.
+//
+// Both are config-dependent, and neither is checked by the compiler or by any
+// test that runs on default configuration, so this is asserted AT BOOT and the
+// process refuses to start when it fails. That is the intended severity: a
+// configuration that re-opens a double-dispatch window must not run. The
+// remedy is in the message, because the operator who raised the timeout is the
+// one who has to read it.
+func ValidateClaimTimings(applyJobTimeout time.Duration) error {
+	bound := ClaimStaleAfter(applyJobTimeout)
+	if applyJobTimeout >= bound {
+		return fmt.Errorf("update: claim staleness bound (%v) must exceed the apply job budget (%v); "+
+			"a worker could reclaim a task another worker is still applying", bound, applyJobTimeout)
+	}
+	if bound >= staleTaskThreshold {
+		return fmt.Errorf("update: claim staleness bound (%v) must stay under the stale-task reaper threshold (%v), "+
+			"but the configured apply budget (%v) pushes it past: lower update.apply_http_timeout "+
+			"(WPMGR_UPDATE_APPLY_HTTP_TIMEOUT) or update.http_timeout, or raise the reaper threshold to match",
+			bound, staleTaskThreshold, applyJobTimeout)
+	}
+	return nil
+}
 
 const (
 	// siteBusyBackoffMin/Max bound the jittered snooze between busy-site
@@ -503,15 +583,39 @@ func (w *Worker) deferForBusySite(ctx context.Context, task Task, why string) er
 //     attempt at that target. Snooze reschedules without spending an attempt,
 //     so the row stays reclaimable if the current holder dies.
 //
-// The snooze cannot loop forever: whoever holds the row either finishes it
-// (terminal => nil on the next pass) or dies, and once its 'running' row ages
-// past siteWriterHoldMax the CAS's own reclaim branch hands it to this job.
+// Termination does NOT rest on the CAS reclaim arm. That arm is bounded by age
+// alone, is disabled entirely for target_type = 'agent', and depends on a
+// config-derived bound; leaning on it would make this path's termination a
+// property of somebody else's tuning. The authoritative bound is the same
+// wall-clock one every other waiting path here uses (siteBusyMaxWait, measured
+// from the task's own CreatedAt), applied below before anything else.
 func (w *Worker) yieldContendedClaim(ctx context.Context, a TaskArgs, task Task) error {
+	// The wall-clock bound comes FIRST, before the re-read, so it holds on
+	// every path out of this function including the one where the re-read
+	// itself fails. Every other waiting path in this worker is bounded this
+	// way (see deferForBusySite and siteBusyMaxWait's own comment); without it
+	// this is the only place that can snooze indefinitely, and an
+	// indefinitely-snoozing job is invisible: no error, no attempt consumed,
+	// no terminal state, nothing to alert on.
+	//
+	// TaskSkipped, never TaskFailed: this worker never got the claim, so it
+	// sent nothing to the site and changed nothing on it. If the holder is in
+	// fact still alive and finishes later, FinishTask refuses to overwrite a
+	// terminal row (ErrTaskNotOpen), so the recorded outcome still wins.
+	if bound := busyBoundExceeded(task); bound != "" {
+		return w.finish(ctx, task, TaskSkipped, task.FromVersion, "",
+			fmt.Sprintf("not attempted: another worker held this task continuously %s. "+
+				"Nothing was sent to the site for this item and nothing on the site was changed. "+
+				"Re-run this update.", bound), "")
+	}
+
 	current, err := w.repo.GetTask(ctx, a.TenantID, a.TaskID)
 	if err != nil {
 		// Cannot tell terminal from contended. Snooze rather than error: the
 		// safe reading of an unknown row is "someone else may hold it", and a
-		// CP-side DB hiccup must not spend this task's retry budget.
+		// CP-side DB hiccup must not spend this task's retry budget. Bounded
+		// by the busyBoundExceeded check above, which is exactly why that
+		// check does not depend on this read succeeding.
 		w.logger.Warn("update: claim was refused and the row could not be re-read; snoozing",
 			slog.String("task_id", a.TaskID.String()), slog.Any("error", err))
 		return river.JobSnooze(w.siteBusyBackoff(task))

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -462,7 +462,8 @@ func ValidateClaimTimings(applyJobTimeout time.Duration) error {
 	if bound >= staleTaskThreshold {
 		return fmt.Errorf("update: claim staleness bound (%v) must stay under the stale-task reaper threshold (%v), "+
 			"but the configured apply budget (%v) pushes it past: lower update.apply_http_timeout "+
-			"(WPMGR_UPDATE_APPLY_HTTP_TIMEOUT) or update.http_timeout, or raise the reaper threshold to match",
+			"(WPMGR_UPDATE_APPLY_HTTP_TIMEOUT) or update.http_timeout (WPMGR_UPDATE_HTTP_TIMEOUT). "+
+			"The reaper threshold is a compile-time constant and cannot be raised by configuration",
 			bound, staleTaskThreshold, applyJobTimeout)
 	}
 	return nil

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -316,7 +316,17 @@ func (w *Worker) Work(ctx context.Context, job *river.Job[TaskArgs]) error {
 		return w.deferForBusySite(ctx, task, "another update is running on this site")
 	}
 
-	running, err := w.repo.MarkTaskRunning(ctx, a.TenantID, a.TaskID)
+	// The claim. Everything above this line is a read; from here on this
+	// worker asserts it is the one talking to this site about this item, and
+	// the assertion is decided by the row itself under its own row lock, not
+	// by the GetTask above. siteWriterHoldMax is the same bound the per-site
+	// gate uses: a 'running' row older than that cannot have a live worker
+	// behind it, so this worker reclaims it rather than leaving it for the
+	// reaper 25 minutes later.
+	running, err := w.repo.MarkTaskRunning(ctx, a.TenantID, a.TaskID, siteWriterHoldMax)
+	if errors.Is(err, ErrTaskNotClaimed) {
+		return w.yieldContendedClaim(ctx, a, task)
+	}
 	if err != nil {
 		return err
 	}
@@ -474,6 +484,44 @@ func (w *Worker) deferForBusySite(ctx context.Context, task Task, why string) er
 	}
 	w.publish(deferred, RunRunning)
 	return river.JobSnooze(w.siteBusyBackoff(deferred))
+}
+
+// yieldContendedClaim handles the one outcome the claim CAS cannot explain
+// itself: zero rows matched, so this worker did NOT get the task and must not
+// dispatch. The statement does not say why, so re-read the row and decide.
+//
+// The two returns here are the whole point, and neither is the obvious one:
+//
+//   - nil, ONLY for a terminal row. Someone else already recorded the outcome;
+//     that outcome wins and there is nothing left to do. This is exactly what
+//     Work already does for a terminal read at its top.
+//   - river.JobSnooze otherwise. NOT an error: an error consumes a retry
+//     attempt, and enough of them dead-letter a task that never actually
+//     failed. NOT nil either: that drops the work silently while the row sits
+//     'pending' forever, holding its (tenant, site, target_type, target_slug)
+//     in-flight slot in m88's partial unique index and 409-ing every future
+//     attempt at that target. Snooze reschedules without spending an attempt,
+//     so the row stays reclaimable if the current holder dies.
+//
+// The snooze cannot loop forever: whoever holds the row either finishes it
+// (terminal => nil on the next pass) or dies, and once its 'running' row ages
+// past siteWriterHoldMax the CAS's own reclaim branch hands it to this job.
+func (w *Worker) yieldContendedClaim(ctx context.Context, a TaskArgs, task Task) error {
+	current, err := w.repo.GetTask(ctx, a.TenantID, a.TaskID)
+	if err != nil {
+		// Cannot tell terminal from contended. Snooze rather than error: the
+		// safe reading of an unknown row is "someone else may hold it", and a
+		// CP-side DB hiccup must not spend this task's retry budget.
+		w.logger.Warn("update: claim was refused and the row could not be re-read; snoozing",
+			slog.String("task_id", a.TaskID.String()), slog.Any("error", err))
+		return river.JobSnooze(w.siteBusyBackoff(task))
+	}
+	if terminal(current.Status) {
+		return nil
+	}
+	w.logger.Info("update: another worker holds this task; snoozing without consuming an attempt",
+		slog.String("task_id", a.TaskID.String()), slog.String("status", current.Status))
+	return river.JobSnooze(w.siteBusyBackoff(current))
 }
 
 // runDry asks the agent what WOULD change without mutating the site.

--- a/apps/api/internal/update/worker.go
+++ b/apps/api/internal/update/worker.go
@@ -587,42 +587,58 @@ func (w *Worker) deferForBusySite(ctx context.Context, task Task, why string) er
 // Termination does NOT rest on the CAS reclaim arm. That arm is bounded by age
 // alone, is disabled entirely for target_type = 'agent', and depends on a
 // config-derived bound; leaning on it would make this path's termination a
-// property of somebody else's tuning. The authoritative bound is the same
-// wall-clock one every other waiting path here uses (siteBusyMaxWait, measured
-// from the task's own CreatedAt), applied below before anything else.
+// property of somebody else's tuning.
+//
+// This function NEVER writes a terminal state, and that is the point. A worker
+// that did not get the claim has no outcome to record: it sent nothing to the
+// site and learned nothing about what the holder did. Terminalizing from here
+// writes the LOSER's verdict onto the WINNER's live row — FinishUpdateTask
+// accepts 'pending' and 'running' alike, so a skip recorded here lands on the
+// row the winner is actively dispatching, and the winner's real result is then
+// rejected as ErrTaskNotOpen. The operator would read "nothing was sent to the
+// site" about a site that was in fact updated, and re-run it. Unlike
+// deferForBusySite, which owns its task and may terminalize it, this path owns
+// nothing.
+//
+// So the wall-clock bound (siteBusyMaxWait, from CreatedAt) chooses between
+// snoozing quietly and failing loudly, never between waiting and writing.
+// Terminalizing a genuinely stuck row belongs to the periodic reaper, whose own
+// threshold (staleTaskThreshold, 45m) sits far inside this bound.
 func (w *Worker) yieldContendedClaim(ctx context.Context, a TaskArgs, task Task) error {
-	// The wall-clock bound comes FIRST, before the re-read, so it holds on
-	// every path out of this function including the one where the re-read
-	// itself fails. Every other waiting path in this worker is bounded this
-	// way (see deferForBusySite and siteBusyMaxWait's own comment); without it
-	// this is the only place that can snooze indefinitely, and an
-	// indefinitely-snoozing job is invisible: no error, no attempt consumed,
-	// no terminal state, nothing to alert on.
-	//
-	// TaskSkipped, never TaskFailed: this worker never got the claim, so it
-	// sent nothing to the site and changed nothing on it. If the holder is in
-	// fact still alive and finishes later, FinishTask refuses to overwrite a
-	// terminal row (ErrTaskNotOpen), so the recorded outcome still wins.
-	if bound := busyBoundExceeded(task); bound != "" {
-		return w.finish(ctx, task, TaskSkipped, task.FromVersion, "",
-			fmt.Sprintf("not attempted: another worker held this task continuously %s. "+
-				"Nothing was sent to the site for this item and nothing on the site was changed. "+
-				"Re-run this update.", bound), "")
-	}
+	// Read from the PRE-CLAIM snapshot, so the bound holds even when the
+	// re-read below is itself what is failing. It selects loud-versus-quiet
+	// ONLY; it never authorises a write.
+	bound := busyBoundExceeded(task)
 
 	current, err := w.repo.GetTask(ctx, a.TenantID, a.TaskID)
 	if err != nil {
+		if bound != "" {
+			// Past the bound AND blind. Snoozing on would be invisible (no
+			// error, no attempt consumed, no terminal state), and writing
+			// would be guessing at a row nobody here can see. Return the
+			// error: it consumes an attempt, backs off, and eventually
+			// dead-letters, which is loud. The row is the reaper's to
+			// terminalize.
+			return fmt.Errorf("update: claim refused and task %s unreadable after waiting %s: %w",
+				a.TaskID, bound, err)
+		}
 		// Cannot tell terminal from contended. Snooze rather than error: the
 		// safe reading of an unknown row is "someone else may hold it", and a
-		// CP-side DB hiccup must not spend this task's retry budget. Bounded
-		// by the busyBoundExceeded check above, which is exactly why that
-		// check does not depend on this read succeeding.
+		// CP-side DB hiccup must not spend this task's retry budget.
 		w.logger.Warn("update: claim was refused and the row could not be re-read; snoozing",
 			slog.String("task_id", a.TaskID.String()), slog.Any("error", err))
 		return river.JobSnooze(w.siteBusyBackoff(task))
 	}
 	if terminal(current.Status) {
 		return nil
+	}
+	if bound != "" {
+		// Still non-terminal past siteBusyMaxWait (6h). Something upstream is
+		// broken: staleTaskThreshold is 45m, so the reaper has had eight
+		// chances at this row. Be loud and let this job dead-letter rather
+		// than snooze on forever or write a verdict that is not ours.
+		return fmt.Errorf("update: claim refused for task %s after waiting %s; row is still %q",
+			a.TaskID, bound, current.Status)
 	}
 	w.logger.Info("update: another worker holds this task; snoozing without consuming an attempt",
 		slog.String("task_id", a.TaskID.String()), slog.String("status", current.Status))

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -72,6 +72,7 @@ func (f *probeFakeRepo) GetTask(_ context.Context, tenantID, taskID uuid.UUID) (
 	}
 	return f.getTask(tenantID, taskID)
 }
+
 // MarkTaskRunning stays a panic by default — several tests (see
 // agent_self_update_test.go) assert a task is refused BEFORE the claim by
 // relying on this fake to blow up if the claim is ever reached. markRunning is

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -40,6 +40,9 @@ type probeFakeRepo struct {
 	// getTaskCalls counts GetTask calls, so a test can tell Work's opening
 	// read apart from yieldContendedClaim's re-read.
 	getTaskCalls int
+	// finishTask, when set, implements FinishTask instead of the default
+	// always-succeeds stub (see FinishTask below).
+	finishTask func(in FinishTaskInput) (Task, error)
 	// countRunning / getRun are the remaining opt-in hooks a test needs to
 	// drive Work all the way to the claim. Both panic unless set, for the
 	// same reason every other stub here does.
@@ -89,6 +92,12 @@ func (f *probeFakeRepo) MarkTaskRunning(_ context.Context, tenantID, taskID uuid
 
 func (f *probeFakeRepo) FinishTask(_ context.Context, in FinishTaskInput) (Task, error) {
 	f.finished = append(f.finished, in)
+	// finishTask, when set, models FinishUpdateTask's real precondition (it
+	// writes only while the row is pending|running) against a row the test
+	// owns. Unset keeps the original always-succeeds behaviour.
+	if f.finishTask != nil {
+		return f.finishTask(in)
+	}
 	return Task{
 		ID:          in.TaskID,
 		TenantID:    in.TenantID,

--- a/apps/api/internal/update/worker_test.go
+++ b/apps/api/internal/update/worker_test.go
@@ -31,13 +31,30 @@ type probeFakeRepo struct {
 	// deferErr, when set, makes DeferTaskToPending return it instead of
 	// recording the defer (used to test deferForBusySite's error branch).
 	deferErr error
+	// markRunning, when set, implements MarkTaskRunning instead of panicking;
+	// markStaleAfter records the staleness bound the caller passed.
+	markRunning    func(tenantID, taskID uuid.UUID, staleAfter time.Duration) (Task, error)
+	markStaleAfter time.Duration
+	// getTask, when set, implements GetTask instead of panicking.
+	getTask func(tenantID, taskID uuid.UUID) (Task, error)
+	// getTaskCalls counts GetTask calls, so a test can tell Work's opening
+	// read apart from yieldContendedClaim's re-read.
+	getTaskCalls int
+	// countRunning / getRun are the remaining opt-in hooks a test needs to
+	// drive Work all the way to the claim. Both panic unless set, for the
+	// same reason every other stub here does.
+	countRunning func(tenantID uuid.UUID) (int64, error)
+	getRun       func(tenantID, runID uuid.UUID) (Run, error)
 }
 
 func (f *probeFakeRepo) CreateRunWithTasks(context.Context, CreateRunInput, []NewTask) (Run, []Task, error) {
 	panic("not implemented")
 }
-func (f *probeFakeRepo) GetRun(context.Context, uuid.UUID, uuid.UUID) (Run, error) {
-	panic("not implemented")
+func (f *probeFakeRepo) GetRun(_ context.Context, tenantID, runID uuid.UUID) (Run, error) {
+	if f.getRun == nil {
+		panic("not implemented")
+	}
+	return f.getRun(tenantID, runID)
 }
 func (f *probeFakeRepo) ListRuns(context.Context, uuid.UUID, int32, int32) ([]Run, error) {
 	panic("not implemented")
@@ -48,11 +65,25 @@ func (f *probeFakeRepo) ListRunSummaries(context.Context, uuid.UUID, int32, int3
 func (f *probeFakeRepo) ListTasks(context.Context, uuid.UUID, uuid.UUID) ([]Task, error) {
 	panic("not implemented")
 }
-func (f *probeFakeRepo) GetTask(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
-	panic("not implemented")
+func (f *probeFakeRepo) GetTask(_ context.Context, tenantID, taskID uuid.UUID) (Task, error) {
+	f.getTaskCalls++
+	if f.getTask == nil {
+		panic("not implemented")
+	}
+	return f.getTask(tenantID, taskID)
 }
-func (f *probeFakeRepo) MarkTaskRunning(context.Context, uuid.UUID, uuid.UUID) (Task, error) {
-	panic("not implemented")
+// MarkTaskRunning stays a panic by default — several tests (see
+// agent_self_update_test.go) assert a task is refused BEFORE the claim by
+// relying on this fake to blow up if the claim is ever reached. markRunning is
+// the opt-in override for the tests that do exercise the claim; it also
+// records the staleAfter it was handed, which is the argument this whole
+// change exists to make non-zero.
+func (f *probeFakeRepo) MarkTaskRunning(_ context.Context, tenantID, taskID uuid.UUID, staleAfter time.Duration) (Task, error) {
+	f.markStaleAfter = staleAfter
+	if f.markRunning == nil {
+		panic("not implemented")
+	}
+	return f.markRunning(tenantID, taskID, staleAfter)
 }
 
 func (f *probeFakeRepo) FinishTask(_ context.Context, in FinishTaskInput) (Task, error) {
@@ -78,8 +109,11 @@ func (f *probeFakeRepo) CountUnfinishedTasks(context.Context, uuid.UUID, uuid.UU
 	return 0, nil
 }
 
-func (f *probeFakeRepo) CountRunningTasksForTenant(context.Context, uuid.UUID) (int64, error) {
-	panic("not implemented")
+func (f *probeFakeRepo) CountRunningTasksForTenant(_ context.Context, tenantID uuid.UUID) (int64, error) {
+	if f.countRunning == nil {
+		panic("not implemented")
+	}
+	return f.countRunning(tenantID)
 }
 
 func (f *probeFakeRepo) ListInFlightTargets(context.Context, uuid.UUID, []uuid.UUID) (map[InFlightKey]struct{}, error) {

--- a/apps/api/tests/update_agent_halt_guard_test.go
+++ b/apps/api/tests/update_agent_halt_guard_test.go
@@ -77,7 +77,7 @@ func TestAgentHaltCancelsOnlyPendingTasks(t *testing.T) {
 
 	// Task 0 has been dispatched: its command is delivered and (in production)
 	// a cron event is spawned on the site. Tasks 1..3 were never sent anything.
-	if _, err := repo.MarkTaskRunning(ctx, tenant, tasks[0].ID); err != nil {
+	if _, err := repo.MarkTaskRunning(ctx, tenant, tasks[0].ID, claimStaleAfter); err != nil {
 		t.Fatalf("mark running: %v", err)
 	}
 
@@ -168,7 +168,7 @@ func TestCancelPendingUpdateTaskRefusesEveryNonPendingRow(t *testing.T) {
 			name: "running",
 			setup: func(t *testing.T, task update.Task) string {
 				t.Helper()
-				if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+				if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 					t.Fatalf("mark running: %v", err)
 				}
 				return ""
@@ -309,7 +309,7 @@ func TestFinishUpdateTaskCannotOverwriteATerminalTask(t *testing.T) {
 	// A second, untouched run: the control that proves the guard below is a
 	// precondition and not a blanket refusal.
 	_, openTasks := seedAgentRun(t, pool, tenant, repo, 1)
-	if _, err := repo.MarkTaskRunning(ctx, tenant, openTasks[0].ID); err != nil {
+	if _, err := repo.MarkTaskRunning(ctx, tenant, openTasks[0].ID, claimStaleAfter); err != nil {
 		t.Fatalf("mark running: %v", err)
 	}
 

--- a/apps/api/tests/update_site_busy_gate_test.go
+++ b/apps/api/tests/update_site_busy_gate_test.go
@@ -49,7 +49,7 @@ func TestSiteHasRunningUpdateTask_Gate(t *testing.T) {
 		site := newSite(t)
 		a := mkTaskOn(t, site, "plugin", "a")
 		b := mkTaskOn(t, site, "plugin", "b")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID, claimStaleAfter); err != nil {
 			t.Fatalf("mark running: %v", err)
 		}
 		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, b.ID, 20*time.Minute)
@@ -64,7 +64,7 @@ func TestSiteHasRunningUpdateTask_Gate(t *testing.T) {
 	t.Run("a task never sees itself as busy", func(t *testing.T) {
 		site := newSite(t)
 		a := mkTaskOn(t, site, "plugin", "c")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID, claimStaleAfter); err != nil {
 			t.Fatalf("mark running: %v", err)
 		}
 		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, a.ID, 20*time.Minute)
@@ -96,7 +96,7 @@ func TestSiteHasRunningUpdateTask_Gate(t *testing.T) {
 		site := newSite(t)
 		a := mkTaskOn(t, site, "plugin", "f")
 		b := mkTaskOn(t, site, "plugin", "g")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID, claimStaleAfter); err != nil {
 			t.Fatalf("mark running: %v", err)
 		}
 		backdateTaskTimestamps(t, pool, a.ID, 30*time.Minute)
@@ -112,7 +112,7 @@ func TestSiteHasRunningUpdateTask_Gate(t *testing.T) {
 		// The SAME row, well within holdMax, DOES gate: proves the staleness
 		// clause (not some other reason) was what ignored it above.
 		fresh := mkTaskOn(t, site, "plugin", "h")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, fresh.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, fresh.ID, claimStaleAfter); err != nil {
 			t.Fatalf("mark running: %v", err)
 		}
 		i := mkTaskOn(t, site, "plugin", "i")
@@ -129,7 +129,7 @@ func TestSiteHasRunningUpdateTask_Gate(t *testing.T) {
 		site := newSite(t)
 		a := mkTaskOn(t, site, "agent", update.AgentTargetSlug)
 		b := mkTaskOn(t, site, "plugin", "j")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, a.ID, claimStaleAfter); err != nil {
 			t.Fatalf("mark running: %v", err)
 		}
 		busy, err := repo.SiteHasRunningTask(ctx, tenant, site, b.ID, 20*time.Minute)
@@ -162,7 +162,7 @@ func TestDeferUpdateTaskToPending_Semantics(t *testing.T) {
 	}
 	task := tasks[0]
 
-	if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+	if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 		t.Fatalf("mark running: %v", err)
 	}
 
@@ -221,7 +221,7 @@ func TestBusyDeferredTask_ReapedOnlyWhenAbandoned(t *testing.T) {
 		t.Fatalf("create task: %v", err)
 	}
 	task := tasks[0]
-	if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+	if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 		t.Fatalf("mark running: %v", err)
 	}
 	if _, err := repo.DeferTaskToPending(ctx, update.DeferTaskInput{TenantID: tenant, TaskID: task.ID, Detail: "waiting: busy"}); err != nil {

--- a/apps/api/tests/update_task_claim_cas_test.go
+++ b/apps/api/tests/update_task_claim_cas_test.go
@@ -35,6 +35,12 @@ import (
 // which is what update.NewWorker is handed in a default-config install.
 var claimStaleAfter = update.ClaimStaleAfter(0)
 
+// abandonedAge backdates a row far enough past claimStaleAfter to sit
+// unambiguously inside the reclaim arm. Derived from the production bound for
+// the same reason claimStaleAfter is: a literal here would keep passing
+// against a stale number after the real bound moved.
+var abandonedAge = claimStaleAfter + 10*time.Minute
+
 func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	pool := startPostgres(t)
 	tenant := seedTenant(t, pool, "upd-cas")
@@ -163,9 +169,9 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 		}
 		// The worker behind it died: its command went out longer ago than the
 		// bound, so River has already cancelled that job's context.
-		backdateTaskTimestamps(t, pool, task.ID, 30*time.Minute)
+		backdateTaskTimestamps(t, pool, task.ID, abandonedAge)
 
-		if _, ok := claimWithBound(t, task.ID, 20*time.Minute); !ok {
+		if _, ok := claimWithBound(t, task.ID, claimStaleAfter); !ok {
 			t.Fatal("a 'running' task older than the staleness bound MUST be reclaimable. " +
 				"Refusing it turns a duplicate-work bug into a dropped-work bug: no live worker " +
 				"is behind this row and nothing else will re-dispatch it before the reaper.")
@@ -179,7 +185,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 			t.Fatalf("initial claim: %v", err)
 		}
 		// Not backdated: the holder claimed moments ago and is mid-dispatch.
-		if _, ok := claimWithBound(t, task.ID, 20*time.Minute); ok {
+		if _, ok := claimWithBound(t, task.ID, claimStaleAfter); ok {
 			t.Fatal("a FRESH 'running' task must not be re-claimable: the worker holding it is " +
 				"still within its own job timeout and is talking to the site right now")
 		}
@@ -209,9 +215,9 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 		// confirmation window (20m, or 90m on external cron) with no live
 		// worker behind it: the apply happens after the ARM response is
 		// released. Age is therefore NOT evidence of abandonment here.
-		backdateTaskTimestamps(t, pool, task.ID, 30*time.Minute)
+		backdateTaskTimestamps(t, pool, task.ID, abandonedAge)
 
-		if _, ok := claimWithBound(t, task.ID, 20*time.Minute); ok {
+		if _, ok := claimWithBound(t, task.ID, claimStaleAfter); ok {
 			t.Fatal("an agent-target 'running' row must NEVER be reclaimed on age alone: " +
 				"it is mid-confirmation by design, and re-dispatching would upgrade the agent twice")
 		}

--- a/apps/api/tests/update_task_claim_cas_test.go
+++ b/apps/api/tests/update_task_claim_cas_test.go
@@ -1,0 +1,234 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+)
+
+// TestMarkUpdateTaskRunning_CompareAndSwap pins the claim precondition on
+// MarkUpdateTaskRunning directly against a real Postgres, as wpmgr_app, and
+// through the same tenant-scoped RLS transaction production uses.
+//
+// The defect it guards: Worker.Work loads a task, returns early only for
+// TERMINAL statuses, and claims some way further down. The claim carried no
+// status precondition, so two River jobs for the same task both observed a
+// non-terminal row in that gap and BOTH dispatched, applying one item to one
+// site twice. The precondition makes the transition a compare-and-swap decided
+// by the row under its own lock.
+//
+// Every claim here goes through update.Repo (InTenantTx -> sqlc), or through
+// sqlc inside pool.InTenantTx where the repo signature cannot yet carry the
+// staleness bound. Nothing opens its own connection, so the RLS policies are
+// live for every statement below rather than inert.
+func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "upd-cas")
+	repo := update.NewRepo(pool)
+	ctx := context.Background()
+
+	// A site per subtest, never shared: a row deliberately left 'running' to
+	// set up one scenario would otherwise leak into the next.
+	newSite := func(t *testing.T) uuid.UUID {
+		t.Helper()
+		url := fmt.Sprintf("https://cas-test-%s.example", uuid.New().String())
+		return enrollFakeSite(t, pool, tenant, url).ID
+	}
+	mkTask := func(t *testing.T, site uuid.UUID, targetType, slug string) update.Task {
+		t.Helper()
+		_, tasks, err := repo.CreateRunWithTasks(ctx, update.CreateRunInput{TenantID: tenant}, []update.NewTask{
+			{SiteID: site, TargetType: targetType, TargetSlug: slug, DesiredVersion: "latest", FromVersion: "1.0.0"},
+		})
+		if err != nil {
+			t.Fatalf("create task: %v", err)
+		}
+		return tasks[0]
+	}
+
+	// claimWithBound issues the claim with an explicit staleness bound, which
+	// update.Repo.MarkTaskRunning cannot yet supply (that is the follow-up Go
+	// change). Still the production path in every way that matters to the
+	// policy: pool.InTenantTx as wpmgr_app, generated sqlc, no bespoke
+	// connection.
+	claimWithBound := func(t *testing.T, taskID uuid.UUID, staleAfter time.Duration) (update.Task, bool) {
+		t.Helper()
+		var got sqlc.UpdateTask
+		claimed := false
+		err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+			row, err := sqlc.New(tx).MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{
+				ID:         taskID,
+				TenantID:   tenant,
+				StaleAfter: pgtype.Interval{Microseconds: staleAfter.Microseconds(), Valid: true},
+			})
+			if err != nil {
+				if err == pgx.ErrNoRows {
+					return nil // no claim; not an error for this helper
+				}
+				return err
+			}
+			got, claimed = row, true
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("claim with bound: %v", err)
+		}
+		_ = got
+		return update.Task{}, claimed
+	}
+
+	// statusOf reads a row back through the same tenant-scoped path.
+	statusOf := func(t *testing.T, taskID uuid.UUID) string {
+		t.Helper()
+		task, err := repo.GetTask(ctx, tenant, taskID)
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		return task.Status
+	}
+
+	// ---- FIRES -------------------------------------------------------------
+
+	t.Run("two concurrent claims of one task: exactly one wins", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "plugin", "cas-race")
+
+		// Both goroutines model a River job that has already passed
+		// Work's terminal check and is about to dispatch.
+		const claimants = 2
+		var wg sync.WaitGroup
+		results := make([]error, claimants)
+		start := make(chan struct{})
+		for i := 0; i < claimants; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				_, err := repo.MarkTaskRunning(ctx, tenant, task.ID)
+				results[i] = err
+			}(i)
+		}
+		close(start) // release both at once
+		wg.Wait()
+
+		winners := 0
+		for i, err := range results {
+			if err == nil {
+				winners++
+			} else {
+				t.Logf("claimant %d was refused, as it must be: %v", i, err)
+			}
+		}
+		if winners != 1 {
+			t.Fatalf("expected EXACTLY ONE claimant to win, got %d of %d. "+
+				"More than one winner means two workers both dispatch this item to this site.", winners, claimants)
+		}
+		if got := statusOf(t, task.ID); got != "running" {
+			t.Fatalf("task status = %q, want \"running\" after the winning claim", got)
+		}
+	})
+
+	// ---- DOES NOT OVER-FIRE ------------------------------------------------
+
+	t.Run("a normal single claim of a pending task still succeeds", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "plugin", "cas-normal")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+			t.Fatalf("the ordinary claim of a pending task must succeed: %v", err)
+		}
+		if got := statusOf(t, task.ID); got != "running" {
+			t.Fatalf("task status = %q, want \"running\"", got)
+		}
+	})
+
+	t.Run("a River retry of an ABANDONED in-flight task reclaims it", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "plugin", "cas-abandoned")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+			t.Fatalf("initial claim: %v", err)
+		}
+		// The worker behind it died: its command went out longer ago than the
+		// bound, so River has already cancelled that job's context.
+		backdateTaskTimestamps(t, pool, task.ID, 30*time.Minute)
+
+		if _, ok := claimWithBound(t, task.ID, 20*time.Minute); !ok {
+			t.Fatal("a 'running' task older than the staleness bound MUST be reclaimable. " +
+				"Refusing it turns a duplicate-work bug into a dropped-work bug: no live worker " +
+				"is behind this row and nothing else will re-dispatch it before the reaper.")
+		}
+	})
+
+	t.Run("a retry does NOT steal a task another worker is actively dispatching", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "plugin", "cas-fresh")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+			t.Fatalf("initial claim: %v", err)
+		}
+		// Not backdated: the holder claimed moments ago and is mid-dispatch.
+		if _, ok := claimWithBound(t, task.ID, 20*time.Minute); ok {
+			t.Fatal("a FRESH 'running' task must not be re-claimable: the worker holding it is " +
+				"still within its own job timeout and is talking to the site right now")
+		}
+	})
+
+	t.Run("the agent wave path still claims its pending task", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "agent", "fleet-agent-site-manager")
+		// ClaimAgentWaveTask reaches MarkUpdateTaskRunning only with the row
+		// still 'pending' (it returns ClaimAlreadyClaimed for anything else
+		// while holding the run's advisory lock). That claim must still work.
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+			t.Fatalf("the agent self-update wave claim of a pending task must still succeed: %v", err)
+		}
+		if got := statusOf(t, task.ID); got != "running" {
+			t.Fatalf("agent task status = %q, want \"running\"", got)
+		}
+	})
+
+	t.Run("an aged RUNNING agent task is never reclaimed", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "agent", "fleet-agent-site-manager")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+			t.Fatalf("initial claim: %v", err)
+		}
+		// An agent task legitimately stays 'running' for its whole
+		// confirmation window (20m, or 90m on external cron) with no live
+		// worker behind it: the apply happens after the ARM response is
+		// released. Age is therefore NOT evidence of abandonment here.
+		backdateTaskTimestamps(t, pool, task.ID, 30*time.Minute)
+
+		if _, ok := claimWithBound(t, task.ID, 20*time.Minute); ok {
+			t.Fatal("an agent-target 'running' row must NEVER be reclaimed on age alone: " +
+				"it is mid-confirmation by design, and re-dispatching would upgrade the agent twice")
+		}
+	})
+
+	t.Run("a terminal task is never claimable", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "plugin", "cas-terminal")
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+			t.Fatalf("initial claim: %v", err)
+		}
+		if _, err := repo.FinishTask(ctx, update.FinishTaskInput{
+			TenantID: tenant, TaskID: task.ID, Status: "succeeded",
+			FromVersion: "1.0.0", ToVersion: "1.1.0",
+		}); err != nil {
+			t.Fatalf("finish: %v", err)
+		}
+		if _, ok := claimWithBound(t, task.ID, time.Nanosecond); ok {
+			t.Fatal("a terminal task must never be re-claimed, at any staleness bound: " +
+				"its outcome is already recorded")
+		}
+	})
+}
+
+var _ = db.Pool{}

--- a/apps/api/tests/update_task_claim_cas_test.go
+++ b/apps/api/tests/update_task_claim_cas_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/update"
 )
@@ -30,11 +29,11 @@ import (
 // sqlc inside pool.InTenantTx where the repo signature cannot yet carry the
 // staleness bound. Nothing opens its own connection, so the RLS policies are
 // live for every statement below rather than inert.
-// claimStaleAfter is the bound every production caller passes to
-// MarkTaskRunning (update.siteWriterHoldMax, unexported). Its value is
-// immaterial to the setup claims below, which all act on a fresh 'pending'
-// row; the subtests that actually depend on the bound pass their own.
-const claimStaleAfter = 20 * time.Minute
+// claimStaleAfter is READ FROM the production derivation, never re-declared.
+// A literal here would keep passing against a stale number after the real
+// bound was retuned, asserting nothing. Zero means "no derived apply budget",
+// which is what update.NewWorker is handed in a default-config install.
+var claimStaleAfter = update.ClaimStaleAfter(0)
 
 func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	pool := startPostgres(t)
@@ -218,6 +217,35 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 		}
 	})
 
+	t.Run("another tenant can never claim this tenant's task", func(t *testing.T) {
+		site := newSite(t)
+		task := mkTask(t, site, "plugin", "cas-cross-tenant")
+
+		// A second tenant, claiming with the victim's real task id. The id is
+		// not a secret — it appears in URLs and audit rows — so the boundary
+		// has to be the tenant scoping itself, not the caller's ignorance of
+		// the id. MarkTaskRunning goes through InTenantTx as wpmgr_app, so
+		// RLS is live for this statement exactly as it is in production.
+		attacker := seedTenant(t, pool, "upd-cas-other")
+		_, err := repo.MarkTaskRunning(ctx, attacker, task.ID, claimStaleAfter)
+		if err == nil {
+			t.Fatal("a tenant claimed another tenant's update task: the claim must be refused")
+		}
+		if !errors.Is(err, update.ErrTaskNotClaimed) {
+			t.Fatalf("a cross-tenant claim must be refused as ErrTaskNotClaimed, got %v (%T)", err, err)
+		}
+
+		// The victim's row must be untouched: still claimable by its OWN
+		// tenant. A refusal that had already flipped the row to 'running'
+		// would be a denial of service even though no data leaked.
+		if got := statusOf(t, task.ID); got != "pending" {
+			t.Fatalf("the victim task status = %q, want \"pending\": a refused cross-tenant claim must not modify the row", got)
+		}
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
+			t.Fatalf("the owning tenant must still be able to claim its own task: %v", err)
+		}
+	})
+
 	t.Run("a terminal task is never claimable", func(t *testing.T) {
 		site := newSite(t)
 		task := mkTask(t, site, "plugin", "cas-terminal")
@@ -236,5 +264,3 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 		}
 	})
 }
-
-var _ = db.Pool{}

--- a/apps/api/tests/update_task_claim_cas_test.go
+++ b/apps/api/tests/update_task_claim_cas_test.go
@@ -2,17 +2,16 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
-	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/update"
 )
 
@@ -31,6 +30,12 @@ import (
 // sqlc inside pool.InTenantTx where the repo signature cannot yet carry the
 // staleness bound. Nothing opens its own connection, so the RLS policies are
 // live for every statement below rather than inert.
+// claimStaleAfter is the bound every production caller passes to
+// MarkTaskRunning (update.siteWriterHoldMax, unexported). Its value is
+// immaterial to the setup claims below, which all act on a fresh 'pending'
+// row; the subtests that actually depend on the bound pass their own.
+const claimStaleAfter = 20 * time.Minute
+
 func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	pool := startPostgres(t)
 	tenant := seedTenant(t, pool, "upd-cas")
@@ -55,35 +60,26 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 		return tasks[0]
 	}
 
-	// claimWithBound issues the claim with an explicit staleness bound, which
-	// update.Repo.MarkTaskRunning cannot yet supply (that is the follow-up Go
-	// change). Still the production path in every way that matters to the
-	// policy: pool.InTenantTx as wpmgr_app, generated sqlc, no bespoke
-	// connection.
+	// claimWithBound issues the claim with an explicit staleness bound. Since
+	// the Go wiring landed, update.Repo.MarkTaskRunning carries that bound
+	// itself, so this is now EXACTLY the production path — the same repo
+	// method Worker.Work calls, over pool.InTenantTx as wpmgr_app, no bespoke
+	// connection. A refusal must surface as update.ErrTaskNotClaimed and must
+	// NOT be a domain error: reporting the losing claimant as NotFound sends
+	// an operator hunting for a row that is still there, held by the winner.
 	claimWithBound := func(t *testing.T, taskID uuid.UUID, staleAfter time.Duration) (update.Task, bool) {
 		t.Helper()
-		var got sqlc.UpdateTask
-		claimed := false
-		err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
-			row, err := sqlc.New(tx).MarkUpdateTaskRunning(ctx, sqlc.MarkUpdateTaskRunningParams{
-				ID:         taskID,
-				TenantID:   tenant,
-				StaleAfter: pgtype.Interval{Microseconds: staleAfter.Microseconds(), Valid: true},
-			})
-			if err != nil {
-				if err == pgx.ErrNoRows {
-					return nil // no claim; not an error for this helper
-				}
-				return err
-			}
-			got, claimed = row, true
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("claim with bound: %v", err)
+		got, err := repo.MarkTaskRunning(ctx, tenant, taskID, staleAfter)
+		if err == nil {
+			return got, true
 		}
-		_ = got
-		return update.Task{}, claimed
+		if !errors.Is(err, update.ErrTaskNotClaimed) {
+			t.Fatalf("a refused claim must report ErrTaskNotClaimed, got %v (%T)", err, err)
+		}
+		if de, ok := domain.AsDomain(err); ok {
+			t.Fatalf("a refused claim must not be a domain error, got %v", de)
+		}
+		return update.Task{}, false
 	}
 
 	// statusOf reads a row back through the same tenant-scoped path.
@@ -113,7 +109,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				<-start
-				_, err := repo.MarkTaskRunning(ctx, tenant, task.ID)
+				_, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter)
 				results[i] = err
 			}(i)
 		}
@@ -125,6 +121,16 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 			if err == nil {
 				winners++
 			} else {
+				// The loser's error is part of the contract, not just noise.
+				// It must say "you did not get the claim", never "no such
+				// task": the row is right there, held by the winner, and
+				// NotFound would send an operator hunting for a deleted row.
+				if !errors.Is(err, update.ErrTaskNotClaimed) {
+					t.Errorf("the losing claimant must be refused with ErrTaskNotClaimed, got %v (%T)", err, err)
+				}
+				if de, ok := domain.AsDomain(err); ok {
+					t.Errorf("the losing claimant must not get a domain error (it was reported as NotFound before this fix), got %v", de)
+				}
 				t.Logf("claimant %d was refused, as it must be: %v", i, err)
 			}
 		}
@@ -142,7 +148,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	t.Run("a normal single claim of a pending task still succeeds", func(t *testing.T) {
 		site := newSite(t)
 		task := mkTask(t, site, "plugin", "cas-normal")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 			t.Fatalf("the ordinary claim of a pending task must succeed: %v", err)
 		}
 		if got := statusOf(t, task.ID); got != "running" {
@@ -153,7 +159,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	t.Run("a River retry of an ABANDONED in-flight task reclaims it", func(t *testing.T) {
 		site := newSite(t)
 		task := mkTask(t, site, "plugin", "cas-abandoned")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 			t.Fatalf("initial claim: %v", err)
 		}
 		// The worker behind it died: its command went out longer ago than the
@@ -170,7 +176,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	t.Run("a retry does NOT steal a task another worker is actively dispatching", func(t *testing.T) {
 		site := newSite(t)
 		task := mkTask(t, site, "plugin", "cas-fresh")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 			t.Fatalf("initial claim: %v", err)
 		}
 		// Not backdated: the holder claimed moments ago and is mid-dispatch.
@@ -186,7 +192,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 		// ClaimAgentWaveTask reaches MarkUpdateTaskRunning only with the row
 		// still 'pending' (it returns ClaimAlreadyClaimed for anything else
 		// while holding the run's advisory lock). That claim must still work.
-		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 			t.Fatalf("the agent self-update wave claim of a pending task must still succeed: %v", err)
 		}
 		if got := statusOf(t, task.ID); got != "running" {
@@ -197,7 +203,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	t.Run("an aged RUNNING agent task is never reclaimed", func(t *testing.T) {
 		site := newSite(t)
 		task := mkTask(t, site, "agent", "fleet-agent-site-manager")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 			t.Fatalf("initial claim: %v", err)
 		}
 		// An agent task legitimately stays 'running' for its whole
@@ -215,7 +221,7 @@ func TestMarkUpdateTaskRunning_CompareAndSwap(t *testing.T) {
 	t.Run("a terminal task is never claimable", func(t *testing.T) {
 		site := newSite(t)
 		task := mkTask(t, site, "plugin", "cas-terminal")
-		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID); err != nil {
+		if _, err := repo.MarkTaskRunning(ctx, tenant, task.ID, claimStaleAfter); err != nil {
 			t.Fatalf("initial claim: %v", err)
 		}
 		if _, err := repo.FinishTask(ctx, update.FinishTaskInput{


### PR DESCRIPTION
Adds a status precondition to `MarkUpdateTaskRunning`, so claiming an update task is decided by the row under its own lock rather than by what the caller read a moment earlier.

## The guarantee

`Worker.Work` loads a task, returns early only for **terminal** statuses, and claims some way further down. The claim itself carried no precondition, so two River jobs for the same task could both observe a non-terminal row in that gap and both dispatch — one item applied to one site twice. The precondition closes that gap the same way `FinishUpdateTask` already does for the terminal transition.

## Which states it transitions from

- **`pending`** — the ordinary claim. Also the only state the agent self-update wave path can present (`ClaimAgentWaveTask` returns `ClaimAlreadyClaimed` for anything not pending, while holding the run advisory lock), and the state `deferForBusySite` leaves a waiter in.
- **`running`, only when abandoned** — older than a caller-supplied staleness bound. `running` is not terminal, so a River retry of a job that already claimed re-enters `Work` with its own row `running`. A strict pending-only claim would match zero rows there and drop that work, which is worse than the duplicate it fixes. Age separates "my previous attempt died" from "another worker is mid-dispatch": River cancels a job context at its own job timeout regardless of whether the site answers.

Agent-target rows are excluded from the reclaim branch, the same exclusion and the same reasoning as `SiteHasRunningUpdateTask` — an agent task stays `running` for its whole confirmation window with no live worker behind it by design, so age is not evidence of abandonment there. Agent rows claim from `pending` only.

## Zero rows

Means: you did not get the claim, do not dispatch. The caller re-reads and decides — terminal, stop; otherwise another worker holds it, so give the row up via `river.JobSnooze` without consuming a retry, since that holder may still die and the row must stay reclaimable.

## Scope

Query layer plus the sqlc regeneration. No schema change. The Go call sites are a follow-up: the generated params struct is keyed, so both sites still compile while passing a NULL interval, which fails **closed** to pending-only claiming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update-task claiming to prevent concurrent processing and safely recover abandoned tasks.
  * Prevented fresh, active tasks and agent tasks from being incorrectly reclaimed.
  * Added clearer handling for contention, terminal tasks, and missing tasks.
  * Added startup validation for incompatible update timing settings.

* **Tests**
  * Expanded coverage for concurrent claims, task recovery, tenant isolation, contention, and timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->