### PR TITLE
feat(web): the operator's view of a scheduled update run (#463 phase 3)

### DIFF
--- a/apps/web/src/features/sites/bulk-action-drawer-panel.tsx
+++ b/apps/web/src/features/sites/bulk-action-drawer-panel.tsx
@@ -306,17 +306,36 @@ function priority(status: UpdateTask["status"]): number {
       return 4;
     case "skipped":
       return 5;
-    default:
+    // GH #463: waiting on its own start time, not yet actionable — same tier
+    // as an ordinary queued task. Matches bulk-action-drawer.tsx.
+    case "scheduled":
+      return 1;
+    // GH #255 / #463: never dispatched, run halted or expired first.
+    case "cancelled":
+    case "expired":
       return 6;
+    default:
+      return 7;
   }
 }
 
 function rollupStatus(tasks: UpdateTask[]): UpdateTask["status"] {
   if (tasks.some((t) => t.status === "running")) return "running";
   if (tasks.some((t) => t.status === "pending")) return "pending";
+  // GH #463: any task still waiting on its schedule means this row is not
+  // done either. This MUST be checked before the terminal rollups below: a
+  // row of entirely `scheduled` tasks previously fell all the way through to
+  // the `return "succeeded"` default, so a deferred bulk update reported
+  // every site as Done while nothing had been sent to any of them.
+  if (tasks.some((t) => t.status === "scheduled")) return "scheduled";
   if (tasks.some((t) => t.status === "failed")) return "failed";
   if (tasks.some((t) => t.status === "rolled_back")) return "rolled_back";
   if (tasks.every((t) => t.status === "skipped")) return "skipped";
+  // A halted run cancels every task it had not dispatched; an expired run
+  // never dispatched any. Neither may fall through to "succeeded", which
+  // would show an untouched site as done. Same reasoning as `scheduled`.
+  if (tasks.every((t) => t.status === "cancelled")) return "cancelled";
+  if (tasks.every((t) => t.status === "expired")) return "expired";
   return "succeeded";
 }
 
