### PR TITLE
fix(web): survive #463 deferred-dispatch status widening

### DIFF
--- a/apps/web/src/features/sites/bulk-action-drawer.tsx
+++ b/apps/web/src/features/sites/bulk-action-drawer.tsx
@@ -566,6 +566,10 @@ function priority(status: UpdateTask["status"]): number {
       return 0;
     case "pending":
       return 1;
+    // GH #463: waiting on its own start time, not yet actionable — same
+    // tier as an ordinary queued task.
+    case "scheduled":
+      return 1;
     case "failed":
       return 2;
     case "rolled_back":
@@ -577,6 +581,10 @@ function priority(status: UpdateTask["status"]): number {
     // GH #255 Phase 2: never dispatched because its run halted first.
     case "cancelled":
       return 6;
+    // GH #463: never dispatched because its run expired first. Same tier as
+    // `cancelled` — nothing was sent, distinct cause.
+    case "expired":
+      return 6;
     default:
       return 7;
   }
@@ -586,6 +594,10 @@ function priority(status: UpdateTask["status"]): number {
 function rollupStatus(tasks: UpdateTask[]): UpdateTask["status"] {
   if (tasks.some((t) => t.status === "running")) return "running";
   if (tasks.some((t) => t.status === "pending")) return "pending";
+  // GH #463: any task still waiting on its schedule means this row is not
+  // done either — must be checked before the terminal-state rollups below,
+  // or a row of entirely `scheduled` tasks falls through to "succeeded".
+  if (tasks.some((t) => t.status === "scheduled")) return "scheduled";
   if (tasks.some((t) => t.status === "failed")) return "failed";
   if (tasks.some((t) => t.status === "rolled_back")) return "rolled_back";
   if (tasks.every((t) => t.status === "skipped")) return "skipped";
@@ -593,6 +605,10 @@ function rollupStatus(tasks: UpdateTask[]): UpdateTask["status"] {
   // must never fall through to the "succeeded" default below, which would
   // show an untouched site as done.
   if (tasks.every((t) => t.status === "cancelled")) return "cancelled";
+  // GH #463: an expired run never dispatched any of its tasks either — same
+  // reasoning as `cancelled` immediately above, different cause. Must also
+  // never fall through to "succeeded".
+  if (tasks.every((t) => t.status === "expired")) return "expired";
   return "succeeded";
 }
 
@@ -608,6 +624,13 @@ function toneFor(status: UpdateTask["status"]): StatusTone {
       return "destructive";
     case "skipped":
     case "cancelled":
+      return "muted";
+    // GH #463: neither reads as an error — see features/updates/update-
+    // status.tsx for the full reasoning on why `scheduled`/`expired` stay
+    // out of "destructive".
+    case "scheduled":
+      return "muted";
+    case "expired":
       return "muted";
     default:
       return "muted";
@@ -630,6 +653,12 @@ function statusLabel(status: UpdateTask["status"]): string {
       return "Skipped";
     case "cancelled":
       return "Cancelled";
+    // GH #463: distinct label from "Cancelled" — one is an operator's
+    // choice, the other is a missed schedule window.
+    case "scheduled":
+      return "Scheduled";
+    case "expired":
+      return "Expired";
     default:
       return "Unknown";
   }

--- a/apps/web/src/features/updates/retry-contract.ts
+++ b/apps/web/src/features/updates/retry-contract.ts
@@ -167,8 +167,28 @@ export function notRetryableReason(task: RetryTask): string {
   if (task.status === "succeeded") {
     return "Cannot be retried: this update succeeded.";
   }
-  if (task.status === "pending" || task.status === "running") {
+  // GH #463: `scheduled` joins this bucket — it has not started either, it
+  // just has not reached its start time yet. Same reason a checkbox is
+  // absent as pending/running: there is nothing to retry, only something to
+  // wait for (or cancel).
+  if (
+    task.status === "pending" ||
+    task.status === "running" ||
+    task.status === "scheduled"
+  ) {
     return "Cannot be retried: this update has not finished yet.";
+  }
+  // GH #463: `expired` is its own case, not the generic terminal fallback
+  // below. Nothing was ever sent to the site (same as `cancelled`/
+  // `never_ran`), so this text must not read like a failed update. Today the
+  // server still classifies an expired task as `not_applicable` (see
+  // apps/api/internal/update/model.go retryClassify, which has no case for
+  // TaskExpired and falls through its default), so this row currently has no
+  // checkbox and this is the reason shown. This client never overrides that
+  // server verdict — see `isRetrySelectable` above — it only has to describe
+  // the true reason accurately.
+  if (task.status === "expired") {
+    return "Cannot be retried: this update expired before it could run.";
   }
   return "Cannot be retried: the control plane cannot run this update again.";
 }

--- a/apps/web/src/features/updates/summarize.ts
+++ b/apps/web/src/features/updates/summarize.ts
@@ -26,6 +26,13 @@ export function summarizeTasks(tasks: UpdateTask[]): {
     // one target) and `failed` (the site was contacted and did not come
     // back): nothing was ever sent here.
     cancelled: 0,
+    // GH #463: not yet eligible for dispatch (parent run hasn't reached its
+    // scheduled_at). Not terminal, so excluded from `done` below, matching
+    // the control plane's own `terminal()` predicate.
+    scheduled: 0,
+    // GH #463: the parent run expired without dispatching. Terminal, and
+    // counted into `done` below, same as `cancelled`.
+    expired: 0,
   };
   for (const task of tasks) counts[task.status] += 1;
   const done =
@@ -33,7 +40,8 @@ export function summarizeTasks(tasks: UpdateTask[]): {
     counts.failed +
     counts.rolled_back +
     counts.skipped +
-    counts.cancelled;
+    counts.cancelled +
+    counts.expired;
   return { total: tasks.length, done, counts };
 }
 
@@ -48,7 +56,12 @@ export function isTerminalTaskStatus(status: TaskStatus): boolean {
     status === "failed" ||
     status === "rolled_back" ||
     status === "skipped" ||
-    status === "cancelled"
+    status === "cancelled" ||
+    // GH #463: the parent run expired without dispatching this task. Never
+    // attempted, and final — matches the control plane's own terminal()
+    // predicate (apps/api/internal/update/model.go), which includes
+    // TaskExpired but deliberately excludes TaskScheduled.
+    status === "expired"
   );
 }
 
@@ -62,7 +75,13 @@ export function isTerminalTaskStatus(status: TaskStatus): boolean {
  * halted run reads as perpetually in progress.
  */
 export function isTerminalRunStatus(status: RunStatus | undefined): boolean {
-  return status === "completed" || status === "halted";
+  // GH #463: `expired` is terminal too — the run came due more than the
+  // grace window ago and was never dispatched, and nothing further happens
+  // to it. `scheduled` and `dispatching` are deliberately excluded: both
+  // still have somewhere to go (scheduled -> dispatching -> running/expired;
+  // dispatching -> running), so a surface gating "still going" must keep
+  // polling/streaming through them.
+  return status === "completed" || status === "halted" || status === "expired";
 }
 
 // GH #255 Phase 2: the agent self-update channel's own outcome vocabulary.

--- a/apps/web/src/features/updates/update-status.tsx
+++ b/apps/web/src/features/updates/update-status.tsx
@@ -11,7 +11,26 @@ import {
 type TaskStatus = UpdateTask["status"];
 type RunStatus = UpdateRun["status"];
 
-const TASK_TONE: Record<TaskStatus, { tone: StatusTone; label: string; pulse?: boolean }> = {
+type ToneCfg = { tone: StatusTone; label: string; pulse?: boolean };
+
+// Defence in depth against version skew: a self-hosted control plane can be
+// newer than the browser bundle it serves and emit a status literal this
+// build has never heard of. `tsc` already refuses to compile TASK_TONE/
+// RUN_TONE below if a status is added to the generated union and this file
+// is not updated to match — that is the exhaustiveness check, and it is real
+// coverage. This fallback is the OTHER case: the type says every key is
+// covered, but the value actually on the wire is not one `tsc` ever checked,
+// so the lookup below is deliberately re-typed as partial for the read.
+const UNKNOWN_TONE: ToneCfg = { tone: "muted", label: "Unknown" };
+
+function toneFor<S extends string>(
+  map: Record<S, ToneCfg>,
+  status: S,
+): ToneCfg {
+  return (map as Partial<Record<S, ToneCfg>>)[status] ?? UNKNOWN_TONE;
+}
+
+const TASK_TONE: Record<TaskStatus, ToneCfg> = {
   succeeded: { tone: "success", label: "Succeeded" },
   failed: { tone: "destructive", label: "Failed" },
   rolled_back: { tone: "warning", label: "Rolled back" },
@@ -22,6 +41,17 @@ const TASK_TONE: Record<TaskStatus, { tone: StatusTone; label: string; pulse?: b
   // relabels it: nobody cancelled this, the control plane withheld it, and
   // nothing was ever sent to the site.
   cancelled: { tone: "muted", label: "Not attempted" },
+  // GH #463: the parent run has not reached its scheduled_at yet. Nothing
+  // has happened. Same neutral tone as "Pending"; the distinct "Scheduled"
+  // label (paired with the run's scheduled_at shown elsewhere) is what
+  // signals "waiting for a future time" rather than "queued now".
+  scheduled: { tone: "muted", label: "Scheduled" },
+  // GH #463: the parent run expired before dispatching, so this task was
+  // never attempted either — same story as `cancelled`, a different cause.
+  // Kept muted (never attempted is not a failure) but with its own label so
+  // it reads distinctly from "Not attempted" (an operator's choice) rather
+  // than collapsing the two together.
+  expired: { tone: "muted", label: "Expired" },
 };
 
 export function TaskStatusBadge({
@@ -53,7 +83,7 @@ export function TaskStatusBadge({
       return <StatusChip tone="muted" label="Not eligible" />;
     }
   }
-  const cfg = TASK_TONE[task.status];
+  const cfg = toneFor(TASK_TONE, task.status);
   return (
     <StatusChip
       tone={cfg.tone}
@@ -63,7 +93,7 @@ export function TaskStatusBadge({
   );
 }
 
-const RUN_TONE: Record<RunStatus, { tone: StatusTone; label: string; pulse?: boolean }> = {
+const RUN_TONE: Record<RunStatus, ToneCfg> = {
   pending: { tone: "muted", label: "Pending" },
   running: { tone: "info", label: "Running", pulse: true },
   completed: { tone: "success", label: "Completed" },
@@ -71,10 +101,25 @@ const RUN_TONE: Record<RunStatus, { tone: StatusTone; label: string; pulse?: boo
   // Destructive tone on purpose: this is the signal that a bad agent build
   // was caught and needs the operator's attention.
   halted: { tone: "destructive", label: "Halted" },
+  // GH #463: waiting for scheduled_at. No site has been contacted yet.
+  // Neutral, not an error — mirrors the task-level "Scheduled" tone.
+  scheduled: { tone: "muted", label: "Scheduled" },
+  // GH #463: transient, held only while the dispatcher enqueues the run's
+  // tasks. An operator will rarely see this; `info` + pulse mirrors
+  // "Running" because something genuinely is happening right now.
+  dispatching: { tone: "info", label: "Dispatching", pulse: true },
+  // GH #463: terminal — the run came due more than the grace window ago
+  // while the control plane was unavailable, so it was never dispatched.
+  // No site was contacted. This is a MISSED SCHEDULE, not a failed update,
+  // so it deliberately does not use "destructive" (that would read as "an
+  // update broke a site", which is false here). `warning` keeps it visible
+  // enough that an operator notices the schedule didn't fire, without the
+  // implication that anything on a site went wrong.
+  expired: { tone: "warning", label: "Expired" },
 };
 
 export function RunStatusBadge({ status }: { status: RunStatus }) {
-  const cfg = RUN_TONE[status];
+  const cfg = toneFor(RUN_TONE, status);
   return (
     <StatusChip
       tone={cfg.tone}

--- a/apps/web/src/routes/_authed/updates/$runId.tsx
+++ b/apps/web/src/routes/_authed/updates/$runId.tsx
@@ -123,6 +123,14 @@ function RunDetailPage() {
 
 type RunStatus = UpdateRun["status"];
 
+// Defence in depth against version skew, mirroring
+// features/updates/update-status.tsx: `tsc` enforces that every RunStatus is
+// covered below, but a self-hosted control plane can still send a status
+// literal this bundle predates, so the dereferences below re-type the lookup
+// as partial rather than trusting the exhaustive type at runtime.
+const UNKNOWN_RUN_TONE: StatusTone = "muted";
+const UNKNOWN_RUN_LABEL = "Unknown";
+
 const RUN_STATUS_TONE: Record<RunStatus, StatusTone> = {
   pending: "muted",
   running: "info",
@@ -130,6 +138,15 @@ const RUN_STATUS_TONE: Record<RunStatus, StatusTone> = {
   // GH #255 Phase 2: a wave failed to prove itself; destructive tone flags
   // it for immediate attention, matching the prominent banner below.
   halted: "destructive",
+  // GH #463: waiting for scheduled_at, nothing has happened yet.
+  scheduled: "muted",
+  // GH #463: transient, the dispatcher is enqueueing this run's tasks right
+  // now — mirrors "Running".
+  dispatching: "info",
+  // GH #463: terminal, no site was contacted — a missed schedule, not a
+  // failed update, so this deliberately avoids "destructive" (see
+  // features/updates/update-status.tsx for the full reasoning).
+  expired: "warning",
 };
 
 const RUN_STATUS_LABEL: Record<RunStatus, string> = {
@@ -137,6 +154,9 @@ const RUN_STATUS_LABEL: Record<RunStatus, string> = {
   running: "Running",
   completed: "Completed",
   halted: "Halted",
+  scheduled: "Scheduled",
+  dispatching: "Dispatching",
+  expired: "Expired",
 };
 
 function RunDetail({
@@ -199,9 +219,17 @@ function RunDetail({
         badges={
           <>
             <StatusChip
-              tone={RUN_STATUS_TONE[run.status]}
-              label={RUN_STATUS_LABEL[run.status]}
-              pulse={run.status === "running"}
+              tone={
+                (RUN_STATUS_TONE as Partial<Record<RunStatus, StatusTone>>)[
+                  run.status
+                ] ?? UNKNOWN_RUN_TONE
+              }
+              label={
+                (RUN_STATUS_LABEL as Partial<Record<RunStatus, string>>)[
+                  run.status
+                ] ?? UNKNOWN_RUN_LABEL
+              }
+              pulse={run.status === "running" || run.status === "dispatching"}
             />
             {run.dry_run ? (
               <Badge variant="outline">Dry run</Badge>
@@ -272,6 +300,7 @@ function RunDetail({
               { label: "Rolled back", value: summary.counts.rolled_back, tabular: true },
               { label: "Running", value: summary.counts.running, tabular: true },
               { label: "Pending", value: summary.counts.pending, tabular: true },
+              { label: "Scheduled", value: summary.counts.scheduled, tabular: true },
               { label: "Skipped", value: summary.counts.skipped, tabular: true },
               // GH #336: nobody cancelled these. The run stopped and the
               // control plane withheld them, so nothing was ever sent to
@@ -279,6 +308,15 @@ function RunDetail({
               {
                 label: "Not attempted",
                 value: summary.counts.cancelled,
+                tabular: true,
+              },
+              // GH #463: the parent run expired without dispatching this
+              // task. Never attempted, same as above, but kept as its own
+              // row rather than folded into "Not attempted" — one is an
+              // operator's choice, the other is a missed schedule window.
+              {
+                label: "Expired",
+                value: summary.counts.expired,
                 tabular: true,
               },
             ]}

--- a/apps/web/src/routes/_authed/updates/index.tsx
+++ b/apps/web/src/routes/_authed/updates/index.tsx
@@ -24,6 +24,14 @@ export const Route = createFileRoute("/_authed/updates/")({
 
 type RunStatus = UpdateRun["status"];
 
+// Defence in depth against version skew, mirroring
+// features/updates/update-status.tsx: `tsc` enforces that every RunStatus is
+// covered below, but a self-hosted control plane can still send a status
+// literal this bundle predates, so the dereferences below re-type the lookup
+// as partial rather than trusting the exhaustive type at runtime.
+const UNKNOWN_RUN_TONE: StatusTone = "muted";
+const UNKNOWN_RUN_LABEL = "Unknown";
+
 const RUN_STATUS_TONE: Record<RunStatus, StatusTone> = {
   pending: "muted",
   running: "info",
@@ -31,6 +39,15 @@ const RUN_STATUS_TONE: Record<RunStatus, StatusTone> = {
   // GH #255 Phase 2: a wave failed to prove itself; destructive tone flags
   // it for immediate attention among an otherwise calm list of runs.
   halted: "destructive",
+  // GH #463: waiting for scheduled_at, nothing has happened yet.
+  scheduled: "muted",
+  // GH #463: transient, the dispatcher is enqueueing this run's tasks right
+  // now — mirrors "Running".
+  dispatching: "info",
+  // GH #463: terminal, no site was contacted — a missed schedule, not a
+  // failed update, so this deliberately avoids "destructive" (see
+  // features/updates/update-status.tsx for the full reasoning).
+  expired: "warning",
 };
 
 const RUN_STATUS_LABEL: Record<RunStatus, string> = {
@@ -38,6 +55,9 @@ const RUN_STATUS_LABEL: Record<RunStatus, string> = {
   running: "Running",
   completed: "Completed",
   halted: "Halted",
+  scheduled: "Scheduled",
+  dispatching: "Dispatching",
+  expired: "Expired",
 };
 
 function UpdatesPage() {
@@ -95,9 +115,22 @@ function UpdatesPage() {
                   </TableCell>
                   <TableCell>
                     <StatusChip
-                      tone={RUN_STATUS_TONE[run.status]}
-                      label={RUN_STATUS_LABEL[run.status]}
-                      pulse={run.status === "running"}
+                      tone={
+                        (
+                          RUN_STATUS_TONE as Partial<
+                            Record<RunStatus, StatusTone>
+                          >
+                        )[run.status] ?? UNKNOWN_RUN_TONE
+                      }
+                      label={
+                        (
+                          RUN_STATUS_LABEL as Partial<Record<RunStatus, string>>
+                        )[run.status] ?? UNKNOWN_RUN_LABEL
+                      }
+                      pulse={
+                        run.status === "running" ||
+                        run.status === "dispatching"
+                      }
                     />
                   </TableCell>
                   <TableCell>


### PR DESCRIPTION
## Summary

PR #475 widens `UpdateRun["status"]` (adds `scheduled`, `dispatching`,
`expired`) and `UpdateTask["status"]` (adds `scheduled`, `expired`). This
branches off `feat/463-phase1-go` and must merge together with #475 — the
dashboard breaks the moment that PR ships on its own.

Two exhaustive `Record<>` maps in `update-status.tsx` were dereferenced with
no fallback, so `tsc --noEmit` failed and, at runtime, the first `scheduled`
run threw inside the updates list and run detail pages.

- `TASK_TONE`/`RUN_TONE` (`update-status.tsx`) — new keys added, tones chosen
  so `scheduled`/`expired` read as neutral, never as a failed update (no site
  was contacted in either case). `expired` is kept visually distinct from
  `cancelled`: one is an operator's choice, the other is a missed window.
- Both maps stay exhaustive (`tsc` still catches a missing key at build time)
  **and** get a safe runtime fallback at the dereference, for the case a
  self-hosted control plane is newer than the browser bundle and sends a
  status literal this build predates.
- The same duplicated `RunStatus` tone/label maps in
  `routes/_authed/updates/$runId.tsx` and `routes/_authed/updates/index.tsx`
  needed the same fix — they're keyed on the same widened `UpdateRun["status"]`
  and would have failed to compile the same way.
- `summarize.ts`: `counts`/`done`/`isTerminalTaskStatus`/`isTerminalRunStatus`
  updated to include the new statuses, matching the control plane's own
  `terminal()` predicate (`scheduled`/`dispatching` are not terminal;
  `expired` is).
- `retry-contract.ts`'s `notRetryableReason`: `scheduled` now reads as
  "has not finished yet" instead of falling through to the generic terminal
  message; `expired` gets its own accurate reason ("expired before it could
  run") rather than reading like a failed update. This is display text only —
  the actual retry decision is still 100% the server's `retryable`/
  `retry_class` fields, never client-inferred.
- `bulk-action-drawer.tsx`'s `rollupStatus` previously had no branch for
  `scheduled`/`expired` and fell through to `"succeeded"` — a site row whose
  tasks were all `scheduled` or all `expired` would have rendered as "Done".
  Fixed with the same tone/label choices as above.

## Finding (GH #463 follow-up, not fixed here)

`apps/api/internal/update/model.go` `retryClassify` (~line 381) has no `case
TaskExpired`; it falls through the `default` (meant for `TaskSucceeded`) and
returns `false, RetryClassNotApplicable`. Per the doc comment on
`RetryClassNeverRan` and the parallel with `TaskCancelled` (also "terminal,
nothing sent"), an `expired` task looks like it should classify the same way
`cancelled` does — retryable, `never_ran`. Today it does not, so an expired
task currently shows no retry checkbox. This is Go, out of scope for this PR,
flagging for backend-architect.

Also found, same defect class, other exhaustive `Record<>`s keyed on
`UpdateTask["status"]`/`UpdateRun["status"]` specifically: none left after
this PR (all six call sites above are the full set — confirmed via
`grep -rn '\["status"\]' apps/web/src`). Other exhaustive status maps in
apps/web are keyed on hand-maintained local unions (`InvitationStatus`,
`ScanStatus`, `RestoreStatus`, `ScheduleRunStatus`, `AssetStatus`, etc.), not
directly derived from a generated type, so they don't fail to compile the
same way when the OpenAPI spec changes — but they carry a related, worse risk
(silent drift, no compile-time enforcement at all) worth a separate pass.
`apps/web/src/features/sites/bulk-action-drawer-panel.tsx` has the identical
`rollupStatus`/`toneFor`/`statusLabel` duplication and the identical
would-roll-up-to-"succeeded" bug, but it is dead code (not imported anywhere
in the route tree) — left as-is.

## Test plan

- [x] `pnpm -C apps/web typecheck` — passes
- [x] `pnpm -C apps/web lint` — 0 errors (9 pre-existing warnings, unrelated)
- [x] `pnpm -C apps/web test -- --run` — 141 files / 1687 tests passed
- [x] `git diff --stat` against base touches only `apps/web/**`