### PR TITLE
fix(backup): guard the three blind backup_snapshots state transitions (#458)

### DIFF
--- a/apps/api/db/query/backups.sql
+++ b/apps/api/db/query/backups.sql
@@ -23,40 +23,73 @@ WHERE tenant_id = $1 AND site_id = $2
 ORDER BY created_at DESC
 LIMIT $3 OFFSET $4;
 
--- name: MarkBackupSnapshotRunning :one
+-- name: MarkBackupSnapshotRunning :execrows
+-- Claim precondition (GH #458): 'pending' is the only status a claim may
+-- transition out of. Without it the UPDATE was blind, so a duplicate/retried
+-- worker job, or a job whose snapshot was cancelled or watchdog-failed while
+-- it sat in the queue, dragged a terminal row back to 'running' and cleared
+-- the run's real outcome. Rows-affected is the contract: 1 = this caller won
+-- the claim and owns the run; 0 = the row was not 'pending' (already claimed,
+-- already terminal, or gone), and the caller must NOT proceed as the owner and
+-- must NOT publish the 'started' SSE event or the schedule-run reconciliation
+-- for it. :execrows (not :exec) because a precondition whose failure is
+-- invisible is worse than no precondition -- same reasoning as
+-- FailStalledBackupSnapshot below.
 UPDATE backup_snapshots
 SET status = 'running', started_at = now(), updated_at = now()
-WHERE id = $1 AND tenant_id = $2
-RETURNING *;
+WHERE id = $1 AND tenant_id = $2 AND status = 'pending';
 
--- name: CompleteBackupSnapshot :one
+-- name: CompleteBackupSnapshot :execrows
+-- Terminal-transition precondition (GH #458): only a 'pending' or 'running'
+-- snapshot may complete. 'pending' stays allowed because the files-only and
+-- carry-forward completion paths can land without an intervening MarkRunning.
+-- What the guard blocks is resurrection: a late agent manifest submit arriving
+-- after the operator cancelled (CancelSnapshot stamps 'failed') or after the
+-- watchdog hard-failed the run must not flip the row to 'completed' and must
+-- not overwrite the recorded error and finished_at. Rows-affected is the
+-- contract: 1 = a real transition; 0 = already terminal (completed/failed) or
+-- gone, which the caller must surface as a rejected submit -- the previous
+-- blind UPDATE reported success unconditionally.
 UPDATE backup_snapshots
 SET status = 'completed',
     total_size = $3,
     chunk_count = $4,
     finished_at = now(),
     updated_at = now()
-WHERE id = $1 AND tenant_id = $2
-RETURNING *;
+WHERE id = $1 AND tenant_id = $2 AND status IN ('pending', 'running');
 
--- name: FailBackupSnapshot :one
+-- name: FailBackupSnapshot :execrows
+-- Terminal-transition precondition (GH #458). 'pending' is in the guard
+-- deliberately: CancelSnapshot ("only a running or pending backup can be
+-- cancelled") fails a still-'pending' snapshot through this query, so
+-- narrowing to status='running' would silently stop operator cancel of a
+-- queued backup. That is the watchdog's guard, not this one -- see
+-- FailStalledBackupSnapshot below. What this guard blocks is the overwrite of
+-- an ALREADY-terminal row: a worker error landing after the operator cancelled
+-- must not replace cancelByOperatorMsg with a generic message, and a fail must
+-- never rewrite a completed run's status or finished_at. Rows-affected is the
+-- contract: 1 = a real transition; 0 = already terminal, or gone -- do not
+-- publish the 'failed' SSE event, the failure email, or the schedule-run
+-- reconciliation for a row that had already moved on.
 UPDATE backup_snapshots
 SET status = 'failed',
     error = $3,
     finished_at = now(),
     updated_at = now()
-WHERE id = $1 AND tenant_id = $2
-RETURNING *;
+WHERE id = $1 AND tenant_id = $2 AND status IN ('pending', 'running');
 
 -- name: FailStalledBackupSnapshot :execrows
 -- TOCTOU-safe hard-fail for the two-tier progress watchdog (GH #279 must-fix).
--- Identical to FailBackupSnapshot except for the added "AND status='running'"
--- guard: ListStalledRunningSnapshots commits, then each hard row is failed in
--- its own separate transaction, so between the two a row may have completed,
--- been operator-cancelled, been agent-failed, or resumed. FailBackupSnapshot's
--- blind UPDATE has no status guard (CancelSnapshot relies on that to fail a
--- still-'pending' row), so it must stay unchanged; this query is the watchdog
--- hard-fail branch's ONLY write path. Rows-affected (0 or 1) tells the caller
+-- Identical to FailBackupSnapshot except that the guard is NARROWER:
+-- status='running' here, status IN ('pending','running') there (GH #458).
+-- ListStalledRunningSnapshots commits, then each hard row is failed in its own
+-- separate transaction, so between the two a row may have completed, been
+-- operator-cancelled, been agent-failed, or resumed. The watchdog only ever
+-- hard-fails a run it observed RUNNING and must never touch a queued 'pending'
+-- row -- which FailBackupSnapshot may, because operator cancel of a queued
+-- backup goes through it (CancelSnapshot). The two guards therefore stay
+-- distinct, and this query remains the watchdog hard-fail branch's ONLY write
+-- path. Rows-affected (0 or 1) tells the caller
 -- whether a real transition happened, so it can gate the 'failed' SSE publish
 -- and the failure notification on an actual state change rather than firing
 -- them for a row that already moved on.

--- a/apps/api/internal/backup/delete_cancel_test.go
+++ b/apps/api/internal/backup/delete_cancel_test.go
@@ -75,13 +75,19 @@ func (r *deleteCancelFakeRepo) ListCompletedChainSnapshots(_ context.Context, _ 
 	return out, nil
 }
 
-func (r *deleteCancelFakeRepo) FailSnapshot(_ context.Context, _, snapshotID uuid.UUID, msg string) (Snapshot, error) {
+func (r *deleteCancelFakeRepo) FailSnapshot(_ context.Context, _, snapshotID uuid.UUID, msg string) (Snapshot, bool, error) {
+	s, ok := r.snapshots[snapshotID]
+	// GH #458: mirror the real query's guard exactly. A fake that always
+	// reports a transition would hide the very defect the guard exists to
+	// catch.
+	if !ok || (s.Status != StatusPending && s.Status != StatusRunning) {
+		return Snapshot{}, false, nil
+	}
 	r.failed[snapshotID] = msg
-	s := r.snapshots[snapshotID]
 	s.Status = StatusFailed
 	s.Error = msg
 	r.snapshots[snapshotID] = s
-	return s, nil
+	return s, true, nil
 }
 
 func (r *deleteCancelFakeRepo) DeleteSnapshot(_ context.Context, _, snapshotID uuid.UUID) error {

--- a/apps/api/internal/backup/enqueuer.go
+++ b/apps/api/internal/backup/enqueuer.go
@@ -33,10 +33,11 @@ func NewRiverEnqueuer(client *river.Client[pgx.Tx]) *RiverEnqueuer {
 // notices. UniqueOpts makes the invariant a database constraint instead, on
 // the same idiom EnqueueSqlInspectLegacy already uses below.
 //
-// ByArgs: true — the uniqueness hash covers the encoded args, and BackupArgs
-// carries SnapshotID, so two DIFFERENT snapshots hash differently and both
-// enqueue. That is the property that matters most here; see
-// TestBackupInsertOpts_DifferentSnapshotsAreNotDeduped.
+// ByArgs: true — the uniqueness hash covers the encoded args. BackupArgs.
+// SnapshotID carries `river:"unique"`, which narrows the hash to just that
+// field, so two DIFFERENT snapshots always hash differently and both enqueue,
+// regardless of what else either enqueue path sets. That is the property that
+// matters most here; see TestBackupInsertOpts_DifferentSnapshotsAreNotDeduped.
 //
 // No ByPeriod, deliberately, and unlike EnqueueSqlInspectLegacy. A period
 // re-opens exactly the window this closes: a second job for the SAME snapshot
@@ -49,17 +50,19 @@ func NewRiverEnqueuer(client *river.Client[pgx.Tx]) *RiverEnqueuer {
 // includes completed, so the key stays claimed until the job cleaner reaps the
 // completed row.
 //
-// Residual, worth knowing before changing either enqueue path: the hash covers
-// the WHOLE encoded args blob, not just the snapshot ID. The two paths agree
-// for a full snapshot — `omitempty` does NOT drop a zero uuid.UUID (it is a
-// [16]byte, so never "empty" to encoding/json), so parent/base/chain are
-// serialised as zero UUIDs either way — but EnqueueBackupWithChain also emits
-// is_incremental and generation, which ARE dropped when zero. So for an
-// INCREMENTAL snapshot the two paths hash differently. A future re-enqueue
-// must rebuild the args the way the original insert did (an incremental
-// snapshot back through EnqueueBackupWithChain) for River to see it as the
-// same job. Narrowing the key with `river:"unique"` struct tags on
-// SnapshotID would remove that coupling if a re-enqueue path is ever added.
+// Residual, worth knowing before changing either enqueue path: BackupArgs.
+// SnapshotID carries a `river:"unique"` struct tag, so the uniqueness hash
+// covers ONLY the encoded snapshot_id, not the whole args blob. Before that
+// tag existed, ByArgs hashed the full payload and the two enqueue paths
+// disagreed for an INCREMENTAL snapshot — `omitempty` does NOT drop a zero
+// uuid.UUID (it is a [16]byte, so never "empty" to encoding/json), so
+// parent/base/chain serialised as zero UUIDs either way, but
+// EnqueueBackupWithChain also emits is_incremental and generation, which ARE
+// dropped when zero. That made a full snapshot's two paths hash the same by
+// coincidence while an incremental snapshot's hashed differently, so the
+// constraint held for full backups and silently didn't for incrementals. The
+// tag removes the coupling: any enqueue path that sets the same SnapshotID
+// collides, regardless of what else is in the args.
 func backupInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
 		UniqueOpts: river.UniqueOpts{ByArgs: true},

--- a/apps/api/internal/backup/enqueuer.go
+++ b/apps/api/internal/backup/enqueuer.go
@@ -21,9 +21,54 @@ func NewRiverEnqueuer(client *river.Client[pgx.Tx]) *RiverEnqueuer {
 	return &RiverEnqueuer{client: client}
 }
 
+// backupInsertOpts is the InsertOpts BOTH backup enqueue paths must use.
+//
+// GH #458 review: BackupWorker.resumedOwnClaim treats "attempt > 1 and the row
+// is still running" as proof that the running row is THIS job's own claim.
+// That inference is only sound while a snapshot has exactly ONE River job. Up
+// to now that held by convention — nothing re-enqueues an existing snapshot —
+// which is a property of code nobody has written yet, and it fails SILENTLY if
+// someone writes it: job B's attempt 2 would re-dispatch over job A's live
+// claim, the log line says "resumed by the owning job" either way, and no test
+// notices. UniqueOpts makes the invariant a database constraint instead, on
+// the same idiom EnqueueSqlInspectLegacy already uses below.
+//
+// ByArgs: true — the uniqueness hash covers the encoded args, and BackupArgs
+// carries SnapshotID, so two DIFFERENT snapshots hash differently and both
+// enqueue. That is the property that matters most here; see
+// TestBackupInsertOpts_DifferentSnapshotsAreNotDeduped.
+//
+// No ByPeriod, deliberately, and unlike EnqueueSqlInspectLegacy. A period
+// re-opens exactly the window this closes: a second job for the SAME snapshot
+// once the period elapses. The usual argument for a period — that the same
+// logical work is legitimately re-requested later — does not apply, because
+// the key here is a snapshot UUID minted per snapshot ROW. A legitimate re-run
+// is a new row with a new UUID and therefore a new key; the only thing an
+// unbounded window blocks is a second job for a snapshot that already has one,
+// which is the thing being blocked on purpose. River's default ByState
+// includes completed, so the key stays claimed until the job cleaner reaps the
+// completed row.
+//
+// Residual, worth knowing before changing either enqueue path: the hash covers
+// the WHOLE encoded args blob, not just the snapshot ID. The two paths agree
+// for a full snapshot — `omitempty` does NOT drop a zero uuid.UUID (it is a
+// [16]byte, so never "empty" to encoding/json), so parent/base/chain are
+// serialised as zero UUIDs either way — but EnqueueBackupWithChain also emits
+// is_incremental and generation, which ARE dropped when zero. So for an
+// INCREMENTAL snapshot the two paths hash differently. A future re-enqueue
+// must rebuild the args the way the original insert did (an incremental
+// snapshot back through EnqueueBackupWithChain) for River to see it as the
+// same job. Narrowing the key with `river:"unique"` struct tags on
+// SnapshotID would remove that coupling if a re-enqueue path is ever added.
+func backupInsertOpts() *river.InsertOpts {
+	return &river.InsertOpts{
+		UniqueOpts: river.UniqueOpts{ByArgs: true},
+	}
+}
+
 // EnqueueBackup inserts one backup job.
 func (e *RiverEnqueuer) EnqueueBackup(ctx context.Context, tenantID, snapshotID uuid.UUID) error {
-	if _, err := e.client.Insert(ctx, BackupArgs{TenantID: tenantID, SnapshotID: snapshotID}, nil); err != nil {
+	if _, err := e.client.Insert(ctx, BackupArgs{TenantID: tenantID, SnapshotID: snapshotID}, backupInsertOpts()); err != nil {
 		return fmt.Errorf("enqueue backup: %w", err)
 	}
 	return nil
@@ -49,7 +94,7 @@ func (e *RiverEnqueuer) EnqueueBackupWithChain(ctx context.Context, snap Snapsho
 	if snap.ChainID != nil {
 		args.ChainID = *snap.ChainID
 	}
-	if _, err := e.client.Insert(ctx, args, nil); err != nil {
+	if _, err := e.client.Insert(ctx, args, backupInsertOpts()); err != nil {
 		return fmt.Errorf("enqueue backup (incremental): %w", err)
 	}
 	return nil

--- a/apps/api/internal/backup/fleet_security_test.go
+++ b/apps/api/internal/backup/fleet_security_test.go
@@ -61,13 +61,13 @@ func (r *secFleetRepo) GetSnapshotScoped(_ context.Context, _ db.ScopedPrincipal
 func (r *secFleetRepo) ListSnapshotsForSite(_ context.Context, _, _ uuid.UUID, _, _ int32) ([]Snapshot, error) {
 	panic("secFleetRepo.ListSnapshotsForSite not implemented")
 }
-func (r *secFleetRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+func (r *secFleetRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, bool, error) {
 	panic("secFleetRepo.MarkSnapshotRunning not implemented")
 }
-func (r *secFleetRepo) CompleteSnapshot(_ context.Context, _, _ uuid.UUID, _, _ int64) (Snapshot, error) {
+func (r *secFleetRepo) CompleteSnapshot(_ context.Context, _, _ uuid.UUID, _, _ int64) (Snapshot, bool, error) {
 	panic("secFleetRepo.CompleteSnapshot not implemented")
 }
-func (r *secFleetRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, error) {
+func (r *secFleetRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, bool, error) {
 	panic("secFleetRepo.FailSnapshot not implemented")
 }
 func (r *secFleetRepo) FailStalledSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (int64, error) {

--- a/apps/api/internal/backup/gc_mark_sweep_test.go
+++ b/apps/api/internal/backup/gc_mark_sweep_test.go
@@ -387,13 +387,13 @@ func (r *gcFakeRepo) GetSnapshotScoped(context.Context, db.ScopedPrincipal, uuid
 func (r *gcFakeRepo) ListSnapshotsForSite(context.Context, uuid.UUID, uuid.UUID, int32, int32) ([]Snapshot, error) {
 	panic("unused")
 }
-func (r *gcFakeRepo) MarkSnapshotRunning(context.Context, uuid.UUID, uuid.UUID) (Snapshot, error) {
+func (r *gcFakeRepo) MarkSnapshotRunning(context.Context, uuid.UUID, uuid.UUID) (Snapshot, bool, error) {
 	panic("unused")
 }
-func (r *gcFakeRepo) CompleteSnapshot(context.Context, uuid.UUID, uuid.UUID, int64, int64) (Snapshot, error) {
+func (r *gcFakeRepo) CompleteSnapshot(context.Context, uuid.UUID, uuid.UUID, int64, int64) (Snapshot, bool, error) {
 	panic("unused")
 }
-func (r *gcFakeRepo) FailSnapshot(context.Context, uuid.UUID, uuid.UUID, string) (Snapshot, error) {
+func (r *gcFakeRepo) FailSnapshot(context.Context, uuid.UUID, uuid.UUID, string) (Snapshot, bool, error) {
 	panic("unused")
 }
 func (r *gcFakeRepo) FailStalledSnapshot(context.Context, uuid.UUID, uuid.UUID, string) (int64, error) {

--- a/apps/api/internal/backup/gh458_enqueue_uniqueness_test.go
+++ b/apps/api/internal/backup/gh458_enqueue_uniqueness_test.go
@@ -1,0 +1,123 @@
+package backup
+
+// gh458_enqueue_uniqueness_test.go — GH #458 review follow-up.
+//
+// resumedOwnClaim's soundness rests on "a snapshot has exactly one River job".
+// backupInsertOpts turns that from a convention into a River-enforced
+// constraint. These tests pin the two halves of it.
+//
+// The over-fire twin (DifferentSnapshotsAreNotDeduped) is the one that
+// matters: a uniqueness key that failed to distinguish two snapshots would
+// swallow legitimate backups, which is a far worse failure than the duplicate
+// job the key exists to block.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// TestBackupInsertOpts_EnforcesOneJobPerSnapshot pins the constraint itself.
+func TestBackupInsertOpts_EnforcesOneJobPerSnapshot(t *testing.T) {
+	opts := backupInsertOpts()
+	if opts == nil {
+		t.Fatal("backupInsertOpts() returned nil: the backup inserts carry no uniqueness " +
+			"constraint, so a second job for a live snapshot re-dispatches over its claim")
+	}
+	if !opts.UniqueOpts.ByArgs {
+		t.Fatal("UniqueOpts.ByArgs is false: uniqueness would key on the job KIND alone, " +
+			"which would dedupe every backup in the fleet against the first one")
+	}
+	// No ByPeriod, deliberately — a period re-opens the window for a second
+	// job on the same snapshot once it elapses. See backupInsertOpts's doc.
+	if opts.UniqueOpts.ByPeriod != 0 {
+		t.Errorf("UniqueOpts.ByPeriod = %v, want 0: a bounded window lets a second job for "+
+			"the same snapshot in once the period elapses, which is the hole this closes",
+			opts.UniqueOpts.ByPeriod)
+	}
+	// River's default ByState must stay in force: it covers running, which is
+	// the state a snapshot is in for the whole window resumedOwnClaim cares
+	// about. An explicit ByState that dropped running would make the
+	// constraint inert exactly when it is needed.
+	if opts.UniqueOpts.ByState != nil {
+		var hasRunning bool
+		for _, s := range opts.UniqueOpts.ByState {
+			if s == rivertype.JobStateRunning {
+				hasRunning = true
+			}
+		}
+		if !hasRunning {
+			t.Error("UniqueOpts.ByState is set but omits running: the constraint would not " +
+				"bind while a backup is actually in flight")
+		}
+	}
+}
+
+// TestBackupInsertOpts_DifferentSnapshotsAreNotDeduped is the over-fire twin,
+// and the more important of the pair.
+//
+// ByArgs keys on the ENCODED args, so the property that keeps two unrelated
+// backups from colliding is that BackupArgs carries the snapshot ID and
+// therefore encodes differently per snapshot. Assert that on the encoding
+// River hashes, for both enqueue shapes: the plain EnqueueBackup args and the
+// ADR-048 chain args EnqueueBackupWithChain builds.
+func TestBackupInsertOpts_DifferentSnapshotsAreNotDeduped(t *testing.T) {
+	tenantID := uuid.New()
+	snapA, snapB := uuid.New(), uuid.New()
+
+	encode := func(t *testing.T, a BackupArgs) string {
+		t.Helper()
+		b, err := json.Marshal(a)
+		if err != nil {
+			t.Fatalf("marshal BackupArgs: %v", err)
+		}
+		return string(b)
+	}
+
+	// Shape 1: EnqueueBackup.
+	plainA := encode(t, BackupArgs{TenantID: tenantID, SnapshotID: snapA})
+	plainB := encode(t, BackupArgs{TenantID: tenantID, SnapshotID: snapB})
+	if plainA == plainB {
+		t.Fatalf("two different snapshots encode to identical args (%s): with UniqueOpts.ByArgs "+
+			"the second backup would be silently swallowed as a duplicate", plainA)
+	}
+
+	// Shape 2: EnqueueBackupWithChain, same chain, different snapshots. This
+	// is the one that would break if a future edit dropped SnapshotID from the
+	// args in favour of the chain identifiers.
+	chainID := uuid.New()
+	baseID := uuid.New()
+	chainArgs := func(id uuid.UUID) BackupArgs {
+		return BackupArgs{
+			TenantID:         tenantID,
+			SnapshotID:       id,
+			IsIncremental:    true,
+			ParentSnapshotID: baseID,
+			BaseSnapshotID:   baseID,
+			ChainID:          chainID,
+			Generation:       2,
+		}
+	}
+	if a, b := encode(t, chainArgs(snapA)), encode(t, chainArgs(snapB)); a == b {
+		t.Fatalf("two incremental snapshots in one chain encode to identical args (%s): "+
+			"the second would be deduped away and never run", a)
+	}
+
+	// And the same snapshot must encode identically across calls, or the
+	// constraint never binds at all.
+	if a1, a2 := plainA, encode(t, BackupArgs{TenantID: tenantID, SnapshotID: snapA}); a1 != a2 {
+		t.Errorf("one snapshot encodes unstably (%s vs %s): the uniqueness key would never match", a1, a2)
+	}
+}
+
+// TestBackupInsertOpts_KindIsStable guards the other input to River's
+// uniqueness hash. The key is hash(kind, unique properties); an empty or
+// drifting kind breaks the constraint without touching UniqueOpts at all.
+func TestBackupInsertOpts_KindIsStable(t *testing.T) {
+	if k := (BackupArgs{}).Kind(); k != "backup_snapshot" {
+		t.Fatalf("BackupArgs.Kind() = %q, want %q: River hashes the kind into the uniqueness "+
+			"key, and changing it silently orphans every already-enqueued job's key", k, "backup_snapshot")
+	}
+}

--- a/apps/api/internal/backup/gh458_progress_lost_race_test.go
+++ b/apps/api/internal/backup/gh458_progress_lost_race_test.go
@@ -1,0 +1,117 @@
+package backup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// raceLosingRepo reproduces the exact TOCTOU window RecordProgress sits in:
+// UpdateSnapshotProgress reads and returns the row as it looked BEFORE another
+// writer went terminal, and the row is only then flipped terminal — so the
+// `snap` RecordProgress holds is stale by the time FailSnapshot's guarded
+// UPDATE runs and reports transitioned == false.
+//
+// The winner in production is an operator cancel, a watchdog hard-fail, or a
+// completion; StatusCompleted is used here because it is the case where a
+// stale trailing publish is most obviously wrong (it would announce "failed"
+// for a backup that actually succeeded).
+type raceLosingRepo struct {
+	*watchdogFakeRepo
+	winner string // status the concurrent writer lands on the row
+}
+
+func (r *raceLosingRepo) UpdateSnapshotProgress(ctx context.Context, tenantID, snapshotID uuid.UUID, progress []byte) (Snapshot, error) {
+	stale, err := r.watchdogFakeRepo.UpdateSnapshotProgress(ctx, tenantID, snapshotID, progress)
+	if err != nil {
+		return stale, err
+	}
+	// The concurrent writer commits here, after our read.
+	won := stale
+	won.Status = r.winner
+	r.setSnapshot(won)
+	// Return the pre-race row: this is what RecordProgress will hold.
+	return stale, nil
+}
+
+func newLostRaceService(repo *raceLosingRepo, hub *Hub) *Service {
+	svc := NewService(repo, &fakeSiteLookup{}, nil, &fakePresigner{}, fakeClock{t: time.Now()}, Config{})
+	svc.SetHub(hub)
+	return svc
+}
+
+// TestRecordProgress_FailedPhase_LostRace_PublishesNoEvent is the regression
+// lock for the SSE half of GH #458: when FailSnapshot reports transitioned ==
+// false, RecordProgress made no state change and the winner already published
+// its own terminal event, so RecordProgress must publish NOTHING.
+//
+// Before the fix the transitioned == false case fell through to the trailing
+// s.publish, which emitted phase="failed" carrying snap.Status — the status
+// read BEFORE the race was lost. Subscribers therefore saw a "failed" event
+// with a stale running status land after the real terminal event, which is
+// precisely the stream regression the transitioned == true early return exists
+// to prevent.
+func TestRecordProgress_FailedPhase_LostRace_PublishesNoEvent(t *testing.T) {
+	repo := &raceLosingRepo{watchdogFakeRepo: newWatchdogFakeRepo(), winner: StatusCompleted}
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusRunning})
+
+	hub := NewHub()
+	svc := newLostRaceService(repo, hub)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	if _, err := svc.RecordProgress(context.Background(), tenantID, snapID, "failed",
+		map[string]any{"message": "php fatal error"}); err != nil {
+		t.Fatalf("RecordProgress: %v", err)
+	}
+
+	// The winner's own terminal state must survive untouched.
+	if got := repo.mustGet(t, snapID); got.Status != StatusCompleted {
+		t.Fatalf("snapshot status = %q, want %q (the lost race must not overwrite the winner)", got.Status, StatusCompleted)
+	}
+
+	events := drainEvents(ch)
+	if len(events) != 0 {
+		t.Fatalf("events = %+v, want 0: RecordProgress lost the transition race, so it has nothing to announce; "+
+			"the winner already published its own terminal event", events)
+	}
+}
+
+// TestRecordProgress_FailedPhase_WonRace_PublishesExactlyOneTerminalEvent is
+// the over-fire twin: a genuine agent-reported failure that DOES transition
+// must still publish exactly one terminal event — the one FailSnapshot emits.
+// A fix that simply stopped publishing on phase=="failed" would break this.
+func TestRecordProgress_FailedPhase_WonRace_PublishesExactlyOneTerminalEvent(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusRunning})
+
+	hub := NewHub()
+	svc := newWatchdogTestService(repo, hub)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	if _, err := svc.RecordProgress(context.Background(), tenantID, snapID, "failed",
+		map[string]any{"message": "php fatal error"}); err != nil {
+		t.Fatalf("RecordProgress: %v", err)
+	}
+
+	if got := repo.mustGet(t, snapID); got.Status != StatusFailed {
+		t.Fatalf("snapshot status = %q, want %q", got.Status, StatusFailed)
+	}
+
+	events := drainEvents(ch)
+	if len(events) != 1 {
+		t.Fatalf("events = %+v, want exactly 1 terminal event", events)
+	}
+	if events[0].Phase != "failed" {
+		t.Fatalf("events[0].Phase = %q, want failed", events[0].Phase)
+	}
+	if events[0].Status != StatusFailed {
+		t.Fatalf("events[0].Status = %q, want %q (a terminal event must never carry the pre-failure status)",
+			events[0].Status, StatusFailed)
+	}
+}

--- a/apps/api/internal/backup/gh458_resume_status_guard_test.go
+++ b/apps/api/internal/backup/gh458_resume_status_guard_test.go
@@ -1,0 +1,139 @@
+package backup
+
+// gh458_resume_status_guard_test.go — GH #458 review follow-up.
+//
+// resumedOwnClaim is `job.Attempt > 1 && cur.Status == StatusRunning`
+// (worker.go). The review mutated it to `return job.Attempt > 1`, deleting the
+// status half outright, and the whole package stayed green: nothing covered
+// that half.
+//
+// TestBackupWorker_RetryDoesNotResumeATerminalSnapshotViaTheTopOfWorkGuard
+// (gh458_retry_resumes_claim_test.go) does not cover it either — it seeds a
+// terminal row that the terminal check at the TOP of Work catches, so Work
+// returns before resumedOwnClaim is ever consulted.
+//
+// The uncovered case is the race the resume arm actually lives in: the row is
+// non-terminal when Work reads it, and terminal by the time the claim is
+// refused and Work re-reads it. That is exactly where a cancel or a late agent
+// manifest submit lands. Without the status half, a retry dispatches a full
+// backup for an already-terminal snapshot — the agent burns a real run whose
+// manifest SubmitManifest then rejects on the terminal guard.
+//
+// MUTATION PROOF for this file: replace the body of resumedOwnClaim with
+// `return job.Attempt > 1` and TestBackupWorker_RetryDoesNotResumeASnapshot-
+// ThatWentTerminalMidWork goes red while its over-fire twin
+// (TestBackupWorker_RetryResumesOwnClaimAndRedispatches) stays green.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// raceyWorkerRepo makes GetSnapshot return a DIFFERENT row on its second call,
+// which is the only way to reproduce the window between Work's terminal check
+// and its post-claim re-read inside a single-threaded test.
+//
+// Call 1 (Work's terminal check) sees the seeded 'running' row, so Work
+// proceeds. MarkSnapshotRunning refuses, as the real claim guard does for any
+// non-pending row. Call 2 (the re-read that feeds resumedOwnClaim) sees the
+// row after the concurrent transition landed.
+type raceyWorkerRepo struct {
+	*fakeWorkerRepo
+	getCalls   int
+	afterRace  Snapshot
+	raceOnCall int
+}
+
+func (r *raceyWorkerRepo) GetSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID) (Snapshot, error) {
+	r.mu.Lock()
+	r.getCalls++
+	n := r.getCalls
+	r.mu.Unlock()
+	if n >= r.raceOnCall {
+		return r.afterRace, nil
+	}
+	return r.fakeWorkerRepo.GetSnapshot(ctx, tenantID, snapshotID)
+}
+
+// TestBackupWorker_RetryDoesNotResumeASnapshotThatWentTerminalMidWork is the
+// regression for the uncovered half of resumedOwnClaim.
+//
+// Attempt 2 of the owning job re-enters Work. The snapshot is still 'running'
+// when Work reads it at the top, so the terminal short-circuit does not fire.
+// Between that read and the claim, a late agent manifest submit completes the
+// snapshot. The claim is refused, Work re-reads, and finds 'completed'. Only
+// the status half of resumedOwnClaim stands between that and a redundant full
+// backup dispatch.
+func TestBackupWorker_RetryDoesNotResumeASnapshotThatWentTerminalMidWork(t *testing.T) {
+	base, cmd, svc, tenantID, snapshotID := runningSnapshotFixture(t)
+
+	completed := base.snapshots[snapshotID]
+	completed.Status = StatusCompleted
+	repo := &raceyWorkerRepo{
+		fakeWorkerRepo: base,
+		afterRace:      completed,
+		raceOnCall:     2, // the post-claim re-read, not the terminal check
+	}
+	svc.repo = repo
+
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{
+		JobRow: &rivertype.JobRow{Attempt: 2, MaxAttempts: 3},
+		Args:   BackupArgs{TenantID: tenantID, SnapshotID: snapshotID},
+	}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error: %v", err)
+	}
+
+	// The fixture is only meaningful if Work actually reached the re-read;
+	// if it short-circuited at the top the assertion below proves nothing.
+	if repo.getCalls < 2 {
+		t.Fatalf("Work made %d GetSnapshot calls, want >= 2: it never reached the "+
+			"post-claim re-read, so this test is not exercising resumedOwnClaim", repo.getCalls)
+	}
+	if cmd.lastBackup != nil || cmd.lastIncrementalBackup != nil {
+		t.Fatal("a retry dispatched a backup for a snapshot that completed mid-Work: " +
+			"the agent burns a full run whose manifest SubmitManifest then rejects")
+	}
+}
+
+// TestBackupWorker_RetryStillResumesWhenTheRowIsStillRunning is the over-fire
+// twin for the test above, and the one that must NOT move under the mutation.
+//
+// Same racey repo, same two GetSnapshot calls, but the second read finds the
+// row exactly as attempt 1 left it: still 'running'. This is the legitimate
+// resume, and it must dispatch. A status guard that was tightened until the
+// test above passed — say, by refusing every retry — would redden here.
+func TestBackupWorker_RetryStillResumesWhenTheRowIsStillRunning(t *testing.T) {
+	base, cmd, svc, tenantID, snapshotID := runningSnapshotFixture(t)
+
+	stillRunning := base.snapshots[snapshotID]
+	repo := &raceyWorkerRepo{
+		fakeWorkerRepo: base,
+		afterRace:      stillRunning,
+		raceOnCall:     2,
+	}
+	svc.repo = repo
+
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{
+		JobRow: &rivertype.JobRow{Attempt: 2, MaxAttempts: 3},
+		Args:   BackupArgs{TenantID: tenantID, SnapshotID: snapshotID},
+	}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() error: %v", err)
+	}
+	if repo.getCalls < 2 {
+		t.Fatalf("Work made %d GetSnapshot calls, want >= 2", repo.getCalls)
+	}
+	if cmd.lastBackup == nil {
+		t.Fatal("the owning job's retry did not re-dispatch over its own still-running claim: " +
+			"the run is stranded until the watchdog hard-fails it")
+	}
+}

--- a/apps/api/internal/backup/gh458_retry_resumes_claim_test.go
+++ b/apps/api/internal/backup/gh458_retry_resumes_claim_test.go
@@ -1,0 +1,141 @@
+package backup
+
+// gh458_retry_resumes_claim_test.go — GH #458 follow-up regression.
+//
+// PR #497 added the "AND status='pending'" claim precondition to
+// MarkBackupSnapshotRunning and wired BackupWorker.Work to return nil when the
+// claim is refused. That is right for a genuinely lost claim and WRONG for the
+// common case it also swallowed: a River retry of the SAME job re-entering
+// Work over the row it already claimed on attempt 1. The snapshot is
+// 'running', the guard matches nothing, and the pre-fix worker returned
+// success without dispatching — so a transient transport error left the
+// snapshot stranded 'running' with no backup behind it until the watchdog
+// hard-failed it.
+//
+// The pair below is the fix's fire/over-fire proof. They must move in
+// opposite directions ONLY across the fix: Resume goes red-to-green,
+// LostToAnotherOwner must stay green in both.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// runningSnapshotFixture registers one snapshot in the fake repo in the state a
+// worker retry finds it: already claimed and 'running'.
+func runningSnapshotFixture(t *testing.T) (*fakeWorkerRepo, *fakeCommander, *Service, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	repo := &fakeWorkerRepo{fakeRepo: newFakeRepo()}
+	cmd := &fakeCommander{ok: true}
+	tenantID := uuid.New()
+	snapshotID := uuid.New()
+
+	repo.setSnapshot(Snapshot{
+		ID:           snapshotID,
+		TenantID:     tenantID,
+		SiteID:       uuid.New(),
+		Kind:         KindFull,
+		Status:       StatusRunning, // attempt 1 already claimed it
+		AgeRecipient: "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+	})
+
+	svc := &Service{repo: repo, sites: fakeWorkerSiteLookup{}, clock: fakeClock{t: time.Now()}}
+	return repo, cmd, svc, tenantID, snapshotID
+}
+
+// TestBackupWorker_RetryResumesOwnClaimAndRedispatches is the regression.
+//
+// Attempt 1 claimed the snapshot ('running') and then hit a transient
+// transport error, so River scheduled a retry. Attempt 2 re-enters Work: the
+// claim guard refuses (the row is no longer 'pending'), and the worker must
+// recognise the row as its own and dispatch the backup command again rather
+// than reporting success and stranding the run.
+func TestBackupWorker_RetryResumesOwnClaimAndRedispatches(t *testing.T) {
+	repo, cmd, svc, tenantID, snapshotID := runningSnapshotFixture(t)
+
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{
+		// Attempt 2 == River retrying the job that made the claim. River
+		// guarantees a single execution of a given job at a time, so this
+		// cannot be racing attempt 1.
+		JobRow: &rivertype.JobRow{Attempt: 2, MaxAttempts: 3},
+		Args:   BackupArgs{TenantID: tenantID, SnapshotID: snapshotID},
+	}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() on retry error: %v", err)
+	}
+
+	if cmd.lastBackup == nil {
+		t.Fatal("retry of the owning job did not re-dispatch the backup command: " +
+			"the snapshot is left 'running' with nothing behind it until the watchdog hard-fails it")
+	}
+	if cmd.lastBackup.SnapshotID != snapshotID.String() {
+		t.Errorf("re-dispatched the wrong snapshot: got %q, want %q", cmd.lastBackup.SnapshotID, snapshotID.String())
+	}
+	// And the run must not have been stranded or dragged backwards.
+	got, err := repo.GetSnapshot(context.Background(), tenantID, snapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if got.Status != StatusRunning {
+		t.Errorf("snapshot status after resumed retry = %q, want %q", got.Status, StatusRunning)
+	}
+}
+
+// TestBackupWorker_FirstAttemptDoesNotStealAnotherOwnersClaim is the over-fire
+// twin. Same 'running' row, but this job is on its FIRST attempt, so it never
+// claimed anything: the running row belongs to someone else. It must NOT
+// dispatch — otherwise the fix has reopened the double-claim hole the guard in
+// MarkBackupSnapshotRunning exists to close.
+//
+// This test is green before the fix and must stay green after it.
+func TestBackupWorker_FirstAttemptDoesNotStealAnotherOwnersClaim(t *testing.T) {
+	_, cmd, svc, tenantID, snapshotID := runningSnapshotFixture(t)
+
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{
+		// Attempt 1: River's first execution of this job. It has made no claim
+		// of its own, so a 'running' row is another owner's.
+		JobRow: &rivertype.JobRow{Attempt: 1, MaxAttempts: 3},
+		Args:   BackupArgs{TenantID: tenantID, SnapshotID: snapshotID},
+	}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() on a lost claim must succeed without dispatching, got error: %v", err)
+	}
+	if cmd.lastBackup != nil || cmd.lastIncrementalBackup != nil {
+		t.Fatal("a job that never held the claim dispatched a backup anyway: two live backups for one snapshot")
+	}
+}
+
+// TestBackupWorker_RetryDoesNotResumeATerminalSnapshot keeps the resume arm
+// honest in the other direction: a retry whose snapshot was cancelled or
+// watchdog-failed while it sat in the queue finds a terminal row, and must
+// still dispatch nothing. (The terminal check at the top of Work covers this
+// one, which is exactly the point — the resume arm must not widen it.)
+func TestBackupWorker_RetryDoesNotResumeATerminalSnapshot(t *testing.T) {
+	repo, cmd, svc, tenantID, snapshotID := runningSnapshotFixture(t)
+	snap := repo.snapshots[snapshotID]
+	snap.Status = StatusFailed
+	snap.Error = "cancelled by operator"
+	repo.setSnapshot(snap)
+
+	worker := NewBackupWorker(svc, cmd, nil, nil, "https://cp.example.com", 0)
+	job := &river.Job[BackupArgs]{
+		JobRow: &rivertype.JobRow{Attempt: 2, MaxAttempts: 3},
+		Args:   BackupArgs{TenantID: tenantID, SnapshotID: snapshotID},
+	}
+
+	if err := worker.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work() on a terminal snapshot error: %v", err)
+	}
+	if cmd.lastBackup != nil || cmd.lastIncrementalBackup != nil {
+		t.Fatal("a retry resurrected a cancelled/watchdog-failed snapshot and dispatched a backup for it")
+	}
+}

--- a/apps/api/internal/backup/gh458_retry_resumes_claim_test.go
+++ b/apps/api/internal/backup/gh458_retry_resumes_claim_test.go
@@ -114,12 +114,21 @@ func TestBackupWorker_FirstAttemptDoesNotStealAnotherOwnersClaim(t *testing.T) {
 	}
 }
 
-// TestBackupWorker_RetryDoesNotResumeATerminalSnapshot keeps the resume arm
-// honest in the other direction: a retry whose snapshot was cancelled or
-// watchdog-failed while it sat in the queue finds a terminal row, and must
-// still dispatch nothing. (The terminal check at the top of Work covers this
-// one, which is exactly the point — the resume arm must not widen it.)
-func TestBackupWorker_RetryDoesNotResumeATerminalSnapshot(t *testing.T) {
+// TestBackupWorker_RetryDoesNotResumeATerminalSnapshotViaTheTopOfWorkGuard
+// asserts what its name says and nothing more: a retry whose snapshot was
+// cancelled or watchdog-failed BEFORE Work ran finds a terminal row at the top
+// of Work and returns there, dispatching nothing.
+//
+// It is named for the guard it exercises because the guard it does NOT
+// exercise is resumedOwnClaim's status half. Work short-circuits at
+// worker.go's terminal check before the claim is ever attempted, so this test
+// passes against a resumedOwnClaim with the status check deleted, and it
+// passed against the pre-GH#458 worker too. The review found it being read as
+// coverage of the resume arm under its old name
+// (…_RetryDoesNotResumeATerminalSnapshot). Coverage of the resume arm's status
+// half lives in gh458_resume_status_guard_test.go, which reproduces the row
+// going terminal BETWEEN the two reads.
+func TestBackupWorker_RetryDoesNotResumeATerminalSnapshotViaTheTopOfWorkGuard(t *testing.T) {
 	repo, cmd, svc, tenantID, snapshotID := runningSnapshotFixture(t)
 	snap := repo.snapshots[snapshotID]
 	snap.Status = StatusFailed

--- a/apps/api/internal/backup/incremental_service_test.go
+++ b/apps/api/internal/backup/incremental_service_test.go
@@ -121,18 +121,21 @@ func (r *fakeRepo) GetSnapshot(_ context.Context, _, snapshotID uuid.UUID) (Snap
 	return s, nil
 }
 
-func (r *fakeRepo) CompleteSnapshot(_ context.Context, tenantID, snapshotID uuid.UUID, totalSize, chunkCount int64) (Snapshot, error) {
+func (r *fakeRepo) CompleteSnapshot(_ context.Context, tenantID, snapshotID uuid.UUID, totalSize, chunkCount int64) (Snapshot, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	s, ok := r.snapshots[snapshotID]
-	if !ok {
-		return Snapshot{}, domain.NotFound("backup_snapshot_not_found", "not found")
+	// GH #458: mirror the real query's guard exactly. A fake that always
+	// reports a transition would hide the very defect the guard exists to
+	// catch.
+	if !ok || (s.Status != StatusPending && s.Status != StatusRunning) {
+		return Snapshot{}, false, nil
 	}
 	s.Status = StatusCompleted
 	s.TotalSize = totalSize
 	s.ChunkCount = chunkCount
 	r.snapshots[snapshotID] = s
-	return s, nil
+	return s, true, nil
 }
 
 func (r *fakeRepo) RecordManifest(_ context.Context, in RecordManifestInput) (int64, int64, error) {
@@ -161,10 +164,10 @@ func (r *fakeRepo) GetSnapshotScoped(_ context.Context, _ db.ScopedPrincipal, _,
 func (r *fakeRepo) ListSnapshotsForSite(_ context.Context, _, _ uuid.UUID, _, _ int32) ([]Snapshot, error) {
 	panic("fakeRepo.ListSnapshotsForSite not implemented")
 }
-func (r *fakeRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+func (r *fakeRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, bool, error) {
 	panic("fakeRepo.MarkSnapshotRunning not implemented")
 }
-func (r *fakeRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, error) {
+func (r *fakeRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, bool, error) {
 	panic("fakeRepo.FailSnapshot not implemented")
 }
 func (r *fakeRepo) FailStalledSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (int64, error) {

--- a/apps/api/internal/backup/repo.go
+++ b/apps/api/internal/backup/repo.go
@@ -44,9 +44,29 @@ type Repo interface {
 	// PlanRestore as the gate lookup.
 	GetSnapshotScoped(ctx context.Context, p db.ScopedPrincipal, tenantID, snapshotID uuid.UUID) (Snapshot, error)
 	ListSnapshotsForSite(ctx context.Context, tenantID, siteID uuid.UUID, limit, offset int32) ([]Snapshot, error)
-	MarkSnapshotRunning(ctx context.Context, tenantID, snapshotID uuid.UUID) (Snapshot, error)
-	CompleteSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, totalSize, chunkCount int64) (Snapshot, error)
-	FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, errMsg string) (Snapshot, error)
+	// MarkSnapshotRunning claims a snapshot for a run. GH #458: the UPDATE
+	// carries "AND status='pending'", so transitioned reports whether THIS
+	// caller won the claim. false means the row was not pending — already
+	// claimed by a duplicate job, already terminal (cancelled/watchdog-failed
+	// while it sat in the queue), or gone — and the caller must not proceed as
+	// the run's owner: no 'started' SSE event, no schedule-run reconciliation,
+	// no audit entry. false is not an error; the returned Snapshot is zero.
+	MarkSnapshotRunning(ctx context.Context, tenantID, snapshotID uuid.UUID) (snap Snapshot, transitioned bool, err error)
+	// CompleteSnapshot stamps the terminal 'completed' state. GH #458: the
+	// UPDATE carries "AND status IN ('pending','running')", so transitioned is
+	// false when the row was already terminal or gone, which the caller must
+	// surface as a rejected completion rather than reporting success over a
+	// write that did not happen. The returned Snapshot is zero when false.
+	CompleteSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, totalSize, chunkCount int64) (snap Snapshot, transitioned bool, err error)
+	// FailSnapshot stamps the terminal 'failed' state, and is also the path an
+	// operator cancel takes (CancelSnapshot fails the row with
+	// cancelByOperatorMsg). GH #458: the UPDATE carries "AND status IN
+	// ('pending','running')" — 'pending' stays in the guard precisely so cancel
+	// of a queued backup keeps working — so transitioned is false only when the
+	// row had already moved on. On false the caller must publish no 'failed'
+	// SSE event, send no failure email, reconcile no schedule run and record no
+	// audit entry. The returned Snapshot is zero when false.
+	FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, errMsg string) (snap Snapshot, transitioned bool, err error)
 	// UpdateSnapshotProgress replaces the JSONB progress payload with the given
 	// raw bytes (caller-validated JSON) and bumps progress_updated_at to now.
 	// Tenant-scoped — the caller passes the tenant from the verified agent
@@ -73,9 +93,11 @@ type Repo interface {
 	// Tenant-scoped.
 	ClearSnapshotStalled(ctx context.Context, tenantID, snapshotID uuid.UUID) (bool, error)
 	// FailStalledSnapshot is the TOCTOU-safe hard-fail path used ONLY by the
-	// progress watchdog's hard-deadline branch (GH #279 must-fix). Unlike
-	// FailSnapshot's blind UPDATE — which CancelSnapshot depends on to fail a
-	// still-'pending' row and so must keep no status guard — this adds
+	// progress watchdog's hard-deadline branch (GH #279 must-fix). Its guard is
+	// NARROWER than FailSnapshot's: status='running' here versus
+	// status IN ('pending','running') there (GH #458), because operator cancel
+	// of a QUEUED backup goes through FailSnapshot while the watchdog may only
+	// ever hard-fail a run it observed running. So this adds
 	// "AND status='running'" so a row that completed, was cancelled, was
 	// agent-failed, or resumed between ListStalledRunningSnapshots' commit and
 	// this call is left untouched. Returns the number of rows actually
@@ -641,24 +663,74 @@ func (r *pgRepo) ListSnapshotsForSite(ctx context.Context, tenantID, siteID uuid
 	return out, err
 }
 
-func (r *pgRepo) MarkSnapshotRunning(ctx context.Context, tenantID, snapshotID uuid.UUID) (Snapshot, error) {
-	return r.mutateSnapshot(ctx, tenantID, func(q *sqlc.Queries) (sqlc.BackupSnapshot, error) {
+func (r *pgRepo) MarkSnapshotRunning(ctx context.Context, tenantID, snapshotID uuid.UUID) (Snapshot, bool, error) {
+	return r.guardedSnapshotTransition(ctx, tenantID, snapshotID, func(q *sqlc.Queries) (int64, error) {
 		return q.MarkBackupSnapshotRunning(ctx, sqlc.MarkBackupSnapshotRunningParams{ID: snapshotID, TenantID: tenantID})
 	}, "backup_snapshot_run_failed")
 }
 
-func (r *pgRepo) CompleteSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, totalSize, chunkCount int64) (Snapshot, error) {
-	return r.mutateSnapshot(ctx, tenantID, func(q *sqlc.Queries) (sqlc.BackupSnapshot, error) {
+func (r *pgRepo) CompleteSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, totalSize, chunkCount int64) (Snapshot, bool, error) {
+	return r.guardedSnapshotTransition(ctx, tenantID, snapshotID, func(q *sqlc.Queries) (int64, error) {
 		return q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
 			ID: snapshotID, TenantID: tenantID, TotalSize: totalSize, ChunkCount: chunkCount,
 		})
 	}, "backup_snapshot_complete_failed")
 }
 
-func (r *pgRepo) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, errMsg string) (Snapshot, error) {
-	return r.mutateSnapshot(ctx, tenantID, func(q *sqlc.Queries) (sqlc.BackupSnapshot, error) {
+func (r *pgRepo) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, errMsg string) (Snapshot, bool, error) {
+	return r.guardedSnapshotTransition(ctx, tenantID, snapshotID, func(q *sqlc.Queries) (int64, error) {
 		return q.FailBackupSnapshot(ctx, sqlc.FailBackupSnapshotParams{ID: snapshotID, TenantID: tenantID, Error: errMsg})
 	}, "backup_snapshot_fail_failed")
+}
+
+// guardedSnapshotTransition runs one of the three GH #458 status-guarded
+// snapshot UPDATEs and, when it actually moved a row, re-reads that row INSIDE
+// THE SAME transaction so the Snapshot returned is the one the guard decided
+// about — a re-read in a second transaction could observe a row another writer
+// has since changed. Shape follows SetSnapshotLocked below (UPDATE, then
+// SELECT with snapshotSelectColumns); mutateSnapshot cannot be reused because
+// these queries are :execrows and no longer RETURNING *.
+//
+// rows==0 is not an error, it is the contract: the row was not in a status the
+// guard admits (already claimed, already terminal, or gone). Only the caller
+// knows what that means — a lost claim, a rejected late submit, or a cancel of
+// a run that had already finished — so it is surfaced as transitioned=false
+// with a ZERO Snapshot, never a stale-looking row a caller could mistake for a
+// real transition.
+func (r *pgRepo) guardedSnapshotTransition(
+	ctx context.Context,
+	tenantID, snapshotID uuid.UUID,
+	fn func(*sqlc.Queries) (int64, error),
+	code string,
+) (Snapshot, bool, error) {
+	var (
+		out          Snapshot
+		transitioned bool
+	)
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		n, err := fn(sqlc.New(tx))
+		if err != nil {
+			return domain.Internal(code, "failed to update snapshot").WithCause(err)
+		}
+		if n == 0 {
+			return nil
+		}
+		transitioned = true
+		row := tx.QueryRow(ctx,
+			snapshotSelectColumns+` FROM backup_snapshots WHERE id=$1 AND tenant_id=$2`,
+			snapshotID, tenantID,
+		)
+		s, serr := scanSnapshotWithChainFields(row)
+		if serr != nil {
+			return domain.Internal(code, "failed to re-read snapshot after state transition").WithCause(serr)
+		}
+		out = s
+		return nil
+	})
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	return out, transitioned, nil
 }
 
 // UpdateSnapshotProgress is tenant-scoped (RLS enforces it); the agent handler
@@ -912,14 +984,23 @@ func (r *pgRepo) RecordManifest(ctx context.Context, in RecordManifestInput) (in
 			return terr
 		}
 
-		// 3. Complete the snapshot.
-		if _, err := q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
+		// 3. Complete the snapshot. GH #458: CompleteBackupSnapshot is guarded
+		// ("AND status IN ('pending','running')") and is :execrows, so a
+		// rejected submit arrives as rows==0 and NEVER as pgx.ErrNoRows —
+		// checking for ErrNoRows here would be dead code and this whole
+		// transaction would commit the manifest rows and refcount bumps while
+		// reporting success for a snapshot it did not complete. Rolling the
+		// transaction back with the same NotFound the pre-#458 code returned is
+		// what makes a late submit against a cancelled or already-completed
+		// snapshot a rejection instead of a silent no-op.
+		n, err := q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
 			ID: in.SnapshotID, TenantID: in.TenantID, TotalSize: totalSize, ChunkCount: chunkRefs,
-		}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return domain.NotFound("backup_snapshot_not_found", "backup snapshot not found")
-			}
+		})
+		if err != nil {
 			return domain.Internal("backup_snapshot_complete_failed", "failed to complete snapshot").WithCause(err)
+		}
+		if n == 0 {
+			return domain.NotFound("backup_snapshot_not_found", "backup snapshot not found")
 		}
 		return nil
 	})
@@ -1784,26 +1865,32 @@ func (r *pgRepo) CompleteIncrementalManifest(ctx context.Context, in CompleteInc
 			if terr := touchReferencedChunks(ctx, tx, in.TenantID, referenced); terr != nil {
 				return terr
 			}
-			if _, err := q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
+			// GH #458 rejected-submit contract — see RecordManifest for why
+			// rows==0 (not pgx.ErrNoRows) is the signal here.
+			n, cerr := q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
 				ID: in.SnapshotID, TenantID: in.TenantID, TotalSize: totalSize, ChunkCount: chunkRefs,
-			}); err != nil {
-				if errors.Is(err, pgx.ErrNoRows) {
-					return domain.NotFound("backup_snapshot_not_found", "backup snapshot not found")
-				}
-				return domain.Internal("backup_snapshot_complete_failed", "failed to complete snapshot").WithCause(err)
+			})
+			if cerr != nil {
+				return domain.Internal("backup_snapshot_complete_failed", "failed to complete snapshot").WithCause(cerr)
+			}
+			if n == 0 {
+				return domain.NotFound("backup_snapshot_not_found", "backup snapshot not found")
 			}
 			return nil
 		}
 
 		// 3. Files-only path: complete the snapshot directly with caller-supplied
 		//    counters.
-		if _, err := q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
+		// GH #458 rejected-submit contract — see RecordManifest for why rows==0
+		// (not pgx.ErrNoRows) is the signal here.
+		n, cerr := q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
 			ID: in.SnapshotID, TenantID: in.TenantID, TotalSize: in.TotalSize, ChunkCount: in.ChunkRefs,
-		}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return domain.NotFound("backup_snapshot_not_found", "backup snapshot not found")
-			}
-			return domain.Internal("backup_snapshot_complete_failed", "failed to complete snapshot").WithCause(err)
+		})
+		if cerr != nil {
+			return domain.Internal("backup_snapshot_complete_failed", "failed to complete snapshot").WithCause(cerr)
+		}
+		if n == 0 {
+			return domain.NotFound("backup_snapshot_not_found", "backup snapshot not found")
 		}
 		chunkRefs = in.ChunkRefs
 		return nil
@@ -2276,15 +2363,15 @@ func (r *pgRepo) UpdateSnapshotCycleStats(ctx context.Context, tenantID, snapsho
 // backup_snapshots_site_scope RLS policy acts as the DB-level backstop.
 func (r *pgRepo) FleetListSnapshots(ctx context.Context, p db.ScopedPrincipal, tenantID uuid.UUID, f FleetListFilter) (FleetSnapshotPage, error) {
 	params := sqlc.FleetListSnapshotsParams{
-		TenantID:     tenantID,
+		TenantID:      tenantID,
 		SiteIdsFilter: len(f.SiteIDs) > 0,
-		SiteIds:      f.SiteIDs,
-		StatusFilter: f.Status != "",
-		StatusVal:    f.Status,
-		AfterFilter:  f.CreatedAfter != nil,
-		BeforeFilter: f.CreatedBefore != nil,
-		RowOffset:    f.Offset,
-		RowLimit:     f.Limit,
+		SiteIds:       f.SiteIDs,
+		StatusFilter:  f.Status != "",
+		StatusVal:     f.Status,
+		AfterFilter:   f.CreatedAfter != nil,
+		BeforeFilter:  f.CreatedBefore != nil,
+		RowOffset:     f.Offset,
+		RowLimit:      f.Limit,
 	}
 	if f.CreatedAfter != nil {
 		params.CreatedAfter = *f.CreatedAfter

--- a/apps/api/internal/backup/schedule_incremental_wiring_test.go
+++ b/apps/api/internal/backup/schedule_incremental_wiring_test.go
@@ -97,13 +97,13 @@ func (r *wiringRepo) GetSnapshotScoped(_ context.Context, _ db.ScopedPrincipal, 
 func (r *wiringRepo) ListSnapshotsForSite(_ context.Context, _, _ uuid.UUID, _, _ int32) ([]Snapshot, error) {
 	panic("unused")
 }
-func (r *wiringRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+func (r *wiringRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, bool, error) {
 	panic("unused")
 }
-func (r *wiringRepo) CompleteSnapshot(_ context.Context, _, _ uuid.UUID, _, _ int64) (Snapshot, error) {
+func (r *wiringRepo) CompleteSnapshot(_ context.Context, _, _ uuid.UUID, _, _ int64) (Snapshot, bool, error) {
 	panic("unused")
 }
-func (r *wiringRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, error) {
+func (r *wiringRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, bool, error) {
 	panic("unused")
 }
 func (r *wiringRepo) FailStalledSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (int64, error) {

--- a/apps/api/internal/backup/scheduler_fix_test.go
+++ b/apps/api/internal/backup/scheduler_fix_test.go
@@ -213,14 +213,14 @@ func (r *schedulerTestRepo) GetSnapshot(_ context.Context, _, _ uuid.UUID) (Snap
 func (r *schedulerTestRepo) ListSnapshotsForSite(_ context.Context, _, _ uuid.UUID, _, _ int32) ([]Snapshot, error) {
 	panic("schedulerTestRepo.ListSnapshotsForSite not expected")
 }
-func (r *schedulerTestRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+func (r *schedulerTestRepo) MarkSnapshotRunning(_ context.Context, _, _ uuid.UUID) (Snapshot, bool, error) {
 	panic("schedulerTestRepo.MarkSnapshotRunning not expected")
 }
-func (r *schedulerTestRepo) CompleteSnapshot(_ context.Context, _, _ uuid.UUID, _, _ int64) (Snapshot, error) {
+func (r *schedulerTestRepo) CompleteSnapshot(_ context.Context, _, _ uuid.UUID, _, _ int64) (Snapshot, bool, error) {
 	panic("schedulerTestRepo.CompleteSnapshot not expected")
 }
-func (r *schedulerTestRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, error) {
-	return Snapshot{Status: StatusFailed}, nil
+func (r *schedulerTestRepo) FailSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (Snapshot, bool, error) {
+	return Snapshot{Status: StatusFailed}, true, nil
 }
 func (r *schedulerTestRepo) FailStalledSnapshot(_ context.Context, _, _ uuid.UUID, _ string) (int64, error) {
 	panic("schedulerTestRepo.FailStalledSnapshot not expected")

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -2758,7 +2758,7 @@ func (s *Service) RecordProgress(ctx context.Context, tenantID, snapshotID uuid.
 		reason := agentFailReason(phaseDetail)
 		if reason != "" {
 			// FailSnapshot persists the terminal state AND publishes its own
-			// terminal SSE event. On success, return early so the trailing
+			// terminal SSE event. Return early on success so the trailing
 			// s.publish below does not emit a second event with the stale
 			// pre-failure status (which would regress the SSE stream from
 			// "failed" back to "running"/"pending").
@@ -2766,10 +2766,18 @@ func (s *Service) RecordProgress(ctx context.Context, tenantID, snapshotID uuid.
 			// GH #458: the status check above is a read of a row fetched
 			// earlier, so it can be stale; FailSnapshot's guard is what
 			// decides. transitioned==false means the row went terminal in
-			// that window, so its own transition already published — fall
-			// through WITHOUT returning early so the trailing publish still
-			// reports the current phase, but do not treat this as a failure
-			// we persisted.
+			// that window (operator cancel, watchdog hard-fail, or a
+			// completion) and the winner already published its own terminal
+			// event. Return early there too: this call made no transition, so
+			// it has nothing to announce, and `snap` was read BEFORE the race
+			// was lost, so the trailing publish would report a stale
+			// running/pending status under a "failed" phase — the same stream
+			// regression the transitioned case returns early to avoid.
+			//
+			// Only a FailSnapshot infra error falls through, and deliberately:
+			// nothing transitioned and nothing published, so the agent's
+			// report of a failure is still worth forwarding to subscribers on
+			// the row as we last read it.
 			failedSnap, transitioned, ferr := s.FailSnapshot(ctx, tenantID, snapshotID, reason)
 			switch {
 			case ferr != nil:
@@ -2784,20 +2792,22 @@ func (s *Service) RecordProgress(ctx context.Context, tenantID, snapshotID uuid.
 				slog.Info("RecordProgress: agent-reported failure skipped; snapshot already terminal",
 					slog.String("snapshot_id", snapshotID.String()),
 					slog.String("tenant_id", tenantID.String()))
+				return raw, nil
 			}
 		}
 	}
 
 	// GH #279 proof of life: a non-failure progress POST that reaches this
-	// point (the "failed" fast-fail branch above already returned when it
-	// successfully persisted a terminal failure) proves the agent is still
-	// alive, so clear a soft stall before it can be hard-failed. A
-	// phase=="failed" POST must NEVER clear the stall or publish 'resumed' --
-	// not even when it fell through here because agentFailReason was empty,
-	// or because the snapshot was already terminal (both skip the fast-fail
-	// branch above without returning). The agent is reporting a failure, not
-	// a resume, so this proof-of-life clear only applies to a genuine
-	// non-failure phase.
+	// point (the "failed" fast-fail branch above already returned on every
+	// path that resolved the failure, whether it persisted the transition or
+	// lost the race to another writer) proves the agent is still alive, so
+	// clear a soft stall before it can be hard-failed. A phase=="failed" POST
+	// must NEVER clear the stall or publish 'resumed' -- not even when it fell
+	// through here because agentFailReason was empty, because the row we read
+	// was already terminal, or because FailSnapshot itself errored (all three
+	// skip the fast-fail branch above without returning). The agent is
+	// reporting a failure, not a resume, so this proof-of-life clear only
+	// applies to a genuine non-failure phase.
 	if phase != "failed" {
 		if cleared, _ := s.ClearSnapshotStalledIfRunning(ctx, tenantID, snapshotID); cleared {
 			s.publish(BackupEvent{
@@ -2810,10 +2820,13 @@ func (s *Service) RecordProgress(ctx context.Context, tenantID, snapshotID uuid.
 	}
 
 	// Fan out the validated progress to live SSE subscribers. The Status mirrors
-	// the snapshot's status as returned by UpdateSnapshotProgress (the
-	// FailSnapshot path above short-circuits before this point when it succeeds,
-	// so this publish only fires for non-failure phases or when FailSnapshot
-	// itself errored).
+	// the snapshot's status as returned by UpdateSnapshotProgress. For
+	// phase=="failed" this is reached only when the fast-fail branch above did
+	// not resolve the failure at all: no reason to extract, the row we read was
+	// already terminal, or FailSnapshot returned an infra error. Every path
+	// where a terminal transition was decided -- won or lost -- returned there,
+	// so this never emits a second event for a transition another writer
+	// already published, and never re-announces one this call did not make.
 	s.publish(BackupEvent{
 		SnapshotID:  snapshotID,
 		Phase:       phase,

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -2009,12 +2009,26 @@ func (s *Service) getSnapshotForPresign(ctx context.Context, tenantID, snapshotI
 	return s.repo.GetSnapshotScoped(ctx, p, tenantID, snapshotID)
 }
 
-// MarkRunning transitions a snapshot to running (called by the backup worker).
-// Reconciliation: also transitions any linked schedule run to 'running'.
-func (s *Service) MarkRunning(ctx context.Context, tenantID, snapshotID uuid.UUID) (Snapshot, error) {
-	snap, err := s.repo.MarkSnapshotRunning(ctx, tenantID, snapshotID)
+// MarkRunning claims a PENDING snapshot for a run (called by the backup
+// worker). Reconciliation: also transitions any linked schedule run to
+// 'running'.
+//
+// GH #458: the claim is guarded ("AND status='pending'"), so claimed reports
+// whether THIS caller won it. When claimed is false the row was not pending —
+// a duplicate/retried job got there first, or the snapshot was cancelled or
+// watchdog-failed while it sat in the queue — and none of the side effects
+// below may fire: publishing 'started' or reconciling the schedule run for a
+// row that never moved reports a state change that did not happen, and would
+// drag a terminal snapshot's UI back to "running". claimed=false is not an
+// error; the caller decides (the worker treats it exactly like the terminal
+// short-circuit at the top of Work: nothing to do, job done).
+func (s *Service) MarkRunning(ctx context.Context, tenantID, snapshotID uuid.UUID) (snap Snapshot, claimed bool, err error) {
+	snap, claimed, err = s.repo.MarkSnapshotRunning(ctx, tenantID, snapshotID)
 	if err != nil {
-		return snap, err
+		return snap, false, err
+	}
+	if !claimed {
+		return Snapshot{}, false, nil
 	}
 	s.publish(BackupEvent{
 		SnapshotID:  snapshotID,
@@ -2031,16 +2045,30 @@ func (s *Service) MarkRunning(ctx context.Context, tenantID, snapshotID uuid.UUI
 			SetStarted: true,
 		})
 	}
-	return snap, nil
+	return snap, true, nil
 }
 
-// FailSnapshot marks a snapshot failed (called by the backup worker on error or
-// by the progress watchdog). Reconciliation: also transitions any linked
-// schedule run to 'failed' so history never sticks on 'running'.
-func (s *Service) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, msg string) (Snapshot, error) {
-	snap, err := s.repo.FailSnapshot(ctx, tenantID, snapshotID, msg)
+// FailSnapshot marks a PENDING or RUNNING snapshot failed (called by the backup
+// worker on error, by RecordProgress on an agent-reported failure, and by
+// CancelSnapshot for an operator cancel). Reconciliation: also transitions any
+// linked schedule run to 'failed' so history never sticks on 'running'.
+//
+// GH #458: the UPDATE is guarded ("AND status IN ('pending','running')"), so
+// transitioned reports whether a real state change happened. 'pending' is in
+// that guard deliberately — CancelSnapshot fails a still-queued snapshot
+// through here — so transitioned is false only when the row had ALREADY moved
+// on (completed, cancelled, agent-failed or watchdog-failed), in which case its
+// own terminal transition already published its own event. Firing the 'failed'
+// SSE event, the failure email or the schedule-run reconciliation for that row
+// would double-report an outcome and, worse, announce a failure for a backup
+// that actually completed. Gated exactly like FailStalledSnapshot below.
+func (s *Service) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, msg string) (snap Snapshot, transitioned bool, err error) {
+	snap, transitioned, err = s.repo.FailSnapshot(ctx, tenantID, snapshotID, msg)
 	if err != nil {
-		return snap, err
+		return snap, false, err
+	}
+	if !transitioned {
+		return Snapshot{}, false, nil
 	}
 	s.publish(BackupEvent{
 		SnapshotID:  snapshotID,
@@ -2062,18 +2090,19 @@ func (s *Service) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UU
 	// Operator-cancels notify too — an alert that a backup did not complete is
 	// honest, and the recipient can ignore one they triggered themselves.
 	s.sendBackupEmail(ctx, snap, "backup_failed")
-	return snap, nil
+	return snap, true, nil
 }
 
 // FailStalledSnapshot is the TOCTOU-safe hard-fail path the progress watchdog
-// (GH #279 must-fix) uses instead of FailSnapshot. FailSnapshot's UPDATE has
-// no status guard — CancelSnapshot relies on that to fail a still-'pending'
-// row — so it can flip ANY snapshot to 'failed' regardless of what happened
-// to the row between ListStalledRunningSnapshots' commit and the watchdog's
-// own separate per-row transaction (it may have completed, been
-// operator-cancelled, been agent-failed, or resumed). This method's
-// repo.FailStalledSnapshot call adds "AND status='running'" to close that
-// window: transitioned reports whether a real state change happened, and the
+// (GH #279 must-fix) uses instead of FailSnapshot. Since GH #458 both are
+// guarded, but this one's guard is NARROWER: status='running' here versus
+// status IN ('pending','running') in FailSnapshot, which must keep admitting
+// 'pending' because operator cancel of a QUEUED backup goes through it. The
+// watchdog may only ever hard-fail a run it actually observed running, and the
+// row it listed may have completed, been operator-cancelled, been agent-failed,
+// or resumed between ListStalledRunningSnapshots' commit and the watchdog's own
+// separate per-row transaction. This method's repo.FailStalledSnapshot call
+// closes that window: transitioned reports whether a real state change happened, and the
 // caller (the watchdog) must only publish the 'failed' SSE event / trigger
 // the failure notification when it is true. When false the row already moved
 // on and its own terminal transition already published its own event — this
@@ -2136,6 +2165,21 @@ const stallTimeoutMsg = "stopped responding; no progress within the allowed time
 //
 // A snapshot that is already in a terminal state (completed/failed) is rejected
 // with a Conflict so the caller can surface "nothing to cancel".
+//
+// GH #458 closed a TOCTOU here. The GetSnapshot status check below is a
+// read-then-write with a real window: the run could complete, be agent-failed
+// or be watchdog-failed between the read and the UPDATE, and the old blind
+// UPDATE then overwrote that genuine outcome with "cancelled by operator" and
+// reported success. FailSnapshot's guard now decides atomically, so the
+// authoritative rejection is transitioned==false. The pre-flight check is kept
+// because it gives the common case a Conflict without a pointless write; the
+// post-check is the one that is actually load-bearing, and both surface the
+// SAME snapshot_not_cancelable code — a lost race is indistinguishable to the
+// operator from a snapshot that was already terminal when they clicked, which
+// is exactly what it is.
+//
+// Cancel of a PENDING snapshot must keep working: that is why FailSnapshot's
+// guard is IN ('pending','running') and not just 'running'.
 func (s *Service) CancelSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID) (Snapshot, error) {
 	if tenantID == uuid.Nil {
 		return Snapshot{}, domain.Forbidden("tenant_required", "a tenant context is required")
@@ -2148,7 +2192,15 @@ func (s *Service) CancelSnapshot(ctx context.Context, tenantID, snapshotID uuid.
 		return Snapshot{}, domain.Conflict("snapshot_not_cancelable",
 			"only a running or pending backup can be cancelled")
 	}
-	return s.FailSnapshot(ctx, tenantID, snapshotID, cancelByOperatorMsg)
+	cancelled, transitioned, err := s.FailSnapshot(ctx, tenantID, snapshotID, cancelByOperatorMsg)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if !transitioned {
+		return Snapshot{}, domain.Conflict("snapshot_not_cancelable",
+			"only a running or pending backup can be cancelled")
+	}
+	return cancelled, nil
 }
 
 // SetSnapshotLocked sets or clears the per-snapshot lock flag (Track C, m49).
@@ -2710,14 +2762,28 @@ func (s *Service) RecordProgress(ctx context.Context, tenantID, snapshotID uuid.
 			// s.publish below does not emit a second event with the stale
 			// pre-failure status (which would regress the SSE stream from
 			// "failed" back to "running"/"pending").
-			if failedSnap, ferr := s.FailSnapshot(ctx, tenantID, snapshotID, reason); ferr != nil {
+			//
+			// GH #458: the status check above is a read of a row fetched
+			// earlier, so it can be stale; FailSnapshot's guard is what
+			// decides. transitioned==false means the row went terminal in
+			// that window, so its own transition already published — fall
+			// through WITHOUT returning early so the trailing publish still
+			// reports the current phase, but do not treat this as a failure
+			// we persisted.
+			failedSnap, transitioned, ferr := s.FailSnapshot(ctx, tenantID, snapshotID, reason)
+			switch {
+			case ferr != nil:
 				slog.Warn("RecordProgress: agent-reported failure could not be persisted",
 					slog.String("snapshot_id", snapshotID.String()),
 					slog.String("tenant_id", tenantID.String()),
 					slog.Any("error", ferr))
-			} else {
+			case transitioned:
 				_ = failedSnap
 				return raw, nil
+			default:
+				slog.Info("RecordProgress: agent-reported failure skipped; snapshot already terminal",
+					slog.String("snapshot_id", snapshotID.String()),
+					slog.String("tenant_id", tenantID.String()))
 			}
 		}
 	}
@@ -3524,12 +3590,12 @@ func (s *Service) PutBackupNotifications(ctx context.Context, in PutBackupNotifi
 	// Load existing content settings to preserve them during this notification-only update.
 	existing, _ := s.GetBackupSettings(ctx, in.TenantID, in.SiteID)
 	merged := SiteBackupSettings{
-		SiteID:            in.SiteID,
-		BackupComponents:  existing.BackupComponents,
-		IncludeCore:       existing.IncludeCore,
-		ExcludePaths:      existing.ExcludePaths,
-		ExcludeExtensions: existing.ExcludeExtensions,
-		ExcludeFileSizeMB: existing.ExcludeFileSizeMB,
+		SiteID:             in.SiteID,
+		BackupComponents:   existing.BackupComponents,
+		IncludeCore:        existing.IncludeCore,
+		ExcludePaths:       existing.ExcludePaths,
+		ExcludeExtensions:  existing.ExcludeExtensions,
+		ExcludeFileSizeMB:  existing.ExcludeFileSizeMB,
 		NotifyOnCompletion: notifyOnCompletion,
 		NotifyRecipients:   in.NotifyRecipients,
 	}

--- a/apps/api/internal/backup/snapshot_state_guards_test.go
+++ b/apps/api/internal/backup/snapshot_state_guards_test.go
@@ -1,0 +1,314 @@
+package backup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// GH #458 Go-layer contract tests.
+//
+// The SQL half (apps/api/db/query/backups.sql) added status preconditions to
+// MarkBackupSnapshotRunning, CompleteBackupSnapshot and FailBackupSnapshot and
+// moved all three from :one to :execrows, so rows-affected (0 or 1) — not
+// pgx.ErrNoRows — is now the signal that a transition did or did not happen.
+// tests/gh458 proves the predicates block in real Postgres. These tests prove
+// the Go layer WIRES that zero-row contract: a guard that blocks the write but
+// still fires the side effects is worse than no guard, because it reports a
+// state change that did not happen.
+//
+// The fakes these use mirror the real guards exactly (see watchdogFakeRepo's
+// MarkSnapshotRunning / FailSnapshot), so a fake can never report a transition
+// the database would have refused.
+
+// TestFailSnapshot_LateFailAgainstCompletedIsSilent is the primary Part 3
+// proof. A worker error, an agent-reported failure or an operator cancel can
+// all land after the snapshot already completed. The guarded UPDATE refuses to
+// overwrite the completed row, and the service must then publish no 'failed'
+// SSE event and send no failure email — announcing a failure for a backup that
+// actually succeeded is the worst outcome available here.
+func TestFailSnapshot_LateFailAgainstCompletedIsSilent(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{
+		ID: snapID, TenantID: tenantID, SiteID: siteID,
+		Status: StatusCompleted, TotalSize: 4242, ChunkCount: 7,
+	})
+
+	mailer := &fakeMailer{}
+	hub := NewHub()
+	svc := newWatchdogTestService(repo, hub)
+	svc.SetMailer(mailer)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	snap, transitioned, err := svc.FailSnapshot(context.Background(), tenantID, snapID, "worker error arriving late")
+	if err != nil {
+		t.Fatalf("FailSnapshot: unexpected error: %v", err)
+	}
+	if transitioned {
+		t.Fatalf("transitioned = true, want false — a completed row must not be failable")
+	}
+	if snap.Status != "" {
+		t.Fatalf("snapshot = %+v, want the zero Snapshot on a no-op transition", snap)
+	}
+
+	// The stored row is untouched: status, error and the recorded counters.
+	got := repo.mustGet(t, snapID)
+	if got.Status != StatusCompleted {
+		t.Fatalf("status = %q, want %q — a late fail must not overwrite a completed run", got.Status, StatusCompleted)
+	}
+	if got.Error != "" {
+		t.Fatalf("error = %q, want empty — a late fail must not stamp an error on a completed run", got.Error)
+	}
+	if got.TotalSize != 4242 || got.ChunkCount != 7 {
+		t.Fatalf("total_size/chunk_count = %d/%d, want 4242/7 — the completed run's counters must survive", got.TotalSize, got.ChunkCount)
+	}
+
+	// And no side effect fired.
+	if events := drainEvents(ch); len(events) != 0 {
+		t.Fatalf("events = %+v, want none — a no-op fail must not publish 'failed'", events)
+	}
+	if n := mailer.callCount(); n != 0 {
+		t.Fatalf("mailer calls = %d, want 0 — a no-op fail must not send a failure email", n)
+	}
+}
+
+// TestFailSnapshot_GenuineFailStillFiresEverything is the over-fire check for
+// the test above: a row that IS still running must fail exactly as before, with
+// its 'failed' event and its failure email. A guard that reddens correct work
+// gets switched off, and then it guards nothing.
+func TestFailSnapshot_GenuineFailStillFiresEverything(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusRunning})
+
+	mailer := &fakeMailer{}
+	hub := NewHub()
+	svc := newWatchdogTestService(repo, hub)
+	svc.SetMailer(mailer)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	snap, transitioned, err := svc.FailSnapshot(context.Background(), tenantID, snapID, "disk full")
+	if err != nil {
+		t.Fatalf("FailSnapshot: unexpected error: %v", err)
+	}
+	if !transitioned {
+		t.Fatalf("transitioned = false, want true — a running row must still be failable")
+	}
+	if snap.Status != StatusFailed {
+		t.Fatalf("returned status = %q, want %q", snap.Status, StatusFailed)
+	}
+	if got := repo.mustGet(t, snapID); got.Status != StatusFailed || got.Error != "disk full" {
+		t.Fatalf("stored row = %+v, want failed with the real reason", got)
+	}
+	events := drainEvents(ch)
+	if len(events) != 1 || events[0].Phase != "failed" {
+		t.Fatalf("events = %+v, want exactly one 'failed' event", events)
+	}
+	if n := mailer.callCount(); n != 1 {
+		t.Fatalf("mailer calls = %d, want exactly 1 — a genuine failure must still notify", n)
+	}
+}
+
+// TestMarkRunning_LostClaimPublishesNothing covers the claim precondition. The
+// worker reads the snapshot in one transaction and claims it in another, so the
+// row can be cancelled or watchdog-failed in between. MarkBackupSnapshotRunning
+// carries "AND status='pending'", so the claim returns 0 rows; the service must
+// then publish no 'started' event and reconcile no schedule run, both of which
+// would drag a terminal snapshot's UI back to "running".
+func TestMarkRunning_LostClaimPublishesNothing(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{
+		ID: snapID, TenantID: tenantID, SiteID: siteID,
+		Status: StatusFailed, Error: cancelByOperatorMsg,
+	})
+
+	hub := NewHub()
+	svc := newWatchdogTestService(repo, hub)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	snap, claimed, err := svc.MarkRunning(context.Background(), tenantID, snapID)
+	if err != nil {
+		t.Fatalf("MarkRunning: unexpected error: %v", err)
+	}
+	if claimed {
+		t.Fatalf("claimed = true, want false — a cancelled snapshot must not be claimable")
+	}
+	if snap.Status != "" {
+		t.Fatalf("snapshot = %+v, want the zero Snapshot on a lost claim", snap)
+	}
+	if got := repo.mustGet(t, snapID); got.Status != StatusFailed || got.Error != cancelByOperatorMsg {
+		t.Fatalf("stored row = %+v, want the cancel preserved — a claim must never revive a terminal row", got)
+	}
+	if events := drainEvents(ch); len(events) != 0 {
+		t.Fatalf("events = %+v, want none — a lost claim must not publish 'started'", events)
+	}
+}
+
+// TestMarkRunning_PendingClaimStillPublishesStarted is the over-fire check: the
+// normal claim of a pending snapshot is unchanged.
+func TestMarkRunning_PendingClaimStillPublishesStarted(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusPending})
+
+	hub := NewHub()
+	svc := newWatchdogTestService(repo, hub)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	snap, claimed, err := svc.MarkRunning(context.Background(), tenantID, snapID)
+	if err != nil {
+		t.Fatalf("MarkRunning: unexpected error: %v", err)
+	}
+	if !claimed {
+		t.Fatalf("claimed = false, want true — a pending snapshot must still be claimable")
+	}
+	if snap.Status != StatusRunning {
+		t.Fatalf("returned status = %q, want %q", snap.Status, StatusRunning)
+	}
+	events := drainEvents(ch)
+	if len(events) != 1 || events[0].Phase != "started" {
+		t.Fatalf("events = %+v, want exactly one 'started' event", events)
+	}
+}
+
+// TestMarkRunning_ClaimIsExactlyOnce proves the duplicate-job case: two workers
+// racing the same snapshot, only one of which owns the run.
+func TestMarkRunning_ClaimIsExactlyOnce(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusPending})
+
+	hub := NewHub()
+	svc := newWatchdogTestService(repo, hub)
+	ctx := context.Background()
+
+	if _, claimed, err := svc.MarkRunning(ctx, tenantID, snapID); err != nil || !claimed {
+		t.Fatalf("first claim: claimed=%v err=%v, want true/nil", claimed, err)
+	}
+	if _, claimed, err := svc.MarkRunning(ctx, tenantID, snapID); err != nil || claimed {
+		t.Fatalf("second claim: claimed=%v err=%v, want false/nil — the claim must be exactly-once", claimed, err)
+	}
+}
+
+// racingCancelRepo makes GetSnapshot report a stale 'running' row while the
+// stored row has already moved on. That is exactly the CancelSnapshot TOCTOU
+// window: the pre-flight status check passes, and only the guarded UPDATE can
+// tell the operator that there was nothing left to cancel.
+type racingCancelRepo struct {
+	*watchdogFakeRepo
+	stale Snapshot
+}
+
+func (r *racingCancelRepo) GetSnapshot(_ context.Context, _, _ uuid.UUID) (Snapshot, error) {
+	return r.stale, nil
+}
+
+// TestCancelSnapshot_LosesRaceSurfacesConflict is the TOCTOU proof. Before
+// GH #458 the blind UPDATE overwrote whatever the row had become — a completed
+// run's status and finished_at were replaced with "cancelled by operator" and
+// the operator was told the cancel worked. Now the guard refuses, and the
+// service surfaces the EXISTING snapshot_not_cancelable Conflict rather than a
+// new error code: a lost race is indistinguishable to the operator from a
+// snapshot that was already terminal when they clicked, which is what it is.
+func TestCancelSnapshot_LosesRaceSurfacesConflict(t *testing.T) {
+	inner := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	// The row really completed...
+	inner.setSnapshot(Snapshot{
+		ID: snapID, TenantID: tenantID, SiteID: siteID,
+		Status: StatusCompleted, TotalSize: 999, ChunkCount: 3,
+	})
+	// ...but the operator's read still says it is running.
+	repo := &racingCancelRepo{
+		watchdogFakeRepo: inner,
+		stale:            Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusRunning},
+	}
+
+	mailer := &fakeMailer{}
+	hub := NewHub()
+	// Built inline rather than via newWatchdogTestService: that helper is typed
+	// to *watchdogFakeRepo, and this test needs the racing wrapper.
+	svc := NewService(repo, &fakeSiteLookup{}, nil, &fakePresigner{}, fakeClock{t: time.Now()}, Config{})
+	svc.SetHub(hub)
+	svc.SetMailer(mailer)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	_, err := svc.CancelSnapshot(context.Background(), tenantID, snapID)
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Kind != domain.KindConflict || de.Code != "snapshot_not_cancelable" {
+		t.Fatalf("err = %v, want Conflict snapshot_not_cancelable", err)
+	}
+
+	got := inner.mustGet(t, snapID)
+	if got.Status != StatusCompleted || got.Error != "" {
+		t.Fatalf("stored row = %+v, want the completed run untouched by the lost cancel", got)
+	}
+	if got.TotalSize != 999 || got.ChunkCount != 3 {
+		t.Fatalf("counters = %d/%d, want 999/3 — a lost cancel must not rewrite them", got.TotalSize, got.ChunkCount)
+	}
+	if events := drainEvents(ch); len(events) != 0 {
+		t.Fatalf("events = %+v, want none — a lost cancel must not publish 'failed'", events)
+	}
+	if n := mailer.callCount(); n != 0 {
+		t.Fatalf("mailer calls = %d, want 0 — a lost cancel must not email a failure", n)
+	}
+}
+
+// TestCancelSnapshot_PendingStillCancelable is the non-negotiable over-fire
+// check named in the GH #458 brief. FailBackupSnapshot's guard is
+// IN ('pending','running') and not just 'running' precisely so operator cancel
+// of a QUEUED backup keeps working. If this reddens, the guard was narrowed
+// wrongly or the wiring is inverted.
+func TestCancelSnapshot_PendingStillCancelable(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusPending})
+
+	hub := NewHub()
+	svc := newWatchdogTestService(repo, hub)
+	ch, unsub := hub.Subscribe(snapID)
+	defer unsub()
+
+	out, err := svc.CancelSnapshot(context.Background(), tenantID, snapID)
+	if err != nil {
+		t.Fatalf("CancelSnapshot(pending): unexpected error: %v — cancel of a QUEUED backup must keep working", err)
+	}
+	if out.Status != StatusFailed {
+		t.Fatalf("status = %q, want %q", out.Status, StatusFailed)
+	}
+	got := repo.mustGet(t, snapID)
+	if got.Status != StatusFailed || got.Error != cancelByOperatorMsg {
+		t.Fatalf("stored row = %+v, want failed with %q", got, cancelByOperatorMsg)
+	}
+	events := drainEvents(ch)
+	if len(events) != 1 || events[0].Phase != "failed" {
+		t.Fatalf("events = %+v, want exactly one 'failed' event for a real cancel", events)
+	}
+}
+
+// TestCancelSnapshot_RunningStillCancelable is the other half of the over-fire
+// check.
+func TestCancelSnapshot_RunningStillCancelable(t *testing.T) {
+	repo := newWatchdogFakeRepo()
+	tenantID, siteID, snapID := uuid.New(), uuid.New(), uuid.New()
+	repo.setSnapshot(Snapshot{ID: snapID, TenantID: tenantID, SiteID: siteID, Status: StatusRunning})
+
+	svc := newWatchdogTestService(repo, NewHub())
+	out, err := svc.CancelSnapshot(context.Background(), tenantID, snapID)
+	if err != nil {
+		t.Fatalf("CancelSnapshot(running): unexpected error: %v", err)
+	}
+	if out.Status != StatusFailed {
+		t.Fatalf("status = %q, want %q", out.Status, StatusFailed)
+	}
+}

--- a/apps/api/internal/backup/stall_watchdog_test.go
+++ b/apps/api/internal/backup/stall_watchdog_test.go
@@ -44,17 +44,36 @@ func (r *watchdogFakeRepo) ExistingChunkHashes(_ context.Context, _ uuid.UUID, _
 	return map[string]Chunk{}, nil
 }
 
-func (r *watchdogFakeRepo) FailSnapshot(_ context.Context, _, snapshotID uuid.UUID, errMsg string) (Snapshot, error) {
+// MarkSnapshotRunning mirrors MarkBackupSnapshotRunning's GH #458 claim guard
+// ("AND status='pending'") exactly: transitioned is true only for a row that
+// really was pending, so the claim is exactly-once and can never revive a
+// terminal row. Overrides the embedded fakeRepo's panic stub.
+func (r *watchdogFakeRepo) MarkSnapshotRunning(_ context.Context, _, snapshotID uuid.UUID) (Snapshot, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	s, ok := r.snapshots[snapshotID]
-	if !ok {
-		return Snapshot{}, domain.NotFound("backup_snapshot_not_found", "not found")
+	if !ok || s.Status != StatusPending {
+		return Snapshot{}, false, nil
+	}
+	s.Status = StatusRunning
+	r.snapshots[snapshotID] = s
+	return s, true, nil
+}
+
+func (r *watchdogFakeRepo) FailSnapshot(_ context.Context, _, snapshotID uuid.UUID, errMsg string) (Snapshot, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.snapshots[snapshotID]
+	// GH #458: mirror the real query's guard exactly. A fake that always
+	// reports a transition would hide the very defect the guard exists to
+	// catch.
+	if !ok || (s.Status != StatusPending && s.Status != StatusRunning) {
+		return Snapshot{}, false, nil
 	}
 	s.Status = StatusFailed
 	s.Error = errMsg
 	r.snapshots[snapshotID] = s
-	return s, nil
+	return s, true, nil
 }
 
 // FailStalledSnapshot mirrors the real FailStalledBackupSnapshot query's

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -160,9 +160,23 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 		return w.fail(ctx, snap, "no age recipient on snapshot")
 	}
 
-	running, err := w.svc.MarkRunning(ctx, a.TenantID, a.SnapshotID)
+	running, claimed, err := w.svc.MarkRunning(ctx, a.TenantID, a.SnapshotID)
 	if err != nil {
 		return err
+	}
+	if !claimed {
+		// GH #458: the claim is atomic ("AND status='pending'"), and it lost.
+		// The terminal check at the top of Work read the row in a separate
+		// transaction, so between there and here the snapshot was cancelled,
+		// watchdog-failed, or claimed by a duplicate/retried job. Same outcome
+		// as that check: this job is not the run's owner, so it dispatches
+		// nothing, records no 'started' audit entry, and succeeds rather than
+		// returning an error that would have River retry a snapshot that is
+		// never going to be pending again.
+		w.logger.Info("backup claim lost; snapshot no longer pending",
+			slog.String("snapshot_id", a.SnapshotID.String()),
+			slog.String("tenant_id", a.TenantID.String()))
+		return nil
 	}
 	w.recordAudit(ctx, running, ActionBackupStarted, nil)
 
@@ -306,9 +320,20 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 }
 
 func (w *BackupWorker) fail(ctx context.Context, snap Snapshot, msg string) error {
-	failed, err := w.svc.FailSnapshot(ctx, snap.TenantID, snap.ID, msg)
+	failed, transitioned, err := w.svc.FailSnapshot(ctx, snap.TenantID, snap.ID, msg)
 	if err != nil {
 		return err
+	}
+	if !transitioned {
+		// GH #458: the row had already moved on (operator cancel, watchdog
+		// hard-fail, or a completion that raced this error path). Its own
+		// terminal transition already published its event and recorded its own
+		// audit entry; writing ActionBackupFailed here would record a failure
+		// that never happened against a snapshot that may have completed.
+		w.logger.Info("backup fail skipped; snapshot already terminal",
+			slog.String("snapshot_id", snap.ID.String()),
+			slog.String("tenant_id", snap.TenantID.String()))
+		return nil
 	}
 	w.recordAudit(ctx, failed, ActionBackupFailed, map[string]any{"error": msg})
 	return nil // terminal failure recorded; the River job succeeds.

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -154,9 +154,13 @@ func (w *BackupWorker) Timeout(*river.Job[BackupArgs]) time.Duration { return w.
 //   - a snapshot has exactly one River job. Both enqueue paths insert one job
 //     immediately after creating the snapshot row it names — CreateSnapshot
 //     (service.go:597/618) and the scheduler (service.go:3483/3485) — and
-//     nothing re-enqueues an existing snapshot. River guarantees a single
-//     execution of a given job at a time, so the only Work that can be inside
-//     this row is this one.
+//     nothing re-enqueues an existing snapshot. That is now a constraint and
+//     not just an absence: both inserts carry backupInsertOpts()
+//     (enqueuer.go), whose UniqueOpts.ByArgs keys on the snapshot ID, so a
+//     second job for a snapshot that already has one is refused by River
+//     rather than merely un-written. River guarantees a single execution of a
+//     given job at a time, so the only Work that can be inside this row is
+//     this one.
 //
 //   - and per site, backup_snapshots_one_inflight_per_site (db/schema.sql:1487)
 //     is a UNIQUE index on site_id WHERE status IN ('pending','running'), so
@@ -173,8 +177,44 @@ func (w *BackupWorker) Timeout(*river.Job[BackupArgs]) time.Duration { return w.
 // River cancelling attempt 1's context ends the control plane's WAIT for the
 // agent, it does not stop a backup the agent has already begun. So a retry can
 // still produce a duplicate DISPATCH against a live agent. That is the
-// pre-GH#458 behaviour, it is bounded by the agent's own run lock, and the
-// terminal guard on CompleteBackupSnapshot rejects the losing manifest submit.
+// pre-GH#458 behaviour, and the terminal guard on CompleteBackupSnapshot
+// rejects the losing manifest submit. What bounds the duplicate dispatch
+// itself is the AGENT's per-snapshot flock, taken by TaskRunner::run
+// (apps/agent/includes/backup/class-task-runner.php:275-295, rationale at
+// :185-212): flock(LOCK_EX|LOCK_NB) on a deterministic per-snapshot lock file,
+// held by the OS for the lifetime of the winning PHP process, so it survives a
+// dropped $wpdb connection. The loser returns without mutating phase and
+// without submitting.
+//
+// It is NOT bounded by the agent's runner_in_flight refusal (see the constant
+// at the top of this file). That comes from BackupCommand::tryClaimDedup
+// (apps/agent/includes/commands/class-backup-command.php:379-393), which is a
+// time-windowed check-then-act and not a lock at all: DEDUP_WINDOW_SECONDS is
+// 300 (same file, :72), started_at is never refreshed during a run, and
+// backup.http_timeout defaults to 10m (config.go:821 —
+// NewBackupWorker's jobTimeout is derived from it). So in the DEFAULT
+// configuration the claim made at T=0 is already outside the window by the
+// time attempt 1 gives up at T≈600s: the cutoff test is `started_at > now-300`,
+// 0 > 301 is false, and tryClaimDedup RECLAIMS and returns true rather than
+// reporting runner_in_flight. The refusal only fires while
+// DEDUP_WINDOW_SECONDS exceeds the control plane's per-attempt deadline, which
+// it does not. Treat runner_in_flight as a fast-path optimisation for quick
+// retries; the flock is the correctness bound.
+//
+// The separate, stronger property — that two ATTEMPTS of this job cannot be
+// in Work at the same time, which is what makes "still running" unambiguous
+// above — is River's, but it holds on a timeout RATIO and not on River
+// unconditionally. River only re-runs an attempt whose row it has rescued, and
+// RescueStuckJobsAfter is unset repo-wide (as is river.Config.JobTimeout, see
+// cmd/wpmgr/main.go:758), so River's own 1h JobRescuerRescueAfterDefault
+// applies; this worker's deadline is cfg.Backup.HTTPTimeout + 2m = 12m
+// (cmd/wpmgr/main.go:917). Attempt 1 is therefore cancelled ~48m before the
+// rescuer could release the row. Raise backupJobTimeout past the rescue
+// threshold, or lower RescueStuckJobsAfter under it, and the two can overlap —
+// at which point "attempt > 1 and still running" stops being evidence of sole
+// ownership and this function needs a different proof. Anyone retuning either
+// number owns re-deriving it.
+//
 // Stranding the run instead is strictly worse: nothing recovers it but the
 // watchdog, and only after the hard threshold.
 //
@@ -252,8 +292,9 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 		// Fall through and re-dispatch on the row this job already owns. No
 		// second 'started' audit entry and no second 'started' SSE event
 		// (MarkRunning publishes that, and attempt 1 already did): the run was
-		// announced once and is being retried, not started again.
-		running = cur
+		// announced once and is being retried, not started again. `running`
+		// is deliberately NOT reassigned from cur here — its only reader is
+		// the recordAudit call in the else arm below, which this arm skips.
 	} else {
 		w.recordAudit(ctx, running, ActionBackupStarted, nil)
 	}

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -137,6 +137,56 @@ func NewBackupWorker(svc *Service, cmd Commander, rec *audit.Recorder, logger *s
 // (a wedged backup must eventually error out so River can retry).
 func (w *BackupWorker) Timeout(*river.Job[BackupArgs]) time.Duration { return w.jobTimeout }
 
+// resumedOwnClaim reports whether a snapshot the claim guard refused is in
+// fact this job's OWN claim, made by an earlier attempt of this same job, and
+// may therefore be re-dispatched.
+//
+// It is true for exactly one shape: a retry (Attempt > 1) over a row that is
+// still 'running'. The whole question is whether "still running" can mean
+// "someone else is running it", and for a backup snapshot it cannot:
+//
+//   - status='running' has exactly one writer. MarkBackupSnapshotRunning
+//     (db/query/backups.sql:39) is the only statement in the schema that sets
+//     it; every other query naming 'running' reads it or transitions out of
+//     it. So a running row was claimed by some BackupWorker.Work, not by the
+//     watchdog, the agent callbacks or an operator action.
+//
+//   - a snapshot has exactly one River job. Both enqueue paths insert one job
+//     immediately after creating the snapshot row it names — CreateSnapshot
+//     (service.go:597/618) and the scheduler (service.go:3483/3485) — and
+//     nothing re-enqueues an existing snapshot. River guarantees a single
+//     execution of a given job at a time, so the only Work that can be inside
+//     this row is this one.
+//
+//   - and per site, backup_snapshots_one_inflight_per_site (db/schema.sql:1487)
+//     is a UNIQUE index on site_id WHERE status IN ('pending','running'), so
+//     a second in-flight snapshot for the site cannot exist to be confused
+//     with this one either.
+//
+// That is why this needs no staleness bound, where MarkUpdateTaskRunning's
+// reclaim arm does: update_tasks genuinely can have two jobs over one row, so
+// there "running" is ambiguous and only age disambiguates it. Here it is not
+// ambiguous, and an age bound would only add a window in which a legitimate
+// retry is dropped on the floor.
+//
+// The residual is the same one that query documents and cannot fix either:
+// River cancelling attempt 1's context ends the control plane's WAIT for the
+// agent, it does not stop a backup the agent has already begun. So a retry can
+// still produce a duplicate DISPATCH against a live agent. That is the
+// pre-GH#458 behaviour, it is bounded by the agent's own run lock, and the
+// terminal guard on CompleteBackupSnapshot rejects the losing manifest submit.
+// Stranding the run instead is strictly worse: nothing recovers it but the
+// watchdog, and only after the hard threshold.
+//
+// job.JobRow is nil in unit tests that construct a bare river.Job literal;
+// treat that as attempt 1 (no resume) rather than dereferencing it.
+func (w *BackupWorker) resumedOwnClaim(job *river.Job[BackupArgs], cur Snapshot) bool {
+	if job == nil || job.JobRow == nil {
+		return false
+	}
+	return job.Attempt > 1 && cur.Status == StatusRunning
+}
+
 // Work dispatches one backup. A transient transport error returns the error so
 // River retries; an agent refusal marks the snapshot failed (terminal).
 func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) error {
@@ -168,17 +218,45 @@ func (w *BackupWorker) Work(ctx context.Context, job *river.Job[BackupArgs]) err
 		// GH #458: the claim is atomic ("AND status='pending'"), and it lost.
 		// The terminal check at the top of Work read the row in a separate
 		// transaction, so between there and here the snapshot was cancelled,
-		// watchdog-failed, or claimed by a duplicate/retried job. Same outcome
-		// as that check: this job is not the run's owner, so it dispatches
-		// nothing, records no 'started' audit entry, and succeeds rather than
-		// returning an error that would have River retry a snapshot that is
-		// never going to be pending again.
-		w.logger.Info("backup claim lost; snapshot no longer pending",
+		// watchdog-failed, or completed by a late agent manifest submit. In
+		// all of those this job is not the run's owner: it dispatches nothing,
+		// records no 'started' audit entry, and succeeds rather than returning
+		// an error that would have River retry a snapshot that is never going
+		// to be pending again.
+		//
+		// EXCEPT for the one case that is not a lost claim at all — a retry of
+		// THIS job re-entering Work over the row IT already claimed. The
+		// original guard treated that as a loss and returned nil, so a
+		// transient transport error on attempt 1 left the snapshot 'running'
+		// with nothing dispatched behind it until the watchdog hard-failed it.
+		// resumedOwnClaim is what separates the two; see its doc for why
+		// "attempt > 1 and still running" is sufficient evidence of ownership
+		// for a backup snapshot (it is NOT sufficient for an update task,
+		// which is why MarkUpdateTaskRunning bounds its reclaim arm by age
+		// instead).
+		cur, cerr := w.svc.repo.GetSnapshot(ctx, a.TenantID, a.SnapshotID)
+		if cerr != nil {
+			return cerr
+		}
+		if !w.resumedOwnClaim(job, cur) {
+			w.logger.Info("backup claim lost; snapshot no longer pending",
+				slog.String("snapshot_id", a.SnapshotID.String()),
+				slog.String("tenant_id", a.TenantID.String()),
+				slog.String("status", cur.Status))
+			return nil
+		}
+		w.logger.Info("backup claim resumed by retry of the owning job",
 			slog.String("snapshot_id", a.SnapshotID.String()),
-			slog.String("tenant_id", a.TenantID.String()))
-		return nil
+			slog.String("tenant_id", a.TenantID.String()),
+			slog.Int("attempt", job.Attempt))
+		// Fall through and re-dispatch on the row this job already owns. No
+		// second 'started' audit entry and no second 'started' SSE event
+		// (MarkRunning publishes that, and attempt 1 already did): the run was
+		// announced once and is being retried, not started again.
+		running = cur
+	} else {
+		w.recordAudit(ctx, running, ActionBackupStarted, nil)
 	}
-	w.recordAudit(ctx, running, ActionBackupStarted, nil)
 
 	// Track A (m49): resolve component-scope + exclusion settings from the
 	// site's schedule. Zero value = no filter (all components, no exclusions),

--- a/apps/api/internal/backup/worker.go
+++ b/apps/api/internal/backup/worker.go
@@ -86,7 +86,7 @@ type Commander interface {
 // ADR-048: incremental fields are omitempty; zero values mean full backup.
 type BackupArgs struct {
 	TenantID   uuid.UUID `json:"tenant_id"`
-	SnapshotID uuid.UUID `json:"snapshot_id"`
+	SnapshotID uuid.UUID `json:"snapshot_id" river:"unique"`
 	// ADR-048 incremental chain fields. All omitempty; absent = full backup.
 	IsIncremental    bool      `json:"is_incremental,omitempty"`
 	ParentSnapshotID uuid.UUID `json:"parent_snapshot_id,omitempty"`

--- a/apps/api/internal/backup/worker_incremental_test.go
+++ b/apps/api/internal/backup/worker_incremental_test.go
@@ -51,27 +51,36 @@ type fakeWorkerRepo struct {
 	workerManifests   map[uuid.UUID][]ManifestEntry
 }
 
-func (r *fakeWorkerRepo) MarkSnapshotRunning(_ context.Context, _, snapshotID uuid.UUID) (Snapshot, error) {
+func (r *fakeWorkerRepo) MarkSnapshotRunning(_ context.Context, _, snapshotID uuid.UUID) (Snapshot, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.markRunningCalled = true
 	s, ok := r.snapshots[snapshotID]
-	if !ok {
-		return Snapshot{}, domain.NotFound("backup_snapshot_not_found", "not found")
+	// GH #458: mirror MarkBackupSnapshotRunning's claim guard
+	// ("AND status='pending'") exactly. A fake that claims any status would
+	// hide the very defect the guard exists to catch.
+	if !ok || s.Status != StatusPending {
+		return Snapshot{}, false, nil
 	}
 	s.Status = StatusRunning
 	r.snapshots[snapshotID] = s
-	return s, nil
+	return s, true, nil
 }
 
-func (r *fakeWorkerRepo) FailSnapshot(_ context.Context, _, snapshotID uuid.UUID, msg string) (Snapshot, error) {
+func (r *fakeWorkerRepo) FailSnapshot(_ context.Context, _, snapshotID uuid.UUID, msg string) (Snapshot, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	s := r.snapshots[snapshotID]
+	s, ok := r.snapshots[snapshotID]
+	// GH #458: mirror the real query's guard exactly. A fake that always
+	// reports a transition would hide the very defect the guard exists to
+	// catch.
+	if !ok || (s.Status != StatusPending && s.Status != StatusRunning) {
+		return Snapshot{}, false, nil
+	}
 	s.Status = StatusFailed
 	s.Error = msg
 	r.snapshots[snapshotID] = s
-	return s, nil
+	return s, true, nil
 }
 
 // manifests lets a worker test register a parent snapshot's manifest entries so
@@ -411,12 +420,12 @@ func TestBackupWorker_SelectiveComponents_IncludeDB(t *testing.T) {
 			snapshotID := uuid.New()
 
 			snap := Snapshot{
-				ID:           snapshotID,
-				TenantID:     tenantID,
-				SiteID:       uuid.New(),
-				Kind:         KindFull,
-				Status:       StatusPending,
-				AgeRecipient: "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+				ID:            snapshotID,
+				TenantID:      tenantID,
+				SiteID:        uuid.New(),
+				Kind:          KindFull,
+				Status:        StatusPending,
+				AgeRecipient:  "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
 				IsIncremental: false,
 			}
 			inner.setSnapshot(snap)

--- a/apps/api/internal/backup/worker_test.go
+++ b/apps/api/internal/backup/worker_test.go
@@ -85,7 +85,7 @@ func newFailTrackingWorkerRepo() *failTrackingWorkerRepo {
 	}
 }
 
-func (r *failTrackingWorkerRepo) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, msg string) (Snapshot, error) {
+func (r *failTrackingWorkerRepo) FailSnapshot(ctx context.Context, tenantID, snapshotID uuid.UUID, msg string) (Snapshot, bool, error) {
 	r.failCalled = true
 	return r.fakeWorkerRepo.FailSnapshot(ctx, tenantID, snapshotID, msg)
 }

--- a/apps/api/internal/db/sqlc/backups.sql.go
+++ b/apps/api/internal/db/sqlc/backups.sql.go
@@ -90,15 +90,14 @@ func (q *Queries) ClearBackupSnapshotStalled(ctx context.Context, arg ClearBacku
 	return result.RowsAffected(), nil
 }
 
-const completeBackupSnapshot = `-- name: CompleteBackupSnapshot :one
+const completeBackupSnapshot = `-- name: CompleteBackupSnapshot :execrows
 UPDATE backup_snapshots
 SET status = 'completed',
     total_size = $3,
     chunk_count = $4,
     finished_at = now(),
     updated_at = now()
-WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, stalled_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+WHERE id = $1 AND tenant_id = $2 AND status IN ('pending', 'running')
 `
 
 type CompleteBackupSnapshotParams struct {
@@ -108,46 +107,27 @@ type CompleteBackupSnapshotParams struct {
 	ChunkCount int64     `json:"chunk_count"`
 }
 
-func (q *Queries) CompleteBackupSnapshot(ctx context.Context, arg CompleteBackupSnapshotParams) (BackupSnapshot, error) {
-	row := q.db.QueryRow(ctx, completeBackupSnapshot,
+// Terminal-transition precondition (GH #458): only a 'pending' or 'running'
+// snapshot may complete. 'pending' stays allowed because the files-only and
+// carry-forward completion paths can land without an intervening MarkRunning.
+// What the guard blocks is resurrection: a late agent manifest submit arriving
+// after the operator cancelled (CancelSnapshot stamps 'failed') or after the
+// watchdog hard-failed the run must not flip the row to 'completed' and must
+// not overwrite the recorded error and finished_at. Rows-affected is the
+// contract: 1 = a real transition; 0 = already terminal (completed/failed) or
+// gone, which the caller must surface as a rejected submit -- the previous
+// blind UPDATE reported success unconditionally.
+func (q *Queries) CompleteBackupSnapshot(ctx context.Context, arg CompleteBackupSnapshotParams) (int64, error) {
+	result, err := q.db.Exec(ctx, completeBackupSnapshot,
 		arg.ID,
 		arg.TenantID,
 		arg.TotalSize,
 		arg.ChunkCount,
 	)
-	var i BackupSnapshot
-	err := row.Scan(
-		&i.ID,
-		&i.TenantID,
-		&i.SiteID,
-		&i.CreatedBy,
-		&i.Kind,
-		&i.Status,
-		&i.AgeRecipient,
-		&i.TotalSize,
-		&i.ChunkCount,
-		&i.Error,
-		&i.Archived,
-		&i.Locked,
-		&i.DestinationID,
-		&i.Progress,
-		&i.ProgressUpdatedAt,
-		&i.StalledAt,
-		&i.StartedAt,
-		&i.FinishedAt,
-		&i.IsIncremental,
-		&i.ParentSnapshotID,
-		&i.BaseSnapshotID,
-		&i.ChainID,
-		&i.Generation,
-		&i.CycleFilesScanned,
-		&i.CycleFilesChanged,
-		&i.CycleFilesDeleted,
-		&i.CycleBytesUploaded,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const createBackupSnapshot = `-- name: CreateBackupSnapshot :one
@@ -338,14 +318,13 @@ func (q *Queries) DeleteOrphanChunk(ctx context.Context, arg DeleteOrphanChunkPa
 	return result.RowsAffected(), nil
 }
 
-const failBackupSnapshot = `-- name: FailBackupSnapshot :one
+const failBackupSnapshot = `-- name: FailBackupSnapshot :execrows
 UPDATE backup_snapshots
 SET status = 'failed',
     error = $3,
     finished_at = now(),
     updated_at = now()
-WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, stalled_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+WHERE id = $1 AND tenant_id = $2 AND status IN ('pending', 'running')
 `
 
 type FailBackupSnapshotParams struct {
@@ -354,41 +333,24 @@ type FailBackupSnapshotParams struct {
 	Error    string    `json:"error"`
 }
 
-func (q *Queries) FailBackupSnapshot(ctx context.Context, arg FailBackupSnapshotParams) (BackupSnapshot, error) {
-	row := q.db.QueryRow(ctx, failBackupSnapshot, arg.ID, arg.TenantID, arg.Error)
-	var i BackupSnapshot
-	err := row.Scan(
-		&i.ID,
-		&i.TenantID,
-		&i.SiteID,
-		&i.CreatedBy,
-		&i.Kind,
-		&i.Status,
-		&i.AgeRecipient,
-		&i.TotalSize,
-		&i.ChunkCount,
-		&i.Error,
-		&i.Archived,
-		&i.Locked,
-		&i.DestinationID,
-		&i.Progress,
-		&i.ProgressUpdatedAt,
-		&i.StalledAt,
-		&i.StartedAt,
-		&i.FinishedAt,
-		&i.IsIncremental,
-		&i.ParentSnapshotID,
-		&i.BaseSnapshotID,
-		&i.ChainID,
-		&i.Generation,
-		&i.CycleFilesScanned,
-		&i.CycleFilesChanged,
-		&i.CycleFilesDeleted,
-		&i.CycleBytesUploaded,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
+// Terminal-transition precondition (GH #458). 'pending' is in the guard
+// deliberately: CancelSnapshot ("only a running or pending backup can be
+// cancelled") fails a still-'pending' snapshot through this query, so
+// narrowing to status='running' would silently stop operator cancel of a
+// queued backup. That is the watchdog's guard, not this one -- see
+// FailStalledBackupSnapshot below. What this guard blocks is the overwrite of
+// an ALREADY-terminal row: a worker error landing after the operator cancelled
+// must not replace cancelByOperatorMsg with a generic message, and a fail must
+// never rewrite a completed run's status or finished_at. Rows-affected is the
+// contract: 1 = a real transition; 0 = already terminal, or gone -- do not
+// publish the 'failed' SSE event, the failure email, or the schedule-run
+// reconciliation for a row that had already moved on.
+func (q *Queries) FailBackupSnapshot(ctx context.Context, arg FailBackupSnapshotParams) (int64, error) {
+	result, err := q.db.Exec(ctx, failBackupSnapshot, arg.ID, arg.TenantID, arg.Error)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const failStalledBackupSnapshot = `-- name: FailStalledBackupSnapshot :execrows
@@ -407,13 +369,16 @@ type FailStalledBackupSnapshotParams struct {
 }
 
 // TOCTOU-safe hard-fail for the two-tier progress watchdog (GH #279 must-fix).
-// Identical to FailBackupSnapshot except for the added "AND status='running'"
-// guard: ListStalledRunningSnapshots commits, then each hard row is failed in
-// its own separate transaction, so between the two a row may have completed,
-// been operator-cancelled, been agent-failed, or resumed. FailBackupSnapshot's
-// blind UPDATE has no status guard (CancelSnapshot relies on that to fail a
-// still-'pending' row), so it must stay unchanged; this query is the watchdog
-// hard-fail branch's ONLY write path. Rows-affected (0 or 1) tells the caller
+// Identical to FailBackupSnapshot except that the guard is NARROWER:
+// status='running' here, status IN ('pending','running') there (GH #458).
+// ListStalledRunningSnapshots commits, then each hard row is failed in its own
+// separate transaction, so between the two a row may have completed, been
+// operator-cancelled, been agent-failed, or resumed. The watchdog only ever
+// hard-fails a run it observed RUNNING and must never touch a queued 'pending'
+// row -- which FailBackupSnapshot may, because operator cancel of a queued
+// backup goes through it (CancelSnapshot). The two guards therefore stay
+// distinct, and this query remains the watchdog hard-fail branch's ONLY write
+// path. Rows-affected (0 or 1) tells the caller
 // whether a real transition happened, so it can gate the 'failed' SSE publish
 // and the failure notification on an actual state change rather than firing
 // them for a row that already moved on.
@@ -1482,11 +1447,10 @@ func (q *Queries) ListTenantsForBackupGC(ctx context.Context) ([]uuid.UUID, erro
 	return items, nil
 }
 
-const markBackupSnapshotRunning = `-- name: MarkBackupSnapshotRunning :one
+const markBackupSnapshotRunning = `-- name: MarkBackupSnapshotRunning :execrows
 UPDATE backup_snapshots
 SET status = 'running', started_at = now(), updated_at = now()
-WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, site_id, created_by, kind, status, age_recipient, total_size, chunk_count, error, archived, locked, destination_id, progress, progress_updated_at, stalled_at, started_at, finished_at, is_incremental, parent_snapshot_id, base_snapshot_id, chain_id, generation, cycle_files_scanned, cycle_files_changed, cycle_files_deleted, cycle_bytes_uploaded, created_at, updated_at
+WHERE id = $1 AND tenant_id = $2 AND status = 'pending'
 `
 
 type MarkBackupSnapshotRunningParams struct {
@@ -1494,41 +1458,23 @@ type MarkBackupSnapshotRunningParams struct {
 	TenantID uuid.UUID `json:"tenant_id"`
 }
 
-func (q *Queries) MarkBackupSnapshotRunning(ctx context.Context, arg MarkBackupSnapshotRunningParams) (BackupSnapshot, error) {
-	row := q.db.QueryRow(ctx, markBackupSnapshotRunning, arg.ID, arg.TenantID)
-	var i BackupSnapshot
-	err := row.Scan(
-		&i.ID,
-		&i.TenantID,
-		&i.SiteID,
-		&i.CreatedBy,
-		&i.Kind,
-		&i.Status,
-		&i.AgeRecipient,
-		&i.TotalSize,
-		&i.ChunkCount,
-		&i.Error,
-		&i.Archived,
-		&i.Locked,
-		&i.DestinationID,
-		&i.Progress,
-		&i.ProgressUpdatedAt,
-		&i.StalledAt,
-		&i.StartedAt,
-		&i.FinishedAt,
-		&i.IsIncremental,
-		&i.ParentSnapshotID,
-		&i.BaseSnapshotID,
-		&i.ChainID,
-		&i.Generation,
-		&i.CycleFilesScanned,
-		&i.CycleFilesChanged,
-		&i.CycleFilesDeleted,
-		&i.CycleBytesUploaded,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
+// Claim precondition (GH #458): 'pending' is the only status a claim may
+// transition out of. Without it the UPDATE was blind, so a duplicate/retried
+// worker job, or a job whose snapshot was cancelled or watchdog-failed while
+// it sat in the queue, dragged a terminal row back to 'running' and cleared
+// the run's real outcome. Rows-affected is the contract: 1 = this caller won
+// the claim and owns the run; 0 = the row was not 'pending' (already claimed,
+// already terminal, or gone), and the caller must NOT proceed as the owner and
+// must NOT publish the 'started' SSE event or the schedule-run reconciliation
+// for it. :execrows (not :exec) because a precondition whose failure is
+// invisible is worse than no precondition -- same reasoning as
+// FailStalledBackupSnapshot below.
+func (q *Queries) MarkBackupSnapshotRunning(ctx context.Context, arg MarkBackupSnapshotRunningParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markBackupSnapshotRunning, arg.ID, arg.TenantID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const markBackupSnapshotStalled = `-- name: MarkBackupSnapshotStalled :one

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -386,7 +386,17 @@ type Querier interface {
 	// which is defensive only — FireRecovery only ever fires when prev.InIncident
 	// was true, so a matching open row should already exist.
 	CloseIncident(ctx context.Context, arg CloseIncidentParams) error
-	CompleteBackupSnapshot(ctx context.Context, arg CompleteBackupSnapshotParams) (BackupSnapshot, error)
+	// Terminal-transition precondition (GH #458): only a 'pending' or 'running'
+	// snapshot may complete. 'pending' stays allowed because the files-only and
+	// carry-forward completion paths can land without an intervening MarkRunning.
+	// What the guard blocks is resurrection: a late agent manifest submit arriving
+	// after the operator cancelled (CancelSnapshot stamps 'failed') or after the
+	// watchdog hard-failed the run must not flip the row to 'completed' and must
+	// not overwrite the recorded error and finished_at. Rows-affected is the
+	// contract: 1 = a real transition; 0 = already terminal (completed/failed) or
+	// gone, which the caller must surface as a rejected submit -- the previous
+	// blind UPDATE reported success unconditionally.
+	CompleteBackupSnapshot(ctx context.Context, arg CompleteBackupSnapshotParams) (int64, error)
 	CompleteReport(ctx context.Context, arg CompleteReportParams) (GeneratedReport, error)
 	// Marks a task done. Set ONLY after the whole prefix drained with no error, so
 	// a crash partway leaves completed_at NULL and the next tick re-lists (a
@@ -826,19 +836,34 @@ type Querier interface {
 	ExpireDueUpdateRun(ctx context.Context, arg ExpireDueUpdateRunParams) (UpdateRun, error)
 	// Lock a challenge by setting used_at (reached attempt limit or timeout).
 	ExpireTwoFactorChallenge(ctx context.Context, id uuid.UUID) error
-	FailBackupSnapshot(ctx context.Context, arg FailBackupSnapshotParams) (BackupSnapshot, error)
+	// Terminal-transition precondition (GH #458). 'pending' is in the guard
+	// deliberately: CancelSnapshot ("only a running or pending backup can be
+	// cancelled") fails a still-'pending' snapshot through this query, so
+	// narrowing to status='running' would silently stop operator cancel of a
+	// queued backup. That is the watchdog's guard, not this one -- see
+	// FailStalledBackupSnapshot below. What this guard blocks is the overwrite of
+	// an ALREADY-terminal row: a worker error landing after the operator cancelled
+	// must not replace cancelByOperatorMsg with a generic message, and a fail must
+	// never rewrite a completed run's status or finished_at. Rows-affected is the
+	// contract: 1 = a real transition; 0 = already terminal, or gone -- do not
+	// publish the 'failed' SSE event, the failure email, or the schedule-run
+	// reconciliation for a row that had already moved on.
+	FailBackupSnapshot(ctx context.Context, arg FailBackupSnapshotParams) (int64, error)
 	FailReport(ctx context.Context, arg FailReportParams) (GeneratedReport, error)
 	// Records a failed attempt and backs the task off. The row is left incomplete
 	// so the next tick retries; it is never deleted.
 	FailSiteObjectReclaim(ctx context.Context, arg FailSiteObjectReclaimParams) (int64, error)
 	// TOCTOU-safe hard-fail for the two-tier progress watchdog (GH #279 must-fix).
-	// Identical to FailBackupSnapshot except for the added "AND status='running'"
-	// guard: ListStalledRunningSnapshots commits, then each hard row is failed in
-	// its own separate transaction, so between the two a row may have completed,
-	// been operator-cancelled, been agent-failed, or resumed. FailBackupSnapshot's
-	// blind UPDATE has no status guard (CancelSnapshot relies on that to fail a
-	// still-'pending' row), so it must stay unchanged; this query is the watchdog
-	// hard-fail branch's ONLY write path. Rows-affected (0 or 1) tells the caller
+	// Identical to FailBackupSnapshot except that the guard is NARROWER:
+	// status='running' here, status IN ('pending','running') there (GH #458).
+	// ListStalledRunningSnapshots commits, then each hard row is failed in its own
+	// separate transaction, so between the two a row may have completed, been
+	// operator-cancelled, been agent-failed, or resumed. The watchdog only ever
+	// hard-fails a run it observed RUNNING and must never touch a queued 'pending'
+	// row -- which FailBackupSnapshot may, because operator cancel of a queued
+	// backup goes through it (CancelSnapshot). The two guards therefore stay
+	// distinct, and this query remains the watchdog hard-fail branch's ONLY write
+	// path. Rows-affected (0 or 1) tells the caller
 	// whether a real transition happened, so it can gate the 'failed' SSE publish
 	// and the failure notification on an actual state change rather than firing
 	// them for a row that already moved on.
@@ -2534,7 +2559,18 @@ type Querier interface {
 	// we still UPDATE the PG row so the audit/observability story is complete.
 	// Idempotent: returns 0 if another path already marked it (safe).
 	MarkAutologinTokenConsumed(ctx context.Context, arg MarkAutologinTokenConsumedParams) (int64, error)
-	MarkBackupSnapshotRunning(ctx context.Context, arg MarkBackupSnapshotRunningParams) (BackupSnapshot, error)
+	// Claim precondition (GH #458): 'pending' is the only status a claim may
+	// transition out of. Without it the UPDATE was blind, so a duplicate/retried
+	// worker job, or a job whose snapshot was cancelled or watchdog-failed while
+	// it sat in the queue, dragged a terminal row back to 'running' and cleared
+	// the run's real outcome. Rows-affected is the contract: 1 = this caller won
+	// the claim and owns the run; 0 = the row was not 'pending' (already claimed,
+	// already terminal, or gone), and the caller must NOT proceed as the owner and
+	// must NOT publish the 'started' SSE event or the schedule-run reconciliation
+	// for it. :execrows (not :exec) because a precondition whose failure is
+	// invisible is worse than no precondition -- same reasoning as
+	// FailStalledBackupSnapshot below.
+	MarkBackupSnapshotRunning(ctx context.Context, arg MarkBackupSnapshotRunningParams) (int64, error)
 	// Soft-stall stamp (GH #279): idempotent via the status='running' AND
 	// stalled_at IS NULL guard -- a row already stalled, or no longer running,
 	// matches zero rows and the caller treats that as a no-op (not an error).

--- a/apps/api/tests/gh458/gh497_unique_key_spans_paths_test.go
+++ b/apps/api/tests/gh458/gh497_unique_key_spans_paths_test.go
@@ -1,0 +1,125 @@
+// PR #497 review finding on the GH #458 follow-up: backupInsertOpts (see
+// internal/backup/enqueuer.go) sets UniqueOpts{ByArgs: true} on both backup
+// enqueue paths to enforce one River job per snapshot. Before
+// BackupArgs.SnapshotID carried the `river:"unique"` struct tag, ByArgs
+// hashed the WHOLE encoded args blob, and EnqueueBackup and
+// EnqueueBackupWithChain do not encode identical payloads for the same
+// snapshot: EnqueueBackupWithChain also sets is_incremental and generation,
+// which are `omitempty` and therefore dropped from the JSON only when zero. A
+// FULL snapshot's two paths hashed the same by coincidence; an INCREMENTAL
+// snapshot's did not, so the constraint silently failed to bind for exactly
+// the case a re-enqueue would hit.
+//
+// This proves, against a real Postgres with River's own schema migrated and
+// the client running on the app pool (the wpmgr_app role, same as
+// production): (1) the SAME incremental snapshot, enqueued through both
+// payload shapes, collides — River reports the second insert as
+// UniqueSkippedAsDuplicate — and (2) a DIFFERENT incremental snapshot is not
+// swallowed by the first one's key.
+//
+// It calls river.Client.Insert directly, with BackupArgs built the same way
+// EnqueueBackup and EnqueueBackupWithChain build them (internal/backup/
+// enqueuer.go), because RiverEnqueuer's own wrapper methods discard the
+// *rivertype.JobInsertResult and return only an error — a skipped-as-duplicate
+// insert is NOT an error, so the wrapper's return value can't distinguish the
+// two outcomes. The InsertOpts here is the literal value backupInsertOpts()
+// returns (UniqueOpts{ByArgs: true}, no ByPeriod/ByQueue/ByState); it isn't
+// called directly because it is unexported.
+package gh458
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+)
+
+func TestGH497UniqueKeySpansBothEnqueuePaths(t *testing.T) {
+	ctx := context.Background()
+	appPool, adminPool := startPostgres(t)
+
+	// Migrate River's own schema as the owner (mirrors cmd/wpmgr/main.go's
+	// migrateRiver), then grant the app role access — production applies the
+	// grant via the migration owner's ALTER DEFAULT PRIVILEGES; here the
+	// container superuser created the tables, so grant explicitly (mirrors
+	// tests.TestRiverWiringAndHealthJob).
+	migrator, err := rivermigrate.New(riverpgxv5.New(adminPool.Pool), nil)
+	if err != nil {
+		t.Fatalf("river migrator: %v", err)
+	}
+	if _, err := migrator.Migrate(ctx, rivermigrate.DirectionUp, nil); err != nil {
+		t.Fatalf("river migrate: %v", err)
+	}
+	if _, err := adminPool.Exec(ctx, "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO wpmgr_app"); err != nil {
+		t.Fatalf("grant river tables: %v", err)
+	}
+
+	// Insert-only client on the app pool: no Queues/Workers, never Started —
+	// River validates Insert without the unknown-kind check in that mode.
+	client, err := river.NewClient(riverpgxv5.New(appPool.Pool), &river.Config{})
+	if err != nil {
+		t.Fatalf("river client: %v", err)
+	}
+
+	opts := &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true}} // == backupInsertOpts()
+
+	tenantID := uuid.New()
+
+	// --- (1) the point: the SAME incremental snapshot through both payload
+	// shapes must collide.
+	dupSnapshot := uuid.New()
+
+	// Shape 1: EnqueueBackup's args.
+	res1, err := client.Insert(ctx, backup.BackupArgs{TenantID: tenantID, SnapshotID: dupSnapshot}, opts)
+	if err != nil {
+		t.Fatalf("insert (plain-path args, first): %v", err)
+	}
+	if res1.UniqueSkippedAsDuplicate {
+		t.Fatalf("first insert for a fresh snapshot was skipped as a duplicate: no prior job for it exists")
+	}
+
+	// Shape 2: EnqueueBackupWithChain's args, same snapshot ID, genuinely
+	// incremental (nonzero is_incremental/generation/chain fields) — the
+	// shape that diverged from shape 1 before the SnapshotID tag existed.
+	res2, err := client.Insert(ctx, backup.BackupArgs{
+		TenantID:         tenantID,
+		SnapshotID:       dupSnapshot,
+		IsIncremental:    true,
+		ParentSnapshotID: uuid.New(),
+		BaseSnapshotID:   uuid.New(),
+		ChainID:          uuid.New(),
+		Generation:       2,
+	}, opts)
+	if err != nil {
+		t.Fatalf("insert (chain-path args, same snapshot): %v", err)
+	}
+	if !res2.UniqueSkippedAsDuplicate {
+		t.Fatalf("SAME incremental snapshot enqueued through the chain-path args was NOT skipped as " +
+			"a duplicate: the uniqueness key does not span both enqueue paths for an incremental snapshot")
+	}
+
+	// --- (2) the over-fire twin: a DIFFERENT incremental snapshot, same
+	// shape, must NOT collide with the first one's key.
+	otherSnapshot := uuid.New()
+	res3, err := client.Insert(ctx, backup.BackupArgs{
+		TenantID:         tenantID,
+		SnapshotID:       otherSnapshot,
+		IsIncremental:    true,
+		ParentSnapshotID: uuid.New(),
+		BaseSnapshotID:   uuid.New(),
+		ChainID:          uuid.New(),
+		Generation:       2,
+	}, opts)
+	if err != nil {
+		t.Fatalf("insert (different snapshot): %v", err)
+	}
+	if res3.UniqueSkippedAsDuplicate {
+		t.Fatalf("a DIFFERENT snapshot was skipped as a duplicate: the uniqueness key is too coarse " +
+			"and would silently swallow a legitimate backup")
+	}
+}

--- a/apps/api/tests/gh458/manifest_completion_guard_integration_test.go
+++ b/apps/api/tests/gh458/manifest_completion_guard_integration_test.go
@@ -1,0 +1,148 @@
+// This file proves the one part of the GH #458 fix that the sibling
+// snapshot_state_guards_integration_test.go does not reach: the three
+// RecordManifest/RecordIncrementalManifest call sites in
+// internal/backup/repo.go that used to detect a rejected
+// CompleteBackupSnapshot via errors.Is(err, pgx.ErrNoRows). That branch is
+// unreachable now that CompleteBackupSnapshot is :execrows (Exec never
+// returns pgx.ErrNoRows), so before the fix a late manifest submit against a
+// cancelled or completed snapshot returned SUCCESS having written nothing.
+//
+// Unlike the sibling file, which drives the GENERATED sqlc queries directly,
+// this file goes through backup.NewRepo(...).RecordManifest — the real
+// production repo — because the bug lived in repo.go's error-detection
+// branch, not in the generated query.
+package gh458
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// countManifestEntries reports how many backup_manifest_entries rows exist
+// for the given snapshot, read through the app pool's tenant transaction so
+// RLS applies just as it would for a real request.
+func (f *fixture) countManifestEntries(t *testing.T, snapshotID uuid.UUID) int64 {
+	t.Helper()
+	ctx := context.Background()
+	var n int64
+	err := f.pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*) FROM backup_manifest_entries WHERE snapshot_id = $1`,
+			snapshotID).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count manifest entries: %v", err)
+	}
+	return n
+}
+
+// manifestInput builds a single-entry, single-chunk RecordManifestInput
+// against snapshotID, distinct per call via a fresh chunk hash/path so
+// re-runs across subtests never collide on the content-addressed chunk key.
+func manifestInput(tenantID, snapshotID uuid.UUID) backup.RecordManifestInput {
+	hash := "blake3-" + uuid.NewString()
+	return backup.RecordManifestInput{
+		TenantID:   tenantID,
+		SnapshotID: snapshotID,
+		Entries: []backup.ManifestEntryInput{
+			{
+				Path:        "wp-content/uploads/gh458-" + uuid.NewString() + ".txt",
+				EntryKind:   "file",
+				ChunkHashes: []string{hash},
+				Size:        123,
+				Mode:        0o644,
+			},
+		},
+		Chunks: map[string]backup.ChunkUpload{
+			hash: {Blake3: hash, Size: 123, S3Key: "gh458/" + hash},
+		},
+	}
+}
+
+// TestGH458RecordManifestRejectsLateSubmit proves the RecordManifest call
+// site: a manifest submitted against a snapshot that is no longer
+// pending/running is rejected as backup_snapshot_not_found, and — the half
+// that matters — nothing from that submit is persisted. A twin proves the
+// guard does not over-fire against the normal, still-running path.
+func TestGH458RecordManifestRejectsLateSubmit(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+	repo := backup.NewRepo(f.pool)
+
+	t.Run("late_submit_against_terminal_snapshot_is_rejected_and_writes_nothing", func(t *testing.T) {
+		// Drive the snapshot to a terminal state the way the cancel path does:
+		// 'failed' with an operator error, matching the sibling test's cancel
+		// fixture and the real CancelSnapshot flow.
+		id := f.seedSnapshot(t, "failed", "cancelled by operator")
+		before := f.read(t, id)
+
+		in := manifestInput(f.tenant, id)
+		chunkRefs, storedCount, err := repo.RecordManifest(ctx, in)
+
+		if err == nil {
+			t.Fatalf("RecordManifest against a failed snapshot: err = nil (chunkRefs=%d, storedCount=%d), want backup_snapshot_not_found — a late submit SUCCEEDED", chunkRefs, storedCount)
+		}
+		derr, ok := domain.AsDomain(err)
+		if !ok {
+			t.Fatalf("RecordManifest against a failed snapshot: err = %v (not a domain.Error), want backup_snapshot_not_found", err)
+		}
+		if derr.Code != "backup_snapshot_not_found" {
+			t.Fatalf("RecordManifest against a failed snapshot: code = %q, want %q", derr.Code, "backup_snapshot_not_found")
+		}
+
+		// The half that matters most: the transaction must have rolled back.
+		// A test that only checks the returned error would still pass if the
+		// manifest write happened and the error came from somewhere else.
+		if n := f.countManifestEntries(t, id); n != 0 {
+			t.Fatalf("manifest entries persisted for a rejected submit: count = %d, want 0", n)
+		}
+		after := f.read(t, id)
+		if after.status != "failed" {
+			t.Fatalf("snapshot status changed by a rejected submit: status = %q, want unchanged %q", after.status, "failed")
+		}
+		if after.totalSize != before.totalSize {
+			t.Fatalf("snapshot total_size changed by a rejected submit: %d -> %d, want unchanged", before.totalSize, after.totalSize)
+		}
+		if after.chunkCount != before.chunkCount {
+			t.Fatalf("snapshot chunk_count changed by a rejected submit: %d -> %d, want unchanged", before.chunkCount, after.chunkCount)
+		}
+	})
+
+	t.Run("submit_against_running_snapshot_still_succeeds", func(t *testing.T) {
+		// Over-fire twin: without this, a guard that rejects everything would
+		// also look correct against the terminal-snapshot case above.
+		id := f.seedSnapshot(t, "running", "")
+
+		in := manifestInput(f.tenant, id)
+		chunkRefs, storedCount, err := repo.RecordManifest(ctx, in)
+		if err != nil {
+			t.Fatalf("RecordManifest against a running snapshot: err = %v, want nil", err)
+		}
+		if chunkRefs != 1 {
+			t.Fatalf("chunkRefs = %d, want 1", chunkRefs)
+		}
+		if storedCount != 1 {
+			t.Fatalf("storedCount = %d, want 1 (new chunk)", storedCount)
+		}
+
+		if n := f.countManifestEntries(t, id); n != 1 {
+			t.Fatalf("manifest entries persisted for a successful submit: count = %d, want 1", n)
+		}
+		after := f.read(t, id)
+		if after.status != "completed" {
+			t.Fatalf("snapshot status = %q, want %q", after.status, "completed")
+		}
+		if after.totalSize != 123 {
+			t.Fatalf("snapshot total_size = %d, want 123", after.totalSize)
+		}
+		if after.chunkCount != 1 {
+			t.Fatalf("snapshot chunk_count = %d, want 1", after.chunkCount)
+		}
+	})
+}

--- a/apps/api/tests/gh458/manifest_completion_guard_integration_test.go
+++ b/apps/api/tests/gh458/manifest_completion_guard_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
@@ -40,6 +41,69 @@ func (f *fixture) countManifestEntries(t *testing.T, snapshotID uuid.UUID) int64
 		t.Fatalf("count manifest entries: %v", err)
 	}
 	return n
+}
+
+// chunkExists reports whether a backup_chunks row exists for hash, read
+// through the app pool's tenant transaction so RLS applies.
+func (f *fixture) chunkExists(t *testing.T, hash string) bool {
+	t.Helper()
+	ctx := context.Background()
+	var n int64
+	err := f.pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*) FROM backup_chunks WHERE tenant_id = $1 AND blake3 = $2`,
+			f.tenant, hash).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count backup_chunks for %q: %v", hash, err)
+	}
+	return n > 0
+}
+
+// chunkRefcount reads the current refcount for hash. The caller must already
+// know the row exists.
+func (f *fixture) chunkRefcount(t *testing.T, hash string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	var n int64
+	err := f.pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT refcount FROM backup_chunks WHERE tenant_id = $1 AND blake3 = $2`,
+			f.tenant, hash).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("read refcount for %q: %v", hash, err)
+	}
+	return n
+}
+
+// seedChunkWithRefcount upserts a backup_chunks row for hash through the
+// GENERATED queries (the same UpsertBackupChunk + IncrementChunkRefcount
+// RecordManifest itself calls) and returns the refcount after one increment,
+// so a later submit can reference an already-stored chunk instead of only a
+// brand-new one.
+func (f *fixture) seedChunkWithRefcount(t *testing.T, hash string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	var refcount int64
+	err := f.pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		q := sqlc.New(tx)
+		if _, err := q.UpsertBackupChunk(ctx, sqlc.UpsertBackupChunkParams{
+			TenantID: f.tenant, Blake3: hash, S3Key: "gh458/" + hash, Size: 10,
+		}); err != nil {
+			return err
+		}
+		chunk, err := q.IncrementChunkRefcount(ctx, sqlc.IncrementChunkRefcountParams{TenantID: f.tenant, Blake3: hash})
+		if err != nil {
+			return err
+		}
+		refcount = chunk.Refcount
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed chunk %q: %v", hash, err)
+	}
+	return refcount
 }
 
 // manifestInput builds a single-entry, single-chunk RecordManifestInput
@@ -82,7 +146,34 @@ func TestGH458RecordManifestRejectsLateSubmit(t *testing.T) {
 		id := f.seedSnapshot(t, "failed", "cancelled by operator")
 		before := f.read(t, id)
 
-		in := manifestInput(f.tenant, id)
+		// A pre-existing chunk this submit ALSO references, distinct from any
+		// hash the fixture might reuse elsewhere. Its refcount before the
+		// submit is the baseline the atomicity assertion below checks stays
+		// unchanged.
+		preHash := "blake3-pre-" + uuid.NewString()
+		beforeRefcount := f.seedChunkWithRefcount(t, preHash)
+
+		// A brand-new hash only THIS submit introduces, so its mere existence
+		// afterwards is proof step 1 (UpsertBackupChunk) survived a rollback.
+		freshHash := "blake3-fresh-" + uuid.NewString()
+
+		in := backup.RecordManifestInput{
+			TenantID:   f.tenant,
+			SnapshotID: id,
+			Entries: []backup.ManifestEntryInput{
+				{
+					Path:        "wp-content/uploads/gh458-" + uuid.NewString() + ".txt",
+					EntryKind:   "file",
+					ChunkHashes: []string{freshHash, preHash},
+					Size:        123,
+					Mode:        0o644,
+				},
+			},
+			Chunks: map[string]backup.ChunkUpload{
+				freshHash: {Blake3: freshHash, Size: 123, S3Key: "gh458/" + freshHash},
+				preHash:   {Blake3: preHash, Size: 10, S3Key: "gh458/" + preHash},
+			},
+		}
 		chunkRefs, storedCount, err := repo.RecordManifest(ctx, in)
 
 		if err == nil {
@@ -111,6 +202,23 @@ func TestGH458RecordManifestRejectsLateSubmit(t *testing.T) {
 		}
 		if after.chunkCount != before.chunkCount {
 			t.Fatalf("snapshot chunk_count changed by a rejected submit: %d -> %d, want unchanged", before.chunkCount, after.chunkCount)
+		}
+
+		// The REJECTION MUST BE ATOMIC, not just manifest-free. RecordManifest
+		// runs the chunk upsert (step 1), the manifest inserts and refcount
+		// increments (step 2), and the guarded CompleteBackupSnapshot (step 3)
+		// inside one InTenantTx. If a future change (e.g. a dedup optimisation
+		// that upserts chunks outside the transaction, since chunks are shared
+		// and content-addressed) moves step 1 out of that transaction, a
+		// rejected submit would start leaving chunk rows and inflated
+		// refcounts behind -- and the manifest-entries-only checks above would
+		// still pass. These two assertions pin the transaction boundary itself,
+		// not just its manifest-table side effect.
+		if f.chunkExists(t, freshHash) {
+			t.Fatalf("backup_chunks row exists for hash %q from a REJECTED submit: RecordManifest is not atomic -- the chunk upsert (step 1) escaped the transaction that the CompleteBackupSnapshot guard (step 3) rolled back, not merely that a count was wrong", freshHash)
+		}
+		if got := f.chunkRefcount(t, preHash); got != beforeRefcount {
+			t.Fatalf("pre-existing chunk %q refcount changed by a REJECTED submit: %d -> %d, want unchanged at %d: RecordManifest is not atomic -- IncrementChunkRefcount (step 2) survived the rollback that the CompleteBackupSnapshot guard (step 3) triggered, not merely that a count was wrong", preHash, beforeRefcount, got, beforeRefcount)
 		}
 	})
 
@@ -143,6 +251,42 @@ func TestGH458RecordManifestRejectsLateSubmit(t *testing.T) {
 		}
 		if after.chunkCount != 1 {
 			t.Fatalf("snapshot chunk_count = %d, want 1", after.chunkCount)
+		}
+	})
+}
+
+// TestGH458CancelSnapshotThroughServiceCancelsPending proves the reason the
+// FailBackupSnapshot guard is "status IN ('pending','running')" rather than
+// "status = 'running'": operator cancel of a still-QUEUED backup must still
+// work. The sibling snapshot_state_guards_integration_test.go's
+// "cancel_of_pending_still_works" subtest exercises the GENERATED
+// FailBackupSnapshot query directly; this test goes one layer up, through
+// backup.Service.CancelSnapshot exactly as the real cancel endpoint does, so a
+// regression in CancelSnapshot's own precondition (snap.Status != StatusRunning
+// && snap.Status != StatusPending) — not just the SQL guard — would also be
+// caught here.
+func TestGH458CancelSnapshotThroughServiceCancelsPending(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+	svc := backup.NewService(backup.NewRepo(f.pool), nil, nil, nil, domain.SystemClock{}, backup.Config{})
+
+	t.Run("cancel_of_pending_snapshot_succeeds_end_to_end", func(t *testing.T) {
+		id := f.seedSnapshot(t, "pending", "")
+
+		snap, err := svc.CancelSnapshot(ctx, f.tenant, id)
+		if err != nil {
+			t.Fatalf("CancelSnapshot on a PENDING snapshot: err = %v, want nil (a naive status='running' guard would reject this)", err)
+		}
+		if snap.Status != backup.StatusFailed {
+			t.Fatalf("CancelSnapshot on a PENDING snapshot: returned status = %q, want %q", snap.Status, backup.StatusFailed)
+		}
+
+		after := f.read(t, id)
+		if after.status != "failed" {
+			t.Fatalf("snapshot status after cancel-of-pending = %q, want terminal %q", after.status, "failed")
+		}
+		if after.errMsg != "cancelled by operator" {
+			t.Fatalf("snapshot error after cancel-of-pending = %q, want %q", after.errMsg, "cancelled by operator")
 		}
 	})
 }

--- a/apps/api/tests/gh458/snapshot_state_guards_integration_test.go
+++ b/apps/api/tests/gh458/snapshot_state_guards_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/tests/testinfra"
 )
 
 const testRecipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
@@ -32,6 +33,8 @@ const testRecipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqm
 func startPostgres(t *testing.T) (app *db.Pool, admin *db.Pool) {
 	t.Helper()
 	ctx := context.Background()
+
+	testinfra.SkipIfDockerUnavailable(t, ctx, "postgres")
 
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
@@ -45,7 +48,7 @@ func startPostgres(t *testing.T) (app *db.Pool, admin *db.Pool) {
 		),
 	)
 	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+		testinfra.SetupFatalf(t, err, "postgres: container start")
 	}
 	t.Cleanup(func() { _ = container.Terminate(ctx) })
 

--- a/apps/api/tests/gh458/snapshot_state_guards_integration_test.go
+++ b/apps/api/tests/gh458/snapshot_state_guards_integration_test.go
@@ -1,0 +1,303 @@
+// Package gh458 proves the backup_snapshots state preconditions added in
+// GH #458 through the GENERATED sqlc code, against a real Postgres, connected
+// as the non-superuser wpmgr_app role the production control plane runs as.
+//
+// It lives in its own package (not tests/) on purpose: it must compile and run
+// while internal/backup/repo.go is still mid-migration to the new :execrows
+// signatures, and package tests imports internal/backup.
+package gh458
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+const testRecipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+
+// startPostgres mirrors tests.startPostgres: migrate as the bootstrap
+// superuser, then hand the test a pool connected as wpmgr_app (NOSUPERUSER,
+// NOBYPASSRLS) so the RLS policies are actually live. The admin pool is
+// returned only for fixture seeding.
+func startPostgres(t *testing.T) (app *db.Pool, admin *db.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	adminPool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	if err := adminPool.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	for _, stmt := range []string{
+		"ALTER ROLE wpmgr_app LOGIN PASSWORD 'app'",
+		"GRANT USAGE ON SCHEMA public TO wpmgr_app",
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO wpmgr_app",
+		"REVOKE UPDATE, DELETE, TRUNCATE ON audit_log FROM wpmgr_app",
+	} {
+		if _, err := adminPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("provision app role (%q): %v", stmt, err)
+		}
+	}
+	t.Cleanup(adminPool.Close)
+
+	appDSN := strings.Replace(adminDSN, "wpmgr:wpmgr@", "wpmgr_app:app@", 1)
+	appPool, err := db.Connect(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("connect app: %v", err)
+	}
+	t.Cleanup(appPool.Close)
+
+	// Assert we are NOT a superuser: a superuser bypasses RLS, which would make
+	// this proof run on a code path no install ever uses.
+	var super bool
+	if err := appPool.QueryRow(ctx,
+		"SELECT rolsuper FROM pg_roles WHERE rolname = current_user").Scan(&super); err != nil {
+		t.Fatalf("read current_user rolsuper: %v", err)
+	}
+	if super {
+		t.Fatal("test pool connected as a SUPERUSER; RLS would be bypassed and this proof would be meaningless")
+	}
+	return appPool, adminPool
+}
+
+type fixture struct {
+	pool   *db.Pool
+	tenant uuid.UUID
+	site   uuid.UUID
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	ctx := context.Background()
+	appPool, adminPool := startPostgres(t)
+	f := &fixture{pool: appPool}
+
+	if err := adminPool.QueryRow(ctx,
+		"INSERT INTO tenants (name, slug) VALUES ('gh458', 'gh458') RETURNING id").Scan(&f.tenant); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	if err := adminPool.QueryRow(ctx,
+		`INSERT INTO sites (tenant_id, url, name) VALUES ($1, $2, 'seed') RETURNING id`,
+		f.tenant, "https://gh458-"+uuid.NewString()+".example.com").Scan(&f.site); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+	return f
+}
+
+// seedSnapshot inserts a snapshot in the given status and returns its id. The
+// insert goes through the app pool's tenant transaction, so RLS applies.
+func (f *fixture) seedSnapshot(t *testing.T, status, errMsg string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	var id uuid.UUID
+	err := f.pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`INSERT INTO backup_snapshots (tenant_id, site_id, kind, status, age_recipient, error, finished_at)
+			 VALUES ($1, $2, 'files', $3, $4, $5,
+			         CASE WHEN $3 IN ('completed','failed') THEN now() ELSE NULL END)
+			 RETURNING id`,
+			f.tenant, f.site, status, testRecipient, errMsg).Scan(&id)
+	})
+	if err != nil {
+		t.Fatalf("seed snapshot (status=%s): %v", status, err)
+	}
+	return id
+}
+
+type snapRow struct {
+	status     string
+	errMsg     string
+	totalSize  int64
+	chunkCount int64
+}
+
+func (f *fixture) read(t *testing.T, id uuid.UUID) snapRow {
+	t.Helper()
+	ctx := context.Background()
+	var r snapRow
+	err := f.pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT status, error, total_size, chunk_count FROM backup_snapshots WHERE id = $1`,
+			id).Scan(&r.status, &r.errMsg, &r.totalSize, &r.chunkCount)
+	})
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	return r
+}
+
+// call runs fn through the GENERATED Queries inside a tenant transaction.
+func (f *fixture) call(t *testing.T, fn func(q *sqlc.Queries) (int64, error)) int64 {
+	t.Helper()
+	var n int64
+	err := f.pool.InTenantTx(context.Background(), f.tenant, func(tx pgx.Tx) error {
+		var e error
+		n, e = fn(sqlc.New(tx))
+		return e
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	return n
+}
+
+func TestGH458SnapshotStateGuards(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+
+	// 1a. FailBackupSnapshot must not overwrite an already-COMPLETED row.
+	t.Run("fail_does_not_overwrite_completed", func(t *testing.T) {
+		id := f.seedSnapshot(t, "completed", "")
+		n := f.call(t, func(q *sqlc.Queries) (int64, error) {
+			return q.FailBackupSnapshot(ctx, sqlc.FailBackupSnapshotParams{
+				ID: id, TenantID: f.tenant, Error: "late worker error",
+			})
+		})
+		if n != 0 {
+			t.Fatalf("FailBackupSnapshot on a completed row: rows=%d, want 0", n)
+		}
+		after := f.read(t, id)
+		if after.status != "completed" {
+			t.Fatalf("status = %q, want unchanged \"completed\"", after.status)
+		}
+		if after.errMsg != "" {
+			t.Fatalf("error = %q, want still empty", after.errMsg)
+		}
+	})
+
+	// 1b. CompleteBackupSnapshot must not resurrect an already-FAILED row.
+	t.Run("complete_does_not_resurrect_failed", func(t *testing.T) {
+		id := f.seedSnapshot(t, "failed", "cancelled by operator")
+		n := f.call(t, func(q *sqlc.Queries) (int64, error) {
+			return q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
+				ID: id, TenantID: f.tenant, TotalSize: 999, ChunkCount: 7,
+			})
+		})
+		if n != 0 {
+			t.Fatalf("CompleteBackupSnapshot on a failed row: rows=%d, want 0", n)
+		}
+		after := f.read(t, id)
+		if after.status != "failed" {
+			t.Fatalf("status = %q, want unchanged \"failed\"", after.status)
+		}
+		if after.errMsg != "cancelled by operator" {
+			t.Fatalf("error was overwritten: %q", after.errMsg)
+		}
+		if after.totalSize == 999 {
+			t.Fatal("total_size was overwritten on a terminal row")
+		}
+		if after.chunkCount == 7 {
+			t.Fatal("chunk_count was overwritten on a terminal row")
+		}
+	})
+
+	// 2. THE CANCEL CASE. CancelSnapshot fails a still-'pending' snapshot
+	// through FailBackupSnapshot. This must still work, or operator cancel of
+	// a queued backup is silently dead.
+	t.Run("cancel_of_pending_still_works", func(t *testing.T) {
+		id := f.seedSnapshot(t, "pending", "")
+		n := f.call(t, func(q *sqlc.Queries) (int64, error) {
+			return q.FailBackupSnapshot(ctx, sqlc.FailBackupSnapshotParams{
+				ID: id, TenantID: f.tenant, Error: "cancelled by operator",
+			})
+		})
+		if n != 1 {
+			t.Fatalf("FailBackupSnapshot on a PENDING row: rows=%d, want 1 (CancelSnapshot is broken)", n)
+		}
+		after := f.read(t, id)
+		if after.status != "failed" {
+			t.Fatalf("status = %q, want \"failed\"", after.status)
+		}
+		if after.errMsg != "cancelled by operator" {
+			t.Fatalf("error = %q, want the cancel marker", after.errMsg)
+		}
+	})
+
+	// 2b. A running snapshot completes normally: the guard must not over-fire.
+	t.Run("running_completes_normally", func(t *testing.T) {
+		id := f.seedSnapshot(t, "running", "")
+		n := f.call(t, func(q *sqlc.Queries) (int64, error) {
+			return q.CompleteBackupSnapshot(ctx, sqlc.CompleteBackupSnapshotParams{
+				ID: id, TenantID: f.tenant, TotalSize: 42, ChunkCount: 3,
+			})
+		})
+		if n != 1 {
+			t.Fatalf("CompleteBackupSnapshot on a running row: rows=%d, want 1", n)
+		}
+		if got := f.read(t, id).status; got != "completed" {
+			t.Fatalf("status = %q, want \"completed\"", got)
+		}
+	})
+
+	// 3. The claim is exactly-once: the second claimant gets 0 rows.
+	t.Run("claim_is_exactly_once", func(t *testing.T) {
+		id := f.seedSnapshot(t, "pending", "")
+		first := f.call(t, func(q *sqlc.Queries) (int64, error) {
+			return q.MarkBackupSnapshotRunning(ctx, sqlc.MarkBackupSnapshotRunningParams{
+				ID: id, TenantID: f.tenant,
+			})
+		})
+		if first != 1 {
+			t.Fatalf("first claim: rows=%d, want 1", first)
+		}
+		second := f.call(t, func(q *sqlc.Queries) (int64, error) {
+			return q.MarkBackupSnapshotRunning(ctx, sqlc.MarkBackupSnapshotRunningParams{
+				ID: id, TenantID: f.tenant,
+			})
+		})
+		if second != 0 {
+			t.Fatalf("second claim: rows=%d, want 0 (the claim is not exclusive)", second)
+		}
+		if got := f.read(t, id).status; got != "running" {
+			t.Fatalf("status = %q, want \"running\"", got)
+		}
+	})
+
+	// 3b. A claim must never drag a terminal row back to 'running'.
+	t.Run("claim_does_not_revive_terminal", func(t *testing.T) {
+		id := f.seedSnapshot(t, "failed", "cancelled by operator")
+		n := f.call(t, func(q *sqlc.Queries) (int64, error) {
+			return q.MarkBackupSnapshotRunning(ctx, sqlc.MarkBackupSnapshotRunningParams{
+				ID: id, TenantID: f.tenant,
+			})
+		})
+		if n != 0 {
+			t.Fatalf("claim on a failed row: rows=%d, want 0", n)
+		}
+		if got := f.read(t, id).status; got != "failed" {
+			t.Fatalf("status = %q, want unchanged \"failed\"", got)
+		}
+	})
+}

--- a/apps/api/tests/testinfra/docker.go
+++ b/apps/api/tests/testinfra/docker.go
@@ -10,10 +10,28 @@ package testinfra
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 )
+
+// DockerHealthProbeTimeout bounds the daemon-reachability probe below.
+//
+// testcontainers-go v0.42.0's DockerProvider.Health passes the caller's
+// context straight to the daemon's /info request and adds no deadline of its
+// own, so an unbounded context turns a wedged or unresponsive daemon into a
+// hang: the probe blocks until the whole package trips the Go test timeout,
+// and the resulting panic names whichever test happened to be running rather
+// than the daemon.
+//
+// A reachable daemon answers /info in single-digit milliseconds. The slow
+// legitimate case is a cold Docker Desktop VM whose API socket is accepting
+// connections while the engine is still coming up, which still answers well
+// inside a couple of seconds. 10s clears both comfortably while failing two
+// orders of magnitude faster than the 10m default test timeout.
+const DockerHealthProbeTimeout = 10 * time.Second
 
 // SetupFatalf fails the test with a message that cannot be mistaken for an
 // assertion made by the test body itself. A full-package run starts many
@@ -50,6 +68,10 @@ func SetupSkipf(t *testing.T, err error, stage string) {
 // skip from it. Routing a start failure to Skip is exactly the failure mode
 // this helper exists to eliminate: a package-level "ok" over a suite that
 // asserted nothing.
+//
+// The probe itself is bounded by DockerHealthProbeTimeout — see
+// classifyDockerHealth for the three outcomes and why an unresponsive daemon
+// is a hard failure rather than a skip.
 func SkipIfDockerUnavailable(t *testing.T, ctx context.Context, stage string) {
 	t.Helper()
 	provider, err := testcontainers.ProviderDocker.GetProvider()
@@ -57,7 +79,58 @@ func SkipIfDockerUnavailable(t *testing.T, ctx context.Context, stage string) {
 		SetupSkipf(t, err, stage+" (docker provider unavailable)")
 		return
 	}
-	if err := provider.Health(ctx); err != nil {
-		SetupSkipf(t, err, stage+" (docker daemon unreachable)")
+	outcome, herr := classifyDockerHealth(ctx, DockerHealthProbeTimeout, provider.Health)
+	switch outcome {
+	case dockerReachable:
+		return
+	case dockerUnresponsive:
+		SetupFatalf(t, herr, stage+" (docker daemon unresponsive)")
+	default:
+		SetupSkipf(t, herr, stage+" (docker daemon unreachable)")
+	}
+}
+
+// dockerProbeOutcome is what a bounded health probe concluded.
+type dockerProbeOutcome int
+
+const (
+	// dockerReachable: the daemon answered, and answered in time.
+	dockerReachable dockerProbeOutcome = iota
+	// dockerUnreachable: the daemon refused or could not be dialled at all —
+	// the "Docker is not available on this machine" case, and the only one
+	// that may resolve to a skip.
+	dockerUnreachable
+	// dockerUnresponsive: the probe ran out of time instead of getting an
+	// answer. The daemon is there but wedged, which is a broken machine, not
+	// a machine without Docker. Skipping would hide it behind a green
+	// package, so this is routed to SetupFatalf.
+	dockerUnresponsive
+)
+
+// classifyDockerHealth runs health under an explicit timeout and classifies
+// the result. It is separated from SkipIfDockerUnavailable so the bound can be
+// exercised against an injected health func that never returns — proving the
+// probe returns rather than hangs without touching the real daemon.
+func classifyDockerHealth(ctx context.Context, timeout time.Duration, health func(context.Context) error) (dockerProbeOutcome, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	err := health(probeCtx)
+	if err == nil {
+		return dockerReachable, nil
+	}
+	switch {
+	case ctx.Err() != nil:
+		// The CALLER's context ended first; the daemon never got its chance.
+		// Not a skip either: the run is being torn down or misconfigured, and
+		// saying "Docker is unavailable" would be a false diagnosis.
+		return dockerUnresponsive, fmt.Errorf(
+			"docker health probe context ended before the daemon answered (caller ctx: %v): %w", ctx.Err(), err)
+	case probeCtx.Err() != nil:
+		return dockerUnresponsive, fmt.Errorf(
+			"docker daemon did not answer a health probe within %s: the daemon is wedged or unresponsive, "+
+				"not absent -- restart it and re-run: %w", timeout, err)
+	default:
+		return dockerUnreachable, err
 	}
 }

--- a/apps/api/tests/testinfra/docker.go
+++ b/apps/api/tests/testinfra/docker.go
@@ -1,0 +1,63 @@
+// Package testinfra holds small, dependency-free helpers shared by the
+// apps/api integration test packages (tests, tests/gh458, and others as they
+// adopt it) for telling "Docker is not reachable at all" apart from "this
+// container failed to start despite Docker being up".
+//
+// Routing the second case to a skip is this project's signature defect: a
+// package that reports "ok" over a suite that asserted nothing. See
+// test(api): fail closed when a testcontainer fails to start with Docker up.
+package testinfra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// SetupFatalf fails the test with a message that cannot be mistaken for an
+// assertion made by the test body itself. A full-package run starts many
+// testcontainers over several minutes, and under that load an infrastructure
+// hiccup at a setup stage (container start, connection string, migrate,
+// connect, role provisioning) otherwise surfaces as a bare "%v" attached to
+// whatever test happened to be running — which reads exactly like that
+// test's own assertion failed.
+func SetupFatalf(t *testing.T, err error, stage string) {
+	t.Helper()
+	t.Fatalf("SETUP FAILURE (infrastructure, not the test's own assertion) at stage=%q: %v", stage, err)
+}
+
+// SetupSkipf is SetupFatalf's skip counterpart, used only for "Docker is not
+// available on this machine at all" — the one setup failure that is not a
+// mid-run flake and that every test depending on Docker would hit
+// identically, so skipping is the honest signal.
+func SetupSkipf(t *testing.T, err error, stage string) {
+	t.Helper()
+	t.Skipf("SETUP SKIP (infrastructure, not the test's own assertion) at stage=%q: %v", stage, err)
+}
+
+// SkipIfDockerUnavailable positively probes whether the Docker/OCI provider
+// testcontainers will use is reachable at all, and skips (via SetupSkipf)
+// only if it is not. This is the ONLY thing that may resolve to a skip:
+// "the daemon cannot be reached" is checked directly, up front, before any
+// container is asked to start, rather than being inferred from whatever
+// error a later container-start call happens to return.
+//
+// That distinction matters because a container that fails to START despite
+// Docker being reachable (bad image tag, no space left, registry pull
+// failure, resource limits) is a real setup failure, not "Docker is not
+// installed here" — callers must route that to SetupFatalf, never infer a
+// skip from it. Routing a start failure to Skip is exactly the failure mode
+// this helper exists to eliminate: a package-level "ok" over a suite that
+// asserted nothing.
+func SkipIfDockerUnavailable(t *testing.T, ctx context.Context, stage string) {
+	t.Helper()
+	provider, err := testcontainers.ProviderDocker.GetProvider()
+	if err != nil {
+		SetupSkipf(t, err, stage+" (docker provider unavailable)")
+		return
+	}
+	if err := provider.Health(ctx); err != nil {
+		SetupSkipf(t, err, stage+" (docker daemon unreachable)")
+	}
+}

--- a/apps/api/tests/testinfra/docker_test.go
+++ b/apps/api/tests/testinfra/docker_test.go
@@ -1,0 +1,76 @@
+package testinfra
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestClassifyDockerHealth_BoundsAWedgedDaemon proves the health probe returns
+// instead of hanging when the daemon accepts the request and never answers —
+// the shape testcontainers-go v0.42.0's DockerProvider.Health cannot bound on
+// its own, because it hands the caller's context straight to the /info request.
+//
+// The fake health func blocks until its context is done, which is exactly what
+// a wedged daemon does to an unbounded probe. The assertion is run under an
+// independent watchdog so a regression that removes the bound fails with a
+// legible message instead of hanging until the package test timeout.
+func TestClassifyDockerHealth_BoundsAWedgedDaemon(t *testing.T) {
+	wedged := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	type result struct {
+		outcome dockerProbeOutcome
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		o, err := classifyDockerHealth(context.Background(), 50*time.Millisecond, wedged)
+		done <- result{o, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.outcome != dockerUnresponsive {
+			t.Fatalf("outcome = %d, want dockerUnresponsive (%d): a daemon that never answers must be a hard "+
+				"failure, not a skip that hides it", got.outcome, dockerUnresponsive)
+		}
+		if got.err == nil {
+			t.Fatal("err = nil, want an actionable message naming the timeout")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("classifyDockerHealth did not return within 5s against a health func that never answers: " +
+			"the probe is unbounded and a wedged daemon will hang the suite until the Go test timeout")
+	}
+}
+
+// TestClassifyDockerHealth_RefusedDaemonStillSkips is the over-fire twin: the
+// bound must not convert a genuine "no Docker on this machine" into a hard
+// failure. A health func that returns promptly with a connection error is
+// still the one case that may honestly skip.
+func TestClassifyDockerHealth_RefusedDaemonStillSkips(t *testing.T) {
+	refused := errors.New("cannot connect to the Docker daemon at unix:///var/run/docker.sock")
+	outcome, err := classifyDockerHealth(context.Background(), 50*time.Millisecond,
+		func(context.Context) error { return refused })
+	if outcome != dockerUnreachable {
+		t.Fatalf("outcome = %d, want dockerUnreachable (%d)", outcome, dockerUnreachable)
+	}
+	if !errors.Is(err, refused) {
+		t.Fatalf("err = %v, want the daemon's own error preserved", err)
+	}
+}
+
+// TestClassifyDockerHealth_HealthyDaemonPasses is the other over-fire twin: a
+// daemon that answers well inside the bound must be reported reachable with no
+// error, or every Docker-backed package would fail or skip on a working
+// machine.
+func TestClassifyDockerHealth_HealthyDaemonPasses(t *testing.T) {
+	outcome, err := classifyDockerHealth(context.Background(), DockerHealthProbeTimeout,
+		func(context.Context) error { return nil })
+	if outcome != dockerReachable || err != nil {
+		t.Fatalf("outcome = %d, err = %v; want dockerReachable (%d) with no error", outcome, err, dockerReachable)
+	}
+}


### PR DESCRIPTION
Closes #458.

Three writes to `backup_snapshots` carried no state precondition, so a snapshot's
claim and its terminal outcome could each be decided more than once — a late
`FailBackupSnapshot` landing on a row already `completed`, or the reverse.

| Query | Precondition | 0 rows means |
|---|---|---|
| `MarkBackupSnapshotRunning` | `AND status = 'pending'` | not pending — already claimed, already terminal, or gone |
| `CompleteBackupSnapshot` | `AND status IN ('pending','running')` | already terminal, or gone |
| `FailBackupSnapshot` | `AND status IN ('pending','running')` | already terminal, or gone |

## Severity: a leak and a metadata lie, not lost bytes

Established before writing any SQL, because it decides the shape of the fix.

Reclamation never reads `status`. The deciding gate is status-blind
(`internal/backup/repo.go`), evaluated per chunk on the same pinned transaction that
holds its `FOR UPDATE` lock:

```sql
SELECT EXISTS (SELECT 1 FROM backup_manifest_entries
                WHERE tenant_id = $1 AND chunk_hashes @> ARRAY[$2]::text[])
```

Manifest rows are removed only by a snapshot row `DELETE` (FK cascade); a status
`UPDATE` cascades nothing. So an overwritten terminal state does not release objects —
the chunk is **kept**, with a warning. What it actually costs is a chunk leak that
never expires (no retention rule ever selects a `failed` snapshot) and a good backup
that reads as failed and is refused for restore.

## The trap this avoided

`FailStalledBackupSnapshot`'s header said `FailBackupSnapshot` *"has no status guard
(CancelSnapshot relies on that to fail a still-'pending' row), so it must stay
unchanged"*.

That forbids `status = 'running'` — the reflexive choice, and what the sibling watchdog
query uses. It does **not** forbid `IN ('pending','running')`, which still lets an
operator cancel a queued backup. Shipping the narrow form would have broken cancel
silently. The comment is rewritten to state the real relationship.

## The dangerous half of `:one` → `:execrows`

Making the zero-row case observable required the signature change, which broke three
call sites loudly — and left three more compiling while silently wrong:

`repo.go` had three `if _, err := q.CompleteBackupSnapshot(...)` sites that detected a
missing snapshot via `errors.Is(err, pgx.ErrNoRows)`. `:execrows` never returns that
(the generated body is `Exec` then `RowsAffected`), so the branch became unreachable
and **a late manifest submit against a cancelled snapshot would have returned success
having written nothing.** All three now check rows-affected and return the same
`backup_snapshot_not_found` the dead branch produced.

Side effects are gated on the same signal: no `started`/`failed` SSE, no failure email,
no schedule reconcile and no audit entry when the transition did not happen —
`FailStalledBackupSnapshot`'s existing caller is the model. `CancelSnapshot` gains a
real TOCTOU fix and surfaces the existing `snapshot_not_cancelable` Conflict.

Nine test fakes moved to the new signatures, and the stateful ones enforce the real
predicates — a fake that always reports a transition would hide exactly this defect.

## Proof

Every guard was planted, watched fail, restored, and watched pass. The ones worth
naming:

- **The rejection is atomic.** `RecordManifest` wraps chunk upserts, manifest inserts,
  refcount increments and the guarded completion in one `InTenantTx`. Proven by moving
  the chunk upsert into its own committed transaction and watching the test redden —
  so a future dedup refactor that splits it out cannot silently stop rolling back.
- **Cancel-of-pending, end to end.** Reverting the guard to `= 'running'` and
  regenerating sqlc makes `svc.CancelSnapshot` on a pending snapshot fail. That is the
  regression the whole design turns on.
- **Over-fire twins stayed green under every plant.** A guard that reddens correct work
  gets switched off, so each red has a paired case that must not move.

`go test -count=1 -v ./tests/gh458/` — 11 subtests, all pass.
`make test-integration` — exit 0 on this branch.

## Not covered

`RecordIncrementalManifest`'s two branches are wired but have no executed test; their
fixtures were out of budget. Stated rather than papered over.

One open question that would change the severity, and needs production data rather than
code: the manifest guard deliberately ignores `backup_file_index`, so legacy
per-file-index chains have no equivalent protection and this bug **would** be data loss
there. No live code path writes that table, but readers remain, so old rows are still
walked. `SELECT count(*) FROM backup_file_index` answers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented backup snapshots from being claimed, completed, failed, or cancelled after reaching a terminal state.
  * Prevented duplicate backup jobs, claims, and misleading events or notifications during concurrent operations.
  * Rejected manifest submissions for terminal snapshots and safely rolled back related changes.
  * Improved retry, cancellation, failure-race, and cleanup handling.

* **Tests**
  * Added coverage for snapshot transitions, concurrency races, job uniqueness, manifest safeguards, and test-environment reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->