### PR TITLE
feat(db): m118 — app.agent RLS policy and due-scan index on update_runs (#463 Phase 0)

### DIFF
--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -922,8 +922,23 @@ CREATE TABLE update_runs (
     -- created_by is the acting user (NULL for an API-key principal); SET NULL on
     -- user deletion so the run history survives.
     created_by   uuid        REFERENCES users (id) ON DELETE SET NULL,
-    -- status: pending (created, tasks enqueued), running (>=1 task running),
-    -- completed (all tasks reached a terminal state). The worker advances it.
+    -- status. NO CHECK CONSTRAINT EXISTS on this column, so this comment (and
+    -- the matching COMMENT ON COLUMN installed by m118, which is what \d+ shows
+    -- in a live database) is the ONLY contract. A typo'd value stores fine and
+    -- silently never dispatches.
+    --   pending      Created, tasks enqueued for immediate execution (the m3
+    --                default). The worker advances it.
+    --   scheduled    (m118/#463) Created with a future scheduled_at, not yet
+    --                handed to the worker. The dispatcher's due-scan selects
+    --                exactly these; update_runs_due_idx is partial on it.
+    --   dispatching  (m118/#463) Claimed by the dispatcher for this tick. The
+    --                row has left update_runs_due_idx, so a concurrent tick, a
+    --                second replica or a restart cannot claim it twice.
+    --   running      >=1 task running.
+    --   completed    All tasks reached a terminal state.
+    --   expired      (m118/#463) Passed its dispatch window undispatched.
+    --                Terminal and never retried: a deferred bulk update that
+    --                fires days late is a surprise, not a service.
     status       text        NOT NULL DEFAULT 'pending',
     dry_run      boolean     NOT NULL DEFAULT false,
     -- scheduled_at is when the run should execute; NULL/now() means immediately.
@@ -934,11 +949,39 @@ CREATE TABLE update_runs (
 
 CREATE INDEX update_runs_tenant_id_created_at_idx ON update_runs (tenant_id, created_at DESC);
 
+-- update_runs_due_idx (m118) serves the #463 dispatcher's cross-tenant tick,
+-- "WHERE status = 'scheduled' AND scheduled_at <= now()". The only other index
+-- here leads on tenant_id, which that query does not filter on at all, so
+-- without this the tick is a sequential scan over every run ever created. A run
+-- leaves the index the instant it is claimed ('scheduled' -> 'dispatching'), so
+-- it stays proportional to the pending queue, not to the run history. Mirrors
+-- backup_schedules_due_idx. The predicate is only the status, because that
+-- clause appears verbatim in the consumer's WHERE and so needs no redundant
+-- clause repeated by the caller to keep the index usable.
+CREATE INDEX update_runs_due_idx ON update_runs (scheduled_at) WHERE status = 'scheduled';
+
 ALTER TABLE update_runs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE update_runs FORCE ROW LEVEL SECURITY;
 CREATE POLICY update_runs_tenant_isolation ON update_runs
     USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
     WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+-- update_runs_agent (m118) lets the #463 deferred-dispatch scan read AND CLAIM
+-- across all tenants under InAgentTx. m3 shipped only the tenant_isolation
+-- policy, so under FORCE ROW LEVEL SECURITY a cross-tenant tick satisfied no
+-- policy and returned zero rows with no error — the third occurrence of the
+-- m84/#96 (backup_schedules) and m89/#131 (update_tasks, this table's sibling)
+-- bug class.
+--
+-- FOR ALL, NOT FOR SELECT, and that is the whole point. The dispatcher claims
+-- rows ('scheduled' -> 'dispatching'); a FOR SELECT policy admits the read and
+-- admits nothing to the UPDATE, so the claim matches zero rows silently. And
+-- PostgreSQL applies the UPDATE policy to SELECT … FOR UPDATE too, so with a
+-- read-only policy even the locking SELECT returns nothing. That is exactly how
+-- Issue #96 stopped every backup schedule from advancing.
+CREATE POLICY update_runs_agent ON update_runs
+    FOR ALL
+    USING (current_setting('app.agent', true) = 'on')
+    WITH CHECK (current_setting('app.agent', true) = 'on');
 
 -- ---------------------------------------------------------------------------
 -- update_tasks  (M3)
@@ -961,6 +1004,17 @@ CREATE TABLE update_tasks (
     from_version text        NOT NULL DEFAULT '',
     to_version   text        NOT NULL DEFAULT '',
     -- status: pending | running | succeeded | failed | rolled_back | skipped.
+    -- NO CHECK CONSTRAINT EXISTS; this comment and m118's COMMENT ON COLUMN are
+    -- the contract. m118/#463 adds two more:
+    --   scheduled  Belongs to a run that is still 'scheduled', not yet
+    --              eligible. WARNING: 'scheduled' is NOT in
+    --              update_tasks_inflight_target_idx's predicate below
+    --              (status IN ('pending','running')), so a scheduled task does
+    --              NOT reserve its (tenant, site, target) pair against a
+    --              concurrent immediate run. Widening that unique index is a
+    --              separate migration with a data-dedup step.
+    --   expired    The parent run expired without dispatching, so this task was
+    --              never attempted. Terminal.
     status       text        NOT NULL DEFAULT 'pending',
     detail       text        NOT NULL DEFAULT '',
     error        text        NOT NULL DEFAULT '',

--- a/apps/api/migrations/20260820000000_m118_update_runs_agent_rls.sql
+++ b/apps/api/migrations/20260820000000_m118_update_runs_agent_rls.sql
@@ -1,0 +1,295 @@
+-- m118 - GH #463 Phase 0 of the deferred-dispatch feature. SCHEMA ONLY.
+--
+-- THIS MIGRATION DELIBERATELY CHANGES NO BEHAVIOUR. It adds one RLS policy,
+-- one partial index and two column comments. No worker reads them, no route
+-- writes them, and no existing row is touched. It ships alone, and first,
+-- because the Go code of Phase 1 is unwritable-without-a-silent-bug until it
+-- exists.
+--
+-- ---------------------------------------------------------------------------
+-- WHY THIS CANNOT WAIT FOR THE CODE THAT NEEDS IT
+-- ---------------------------------------------------------------------------
+--
+-- update_runs was created by m3 with exactly ONE policy,
+-- update_runs_tenant_isolation, keyed on app.tenant_id. Every query written
+-- against it in the three months since has run under InTenantTx, so one policy
+-- has always been enough and nobody noticed the other one missing.
+--
+-- The #463 dispatcher is the FIRST cross-tenant reader of this table. It runs
+-- on a tick under InAgentTx (internal/db/db.go InAgentTx: app.agent = 'on',
+-- app.tenant_id UNSET) and asks "which runs, belonging to ANY tenant, are due
+-- to dispatch?". Under FORCE ROW LEVEL SECURITY with only a tenant_isolation
+-- policy present, that context satisfies no policy at all:
+-- nullif(current_setting('app.tenant_id', true), '')::uuid is NULL, and
+-- tenant_id = NULL is NULL, which is not TRUE, so no row is admitted.
+--
+-- The failure is SILENT. Postgres does not error; it returns the empty set.
+-- The dispatcher would log a cheerful "0 due runs" on every tick, forever, and
+-- the feature would look shipped and do nothing. That is not a hypothesis. This
+-- repository has shipped this exact bug twice already, and both post-mortems
+-- are written into the schema:
+--
+--   m84 / Issue #96  backup_schedules. The scheduler's claim returned zero rows
+--                    on every tick, so no backup schedule ever advanced.
+--   m89 / #131       update_tasks. THE SIBLING OF THIS VERY TABLE. The stale-task
+--                    reaper's cross-tenant sweep returned zero rows on every
+--                    sweep. m89 calls it "the same bug class as m84's
+--                    backup_schedules fix".
+--
+-- This is the third table in the same family and the same defect. Adding the
+-- policy before the dispatcher exists means Phase 1 is written against a
+-- database that can actually answer it.
+--
+-- ---------------------------------------------------------------------------
+-- DECISION 1: FOR ALL, not FOR SELECT. This is the whole lesson of Issue #96.
+-- ---------------------------------------------------------------------------
+--
+-- The obvious policy is a read policy: the dispatcher is "a scan", so let it
+-- SELECT. That is precisely the mistake m84 had to undo, and writing it here
+-- would reproduce Issue #96 line for line.
+--
+-- Two independent reasons a FOR SELECT policy is wrong for this consumer:
+--
+--   1. The dispatcher WRITES. Its job is not to read due runs, it is to CLAIM
+--      them: status 'scheduled' -> 'dispatching', so a second tick, a second
+--      control-plane replica, or a restart mid-dispatch does not dispatch the
+--      same run twice. A FOR SELECT policy admits the row to the SELECT and
+--      admits NOTHING to the UPDATE, so the UPDATE matches zero rows. It does
+--      not error. It reports "0 rows affected" and the run sits at 'scheduled'
+--      forever, re-read and re-skipped on every tick.
+--
+--   2. Even a pure read would break, because the read will not be pure. The
+--      claim is a locking read - SELECT ... FOR UPDATE, or UPDATE ... WHERE id
+--      IN (SELECT ... FOR UPDATE SKIP LOCKED), which is the shape every claim
+--      in this codebase uses. PostgreSQL applies BOTH the SELECT policy and the
+--      UPDATE policy to a SELECT ... FOR UPDATE, because the row lock is a
+--      declaration of intent to write. With only a FOR SELECT policy the UPDATE
+--      USING is unsatisfied and the LOCKING SELECT ITSELF returns zero rows -
+--      the counter-intuitive half of #96, where the plain SELECT worked in
+--      psql and the real query returned nothing.
+--
+-- So: FOR ALL, with WITH CHECK mirroring USING so the claim's new row version
+-- is admitted too. This matches backup_schedules_scheduler (m84, which spells
+-- the same reasoning out at db/schema.sql), backup_schedule_runs_agent, and
+-- update_tasks_agent (m89), which is FOR ALL by omission - CREATE POLICY
+-- defaults to FOR ALL, and m89 relies on that default. This policy states FOR
+-- ALL explicitly rather than relying on the default, because the default is the
+-- thing a reviewer cannot see and this is the exact clause the bug turns on.
+--
+-- THE GUC IS COMPARED AGAINST THE LITERAL 'on'. Not 'true', not '1', not a
+-- cast to boolean. InAgentTx executes set_config('app.agent', 'on', true) and
+-- every sibling policy in this schema compares to 'on'. current_setting(...,
+-- true) returns NULL when the GUC was never set, and NULL = 'on' is NULL, not
+-- FALSE - which is why this policy admits nothing outside InAgentTx and is
+-- therefore not a widening of any operator path. Permissive policies are OR'd,
+-- so an operator request (app.tenant_id set, app.agent unset) is admitted by
+-- update_runs_tenant_isolation exactly as before and by this policy never.
+--
+-- ---------------------------------------------------------------------------
+-- DECISION 2: the due-scan index, and why its predicate is only the status
+-- ---------------------------------------------------------------------------
+--
+-- The dispatcher's tick asks "WHERE status = 'scheduled' AND scheduled_at <=
+-- now()", cross-tenant. The only index on this table today is
+-- update_runs_tenant_id_created_at_idx (tenant_id, created_at DESC), whose
+-- leading column the dispatcher does not filter on at all, so that query is a
+-- sequential scan over every run this installation has ever created - a table
+-- that only grows, scanned on every tick, to find the handful of rows that are
+-- due. The index below is created now, with the policy, so the dispatcher never
+-- ships against an unindexed whole-table predicate; migrate.go runs each
+-- migration in one transaction and therefore cannot use CREATE INDEX
+-- CONCURRENTLY, so taking the lock now - while 'scheduled' matches zero rows,
+-- because no code writes that value yet - is far cheaper than taking it later.
+--
+-- It mirrors backup_schedules_due_idx (next_run_at) WHERE enabled: the ordering
+-- column indexed, the "is this row even a candidate" test in the predicate. A
+-- run leaves the index the instant the dispatcher claims it ('scheduled' ->
+-- 'dispatching'), so the index stays proportional to the pending queue and not
+-- to the run history, which is the entire point of the partial form.
+--
+-- The predicate is ONLY "status = 'scheduled'". It deliberately does NOT also
+-- say "AND scheduled_at IS NOT NULL", even though scheduled_at is nullable and
+-- a NULL-scheduled_at row can never satisfy "scheduled_at <= now()":
+--
+--   * The planner proves a partial index usable from the query's own WHERE
+--     clauses. "status = 'scheduled'" appears verbatim in the dispatcher's
+--     query, so this predicate is discharged directly and the index is usable
+--     with no clause the consumer must remember to repeat. That is the failure
+--     mode m117's sites_monitoring_resume_due_idx comment documents at length,
+--     and the way to avoid it is to keep the predicate to clauses the query
+--     already states for its own reasons.
+--   * The rows it would exclude are rows where status = 'scheduled' and
+--     scheduled_at IS NULL - a state that should not exist (a scheduled run
+--     with no time to run at), and if it does exist, one we WANT visible in
+--     this index so it can be found rather than silently unindexed.
+--
+-- ---------------------------------------------------------------------------
+-- DECISION 3: the status comments are the contract, because nothing else is
+-- ---------------------------------------------------------------------------
+--
+-- Neither update_runs.status nor update_tasks.status has a CHECK constraint;
+-- both are plain text NOT NULL DEFAULT 'pending' (m3, lines 6 and 28). Verified
+-- rather than assumed. So there is no DDL to change to admit a new value, and
+-- consequently NOTHING in the database will reject a typo: a dispatcher that
+-- writes 'sheduled' will store it, the partial index will not contain the row,
+-- and the run will never dispatch, silently. The column comment is the only
+-- contract that exists, which is why naming the values here - BEFORE any code
+-- writes them - is a real deliverable and not documentation housekeeping.
+--
+-- COMMENT ON COLUMN is used here, rather than relying on db/schema.sql's inline
+-- "--" comments alone, so the contract lives in the DATABASE, where \d+ shows
+-- it to whoever is debugging at 3am, instead of only in a file they would have
+-- to know to open. db/schema.sql carries the SAME contract text in the same
+-- commit, but as inline "--" comments: that file contains no COMMENT ON
+-- statement anywhere (verified: grep -c 'COMMENT ON' db/schema.sql -> 0), it is
+-- sqlc's input rather than a dump of the database, and it is already well
+-- behind the migrations on RLS. Introducing a construct it has never used, to
+-- restate text it already carries, would buy nothing. The policy and the index
+-- below ARE mirrored there as real DDL.
+--
+-- A NOTE FOR PHASE 1, stated here because this comment outlives the phase doc:
+-- these strings are declared ahead of the code that writes them. Phase 1 must
+-- use exactly these spellings. If Phase 1 concludes it needs a different value
+-- or a different meaning, that is a NEW ordinal amending the comment - never an
+-- edit to this file, which will already have applied.
+--
+-- ---------------------------------------------------------------------------
+-- WHAT THIS MIGRATION DELIBERATELY DOES NOT ADD
+-- ---------------------------------------------------------------------------
+--
+-- No update_runs_site_scope RESTRICTIVE policy. m19 gave update_tasks one and
+-- gave update_runs none, and that asymmetry is correct rather than an m112-style
+-- omission: the site-scope policy is "site_id = ANY (app.allowed_site_ids)",
+-- and update_runs HAS NO site_id COLUMN. It is a tenant-level grouping row
+-- (id, tenant_id, created_by, status, dry_run, scheduled_at); the site linkage
+-- lives entirely on update_tasks, which is site-keyed and which m19 duly
+-- scoped. Scoping update_runs would mean a correlated EXISTS over update_tasks
+-- in a RESTRICTIVE policy on every read of the table - a behaviour change to
+-- the operator and client-portal read paths, a new plan for every run query,
+-- and squarely a security-reviewer decision. It is not a Phase 0 change and it
+-- is not made silently: see the note handed back with this migration.
+--
+-- No GRANT. The grants on update_runs are table-level and already in place; a
+-- policy is not a privilege and adding one grants nothing.
+--
+-- No CHECK constraint on status. Adding one would be a strictly larger and
+-- riskier change than this phase needs - it would have to enumerate every value
+-- Phase 1 through Phase N will ever write, and getting that list wrong turns a
+-- typo into a 23514 outage inside main() rather than a caught bug. The comment
+-- is the contract here, consistent with audit_log.action and every other status
+-- column in this schema.
+--
+-- ---------------------------------------------------------------------------
+-- IDEMPOTENCE AND CONVERGE PATH
+-- ---------------------------------------------------------------------------
+--
+-- Every statement is a no-op on second application: the policy is guarded by a
+-- pg_policies existence check (the m89 pattern for this exact policy on the
+-- sibling table), the index by a pg_indexes check (the m116/m117 house
+-- pattern), and COMMENT ON COLUMN is idempotent by nature. migrate.go applies
+-- this on boot inside main(), in one transaction, so a failure here is a
+-- control-plane outage on every install at once; nothing below can fail on a
+-- database that has already run it.
+--
+-- CONVERGE PATH: none is required, and this is not a formality. No prior
+-- version of this migration has ever been applied to any database. This is a
+-- new ordinal - 20260820000000, after m117's 20260819000000, which is the
+-- highest ordinal reachable from ANY ref in this repository at the time of
+-- writing and not merely the highest on main. It corrects nothing, it edits no
+-- applied file, and it changes no existing row, so a database at m117 and a
+-- database created fresh from this migration set reach the same end state.
+
+-- ---------------------------------------------------------------------------
+-- The agent policy. FOR ALL - see DECISION 1.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'update_runs'
+          AND policyname = 'update_runs_agent'
+    ) THEN
+        CREATE POLICY "update_runs_agent" ON "public"."update_runs"
+            FOR ALL
+            USING (current_setting('app.agent', true) = 'on')
+            WITH CHECK (current_setting('app.agent', true) = 'on');
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- The due-scan index - see DECISION 2. Mirrors backup_schedules_due_idx.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public' AND tablename = 'update_runs'
+          AND indexname = 'update_runs_due_idx'
+    ) THEN
+        CREATE INDEX "update_runs_due_idx"
+            ON "public"."update_runs" ("scheduled_at")
+            WHERE "status" = 'scheduled';
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- The status contracts - see DECISION 3. Comment-only; no constraint exists on
+-- either column, so this is the only statement of what the values mean.
+-- ---------------------------------------------------------------------------
+
+COMMENT ON COLUMN "public"."update_runs"."status" IS
+$c$Run lifecycle. No CHECK constraint exists; this comment is the contract.
+
+  pending      Created and its tasks enqueued for immediate execution. The m3
+               default, and still the only state an immediate run passes
+               through.
+  scheduled    (#463) Created with a future scheduled_at and NOT yet handed to
+               the worker. The dispatcher's due-scan selects exactly these,
+               and update_runs_due_idx is partial on this value.
+  dispatching  (#463) Claimed by the dispatcher for this tick. The row has left
+               update_runs_due_idx, so a concurrent tick, a second replica or a
+               restart mid-dispatch cannot claim it again. Transient: the same
+               transaction that sets it enqueues the work.
+  running      At least one task is running.
+  completed    Every task reached a terminal state.
+  expired      (#463) The run passed its dispatch window without being
+               dispatched - the control plane was down across scheduled_at, or
+               the run sat past the point where executing it is still what the
+               operator asked for. Terminal, and NEVER retried: a deferred bulk
+               update that fires days late is a surprise, not a service.
+               Distinct from 'completed' with failures, which was attempted.
+
+Cross-tenant readers of this column run under InAgentTx and are admitted by
+update_runs_agent (m118), not by update_runs_tenant_isolation.$c$;
+
+COMMENT ON COLUMN "public"."update_tasks"."status" IS
+$c$Per-task lifecycle. No CHECK constraint exists; this comment is the contract.
+
+  pending      Created, awaiting execution.
+  running      In flight on the agent.
+  succeeded    Applied.
+  failed       Attempted and failed.
+  rolled_back  Attempted, failed, and reverted from the snapshot.
+  skipped      Not attempted, by decision at plan time.
+  scheduled    (#463) Belongs to a run that is 'scheduled' and is not yet
+               eligible for execution. NOTE: 'scheduled' is NOT one of the
+               statuses in update_tasks_inflight_target_idx, whose predicate is
+               status IN ('pending','running'). That index is the authoritative
+               cross-run dedup guard (m88), so a scheduled task does NOT reserve
+               its (tenant, site, target) pair against a concurrent immediate
+               run. See the note handed to backend-architect with this
+               migration: Phase 1 must decide deliberately whether scheduled
+               tasks reserve their target, and widening that unique index is a
+               separate migration with a data-dedup step, not a comment.
+  expired      (#463) The parent run expired without dispatching, so this task
+               was never attempted. Terminal.
+
+The RESTRICTIVE update_tasks_site_scope policy (m19) and the cross-tenant
+update_tasks_agent policy (m89) both apply to this table; update_runs carries
+the agent policy from m118 but no site-scope policy, because it has no
+site_id.$c$;

--- a/apps/api/migrations/20260820000000_m118_update_runs_agent_rls.sql
+++ b/apps/api/migrations/20260820000000_m118_update_runs_agent_rls.sql
@@ -141,11 +141,24 @@
 -- it to whoever is debugging at 3am, instead of only in a file they would have
 -- to know to open. db/schema.sql carries the SAME contract text in the same
 -- commit, but as inline "--" comments: that file contains no COMMENT ON
--- statement anywhere (verified: grep -c 'COMMENT ON' db/schema.sql -> 0), it is
--- sqlc's input rather than a dump of the database, and it is already well
--- behind the migrations on RLS. Introducing a construct it has never used, to
--- restate text it already carries, would buy nothing. The policy and the index
--- below ARE mirrored there as real DDL.
+-- STATEMENT anywhere (verified at this commit:
+-- grep -cE '^\s*COMMENT ON' db/schema.sql -> 0), it is sqlc's input rather than
+-- a dump of the database, and it is already well behind the migrations on RLS.
+-- Introducing a construct it has never used, to restate text it already
+-- carries, would buy nothing. The policy and the index below ARE mirrored there
+-- as real DDL.
+--
+-- THE ANCHOR IN THAT PATTERN IS LOAD-BEARING; do not "simplify" it away. The
+-- unanchored grep -c 'COMMENT ON' db/schema.sql returns 2 at this commit, and
+-- both hits are PROSE THIS COMMIT ADDED - the two inline comments in that file
+-- that point back at the COMMENT ON COLUMN statements below. Neither is a
+-- statement. Only the anchored form counts statements, which is the thing being
+-- claimed here.
+--
+-- Recorded because it is this migration's own subject in miniature: the
+-- unanchored claim was TRUE WHEN WRITTEN, and writing it down is what made it
+-- false. A comment whose own quoted command disproves it misleads the next
+-- reader in exactly the way the silent zero-rows scan above would have.
 --
 -- A NOTE FOR PHASE 1, stated here because this comment outlives the phase doc:
 -- these strings are declared ahead of the code that writes them. Phase 1 must

--- a/apps/api/tests/gh463_update_runs_agent_rls_integration_test.go
+++ b/apps/api/tests/gh463_update_runs_agent_rls_integration_test.go
@@ -1,0 +1,288 @@
+// gh463_update_runs_agent_rls_integration_test.go — GH #463 Phase 0.
+//
+// These tests are the entire justification for shipping m118 alone and before
+// any dispatcher code exists. They assert, against a real Postgres, that the
+// cross-tenant deferred-dispatch scan can both SEE and CLAIM a due run.
+//
+// WITHOUT m118 THEY FAIL BY RETURNING ZERO ROWS AND NO ERROR. That is the
+// failure mode worth the whole phase: update_runs carried only
+// update_runs_tenant_isolation (m3), so under FORCE ROW LEVEL SECURITY a
+// transaction with app.agent='on' and app.tenant_id UNSET satisfied no policy
+// at all, and Postgres answered "no rows" rather than raising. A dispatcher
+// built against that database would log "0 due runs" on every tick forever and
+// look like it worked. The same defect shipped twice before, as m84/#96
+// (backup_schedules) and m89/#131 (update_tasks — this table's sibling).
+//
+// Every assertion reaches the database on the pool startPostgres hands back,
+// which connects as the NON-superuser, NOBYPASSRLS wpmgr_app role — the role
+// every real install runs as — and every transaction goes through the real
+// db.Pool wrappers (InAgentTx / InTenantTx) that production uses, so the
+// policies under test are live rather than inert. A test that opened its own
+// connection, or that connected as the container superuser, would pass against
+// the broken schema and prove nothing.
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+)
+
+// seedScheduledRun inserts a due 'scheduled' run for one tenant through the
+// REAL tenant wrapper, so update_runs_tenant_isolation's WITH CHECK applies to
+// the insert exactly as it would for an operator-created run. There is no repo
+// method for a deferred run yet — creating one is Phase 1's Go work, which by
+// design does not exist while this migration ships.
+func seedScheduledRun(t *testing.T, pool *db.Pool, tenantID uuid.UUID, scheduledAt time.Time) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	var id uuid.UUID
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			INSERT INTO update_runs (tenant_id, status, dry_run, scheduled_at)
+			VALUES ($1, 'scheduled', false, $2)
+			RETURNING id`, tenantID, scheduledAt).Scan(&id)
+	}); err != nil {
+		t.Fatalf("seed scheduled run: %v", err)
+	}
+	return id
+}
+
+// TestGH463_Phase0_AgentTxSeesAndClaimsDueRunCrossTenant is the core proof.
+//
+// It walks the three database operations the #463 dispatcher will perform, in
+// order, all under InAgentTx with NO tenant GUC set — the plain read, the
+// locking read, and the claim. Each is a separate assertion because each fails
+// differently without the policy, and the second and third are the ones a
+// FOR SELECT policy would still break.
+func TestGH463_Phase0_AgentTxSeesAndClaimsDueRunCrossTenant(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	tenantA := seedTenant(t, pool, "gh463-tenant-a")
+	tenantB := seedTenant(t, pool, "gh463-tenant-b")
+
+	due := time.Now().Add(-time.Minute)
+	runA := seedScheduledRun(t, pool, tenantA, due)
+	runB := seedScheduledRun(t, pool, tenantB, due)
+
+	// A run that is not yet due, to prove the scan is selective and not simply
+	// returning everything once the policy admits rows.
+	notYet := seedScheduledRun(t, pool, tenantA, time.Now().Add(time.Hour))
+
+	// (1) THE PLAIN CROSS-TENANT READ. No tenant_id in the WHERE and no
+	// app.tenant_id in the session: this is admitted only by update_runs_agent.
+	var seen []uuid.UUID
+	if err := pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id FROM update_runs
+			WHERE status = 'scheduled' AND scheduled_at <= now()
+			ORDER BY scheduled_at`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id uuid.UUID
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			seen = append(seen, id)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("cross-tenant due scan: %v", err)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("cross-tenant due scan returned %d rows, want 2 (runs %s and %s, "+
+			"one per tenant). Zero rows with no error is the m84/#96 + m89/#131 "+
+			"failure: update_runs has no app.agent policy, so FORCE ROW LEVEL "+
+			"SECURITY silently admits nothing. Got: %v",
+			len(seen), runA, runB, seen)
+	}
+	for _, id := range seen {
+		if id == notYet {
+			t.Fatalf("due scan returned the not-yet-due run %s", notYet)
+		}
+	}
+
+	// (2) THE LOCKING READ. This is the shape every claim in this codebase
+	// uses, and it is the half that surprises people: PostgreSQL applies the
+	// UPDATE policy to SELECT ... FOR UPDATE as well as the SELECT policy,
+	// because taking a row lock declares intent to write. A FOR SELECT-only
+	// agent policy would make THIS return zero rows while step (1) above still
+	// passed — precisely how Issue #96 stopped every backup schedule from
+	// advancing while the same query worked by hand in psql.
+	var locked []uuid.UUID
+	if err := pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id FROM update_runs
+			WHERE status = 'scheduled' AND scheduled_at <= now()
+			ORDER BY scheduled_at
+			FOR UPDATE SKIP LOCKED`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id uuid.UUID
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			locked = append(locked, id)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("cross-tenant locking scan: %v", err)
+	}
+	if len(locked) != 2 {
+		t.Fatalf("SELECT ... FOR UPDATE returned %d rows, want 2. If the plain "+
+			"read above passed and this did not, the agent policy is FOR SELECT "+
+			"where it must be FOR ALL (Issue #96)", len(locked))
+	}
+
+	// (3) THE CLAIM. 'scheduled' -> 'dispatching', cross-tenant. This needs the
+	// UPDATE policy's USING to admit the old row AND the WITH CHECK to admit
+	// the new one. Without m118 this reports 0 rows affected and raises
+	// nothing, leaving every run at 'scheduled' forever.
+	var claimed int64
+	if err := pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `
+			UPDATE update_runs
+			   SET status = 'dispatching', updated_at = now()
+			 WHERE status = 'scheduled' AND scheduled_at <= now()`)
+		if err != nil {
+			return err
+		}
+		claimed = tag.RowsAffected()
+		return nil
+	}); err != nil {
+		t.Fatalf("cross-tenant claim: %v", err)
+	}
+	if claimed != 2 {
+		t.Fatalf("claim affected %d rows, want 2. Zero-rows-affected with no "+
+			"error is the silent failure this phase exists to prevent", claimed)
+	}
+
+	// The claim must have COMMITTED, and must be visible to the owning tenant.
+	// Reading it back through InTenantTx also proves the agent path did not
+	// somehow write a row the tenant path can no longer see.
+	for _, tc := range []struct {
+		tenantID uuid.UUID
+		runID    uuid.UUID
+	}{{tenantA, runA}, {tenantB, runB}} {
+		var status string
+		if err := pool.InTenantTx(ctx, tc.tenantID, func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx,
+				`SELECT status FROM update_runs WHERE id = $1`, tc.runID).Scan(&status)
+		}); err != nil {
+			t.Fatalf("read back run %s: %v", tc.runID, err)
+		}
+		if status != "dispatching" {
+			t.Fatalf("run %s status = %q, want \"dispatching\"", tc.runID, status)
+		}
+	}
+}
+
+// TestGH463_Phase0_AgentPolicyDoesNotWidenTenantIsolation is the over-fire
+// guard. update_runs_agent is PERMISSIVE, and permissive policies are OR'd, so
+// a policy written even slightly wrong here would admit every tenant's runs to
+// every operator request. It must admit nothing outside InAgentTx.
+//
+// The load-bearing detail is that the GUC is compared against the literal 'on'
+// and that current_setting('app.agent', true) returns NULL — not 'off', not
+// '' — when the GUC was never set, so the comparison is NULL and the row is
+// not admitted.
+func TestGH463_Phase0_AgentPolicyDoesNotWidenTenantIsolation(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	tenantA := seedTenant(t, pool, "gh463-widen-a")
+	tenantB := seedTenant(t, pool, "gh463-widen-b")
+	runA := seedScheduledRun(t, pool, tenantA, time.Now().Add(-time.Minute))
+
+	// Tenant B, on the ordinary operator path, must not see tenant A's run —
+	// neither by unfiltered enumeration nor by direct id.
+	var n int
+	if err := pool.InTenantTx(ctx, tenantB, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM update_runs`).Scan(&n)
+	}); err != nil {
+		t.Fatalf("tenant B enumerate: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("tenant B saw %d update_runs rows, want 0: the agent policy has "+
+			"widened the operator path", n)
+	}
+
+	if err := pool.InTenantTx(ctx, tenantB, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM update_runs WHERE id = $1`, runA).Scan(&n)
+	}); err != nil {
+		t.Fatalf("tenant B fetch by id: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("tenant B fetched tenant A's run %s by id", runA)
+	}
+
+	// And tenant B must not be able to CLAIM tenant A's run either — the
+	// WITH CHECK half. This must affect zero rows.
+	var affected int64
+	if err := pool.InTenantTx(ctx, tenantB, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE update_runs SET status = 'dispatching' WHERE id = $1`, runA)
+		if err != nil {
+			return err
+		}
+		affected = tag.RowsAffected()
+		return nil
+	}); err != nil {
+		t.Fatalf("tenant B claim attempt: %v", err)
+	}
+	if affected != 0 {
+		t.Fatalf("tenant B claimed %d of tenant A's runs, want 0", affected)
+	}
+
+	// Tenant A still sees its own run, untouched. A guard that blocked the
+	// legitimate path too would be switched off, and then it would guard
+	// nothing.
+	var status string
+	if err := pool.InTenantTx(ctx, tenantA, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT status FROM update_runs WHERE id = $1`, runA).Scan(&status)
+	}); err != nil {
+		t.Fatalf("tenant A read own run: %v", err)
+	}
+	if status != "scheduled" {
+		t.Fatalf("tenant A's run status = %q, want \"scheduled\"", status)
+	}
+}
+
+// TestGH463_Phase0_DueIndexExistsWithExpectedPredicate asserts the partial
+// index m118 creates is present and partial on the status the dispatcher
+// filters by. Presence is worth asserting on its own: the index is created
+// while 'scheduled' matches zero rows, so nothing else in the suite would
+// notice if it silently failed to be created, and the dispatcher would ship
+// against a sequential scan of the entire run history on every tick.
+func TestGH463_Phase0_DueIndexExistsWithExpectedPredicate(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var indexdef string
+	err := pool.QueryRow(ctx, `
+		SELECT indexdef FROM pg_indexes
+		 WHERE schemaname = 'public'
+		   AND tablename  = 'update_runs'
+		   AND indexname  = 'update_runs_due_idx'`).Scan(&indexdef)
+	if err != nil {
+		t.Fatalf("update_runs_due_idx not found (m118 did not apply?): %v", err)
+	}
+	for _, want := range []string{"scheduled_at", "status", "'scheduled'"} {
+		if !strings.Contains(indexdef, want) {
+			t.Fatalf("update_runs_due_idx definition %q does not mention %q", indexdef, want)
+		}
+	}
+}

--- a/apps/api/tests/gh463_update_runs_agent_rls_integration_test.go
+++ b/apps/api/tests/gh463_update_runs_agent_rls_integration_test.go
@@ -190,6 +190,162 @@ func TestGH463_Phase0_AgentTxSeesAndClaimsDueRunCrossTenant(t *testing.T) {
 	}
 }
 
+// TestGH463_Phase0_WithoutAgentPolicyTheScanIsSilentlyEmpty plants the real
+// failure and watches it go red, then restores the policy and watches it go
+// green — in one test, against one container, through the same code path.
+//
+// Dropping update_runs_agent returns the table to EXACTLY its pre-m118 state:
+// FORCE ROW LEVEL SECURITY with update_runs_tenant_isolation as its only
+// policy, which is what m3 shipped and what origin/main carried until this
+// commit. So the first half of this test is a measurement of the bug, not a
+// simulation of it.
+//
+// The assertion that matters is NOT that the scan fails. It is that it does
+// NOT fail: err is nil, no SQLSTATE, no log line, and the answer is simply
+// "no rows" and "0 rows affected". A dispatcher cannot tell that apart from a
+// quiet fleet, which is why this defect has now shipped three times here.
+func TestGH463_Phase0_WithoutAgentPolicyTheScanIsSilentlyEmpty(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	tenantA := seedTenant(t, pool, "gh463-red-a")
+	runA := seedScheduledRun(t, pool, tenantA, time.Now().Add(-time.Minute))
+
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	// --- RED: reproduce the pre-m118 schema -------------------------------
+	if _, err := admin.Exec(ctx, `DROP POLICY update_runs_agent ON update_runs`); err != nil {
+		t.Fatalf("drop agent policy (is m118 applied?): %v", err)
+	}
+
+	rows, claimed, err := agentDueScanAndClaim(ctx, pool)
+	if err != nil {
+		t.Fatalf("pre-m118 scan returned an ERROR (%v). The documented failure is "+
+			"a silent empty result, not an error; if Postgres now raises here, "+
+			"this test's premise has changed and the migration's rationale needs "+
+			"re-reading", err)
+	}
+	if rows != 0 || claimed != 0 {
+		t.Fatalf("pre-m118 scan saw %d rows and claimed %d, want 0 and 0. The "+
+			"table should be unreadable under app.agent with only "+
+			"update_runs_tenant_isolation present", rows, claimed)
+	}
+	t.Logf("RED confirmed: with only update_runs_tenant_isolation, the "+
+		"cross-tenant scan returned %d rows and claimed %d, err=%v — run %s is "+
+		"invisible and unclaimable, silently", rows, claimed, err, runA)
+
+	// --- GREEN: restore exactly what m118 creates -------------------------
+	if _, err := admin.Exec(ctx, `
+		CREATE POLICY update_runs_agent ON update_runs
+			FOR ALL
+			USING (current_setting('app.agent', true) = 'on')
+			WITH CHECK (current_setting('app.agent', true) = 'on')`); err != nil {
+		t.Fatalf("recreate agent policy: %v", err)
+	}
+
+	rows, claimed, err = agentDueScanAndClaim(ctx, pool)
+	if err != nil {
+		t.Fatalf("post-m118 scan: %v", err)
+	}
+	if rows != 1 || claimed != 1 {
+		t.Fatalf("post-m118 scan saw %d rows and claimed %d, want 1 and 1", rows, claimed)
+	}
+	t.Logf("GREEN confirmed: with update_runs_agent present, the same scan saw "+
+		"%d row and claimed %d", rows, claimed)
+}
+
+// TestGH463_Phase0_ForSelectPolicyStillBreaksTheClaim is the second half of the
+// FOR ALL decision, proved rather than argued. It installs the policy a
+// reasonable person would write — FOR SELECT, because "the dispatcher scans" —
+// and shows the read succeeding while the claim silently matches nothing.
+//
+// This is Issue #96 reproduced on this table. Without this test, "FOR ALL not
+// FOR SELECT" is a claim in a migration comment that nobody has ever seen fail.
+func TestGH463_Phase0_ForSelectPolicyStillBreaksTheClaim(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	tenantA := seedTenant(t, pool, "gh463-forselect-a")
+	seedScheduledRun(t, pool, tenantA, time.Now().Add(-time.Minute))
+
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	if _, err := admin.Exec(ctx, `DROP POLICY update_runs_agent ON update_runs`); err != nil {
+		t.Fatalf("drop agent policy: %v", err)
+	}
+	if _, err := admin.Exec(ctx, `
+		CREATE POLICY update_runs_agent ON update_runs
+			FOR SELECT
+			USING (current_setting('app.agent', true) = 'on')`); err != nil {
+		t.Fatalf("create FOR SELECT policy: %v", err)
+	}
+
+	rows, claimed, err := agentDueScanAndClaim(ctx, pool)
+	if err != nil {
+		t.Fatalf("FOR SELECT scan: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("FOR SELECT plain read saw %d rows, want 1 — the read half "+
+			"should work, that is what makes this bug so hard to spot", rows)
+	}
+	if claimed != 0 {
+		t.Fatalf("FOR SELECT policy claimed %d rows, want 0. If a read-only "+
+			"policy can now claim, PostgreSQL's behaviour has changed and the "+
+			"FOR ALL rationale in m118 must be revisited", claimed)
+	}
+	t.Logf("Issue #96 reproduced on update_runs: a FOR SELECT agent policy read "+
+		"%d row but claimed %d, with err=%v. The read works, the write silently "+
+		"matches nothing. This is why m118's policy is FOR ALL", rows, claimed, err)
+
+	// And the locking read — the shape the real claim uses — returns nothing at
+	// all under the same FOR SELECT policy, even though the plain read above
+	// returned a row.
+	var lockedCount int
+	if err := pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM (
+				SELECT id FROM update_runs
+				 WHERE status = 'scheduled' AND scheduled_at <= now()
+				 FOR UPDATE SKIP LOCKED
+			) s`).Scan(&lockedCount)
+	}); err != nil {
+		t.Fatalf("FOR SELECT locking read: %v", err)
+	}
+	if lockedCount != 0 {
+		t.Fatalf("SELECT ... FOR UPDATE under a FOR SELECT policy returned %d "+
+			"rows, want 0", lockedCount)
+	}
+	t.Logf("and SELECT ... FOR UPDATE returned %d rows under the same policy "+
+		"that let the plain SELECT through — the counter-intuitive half of #96",
+		lockedCount)
+}
+
+// agentDueScanAndClaim performs the two operations the #463 dispatcher will
+// perform, in one InAgentTx, and reports what each saw. It returns an error
+// only if Postgres actually raised one — the whole point is to distinguish
+// "refused" from "returned nothing".
+func agentDueScanAndClaim(ctx context.Context, pool *db.Pool) (seen int, claimed int64, err error) {
+	err = pool.InAgentTx(ctx, func(tx pgx.Tx) error {
+		if e := tx.QueryRow(ctx, `
+			SELECT count(*) FROM update_runs
+			 WHERE status = 'scheduled' AND scheduled_at <= now()`).Scan(&seen); e != nil {
+			return e
+		}
+		tag, e := tx.Exec(ctx, `
+			UPDATE update_runs
+			   SET status = 'dispatching', updated_at = now()
+			 WHERE status = 'scheduled' AND scheduled_at <= now()`)
+		if e != nil {
+			return e
+		}
+		claimed = tag.RowsAffected()
+		return nil
+	})
+	return seen, claimed, err
+}
+
 // TestGH463_Phase0_AgentPolicyDoesNotWidenTenantIsolation is the over-fire
 // guard. update_runs_agent is PERMISSIVE, and permissive policies are OR'd, so
 // a policy written even slightly wrong here would admit every tenant's runs to


