### PR TITLE
fix(marketing): correct uptime incident-history copy

### DIFF
--- a/apps/marketing/lib/content/features/uptime-monitoring.ts
+++ b/apps/marketing/lib/content/features/uptime-monitoring.ts
@@ -66,7 +66,7 @@ export const UPTIME_MONITORING_PAGE: FeaturePageData = {
     {
       icon: "LayoutGrid",
       title: "Incident history",
-      desc: "Every down and recovery event is recorded with a timestamp and duration so you can produce accurate uptime statistics for client reports.",
+      desc: "Every down and recovery event is recorded with a timestamp and duration, giving you a durable log to draw on for client reports.",
     },
     {
       icon: "Network",


### PR DESCRIPTION
## Summary
- The incident history subfeature on the uptime monitoring page promised "accurate uptime statistics for client reports." That overstates what the 90-day availability view currently does: most of the strip is derived from a single 7-day scalar rather than measured per day, so a number pulled from it into a client report could be wrong in a way the reader has no way to detect.
- Kept the true half (events are recorded with timestamp and duration) and dropped the "accurate statistics" promise, without replacing it with a vague hedge.

## Before / after
Before: "Every down and recovery event is recorded with a timestamp and duration so you can produce accurate uptime statistics for client reports."

After: "Every down and recovery event is recorded with a timestamp and duration, giving you a durable log to draw on for client reports."

## Test plan
- [x] `node apps/marketing/scripts/check-copy.mjs` passes
- [x] Docs vocabulary check (competitor names in docs/*.md) passes
- [x] `git diff --stat` against main touches exactly one file