### PR TITLE
fix(api): release session advisory locks on a detached, bounded context

### DIFF
--- a/apps/api/internal/backup/repo.go
+++ b/apps/api/internal/backup/repo.go
@@ -1432,11 +1432,21 @@ func (r *pgRepo) SweepTenantChunks(ctx context.Context, tenantID uuid.UUID, floo
 	}
 	*acquired = true
 	// Always release the session lock on the SAME conn, on every path (incl.
-	// error), BEFORE Release returns the conn to the pool. Best-effort: a failed
-	// unlock is harmless — the lock is session-scoped and also drops when the
-	// session closes.
+	// error), BEFORE Release returns the conn to the pool.
+	//
+	// GH #483: on db.CleanupContext, never on ctx, and NOT best-effort in the
+	// sense this comment used to claim. "A failed unlock is harmless, the lock
+	// drops when the session closes" is false for a POOLED connection: the
+	// session does not close, it goes back to the pool. Worse, the unlock on a
+	// cancelled ctx never reaches the wire at all — pgx returns early — so the
+	// connection returns healthy and still holding this tenant's GC lock, and
+	// every later sweep for the tenant takes a different connection, fails
+	// pg_try_advisory_lock and returns with *acquired false. GC for that tenant
+	// silently stops until MaxConnLifetime (30 min) closes the connection.
 	defer func() {
-		_, _ = conn.Exec(ctx,
+		cctx, ccancel := db.CleanupContext(ctx)
+		defer ccancel()
+		_, _ = conn.Exec(cctx,
 			`SELECT pg_advisory_unlock(hashtext('backup_gc'), hashtext($1))`,
 			tenantID.String(),
 		)

--- a/apps/api/internal/backup/tenant_reclaim_worker.go
+++ b/apps/api/internal/backup/tenant_reclaim_worker.go
@@ -662,10 +662,11 @@ func NewTenantReclaimStore(pool *db.Pool) TenantReclaimStore {
 //     There is no "the session closes anyway" fallback here, because the
 //     connection is POOLED: Release hands the session back alive, still holding
 //     whatever it was holding. An unlock that does not reach the wire therefore
-//     strands org.LifecycleLockKey for this tenant on an idle pooled connection
-//     and blocks DELETE /orgs/{orgId}, POST /orgs/{orgId}/restore and the Lane B
-//     purge until db.MaxConnLifetime (30m) recycles it. See GH #483 and the
-//     comment on the returned closure.
+//     strands org.LifecycleLockKey for this tenant on an idle pooled connection:
+//     the Lane B purge and the next drain read false and skip, DELETE
+//     /orgs/{orgId} and POST /orgs/{orgId}/restore block on it, and none of that
+//     clears until db.MaxConnLifetime (30m) recycles the connection. See GH #483
+//     and the comment on the returned closure.
 func (s *pgTenantReclaimStore) LockTenantLifecycle(ctx context.Context, tenantID uuid.UUID) (func(), bool, error) {
 	conn, err := s.pool.Acquire(ctx)
 	if err != nil {
@@ -694,9 +695,11 @@ func (s *pgTenantReclaimStore) LockTenantLifecycle(ctx context.Context, tenantID
 		// rolling deploy, River job timeout — leaves ctx dead by the time this
 		// runs, and on a dead ctx pgx returns BEFORE the statement reaches the
 		// wire. That does not break the connection, so the pool takes it back
-		// healthy and locked, and every later reclaim, DELETE /orgs/{orgId},
-		// POST /orgs/{orgId}/restore and Lane B purge for this tenant reads false
-		// from pg_try_advisory_lock until db.MaxConnLifetime (30m) recycles it.
+		// healthy and locked. Every later drain and Lane B purge for this tenant
+		// then reads false from pg_try_advisory_lock and skips, while DELETE
+		// /orgs/{orgId} and POST /orgs/{orgId}/restore — same key, taken with the
+		// BLOCKING pg_advisory_xact_lock — wait on it instead, until
+		// db.MaxConnLifetime (30m) recycles the connection.
 		// WithoutCancel is what puts the statement on the wire;
 		// db.SessionCleanupTimeout is what stops an uncancellable Exec in a defer
 		// from hanging a graceful drain on a wedged socket. The bound cannot

--- a/apps/api/internal/backup/tenant_reclaim_worker.go
+++ b/apps/api/internal/backup/tenant_reclaim_worker.go
@@ -658,8 +658,14 @@ func NewTenantReclaimStore(pool *db.Pool) TenantReclaimStore {
 //     scope, so session and xact holders mutually exclude.
 //   - Released on EVERY path including error and panic: the caller defers the
 //     returned func, which unlocks and then returns the connection to the pool,
-//     in that order. Even if the unlock statement itself fails the lock still
-//     drops when the session closes, so the failure mode is bounded.
+//     in that order — and the unlock runs on db.CleanupContext, never on ctx.
+//     There is no "the session closes anyway" fallback here, because the
+//     connection is POOLED: Release hands the session back alive, still holding
+//     whatever it was holding. An unlock that does not reach the wire therefore
+//     strands org.LifecycleLockKey for this tenant on an idle pooled connection
+//     and blocks DELETE /orgs/{orgId}, POST /orgs/{orgId}/restore and the Lane B
+//     purge until db.MaxConnLifetime (30m) recycles it. See GH #483 and the
+//     comment on the returned closure.
 func (s *pgTenantReclaimStore) LockTenantLifecycle(ctx context.Context, tenantID uuid.UUID) (func(), bool, error) {
 	conn, err := s.pool.Acquire(ctx)
 	if err != nil {
@@ -678,9 +684,29 @@ func (s *pgTenantReclaimStore) LockTenantLifecycle(ctx context.Context, tenantID
 		return nil, false, nil
 	}
 	return func() {
-		// Best effort, then hand the connection back. A failed unlock is harmless:
-		// the lock is session-scoped and drops with the session either way.
-		_, _ = conn.Exec(context.WithoutCancel(ctx),
+		// Unlock, then hand the connection back, in that order — and NOT "best
+		// effort, a failed unlock is harmless because the lock drops with the
+		// session", which is what this comment used to say and is false on a
+		// POOLED connection. Release does not close the session; it returns it to
+		// the pool, still holding this tenant's org_lifecycle lock.
+		//
+		// GH #483: db.CleanupContext, never ctx. A drain cancelled mid-flight —
+		// rolling deploy, River job timeout — leaves ctx dead by the time this
+		// runs, and on a dead ctx pgx returns BEFORE the statement reaches the
+		// wire. That does not break the connection, so the pool takes it back
+		// healthy and locked, and every later reclaim, DELETE /orgs/{orgId},
+		// POST /orgs/{orgId}/restore and Lane B purge for this tenant reads false
+		// from pg_try_advisory_lock until db.MaxConnLifetime (30m) recycles it.
+		// WithoutCancel is what puts the statement on the wire;
+		// db.SessionCleanupTimeout is what stops an uncancellable Exec in a defer
+		// from hanging a graceful drain on a wedged socket. The bound cannot
+		// itself strand a lock: a deadline that fires MID-statement makes pgx
+		// close the connection, Release then destroys it, and the backend exits —
+		// which drops the lock. A too-short bound degrades to connection churn,
+		// never to a retained lock.
+		cctx, ccancel := db.CleanupContext(ctx)
+		defer ccancel()
+		_, _ = conn.Exec(cctx,
 			`SELECT pg_advisory_unlock(hashtext($1), hashtext($2))`,
 			org.LifecycleLockKey, tenantID.String())
 		conn.Release()

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -917,8 +917,20 @@ func (w *ScheduleWorker) Work(ctx context.Context, _ *river.Job[ScheduleArgs]) e
 			w.logger.Info("backup_scheduler: advisory lock acquired")
 			// Release the advisory lock when the pass finishes (session-level, so
 			// it must be explicitly released on the pinned conn, not left to GC).
+			//
+			// GH #483: on db.CleanupContext, never on ctx. A pass cancelled
+			// mid-flight — rolling deploy, River job timeout — leaves ctx
+			// cancelled by the time this defer runs, and pgx then returns
+			// without sending the unlock while the connection goes back to the
+			// pool healthy and still locked. Every later tick takes a different
+			// connection, reads false, logs "advisory lock held by peer" and
+			// returns nil: SCHEDULED BACKUPS STOP FIRING FLEET-WIDE, with no
+			// error anywhere, until MaxConnLifetime closes the connection half
+			// an hour later.
 			defer func() {
-				_, _ = conn.Exec(ctx, `SELECT pg_advisory_unlock(hashtext('backup_scheduler'))`)
+				cctx, ccancel := db.CleanupContext(ctx)
+				defer ccancel()
+				_, _ = conn.Exec(cctx, `SELECT pg_advisory_unlock(hashtext('backup_scheduler'))`)
 			}()
 		}
 	} else {

--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -21,6 +21,51 @@ type Pool struct {
 	*pgxpool.Pool
 }
 
+// SessionCleanupTimeout bounds a session-scoped cleanup statement issued from a
+// defer — pg_advisory_unlock above all — on a pinned pooled connection.
+//
+// Two failure modes, and the value has to sit between them:
+//
+//  1. Running the cleanup on the caller's own ctx is a leak. When ctx is already
+//     cancelled (graceful shutdown mid-pass, a River job timeout, a client
+//     disconnect) pgx returns immediately WITHOUT PUTTING THE STATEMENT ON THE
+//     WIRE. The connection then goes back to the pool healthy, still holding a
+//     SESSION-scoped advisory lock, and every later pass takes a different
+//     connection, gets false from pg_try_advisory_lock, concludes a peer is
+//     working and skips. Nothing errors; the work simply stops happening until
+//     MaxConnLifetime (30 min, below) finally closes the connection.
+//     context.WithoutCancel is what stops that.
+//
+//  2. WithoutCancel alone is unbounded. If the socket is wedged rather than the
+//     context cancelled, an uncancellable Exec in a defer blocks shutdown for as
+//     long as the kernel takes to give up. That case is also the case where the
+//     unlock is pointless: a session that cannot be reached is a session that is
+//     about to end, and its locks drop with it. So the bound costs nothing where
+//     it fires.
+//
+// 5 s is the gap. A single unlock round-trip on an ALREADY-ESTABLISHED
+// connection is <10 ms against Cloud SQL over the VPC connector (the same
+// measurement BeforeAcquire's 500 ms ping budget is sized from), so 5 s is
+// ~500× headroom for the healthy path, while staying inside the shutdown grace
+// so a cleanup cannot be what makes a drain overrun.
+const SessionCleanupTimeout = 5 * time.Second
+
+// CleanupContext returns a context for undoing session-scoped state (an advisory
+// unlock, a RESET) before a pinned connection returns to the pool. It detaches
+// from ctx's cancellation and deadline while keeping its values, then bounds
+// itself by SessionCleanupTimeout. See that constant for why it is both.
+//
+// The caller must defer the returned cancel, as with context.WithTimeout:
+//
+//	defer func() {
+//		cctx, ccancel := db.CleanupContext(ctx)
+//		defer ccancel()
+//		_, _ = conn.Exec(cctx, `SELECT pg_advisory_unlock(...)`)
+//	}()
+func CleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), SessionCleanupTimeout)
+}
+
 // Connect opens a pgx connection pool and verifies connectivity. It applies no
 // MinConns floor, making it suitable for short-lived pools such as the
 // migration runner that are closed immediately after use.

--- a/apps/api/internal/org/purge_worker.go
+++ b/apps/api/internal/org/purge_worker.go
@@ -217,9 +217,19 @@ func (w *PurgeWorker) purgeOne(ctx context.Context, tenantID uuid.UUID) (purgeOu
 			slog.String("tenant_id", tenantID.String()))
 		return purgeSkipped, nil
 	}
+	// GH #483: on db.CleanupContext, never on ctx. A purge cancelled mid-pass —
+	// and this pass makes slow network calls, so cancellation is the ordinary
+	// case, not the exotic one — leaves ctx cancelled when this defer runs, and
+	// pgx then returns without sending the unlock while the connection goes back
+	// to the pool healthy and still holding the tenant's org_lifecycle lock.
+	// That key is shared with DELETE /orgs/{orgId} and POST
+	// /orgs/{orgId}/restore, so the leak blocks TENANT DELETION AND RESTORE, not
+	// just the next purge tick, until MaxConnLifetime closes the connection.
 	defer func() {
-		if _, uerr := conn.Exec(ctx, `SELECT pg_advisory_unlock(hashtext($1), hashtext($2))`, orgLifecycleLockKey, tenantID.String()); uerr != nil {
-			w.logger.Warn("org purge: advisory unlock failed (released on connection close regardless)",
+		cctx, ccancel := db.CleanupContext(ctx)
+		defer ccancel()
+		if _, uerr := conn.Exec(cctx, `SELECT pg_advisory_unlock(hashtext($1), hashtext($2))`, orgLifecycleLockKey, tenantID.String()); uerr != nil {
+			w.logger.Warn("org purge: advisory unlock failed, tenant lifecycle operations are blocked until this connection is recycled",
 				slog.String("tenant_id", tenantID.String()), slog.Any("error", uerr))
 		}
 	}()

--- a/apps/api/internal/update/dispatch_sweeper.go
+++ b/apps/api/internal/update/dispatch_sweeper.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 )
 
 // GH #463 Phase 2 — the safety net, and the alarms.
@@ -239,7 +241,7 @@ func (w *SweepWorker) sweep(ctx context.Context) (SweepStats, error) {
 			return stats, nil
 		} else {
 			defer func() {
-				// context.WithoutCancel, and it is NOT belt-and-braces. If ctx
+				// db.CleanupContext, and it is NOT belt-and-braces. If ctx
 				// is already cancelled when this defer runs — a graceful
 				// shutdown mid-pass, or a River job timeout — pgx returns
 				// immediately WITHOUT SENDING THE UNLOCK, and the connection
@@ -256,9 +258,21 @@ func (w *SweepWorker) sweep(ctx context.Context) (SweepStats, error) {
 				// Bounded rather than permanent — db.MaxConnLifetime (30m)
 				// eventually closes the connection and drops the lock — but
 				// half an hour of a silently skipped safety net is exactly the
-				// window this feature keeps being bitten in. Same form as
+				// window this feature keeps being bitten in.
+				//
+				// db.CleanupContext is WithoutCancel (so the statement is
+				// actually sent) plus db.SessionCleanupTimeout (so an
+				// uncancellable Exec in a defer cannot hang a graceful drain on
+				// a wedged socket). The bound cannot itself strand the lock: a
+				// deadline that fires MID-statement makes pgx close the
+				// connection, Release destroys it and the backend exits, which
+				// drops the lock. Too short degrades to connection churn, never
+				// to a retained lock. One idiom across every session-lock
+				// release in this codebase; see db.SessionCleanupTimeout and
 				// backup/tenant_reclaim_worker.go's reclaim-lock release.
-				_, _ = conn.Exec(context.WithoutCancel(ctx),
+				cctx, ccancel := db.CleanupContext(ctx)
+				defer ccancel()
+				_, _ = conn.Exec(cctx,
 					`SELECT pg_advisory_unlock(hashtext($1))`, sweepLockKey)
 			}()
 		}

--- a/apps/api/tests/gh483_advisory_unlock_cancelled_ctx_integration_test.go
+++ b/apps/api/tests/gh483_advisory_unlock_cancelled_ctx_integration_test.go
@@ -1,0 +1,223 @@
+package tests
+
+// gh483_advisory_unlock_cancelled_ctx_integration_test.go — GH #483.
+//
+// THE DEFECT. Three workers took a SESSION-scoped advisory lock on a pinned
+// pooled connection and released it from a defer that ran on the CALLER'S OWN
+// context:
+//
+//	defer func() { _, _ = conn.Exec(ctx, `SELECT pg_advisory_unlock(...)`) }()
+//
+// When ctx is already cancelled by the time that defer runs — a graceful
+// shutdown mid-pass, a River job timeout, a client disconnect — pgx returns
+// immediately WITHOUT PUTTING THE UNLOCK ON THE WIRE. Nothing errors. The
+// connection is not broken, so pgxpool takes it back as healthy and hands it to
+// the next caller, still holding the lock. Every later pass runs on a DIFFERENT
+// connection, gets false from pg_try_advisory_lock, concludes a peer replica is
+// working, and skips. The only recovery is MaxConnLifetime (db.go, 30 min)
+// eventually closing the connection.
+//
+// This file proves it against real Postgres for org.PurgeWorker, whose key is
+// the shared org_lifecycle one — so the leak does not merely stall the next
+// purge tick, it blocks DELETE /orgs/{orgId} and POST /orgs/{orgId}/restore for
+// the tenant, both of which block on the same key.
+//
+// WHY THE PURGE WORKER IS THE SITE THAT GETS THE TEST. All three sites are the
+// same three lines with the same fix, but only this one has a seam where the
+// context can be cancelled while the pinned connection is IDLE and CLEAN, which
+// is what the production failure looks like. purgeOne's object-storage step runs
+// through the injectable ObjectPurger, outside any transaction on the pinned
+// conn, so cancelling there leaves that conn exactly as a mid-pass SIGTERM would.
+// That distinction is load-bearing rather than cosmetic: if the cancellation
+// instead landed inside a transaction on the pinned conn, pgxpool.Conn.Release
+// would see TxStatus != 'I' and DESTROY the connection, which closes the session
+// and drops the lock — and the test would pass against the unfixed code for a
+// reason that has nothing to do with the fix. The two backup sites
+// (internal/backup/worker.go's scheduler lock, internal/backup/repo.go's
+// per-tenant GC lock) have no such seam without reshaping production code to
+// suit a test, and are covered by inspection; see the PR body.
+//
+// NOT RUN BY CI (apps/api/tests is excluded from the fast lane by owner
+// decision). Run with `make test-integration` from the repository root, or
+// directly with the command in each test's doc comment.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/org"
+)
+
+// gh483CancellingStore is the seam. Its List cancels the context the purge is
+// running under and then fails, which is what a SIGTERM landing between the
+// "mark purge started" write and the first object delete does to a real sweep:
+// the pass unwinds, and purgeOne's deferred pg_advisory_unlock is reached with a
+// dead context. Failing before any Delete also keeps the test repeatable and
+// destroys nothing — the tenant row survives, because purgeOne's hard delete is
+// the step after this one.
+type gh483CancellingStore struct {
+	cancel   context.CancelFunc
+	listCall int
+}
+
+func (s *gh483CancellingStore) List(_ context.Context, _ string) ([]string, error) {
+	s.listCall++
+	s.cancel()
+	return nil, errors.New("gh483: object storage unreachable (test injects the cancellation here)")
+}
+
+func (s *gh483CancellingStore) Delete(_ context.Context, _ string) error {
+	return errors.New("gh483: Delete must not be reached; List fails first")
+}
+
+// gh483OrgLockHeld reports whether the two-int org_lifecycle advisory lock for
+// tenant is held by ANY session, read from pg_locks THROUGH THE APPLICATION POOL
+// as the application role — the same view the next purge tick, the delete
+// endpoint and the restore endpoint get.
+//
+// Two-int advisory locks appear in pg_locks as classid = key1, objid = key2,
+// objsubid = 2. hashtext returns int4 and is routinely negative; int4 -> oid is
+// a binary coercion, so the casts below reinterpret the bits exactly as the lock
+// manager stored them rather than erroring on the sign.
+//
+// This reads pg_locks rather than probing with pg_try_advisory_lock because the
+// probe would be unsound here: the pool can hand back the very connection that
+// leaked the lock, and a second acquisition on the SAME session succeeds
+// (advisory locks are re-entrant per session), so a probe can report "free"
+// while the lock is held.
+func gh483OrgLockHeld(t *testing.T, pool *db.Pool, tenant uuid.UUID) bool {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM pg_locks
+		  WHERE locktype = 'advisory'
+		    AND classid  = hashtext($1)::oid
+		    AND objid    = hashtext($2)::oid
+		    AND objsubid = 2`,
+		org.LifecycleLockKey, tenant.String()).Scan(&n); err != nil {
+		t.Fatalf("read pg_locks for the org_lifecycle advisory lock: %v", err)
+	}
+	return n > 0
+}
+
+// TestGH483_PurgeCancelledMidPassDoesNotLeakTheOrgLifecycleLock is the
+// regression. It runs the real org.PurgeWorker over a real tenant, cancels the
+// sweep's context mid-pass at a real seam, and then requires the tenant's
+// org_lifecycle advisory lock to be gone.
+//
+// Against the unfixed code (conn.Exec(ctx, ...)) the lock is still held when
+// Work returns and this fails. Against the fix (db.CleanupContext) it is
+// released.
+//
+//	go test ./tests/ -run TestGH483_PurgeCancelledMidPassDoesNotLeakTheOrgLifecycleLock -v -count=1
+func TestGH483_PurgeCancelledMidPassDoesNotLeakTheOrgLifecycleLock(t *testing.T) {
+	pool := startPostgres(t) // wpmgr_app: NOSUPERUSER, NOBYPASSRLS
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	tenant := seedTenant(t, pool, "gh483-cancel-"+uuid.NewString()[:8])
+	odBackdateDeletedAt(t, admin, tenant, 30*24*time.Hour)
+
+	if gh483OrgLockHeld(t, pool, tenant) {
+		t.Fatalf("the org_lifecycle lock for %s was already held before the sweep ran; "+
+			"this test cannot attribute anything it observes afterwards", tenant)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := &gh483CancellingStore{cancel: cancel}
+
+	// grace=time.Hour matches the existing purge integration test; the tenant is
+	// back-dated 30 days so it is unambiguously due. sites/revoker nil: the
+	// revoke step is best-effort and not what is under test.
+	worker := org.NewPurgeWorker(pool, nil, nil, store, time.Hour, nil)
+
+	// Work never returns the per-tenant error (a failed tenant is logged and the
+	// sweep continues), so the assertion cannot be on its return value. It is on
+	// the database.
+	if err := worker.Work(ctx, nil); err != nil {
+		t.Fatalf("purge sweep returned an error at the sweep level: %v", err)
+	}
+	if store.listCall == 0 {
+		t.Fatal("the purge never reached the object-storage step, so the context was never " +
+			"cancelled mid-pass and this test proved nothing. Check that the tenant is due " +
+			"(deleted_at back-dated past the grace window) and that it still exists")
+	}
+	if ctx.Err() == nil {
+		t.Fatal("the context was not cancelled, so the deferred unlock ran on a live context " +
+			"and this test proved nothing")
+	}
+
+	if gh483OrgLockHeld(t, pool, tenant) {
+		t.Fatalf("GH #483: the org_lifecycle advisory lock for tenant %s is STILL HELD after a "+
+			"purge pass that was cancelled mid-flight. The connection went back to the pool "+
+			"healthy and still locked, so every later purge tick reads false from "+
+			"pg_try_advisory_lock and skips, and DELETE /orgs/{orgId} and POST "+
+			"/orgs/{orgId}/restore — which take this same key — block until "+
+			"MaxConnLifetime (30m) recycles the connection", tenant)
+	}
+}
+
+// TestGH483_PurgeOnALiveContextStillReleasesTheLock is the over-fire guard. The
+// fix must not be a fix that only works when something went wrong: the ordinary
+// completed sweep, on a context nobody cancelled, must still leave the lock
+// released, and the purge must still do its job.
+//
+// It passes both before and after the fix — that is the point of it. It fails if
+// a future "fix" releases the lock only on the cancelled path, or drops the
+// unlock altogether.
+//
+//	go test ./tests/ -run TestGH483_PurgeOnALiveContextStillReleasesTheLock -v -count=1
+func TestGH483_PurgeOnALiveContextStillReleasesTheLock(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	tenant := seedTenant(t, pool, "gh483-live-"+uuid.NewString()[:8])
+	odBackdateDeletedAt(t, admin, tenant, 30*24*time.Hour)
+
+	store := &gh483EmptyStore{}
+	worker := org.NewPurgeWorker(pool, nil, nil, store, time.Hour, nil)
+
+	ctx := context.Background()
+	if err := worker.Work(ctx, nil); err != nil {
+		t.Fatalf("purge sweep: %v", err)
+	}
+	if store.listCall == 0 {
+		t.Fatal("the purge never reached the object-storage step, so this ran over a tenant " +
+			"that was not due and proved nothing")
+	}
+
+	// The purge completed, so the tenant row is gone.
+	var alive int
+	if err := admin.QueryRow(context.Background(),
+		`SELECT count(*) FROM tenants WHERE id = $1`, tenant).Scan(&alive); err != nil {
+		t.Fatalf("count the purged tenant: %v", err)
+	}
+	if alive != 0 {
+		t.Fatalf("the uncancelled sweep left tenant %s in place (%d rows); the lock assertion "+
+			"below would be meaningless because the purge did not run", tenant, alive)
+	}
+
+	if gh483OrgLockHeld(t, pool, tenant) {
+		t.Fatalf("a NORMAL, uncancelled purge pass left the org_lifecycle advisory lock for "+
+			"tenant %s held. The unlock is broken on the ordinary path, not just the "+
+			"cancelled one", tenant)
+	}
+}
+
+// gh483EmptyStore is a storage backend with nothing in it: every prefix lists
+// empty, so the purge walks all seven roots and completes.
+type gh483EmptyStore struct{ listCall int }
+
+func (s *gh483EmptyStore) List(_ context.Context, _ string) ([]string, error) {
+	s.listCall++
+	return nil, nil
+}
+
+func (s *gh483EmptyStore) Delete(_ context.Context, _ string) error { return nil }

--- a/apps/api/tests/gh483_dispatch_sweeper_cancelled_ctx_integration_test.go
+++ b/apps/api/tests/gh483_dispatch_sweeper_cancelled_ctx_integration_test.go
@@ -1,0 +1,205 @@
+package tests
+
+// gh483_dispatch_sweeper_cancelled_ctx_integration_test.go — GH #483, the
+// third converted site.
+//
+// 71fed5ef's commit message said update/dispatch_sweeper.go's
+// update_dispatch_sweeper lock (like backup/tenant_reclaim_worker.go's) was
+// "covered by inspection only" because no seam existed to cancel the pass's
+// context between taking the advisory lock and releasing it, without
+// reshaping production code. A security review on PR #495 established that
+// claim was wrong here too: update.SweepWorker already takes its Repo through
+// an injectable interface (NewSweepWorker(repo Repo, enq SweepEnqueuer, pool
+// *pgxpool.Pool, logger)), and ListDueRuns runs AFTER the advisory lock is
+// taken and BEFORE the deferred unlock — the identical seam
+// gh483_advisory_unlock_cancelled_ctx_integration_test.go already uses for
+// org.PurgeWorker's ObjectPurger. A fake Repo whose ListDueRuns cancels the
+// sweep's own context and then fails reaches the exact same release-on-a-
+// dead-context path, with nothing in dispatch_sweeper.go touched.
+//
+// See gh483_advisory_unlock_cancelled_ctx_integration_test.go for the full
+// defect writeup.
+//
+// NOT RUN BY CI (apps/api/tests is excluded from the fast lane by owner
+// decision). Run with `make test-integration` from the repository root, or
+// directly with the command in each test's doc comment.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+)
+
+// gh483CancellingSweepRepo is the seam. It embeds update.Repo as a nil
+// interface so every method the sweeper does not reach (DispatchDueRun,
+// ExpireDueRun, ...) is promoted and compiles the fake against the full
+// interface without hand-writing panics for each; sweep() only ever calls
+// ListDueRuns before reaching any of them, which the assertions below verify.
+//
+// ListDueRuns cancels the pass's own context and fails, which is what a
+// SIGTERM landing between "advisory lock acquired" and "due-run scan
+// returned" does to a real sweep tick: the pass unwinds, and the deferred
+// pg_advisory_unlock in dispatch_sweeper.go's sweep() is reached with a dead
+// context.
+type gh483CancellingSweepRepo struct {
+	update.Repo
+	cancel  context.CancelFunc
+	dueCall int
+}
+
+func (r *gh483CancellingSweepRepo) ListDueRuns(_ context.Context, _ int32) ([]update.Run, error) {
+	r.dueCall++
+	r.cancel()
+	return nil, errors.New("gh483: due-run scan unreachable (test injects the cancellation here)")
+}
+
+// gh483EmptySweepRepo returns no due runs and never touches the rest of the
+// Repo interface, for the uncancelled over-fire proof.
+type gh483EmptySweepRepo struct {
+	update.Repo
+	dueCall int
+}
+
+func (r *gh483EmptySweepRepo) ListDueRuns(_ context.Context, _ int32) ([]update.Run, error) {
+	r.dueCall++
+	return nil, nil
+}
+
+// gh483NoopSweepEnqueuer is wired only so SweepWorker.sweep passes its
+// "enqueuer is wired" guard; the fakes above make sure it is never actually
+// invoked (ListDueRuns fails or returns empty before any enqueue).
+type gh483NoopSweepEnqueuer struct{}
+
+func (gh483NoopSweepEnqueuer) EnqueueDispatchIfAbsent(context.Context, uuid.UUID, uuid.UUID, time.Time) (bool, error) {
+	return false, nil
+}
+
+// gh483SweepLockHeld reports whether the update_dispatch_sweeper SESSION
+// advisory lock (dispatch_sweeper.go's sweepLockKey, a single-bigint
+// pg_advisory_lock(hashtext($1)), confirmed at dispatch_sweeper.go:232) is
+// held by ANY session, read from pg_locks THROUGH THE APPLICATION POOL as the
+// application role.
+//
+// A single-bigint advisory lock stores key = hashtext(key)::bigint (an
+// implicit, sign-extending int4->int8 cast) and pg_locks exposes it as
+// classid = uint32(key >> 32), objid = uint32(key), objsubid = 1 — as opposed
+// to the two-int form's objsubid = 2 that gh483OrgLockHeld reads. hashtext
+// returns int4 and is routinely negative; sign-extension means the high 32
+// bits of the bigint are either all-zero (hashtext >= 0) or all-one (hashtext
+// < 0), so classid is computed here with a bitmask rather than the
+// binary-coercion cast gh483OrgLockHeld uses for the two-int form, and objid
+// is the same hashtext($1)::oid bit-reinterpretation as that helper.
+//
+// This reads pg_locks rather than probing with pg_try_advisory_lock for the
+// same reason gh483OrgLockHeld does: the pool can hand back the very
+// connection that leaked the lock, and advisory locks are re-entrant per
+// session, so a same-session probe can report "free" while the lock is held.
+func gh483SweepLockHeld(t *testing.T, pool *db.Pool, key string) bool {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM pg_locks
+		  WHERE locktype = 'advisory'
+		    AND objsubid = 1
+		    AND objid    = hashtext($1)::oid
+		    AND classid  = ((hashtext($1)::bigint >> 32) & 4294967295)::oid`,
+		key).Scan(&n); err != nil {
+		t.Fatalf("read pg_locks for the %s advisory lock: %v", key, err)
+	}
+	return n > 0
+}
+
+// gh483SweepLockKey mirrors the unexported sweepLockKey constant in
+// dispatch_sweeper.go (":232" per the task brief), duplicated here because the
+// production constant is unexported and this package cannot reach it. Its
+// value is confirmed against the production source at review time; a rename
+// there without an update here would make gh483SweepLockHeld probe the wrong
+// key and every assertion below would report "not held" regardless of the
+// actual bug, so a drift here is not silently safe.
+const gh483SweepLockKey = "update_dispatch_sweeper"
+
+// TestGH483_SweepLockCancelledMidPassDoesNotLeakTheDispatchSweepLock is the
+// regression. It runs a real update.SweepWorker.Work over a real Postgres
+// pool, cancels the pass's context mid-pass at the ListDueRuns seam, and then
+// requires the update_dispatch_sweeper advisory lock to be gone.
+//
+// Against the unfixed code (conn.Exec(ctx, ...) in the release defer) the lock
+// is still held when Work returns and this fails. Against the fix
+// (db.CleanupContext) it is released.
+//
+//	go test ./tests/ -run TestGH483_SweepLockCancelledMidPassDoesNotLeakTheDispatchSweepLock -v -count=1
+func TestGH483_SweepLockCancelledMidPassDoesNotLeakTheDispatchSweepLock(t *testing.T) {
+	pool := startPostgres(t) // wpmgr_app: NOSUPERUSER, NOBYPASSRLS
+
+	if gh483SweepLockHeld(t, pool, gh483SweepLockKey) {
+		t.Fatalf("the %s lock was already held before the sweep ran; this test cannot "+
+			"attribute anything it observes afterwards", gh483SweepLockKey)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	repo := &gh483CancellingSweepRepo{cancel: cancel}
+
+	worker := update.NewSweepWorker(repo, gh483NoopSweepEnqueuer{}, pool.Pool, nil)
+
+	// Work swallows the pass-level error (sweep() failing is logged, not
+	// returned) exactly like org.PurgeWorker.Work, so the assertion is on the
+	// database, not on Work's return value.
+	if err := worker.Work(ctx, nil); err != nil {
+		t.Fatalf("sweep pass returned an error at the Work level: %v", err)
+	}
+	if repo.dueCall == 0 {
+		t.Fatal("the sweep never reached ListDueRuns, so the context was never cancelled " +
+			"mid-pass and this test proved nothing. Check that the advisory lock was " +
+			"actually acquired before the scan ran")
+	}
+	if ctx.Err() == nil {
+		t.Fatal("the context was not cancelled, so the deferred unlock ran on a live context " +
+			"and this test proved nothing")
+	}
+
+	if gh483SweepLockHeld(t, pool, gh483SweepLockKey) {
+		t.Fatalf("GH #483: the %s advisory lock is STILL HELD after a sweep pass that was "+
+			"cancelled mid-flight. The connection went back to the pool healthy and still "+
+			"locked, so every later pass reads false from pg_try_advisory_lock, logs "+
+			"\"another replica holds the lock\" and skips — and the heartbeat whose ABSENCE "+
+			"is the sweeper's own dead-process detector goes quiet right along with it, "+
+			"until db.MaxConnLifetime (30m) recycles the connection", gh483SweepLockKey)
+	}
+}
+
+// TestGH483_SweepOnALiveContextStillReleasesTheDispatchSweepLock is the
+// over-fire guard. The fix must not be a fix that only works when something
+// went wrong: the ordinary completed pass, on a context nobody cancelled, must
+// still leave the lock released.
+//
+//	go test ./tests/ -run TestGH483_SweepOnALiveContextStillReleasesTheDispatchSweepLock -v -count=1
+func TestGH483_SweepOnALiveContextStillReleasesTheDispatchSweepLock(t *testing.T) {
+	pool := startPostgres(t)
+
+	if gh483SweepLockHeld(t, pool, gh483SweepLockKey) {
+		t.Fatalf("the %s lock was already held before the sweep ran", gh483SweepLockKey)
+	}
+
+	repo := &gh483EmptySweepRepo{}
+	worker := update.NewSweepWorker(repo, gh483NoopSweepEnqueuer{}, pool.Pool, nil)
+
+	ctx := context.Background()
+	if err := worker.Work(ctx, nil); err != nil {
+		t.Fatalf("sweep pass: %v", err)
+	}
+	if repo.dueCall == 0 {
+		t.Fatal("the sweep never reached ListDueRuns; this run proved nothing")
+	}
+
+	if gh483SweepLockHeld(t, pool, gh483SweepLockKey) {
+		t.Fatalf("a NORMAL, uncancelled sweep pass left the %s advisory lock held. The unlock "+
+			"is broken on the ordinary path, not just the cancelled one", gh483SweepLockKey)
+	}
+}

--- a/apps/api/tests/gh483_dispatch_sweeper_cancelled_ctx_integration_test.go
+++ b/apps/api/tests/gh483_dispatch_sweeper_cancelled_ctx_integration_test.go
@@ -49,12 +49,28 @@ import (
 // context.
 type gh483CancellingSweepRepo struct {
 	update.Repo
+	t       *testing.T
+	pool    *db.Pool
 	cancel  context.CancelFunc
 	dueCall int
+
+	// heldDuringScan is the positive control. It records whether
+	// gh483SweepLockKey was observed HELD at the one point in the pass
+	// where it must be: after SweepWorker.Work has taken the advisory lock
+	// and before the deferred unlock runs. Without this, a rename of
+	// dispatch_sweeper.go's unexported sweepLockKey out from under
+	// gh483SweepLockKey makes gh483SweepLockHeld probe a key nobody holds,
+	// report "not held" both here and in the pre/post checks below, and
+	// every assertion in this test would then be satisfied vacuously —
+	// this is the control that turns that drift into a failure instead.
+	heldDuringScan bool
 }
 
 func (r *gh483CancellingSweepRepo) ListDueRuns(_ context.Context, _ int32) ([]update.Run, error) {
 	r.dueCall++
+	// Read BEFORE cancel(): this is the seam where the lock is live —
+	// taken by sweep(), not yet released by its deferred unlock.
+	r.heldDuringScan = gh483SweepLockHeld(r.t, r.pool, gh483SweepLockKey)
 	r.cancel()
 	return nil, errors.New("gh483: due-run scan unreachable (test injects the cancellation here)")
 }
@@ -144,7 +160,7 @@ func TestGH483_SweepLockCancelledMidPassDoesNotLeakTheDispatchSweepLock(t *testi
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	repo := &gh483CancellingSweepRepo{cancel: cancel}
+	repo := &gh483CancellingSweepRepo{t: t, pool: pool, cancel: cancel}
 
 	worker := update.NewSweepWorker(repo, gh483NoopSweepEnqueuer{}, pool.Pool, nil)
 
@@ -162,6 +178,13 @@ func TestGH483_SweepLockCancelledMidPassDoesNotLeakTheDispatchSweepLock(t *testi
 	if ctx.Err() == nil {
 		t.Fatal("the context was not cancelled, so the deferred unlock ran on a live context " +
 			"and this test proved nothing")
+	}
+	if !repo.heldDuringScan {
+		t.Fatalf("the %s advisory lock was NOT observed held during the due-run scan, before "+
+			"the pass released it. Every assertion below this point is vacuous, most likely "+
+			"because gh483SweepLockKey (%q) no longer matches dispatch_sweeper.go's "+
+			"unexported sweepLockKey — check that constant first, before suspecting the "+
+			"unlock fix itself", gh483SweepLockKey, gh483SweepLockKey)
 	}
 
 	if gh483SweepLockHeld(t, pool, gh483SweepLockKey) {

--- a/apps/api/tests/gh483_reclaim_lock_cancelled_ctx_integration_test.go
+++ b/apps/api/tests/gh483_reclaim_lock_cancelled_ctx_integration_test.go
@@ -1,0 +1,138 @@
+package tests
+
+// gh483_reclaim_lock_cancelled_ctx_integration_test.go — GH #483, the second
+// converted site.
+//
+// 71fed5ef's commit message said backup/tenant_reclaim_worker.go's
+// org_lifecycle lock (like update/dispatch_sweeper.go's) was "covered by
+// inspection only" because no seam existed to cancel the caller's context
+// between the lock and its release without reshaping production code. A
+// security review on PR #495 established that claim was wrong for this site: no
+// reshaping is needed, because LockTenantLifecycle's returned closure captures
+// its ctx PARAMETER by reference, not by value. A caller can cancel that same
+// context object after LockTenantLifecycle returns (lock already taken) and
+// before invoking the returned release func — at which point the closure's
+// deferred db.CleanupContext(ctx) sees an already-cancelled ctx, exactly the
+// shape GH #483 is about, with nothing in tenant_reclaim_worker.go touched.
+//
+// See gh483_advisory_unlock_cancelled_ctx_integration_test.go for the full
+// defect writeup and gh483OrgLockHeld, reused here unmodified.
+//
+// NOT RUN BY CI (apps/api/tests is excluded from the fast lane by owner
+// decision). Run with `make test-integration` from the repository root, or
+// directly with the command in each test's doc comment.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+)
+
+// TestGH483_ReclaimLockCancelledBeforeReleaseDoesNotLeakTheOrgLifecycleLock is
+// the regression for backup.pgTenantReclaimStore.LockTenantLifecycle.
+//
+// It takes the lock on a cancellable context, cancels that SAME context object
+// after the lock is confirmed acquired, and only then calls the returned
+// release func — so release's deferred unlock runs on a context that is
+// already Err() != nil by the time db.CleanupContext reads it, matching a
+// drain cancelled mid-flight (rolling deploy, River job timeout) between
+// acquiring the lock and reaching its own release path.
+//
+// Against the unfixed code (conn.Exec(ctx, ...) in the release closure) the
+// unlock never reaches the wire on a dead ctx, the pooled connection goes back
+// healthy and still locked, and this fails. Against the fix
+// (db.CleanupContext) it is released.
+//
+//	go test ./tests/ -run TestGH483_ReclaimLockCancelledBeforeReleaseDoesNotLeakTheOrgLifecycleLock -v -count=1
+func TestGH483_ReclaimLockCancelledBeforeReleaseDoesNotLeakTheOrgLifecycleLock(t *testing.T) {
+	pool := startPostgres(t) // wpmgr_app: NOSUPERUSER, NOBYPASSRLS
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	tenant := uuid.New()
+	if gh483OrgLockHeld(t, pool, tenant) {
+		t.Fatalf("the org_lifecycle lock for %s was already held before the test ran; this test "+
+			"cannot attribute anything it observes afterwards", tenant)
+	}
+
+	store := backup.NewTenantReclaimStore(pool)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release, acquired, err := store.LockTenantLifecycle(ctx, tenant)
+	if err != nil {
+		t.Fatalf("take the lock: %v", err)
+	}
+	if !acquired {
+		t.Fatal("an uncontended lock was not acquired")
+	}
+
+	// Cancel the SAME ctx object LockTenantLifecycle was called with, BEFORE
+	// calling release. release's closure captured this ctx variable by
+	// reference (it is a func literal over the enclosing parameter, not a
+	// value copied at call time), so the deferred db.CleanupContext(ctx) inside
+	// it observes cancellation that happened after the lock was taken and
+	// before release ran — not cancellation racing the lock acquisition
+	// itself.
+	cancel()
+	if ctx.Err() == nil {
+		t.Fatal("cancel() did not mark ctx done; the release below would run on a live context and " +
+			"this test would prove nothing")
+	}
+
+	release()
+
+	if gh483OrgLockHeld(t, pool, tenant) {
+		t.Fatalf("GH #483: the org_lifecycle advisory lock for tenant %s is STILL HELD after "+
+			"release() ran on an already-cancelled context. The connection went back to the "+
+			"pool healthy and still locked, so DELETE /orgs/{orgId}, POST "+
+			"/orgs/{orgId}/restore and the Lane B purge worker for this tenant all block on "+
+			"it until db.MaxConnLifetime (30m) recycles the connection", tenant)
+	}
+}
+
+// TestGH483_ReclaimLockOnALiveContextStillReleases is the over-fire guard for
+// the same seam: cancelling ctx must not become the ONLY path that releases
+// the lock. A normal caller that never cancels anything — the drain's actual
+// steady state — must still get the lock back.
+//
+// This is a second, direct proof of the same fact
+// TestGH408_TheDrainTakesTheSameLockTheOrgLifecycleUses already establishes via
+// its post-release probe; it is kept here, alongside the cancelled-path test
+// above, so the pair sits together and so deleting the unlock line (the
+// over-fire check on THIS pair, see the PR body / worklog) has an
+// uncancelled-path failure to point at without depending on an unrelated file.
+//
+//	go test ./tests/ -run TestGH483_ReclaimLockOnALiveContextStillReleases -v -count=1
+func TestGH483_ReclaimLockOnALiveContextStillReleases(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	tenant := uuid.New()
+	if gh483OrgLockHeld(t, pool, tenant) {
+		t.Fatalf("the org_lifecycle lock for %s was already held before the test ran", tenant)
+	}
+
+	store := backup.NewTenantReclaimStore(pool)
+	ctx := context.Background()
+
+	release, acquired, err := store.LockTenantLifecycle(ctx, tenant)
+	if err != nil {
+		t.Fatalf("take the lock: %v", err)
+	}
+	if !acquired {
+		t.Fatal("an uncontended lock was not acquired")
+	}
+	release()
+
+	if gh483OrgLockHeld(t, pool, tenant) {
+		t.Fatalf("a NORMAL release on a live, uncancelled context left the org_lifecycle "+
+			"advisory lock for tenant %s held. The unlock is broken on the ordinary path, "+
+			"not just the cancelled one", tenant)
+	}
+}


### PR DESCRIPTION
Closes #483.

A deferred `conn.Exec(ctx, "SELECT pg_advisory_unlock(...)")` sends nothing when
`ctx` is already cancelled — pgx returns before the statement reaches the wire.
That does not mark the connection broken, so pgxpool takes it back as healthy and
hands it to the next caller **still holding a session-scoped lock**. Later passes
run on a different connection, read `false` from `pg_try_advisory_lock`, conclude a
peer replica is working, and skip. Nothing errors. The work just stops until
`MaxConnLifetime` (30m) recycles the connection.

The issue reported one site. A sweep found three:

| Site | Lock | Consequence while leaked |
|---|---|---|
| `backup/worker.go` | `backup_scheduler` | no scheduled backup fires, for any tenant |
| `backup/repo.go` | `backup_gc` + tenant | chunk GC stops for that tenant |
| `org/purge_worker.go` | `org_lifecycle` | blocks `DELETE /orgs/{orgId}` and `POST /orgs/{orgId}/restore` |

The third is the shared lifecycle key, so the leak fails those endpoints directly
rather than only delaying a background tick.

All three now release on `db.CleanupContext`: `context.WithoutCancel` so the
statement is actually sent, bounded by `db.SessionCleanupTimeout` so an
uncancellable `Exec` inside a `defer` cannot hang shutdown on a wedged socket. The
bound costs nothing where it fires — a session that cannot be reached is one whose
locks are about to drop anyway.

`backup/repo.go` also carried a comment arguing the unlock was best-effort because
"the lock drops when the session closes". True of a session that closes, false of
the pooled connection this code actually uses. The prose is corrected with the code.

## Proof

`tests/gh483_advisory_unlock_cancelled_ctx_integration_test.go` runs against real
Postgres as `wpmgr_app`, reading `pg_locks` through the application pool — the same
path and role production uses, so the assertion reflects what the next pass would
actually see. Verified red before the change and green after.

A second test covers the **uncancelled** path, so a fix that released the lock only
on the cancelled path, or one that over-fired and broke normal operation, would be
caught rather than passing quietly.

## Five sites, one idiom

An initial pass treated `backup/tenant_reclaim_worker.go` and
`update/dispatch_sweeper.go` as already correct, because both already use
`context.WithoutCancel`. A security review showed that is only half the story: they
send the unlock, so they never had the original bug, but they carry no bound — which
leaves the *second* failure mode open, an uncancellable `Exec` in a `defer` blocking a
graceful drain on a wedged socket. `tenant_reclaim_worker.go` takes the **same**
`org.LifecycleLockKey` as the purge worker and the delete/restore endpoints.

Both are now on `db.CleanupContext` as well, so there is one idiom for releasing a
session advisory lock rather than two.

The same review also found the false "the lock drops when the session closes" comment
this PR corrects in `backup/repo.go` still live, verbatim, on the pooled path in
`tenant_reclaim_worker.go`. Corrected there too — it is the comment most likely to talk
the next reader out of the fix.

## Why the bound is safe

Proven against real Postgres rather than argued:

| Context state when `Exec` runs | pgx behaviour | Lock outcome |
|---|---|---|
| already cancelled | returns before the wire; `IsClosed()==false`, so `Release` does **not** destroy | **still held** — the original bug |
| deadline fires mid-statement | `asyncClose`; `IsClosed()==true`, `Release` destroys, backend dies | dropped, because the session ended |

So a too-short `SessionCleanupTimeout` degrades to connection churn, never to a
retained lock. That asymmetry is the whole safety argument for bounding a release that
must happen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of database session locks when background operations are cancelled or time out.
  - Prevented retained locks from blocking tenant lifecycle, purge, backup, and dispatch operations.
  - Added bounded cleanup handling to ensure connections are safely returned for reuse.

- **Tests**
  - Added integration coverage confirming locks are released after cancelled and successful operations across tenant purge, reclaim, and dispatch workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->