### PR TITLE
test(api): anchor the GH #463 due-scan seeds to the database clock

### DIFF
--- a/apps/api/tests/gh463_paused_site_dispatch_integration_test.go
+++ b/apps/api/tests/gh463_paused_site_dispatch_integration_test.go
@@ -224,7 +224,7 @@ func TestGH463_PausedSiteIsSkippedAndTheUnpausedSiteStillDispatches(t *testing.T
 	healthy := seedSite(t, pool, tenant, "")
 
 	// STEP 1 — schedule, while BOTH sites are active.
-	run, tasks := seedRunAcrossSites(t, repo, tenant, time.Now().Add(-time.Minute), map[string]uuid.UUID{
+	run, tasks := seedRunAcrossSites(t, repo, tenant, dbNow(t, pool).Add(-time.Minute), map[string]uuid.UUID{
 		"akismet": frozen,
 		"jetpack": healthy,
 	})
@@ -305,7 +305,7 @@ func TestGH463_ResumingBeforeTheRunFiresDispatchesNormally(t *testing.T) {
 	tenant := seedTenant(t, pool, "gh463-resume-fires")
 	siteID := seedSite(t, pool, tenant, "")
 
-	run, tasks := seedRunAcrossSites(t, repo, tenant, time.Now().Add(-time.Minute), map[string]uuid.UUID{
+	run, tasks := seedRunAcrossSites(t, repo, tenant, dbNow(t, pool).Add(-time.Minute), map[string]uuid.UUID{
 		"akismet": siteID,
 	})
 
@@ -358,7 +358,7 @@ func TestGH463_ARunWhoseSitesAreAllPausedCompletesWithoutContactingAnySite(t *te
 	siteA := seedSite(t, pool, tenant, "")
 	siteB := seedSite(t, pool, tenant, "")
 
-	run, tasks := seedRunAcrossSites(t, repo, tenant, time.Now().Add(-time.Minute), map[string]uuid.UUID{
+	run, tasks := seedRunAcrossSites(t, repo, tenant, dbNow(t, pool).Add(-time.Minute), map[string]uuid.UUID{
 		"akismet": siteA,
 		"jetpack": siteB,
 	})

--- a/apps/api/tests/gh463_phase1_dispatch_integration_test.go
+++ b/apps/api/tests/gh463_phase1_dispatch_integration_test.go
@@ -66,6 +66,39 @@ func (e *countingTxEnqueuer) count() int {
 	return e.n
 }
 
+// dbNow returns now() as the DATABASE sees it, read through the same pool and
+// the same InAgentTx wrapper the due scan itself runs under.
+//
+// EVERY DEFERRED-DISPATCH ASSERTION IN THIS FILE AND ITS SIBLINGS TURNS ON ONE
+// PREDICATE: ListDueUpdateRuns' "scheduled_at <= now()", where now() is the
+// DATABASE clock. updates.sql chose that clock deliberately, so two control
+// planes with drifting wall clocks cannot disagree about whether a run has
+// arrived. Seeding scheduled_at from the Go host clock therefore compares two
+// DIFFERENT clocks: this process's, and the one inside the Postgres container.
+//
+// They are not the same clock. The container inherits the Docker VM's clock,
+// which lags the host across a host sleep until Docker's time-sync corrects it,
+// and a seed one minute in the HOST's past lands in the DATABASE's FUTURE for
+// as long as that lag exceeds a minute. The run is then absent from the due
+// scan and the test fails on an assertion that says nothing about clocks —
+// reproducibly under the full suite, which runs long enough to straddle a sleep,
+// and never in isolation, which does not.
+//
+// Anchoring every seed here removes the second clock: the margins below are then
+// margins against the clock that actually decides, not a bet on how far two
+// clocks have drifted apart. This is not a tolerance and not a retry; the scan
+// is still asserted exactly once, on its first call.
+func dbNow(t *testing.T, pool *db.Pool) time.Time {
+	t.Helper()
+	var now time.Time
+	if err := pool.InAgentTx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), "SELECT now()").Scan(&now)
+	}); err != nil {
+		t.Fatalf("read the database clock: %v", err)
+	}
+	return now
+}
+
 // seedScheduledRunWithTask creates a deferred run through the REAL repo method,
 // so the row is born exactly as Service.CreateRun would create it.
 func seedScheduledRunWithTask(t *testing.T, repo update.Repo, tenant, siteID uuid.UUID, at time.Time, slugs ...string) (update.Run, []update.Task) {
@@ -143,7 +176,7 @@ func TestGH463_Phase1_ScheduledRunContactsNoSiteUntilItsTime(t *testing.T) {
 	tenant := seedTenant(t, pool, "gh463-p1-e2e")
 	siteID := seedSite(t, pool, tenant, "")
 
-	future := time.Now().Add(10 * time.Minute)
+	future := dbNow(t, pool).Add(10 * time.Minute)
 	run, tasks := seedScheduledRunWithTask(t, repo, tenant, siteID, future, "akismet")
 	if run.Status != update.RunScheduled {
 		t.Fatalf("run born %q, want %q", run.Status, update.RunScheduled)
@@ -235,7 +268,7 @@ func TestGH463_Phase1_ScheduledTaskDoesNotBlockAnImmediateUpdate(t *testing.T) {
 	siteID := seedSite(t, pool, tenant, "")
 
 	// Tomorrow's scheduled update of akismet.
-	_, _ = seedScheduledRunWithTask(t, repo, tenant, siteID, time.Now().Add(20*time.Hour), "akismet")
+	_, _ = seedScheduledRunWithTask(t, repo, tenant, siteID, dbNow(t, pool).Add(20*time.Hour), "akismet")
 
 	// The dedup pre-check must not see it.
 	inFlight, err := repo.ListInFlightTargets(ctx, tenant, []uuid.UUID{siteID})
@@ -279,7 +312,7 @@ func TestGH463_Phase1_ReaperLeavesScheduledTasksAlone(t *testing.T) {
 	tenant := seedTenant(t, pool, "gh463-p1-reaper")
 	siteID := seedSite(t, pool, tenant, "")
 
-	_, tasks := seedScheduledRunWithTask(t, repo, tenant, siteID, time.Now().Add(6*time.Hour), "akismet")
+	_, tasks := seedScheduledRunWithTask(t, repo, tenant, siteID, dbNow(t, pool).Add(6*time.Hour), "akismet")
 	taskID := tasks[0].ID
 
 	// Age it three hours — four times staleTaskThreshold (45m).
@@ -343,7 +376,7 @@ func TestGH463_Phase1_ConcurrentClaimsExactlyOneWins(t *testing.T) {
 
 	tenant := seedTenant(t, pool, "gh463-p1-claim")
 	siteID := seedSite(t, pool, tenant, "")
-	run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, time.Now().Add(-time.Minute), "akismet")
+	run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, dbNow(t, pool).Add(-time.Minute), "akismet")
 
 	due, err := repo.ListDueRuns(ctx, 100)
 	if err != nil || len(due) == 0 {
@@ -410,7 +443,7 @@ func TestGH463_Phase1_DispatchIsAllOrNothing(t *testing.T) {
 
 	tenant := seedTenant(t, pool, "gh463-p1-atomic")
 	siteID := seedSite(t, pool, tenant, "")
-	run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, time.Now().Add(-time.Minute), "akismet", "jetpack")
+	run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, dbNow(t, pool).Add(-time.Minute), "akismet", "jetpack")
 
 	due, _ := repo.ListDueRuns(ctx, 100)
 	var target update.Run
@@ -487,7 +520,7 @@ func TestGH463_Phase1_ABusyTargetIsSkippedAndTheRunSurvives(t *testing.T) {
 
 	tenant := seedTenant(t, pool, "gh463-p1-skip")
 	siteID := seedSite(t, pool, tenant, "")
-	run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, time.Now().Add(-time.Minute), "akismet", "jetpack")
+	run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, dbNow(t, pool).Add(-time.Minute), "akismet", "jetpack")
 
 	// The operator's urgent update of akismet, created while the run waited.
 	if _, _, err := repo.CreateRunWithTasks(ctx, update.CreateRunInput{TenantID: tenant}, []update.NewTask{{
@@ -559,7 +592,7 @@ func TestGH463_Phase1_ARunWithLiveWorkIsNotMarkedCompleted(t *testing.T) {
 	tenant := seedTenant(t, pool, "gh463-p1-livework")
 	siteID := seedSite(t, pool, tenant, "")
 	run, tasks := seedScheduledRunWithTask(t, repo, tenant, siteID,
-		time.Now().Add(-time.Minute), "akismet", "jetpack")
+		dbNow(t, pool).Add(-time.Minute), "akismet", "jetpack")
 
 	// An earlier partial pass: move ONE task to 'pending' by hand, exactly as a
 	// previous dispatch would have left it. Its command is notionally out on
@@ -667,11 +700,11 @@ func TestGH463_Phase1_ExpiryPastTheGraceWindow(t *testing.T) {
 	siteID := seedSite(t, pool, tenant, "")
 
 	// Came due three hours ago; the grace window is two.
-	stale, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, time.Now().Add(-3*time.Hour), "akismet")
+	stale, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, dbNow(t, pool).Add(-3*time.Hour), "akismet")
 	// Came due one minute ago; comfortably inside it.
-	fresh, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, time.Now().Add(-time.Minute), "jetpack")
+	fresh, _ := seedScheduledRunWithTask(t, repo, tenant, siteID, dbNow(t, pool).Add(-time.Minute), "jetpack")
 
-	cutoff := time.Now().Add(-2 * time.Hour)
+	cutoff := dbNow(t, pool).Add(-2 * time.Hour)
 
 	expired, nTasks, err := repo.ExpireDueRun(ctx, tenant, stale.ID, cutoff,
 		"not attempted: the run passed its dispatch window")
@@ -761,7 +794,7 @@ func TestGH463_Phase1_CancelScheduledRun(t *testing.T) {
 
 	t.Run("a scheduled run cancels and contacts no site", func(t *testing.T) {
 		run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID,
-			time.Now().Add(2*time.Hour), "akismet", "jetpack")
+			dbNow(t, pool).Add(2*time.Hour), "akismet", "jetpack")
 
 		cancelled, tasks, ok, err := repo.CancelScheduledRun(ctx, tenant, run.ID, "cancelled by an operator")
 		if err != nil {
@@ -815,7 +848,7 @@ func TestGH463_Phase1_CancelScheduledRun(t *testing.T) {
 
 	t.Run("a run that already fired is refused", func(t *testing.T) {
 		run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID,
-			time.Now().Add(-time.Minute), "wordfence")
+			dbNow(t, pool).Add(-time.Minute), "wordfence")
 
 		// Fire it, so it is 'running' with a live task.
 		due, _ := repo.ListDueRuns(ctx, 200)
@@ -851,7 +884,7 @@ func TestGH463_Phase1_CancelScheduledRun(t *testing.T) {
 
 	t.Run("two concurrent cancels give exactly one winner", func(t *testing.T) {
 		run, _ := seedScheduledRunWithTask(t, repo, tenant, siteID,
-			time.Now().Add(3*time.Hour), "yoast")
+			dbNow(t, pool).Add(3*time.Hour), "yoast")
 
 		const operators = 4
 		wins := make([]bool, operators)
@@ -916,7 +949,7 @@ func TestGH463_Phase1_DueScanUsesTheDueIndex(t *testing.T) {
 	siteID := seedSite(t, pool, tenant, "")
 	for i := 0; i < 25; i++ {
 		seedScheduledRunWithTask(t, repo, tenant, siteID,
-			time.Now().Add(time.Duration(i-30)*time.Minute), fmt.Sprintf("p%d", i))
+			dbNow(t, pool).Add(time.Duration(i-30)*time.Minute), fmt.Sprintf("p%d", i))
 	}
 
 	var plan strings.Builder

--- a/apps/api/tests/gh463_update_runs_agent_rls_integration_test.go
+++ b/apps/api/tests/gh463_update_runs_agent_rls_integration_test.go
@@ -68,13 +68,13 @@ func TestGH463_Phase0_AgentTxSeesAndClaimsDueRunCrossTenant(t *testing.T) {
 	tenantA := seedTenant(t, pool, "gh463-tenant-a")
 	tenantB := seedTenant(t, pool, "gh463-tenant-b")
 
-	due := time.Now().Add(-time.Minute)
+	due := dbNow(t, pool).Add(-time.Minute)
 	runA := seedScheduledRun(t, pool, tenantA, due)
 	runB := seedScheduledRun(t, pool, tenantB, due)
 
 	// A run that is not yet due, to prove the scan is selective and not simply
 	// returning everything once the policy admits rows.
-	notYet := seedScheduledRun(t, pool, tenantA, time.Now().Add(time.Hour))
+	notYet := seedScheduledRun(t, pool, tenantA, dbNow(t, pool).Add(time.Hour))
 
 	// (1) THE PLAIN CROSS-TENANT READ. No tenant_id in the WHERE and no
 	// app.tenant_id in the session: this is admitted only by update_runs_agent.
@@ -209,7 +209,7 @@ func TestGH463_Phase0_WithoutAgentPolicyTheScanIsSilentlyEmpty(t *testing.T) {
 	ctx := context.Background()
 
 	tenantA := seedTenant(t, pool, "gh463-red-a")
-	runA := seedScheduledRun(t, pool, tenantA, time.Now().Add(-time.Minute))
+	runA := seedScheduledRun(t, pool, tenantA, dbNow(t, pool).Add(-time.Minute))
 
 	admin := connectAdmin(t, pool)
 	defer admin.Close()
@@ -267,7 +267,7 @@ func TestGH463_Phase0_ForSelectPolicyStillBreaksTheClaim(t *testing.T) {
 	ctx := context.Background()
 
 	tenantA := seedTenant(t, pool, "gh463-forselect-a")
-	seedScheduledRun(t, pool, tenantA, time.Now().Add(-time.Minute))
+	seedScheduledRun(t, pool, tenantA, dbNow(t, pool).Add(-time.Minute))
 
 	admin := connectAdmin(t, pool)
 	defer admin.Close()
@@ -361,7 +361,7 @@ func TestGH463_Phase0_AgentPolicyDoesNotWidenTenantIsolation(t *testing.T) {
 
 	tenantA := seedTenant(t, pool, "gh463-widen-a")
 	tenantB := seedTenant(t, pool, "gh463-widen-b")
-	runA := seedScheduledRun(t, pool, tenantA, time.Now().Add(-time.Minute))
+	runA := seedScheduledRun(t, pool, tenantA, dbNow(t, pool).Add(-time.Minute))
 
 	// Tenant B, on the ordinary operator path, must not see tenant A's run —
 	// neither by unfiltered enumeration nor by direct id.


### PR DESCRIPTION
Fixes a real test failure on `main`, reproduced under full-suite load. **No production
change** — `ListDueUpdateRuns` is correct.

## What failed

```
--- FAIL: TestGH463_ARunWhoseSitesAreAllPausedCompletesWithoutContactingAnySite (7.17s)
    gh463_paused_site_dispatch_integration_test.go:370: run c4e3b2f1-... was not returned by the due scan
FAIL	github.com/mosamlife/wpmgr/apps/api/tests	884.836s
```

One failure, zero skips, in an 884 s run. Green every time in isolation.

## Root cause: the test compared two different clocks

`ListDueUpdateRuns` has exactly two predicates and no others:

```sql
WHERE status = 'scheduled' AND scheduled_at <= now()
ORDER BY scheduled_at ASC, id ASC LIMIT @row_limit
```

By elimination: `status` is set at creation and nothing between seed and scan moves it;
`LIMIT 100` cannot bite because `startPostgres` gives each test its own container, so the
DB holds one run; an RLS failure would return zero rows and redden the whole family, not
one test. That leaves `scheduled_at <= now()`.

`now()` is the **database** clock — chosen deliberately so drifting control planes cannot
disagree. The seeds used `time.Now()`, the **Go host** clock. The Postgres container
inherits the Docker VM clock, which lags the host across a host sleep until Docker's
time-sync corrects it. While that lag exceeds 60 s, a row seeded one minute in the host's
past sits in the *database's* future, and the scan correctly omits it.

That accounts for every observation: green in isolation (a 30 s run never straddles a
sleep), red under an 884 s suite, exactly one failure (the correction window is short —
Docker Desktop resynced a deliberately-set 120 s offset within ~17 s), and this machine
having slept twice during the session.

**Not a production defect.** Production compares the DB clock against a `scheduled_at`
written hours earlier, so a transient DB-clock lag only delays firing, well inside the 2 h
grace window. The grace window is deliberately not applied in the scan at all — it is
applied at fire time.

## The fix

A `dbNow(t, pool)` helper reads `SELECT now()` through the **same pool and the same
`InAgentTx` wrapper the scan runs under**, and every seed is anchored to it. Both sides of
`scheduled_at <= now()` now come from one clock.

No assertion weakened, no tolerance widened, no retry added — the scan is still asserted on
its first call. A retry would have hidden exactly the class of bug these tests exist to catch.

Siblings carried the same latent fragility and are fixed consistently — including the
`+10 min` / `+1 h` "not yet due" seeds, which were exposed in the **opposite** direction: a
DB clock running ahead would make a not-yet-due run appear due.

`grep -c "time.Now()"` across the three files: **22 on `main`, 0 here.**

## Proof

RED, reproducing the reported assertion byte for byte by seeding into the database's future:

```
--- FAIL: TestGH463_ARunWhoseSitesAreAllPausedCompletesWithoutContactingAnySite (1.55s)
    gh463_paused_site_dispatch_integration_test.go:370: run 18814c75-... was not returned by the due scan
```

GREEN with the fix: `go test -run 'TestGH463' ./tests/` → `ok 28.058s`.

**The guard still fires.** With the real bug planted (the paused-site skip disabled), the
fixed tests go red for the right reason — reaching the due scan, then failing on the pause
policy: *"a job was enqueued for the PAUSED site"* and *"enqueued 2 jobs, want 0"*.

## Stated plainly

Not reproduced under the real full suite — the trigger is a host sleep, which cannot be
scheduled, and an 884 s run did not fit the budget. The mechanism is established by
elimination plus the byte-identical RED above, not by a full-suite reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scheduled-run integration test reliability by aligning test timestamps with the database clock.
  * Reduced the risk of flaky results caused by differences between application and database time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->