@@ -331,6 +350,13 @@ function toneFor(status: UpdateTask["status"]): StatusTone {
     case "rolled_back":
       return "destructive";
     case "skipped":
+      return "muted";
+    // GH #255 / #463: none of these read as an error — nothing was sent to
+    // the site. See features/updates/update-status.tsx for why `expired` in
+    // particular stays out of "destructive".
+    case "cancelled":
+    case "scheduled":
+    case "expired":
       return "muted";
     default:
       return "muted";
@@ -351,6 +377,15 @@ function statusLabel(status: UpdateTask["status"]): string {
       return "Rolled back";
     case "skipped":
       return "Skipped";
+    // GH #255 / #463: all three previously rendered as "Unknown", which tells
+    // an operator nothing about the one fact that matters for each of them:
+    // no site was contacted.
+    case "cancelled":
+      return "Not attempted";
+    case "scheduled":
+      return "Scheduled";
+    case "expired":
+      return "Expired";
     default:
       return "Unknown";
   }

--- a/apps/web/src/features/updates/retry-contract.ts
+++ b/apps/web/src/features/updates/retry-contract.ts
@@ -180,13 +180,18 @@ export function notRetryableReason(task: RetryTask): string {
   }
   // GH #463: `expired` is its own case, not the generic terminal fallback
   // below. Nothing was ever sent to the site (same as `cancelled`/
-  // `never_ran`), so this text must not read like a failed update. Today the
-  // server still classifies an expired task as `not_applicable` (see
-  // apps/api/internal/update/model.go retryClassify, which has no case for
-  // TaskExpired and falls through its default), so this row currently has no
-  // checkbox and this is the reason shown. This client never overrides that
-  // server verdict — see `isRetrySelectable` above — it only has to describe
-  // the true reason accurately.
+  // `never_ran`), so this text must not read like a failed update.
+  //
+  // The control plane classifies an expired task as retryable/`never_ran`
+  // (apps/api/internal/update/model.go:405, `case TaskCancelled, TaskExpired:
+  // return true, RetryClassNeverRan`), so in practice an expired row DOES get
+  // a checkbox and this string is unreachable for it. It stays because this
+  // function is keyed on `status` while selectability is keyed on the
+  // server's `retry_class`, and a control plane that withheld the class would
+  // otherwise fall through to the generic "cannot run this update again"
+  // below, which is the wrong story. This client never overrides the server
+  // verdict — see `isRetrySelectable` above — it only has to describe
+  // whatever reason applies accurately.
   if (task.status === "expired") {
     return "Cannot be retried: this update expired before it could run.";
   }

--- a/apps/web/src/features/updates/schedule-notices.tsx
+++ b/apps/web/src/features/updates/schedule-notices.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from "react";
+import { CalendarClock } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  GRACE_WINDOW_HOURS,
+  formatAbsolute,
+  formatClockAndDay,
+  formatCountdown,
+  outstandingWork,
+} from "./schedule";
+import type { UpdateRun } from "@wpmgr/api";
+
+/**
+ * How often a live countdown re-renders. One second reads as a clock rather
+ * than a stale label, and a scheduled run is the one screen an operator sits
+ * on waiting for something to happen. Cheap: one `setInterval` per mounted
+ * countdown, cleared on unmount, and only ever mounted for a run that is
+ * actually `scheduled`.
+ */
+const TICK_MS = 1000;
+
+/** Current wall clock, re-read every second while mounted. */
+function useTick(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = window.setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => window.clearInterval(id);
+  }, [active]);
+  return now;
+}
+
+/**
+ * "Starts in 8h 42m · 02:00 19 Aug 2026 Europe/London".
+ *
+ * GH #463: relative AND absolute, and the absolute always carries its zone.
+ * The countdown answers "how long have I got"; the stamp answers "is that the
+ * time I meant"; the zone is what makes the second answer true. Before this,
+ * the run page printed the raw ISO string and the wizard's `datetime-local`
+ * named no zone at all, so an operator in one zone scheduling a site in
+ * another was shown neither.
+ */
+export function ScheduleCountdown({
+  scheduledAt,
+  className,
+}: {
+  scheduledAt: string;
+  className?: string;
+}) {
+  const now = useTick(true);
+  const countdown = formatCountdown(scheduledAt, now);
+  const absolute = formatAbsolute(scheduledAt);
+
+  return (
+    <span
+      className={cn(
+        "inline-flex flex-wrap items-baseline gap-x-1.5 tabular-nums",
+        className,
+      )}
+    >
+      <span className="font-medium text-[var(--color-foreground)]">
+        {countdown ? `Starts in ${countdown}` : "Due now"}
+      </span>
+      <span aria-hidden="true" className="text-[var(--color-muted-foreground)]">
+        ·
+      </span>
+      <time
+        dateTime={scheduledAt}
+        className="text-[var(--color-muted-foreground)]"
+      >
+        {absolute}
+      </time>
+    </span>
+  );
+}
+
+/**
+ * GH #463 — the expired state. This is the feature, not an error message.
+ *
+ * A schedule that quietly stops is the defining failure of this product
+ * category, so this says three things in this order: what was supposed to
+ * happen, why it did not, and that NOTHING WAS TOUCHED. Then one action.
+ *
+ * Two deliberate choices that are easy to undo by accident:
+ *
+ *  1. `warning`, never `destructive`. A missed schedule is not a broken site.
+ *     Red here would tell an agency that their client's sites failed when
+ *     nothing was ever sent to them, which is both false and the more
+ *     alarming of the two readings. Same call as the `expired` run tone in
+ *     features/updates/update-status.tsx.
+ *  2. No apology. "Sorry, something went wrong" hides the one fact the
+ *     operator needs, which is that their fleet is untouched and the updates
+ *     are still outstanding.
+ *
+ * The grace window is stated as a number the control plane enforces
+ * (apps/api/internal/update/dispatch.go:45), not as a vague "too long ago".
+ */
+export function ExpiredRunNotice({
+  run,
+  onRunNow,
+}: {
+  run: UpdateRun;
+  /**
+   * Re-run the work now. Undefined when the operator's role or the run's
+   * shape makes retry unavailable, in which case no button is rendered at
+   * all: a disabled action with no stated cause is worse than none.
+   */
+  onRunNow?: () => void;
+}) {
+  const { updates, sites } = outstandingWork(run);
+  // `updated_at` is the instant the dispatcher moved this run to `expired`,
+  // which is the moment WPMgr reached it. There is no separate `expired_at`
+  // on the wire, and inventing one client-side would be a guess.
+  const reachedAt = formatClockAndDay(run.updated_at);
+  const scheduledFor = run.scheduled_at
+    ? formatClockAndDay(run.scheduled_at)
+    : null;
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "rounded-xl border p-4 sm:p-5",
+        "border-[var(--color-warning)]/30 bg-[var(--color-warning-subtle)]",
+        "text-[var(--color-warning-subtle-fg)]",
+      )}
+    >
+      <div className="flex gap-3">
+        <CalendarClock
+          aria-hidden="true"
+          className="mt-0.5 size-5 shrink-0 text-[var(--color-warning)]"
+        />
+        <div className="space-y-2">
+          <h2 className="text-sm font-semibold text-[var(--color-foreground)]">
+            This run didn&rsquo;t start, and nothing was sent to your sites
+          </h2>
+          <p className="text-sm">
+            {scheduledFor ? `Scheduled for ${scheduledFor}. ` : null}
+            WPMgr couldn&rsquo;t reach it until {reachedAt}, past the{" "}
+            {GRACE_WINDOW_HOURS}-hour window for update runs.
+          </p>
+          <p className="text-sm">
+            All {updates} update{updates === 1 ? "" : "s"}{" "}
+            {updates === 1 ? "is" : "are"} still outstanding across {sites}{" "}
+            site{sites === 1 ? "" : "s"}. No site was contacted.
+          </p>
+          {onRunNow ? (
+            <div className="pt-1">
+              <Button type="button" size="sm" onClick={onRunNow}>
+                Run now
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * GH #463 — the waiting state on the run detail page. Says plainly that the
+ * fleet has not been touched yet, which is the fact an operator opening a
+ * scheduled run is checking for.
+ */
+export function ScheduledRunNotice({
+  scheduledAt,
+  onCancel,
+}: {
+  scheduledAt: string;
+  /** Omitted entirely while no cancel endpoint exists; see the route file. */
+  onCancel?: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "rounded-xl border p-4 sm:p-5",
+        "border-[var(--color-border)] bg-[var(--color-muted)]/40",
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex gap-3">
+          <CalendarClock
+            aria-hidden="true"
+            className="mt-0.5 size-5 shrink-0 text-[var(--color-muted-foreground)]"
+          />
+          <div className="space-y-1.5">
+            <h2 className="text-sm font-semibold text-[var(--color-foreground)]">
+              Waiting for its start time
+            </h2>
+            <ScheduleCountdown scheduledAt={scheduledAt} className="text-sm" />
+            <p className="text-sm text-[var(--color-muted-foreground)]">
+              No site has been contacted yet. You can still update these
+              plugins immediately in the meantime.
+            </p>
+          </div>
+        </div>
+        {onCancel ? (
+          <Button type="button" size="sm" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/updates/schedule.test.ts
+++ b/apps/web/src/features/updates/schedule.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SCHEDULE_MAX_LEAD_DAYS,
+  SCHEDULE_SKEW_GRACE_MS,
+  formatAbsolute,
+  formatCountdown,
+  toLocalInputValue,
+  validateSchedule,
+} from "./schedule";
+
+const NOW = Date.UTC(2026, 7, 19, 6, 0, 0); // 2026-08-19T06:00:00Z
+
+describe("formatCountdown", () => {
+  it("counts down in days and hours past a day out", () => {
+    expect(formatCountdown(new Date(NOW + 3 * 86400_000 + 4 * 3600_000).toISOString(), NOW)).toBe(
+      "3d 4h",
+    );
+  });
+
+  it("counts down in hours and minutes inside a day", () => {
+    expect(
+      formatCountdown(new Date(NOW + 8 * 3600_000 + 42 * 60_000).toISOString(), NOW),
+    ).toBe("8h 42m");
+  });
+
+  it("counts down in minutes, then seconds, as it closes in", () => {
+    expect(formatCountdown(new Date(NOW + 5 * 60_000).toISOString(), NOW)).toBe("5m");
+    expect(formatCountdown(new Date(NOW + 45_000).toISOString(), NOW)).toBe("45s");
+  });
+
+  // A countdown that runs negative is how an operator learns not to trust the
+  // number. Null is the caller's signal to stop saying "starts in".
+  it("returns null once the instant has passed", () => {
+    expect(formatCountdown(new Date(NOW - 1000).toISOString(), NOW)).toBeNull();
+    expect(formatCountdown(new Date(NOW).toISOString(), NOW)).toBeNull();
+  });
+
+  it("returns null rather than NaN for an unparseable instant", () => {
+    expect(formatCountdown("not a date", NOW)).toBeNull();
+  });
+});
+
+describe("formatAbsolute", () => {
+  // The defect: the run page printed the raw ISO string, so an operator was
+  // never told which zone the time was in.
+  it("always names the zone the time is expressed in", () => {
+    const out = formatAbsolute("2026-08-19T02:00:00Z", "Australia/Sydney");
+    expect(out).toContain("Australia/Sydney");
+    // 02:00 UTC is 12:00 the same day in Sydney (AEST, UTC+10).
+    expect(out).toContain("12:00");
+    expect(out).toContain("19");
+  });
+
+  it("renders the same instant differently in two zones", () => {
+    const iso = "2026-08-19T02:00:00Z";
+    expect(formatAbsolute(iso, "Europe/London")).not.toBe(
+      formatAbsolute(iso, "Australia/Sydney"),
+    );
+  });
+
+  it("returns the input unchanged rather than 'Invalid Date'", () => {
+    expect(formatAbsolute("nonsense", "UTC")).toBe("nonsense");
+  });
+});
+
+describe("validateSchedule", () => {
+  it("accepts an empty value: no schedule means run now", () => {
+    expect(validateSchedule("", NOW)).toBeNull();
+  });
+
+  it("accepts a future time inside the cap", () => {
+    expect(
+      validateSchedule(toLocalInputValue(new Date(NOW + 3600_000)), NOW),
+    ).toBeNull();
+  });
+
+  // Mirrors apps/api/internal/update/service.go:319, which refuses with
+  // domain.Validation("schedule_in_past", ...).
+  it("refuses a past time with the server's own code", () => {
+    const problem = validateSchedule(
+      toLocalInputValue(new Date(NOW - 60 * 60_000)),
+      NOW,
+    );
+    expect(problem?.code).toBe("schedule_in_past");
+  });
+
+  // scheduleSkewGrace (service.go:289) is 2 minutes: the instant is built
+  // from a browser clock, so "now" routinely lands slightly behind the
+  // server's. A client bound stricter than the server would refuse a
+  // schedule the API accepts, which is the one direction this must not fail.
+  it("tolerates the server's clock-skew grace instead of refusing inside it", () => {
+    const justBehind = new Date(NOW - (SCHEDULE_SKEW_GRACE_MS - 1000));
+    expect(validateSchedule(toLocalInputValue(justBehind), NOW)).toBeNull();
+  });
+
+  // Mirrors service.go:322, domain.Validation("schedule_too_far", ...).
+  it("refuses beyond the 30-day cap with the server's own code", () => {
+    const tooFar = new Date(NOW + (SCHEDULE_MAX_LEAD_DAYS + 1) * 86400_000);
+    expect(validateSchedule(toLocalInputValue(tooFar), NOW)?.code).toBe(
+      "schedule_too_far",
+    );
+  });
+
+  it("accepts a time just inside the cap", () => {
+    const nearly = new Date(NOW + (SCHEDULE_MAX_LEAD_DAYS - 1) * 86400_000);
+    expect(validateSchedule(toLocalInputValue(nearly), NOW)).toBeNull();
+  });
+
+  it("reports an unparseable value rather than passing it through", () => {
+    expect(validateSchedule("13:00 tomorrow", NOW)?.code).toBe(
+      "schedule_unparseable",
+    );
+  });
+});
+
+describe("toLocalInputValue", () => {
+  // toISOString() would shift to UTC and silently move the operator's time.
+  it("formats in LOCAL time, not UTC", () => {
+    const at = new Date(2026, 7, 19, 2, 0, 0);
+    expect(toLocalInputValue(at)).toBe("2026-08-19T02:00");
+  });
+
+  it("zero-pads every component", () => {
+    expect(toLocalInputValue(new Date(2026, 0, 5, 9, 7))).toBe("2026-01-05T09:07");
+  });
+});

--- a/apps/web/src/features/updates/schedule.ts
+++ b/apps/web/src/features/updates/schedule.ts
@@ -1,0 +1,235 @@
+// GH #463 Phase 3 — the operator's view of a scheduled run.
+//
+// Pure helpers only, so they can be unit-tested without a DOM and imported by
+// both components and route files without tripping react-refresh's
+// only-export-components rule.
+//
+// Every bound below mirrors a constant the control plane actually enforces.
+// The client re-states them so an operator is told at the point of typing
+// rather than by a 422 after submit; the SERVER remains the authority, and
+// these are deliberately never stricter than it, or the UI would refuse a
+// schedule the API would have accepted.
+
+import type { UpdateRun } from "@wpmgr/api";
+
+/**
+ * How late a scheduled run may fire and still be run at all. Beyond this the
+ * control plane moves it to `expired` and contacts no site.
+ *
+ * Mirrors `dispatchGraceWindow` — apps/api/internal/update/dispatch.go:45
+ * (`const dispatchGraceWindow = 2 * time.Hour`).
+ */
+export const GRACE_WINDOW_HOURS = 2;
+
+/**
+ * The furthest ahead a run may be scheduled.
+ *
+ * Mirrors `scheduleMaxLead` — apps/api/internal/update/service.go:280
+ * (`scheduleMaxLead = 30 * 24 * time.Hour`). The server rejects anything
+ * beyond it with `422 schedule_too_far`.
+ */
+export const SCHEDULE_MAX_LEAD_DAYS = 30;
+
+/**
+ * How far in the PAST a scheduled time may land and still be read as "now".
+ *
+ * Mirrors `scheduleSkewGrace` — apps/api/internal/update/service.go:289
+ * (`scheduleSkewGrace = 2 * time.Minute`). This exists because the instant is
+ * computed from a browser clock, so a submission for "now" routinely lands a
+ * few seconds behind the server's. The client MUST honour it: rejecting
+ * inside this window would refuse a schedule the API accepts, which is the
+ * one direction a client-side bound must never fail in.
+ */
+export const SCHEDULE_SKEW_GRACE_MS = 2 * 60 * 1000;
+
+/**
+ * The IANA zone the browser is in, which is the zone a `datetime-local` value
+ * is interpreted in. Falls back to the empty string on a runtime with no
+ * `Intl` resolution rather than guessing UTC, so callers can drop the label
+ * instead of printing something false.
+ *
+ * This is deliberately the OPERATOR's zone and never a site's: an update run
+ * targets many sites (or a whole tag), so there is no single site zone to
+ * resolve, and the instant actually submitted is built from this one.
+ */
+export function browserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Absolute time, always carrying the zone it is expressed in.
+ *
+ * The defect this exists to fix: the run page printed `run.scheduled_at` raw
+ * (an ISO-8601 UTC string) and the wizard offered a bare `datetime-local`, so
+ * an operator in London scheduling a Sydney site was shown neither zone.
+ * A time without its zone is not an answer to "when does this run".
+ */
+export function formatAbsolute(iso: string, timeZone?: string): string {
+  const at = new Date(iso);
+  if (Number.isNaN(at.getTime())) return iso;
+  const zone = timeZone || browserTimeZone();
+  const stamp = new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    ...(zone ? { timeZone: zone } : {}),
+  }).format(at);
+  return zone ? `${stamp} ${zone}` : stamp;
+}
+
+/** Short "02:00 on 19 Aug" form used inside the expired notice's prose. */
+export function formatClockAndDay(iso: string, timeZone?: string): string {
+  const at = new Date(iso);
+  if (Number.isNaN(at.getTime())) return iso;
+  const zone = timeZone || browserTimeZone();
+  const opts = zone ? { timeZone: zone } : {};
+  const clock = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    ...opts,
+  }).format(at);
+  const day = new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "short",
+    ...opts,
+  }).format(at);
+  return `${clock} on ${day}`;
+}
+
+/**
+ * "8h 42m" / "3d 4h" / "45s". Returns null once the instant has passed, which
+ * is the caller's signal to stop saying "starts in" — a countdown that runs
+ * negative is how an operator learns not to trust the number.
+ */
+export function formatCountdown(iso: string, now: number = Date.now()): string | null {
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) return null;
+  const ms = target - now;
+  if (ms <= 0) return null;
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+}
+
+/**
+ * The full waiting line: "Starts in 8h 42m · 02:00 19 Aug 2026 Europe/London".
+ *
+ * Relative AND absolute, together, because neither alone is enough: the
+ * countdown answers "how long do I have", the stamp answers "did I pick the
+ * time I meant", and the zone is what makes the second one true.
+ */
+export function scheduleSubline(iso: string, now: number = Date.now()): string {
+  const countdown = formatCountdown(iso, now);
+  const absolute = formatAbsolute(iso);
+  return countdown ? `Starts in ${countdown} · ${absolute}` : `Due now · ${absolute}`;
+}
+
+export type ScheduleProblem =
+  | { code: "schedule_in_past"; message: string }
+  | { code: "schedule_too_far"; message: string }
+  | { code: "schedule_unparseable"; message: string };
+
+/**
+ * Client-side pre-flight for the wizard's `datetime-local` value.
+ *
+ * The two codes are the server's own, quoted from
+ * apps/api/internal/update/service.go:320 and :323 — `schedule_in_past` and
+ * `schedule_too_far`, both `domain.Validation`. Matching them keeps one
+ * vocabulary across the wire rather than inventing a second client-only one.
+ *
+ * `value` is a raw `datetime-local` string ("2026-08-19T02:00"), which the
+ * browser interprets in its own zone. That is the same reading `new Date()`
+ * gives it and the same instant the wizard submits, so validating here
+ * validates exactly what will be sent.
+ */
+export function validateSchedule(
+  value: string,
+  now: number = Date.now(),
+): ScheduleProblem | null {
+  if (!value) return null;
+  const at = new Date(value).getTime();
+  if (Number.isNaN(at)) {
+    return {
+      code: "schedule_unparseable",
+      message: "That is not a valid date and time.",
+    };
+  }
+  if (at < now - SCHEDULE_SKEW_GRACE_MS) {
+    return {
+      code: "schedule_in_past",
+      message:
+        "That time has already passed. Pick a future time, or clear the schedule to run now.",
+    };
+  }
+  if (at > now + SCHEDULE_MAX_LEAD_DAYS * 24 * 60 * 60 * 1000) {
+    return {
+      code: "schedule_too_far",
+      message: `A run cannot be scheduled more than ${SCHEDULE_MAX_LEAD_DAYS} days ahead.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * `min` / `max` for the wizard's `<input type="datetime-local">`, in the
+ * local-naive format the control expects. Native bounds are a hint the
+ * browser can enforce in its own picker; `validateSchedule` above is the real
+ * gate, because a typed value can still land outside them.
+ */
+export function scheduleBounds(now: number = Date.now()): {
+  min: string;
+  max: string;
+} {
+  return {
+    min: toLocalInputValue(new Date(now)),
+    max: toLocalInputValue(
+      new Date(now + SCHEDULE_MAX_LEAD_DAYS * 24 * 60 * 60 * 1000),
+    ),
+  };
+}
+
+/**
+ * The numbers the expired notice quotes, taken from the run's own tasks.
+ *
+ * An expired run's tasks are all `expired` too (the control plane moves them
+ * together), so the outstanding count is that set. It falls back to the whole
+ * task list, and then to the list-response `task_count`/`site_count`, rather
+ * than printing a confident zero: "0 updates are still outstanding" would be
+ * the exact reassurance this notice exists to withhold.
+ */
+export function outstandingWork(run: UpdateRun): {
+  updates: number;
+  sites: number;
+} {
+  const tasks = run.tasks ?? [];
+  const neverRan = tasks.filter((t) => t.status === "expired");
+  const counted = neverRan.length > 0 ? neverRan : tasks;
+  const sites = new Set(counted.map((t) => t.site_id)).size;
+  return {
+    updates: counted.length || run.task_count || 0,
+    sites: sites || run.site_count || 0,
+  };
+}
+
+/** "2026-08-19T02:00" in LOCAL time — `toISOString()` would silently shift to UTC. */
+export function toLocalInputValue(at: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${at.getFullYear()}-${pad(at.getMonth() + 1)}-${pad(at.getDate())}` +
+    `T${pad(at.getHours())}:${pad(at.getMinutes())}`
+  );
+}

--- a/apps/web/src/features/updates/update-wizard.tsx
+++ b/apps/web/src/features/updates/update-wizard.tsx
@@ -16,6 +16,13 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useCreateUpdateRun } from "@/features/updates/use-updates";
 import { isAgentPluginComponent } from "@/features/updates/agent-plugin";
