### PR TITLE
release: 0.61.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.140] - 2026-08-19
+
+### Changed
+
+- The control plane now validates its update-timing configuration at startup and refuses to boot when `update.apply_http_timeout` (env `WPMGR_UPDATE_APPLY_HTTP_TIMEOUT`) is set high enough that the derived claim-staleness bound reaches the stale-task reaper's threshold, naming the variable to lower in the refusal message. Measured against the real loader: an `apply_http_timeout` of 33m7s boots, 33m8s refuses. The default (8m) has roughly 25 minutes of headroom, so no ordinary install is affected, but anyone who raised the timeout will find out at startup rather than at deploy time.
+- Self-hosted installs now require `WPMGR_BOOTSTRAP_CLAIM_SECRET` to establish first-run ownership. `scripts/init-env.sh` generates it, and both quickstart paths route through that script. An existing install that already has an owner is unaffected. An existing install that was stood up and never claimed needs the operator to re-run `scripts/init-env.sh` (idempotent, it fills only the missing key) or set the variable directly, then restart the `api` service; see "First-run notes" in `docs/install.md` for the claim command.
+- `DECISIONS.md` and the ADR index were repaired: a false boundary in the record was corrected and `docs/adr/README.md` was added as the index. This affects people reading WPMgr's own decision history and changes nothing about installing or running it.
+
+### Fixed
+
+- Claiming an update task could race: two workers could each observe the same non-terminal task row and both dispatch it, applying one item to a site twice. Claiming a task is now a compare-and-swap against the row's own status, so only one worker can win it.
+
 ## [0.61.139] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.138**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.139**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.138
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.138
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.138
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.139
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.139
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.139
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.138   # omit to track :latest
+export WPMGR_VERSION=v0.61.139   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.140",
+    date: "2026-08-19",
+    summary:
+      "Two operational changes for self-hosters. First-run ownership now requires a provisioning claim, and the control plane validates its update-timing configuration at startup rather than allowing a combination that could dispatch the same update twice. Also fixes a race in claiming an update task.",
+    items: [
+      {
+        tag: "Changed",
+        text: "The control plane now validates its update-timing configuration at startup and refuses to boot when the apply-timeout setting is high enough that the derived claim-staleness bound reaches the stale-task reaper's threshold, naming the setting to lower. The default has roughly 25 minutes of headroom, so no ordinary install is affected.",
+      },
+      {
+        tag: "Changed",
+        text: "Self-hosted installs now require a bootstrap claim secret to establish first-run ownership. scripts/init-env.sh generates it and both quickstart paths route through that script. An install that already has an owner is unaffected; one that was stood up and never claimed needs the operator to re-run the script or set the variable, then restart the api service.",
+      },
+      {
+        tag: "Fixed",
+        text: "Claiming an update task could race, letting two workers both dispatch the same task and apply one item to a site twice. Claiming a task is now a compare-and-swap against the row's own status.",
+      },
+    ],
+  },
+  {
     version: "0.61.139",
     date: "2026-08-17",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -225,7 +225,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.138   # omit to track :latest
+export WPMGR_VERSION=v0.61.139   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.139
+  version: 0.61.140
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Control-plane-only release: 0.61.140

Version surfaces and CHANGELOG only, no product code. The agent version is
frozen at 0.61.139 (verified: `git diff --stat v0.61.139..origin/main -- apps/agent/` is empty), so the marketing hero badge (which names the
agent version) does not move.

### What shipped (three merges already on main)
- #457 `fix(update): make the update-task claim a compare-and-swap`
- #456 `feat(auth): require the provisioning claim for first-run ownership`
- #455 `docs: repair the ADR record (restore DECISIONS.md, add docs/adr/README.md)`

### Operator-facing notes in the CHANGELOG
1. The control plane now refuses to start on a timing configuration that
   would allow duplicate update dispatch (`update.apply_http_timeout` /
   `WPMGR_UPDATE_APPLY_HTTP_TIMEOUT`). Default has ~25 minutes of headroom.
2. Self-hosted installs now require `WPMGR_BOOTSTRAP_CLAIM_SECRET` for
   first-run ownership. Existing claimed installs are unaffected; an
   unclaimed install needs `scripts/init-env.sh` re-run (idempotent) or the
   variable set, then an `api` restart. Detail is in `docs/install.md`.

### Version surfaces touched
- `CHANGELOG.md`: new `[0.61.140]` entry
- `packages/openapi/openapi.yaml`: `info.version` to 0.61.140
- `apps/marketing/app/(marketing)/changelog/page.tsx`: curated entry added
- `README.md` / `docs/install.md`: install pins advanced to v0.61.139 (one
  release behind the new top entry, per the tolerance-1 design)

### NOT touched
- `apps/agent/wpmgr-agent.php`, `apps/agent/readme.txt`, and
  `AGENT_VERSION` in `apps/marketing/lib/content/home.ts` all stay at
  0.61.139.

## Checks run locally
- `make check-versions-test` — 76 passed, 0 failed
- `make check-versions` — all surfaces consistent
- `node apps/marketing/scripts/check-copy.mjs` — passed
- `ci.yml`'s Docs vocabulary check grep, copied verbatim from the workflow — empty

Do not merge without review; not tagging or deploying from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup validation for update timing settings.
  * Self-hosted installations now require bootstrap claim secrets during first-run ownership setup.
  * Documented repaired decision records in the changelog.

* **Bug Fixes**
  * Prevented duplicate update tasks from being dispatched during concurrent updates.

* **Documentation**
  * Updated release references and prebuilt image examples to the latest documented versions.
  * Published release notes for version 0.61.140.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->