### PR TITLE
Tooling quick wins: stop test-integration caching a pass, stop init-env.sh lying about success

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,14 @@ test: test-api test-web ## Run all tests
 # package alone and 601s under the parallel load of `go test ./...`, which
 # panicked with "test timed out after 10m0s". The tests were fine; the limit
 # was not. Without this flag the full run flakes on a busy machine.
-test-api: ## Run Go tests (unit plus integration; needs Docker for the integration package)
-	cd apps/api && go test -timeout 45m ./...
+#
+# -count=1 (GH #464): this target's own help text calls it "unit plus
+# integration", i.e. the thing you run to know whether apps/api is actually
+# green, not a fast iteration loop. Go caches a successful `go test` result
+# keyed on inputs, so without -count=1 a second run after an unrelated change
+# elsewhere in the repo prints "ok ... (cached)" and executes nothing.
+test-api: ## Run Go tests (unit plus integration; needs Docker for the integration package; never cached, see -count=1)
+	cd apps/api && go test -count=1 -timeout 45m ./...
 
 .PHONY: test-integration
 # The integration package on its own, which is where the security proofs live:
@@ -153,8 +159,16 @@ test-api: ## Run Go tests (unit plus integration; needs Docker for the integrati
 # yet. So this command is the only thing standing in front of a regression in
 # it. Run it before merging anything that touches RLS, the email domain or
 # tenant scoping. Needs a working Docker daemon (testcontainers).
-test-integration: ## Run the Go integration tests (Docker required, about 9 minutes)
-	cd apps/api && go test -timeout 45m ./tests/...
+#
+# -count=1 (GH #464): without it, Go caches a pass and a re-run after an
+# unrelated change reports "ok ... (cached)" having executed nothing — for the
+# one target CI deliberately never runs, that is a silent pass over the RLS
+# proofs above. This target is a gate, not an iteration loop, so it is never
+# cached. (test-api, above, has the same flag for the same reason; the other
+# test targets in this file — test-web, check-versions-test — do not invoke
+# `go test` at all, so Go's result cache does not apply to them.)
+test-integration: ## Run the Go integration tests (Docker required, about 9 minutes; never cached, see -count=1)
+	cd apps/api && go test -count=1 -timeout 45m ./tests/...
 
 .PHONY: test-web
 test-web: ## Run frontend tests

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -84,7 +84,15 @@ log()  { printf '==> %s\n' "$*"; }
 warn() { printf 'WARN: %s\n' "$*" >&2; }
 die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
-cleanup() { [ -n "${GEN_FILE}" ] && rm -f "${GEN_FILE}"; }
+# GH #467: on the idempotent fast path (every managed secret already set),
+# GEN_FILE stays "". `[ -n "" ]` is false, and under `set -e` a trap function's
+# own exit status is the exit status of its last command — so that false test,
+# not this script's own `exit 0`, became the process's exit code. The explicit
+# `return 0` makes cleanup's job (best-effort temp-file removal) unable to ever
+# set the script's exit status, on this path or any other: a genuine failure
+# earlier in the script still exits non-zero, because that status is already
+# set by the time this trap runs and nothing here touches it.
+cleanup() { [ -n "${GEN_FILE}" ] && rm -f "${GEN_FILE}"; return 0; }
 trap cleanup EXIT
 
 # current_value: prints the current value of KEY in .env (empty if absent/blank).


### PR DESCRIPTION
## Summary

Two independent fixes, both filed and reproduced, batched as one PR (each commit reverts alone):

- **GH #464**: `make test-integration` (and `test-api`) had no `-count=1`, so Go's build cache could report `ok ... (cached)` on a second invocation without running anything — the one target standing in front of the RLS/tenancy proofs `ci.yml` deliberately does not run. Added `-count=1` to both. Audited every other test target in the Makefile; `test-web` and `check-versions-test` do not invoke `go test`, so the cache does not apply to them.
- **GH #467**: `scripts/init-env.sh`'s `cleanup()` EXIT trap ended on `[ -n "${GEN_FILE}" ] && rm -f ...`. On the idempotent fast path (every secret already set) `GEN_FILE` is empty, that test is false, and under `set -e` the trap's own exit status became the script's exit status — so a fully-configured re-run reported failure. Fixed with an explicit `return 0` so the trap's best-effort cleanup can never set the script's exit code in either direction. Audited every other trap in `scripts/**`, `infra/**` and `.github/workflows/**`: `check-version-surfaces_test.sh` and `infra/nginx/routing_smoke_test.sh` both end on `rm -rf`, which exits 0 regardless of whether the target exists, so neither shares the shape.

## Test plan

- [x] `make test-integration` run twice in a row, no source change between runs: `grep -c "(cached)" run1.log` → 0, `grep -c "(cached)" run2.log` → 0. Run 1 took 725s (failed on an unrelated Docker/testcontainers port-mapping flake — `connection string: port "5432/tcp" not found`, in `TestAuditConcurrentAppendChainIntact` / `TestAutologinConsumePGFallback`, neither of which this PR touches); run 2 took 788s and passed clean. Confirms the fix forces a genuine re-execution every time rather than trusting a stale cache entry.
- [x] Reproduced the pre-fix bug directly against `origin/main`'s `scripts/init-env.sh` in an isolated `/tmp` fixture with a fully-configured `.env` (fake placeholder values, never written into the repo tree): exits 1. The fixed script against the identical fixture exits 0, twice in a row.
- [x] A genuinely failing `init-env.sh` run (unknown argument) still exits non-zero (2).
- [x] `scripts/check-version-surfaces_test.sh`: 76 passed, 0 failed.
- [x] `make hooks-status`: pre-push hook installed and current.

## Not in scope

The testcontainers port-mapping flake surfaced above is pre-existing, environment-specific (this sandbox's Docker networking), and unrelated to both commits here (neither touches `apps/api`). Not fixed in this PR.