### PR TITLE
release: 0.61.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ### Added
 
-- A new endpoint, `POST /api/v1/updates/runs/{id}/cancel`, calls back a scheduled update run before it fires (GH #463). It only succeeds while the run is still `scheduled`; once dispatch has claimed it, stopping it means using the existing halt path instead, because work may already be on real sites by then. Cancelling terminalizes the run and every one of its tasks in one transaction, and a second cancel of an already-cancelled or already-started run returns an error rather than a silent no-op.
+- A new endpoint, `POST /api/v1/updates/runs/{id}/cancel`, cancels a scheduled update run before it fires (GH #463). It only succeeds while the run is still `scheduled`; once dispatch has claimed it, stopping it means using the existing halt path instead, because work may already be on real sites by then. Cancelling terminalizes the run and every one of its tasks in one transaction, and a second cancel of an already-cancelled or already-started run returns an error rather than a silent no-op.
 
 ### Changed
 
-- Scheduled update runs now actually wait for their scheduled time instead of running immediately (GH #463). A run submitted with a future `scheduled_at` is held until that time and then dispatched; a run submitted to run now is unaffected. Any run already sitting with a future `scheduled_at` from before this release will, on upgrade, wait for that time rather than having already run, so an operator with pending scheduled rows should expect them to hold, not to have already fired.
+- Scheduled update runs now actually wait for their scheduled time instead of running immediately (GH #463). A run submitted after this release with a future `scheduled_at` is held until that time and then dispatched; a run submitted to run now is unaffected. This does not apply retroactively: a run created before this release was enqueued immediately regardless of its `scheduled_at`, so upgrading does not put any existing row on hold. If one of those older runs is still sitting unfinished, that reflects a stranded enqueue from before this change, not a deferral, and this release does not alter it.
 - Update runs and tasks carry new statuses that the API and the dashboard now show: runs can be `scheduled`, `dispatching` or `expired`; tasks can be `scheduled` or `expired`. Anything consuming the API programmatically should handle all of them.
 - A scheduled run whose start time passed more than two hours ago is marked `expired` rather than dispatched late, and the dashboard says plainly that nothing was sent to any of its sites.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.141] - 2026-08-19
+
+### Added
+
+- A new endpoint, `POST /api/v1/updates/runs/{id}/cancel`, calls back a scheduled update run before it fires (GH #463). It only succeeds while the run is still `scheduled`; once dispatch has claimed it, stopping it means using the existing halt path instead, because work may already be on real sites by then. Cancelling terminalizes the run and every one of its tasks in one transaction, and a second cancel of an already-cancelled or already-started run returns an error rather than a silent no-op.
+
+### Changed
+
+- Scheduled update runs now actually wait for their scheduled time instead of running immediately (GH #463). A run submitted with a future `scheduled_at` is held until that time and then dispatched; a run submitted to run now is unaffected. Any run already sitting with a future `scheduled_at` from before this release will, on upgrade, wait for that time rather than having already run, so an operator with pending scheduled rows should expect them to hold, not to have already fired.
+- Update runs and tasks carry new statuses that the API and the dashboard now show: runs can be `scheduled`, `dispatching` or `expired`; tasks can be `scheduled` or `expired`. Anything consuming the API programmatically should handle all of them.
+- A scheduled run whose start time passed more than two hours ago is marked `expired` rather than dispatched late, and the dashboard says plainly that nothing was sent to any of its sites.
+
+### Fixed
+
+- `scripts/init-env.sh` could report failure on a successful, fully-configured re-run: its cleanup step's own exit status silently overrode the script's own `exit 0` on that path (GH #467). Re-running it against an already-configured `.env` now exits 0 as it should.
+
 ## [0.61.140] - 2026-08-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.139**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.140**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.139
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.139
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.139
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.140
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.140
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.140
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.139   # omit to track :latest
+export WPMGR_VERSION=v0.61.140   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -225,7 +225,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.139   # omit to track :latest
+export WPMGR_VERSION=v0.61.140   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.140
+  version: 0.61.141
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. Cuts version surfaces and the CHANGELOG entry for 0.61.141.

Five merges since 0.61.140, verified with `git log`:
- #475 — `feat(update): defer a scheduled update run instead of running it immediately` (the whole GH #463 feature)
- #486 — tooling: `-count=1` on the test targets, and `init-env.sh` no longer exits 1 on a successful re-run (GH #467)
- #477 — marketing copy correction (uptime incident-history claim)
- #472 — the in-flight status constant and its drift guard (GH #463 Phase 0)
- #469 — m118, RLS policy and due-scan index on `update_runs` (GH #463 Phase 0)

**Agent version is unchanged.** `git diff --stat v0.61.140..origin/main -- apps/agent/` is empty; the agent stays at 0.61.139, and so does the marketing hero badge, which names the agent version rather than the control-plane one.

### Version surfaces
- `CHANGELOG.md`: `[0.61.141] - 2026-08-19` added under a bare `[Unreleased]`.
- `packages/openapi/openapi.yaml`: `info.version` → `0.61.141`.
- `README.md` / `docs/install.md`: install pins move `v0.61.139` → `v0.61.140` (one release behind the new top, per the guard's tolerance of 1). All three `v0.61.140` images confirmed pullable from GHCR via `docker manifest inspect` before the pin moved.
- Agent triple, hero badge: untouched, all still `0.61.139`.

### CHANGELOG highlights
- New endpoint `POST /api/v1/updates/runs/{id}/cancel`.
- Scheduled update runs now actually wait for `scheduled_at` instead of running immediately, including the upgrade-visible consequence for runs already sitting with a future `scheduled_at`.
- New statuses on runs (`scheduled`, `dispatching`, `expired`) and tasks (`scheduled`, `expired`).
- A run more than two hours past its start time is `expired`, not dispatched late.
- `scripts/init-env.sh` re-run fix (GH #467).

## Test plan
- [x] `make check-versions-test` — 76 passed, 0 failed
- [x] `make check-versions` — all surfaces consistent
- [x] `node apps/marketing/scripts/check-copy.mjs` — passed
- [x] `ci.yml`'s Docs vocabulary check grep run verbatim — no hits, paired with a positive control proving the pattern matches
- [x] Confirmed `apps/agent/wpmgr-agent.php`, `apps/agent/readme.txt`, `apps/marketing/lib/content/home.ts` unchanged

Not merging, tagging, or deploying this PR myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scheduled update runs can now be canceled before execution.
  - Scheduled runs are dispatched at their designated times.
  - Added clearer run and task statuses.
  - Overdue runs now expire automatically.

- **Bug Fixes**
  - Corrected exit-status handling when rerunning the environment initialization script.

- **Documentation**
  - Updated release notes, installation instructions, container image examples, and API version information for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->