+import {
+  SCHEDULE_MAX_LEAD_DAYS,
+  browserTimeZone,
+  formatAbsolute,
+  scheduleBounds,
+  validateSchedule,
+} from "@/features/updates/schedule";
 import type { Site, UpdateItem, UpdateRunCreate } from "@wpmgr/api";
 
 // Bulk update wizard (operator+). Opened from the sites list once the user has
@@ -248,6 +255,17 @@ function WizardForm({
   }
 
   const items = buildItems();
+
+  // GH #463: the schedule bounds the control plane enforces, restated at the
+  // point of typing. `scheduleProblem` is recomputed on every render rather
+  // than memoised on `scheduleAt` alone, because it is time-relative: a value
+  // that was two minutes out when it was typed is in the past by the time the
+  // operator finishes choosing plugins, and the stale verdict would let it
+  // through to a 422.
+  const scheduleZone = browserTimeZone();
+  const scheduleBoundsValue = scheduleBounds();
+  const scheduleProblem = validateSchedule(scheduleAt);
+
   const targetDescribed =
     target.kind === "sites"
       ? `${target.siteIds.length} selected site${target.siteIds.length === 1 ? "" : "s"}`
@@ -262,6 +280,10 @@ function WizardForm({
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (items.length === 0) return;
+    // GH #463: re-validate against the clock AT SUBMIT, not against the
+    // verdict rendered earlier. The form is `noValidate`, so `min`/`max` on
+    // the input are a picker hint only and never a gate.
+    if (validateSchedule(scheduleAt)) return;
 
     const scheduleIso = scheduleAt
       ? new Date(scheduleAt).toISOString()
@@ -439,17 +461,50 @@ function WizardForm({
             </label>
 
             <div className="space-y-1">
-              <Label htmlFor="schedule-at">Schedule (optional)</Label>
+              {/* GH #463: the field now names the zone it is read in. A
+                  `datetime-local` value is interpreted in the BROWSER's zone,
+                  and that is the instant submitted below — so an operator in
+                  London scheduling a Sydney site was previously shown neither
+                  zone and had no way to tell which one they had picked. */}
+              <Label htmlFor="schedule-at">
+                Schedule (optional)
+                {scheduleZone ? (
+                  <span className="ml-1.5 font-normal text-[var(--color-muted-foreground)]">
+                    in {scheduleZone}
+                  </span>
+                ) : null}
+              </Label>
               <Input
                 id="schedule-at"
                 type="datetime-local"
                 value={scheduleAt}
                 onChange={(e) => setScheduleAt(e.target.value)}
                 className="w-60"
+                min={scheduleBoundsValue.min}
+                max={scheduleBoundsValue.max}
+                aria-invalid={scheduleProblem ? true : undefined}
+                aria-describedby={
+                  scheduleProblem ? "schedule-at-error" : "schedule-at-hint"
+                }
               />
-              <p className="text-xs text-[var(--color-muted-foreground)]">
-                Leave empty to run immediately.
-              </p>
+              {scheduleProblem ? (
+                <p
+                  id="schedule-at-error"
+                  role="alert"
+                  className="text-xs text-[var(--color-destructive)]"
+                >
+                  {scheduleProblem.message}
+                </p>
+              ) : (
+                <p
+                  id="schedule-at-hint"
+                  className="text-xs text-[var(--color-muted-foreground)]"
+                >
+                  {scheduleAt
+                    ? `Runs at ${formatAbsolute(new Date(scheduleAt).toISOString())}. Leave empty to run immediately.`
+                    : `Leave empty to run immediately. Up to ${SCHEDULE_MAX_LEAD_DAYS} days ahead.`}
+                </p>
+              )}
             </div>
           </div>
 
@@ -482,7 +537,13 @@ function WizardForm({
           </Button>
           <Button
             type="submit"
-            disabled={create.isPending || items.length === 0}
+            disabled={
+              create.isPending ||
+              items.length === 0 ||
+              // GH #463: a schedule the control plane would refuse
+              // (`schedule_in_past` / `schedule_too_far`) never reaches it.
+              scheduleProblem !== null
+            }
           >
             {submitLabel}
           </Button>

--- a/apps/web/src/features/updates/use-row-update.ts
+++ b/apps/web/src/features/updates/use-row-update.ts
@@ -98,6 +98,24 @@ function projectStatus(
       return "rolled_back";
     case "skipped":
       return "skipped";
+    // GH #463: `scheduled` reached this switch through the `default` arm and
+    // came out "pending", so a row whose update was deferred read as though
+    // it were queued and about to go — for hours. It has not been sent and
+    // will not be until its start time, which is a different thing to tell
+    // an operator. RowUpdateState has no deferred member and widening it
+    // would change every consumer of this hook, so this maps to `idle`: the
+    // row is not mid-flight, and the run's own page carries the countdown.
+    case "scheduled":
+      return "idle";
+    // GH #463: `expired` likewise fell through to "pending", leaving a row
+    // spinning forever on work that will never be attempted. Nothing was
+    // sent to the site, which is `skipped`'s meaning here, not `failed`'s.
+    case "expired":
+      return "skipped";
+    // GH #255: never dispatched because its run halted first. Same shape as
+    // `expired` above, and it had the same `default` bug.
+    case "cancelled":
+      return "skipped";
     default:
       return "pending";
   }

--- a/apps/web/src/routes/_authed/updates/$runId.tsx
+++ b/apps/web/src/routes/_authed/updates/$runId.tsx
@@ -38,6 +38,11 @@ import {
   type RetryTask,
 } from "@/features/updates/retry-contract";
 import { useRetrySelection } from "@/features/updates/use-retry-selection";
+import { formatAbsolute } from "@/features/updates/schedule";
+import {
+  ExpiredRunNotice,
+  ScheduledRunNotice,
+} from "@/features/updates/schedule-notices";
 import { RetryActionBar } from "@/features/updates/retry-action-bar";
 import { RetryRunDialog } from "@/features/updates/retry-dialog";
 import { useSites } from "@/features/sites/use-sites";
@@ -244,8 +249,12 @@ function RunDetail({
         subline={
           <>
             Created {created ?? run.created_at}
+            {/* GH #463: this printed `run.scheduled_at` raw — an ISO-8601 UTC
+                string, in a UI whose whole job here is telling an operator
+                WHEN their fleet gets touched. formatAbsolute always names the
+                zone the time is expressed in. */}
             {run.scheduled_at
-              ? ` · Scheduled for ${run.scheduled_at}`
+              ? ` · Scheduled for ${formatAbsolute(run.scheduled_at)}`
               : ""}
           </>
         }
@@ -263,6 +272,38 @@ function RunDetail({
           ) : undefined
         }
       />
+
+      {/* GH #463: waiting. Says plainly that no site has been contacted, which
+          is what an operator opening a scheduled run is checking. `onCancel`
+          is deliberately omitted: the control plane has the
+          CancelScheduledUpdateRun query but no HTTP route yet, and a Cancel
+          button that cannot cancel is worse than none. */}
+      {run.status === "scheduled" && run.scheduled_at ? (
+        <ScheduledRunNotice scheduledAt={run.scheduled_at} />
+      ) : null}
+
+      {/* GH #463: the expired state. Warning, never destructive — a missed
+          schedule is not a broken site, and red here would tell an agency
+          that a client's sites failed when nothing was ever sent. "Run now"
+          reuses the retry path, which is genuinely available: the control
+          plane classifies an expired task as retryable/`never_ran`
+          (apps/api/internal/update/model.go:405). */}
+      {run.status === "expired" ? (
+        <ExpiredRunNotice
+          run={run}
+          onRunNow={
+            retryAvailable && selection.selectableTasks.length > 0
+              ? () => {
+                  // Every task of an expired run is `never_ran`, so "Run now"
+                  // means all of them, not whatever the default selection
+                  // happened to be.
+                  selection.setAllSelectable(true);
+                  setRetryOpen(true);
+                }
+              : undefined
+          }
+        />
+      ) : null}
 
       {halted ? (
         // GH #255 Phase 2: a halt means a bad agent build was caught before

--- a/apps/web/src/routes/_authed/updates/index.tsx
+++ b/apps/web/src/routes/_authed/updates/index.tsx
@@ -14,6 +14,7 @@ import { PageHeader } from "@/components/shared/page-header";
 import { StatusChip } from "@/components/status/status-chip";
 import type { StatusTone } from "@/components/status/status-dot";
 import { useUpdateRuns } from "@/features/updates/use-updates";
+import { ScheduleCountdown } from "@/features/updates/schedule-notices";
 import { AgentFleetSummaryCard } from "@/features/fleet/AgentFleetSummaryCard";
 import { relativeTime } from "@/lib/utils";
 import type { UpdateRun } from "@wpmgr/api";
@@ -105,13 +106,26 @@ function UpdatesPage() {
               {runs.map((run) => (
                 <TableRow key={run.id} data-testid="update-run-row">
                   <TableCell className="font-medium">
-                    <Link
-                      to="/updates/$runId"
-                      params={{ runId: run.id }}
-                      className="font-mono text-sm underline-offset-4 hover:underline"
-                    >
-                      {run.id.slice(0, 8)}…
-                    </Link>
+                    <div className="flex flex-col gap-0.5">
+                      <Link
+                        to="/updates/$runId"
+                        params={{ runId: run.id }}
+                        className="font-mono text-sm underline-offset-4 hover:underline"
+                      >
+                        {run.id.slice(0, 8)}…
+                      </Link>
+                      {/* GH #463: a scheduled run is the one row in this list
+                          where "when" is the whole point, so the countdown and
+                          the zone-labelled absolute time sit directly under the
+                          id rather than in the Created column, which means
+                          something else. */}
+                      {run.status === "scheduled" && run.scheduled_at ? (
+                        <ScheduleCountdown
+                          scheduledAt={run.scheduled_at}
+                          className="text-xs font-normal"
+                        />
+                      ) : null}
+                    </div>
                   </TableCell>
                   <TableCell>
                     <StatusChip


### PR DESCRIPTION
Phase 3 of #463. Frontend only, stacked on `feat/463-phase1-go`.

The premise, from section 3 of the design: three of the five terminal
states mean **nothing was ever sent to your site**. If the dashboard does
not draw that line, an operator reading "failed" cannot tell a broken
update from an update that never left the building.

## What is here

**1. Scheduled runs in the runs list.** Relative countdown plus the
absolute time labelled with the zone it means, under the run id, matching
the design's mock. Live-ticking, one interval, mounted only for a run
that is actually `scheduled`.

**2. Cancel — blocked, see below.**

**3. The expired state.** Its own notice on the run detail page, saying in
order: what was supposed to happen, why it didn't, and that nothing was
touched, with the run's real task and site counts rather than the
design's illustrative numbers. Warning tone, never destructive. One
action, "Run now", wired to the existing retry dialog with everything
selected.

**4. The wizard.** Zone-labelled input, past-time rejection, 30-day cap,
`min`/`max` bounds, `aria-invalid`/`aria-describedby` and `role="alert"`.
Every bound restated from the constant the control plane enforces, and
never stricter than it.

**5. Skipped.** Already tone-correct from #480; the gap was elsewhere
(below).

## Finding: two surfaces #480's exhaustive maps could not reach

Both are `switch` with a `default`, so neither failed typecheck.

- `features/updates/use-row-update.ts` `projectStatus()` returned
  `"pending"` for `scheduled` / `expired` / `cancelled`. A deferred row
  read as queued and about to go, for hours; an expired one spun forever.
- `features/sites/bulk-action-drawer-panel.tsx` `rollupStatus()` fell
  through to `return "succeeded"` for a row of entirely `scheduled`
  tasks, so **a deferred bulk update reported every site as Done while
  nothing had been sent to any of them.** Same for all-`expired` and
  all-`cancelled`. `toneFor()` / `statusLabel()` / `priority()` rendered
  all three as "Unknown". This file is currently imported by nothing, so
  it is a landmine rather than a live defect; `bulk-action-drawer.tsx`,
  its near-duplicate, was taught correctly.

Also: `retry-contract.ts` carried a comment asserting the server still
classifies an expired task as `not_applicable`. It has not since
`a1fb03f`; `internal/update/model.go:405` returns
`(true, RetryClassNeverRan)`. Corrected, and that is what makes "Run now"
genuinely available.

## Blocked, needs backend-architect

**Cancel has no endpoint.** `CancelScheduledUpdateRun` exists only as a
sqlc query (`apps/api/db/query/updates.sql:710` → `internal/db/sqlc/
updates.sql.go:117`). No service method, no handler, no OpenAPI path, no
generated client operation. Rather than invent one, the scheduled-run
notice takes an optional `onCancel` and renders no button without it.

**Reschedule likewise.** `UpdateRunRetryRequest` takes `task_ids` only,
so there is no way to retry-at-a-time. Only "Run now" ships.

## Gates

```
pnpm -C apps/web typecheck   # $ tsc --noEmit, clean
pnpm -C apps/web lint        # 9 problems (0 errors, 9 warnings) - all pre-existing
pnpm -C apps/web test        # 142 files, 1704 tests passed
```
