### PR TITLE
feat(marketing): add roadmap page, unlinked pending #460

### DIFF
--- a/apps/marketing/app/(marketing)/roadmap/page.tsx
+++ b/apps/marketing/app/(marketing)/roadmap/page.tsx
@@ -1,0 +1,275 @@
+// This route is intentionally unlinked from nav, footer, and every other
+// page. It goes live only after #460 ships: our uptime page currently derives
+// most of its 90-day history from a single 7-day figure, and a never-probed
+// site renders as 90 days of solid outage. A roadmap invites people to check
+// our work, and that is the wrong pair of facts to have live while inviting
+// it. Do not add a link to this page anywhere until #460 is deployed and
+// verified against the running system.
+import type { Metadata } from "next";
+import { buildMetadata, buildBreadcrumbLd } from "@/lib/seo";
+import { JsonLd } from "@/lib/json-ld";
+import { Container, Section, SectionHeading, Eyebrow } from "@/components/ui/primitives";
+import { Icon } from "@/components/ui/icon";
+import { Reveal } from "@/components/motion/reveal";
+import { Stagger, StaggerItem } from "@/components/motion/stagger";
+import { ROADMAP } from "@/lib/content/roadmap";
+
+export const metadata: Metadata = buildMetadata({
+  title: ROADMAP.metaTitle,
+  description: ROADMAP.metaDescription,
+  canonical: "/roadmap",
+  // Not announced yet. Kept out of the sitemap and out of search results
+  // until the gate above clears, so the first place anyone finds this page
+  // is a deliberate link, not a crawl.
+  noindex: true,
+});
+
+export default function RoadmapPage() {
+  return (
+    <>
+      <Section className="pb-14 sm:pb-16">
+        <Container>
+          <Eyebrow>Roadmap</Eyebrow>
+          <h1 className="mt-4 max-w-[20ch] text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            {ROADMAP.hero.subhead}
+          </h1>
+          <p className="mt-5 max-w-[62ch] text-lg leading-relaxed text-[var(--muted-foreground)]">
+            {ROADMAP.hero.note}
+          </p>
+        </Container>
+      </Section>
+
+      {/* Shipping now */}
+      <Section tone="muted" className="border-y border-[var(--border)]">
+        <Container>
+          <Reveal>
+            <SectionHeading
+              align="left"
+              eyebrow={ROADMAP.shippingNow.eyebrow}
+              title={ROADMAP.shippingNow.heading}
+            />
+          </Reveal>
+
+          <Stagger className="mt-10 flex flex-col gap-6">
+            {ROADMAP.shippingNow.items.map((item) => (
+              <StaggerItem key={item.title}>
+                <div className="rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm sm:p-8">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <h3 className="text-xl font-semibold text-foreground">{item.title}</h3>
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--warning-subtle)] px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.06em] text-[var(--warning-subtle-fg)]">
+                      <Icon name="RefreshCw" size={12} />
+                      {item.badge}
+                    </span>
+                  </div>
+                  <p className="mt-4 text-lg leading-relaxed text-foreground">{item.summary}</p>
+                  <p className="mt-3 leading-relaxed text-[var(--muted-foreground)]">
+                    {item.context}
+                  </p>
+                  <ul className="mt-6 flex flex-col gap-3 border-t border-[var(--border)] pt-6">
+                    {item.points.map((point) => (
+                      <li key={point} className="flex gap-3 leading-relaxed text-foreground">
+                        <Icon
+                          name="Check"
+                          size={16}
+                          className="mt-1 shrink-0 text-[var(--primary)]"
+                        />
+                        {point}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-6 text-sm text-[var(--muted-foreground)]">
+                    <a
+                      href={item.tracking.href}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="font-medium text-[var(--primary-pressed)] underline-offset-4 hover:underline"
+                    >
+                      {item.tracking.label}
+                    </a>
+                    {". "}
+                    {item.tracking.note}
+                  </p>
+                </div>
+              </StaggerItem>
+            ))}
+          </Stagger>
+        </Container>
+      </Section>
+
+      {/* Committed next */}
+      <Section>
+        <Container>
+          <Reveal>
+            <SectionHeading
+              align="left"
+              eyebrow={ROADMAP.committedNext.eyebrow}
+              title={ROADMAP.committedNext.heading}
+            />
+          </Reveal>
+
+          <Stagger className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {ROADMAP.committedNext.items.map((item) => (
+              <StaggerItem key={item.title}>
+                <div className="flex h-full flex-col gap-4 rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--success-subtle)] text-[var(--success-subtle-fg)]">
+                      <Icon name="Check" size={16} />
+                    </span>
+                    <h3 className="text-lg font-semibold text-foreground">{item.title}</h3>
+                  </div>
+
+                  {"summary" in item && item.summary ? (
+                    <p className="leading-relaxed text-foreground">{item.summary}</p>
+                  ) : null}
+                  {"detail" in item && item.detail ? (
+                    <p className="leading-relaxed text-[var(--muted-foreground)]">{item.detail}</p>
+                  ) : null}
+                  {"points" in item && item.points ? (
+                    <ul className="flex flex-col gap-2.5">
+                      {item.points.map((point) => (
+                        <li
+                          key={point}
+                          className="flex gap-2.5 text-sm leading-relaxed text-foreground"
+                        >
+                          <Icon
+                            name="Check"
+                            size={14}
+                            className="mt-0.5 shrink-0 text-[var(--primary)]"
+                          />
+                          {point}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+
+                  {"tracking" in item && item.tracking ? (
+                    <a
+                      href={item.tracking.href}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="mt-auto inline-flex items-center gap-1.5 text-sm font-medium text-[var(--primary-pressed)] underline-offset-4 hover:underline"
+                    >
+                      {item.tracking.label}
+                      <Icon name="ArrowRight" size={14} />
+                    </a>
+                  ) : null}
+                </div>
+              </StaggerItem>
+            ))}
+          </Stagger>
+        </Container>
+      </Section>
+
+      {/* Under research, not yet committed */}
+      <Section tone="muted" className="border-y border-[var(--border)]">
+        <Container className="max-w-3xl">
+          <Reveal>
+            <div className="rounded-xl border border-dashed border-[var(--border)] bg-card p-6 sm:p-8">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--muted)] text-foreground">
+                  <Icon name="HelpCircle" size={18} />
+                </span>
+                <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--muted-foreground)]">
+                  {ROADMAP.underResearch.eyebrow}
+                </span>
+              </div>
+
+              <h2 className="mt-5 text-2xl font-semibold text-foreground sm:text-3xl">
+                {ROADMAP.underResearch.heading}
+              </h2>
+
+              <p className="mt-3 inline-flex rounded-md border border-dashed border-[var(--border)] bg-[var(--muted)] px-3 py-1.5 text-sm font-medium text-[var(--muted-foreground)]">
+                {ROADMAP.underResearch.disclaimer}
+              </p>
+
+              <div className="mt-5 flex flex-col gap-4">
+                {ROADMAP.underResearch.body.map((p) => (
+                  <p key={p} className="leading-relaxed text-foreground">
+                    {p}
+                  </p>
+                ))}
+              </div>
+
+              <p className="mt-6 text-sm font-semibold text-[var(--muted-foreground)]">
+                {ROADMAP.underResearch.prerequisitesLabel}
+              </p>
+              <ul className="mt-3 flex flex-col gap-3">
+                {ROADMAP.underResearch.prerequisites.map((point) => (
+                  <li key={point} className="flex gap-3 leading-relaxed text-foreground">
+                    <Icon
+                      name="HelpCircle"
+                      size={16}
+                      className="mt-1 shrink-0 text-[var(--muted-foreground)]"
+                    />
+                    {point}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </Reveal>
+        </Container>
+      </Section>
+
+      {/* Explicit non-goals: the section this page exists to publish, so it
+          gets the biggest heading on the page and cards with real weight
+          rather than a footnote list. */}
+      <Section>
+        <Container>
+          <Reveal>
+            <div className="max-w-2xl">
+              <Eyebrow>{ROADMAP.nonGoals.eyebrow}</Eyebrow>
+              <h2 className="mt-4 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+                {ROADMAP.nonGoals.heading}
+              </h2>
+              <p className="mt-4 text-lg leading-relaxed text-[var(--muted-foreground)]">
+                {ROADMAP.nonGoals.lead}
+              </p>
+            </div>
+          </Reveal>
+
+          <Stagger className="mt-12 grid gap-6 sm:grid-cols-2">
+            {ROADMAP.nonGoals.items.map((item) => (
+              <StaggerItem key={item.title}>
+                <div className="flex h-full gap-5 rounded-xl border border-[var(--border)] bg-card p-6 shadow-sm sm:p-8">
+                  <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--muted)] text-foreground">
+                    <Icon name="X" size={20} />
+                  </span>
+                  <div>
+                    <h3 className="text-xl font-semibold text-foreground">{item.title}</h3>
+                    <p className="mt-2 leading-relaxed text-[var(--muted-foreground)]">
+                      {item.body}
+                    </p>
+                  </div>
+                </div>
+              </StaggerItem>
+            ))}
+          </Stagger>
+        </Container>
+      </Section>
+
+      {/* How to read this: a closing note, deliberately low-key. */}
+      <Section tone="muted" className="border-t border-[var(--border)] py-14 sm:py-16">
+        <Container className="max-w-3xl">
+          <h2 className="text-lg font-semibold text-foreground">{ROADMAP.howToRead.heading}</h2>
+          <ul className="mt-4 flex flex-col gap-2.5">
+            {ROADMAP.howToRead.points.map((point) => (
+              <li
+                key={point}
+                className="text-sm leading-relaxed text-[var(--muted-foreground)]"
+              >
+                {point}
+              </li>
+            ))}
+          </ul>
+        </Container>
+      </Section>
+
+      <JsonLd
+        data={buildBreadcrumbLd([
+          { name: "Home", href: "/" },
+          { name: "Roadmap", href: "/roadmap" },
+        ])}
+      />
+    </>
+  );
+}

--- a/apps/marketing/lib/content/roadmap.ts
+++ b/apps/marketing/lib/content/roadmap.ts
@@ -1,0 +1,124 @@
+// /roadmap page content.
+// House rules: no em dashes, no en dashes, no competitor plugin names.
+//
+// Source of truth is GitHub issue #474 ("Roadmap"). This file is a copy of
+// that issue's structure and claims, not a new statement: shipping now,
+// committed next, under research, explicit non-goals, and a closing note on
+// how to read the list. Dates are deliberately absent throughout, matching
+// the issue: this is a statement of intent, not a delivery schedule.
+import { SITE_CONFIG } from "@/lib/site";
+
+const issueHref = (n: number) => `${SITE_CONFIG.github}/issues/${n}`;
+
+export const ROADMAP = {
+  metaTitle: "Roadmap: what we are building and what we are not",
+  metaDescription:
+    "What WPMgr is building next, what is only under research, and what we have explicitly decided not to build. No dates: we would rather move an item than defend one.",
+  hero: {
+    heading: "Roadmap",
+    subhead: "What we are building, and what we have decided not to build.",
+    note: "This is a statement of intent, not a delivery schedule. Dates are deliberately absent, because we would rather move an item than defend a date.",
+  },
+
+  shippingNow: {
+    eyebrow: "Shipping now",
+    heading: "In build today",
+    items: [
+      {
+        title: "Scheduled operations",
+        badge: "In build",
+        summary: "Set a time for updates, backups, and scans, and have them run at that time.",
+        context:
+          "Today scheduled_at is accepted and stored but not honoured: a run submitted for 02:00 executes immediately. That is being fixed properly rather than patched.",
+        points: [
+          "Work waits for its start time without being mistaken for stalled work.",
+          "A run that could not start reports that it did not start, and that nothing was sent to your sites, rather than failing silently or arriving hours late at business open.",
+          "A scheduled run does not block an urgent update to the same plugin in the meantime.",
+          "Runs on our own infrastructure. No third-party scheduling service.",
+        ],
+        tracking: { label: "Tracked in #463", href: issueHref(463), note: "The first piece is merged." },
+      },
+    ],
+  },
+
+  committedNext: {
+    eyebrow: "Committed next",
+    heading: "Decided, not yet shipped",
+    items: [
+      {
+        title: "Honest uptime history",
+        summary:
+          "Our 90-day availability chart currently derives most of its cells from a single 7-day figure, and a site that has never been probed renders as 90 days of outage.",
+        detail:
+          "Both are being replaced with measured data and an explicit state for a site that has not been measured yet.",
+        tracking: { label: "Tracked in #460", href: issueHref(460) },
+      },
+      {
+        title: "Backup and restore depth",
+        points: [
+          "Bring your own storage: S3, Backblaze B2, Google Drive, Dropbox.",
+          "A destination chosen per backup rather than one global setting.",
+          "Restore to a different domain, with URLs rewritten inside serialised data.",
+          "Retention policies.",
+          "Verification that asks the destination whether the bytes are retrievable, rather than only confirming our own counters agree.",
+        ],
+      },
+      {
+        title: "Clone and host-change detection",
+        summary:
+          "A restored backup or a staging clone currently carries live control-plane authority for the site it was copied from.",
+        detail: "Detecting that a site has moved, and requiring re-enrolment, closes it.",
+      },
+    ],
+  },
+
+  underResearch: {
+    eyebrow: "Under research, not yet committed",
+    heading: "Assistant and AI integration",
+    disclaimer: "This is not a commitment. It has no shipping date and no decided shape.",
+    body: [
+      "We are not announcing a shape for this yet, deliberately.",
+      "WordPress has published an official MCP adapter and an Abilities API. Whether the right answer is to implement that standard or to build our own connector is a decision we have not finished making, and committing publicly before making it would be committing to the wrong thing.",
+      "What we can say: the capability an assistant would drive already exists. Every operation is an authorised, per-site, per-command signed instruction with an audit record. The work is exposure and authorisation, not new capability.",
+    ],
+    prerequisitesLabel: "Two things we consider prerequisites rather than follow-ons:",
+    prerequisites: [
+      "A read-only ceiling that applies at discovery as well as execution, so an assistant cannot reach what it cannot see.",
+      "Approval as a distinct act by a person, enforced by the server. A flag an automated caller can set for itself is not an approval, and an instruction in a description is not a control.",
+    ],
+  },
+
+  nonGoals: {
+    eyebrow: "Explicit non-goals",
+    heading: "What we will not build",
+    lead: "Published so they stop being re-proposed.",
+    items: [
+      {
+        title: "Prompt-to-site generation",
+        body: "Not our product. Generating a site from a description is a different business from operating sites that already exist.",
+      },
+      {
+        title: "Starter-template libraries",
+        body: "A content-production investment, not an engineering one, and only useful alongside a generator we are not building.",
+      },
+      {
+        title: "Credit-metered AI billing",
+        body: "Metering the iteration that makes an answer useful is a bad trade for the operator.",
+      },
+      {
+        title: "A chat interface inside our dashboard",
+        body: "If you are using an assistant, that assistant is the interface. Building a second one is the thing the protocol exists to avoid.",
+      },
+    ],
+  },
+
+  howToRead: {
+    heading: "How to read this",
+    points: [
+      "Items move down this list, not up.",
+      "Anything under Under research may change shape entirely, or be dropped.",
+      "Anything under Non-goals will not appear later without a public change of mind and a stated reason.",
+      "Issues are the source of truth for detail. This page is the intent behind them.",
+    ],
+  },
+} as const;


### PR DESCRIPTION
## Summary
- Adds `/roadmap` on the marketing site, sourced from issue #474: shipping now, committed next, under research, and explicit non-goals, plus a "how to read this" closing note.
- The non-goals section gets the largest heading and heaviest cards on the page, not a footnote treatment.
- The "under research" section (assistant/AI integration) sits in a dashed-border card with an explicit "not a commitment" chip, visually distinct from the committed/shipping sections.
- No dates anywhere, matching the issue's intent.

## The gate
Per the task, this page must not go live to visitors until #460 ships (the uptime page currently derives most of its 90-day history from a single 7-day figure, so a never-probed site renders as 90 days of solid outage; publishing a roadmap that invites scrutiny while that's true is the wrong pair of facts).

- Not linked from nav, footer, or any other page (verified: only the page's own files reference `/roadmap`).
- Not in `sitemap.ts` (manually curated, untouched).
- `metadata.robots` set to `noindex` as defense in depth.
- A comment at the top of `page.tsx` names #460 and states not to link this page until it ships and is verified.

## Finding (not fixed here, out of scope for this PR)
Existing marketing copy claims **scheduled backups/updates work today** in multiple places (e.g. `apps/marketing/lib/content/features/backups.ts:29` "Schedule backups per site", `apps/marketing/lib/content/home.ts:81`, `apps/marketing/app/product-hunt/page.tsx:22`, `apps/marketing/app/guides/page.tsx:170`, several `solutions/*.ts` files), while the roadmap (and issue #463) states scheduling is only *accepted and stored*, not honoured: a run submitted for a future time executes immediately today. That is a live over-claim on the shipped site.

Separately, `apps/marketing/lib/content/features/uptime-monitoring.ts:69` claims "you can produce accurate uptime statistics for client reports," while #460 states the 90-day availability chart is currently mostly derived from a single 7-day figure. Same shape of over-claim, adjacent to the exact reason this page stays unlinked.

Neither is fixed in this PR; flagging per the task brief.

## Test plan
- [x] `node apps/marketing/scripts/check-copy.mjs` passes
- [x] `pnpm --filter @wpmgr/marketing typecheck` passes
- [x] `pnpm --filter @wpmgr/marketing lint` passes
- [x] `pnpm --filter @wpmgr/marketing build` succeeds, `/roadmap` renders as a static route
- [x] `impeccable detect` on `apps/marketing` reports no new findings in the added files
- [x] docs vocabulary grep (ci.yml's competitor-name check) passes
- [x] `git diff --stat` against `origin/main` touches only `apps/marketing/**` (2 new files)