### PR TITLE
fix(updates): stop scheduled/expired/cancelled tasks from mis-projecting row state

### DIFF
--- a/apps/web/src/features/updates/available-updates-card.tsx
+++ b/apps/web/src/features/updates/available-updates-card.tsx
@@ -580,16 +580,53 @@ function RowStateLine({
           Skipped
         </span>
       );
+    // GH #463: not yet eligible for dispatch (parent run hasn't reached its
+    // scheduled_at). Nothing is imminent, so plain muted static text —
+    // NOT the pulsing LiveIndicator used for pending/running.
+    case "scheduled":
+      return (
+        <span role="status" className="text-[var(--color-muted-foreground)]">
+          Scheduled
+        </span>
+      );
+    // GH #255 Phase 2: never dispatched because its run halted first.
+    case "cancelled":
+      return (
+        <span role="status" className="text-[var(--color-muted-foreground)]">
+          Not attempted
+        </span>
+      );
+    // GH #463: the parent run expired without dispatching this task.
+    case "expired":
+      return (
+        <span role="status" className="text-[var(--color-muted-foreground)]">
+          Expired
+        </span>
+      );
   }
 }
 
 function RowActionButton({ row, label }: { row: RowUpdate; label: string }) {
-  const isTerminalError = row.state === "failed" || row.state === "rolled_back";
+  // GH #463: expired/cancelled are terminal with nothing ever sent — give
+  // the operator a way to actually start it. Folded into the same Retry
+  // bucket as failed/rolled_back (row.retry() just calls trigger() again, a
+  // fresh immediate run), but the button itself is already the neutral
+  // `variant="outline"` treatment below, not destructive/warning styling, so
+  // nothing extra is needed to keep this muted since nothing actually failed.
+  const isTerminalError =
+    row.state === "failed" ||
+    row.state === "rolled_back" ||
+    row.state === "expired" ||
+    row.state === "cancelled";
   const isBusy =
     row.state === "starting" ||
     row.state === "pending" ||
     row.state === "running";
-  const isDone = row.state === "succeeded" || row.state === "skipped";
+  // GH #463: `scheduled` means a run already exists for this row and will
+  // fire later on its own — hide the action button entirely rather than show
+  // a disabled "Working…" button, since nothing is actively in progress.
+  const isDone =
+    row.state === "succeeded" || row.state === "skipped" || row.state === "scheduled";
 
   if (isDone) return null;
   if (isTerminalError) {

--- a/apps/web/src/features/updates/summarize.test.ts
+++ b/apps/web/src/features/updates/summarize.test.ts
@@ -1,14 +1,95 @@
 import { describe, it, expect } from "vitest";
 import type { UpdateTask } from "@wpmgr/api";
 
-import { serverRetryFields } from "@/test/update-task-fixtures";
+import { makeUpdateTask, serverRetryFields } from "@/test/update-task-fixtures";
 
 import {
   isSiteDownRecovery,
   isTerminalRunStatus,
   isAgentNotEligible,
   haltReason,
+  summarizeTasks,
 } from "./summarize";
+
+// GH #463: regression coverage for a self-hosted control plane sending a
+// task status literal outside this bundle's generated TaskStatus union
+// (`tsc` never checked the wire value). Before the fix,
+// `counts[task.status] += 1` on a status the `counts` initializer never
+// declared was `undefined += 1` — NaN — written onto a brand-new stray
+// property keyed by that unrecognized string (verified directly: the
+// pre-fix `counts` object comes back with an extra `"<unknown-status>": NaN`
+// entry alongside its 9 declared keys). `done`/`total`/the progress
+// percentage at $runId.tsx:292 happen to stay finite regardless in the
+// current shape of this function, because `done` sums six explicitly named,
+// already-initialized keys rather than reducing over the whole `counts`
+// object — but `summary.counts` no longer matches its own declared type
+// (`Record<TaskStatus, number>`), which is exactly the kind of drift that
+// breaks the next piece of code that DOES iterate `counts` wholesale (a
+// stacked bar, an `Object.values` reduction). The fix's `key in counts`
+// guard keeps `counts` to exactly its declared keys, and keeps `done`
+// undercounting (never crediting an unrecognized status as complete) as an
+// explicit invariant rather than an accident of the current arithmetic.
+describe("summarizeTasks", () => {
+  it("does not add a stray NaN-valued property for a status outside the TaskStatus union", () => {
+    const tasks = [makeUpdateTask({ status: "reconciling" as UpdateTask["status"] })];
+    const { counts } = summarizeTasks(tasks);
+    expect(Object.prototype.hasOwnProperty.call(counts, "reconciling")).toBe(false);
+    expect(Object.keys(counts).sort()).toEqual(
+      [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "rolled_back",
+        "skipped",
+        "cancelled",
+        "scheduled",
+        "expired",
+      ].sort(),
+    );
+  });
+
+  it("does not produce NaN for a single task whose status is outside the TaskStatus union", () => {
+    const tasks = [makeUpdateTask({ status: "reconciling" as UpdateTask["status"] })];
+    const { done, total } = summarizeTasks(tasks);
+    expect(Number.isFinite(done)).toBe(true);
+    expect(done).toBe(0);
+    expect(total).toBe(1);
+  });
+
+  it("excludes an unknown-status task from done in a mix of known and unknown statuses", () => {
+    const tasks = [
+      makeUpdateTask({ id: "44444444-4444-4444-4444-444444444441", status: "succeeded" }),
+      makeUpdateTask({ id: "44444444-4444-4444-4444-444444444442", status: "failed" }),
+      makeUpdateTask({
+        id: "44444444-4444-4444-4444-444444444443",
+        status: "reconciling" as UpdateTask["status"],
+      }),
+    ];
+    const { done, total, counts } = summarizeTasks(tasks);
+    expect(Number.isFinite(done)).toBe(true);
+    // Only the succeeded + failed tasks count; the unknown-status task is not
+    // folded into any bucket, so it must not appear in `done`.
+    expect(done).toBe(2);
+    expect(total).toBe(3);
+    expect(counts.succeeded).toBe(1);
+    expect(counts.failed).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(counts, "reconciling")).toBe(false);
+  });
+
+  it("keeps the $runId.tsx:292 progress percentage finite for an unknown status", () => {
+    const tasks = [
+      makeUpdateTask({ id: "44444444-4444-4444-4444-444444444441", status: "succeeded" }),
+      makeUpdateTask({
+        id: "44444444-4444-4444-4444-444444444442",
+        status: "reconciling" as UpdateTask["status"],
+      }),
+    ];
+    const { done, total } = summarizeTasks(tasks);
+    const pct = Math.round((done / total) * 100);
+    expect(Number.isFinite(pct)).toBe(true);
+  });
+});
 
 // GH #210: pure-logic coverage for the site-down-recovery detector: the
 // worst-case rollback failure (site-wide PHP fatal, undeliverable rollback,

--- a/apps/web/src/features/updates/summarize.ts
+++ b/apps/web/src/features/updates/summarize.ts
@@ -34,7 +34,23 @@ export function summarizeTasks(tasks: UpdateTask[]): {
     // counted into `done` below, same as `cancelled`.
     expired: 0,
   };
-  for (const task of tasks) counts[task.status] += 1;
+  for (const task of tasks) {
+    // Defence in depth against version skew (see TASK_TONE in
+    // update-status.tsx): `tsc` enforces every TaskStatus is a key of
+    // `counts` above, but a self-hosted control plane can still send a
+    // status literal this bundle predates, and `task.status` at that point
+    // is a value `tsc` never checked. Unguarded, `counts[task.status] += 1`
+    // on a key `counts` never declared is `undefined += 1` (NaN), written
+    // onto a brand-new stray property — `counts` silently stops matching its
+    // own `Record<TaskStatus, number>` type. The guard below keeps `counts`
+    // to exactly its declared keys and deliberately counts the unrecognized
+    // status nowhere (not `done`, not any bucket): that undercounts `done`
+    // rather than lying that the run is finished, which is the safe
+    // direction — see GH #463 PR body for the full reasoning.
+    if (task.status in counts) {
+      counts[task.status] += 1;
+    }
+  }
   const done =
     counts.succeeded +
     counts.failed +

--- a/apps/web/src/features/updates/use-row-update.ts
+++ b/apps/web/src/features/updates/use-row-update.ts
@@ -40,7 +40,17 @@ export type RowUpdateState =
   | "succeeded"
   | "failed"
   | "rolled_back"
-  | "skipped";
+  | "skipped"
+  // GH #463: the parent run has not reached its scheduled_at yet — nothing
+  // has happened, distinct from "pending" (queued now) so the row doesn't
+  // read as imminent.
+  | "scheduled"
+  // GH #463: the parent run expired before dispatching this task. Terminal,
+  // nothing was ever sent.
+  | "expired"
+  // GH #255 Phase 2: never dispatched because its run halted first. Terminal,
+  // nothing was ever sent.
+  | "cancelled";
 
 export interface RowUpdate {
   state: RowUpdateState;
@@ -98,7 +108,17 @@ function projectStatus(
       return "rolled_back";
     case "skipped":
       return "skipped";
+    case "cancelled":
+      return "cancelled";
+    case "scheduled":
+      return "scheduled";
+    case "expired":
+      return "expired";
     default:
+      // A status literal outside the current TaskStatus union entirely (a
+      // self-hosted control plane ahead of this bundle's generated types).
+      // "still going, poll will resolve it" matches how isTerminalTaskStatus
+      // treats an unmatched status as non-terminal.
       return "pending";
   }
 }
@@ -255,23 +275,7 @@ export function useCoreRowUpdate(
   useRunEventStream(runId ?? "", { enabled: Boolean(runId) });
 
   const task = run?.tasks?.find((t) => t.target_type === "core");
-  const state: RowUpdateState = !runId
-    ? create.isPending
-      ? "starting"
-      : "idle"
-    : !task
-      ? "pending"
-      : task.status === "pending"
-        ? "pending"
-        : task.status === "running"
-          ? "running"
-          : task.status === "succeeded"
-            ? "succeeded"
-            : task.status === "failed"
-              ? "failed"
-              : task.status === "rolled_back"
-                ? "rolled_back"
-                : "skipped";
+  const state = projectStatus(task, runId, create.isPending);
 
   const trigger = useCallback(async () => {
     setRunId(null);


### PR DESCRIPTION
Part of #463.

Third and fourth instances of the version-skew defect PR #480 fixed for the two tone maps: exhaustive-looking code indexed by a generated status union that the wire can violate, because a self-hosted control plane can run ahead of this bundle's generated types.

## Bug 1 — `summarize.ts`

`counts[task.status] += 1` on a status the `counts` initializer never declared (`undefined += 1`) writes a stray `NaN`-valued property onto the returned record, so `summary.counts` silently stops matching its own `Record<TaskStatus, number>` type.

**Correction to the original bug description**: I verified directly (node repro, and a test that asserts on it) that in the *current* shape of this function `done`/`total`/the `$runId.tsx:292` percentage stay finite regardless, because `done` is a sum of six explicitly-named, already-initialized keys (`counts.succeeded + counts.failed + ...`) rather than a reduction over the whole `counts` object — the stray key just sits there unread. The real, provable defect is the type-violating stray property itself, which would matter the moment any consumer iterates `counts` wholesale (`Object.values`, a stacked bar, etc.) instead of reading named fields one at a time, and it's exactly the kind of drift this bundle can't detect at compile time. Fixed with a `task.status in counts` guard before the increment, so `counts` never grows beyond its declared keys. **Decision on what an unknown status counts as**: neither `done` nor any bucket — undercounting is the safe direction (never implies "finished" for a status this bundle can't classify).

## Bug 2 — `use-row-update.ts`

Same defect class, twice, with two different wrong fallbacks:
- `projectStatus()` fell through `default: return "pending"` for `cancelled`/`scheduled`/`expired`, so a deferred row read as an imminent "Queued" update for hours.
- `useCoreRowUpdate()` re-derived the identical mapping as its own nested ternary with a *different* wrong fallback (`"skipped"`), so the same bug produced a different wrong answer on the WP-core row.

Fix: extended `RowUpdateState` with `"scheduled" | "expired" | "cancelled"`, added explicit cases to `projectStatus()` (kept `default: return "pending"` only as the residual "status outside even the current union" fallback, matching how `isTerminalTaskStatus` treats an unmatched status as non-terminal), and had `useCoreRowUpdate()` call the shared `projectStatus()` instead of duplicating the logic.

`available-updates-card.tsx`'s `RowStateLine` and `RowActionButton` got explicit cases for the three new states, agreeing with the tone/label vocabulary PR #481 established at the run level (`Scheduled` / `Not attempted` / `Expired`, all muted, matching `TASK_TONE` in `update-status.tsx`):
- `RowStateLine`: plain muted static text for all three (not the pulsing `LiveIndicator`).
- `RowActionButton`: `scheduled` hides the action button (a run already exists and will fire later, nothing imminent). `expired`/`cancelled` fold into the existing Retry bucket — already `variant="outline"` (neutral), not the destructive/warning styling `failed`/`rolled_back` get, since nothing actually failed.

## Out of scope

`apps/web/src/features/sites/bulk-action-drawer-panel.tsx` has the identical `rollupStatus()` bug. Confirmed dead code — nothing imports it:
```
$ grep -rn "bulk-action-drawer-panel" apps/web/src --include="*.ts" --include="*.tsx"
(no output)
```
Its live near-duplicate `bulk-action-drawer.tsx` was already fixed by #480 (verified: its `rollupStatus`/`toneFor`/`statusLabel` already handle `scheduled`/`expired`/`cancelled` explicitly). Left both untouched.

## Finding grep — any other instance?

```
$ grep -rn '["status"]' apps/web/src
```
Beyond the files this PR and #480 already touch, one additional real instance: `apps/web/src/features/backups/backup-badges.tsx:20` — `statusMeta[status]` has no `?? UNKNOWN` fallback (unlike `TASK_TONE`'s `toneFor` helper or the `RUN_STATUS_TONE` maps in the updates routes, which are already defended). An unrecognized `BackupSnapshot["status"]` makes `meta` `undefined`, and `meta.variant`/`meta.label` then throw a `TypeError`, crashing the badge instead of silently mis-rendering. Reporting only, per brief — not fixed here (out of scope for this stack, different feature area).

Everything else the grep turns up (`monitoring-pause.ts`, `format-progress.ts`, the two `updates` route files) is either derived from a boolean/local status (not a raw wire enum) or already has a safe fallback — checked each individually.

## Regression test — red then green

Added `describe("summarizeTasks", ...)` to `summarize.test.ts` (didn't exist before). Uses `makeUpdateTask({ status: "reconciling" as UpdateTask["status"] })` — a status outside the `TaskStatus` union.

**Red** (stashed the `summarize.ts` fix, ran against the pre-fix code):
```
❯ src/features/updates/summarize.test.ts (22 tests | 2 failed)
  × summarizeTasks > does not add a stray NaN-valued property for a status outside the TaskStatus union
    → expected true to be false // Object.is equality
  × summarizeTasks > excludes an unknown-status task from done in a mix of known and unknown statuses
    → expected true to be false // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed | 20 passed (22)
```
(The `Number.isFinite(done)`/percentage assertions pass even pre-fix, for the reason explained above — they're still worth locking in as an invariant, but the two failing assertions above are what actually distinguishes broken from fixed.)

**Green** (fix restored):
```
✓ src/features/updates/summarize.test.ts (22 tests) 2ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
```

## Definition of done

```
$ pnpm -C apps/web typecheck
$ tsc --noEmit
(clean, exit 0)

$ pnpm -C apps/web lint
✖ 9 problems (0 errors, 9 warnings)
(all 9 warnings pre-existing/unrelated — react-compiler and react-refresh notices in files this PR doesn't touch; exit 0)

$ pnpm -C apps/web test -- --run
 Test Files  141 passed (141)
      Tests  1691 passed (1691)
```

`git diff --stat origin/feat/463-phase1-go...HEAD` touches only:
```
apps/web/src/features/updates/available-updates-card.tsx
apps/web/src/features/updates/summarize.test.ts
apps/web/src/features/updates/summarize.ts
apps/web/src/features/updates/use-row-update.ts
```
