### PR TITLE
fix(ci): stop Go build/test filters missing test-only subpackages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,22 @@ jobs:
         env:
           GOWORK: "off"
           CGO_ENABLED: "0"
-        # apps/api/tests is excluded from BUILD specifically: every file in it is
-        # a _test.go file, so it has no buildable non-test files and `go build`
-        # errors on it when named explicitly. Vet (below) keeps it: vet compiles
-        # the _test.go files, so the integration tests still cannot silently rot.
+        # A package with no buildable non-test file (every .go file in it is
+        # _test.go) makes `go build` error with "no non-test Go files" the
+        # moment it is named explicitly. apps/api/tests is one today; any test-
+        # only subpackage added under it (or anywhere else in apps/api) is
+        # another. Rather than excluding by path — which has to be re-anchored
+        # by hand every time such a package is added, and silently stops
+        # covering the NEXT one — filter by the actual property `go build`
+        # cares about: `go list -f '{{if .GoFiles}}...{{end}}'` prints an
+        # import path only for packages that have buildable files at all, so
+        # a test-only package drops out of the build set on its own. This
+        # also means apps/api/tests/contract, which carries doc.go for
+        # exactly this reason, keeps building here with no special case.
         #
-        # The pattern is anchored with $ so it excludes ONLY that package and not
-        # its subpackages. apps/api/tests/contract must keep building here.
-        run: go build $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e '/apps/api/tests$')
+        # Vet (below) still covers the packages this drops: vet compiles the
+        # _test.go files too, so a test-only package still cannot silently rot.
+        run: go build $(go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder)
 
       - name: Vet
         env:
@@ -86,13 +94,28 @@ jobs:
         # rotting between integration runs. Note that is VET doing it, not
         # Build, for the reason given on the Build step above.
         #
-        # The pattern is anchored with $ so it excludes ONLY that package.
-        # apps/api/tests/contract holds the containerless spec-versus-code gates
-        # (TestOpenAPIRouteCoverage and TestOpenAPIRequestBodyFieldCoverage);
-        # they run against an empty *db.Pool in about a second and MUST run on
-        # every PR, because they are what stops an undocumented route or a
-        # handler json tag that no longer matches its schema from merging.
-        run: go test $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e '/apps/api/tests$')
+        # The pattern excludes apps/api/tests ITSELF AND EVERY SUBDIRECTORY
+        # ( '/apps/api/tests($|/)' ), not just the exact path: a subpackage
+        # added under it (e.g. apps/api/tests/gh458) is, by the convention
+        # every existing one follows, container-backed like its siblings, so
+        # it belongs in api-integration.yml's lane too and must not silently
+        # start running here — an anchor of just `$` would miss it and this
+        # fast lane would eat a testcontainers run with none of the Docker
+        # prep api-integration.yml does for it. That is not hypothetical: it
+        # is what apps/api/tests/gh458 does the moment the anchor is `$`-only.
+        #
+        # apps/api/tests/contract is the one deliberate exception, so it is
+        # added back explicitly rather than by pattern. It holds the
+        # containerless spec-versus-code gates (TestOpenAPIRouteCoverage and
+        # TestOpenAPIRequestBodyFieldCoverage); they run against an empty
+        # *db.Pool in about a second and MUST run on every PR, because they
+        # are what stops an undocumented route or a handler json tag that no
+        # longer matches its schema from merging. A future package that is
+        # deliberately fast and containerless needs the same explicit
+        # addition — that is a one-time choice made when such a package is
+        # created, the same way contract's was, not something this pattern
+        # can infer from a path.
+        run: go test $(go list ./... | grep -Ev -e '/cmd/media-encoder' -e '/internal/media/encoder' -e '/apps/api/tests($|/)') ./tests/contract/...
 
   # ---- JS / web ----
   js:


### PR DESCRIPTION
Unblocks #497. CI's Go job broke on `apps/api/tests/gh458` (added by #497)
because the Build step's exclusion pattern (`/apps/api/tests$`) is anchored
to the exact path and does not match a subdirectory. `go build` errors on
any package with no non-test Go files, which is what any test-only
subpackage under `apps/api/tests/` will always be.

## What changed

**Build step**: instead of excluding by path, filter by the property
`go build` actually cares about — `go list -f '{{if .GoFiles}}...{{end}}'`
only prints packages that have a buildable non-test file, so a test-only
package (anywhere in apps/api, not just under `apps/api/tests/`) drops out
on its own. `apps/api/tests/contract` keeps building unchanged: it carries
`doc.go` for exactly this reason, and the new filter finds it.

**Test step**: this had the same anchoring gap in the other direction. The
`$`-anchor let a subdirectory like `gh458` (container-backed like its
siblings) slip into the fast per-PR lane, which has no Docker prep and is
not where those tests are meant to run — they belong in
`api-integration.yml`. Now excludes `apps/api/tests` and every
subdirectory, with `apps/api/tests/contract` added back explicitly, since
it's the one deliberately containerless exception (`TestOpenAPIRouteCoverage`,
`TestOpenAPIRequestBodyFieldCoverage`) that must keep running on every PR.

Both occurrences of the old `/apps/api/tests$` pattern are fixed
consistently; `grep -n` over `.github/workflows/*.yml` confirms no others
remain.

## Why not just widen the exclusion to the whole tree

Considered and rejected: it would have to explicitly special-case
`apps/api/tests/contract` to keep it in the *build* set too, and that's a
maintenance burden the property-based filter above doesn't need — it finds
`contract` (and any future package like it) automatically, without naming
it. The *test* step still needs the explicit exception, because "fast and
containerless" isn't something `go list` can infer from a package the way
"has a buildable file" can — that one deliberate case is named, not
guessed.

## Proof

Reproduced against a checkout with `apps/api/tests/gh458` materialized
(from `fix/458-snapshot-state-guards`, not merged):

```
$ go build $(go list ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder -e '/apps/api/tests$')
github.com/mosamlife/wpmgr/apps/api/tests/gh458: no non-test Go files in .../apps/api/tests/gh458
```

Same reproduction with the new Build line: `go build $(go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /cmd/media-encoder -e /internal/media/encoder)` — exit 0.

Package-set diff (old exclusion vs. new), Build step: the only package that
stops being built is `apps/api/tests/gh458` itself — a package that could
never build anyway. Nothing else moves.

Test step: with the old `$`-anchor, `gh458` was present in the fast-lane
package list (confirmed by listing it explicitly) — i.e., a future
container-backed test package really would start running in the wrong
lane, not just fail to build. With the new pattern, `gh458` is absent and
`apps/api/tests/contract` still runs (`go test ./tests/contract/...` — ok,
1 test, ~1s).

Over-fire control: planted a real syntax error in
`apps/api/internal/backup/repo.go`, ran the new Build pipeline — failed
with the real compile error at the real line. Restored the file, ran
again — exit 0.

`git diff --stat` is clean of the plant; only `.github/workflows/ci.yml`
changed.

## Not in scope here

`api-integration.yml`'s integration lane runs `go test ./tests/` (not
`./tests/...`), so it does not recurse into subdirectories like `gh458`
either — that's a separate gap in the manual integration lane's own
package selection, not the fast-lane anchoring bug this PR fixes. Flagging
it since #497 adds a subdirectory there too, but leaving it to #497 or a
follow-up rather than folding it into this fix.