### PR DESCRIPTION
GH #463 Phase 0. **Schema only. No behaviour change, no Go beyond the proof.**

This must land before any deferred-dispatch code is written, because the code
cannot be tested against a database that silently refuses it.

## The bug this prevents

`update_runs` was created by m3 with exactly one policy,
`update_runs_tenant_isolation`, keyed on `app.tenant_id`. Its sibling
`update_tasks` has two. The #463 dispatcher is the first cross-tenant reader of
this table: it runs under `InAgentTx` (`app.agent='on'`, no tenant GUC). Under
`FORCE ROW LEVEL SECURITY` that context satisfied no policy, so the scan
returned the empty set **with no error**, forever.

Measured, not argued — from `TestGH463_Phase0_WithoutAgentPolicyTheScanIsSilentlyEmpty`:

```
RED confirmed: with only update_runs_tenant_isolation, the cross-tenant scan
returned 0 rows and claimed 0, err=<nil> — run 5a2fee78-... is invisible and
unclaimable, silently
GREEN confirmed: with update_runs_agent present, the same scan saw 1 row and
claimed 1
```

This is the third occurrence of the same defect in this repo: m84/#96
(`backup_schedules`) and m89/#131 (`update_tasks`).

## FOR ALL, not FOR SELECT

The dispatcher *claims* rows (`scheduled` → `dispatching`), and PostgreSQL
applies the UPDATE policy to `SELECT … FOR UPDATE` as well. A read-only policy
breaks both the claim and the locking read, silently. Proved rather than
asserted, from `TestGH463_Phase0_ForSelectPolicyStillBreaksTheClaim`:

```
Issue #96 reproduced on update_runs: a FOR SELECT agent policy read 1 row but
claimed 0, with err=<nil>. The read works, the write silently matches nothing.
and SELECT ... FOR UPDATE returned 0 rows under the same policy that let the
plain SELECT through — the counter-intuitive half of #96
```

`FOR ALL` is stated explicitly rather than left to `CREATE POLICY`'s default,
because the default is the thing a reviewer cannot see and it is the exact
clause the bug turns on.

## Also in this migration

- `update_runs_due_idx (scheduled_at) WHERE status = 'scheduled'`, mirroring
  `backup_schedules_due_idx`. Without it the tick sequentially scans every run
  ever created. Created now, while `'scheduled'` matches zero rows, because
  `migrate.go` runs each migration in one transaction and so cannot use
  `CREATE INDEX CONCURRENTLY`.
- Status contracts for `update_runs.status` (`scheduled`, `dispatching`,
  `expired`) and `update_tasks.status` (`scheduled`, `expired`), as
  `COMMENT ON COLUMN` plus matching inline comments in `schema.sql`. Neither
  column has a `CHECK` constraint (verified), so the comment is the only
  contract that exists and a typo'd status stores fine and never dispatches.

## Deliberately not added

- **No `update_runs_site_scope`.** `update_runs` has no `site_id` column; m19
  scoped `update_tasks`, which is site-keyed, and left this table alone. Adding
  one would mean a correlated `EXISTS` over `update_tasks` in a RESTRICTIVE
  policy on every read — a behaviour change to the operator and client-portal
  read paths, and a `security-reviewer` decision, not a Phase 0 one.
