### PR TITLE
test(api): fail closed on testcontainer start failures in 11 more files

### DIFF
--- a/apps/api/tests/backup_m96_migration_test.go
+++ b/apps/api/tests/backup_m96_migration_test.go
@@ -43,6 +43,8 @@ func startPostgresBeforeM96(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -54,10 +56,15 @@ func startPostgresBeforeM96(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/billing_hosted_test.go
+++ b/apps/api/tests/billing_hosted_test.go
@@ -411,6 +411,8 @@ func startPostgresBeforeM91(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -422,10 +424,15 @@ func startPostgresBeforeM91(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/blobstore_integration_test.go
+++ b/apps/api/tests/blobstore_integration_test.go
@@ -21,14 +21,21 @@ func startBlobstore(t *testing.T) *blobstore.Store {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "minio")
+
 	container, err := minio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z",
 		minio.WithUsername("wpmgr"),
 		minio.WithPassword("wpmgr-dev-secret"),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start minio container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "minio: container start")
+	}
 
 	endpoint, err := container.ConnectionString(ctx)
 	if err != nil {

--- a/apps/api/tests/identity_backfill_m111_test.go
+++ b/apps/api/tests/identity_backfill_m111_test.go
@@ -37,6 +37,8 @@ func startPostgresBeforeM111(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -48,10 +50,15 @@ func startPostgresBeforeM111(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/metrics_integration_test.go
+++ b/apps/api/tests/metrics_integration_test.go
@@ -19,6 +19,8 @@ func startClickHouse(t *testing.T) metrics.Store {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "clickhouse")
+
 	container, err := tcclickhouse.Run(ctx,
 		"clickhouse/clickhouse-server:24.3-alpine",
 		tcclickhouse.WithUsername("wpmgr"),
@@ -31,10 +33,15 @@ func startClickHouse(t *testing.T) metrics.Store {
 			wait.ForListeningPort("9000/tcp").WithStartupTimeout(120*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start clickhouse container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "clickhouse: container start")
+	}
 
 	host, err := container.ConnectionHost(ctx)
 	if err != nil {

--- a/apps/api/tests/metrics_schema_convergence_integration_test.go
+++ b/apps/api/tests/metrics_schema_convergence_integration_test.go
@@ -27,6 +27,8 @@ import (
 func TestMetricsClickHouseSchemaConvergence(t *testing.T) {
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "clickhouse")
+
 	container, err := tcclickhouse.Run(ctx,
 		"clickhouse/clickhouse-server:24.3-alpine",
 		tcclickhouse.WithUsername("wpmgr"),
@@ -36,10 +38,15 @@ func TestMetricsClickHouseSchemaConvergence(t *testing.T) {
 			wait.ForListeningPort("9000/tcp").WithStartupTimeout(120*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start clickhouse container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "clickhouse: container start")
+	}
 
 	host, err := container.ConnectionHost(ctx)
 	if err != nil {

--- a/apps/api/tests/sitetag_migration_test.go
+++ b/apps/api/tests/sitetag_migration_test.go
@@ -41,6 +41,8 @@ func startPostgresBeforeM100(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -52,10 +54,15 @@ func startPostgresBeforeM100(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/update_m88_dedup_test.go
+++ b/apps/api/tests/update_m88_dedup_test.go
@@ -34,6 +34,8 @@ func startPostgresBeforeM88(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -45,10 +47,15 @@ func startPostgresBeforeM88(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/uptime_app_alert_rollout_m108_test.go
+++ b/apps/api/tests/uptime_app_alert_rollout_m108_test.go
@@ -38,6 +38,8 @@ func startPostgresBeforeM108(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -49,10 +51,15 @@ func startPostgresBeforeM108(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/uptime_rollup_backfill_test.go
+++ b/apps/api/tests/uptime_rollup_backfill_test.go
@@ -40,6 +40,8 @@ func startPostgresBeforeM99(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -51,10 +53,15 @@ func startPostgresBeforeM99(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {

--- a/apps/api/tests/vuln_alerting_m103_test.go
+++ b/apps/api/tests/vuln_alerting_m103_test.go
@@ -39,6 +39,8 @@ func startPostgresBeforeM103(t *testing.T) *db.Pool {
 	t.Helper()
 	ctx := context.Background()
 
+	skipIfDockerUnavailable(t, ctx, "postgres")
+
 	container, err := tcpostgres.Run(ctx,
 		"postgres:16-alpine",
 		tcpostgres.WithDatabase("wpmgr"),
@@ -50,10 +52,15 @@ func startPostgresBeforeM103(t *testing.T) *db.Pool {
 				WithStartupTimeout(60*time.Second),
 		),
 	)
-	if err != nil {
-		t.Skipf("skipping: cannot start postgres container (docker unavailable?): %v", err)
+	// container can be non-nil even when err != nil (partial start); register
+	// cleanup before the error check so a failure path cannot leak it (see
+	// rls_integration_test.go's startPostgres).
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
 	}
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		setupFatalfOrSkipIfDaemonDied(t, ctx, err, "postgres: container start")
+	}
 
 	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {


### PR DESCRIPTION
## Summary
- GH #501: 11 integration test files (`backup_m96_migration_test.go`, `billing_hosted_test.go`, `blobstore_integration_test.go`, `identity_backfill_m111_test.go`, `metrics_integration_test.go`, `metrics_schema_convergence_integration_test.go`, `sitetag_migration_test.go`, `update_m88_dedup_test.go`, `uptime_app_alert_rollout_m108_test.go`, `uptime_rollup_backfill_test.go`, `vuln_alerting_m103_test.go`) each had a local container-start harness that routed a testcontainer START failure straight to `t.Skipf`, so a Docker hiccup made the proof silently not run while the package still printed `ok`. `make test-integration` is the only gate for this package (CI excludes it by name), so a skip there read as a pass.
- Adopts the package-level helpers `rls_integration_test.go`/`autologin_integration_test.go` already established: `skipIfDockerUnavailable` positively probes the daemon before any container starts (the only thing allowed to skip), and a container-start error routes to `setupFatalfOrSkipIfDaemonDied`, which re-probes health and only skips if the daemon died in the window between the probe and the start — never by pattern-matching the error text.
- Also closes a container-cleanup leak present at all 11 call sites: `t.Cleanup` was registered after the error check, which is unreachable on every failure path since `setupFatalf` calls `t.Fatalf` → `runtime.Goexit`. testcontainers-go can return a non-nil container alongside a non-nil error on a partial start, so every one of these leaked its container on that path. Cleanup is now registered first, nil-guarded.

## Test plan
- [x] `git grep -c 't.Skipf("skipping: cannot start' -- apps/api/tests/` returns nothing (0 matches) after; before-count was 11 files, matching the 11 files edited.
- [x] `cd apps/api && go build ./...` — passes (one pre-existing, unrelated linker alignment warning on `cmd/media-encoder`).
- [x] `go vet ./tests/...` — clean.
- [x] `go test -run '^$' -count=1 ./tests/...` — all 4 subpackages compile, `[no tests to run]`.
- [ ] One converted file genuinely reddens on a bad image tag with Docker healthy (fails, not skips) — to be run against a live Docker daemon.
- [ ] Full package `go test -count=1 ./tests/...` with Docker healthy — to be run and pasted before merge.