### PR TITLE
release: 0.61.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.142] - 2026-08-20
+
+### Added
+
+- New endpoint `GET /api/v1/fleet/uptime-history` returns a measured 90-day availability strip, one entry per UTC day, in place of a figure the dashboard previously derived from a single 7-day number (GH #460).
+
+### Changed
+
+- The probe-retention window the new uptime strip depends on is now pinned, and the retention guard that enforces it derives from that same window instead of a separate value (GH #460).
+
+### Fixed
+
+- A scheduled update run no longer dispatches to a site that was paused after the run was scheduled (GH #463, #492).
+- Scheduled database cleaning, which deletes rows from a customer's own live database, and the vulnerability digest now both decline a paused site the same way (GH #493, #494).
+- A site with no measurement now reports uptime as null instead of 0%; previously a site that had never been probed rendered as 90 days of solid outage (GH #460).
+- Session advisory locks are now released on a detached, bounded context. Three call sites, all reachable by an ordinary graceful shutdown or a River job timeout, could leak a session-scoped lock because the deferred unlock ran on an already-cancelled context and silently did nothing: while leaked, scheduled backups stopped fleet-wide, per-tenant chunk GC stopped, and `DELETE /orgs/{orgId}` / `POST /orgs/{orgId}/restore` blocked until the pooled connection recycled, up to 30 minutes later (GH #483, #495).
+- The webhook dedup GC worker is now registered with River; it was written but never wired in, so it has never run (GH #461).
+- Email GC registration now fails startup instead of being silently skipped when it is handed a nil worker.
+- Removed a migrations stub that advertised a capability that was never built (GH #462).
+- Removed dead RUM hourly/daily fold paths and an unreachable ClickHouse store.
+
 ## [0.61.141] - 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.140**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.141**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.140
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.140
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.140
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.141
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.141
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.141
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.140   # omit to track :latest
+export WPMGR_VERSION=v0.61.141   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -225,7 +225,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.140   # omit to track :latest
+export WPMGR_VERSION=v0.61.141   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.141
+  version: 0.61.142
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. Verified with `git diff --stat v0.61.141..origin/main -- apps/agent/` (empty).

- Monitoring pause is now honoured in scheduled update dispatch, scheduled db-clean, and the vulnerability digest (GH #463, #492, #493, #494).
- Uptime reporting corrected: a never-probed site reports null instead of 0%, and a new `GET /api/v1/fleet/uptime-history` endpoint replaces a figure derived from a single 7-day number (GH #460).
- Session advisory locks are released on a detached, bounded context, fixing a leak that could stall fleet-wide backups, per-tenant chunk GC, and org delete/restore (GH #483, #495).
- Webhook dedup GC worker wired into River (GH #461); email GC registration now fails startup instead of silently skipping; dead migrations stub, RUM fold paths, and unreachable ClickHouse store removed (GH #462).

## Version surfaces

- `packages/openapi/openapi.yaml` info.version: 0.61.141 to 0.61.142 (exact match to CHANGELOG top).
- Agent plugin (`apps/agent/wpmgr-agent.php`) and marketing hero badge: unchanged, both stay at 0.61.139.
- Install pins (README.md, docs/install.md): 0.61.140 to 0.61.141, one release behind (published images for 0.61.142 do not exist yet).

## Test plan

- [x] `make check-versions-test` (self-test, 76 passed, 0 failed)
- [x] `make check-versions` (all surfaces OK)
- [x] Docs vocabulary check (banned-name grep from `ci.yml`, run verbatim): clean
- [x] `node apps/marketing/scripts/check-copy.mjs`: passed
- [ ] `ci.yml` on this PR