- **No `CHECK` on `status`.** It would have to enumerate every value Phase 1..N
  will write; getting that wrong turns a typo into a 23514 inside `main()`.

## Converge path

None required. New ordinal `20260820000000`, after m117's `20260819000000` —
the highest reachable from any ref, not merely from `main`. It corrects
nothing, edits no applied file, and writes no existing row. Every statement is
idempotent (`pg_policies` / `pg_indexes` guards, the m89/m116 house patterns).

## Verification

Every proof runs as the non-superuser `NOBYPASSRLS` `wpmgr_app` role, through
the real `InAgentTx` / `InTenantTx` wrappers, against a real Postgres 16 —
never a self-opened connection and never as superuser.

```
$ go test ./tests/ -run 'TestGH463_Phase0' -v -count=1
--- PASS: TestGH463_Phase0_AgentTxSeesAndClaimsDueRunCrossTenant (8.02s)
--- PASS: TestGH463_Phase0_WithoutAgentPolicyTheScanIsSilentlyEmpty (1.37s)
--- PASS: TestGH463_Phase0_ForSelectPolicyStillBreaksTheClaim (1.33s)
--- PASS: TestGH463_Phase0_AgentPolicyDoesNotWidenTenantIsolation (1.34s)
--- PASS: TestGH463_Phase0_DueIndexExistsWithExpectedPredicate (1.32s)
ok      github.com/mosamlife/wpmgr/apps/api/tests       14.473s
```

`go build ./...`, `go vet ./...` clean. `sqlc` resolved at
`/Users/mosamgor/go/bin/sqlc`, `v1.31.1`, matching the committed stamp
(`grep -h 'sqlc v' apps/api/internal/db/sqlc/*.go | sort -u`); regenerated, and
`git diff --quiet -- internal/db/sqlc/` is clean — expected, since no query or
column set changed.

Draft until `backend-architect` has the handover note and `security-reviewer`
has reviewed the policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for scheduled and deferred update-run processing.
  - Introduced lifecycle statuses for scheduled, dispatching, and expired runs and tasks.
  - Improved dispatcher access to find, lock, and claim due runs while preserving tenant isolation.
  - Added optimized lookup for scheduled runs that are ready for processing.

- **Bug Fixes**
  - Resolved issues where dispatcher scans could silently return no eligible runs or fail during claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->