### PR TITLE
release: 0.61.143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.143] - 2026-08-20
+
+### Fixed
+
+- An agent self-update run halted by the kill switch, or by a withdrawn release manifest, could be overwritten to `completed` when a task already in flight finished afterward: the run status write carried no precondition against writing over a terminal `halted` or `expired` run. Operators saw a rollout they had stopped reported as finished. `SetUpdateRunStatus` now refuses to move a run off `halted` or `expired` (GH #482, #490).
+- A backup snapshot's claim (`pending` to `running`) and its terminal outcome (to `completed` or `failed`) were each a blind update keyed only on `(id, tenant_id)`, so a late failure could land on a snapshot already completed, or the reverse, with nothing stopping either. That leaked chunk storage permanently, since no retention rule selects a failed snapshot for cleanup, and could leave a good backup refused for restore. A late manifest submit against a cancelled or already completed snapshot also returned success while writing nothing; it now returns not found and the transaction rolls back. All three writes are now guarded by the snapshot's current status (GH #458, #497).
+- `events.Listener` released its Postgres connection back to the shared application pool on cancellation without issuing `UNLISTEN` first. `LISTEN` is session state, so the connection returned to the pool still subscribed, and the next unrelated caller to acquire it could receive notifications meant for the cancelled listener. The listener now unsubscribes before releasing the connection, and hijacks it out of the pool entirely when the `UNLISTEN` cannot be confirmed (GH #496, #504).
+- Thirteen integration test files turned any container start failure, not only an unreachable Docker daemon, into a skip, so a bad image pull, low disk space, or a resource limit read as `SKIP` and the suite still printed `ok` having asserted nothing. A container start failure is now fatal; only a positively probed unreachable Docker daemon still skips (GH #501, #503).
+- A rules file and an agent definition each claimed a `PreToolUse` hook still blocks an edit to an already applied migration and backs up the generated tree permission rule. That hook, and the rest of the shell guards, was removed on 2026-08-14; `.claude/settings.json` configures no hooks at all today. The three stale claims now say what still enforces what and point at `docs/harness.md` (GH #471, #505). Affects contributors to this repository, not the running system.
+
 ## [0.61.142] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.141**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.142**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.141
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.141
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.141
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.142
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.142
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.142
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.141   # omit to track :latest
+export WPMGR_VERSION=v0.61.142   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -225,7 +225,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.141   # omit to track :latest
+export WPMGR_VERSION=v0.61.142   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.142
+  version: 0.61.143
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. Verified `git diff --stat v0.61.142..origin/main -- apps/agent/` is empty, and only `apps/api` (plus repo docs/CI history) changed between v0.61.142 and this branch point; `apps/web` and `apps/marketing` are untouched.

Five fixes:

- A stopped rollout is no longer reported as finished (GH #482, #490)
- Backup snapshot state transitions are guarded (GH #458, #497)
- A cancelled site-events listener no longer leaves its connection subscribed (GH #496, #504)
- Test suites can no longer report success without running (GH #501, #503)
- Corrected three documentation claims about a removed safety hook (GH #471, #505)

Version surfaces moved:

- `CHANGELOG.md` top entry: 0.61.142 -> 0.61.143
- `packages/openapi/openapi.yaml` `info.version`: 0.61.142 -> 0.61.143
- `README.md` / `docs/install.md` install pins: v0.61.141 -> v0.61.142 (one release behind, by policy, since the 0.61.143 images do not exist yet)

Held fixed on purpose:

- `apps/agent/wpmgr-agent.php` plugin version stays 0.61.139 (agent unchanged)
- `apps/marketing/lib/content/home.ts` hero badge (`AGENT_VERSION`) stays 0.61.139, matching the agent

## Test plan

- [x] `make check-versions-test` - 76 passed, 0 failed
- [x] `make check-versions` - all surfaces OK, agent frozen at 0.61.139, install pins one release behind at tolerance 1
- [x] Docs vocabulary check (copied verbatim from `.github/workflows/ci.yml`) - no hits
- [x] `node apps/marketing/scripts/check-copy.mjs` - passed, no em/en dashes or competitor names
- [x] `git diff --stat` reviewed: only `CHANGELOG.md`, `README.md`, `docs/install.md`, `packages/openapi/openapi.yaml` changed
- [ ] Not merged. CI (`ci.yml`) still needs to run on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against invalid terminal status updates during run updates.
  - Improved backup snapshot cancellation handling and status validation.
  - Fixed listener connection cleanup.
  - Improved integration-test failure classification.
  - Removed outdated documentation references to retired hooks.

- **Documentation**
  - Updated installation instructions, container image examples, and release metadata to reflect the latest version.
  - Added changelog details for the latest fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->