### PR TITLE
fix(build): make `make gen` regenerate both trees or fail loudly (#511)

### DIFF
--- a/.claude/rules/ci-and-build-logic.md
+++ b/.claude/rules/ci-and-build-logic.md
@@ -38,9 +38,17 @@ declaration.
 Seven workflows: `ci.yml`, `api-integration.yml`, `e2e-agent.yml`,
 `plugincheck.yml`, `release.yml`, `security.yml`, `wporg-deploy.yml`.
 
-`ci.yml` is the gate and has seven jobs: `go`, `js`, `commit-hygiene`,
-`marketing`, `security`, `nginx-routing`, `php`. Green before and after every
-merge. Run the same command CI runs, locally, not an approximation.
+`ci.yml` is the gate and has eight jobs: `go`, `js`, `codegen-drift`,
+`commit-hygiene`, `marketing`, `security`, `nginx-routing`, `php`. Green before
+and after every merge. Run the same command CI runs, locally, not an
+approximation.
+
+`codegen-drift` regenerates both OpenAPI-derived trees
+(`apps/api/internal/api/gen`, `packages/openapi-client/src/generated`) and
+fails if what is committed differs from what `packages/openapi/openapi.yaml`
+now produces. It runs `scripts/gen-openapi_test.sh` first, then
+`scripts/gen-openapi.sh --check` — the same script `make gen` runs, so the
+developer command and the CI command cannot drift apart.
 
 `release.yml` is build-only; its image matrix is `api`, `web`, `media-encoder`
 to ghcr.io, and it never builds marketing. The marketing image ships only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,63 @@ jobs:
       - name: Test
         run: pnpm --filter @wpmgr/web test
 
+  # ---- Codegen drift ----
+  # packages/openapi/openapi.yaml is the source of truth for two committed
+  # generated trees: apps/api/internal/api/gen (ogen) and
+  # packages/openapi-client/src/generated (@hey-api/openapi-ts). This job
+  # regenerates both and fails if what is committed differs from what the spec
+  # now produces.
+  #
+  # WHY IT EXISTS (GH #511). `make gen` used to run a script that echoed
+  # "wired in Phase 4" and exited 0 while both generators had been wired and in
+  # daily use for months. So the documented command reported success and
+  # regenerated nothing, and a spec edit could be committed with a stale
+  # generated tree that looked freshly generated. Fixing the script fixes the
+  # command; this job is what stops the stale commit itself, rather than
+  # trusting every contributor to have run the right thing.
+  #
+  # THE LOGIC LIVES IN A SCRIPT, NOT IN THIS FILE, and so does the drift
+  # comparison: `scripts/gen-openapi.sh --check` is the same script `make gen`
+  # runs, with the diff on the end, so the developer command and the CI command
+  # cannot drift apart the way the thing they check drifts apart. The suite runs
+  # FIRST, as it does for the version-surface guard: if the guard's own
+  # behaviour has regressed, that is the more useful failure to read, and a
+  # guard that has failed open cannot pass by finding nothing.
+  codegen-drift:
+    name: Codegen drift (OpenAPI -> Go + TS)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Shims only, no toolchain needed, so a broken guard is caught before the
+      # expensive setup below rather than after it.
+      - name: Codegen guard self-test
+        run: scripts/gen-openapi_test.sh
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.6"
+          cache-dependency-path: apps/api/go.sum
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Regenerates both trees and fails if either generator is absent, exits
+      # non-zero, or exits 0 without writing; then fails if the committed trees
+      # differ from the fresh generation.
+      - name: Regenerate and compare against the committed trees
+        run: scripts/gen-openapi.sh --check
+
   # ---- Commit message hygiene ----
   # Refuses a PR whose own commits carry an assistant trailer or a session URL.
   #

--- a/Makefile
+++ b/Makefile
@@ -490,8 +490,20 @@ agent-release-dry-run: agent-zip ## Preview the agent release (build zip + print
 	./scripts/release-agent.sh --dry-run
 
 .PHONY: gen
-gen: ## Regenerate OpenAPI clients (Go + TS)
+gen: ## Regenerate OpenAPI clients (Go + TS) from packages/openapi/openapi.yaml
+	# Until GH #511 this target ran a script that echoed "wired in Phase 4" and
+	# exited 0 while both generators had been wired for months, so editing the
+	# spec and running `make gen` produced a stale tree that looked fresh. The
+	# script now fails if either generator is missing or writes nothing.
 	./scripts/gen-openapi.sh
+
+.PHONY: gen-check
+gen-check: ## Fail if the committed generated trees differ from a fresh generation
+	./scripts/gen-openapi.sh --check
+
+.PHONY: gen-test
+gen-test: ## Test suite for scripts/gen-openapi.sh (shims only, no toolchain needed)
+	./scripts/gen-openapi_test.sh
 
 .PHONY: gen-secrets
 gen-secrets: ## Print the boot-critical self-host secrets as ready-to-paste env lines

--- a/scripts/gen-openapi.sh
+++ b/scripts/gen-openapi.sh
@@ -186,7 +186,7 @@ run_generator() {
 	local label="$1" out="$2" workdir="$3"
 	shift 3
 	local ps_probe ps_probe_status ps_usable ps_pid ps_ppid
-	local tick_probe tick_advanced tick_attempt
+	local tick_probe tick_advanced tick_budget tick_deadline tick_now
 
 	MARKER="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-marker.XXXXXX")"
 	# Left at its mktemp-assigned "now", deliberately NOT back-dated. An
@@ -213,24 +213,57 @@ run_generator() {
 	# against MARKER with the same `find -newer` the real check below uses.
 	# Once a probe write is observably newer than MARKER, every subsequent
 	# write -- including the generator's -- is guaranteed strictly newer too,
-	# on any clock granularity. Bounded to a fixed number of attempts, not an
-	# unbounded loop: if the clock cannot be observed to advance at all, that
-	# is a hard stop, not a silent hang.
+	# on any clock granularity.
+	#
+	# A third attempt bounded this loop by a fixed attempt count (2000
+	# undelayed touch+find pairs), not by elapsed time, and that was also
+	# wrong (PR #512 review, gen-openapi.sh:227): on a fast host with coarse
+	# (e.g. whole-second) mtime granularity, all 2000 attempts can complete
+	# well inside a single tick with no sleep between them, so the clock
+	# never advances, the count is exhausted, and a perfectly healthy run
+	# fails before the generator is even invoked. That is the mirror image
+	# of the original GH #511-follow-up defect: a wait bounded in the wrong
+	# unit is the same shape as a wait with no bound at all. Bounded by
+	# wall-clock time instead, via `date +%s` (whole seconds only -- `%N`
+	# subsecond formatting is a GNU date extension this script cannot rely
+	# on portably), with a short sleep between attempts so the loop yields
+	# instead of spinning through however many attempts it takes without
+	# ever giving the clock a chance to move. Fractional `sleep` was checked
+	# rather than assumed: both this machine's BSD `sleep` (`Intervals can be
+	# written in any form allowed by strtod(3)`, confirmed with `sleep 0.1`)
+	# and GNU coreutils `sleep` support sub-second intervals, so 0.05s here
+	# is safe on both platforms this script runs on. GEN_OPENAPI_TICK_WAIT
+	# overrides the budget; this is a debug/test knob, not a documented
+	# public interface the way GEN_OPENAPI_DEADLINE is, so it is not
+	# separately validated -- a bad value fails loudly via bash's own
+	# arithmetic error rather than silently.
 	tick_probe="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-tick.XXXXXX")"
+	tick_budget="${GEN_OPENAPI_TICK_WAIT:-5}"
 	tick_advanced=0
-	for ((tick_attempt = 1; tick_attempt <= 2000; tick_attempt++)); do
+	tick_deadline=$(($(date +%s) + tick_budget))
+	while :; do
 		touch "$tick_probe" 2>/dev/null || true
 		if [ -n "$(find "$tick_probe" -newer "$MARKER" -print -quit 2>/dev/null)" ]; then
 			tick_advanced=1
 			break
 		fi
+		tick_now="$(date +%s)"
+		if [ "$tick_now" -ge "$tick_deadline" ]; then
+			break
+		fi
+		sleep 0.05
 	done
 	rm -f "$tick_probe"
 	if [ "$tick_advanced" -ne 1 ]; then
 		die "the filesystem clock did not observably advance past the
-    write-detection marker after 2000 attempts, so $label cannot be started
-    with a write-detection check this script can trust.
-    Marker: $MARKER"
+    write-detection marker within ${tick_budget}s, so $label cannot be
+    started with a write-detection check this script can trust.
+    Marker: $MARKER
+    Probe:  $tick_probe (already removed)
+    This filesystem's mtime granularity is coarser than this script's
+    ${tick_budget}s budget for observing it advance -- a real condition
+    worth investigating directly, not a generic failure. Override
+    GEN_OPENAPI_TICK_WAIT for a longer budget if that is expected here."
 	fi
 
 	# A bounded, process-tree-aware deadline (GH #511 follow-up). Without

--- a/scripts/gen-openapi.sh
+++ b/scripts/gen-openapi.sh
@@ -50,6 +50,9 @@ usage: scripts/gen-openapi.sh [--check] [ROOT]
             from what was just generated (drift detection for CI)
   ROOT      repository root to operate on (default: the repo containing this
             script)
+
+  GEN_OPENAPI_DEADLINE  seconds each generator gets before it is killed
+                         (default: 120). See run_generator in this script.
 USAGE
 }
 
@@ -129,8 +132,39 @@ require_dir() {
 }
 
 MARKER=""
-cleanup() { [ -n "$MARKER" ] && rm -f "$MARKER"; return 0; }
+TIMEOUT_FLAG=""
+cleanup() {
+	[ -n "$MARKER" ] && rm -f "$MARKER"
+	[ -n "$TIMEOUT_FLAG" ] && rm -f "$TIMEOUT_FLAG"
+	return 0
+}
 trap cleanup EXIT
+
+# Print $1 and every descendant pid of it, one per line, by walking
+# `ps`-reported parent links. Used to reach a whole subprocess tree (a
+# generator plus whatever it spawned) without process-group/job-control
+# machinery: enabling job control (`set -m`) to get a fresh pgid needs a
+# controlling terminal, and this script has none when it runs inside a pipe
+# or `$(...)` -- which is exactly how its own test suite invokes it, and
+# exactly how the `codegen-drift` CI job invokes it too. A bare `set -m` in
+# that context does not reliably return; that was tried here and hung.
+pid_tree() {
+	local root="$1" pid ppid
+	printf '%s\n' "$root"
+	ps -Ao pid=,ppid= 2>/dev/null | while read -r pid ppid; do
+		[ "$ppid" = "$root" ] && pid_tree "$pid"
+	done
+}
+
+# Send $1 (a signal name) to $2 and every descendant it has *right now*. Called
+# twice (TERM, then KILL after a grace period) so it re-walks the tree fresh
+# each time rather than trusting a snapshot taken before the first signal.
+kill_tree() {
+	local sig="$1" root="$2" p
+	for p in $(pid_tree "$root"); do
+		kill -"$sig" "$p" 2>/dev/null || true
+	done
+}
 
 # Run one generator, from a given working directory, and prove it actually
 # wrote to its output tree.
@@ -154,8 +188,117 @@ run_generator() {
 
 	MARKER="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-marker.XXXXXX")"
 
-	say "$label: running (in $workdir): $*"
-	if ! (cd "$workdir" && "$@"); then
+	# A bounded, process-tree-aware deadline (GH #511 follow-up). Without
+	# this, a generator -- or a child it spawns, which matters because pnpm
+	# spawns its own children -- that stalls means this script cannot return,
+	# and `make gen` hangs indefinitely. That is exactly the shape this
+	# project's working agreement calls out: never wait on a process with an
+	# unbounded loop.
+	#
+	# This is implemented directly in shell rather than shelled out to
+	# `timeout(1)`: that binary is not installed on every machine this script
+	# runs on (notably not on macOS by default), and a `timeout`-wrapped
+	# command that silently fails to resolve reads as a pass, which is the
+	# exact failure this file exists to prevent. `command -v timeout` was
+	# checked and came back empty here, so the deadline below uses only
+	# `sleep`, `kill` and `ps`, which are assumed present the same way the
+	# rest of the script already assumes `find`/`mktemp`/`cat`.
+	#
+	# An earlier version of this tried to get the child a fresh process group
+	# via job control (`set -m`) and signal `-$pgid`. That is the obvious
+	# answer and it is wrong here: job control needs a controlling terminal,
+	# and `set -m` inside a pipe or `$(...)` -- with no tty -- does not
+	# reliably return. It hung this exact script when driven from the test
+	# suite's `OUT="$(... bash gen-openapi.sh ...)"`, and `ci.yml`'s
+	# `codegen-drift` job invokes this script the same way (piped, no tty), so
+	# the hang was not a test-harness artifact, it would have hung CI. The
+	# watchdog below instead walks `ps`'s parent-pid links (`pid_tree` /
+	# `kill_tree`, defined above) to find every real descendant of the
+	# generator and signals each by pid. TERM first, then KILL after a short
+	# grace period, in case something in the tree traps or ignores TERM.
+	#
+	# Default: 120s. `time make gen` regenerates both trees, together, in
+	# 3.3-4.3s warm. 120s is roughly 30-35x that for a single generator's
+	# share of the work, which comfortably covers a cold CI cache (go module
+	# download, pnpm install) while still turning a real hang into a bounded,
+	# actionable failure within two minutes instead of never returning.
+	# Overridable via GEN_OPENAPI_DEADLINE, which is how the test suite
+	# proves this in seconds rather than minutes.
+	local deadline="${GEN_OPENAPI_DEADLINE:-120}"
+
+	say "$label: running (in $workdir, ${deadline}s deadline): $*"
+
+	# stdin is explicitly /dev/null, not inherited. A backgrounded child that
+	# keeps the invoking shell's controlling terminal as its stdin can stall
+	# indefinitely under that terminal's job-control arbitration even though
+	# it never reads from stdin -- reproduced directly while building this:
+	# the identical command hung until the deadline killed it with stdin
+	# inherited, and returned in under a second with stdin as /dev/null.
+	# Neither generator needs interactive input, so this is also just
+	# correct for a background, deadline-guarded process.
+	(cd "$workdir" && exec "$@") </dev/null &
+	local pid=$!
+
+	TIMEOUT_FLAG="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-timeout.XXXXXX")"
+	rm -f "$TIMEOUT_FLAG"
+
+	(
+		sleep "$deadline"
+		if kill -0 "$pid" 2>/dev/null; then
+			(: >"$TIMEOUT_FLAG") 2>/dev/null || true
+			kill_tree TERM "$pid"
+			sleep 2
+			kill_tree KILL "$pid"
+		fi
+	) &
+	local watchdog=$!
+
+	# Deliberately `if wait; then ... else status=$?; fi`, not `if ! wait;
+	# then status=$?; fi`: with `!`, the `$?` seen inside the `then` branch is
+	# the *negated* status bash assigns to the `!`-prefixed pipeline, not
+	# wait's own exit code, so it silently records the wrong value on every
+	# failure. Caught by the go-fail case below, which expects to see "go/ogen
+	# generator failed" and instead got the wrong branch entirely.
+	local status=0
+	if wait "$pid"; then
+		status=0
+	else
+		status=$?
+	fi
+
+	# The job finished (or was killed) either way; stop the watchdog if it is
+	# still sleeping so a fast, successful run does not wait out the deadline.
+	# `kill "$watchdog"` alone is not enough: the watchdog is a subshell
+	# blocked inside its own `sleep "$deadline"`, and signalling the subshell
+	# terminates the subshell without touching the `sleep` process it is
+	# waiting on -- that leaves `sleep` orphaned (reparented to pid 1) but
+	# still running for the rest of the deadline, still holding this script's
+	# inherited stdout/stderr open. Any caller reading this script's output
+	# through a pipe -- exactly how `scripts/gen-openapi_test.sh` captures it,
+	# and exactly how a caller doing `out=$(... scripts/gen-openapi.sh ...)`
+	# would too -- then blocks reading for EOF that never comes until that
+	# orphaned `sleep` finally finishes. Reproduced directly while building
+	# this: the happy-path case hung past its default 120s deadline with
+	# plain `kill`, and returned immediately once this used `kill_tree`.
+	kill_tree TERM "$watchdog"
+	wait "$watchdog" 2>/dev/null || true
+
+	if [ -f "$TIMEOUT_FLAG" ]; then
+		rm -f "$TIMEOUT_FLAG"
+		TIMEOUT_FLAG=""
+		die "$label generator exceeded its ${deadline}s deadline and was killed, along with
+    every descendant process it had at the time.
+    Working directory: $workdir
+    Command: $*
+    This is the unbounded-wait failure mode: the generator, or a child it
+    spawned, stalled and never returned. Override GEN_OPENAPI_DEADLINE if
+    $label is legitimately this slow; otherwise treat this as a hang in
+    $label and investigate it directly."
+	fi
+	rm -f "$TIMEOUT_FLAG"
+	TIMEOUT_FLAG=""
+
+	if [ "$status" -ne 0 ]; then
 		die "$label generator failed (see its output above).
     Working directory: $workdir
     Command: $*"

--- a/scripts/gen-openapi.sh
+++ b/scripts/gen-openapi.sh
@@ -187,6 +187,19 @@ run_generator() {
 	shift 3
 
 	MARKER="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-marker.XXXXXX")"
+	# Back-dated years into the past, not left at its mktemp-assigned "now":
+	# the write-detection check below is `find -newer "$MARKER"`, a *strict*
+	# newer-than comparison, and a marker created microseconds before a fast
+	# shim's write can tie with it on a coarse-grained filesystem clock. That
+	# tie reads as "wrote nothing" even though the write happened -- caught as
+	# a real, intermittent GH #511-follow-up CI flake (the same commit passed
+	# on one Linux runner and failed on another two seconds later; the failing
+	# run's own output showed the shim ran and printed normally, immediately
+	# followed by "exited 0 but wrote nothing"). Reusing the exact stale
+	# timestamp `make_tree` already seeds output files with removes any chance
+	# of a tie: a live write is unambiguously newer than 2020 regardless of
+	# clock resolution.
+	touch -t 202001010000 "$MARKER"
 
 	# A bounded, process-tree-aware deadline (GH #511 follow-up). Without
 	# this, a generator -- or a child it spawns, which matters because pnpm

--- a/scripts/gen-openapi.sh
+++ b/scripts/gen-openapi.sh
@@ -185,21 +185,20 @@ kill_tree() {
 run_generator() {
 	local label="$1" out="$2" workdir="$3"
 	shift 3
+	local ps_probe ps_probe_status ps_usable ps_pid ps_ppid
 
 	MARKER="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-marker.XXXXXX")"
-	# Back-dated years into the past, not left at its mktemp-assigned "now":
-	# the write-detection check below is `find -newer "$MARKER"`, a *strict*
-	# newer-than comparison, and a marker created microseconds before a fast
-	# shim's write can tie with it on a coarse-grained filesystem clock. That
-	# tie reads as "wrote nothing" even though the write happened -- caught as
-	# a real, intermittent GH #511-follow-up CI flake (the same commit passed
-	# on one Linux runner and failed on another two seconds later; the failing
-	# run's own output showed the shim ran and printed normally, immediately
-	# followed by "exited 0 but wrote nothing"). Reusing the exact stale
-	# timestamp `make_tree` already seeds output files with removes any chance
-	# of a tie: a live write is unambiguously newer than 2020 regardless of
-	# clock resolution.
-	touch -t 202001010000 "$MARKER"
+	# Left at its mktemp-assigned "now", deliberately NOT back-dated. An
+	# earlier version of this back-dated MARKER to a fixed 2020 timestamp to
+	# fix a real, reproduced CI flake (a live write tying with the marker's
+	# creation on a coarse-grained filesystem clock, read by strict `-newer`
+	# as "wrote nothing"). That "fix" was itself wrong and was reverted (PR
+	# #512 review): on a real checkout, the committed tree's files already
+	# have a recent mtime from `git checkout`, not 2020, so *any* pre-existing
+	# file would look "newer than 2020" whether or not this run's generator
+	# wrote anything -- silently reintroducing the exact GH #511 defect this
+	# script exists to catch. See the retry below for how the clock-tie flake
+	# is actually handled without that regression.
 
 	# A bounded, process-tree-aware deadline (GH #511 follow-up). Without
 	# this, a generator -- or a child it spawns, which matters because pnpm
@@ -238,6 +237,67 @@ run_generator() {
 	# Overridable via GEN_OPENAPI_DEADLINE, which is how the test suite
 	# proves this in seconds rather than minutes.
 	local deadline="${GEN_OPENAPI_DEADLINE:-120}"
+
+	# Validated before use: this feeds straight into `sleep "$deadline"`
+	# below. A non-numeric value makes `sleep` error or return immediately,
+	# the watchdog then finds the generator still alive at once, and kills a
+	# perfectly healthy generator while reporting a deadline breach -- a
+	# false accusation indistinguishable from a real one. `0` has the same
+	# effect (`sleep 0` returns immediately too). Reject both, naming what
+	# was actually passed.
+	case "$deadline" in
+	'' | *[!0-9]*)
+		die "GEN_OPENAPI_DEADLINE must be a positive integer number of seconds, got: '$deadline'" ;;
+	esac
+	case "$deadline" in
+	*[1-9]*) : ;;
+	*) die "GEN_OPENAPI_DEADLINE must be greater than 0, got: '$deadline'" ;;
+	esac
+
+	# `sleep` backs the deadline itself (the watchdog's very first command).
+	# If it is missing, the watchdog subshell dies on that line before it can
+	# ever check on the generator, silently disabling the deadline rather
+	# than enforcing it -- the exact unbounded-wait failure this file exists
+	# to prevent, just reached through a missing dependency instead of a
+	# stalled process.
+	if ! command -v sleep >/dev/null 2>&1; then
+		die "'sleep' was not found on PATH, so the ${deadline}s deadline for
+    $label cannot be enforced. Refusing to start $label rather than run it
+    with no enforceable deadline."
+	fi
+
+	# `ps -Ao pid=,ppid=` must both succeed and return data pid_tree can
+	# actually parse, checked before the generator starts, not discovered
+	# when the watchdog needs it. A status-only check is not enough: `ps` can
+	# exit 0 and print nothing (or something that is not "PID PPID" pairs),
+	# and pid_tree/kill_tree would then silently walk zero descendants --
+	# kill_tree still returns success in that case, so a stalled generator's
+	# children, and the watchdog's own `sleep`, would survive a "kill" that
+	# never reached them. That is the exact hang already fixed once in this
+	# file (see kill_tree's own comment above), reachable again by a
+	# different route: a broken `ps` instead of a broken job-control model.
+	ps_probe="$(ps -Ao pid=,ppid= 2>&1)" && ps_probe_status=0 || ps_probe_status=$?
+	if [ "$ps_probe_status" -ne 0 ]; then
+		die "'ps -Ao pid=,ppid=' failed (exit $ps_probe_status), so the deadline
+    watchdog cannot find or signal a stalled generator's descendants.
+    Refusing to start $label rather than start something this script could
+    not safely kill.
+    Output: $ps_probe"
+	fi
+	ps_usable=0
+	while read -r ps_pid ps_ppid; do
+		case "$ps_pid" in '' | *[!0-9]*) continue ;; esac
+		case "$ps_ppid" in '' | *[!0-9]*) continue ;; esac
+		ps_usable=1
+		break
+	done <<<"$ps_probe"
+	if [ "$ps_usable" -ne 1 ]; then
+		die "'ps -Ao pid=,ppid=' exited 0 but returned no usable PID/PPID pairs,
+    so the deadline watchdog cannot find or signal a stalled generator's
+    descendants. Refusing to start $label rather than start something this
+    script could not safely kill.
+    Output: $ps_probe"
+	fi
 
 	say "$label: running (in $workdir, ${deadline}s deadline): $*"
 
@@ -318,11 +378,24 @@ run_generator() {
 	fi
 
 	if [ -z "$(find "$out" -type f -newer "$MARKER" -print -quit 2>/dev/null)" ]; then
-		die "$label generator exited 0 but wrote nothing under:
+		# Ambiguous, not yet a failure: either the generator genuinely wrote
+		# nothing (the GH #511 defect), or it wrote something in the same
+		# filesystem-clock tick as $MARKER's creation, which strict `-newer`
+		# cannot tell apart from "nothing" -- a real, reproduced flake. Wait
+		# out one tick and check exactly once more: a real write, even one
+		# that landed on the same tick as the marker, is unambiguously newer
+		# by then; a genuine no-op still shows nothing. This only costs the
+		# extra second on the rare ambiguous path or the (already-failing)
+		# no-op path -- the common "wrote something, clearly" case never
+		# reaches here.
+		sleep 1
+		if [ -z "$(find "$out" -type f -newer "$MARKER" -print -quit 2>/dev/null)" ]; then
+			die "$label generator exited 0 but wrote nothing under:
       $out
     That is the GH #511 failure: a codegen command that reports success and
     regenerates nothing, leaving a stale tree that looks freshly generated.
     Command: $*"
+		fi
 	fi
 
 	rm -f "$MARKER"

--- a/scripts/gen-openapi.sh
+++ b/scripts/gen-openapi.sh
@@ -186,6 +186,7 @@ run_generator() {
 	local label="$1" out="$2" workdir="$3"
 	shift 3
 	local ps_probe ps_probe_status ps_usable ps_pid ps_ppid
+	local tick_probe tick_advanced tick_attempt
 
 	MARKER="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-marker.XXXXXX")"
 	# Left at its mktemp-assigned "now", deliberately NOT back-dated. An
@@ -197,8 +198,40 @@ run_generator() {
 	# have a recent mtime from `git checkout`, not 2020, so *any* pre-existing
 	# file would look "newer than 2020" whether or not this run's generator
 	# wrote anything -- silently reintroducing the exact GH #511 defect this
-	# script exists to catch. See the retry below for how the clock-tie flake
-	# is actually handled without that regression.
+	# script exists to catch.
+	#
+	# A second attempt at the clock-tie flake -- sleeping one second *after*
+	# an ambiguous (empty) `-newer` result, then re-checking -- was also
+	# wrong and was reverted (PR #512 review, gen-openapi.sh:398). Sleeping
+	# after the fact changes neither MARKER's mtime nor the write's mtime:
+	# both already happened, so the second check compares the exact same two
+	# unchanged values and returns the exact same (empty) answer. A tie
+	# cannot be detected after it has already occurred; it can only be
+	# prevented from occurring. So: prove, not assume, that the filesystem
+	# clock has advanced past MARKER's own mtime before the generator is
+	# allowed to start, by touching a throwaway probe file and checking it
+	# against MARKER with the same `find -newer` the real check below uses.
+	# Once a probe write is observably newer than MARKER, every subsequent
+	# write -- including the generator's -- is guaranteed strictly newer too,
+	# on any clock granularity. Bounded to a fixed number of attempts, not an
+	# unbounded loop: if the clock cannot be observed to advance at all, that
+	# is a hard stop, not a silent hang.
+	tick_probe="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-tick.XXXXXX")"
+	tick_advanced=0
+	for ((tick_attempt = 1; tick_attempt <= 2000; tick_attempt++)); do
+		touch "$tick_probe" 2>/dev/null || true
+		if [ -n "$(find "$tick_probe" -newer "$MARKER" -print -quit 2>/dev/null)" ]; then
+			tick_advanced=1
+			break
+		fi
+	done
+	rm -f "$tick_probe"
+	if [ "$tick_advanced" -ne 1 ]; then
+		die "the filesystem clock did not observably advance past the
+    write-detection marker after 2000 attempts, so $label cannot be started
+    with a write-detection check this script can trust.
+    Marker: $MARKER"
+	fi
 
 	# A bounded, process-tree-aware deadline (GH #511 follow-up). Without
 	# this, a generator -- or a child it spawns, which matters because pnpm
@@ -377,25 +410,16 @@ run_generator() {
     Command: $*"
 	fi
 
+	# No retry needed here: the clock-advance wait above already guarantees
+	# MARKER is strictly older than anything written from this point on, so
+	# a single strict `-newer` check is unambiguous -- empty means the
+	# generator genuinely wrote nothing.
 	if [ -z "$(find "$out" -type f -newer "$MARKER" -print -quit 2>/dev/null)" ]; then
-		# Ambiguous, not yet a failure: either the generator genuinely wrote
-		# nothing (the GH #511 defect), or it wrote something in the same
-		# filesystem-clock tick as $MARKER's creation, which strict `-newer`
-		# cannot tell apart from "nothing" -- a real, reproduced flake. Wait
-		# out one tick and check exactly once more: a real write, even one
-		# that landed on the same tick as the marker, is unambiguously newer
-		# by then; a genuine no-op still shows nothing. This only costs the
-		# extra second on the rare ambiguous path or the (already-failing)
-		# no-op path -- the common "wrote something, clearly" case never
-		# reaches here.
-		sleep 1
-		if [ -z "$(find "$out" -type f -newer "$MARKER" -print -quit 2>/dev/null)" ]; then
-			die "$label generator exited 0 but wrote nothing under:
+		die "$label generator exited 0 but wrote nothing under:
       $out
     That is the GH #511 failure: a codegen command that reports success and
     regenerates nothing, leaving a stale tree that looks freshly generated.
     Command: $*"
-		fi
 	fi
 
 	rm -f "$MARKER"

--- a/scripts/gen-openapi.sh
+++ b/scripts/gen-openapi.sh
@@ -1,6 +1,241 @@
 #!/usr/bin/env bash
-# Regenerate Go server types and the TS client from the OpenAPI source of truth.
-# Codegen tooling is wired in Phase 4 (ADR-004 Go codegen, ADR-013 TS client).
+# scripts/gen-openapi.sh
+#
+# Regenerate both OpenAPI-derived trees from the single source of truth at
+# packages/openapi/openapi.yaml:
+#
+#   apps/api/internal/api/gen/**            (ogen, Go types + validation)
+#   packages/openapi-client/src/generated/**(@hey-api/openapi-ts, TS client)
+#
+# WHY THIS FILE IS NOT THREE LINES (GH #511). Until this commit it was an
+# `echo` that said codegen was "wired in Phase 4" and exited 0. Both
+# generators had been wired and in daily use for months. So the documented
+# command reported success and regenerated nothing: you edited the spec, ran
+# `make gen`, saw it pass, and committed a stale generated tree. Everything
+# downstream then coded against a contract the API no longer served.
+#
+# The lesson this file encodes is that a generator which cannot prove it wrote
+# something is indistinguishable from that `echo`. Every step below is
+# therefore checked three ways: the tool is resolved before it is called, the
+# call must exit 0, and the output tree must contain a file newer than a marker
+# taken immediately before the call. A step that "succeeds" without touching
+# its output tree is a failure here, loudly, with the tree named.
+#
+# RUN IT:
+#   make gen                       regenerate both trees
+#   make gen-check                 regenerate, then fail if the committed trees
+#                                  differ from what was just generated
+#   scripts/gen-openapi.sh [ROOT]  same, against another checkout
+#   scripts/gen-openapi_test.sh    the test suite for this script
+#
+# Exit 0 only when both trees were regenerated (and, under --check, match what
+# is committed). Every other outcome is a non-zero exit with a reason on stderr.
+# There is no skip path and no "tool not installed, moving on" path: a missing
+# tool is a hard stop, because silently skipping half of a two-tree codegen is
+# how the two trees drift apart in the first place.
+#
+# TESTABILITY. ROOT is an argument and both generators are invoked through
+# `go` and `pnpm` found on PATH, so scripts/gen-openapi_test.sh can build a
+# throwaway tree, put shims on PATH, and drive every branch below — including
+# the "generator exited 0 and wrote nothing" branch — without running the real
+# generators or touching this repo.
+
 set -euo pipefail
-cd "$(dirname "$0")/.."
-echo "OpenAPI codegen is wired in Phase 4. Source: packages/openapi/openapi.yaml"
+
+usage() {
+	cat <<'USAGE'
+usage: scripts/gen-openapi.sh [--check] [ROOT]
+
+  --check   after generating, fail if the committed generated trees differ
+            from what was just generated (drift detection for CI)
+  ROOT      repository root to operate on (default: the repo containing this
+            script)
+USAGE
+}
+
+CHECK=0
+ROOT=""
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--check) CHECK=1 ;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		printf 'gen-openapi: unknown option: %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	*)
+		if [ -n "$ROOT" ]; then
+			printf 'gen-openapi: unexpected extra argument: %s\n' "$1" >&2
+			exit 2
+		fi
+		ROOT="$1"
+		;;
+	esac
+	shift
+done
+
+if [ -z "$ROOT" ]; then
+	ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+if [ ! -d "$ROOT" ]; then
+	printf 'gen-openapi: root is not a directory: %s\n' "$ROOT" >&2
+	exit 1
+fi
+ROOT="$(cd "$ROOT" && pwd)"
+
+# The source of truth and the two trees derived from it. Kept as variables so
+# the messages below can always name the concrete path that failed.
+SPEC="$ROOT/packages/openapi/openapi.yaml"
+GO_MOD_DIR="$ROOT/apps/api"
+GO_OUT="$ROOT/apps/api/internal/api/gen"
+TS_PKG="$ROOT/packages/openapi-client"
+TS_OUT="$ROOT/packages/openapi-client/src/generated"
+
+die() {
+	printf 'gen-openapi: ERROR: %s\n' "$*" >&2
+	exit 1
+}
+
+say() { printf 'gen-openapi: %s\n' "$*"; }
+
+# Resolve a required binary or stop. `command -v` returning empty is a hard
+# stop, never a shrug: a codegen step that cannot find its generator must fail
+# loudly, because the alternative is a half-generated pair of trees that looks
+# like a success.
+require_tool() {
+	local bin="$1" why="$2" resolved
+	resolved="$(command -v "$bin" 2>/dev/null || true)"
+	if [ -z "$resolved" ]; then
+		die "required tool '$bin' was not found on PATH.
+    It is needed to $why.
+    PATH=$PATH
+    Install '$bin' and re-run. This step is never skipped."
+	fi
+	printf 'gen-openapi:   %-6s %s\n' "$bin" "$resolved"
+}
+
+require_file() {
+	[ -f "$1" ] || die "$2 is missing: $1"
+}
+
+require_dir() {
+	[ -d "$1" ] || die "$2 is missing: $1"
+}
+
+MARKER=""
+cleanup() { [ -n "$MARKER" ] && rm -f "$MARKER"; return 0; }
+trap cleanup EXIT
+
+# Run one generator, from a given working directory, and prove it actually
+# wrote to its output tree.
+#
+# The marker file is created immediately before the generator runs, so any file
+# the generator writes has a strictly newer mtime. If nothing under the output
+# tree is newer than the marker, the generator did not regenerate anything --
+# which is exactly the GH #511 failure -- and that is an error, not a pass.
+#
+# This does not over-fire on a no-change run: ogen is invoked with --clean and
+# openapi-ts rewrites its output directory, so both rewrite every file on every
+# run even when the bytes are identical. Idempotence here means "same content",
+# not "untouched files"; `--check` is what asserts the content half.
+#
+# The working directory is a parameter and the command runs in a subshell,
+# rather than under `env -C`: `env -C` needs coreutils >= 8.33, which is newer
+# than some CI images ship.
+run_generator() {
+	local label="$1" out="$2" workdir="$3"
+	shift 3
+
+	MARKER="$(mktemp "${TMPDIR:-/tmp}/gen-openapi-marker.XXXXXX")"
+
+	say "$label: running (in $workdir): $*"
+	if ! (cd "$workdir" && "$@"); then
+		die "$label generator failed (see its output above).
+    Working directory: $workdir
+    Command: $*"
+	fi
+
+	if [ -z "$(find "$out" -type f -newer "$MARKER" -print -quit 2>/dev/null)" ]; then
+		die "$label generator exited 0 but wrote nothing under:
+      $out
+    That is the GH #511 failure: a codegen command that reports success and
+    regenerates nothing, leaving a stale tree that looks freshly generated.
+    Command: $*"
+	fi
+
+	rm -f "$MARKER"
+	MARKER=""
+	say "$label: regenerated $out"
+}
+
+say "root: $ROOT"
+say "spec: $SPEC"
+
+require_file "$SPEC" "the OpenAPI source of truth"
+require_dir "$GO_MOD_DIR" "the Go module directory"
+require_dir "$GO_OUT" "the ogen output tree"
+require_dir "$TS_PKG" "the TypeScript client package"
+require_dir "$TS_OUT" "the openapi-ts output tree"
+
+say "tools:"
+require_tool go "run ogen and regenerate $GO_OUT"
+require_tool pnpm "run @hey-api/openapi-ts and regenerate $TS_OUT"
+
+# Go: driven through the //go:generate directive in
+# apps/api/internal/api/gen/generate.go so the ogen flags live in exactly one
+# place. Changing the directive changes what this script runs; there is no
+# second copy of the command here to drift out of sync with it.
+run_generator "go/ogen" "$GO_OUT" "$GO_MOD_DIR" \
+	go generate ./internal/api/gen
+
+# TypeScript: driven through the package's own `generate` script so the
+# openapi-ts flags live in packages/openapi-client/openapi-ts.config.ts, again
+# in exactly one place.
+run_generator "ts/openapi-ts" "$TS_OUT" "$TS_PKG" \
+	pnpm generate
+
+if [ "$CHECK" -eq 0 ]; then
+	say "OK: both trees regenerated from $SPEC"
+	exit 0
+fi
+
+# --check: the committed trees must equal what was just generated. This is the
+# check that catches the stale-tree commit itself, rather than trusting every
+# contributor to have run the command. It is deliberately scoped to the two
+# generated trees, so an unrelated dirty file in the working tree cannot redden
+# it.
+require_tool git "compare the committed generated trees against a fresh generation"
+
+if ! (cd "$ROOT" && git rev-parse --git-dir >/dev/null 2>&1); then
+	die "--check needs a git checkout, and $ROOT is not one."
+fi
+
+say "check: comparing committed trees against the fresh generation"
+
+# --exit-code is what fails; --stat gives a reviewer the shape of the drift.
+if (cd "$ROOT" && git diff --exit-code --stat -- "$GO_OUT" "$TS_OUT"); then
+	say "OK: committed generated trees match a fresh generation"
+	exit 0
+fi
+
+printf '\n' >&2
+cat >&2 <<EOF
+gen-openapi: ERROR: the committed generated trees do not match a fresh
+    generation from packages/openapi/openapi.yaml. The spec and the generated
+    clients have drifted apart.
+
+    Fix it by committing the regeneration:
+
+      make gen
+      git add apps/api/internal/api/gen packages/openapi-client/src/generated
+      git commit
+
+    The full drift is printed above as a diffstat.
+EOF
+exit 1

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -39,16 +39,45 @@ FAIL=0
 WORKROOT="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/gen-openapi-test.XXXXXX")" && pwd)"
 trap 'rm -rf "$WORKROOT"' EXIT
 
-# A PATH with neither `go` nor `pnpm` on it, but with the coreutils the script
-# needs. Cases add a shim directory in front of this.
-BASE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+# The missing-tool cases need a PATH that provably does NOT contain `go` or
+# `pnpm` but still contains the utilities the script under test calls. It is
+# built here as a directory of symlinks to exactly those utilities, rather than
+# hard-coded as a list of system directories.
+#
+# Hard-coding it was wrong, and CI said so: an earlier version used
+# "/usr/bin:/bin:/usr/sbin:/sbin", which is genuinely stripped on macOS but not
+# on a GitHub ubuntu runner, where Go is installed at /usr/bin/go. The abort
+# below caught it rather than letting the missing-tool cases quietly test
+# nothing, which is the whole point of having it.
+BASE_BIN="$WORKROOT/basebin"
+mkdir -p "$BASE_BIN"
 
-if command -v go >/dev/null 2>&1 && PATH="$BASE_PATH" command -v go >/dev/null 2>&1; then
-	printf 'gen-openapi_test: FATAL: `go` is on the stripped PATH (%s), so the\n' "$BASE_PATH" >&2
-	printf '  missing-tool cases cannot be tested honestly. Aborting rather than\n' >&2
-	printf '  reporting a pass that proved nothing.\n' >&2
-	exit 1
-fi
+# bash runs the script under test; the rest are what the script itself calls
+# (mktemp/find/rm for the marker, cat for the drift message, git for --check).
+for tool in bash mktemp find rm cat git; do
+	resolved="$(command -v "$tool" 2>/dev/null || true)"
+	if [ -z "$resolved" ]; then
+		printf 'gen-openapi_test: FATAL: required utility %s not found on PATH.\n' "$tool" >&2
+		printf '  The suite cannot build its stripped PATH without it. Aborting\n' >&2
+		printf '  rather than reporting a pass that proved nothing.\n' >&2
+		exit 1
+	fi
+	ln -sf "$resolved" "$BASE_BIN/$tool"
+done
+
+BASE_PATH="$BASE_BIN"
+
+# Assert the stripped PATH really is stripped. If either generator resolves
+# under it, every missing-tool case below would silently test the opposite of
+# what it claims, so stop instead.
+for tool in go pnpm; do
+	if PATH="$BASE_PATH" command -v "$tool" >/dev/null 2>&1; then
+		printf 'gen-openapi_test: FATAL: `%s` resolves on the stripped PATH (%s),\n' "$tool" "$BASE_PATH" >&2
+		printf '  so the missing-tool cases cannot be tested honestly. Aborting\n' >&2
+		printf '  rather than reporting a pass that proved nothing.\n' >&2
+		exit 1
+	fi
+done
 
 ok() {
 	PASS=$((PASS + 1))

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -53,8 +53,10 @@ BASE_BIN="$WORKROOT/basebin"
 mkdir -p "$BASE_BIN"
 
 # bash runs the script under test; the rest are what the script itself calls
-# (mktemp/find/rm for the marker, cat for the drift message, git for --check).
-for tool in bash mktemp find rm cat git; do
+# (mktemp/find/rm for the marker, cat for the drift message, git for --check,
+# ps/sleep/kill for the run_generator deadline watchdog -- kill is a bash
+# builtin so it needs no PATH entry, but ps and sleep are external).
+for tool in bash mktemp find rm cat git ps sleep; do
 	resolved="$(command -v "$tool" 2>/dev/null || true)"
 	if [ -z "$resolved" ]; then
 		printf 'gen-openapi_test: FATAL: required utility %s not found on PATH.\n' "$tool" >&2

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -404,6 +404,106 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# PR #512 review, finding 1: pid_tree/kill_tree rely on `ps -Ao pid=,ppid=`
+# succeeding with output it can parse. If `ps` is broken, kill_tree still
+# returns success after walking zero descendants -- the watchdog's kill would
+# silently do nothing. run_generator must refuse to start a generator it
+# cannot safely deadline-kill, not proceed and hope. Two failure shapes, since
+# the reviewer named them separately: outright failure, and exit 0 with
+# unusable output (a status-only check would wrongly accept the latter).
+printf '\ncase: ps exits non-zero -- must refuse to start, not proceed\n'
+T="$(make_tree ps_broken)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+printf '#!/bin/sh\nprintf "ps: simulated failure\\n" >&2\nexit 1\n' >"$T/bin/ps"
+chmod +x "$T/bin/ps"
+run_case "$T" "$T"
+expect_status "ps-broken" 1
+expect_output "ps-broken" "'ps -Ao pid=,ppid=' failed"
+
+printf '\ncase: ps exits 0 but returns no usable PID/PPID pairs -- must refuse to start\n'
+T="$(make_tree ps_unusable)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+printf '#!/bin/sh\nexit 0\n' >"$T/bin/ps"
+chmod +x "$T/bin/ps"
+run_case "$T" "$T"
+expect_status "ps-unusable" 1
+expect_output "ps-unusable" "no usable PID/PPID pairs"
+
+# Over-fire control: a working `ps` (the real one, from BASE_PATH -- every
+# other case above already runs with it) must not be blocked by this
+# preflight. The `happy` case already proves this; restated here so the
+# ps-broken/ps-unusable pair has an explicit positive counterpart beside it.
+printf '\ncase: ps works normally -- preflight must not block a real run\n'
+T="$(make_tree ps_ok)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+run_case "$T" "$T"
+expect_status "ps-ok" 0
+expect_output "ps-ok" "OK: both trees regenerated"
+
+# ---------------------------------------------------------------------------
+# PR #512 review, finding 2: GEN_OPENAPI_DEADLINE is used unvalidated. A
+# non-numeric value makes `sleep` error/return immediately, the watchdog then
+# finds the generator still alive at once, and kills a healthy generator
+# while reporting a deadline breach -- a false accusation indistinguishable
+# from a real one. `0` has the same effect. Both must be refused, naming the
+# offending value.
+printf '\ncase: GEN_OPENAPI_DEADLINE is non-numeric -- must be refused, naming it\n'
+T="$(make_tree deadline_nan)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+OUT="$(GEN_OPENAPI_DEADLINE=soon PATH="$T/bin:$BASE_PATH" bash "$UNDER_TEST" "$T" 2>&1)"
+STATUS=$?
+expect_status "deadline-nan" 1
+expect_output "deadline-nan" "GEN_OPENAPI_DEADLINE must be a positive integer"
+expect_output "deadline-nan" "got: 'soon'"
+
+printf '\ncase: GEN_OPENAPI_DEADLINE=0 -- must be refused, naming it\n'
+T="$(make_tree deadline_zero)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+OUT="$(GEN_OPENAPI_DEADLINE=0 PATH="$T/bin:$BASE_PATH" bash "$UNDER_TEST" "$T" 2>&1)"
+STATUS=$?
+expect_status "deadline-zero" 1
+expect_output "deadline-zero" "GEN_OPENAPI_DEADLINE must be greater than 0"
+expect_output "deadline-zero" "got: '0'"
+
+# Over-fire control: a valid, positive-integer deadline must still run
+# normally. The `hang` case above (GEN_OPENAPI_DEADLINE=2) already proves a
+# valid override is accepted and enforced; this proves a valid override still
+# lets a healthy run succeed rather than merely being parsed.
+printf '\ncase: GEN_OPENAPI_DEADLINE is a valid positive integer -- must run normally\n'
+T="$(make_tree deadline_valid)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+OUT="$(GEN_OPENAPI_DEADLINE=30 PATH="$T/bin:$BASE_PATH" bash "$UNDER_TEST" "$T" 2>&1)"
+STATUS=$?
+expect_status "deadline-valid" 0
+expect_output "deadline-valid" "OK: both trees regenerated"
+
+# ---------------------------------------------------------------------------
+# PR #512 review, finding 3: a back-dated MARKER (tried, then reverted) fixed
+# the clock-tie flake but broke the thing this whole script exists to catch --
+# on a real checkout, a pre-existing file already has a recent mtime from
+# `git checkout`, not the test's year-2020 seed stamp, so it would look
+# "newer than 2020" whether or not the generator wrote anything this run. The
+# other no-op cases above (go-noop, ts-noop) do not catch this: their seed
+# files are backdated to 2020 by make_tree, which happened to also satisfy
+# the (wrong) back-dated-marker fix. This case seeds the file at "now",
+# like a real checkout, so it is the one that would have gone wrongly green
+# under that fix.
+printf '\ncase: go writes nothing, pre-existing file has a fresh (checkout-like) mtime -- must still fail\n'
+T="$(make_tree go_noop_fresh)"
+write_shim "$T" go nothing
+write_shim "$T" pnpm write
+touch "$T/apps/api/internal/api/gen/oas_schemas_gen.go"
+run_case "$T" "$T"
+expect_status "go-noop-fresh" 1
+expect_output "go-noop-fresh" "exited 0 but wrote nothing"
+
+# ---------------------------------------------------------------------------
 printf '\n'
 printf 'gen-openapi_test: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -197,8 +197,15 @@ write_shim "$T" go write
 write_shim "$T" pnpm write
 run_case "$T" "$T"
 expect_status "happy" 0
-expect_output "happy" "regenerated $T/apps/api/internal/api/gen"
-expect_output "happy" "regenerated $T/packages/openapi-client/src/generated"
+# Trailing relative portion only, not the full "$T/..." path: $T comes from
+# mktemp -d, and on macOS /tmp is a symlink to /private/tmp (mktemp itself
+# resolves it, so the absolute prefix happens to match), while on Linux
+# there is no such symlink and the prefixes diverge even though the script's
+# behaviour is identical. See go-noop/ts-noop below for where this was
+# caught: it still fails if the message stops naming the tree.
+expect_output "happy" "regenerated"
+expect_output "happy" "apps/api/internal/api/gen"
+expect_output "happy" "packages/openapi-client/src/generated"
 expect_output "happy" "OK: both trees regenerated"
 
 # ---------------------------------------------------------------------------
@@ -227,7 +234,13 @@ write_shim "$T" pnpm write
 run_case "$T" "$T"
 expect_status "go-noop" 1
 expect_output "go-noop" "exited 0 but wrote nothing"
-expect_output "go-noop" "$T/apps/api/internal/api/gen"
+# Trailing relative portion only, not "$T/...": $T is built from mktemp -d,
+# and the absolute prefix the script prints does not portably equal it (this
+# assertion was "$T/apps/api/internal/api/gen" and failed on Linux CI while
+# passing locally on macOS, where /tmp happens to resolve through /private/tmp
+# to the same path mktemp already returns). Still fails if the message stops
+# naming which tree was empty.
+expect_output "go-noop" "apps/api/internal/api/gen"
 
 printf '\ncase: ts generator exits 0 and writes nothing -- must fail\n'
 T="$(make_tree ts_noop)"
@@ -236,7 +249,12 @@ write_shim "$T" pnpm nothing
 run_case "$T" "$T"
 expect_status "ts-noop" 1
 expect_output "ts-noop" "exited 0 but wrote nothing"
-expect_output "ts-noop" "$T/packages/openapi-client/src/generated"
+# Trailing relative portion only -- see the go-noop comment above. This is
+# the exact assertion that failed on Linux CI ("does not mention
+# '/tmp/gen-openapi-test.FsicRA/ts_noop/packages/openapi-client/src/generated'")
+# while the underlying behaviour (exit 1, message naming the tree) was
+# already correct there.
+expect_output "ts-noop" "packages/openapi-client/src/generated"
 
 # ---------------------------------------------------------------------------
 printf '\ncase: generator exits non-zero -- must fail, not continue\n'

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -504,6 +504,64 @@ expect_status "go-noop-fresh" 1
 expect_output "go-noop-fresh" "exited 0 but wrote nothing"
 
 # ---------------------------------------------------------------------------
+# PR #512 review, gen-openapi.sh:398: a marker/write timestamp TIE, deliberately
+# constructed with `touch -r`, exactly as this suite's own comment on
+# write_shim's write/write-b split already warns is fragile if left to real
+# timing ("both runs landed in the same second"). The finding was that
+# sleeping *after* the tie is detected changes neither timestamp, so it
+# cannot resolve one -- the write and the marker both already exist. This
+# case proves that directly: the OLD approach (sleep after an ambiguous
+# result) leaves the tie unresolved; the NEW approach (this script's actual
+# mechanism: wait for an observable clock advance BEFORE the write can
+# happen) resolves it. It is a mechanism proof, not a run through
+# run_generator: a real coarse-grained filesystem clock cannot be forced onto
+# this machine to make run_generator hit a tie honestly, and the earlier
+# version of this suite already learned that lesson the hard way (the
+# write/write-b split above exists because a *different* timing assumption
+# failed silently in the same spot).
+printf '\ncase: a deliberately tied marker/write -- sleep-after does not resolve it, wait-before does\n'
+TIE_DIR="$WORKROOT/tie_mechanism"
+mkdir -p "$TIE_DIR"
+TIE_MARKER="$TIE_DIR/marker"
+touch "$TIE_MARKER"
+TIE_WRITE="$TIE_DIR/write"
+touch -r "$TIE_MARKER" "$TIE_WRITE" # force an exact tie with the marker
+
+if [ -n "$(find "$TIE_WRITE" -newer "$TIE_MARKER" -print -quit 2>/dev/null)" ]; then
+	not_ok "tie-setup" "touch -r did not produce a tie; this case cannot test anything"
+else
+	sleep 1
+	if [ -n "$(find "$TIE_WRITE" -newer "$TIE_MARKER" -print -quit 2>/dev/null)" ]; then
+		not_ok "tie-sleep-after" "sleep-after resolved the tie; expected it not to (this was the bug)"
+	else
+		ok "tie-sleep-after: sleep after the tie leaves it unresolved, as gen-openapi.sh:398 found"
+	fi
+
+	TIE_MARKER2="$TIE_DIR/marker2"
+	touch "$TIE_MARKER2"
+	TIE_PROBE="$TIE_DIR/probe"
+	TIE_ADVANCED=0
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		touch "$TIE_PROBE"
+		if [ -n "$(find "$TIE_PROBE" -newer "$TIE_MARKER2" -print -quit 2>/dev/null)" ]; then
+			TIE_ADVANCED=1
+			break
+		fi
+	done
+	if [ "$TIE_ADVANCED" -ne 1 ]; then
+		not_ok "tie-wait-before" "clock never observably advanced in 10 attempts on this machine"
+	else
+		TIE_WRITE_AFTER="$TIE_DIR/write_after"
+		touch "$TIE_WRITE_AFTER" # the "generator" writes only after the wait
+		if [ -n "$(find "$TIE_WRITE_AFTER" -newer "$TIE_MARKER2" -print -quit 2>/dev/null)" ]; then
+			ok "tie-wait-before: waiting for an observable advance before the write resolves the tie"
+		else
+			not_ok "tie-wait-before" "write after the wait was still not detected as newer"
+		fi
+	fi
+fi
+
+# ---------------------------------------------------------------------------
 printf '\n'
 printf 'gen-openapi_test: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [ "$FAIL" -ne 0 ]; then

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# scripts/gen-openapi_test.sh
+#
+# Test suite for scripts/gen-openapi.sh (GH #511).
+#
+# The bug this guards against is a codegen entry point that exits 0 without
+# generating anything. A suite that only ran the real generators could not test
+# that, because the real generators do work. So each case here builds a
+# throwaway repo-shaped tree and puts shims named `go` and `pnpm` on PATH that
+# behave exactly as badly as we need: write nothing, exit non-zero, or work.
+# That drives every branch of gen-openapi.sh in about a second, with no Go
+# toolchain, no node_modules and no network, and without touching this repo.
+#
+# The one thing shims cannot prove is that the REAL generators regenerate the
+# real trees. That is proven by running `make gen` on the real checkout and by
+# the codegen-drift job in ci.yml, not here.
+#
+# RUN IT:
+#   make gen-test        or  scripts/gen-openapi_test.sh
+#
+# Exit 0 when every case passes, 1 when any case fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="$SCRIPT_DIR/gen-openapi.sh"
+
+if [ ! -f "$UNDER_TEST" ]; then
+	printf 'gen-openapi_test: script under test not found: %s\n' "$UNDER_TEST" >&2
+	exit 1
+fi
+
+PASS=0
+FAIL=0
+# Normalised through `cd && pwd`, because TMPDIR often carries a trailing
+# slash and the script under test normalises its own root the same way. Without
+# this the expected and actual paths differ only by a doubled slash, which is a
+# test bug that reads exactly like a product bug.
+WORKROOT="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/gen-openapi-test.XXXXXX")" && pwd)"
+trap 'rm -rf "$WORKROOT"' EXIT
+
+# A PATH with neither `go` nor `pnpm` on it, but with the coreutils the script
+# needs. Cases add a shim directory in front of this.
+BASE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+if command -v go >/dev/null 2>&1 && PATH="$BASE_PATH" command -v go >/dev/null 2>&1; then
+	printf 'gen-openapi_test: FATAL: `go` is on the stripped PATH (%s), so the\n' "$BASE_PATH" >&2
+	printf '  missing-tool cases cannot be tested honestly. Aborting rather than\n' >&2
+	printf '  reporting a pass that proved nothing.\n' >&2
+	exit 1
+fi
+
+ok() {
+	PASS=$((PASS + 1))
+	printf '  ok   %s\n' "$1"
+}
+
+not_ok() {
+	FAIL=$((FAIL + 1))
+	printf '  FAIL %s\n' "$1"
+	if [ -n "${2:-}" ]; then
+		printf '       %s\n' "$2"
+	fi
+}
+
+# Build a repo-shaped tree: the spec, both output trees (each seeded with an
+# old file so "wrote nothing" is distinguishable from "wrote something"), and a
+# shim directory.
+#
+# $1 = case name. Echoes the tree root.
+make_tree() {
+	local name="$1" root="$WORKROOT/$1"
+	mkdir -p "$root/packages/openapi"
+	mkdir -p "$root/apps/api/internal/api/gen"
+	mkdir -p "$root/packages/openapi-client/src/generated"
+	mkdir -p "$root/bin"
+	printf 'openapi: 3.1.0\n' >"$root/packages/openapi/openapi.yaml"
+	printf 'package gen // stale\n' >"$root/apps/api/internal/api/gen/oas_schemas_gen.go"
+	printf 'export const stale = 1;\n' >"$root/packages/openapi-client/src/generated/types.gen.ts"
+	# Backdate the seeded output so a generator that writes nothing leaves
+	# nothing newer than the marker, on any filesystem timestamp granularity.
+	touch -t 202001010000 "$root/apps/api/internal/api/gen/oas_schemas_gen.go"
+	touch -t 202001010000 "$root/packages/openapi-client/src/generated/types.gen.ts"
+	printf '%s' "$root"
+}
+
+# Install a shim. $1=tree root, $2=name (go|pnpm|git), $3=behaviour:
+#   write    -- exit 0 after writing "generation A" into the output tree
+#   write-b  -- exit 0 after writing "generation B", i.e. different bytes
+#   nothing  -- exit 0 and touch nothing
+#   fail     -- exit 3 with a message
+#
+# `write` and `write-b` differ by content, not by a timestamp. An earlier
+# version of this file wrote `$(date)` and expected two runs to differ; both
+# runs landed in the same second, the bytes matched, and the drift case passed
+# by accident in the wrong direction.
+write_shim() {
+	local root="$1" name="$2" behaviour="$3" target="" shim="$1/bin/$2"
+	case "$name" in
+	go) target="$root/apps/api/internal/api/gen/oas_schemas_gen.go" ;;
+	pnpm) target="$root/packages/openapi-client/src/generated/types.gen.ts" ;;
+	esac
+	{
+		printf '#!/bin/sh\n'
+		printf 'printf "shim %s: %%s\\n" "$*"\n' "$name"
+		case "$behaviour" in
+		write) printf 'printf "generation A\\n" > "%s"\nexit 0\n' "$target" ;;
+		write-b) printf 'printf "generation B, from a changed spec\\n" > "%s"\nexit 0\n' "$target" ;;
+		nothing) printf 'exit 0\n' ;;
+		fail) printf 'printf "shim %s: boom\\n" >&2\nexit 3\n' "$name" ;;
+		esac
+	} >"$shim"
+	chmod +x "$shim"
+}
+
+# Run the script under test against a tree with a shimmed PATH.
+# $1=tree root; remaining args go to the script. Captures combined output in
+# $OUT and the exit status in $STATUS.
+run_case() {
+	local root="$1"
+	shift
+	OUT="$(PATH="$root/bin:$BASE_PATH" bash "$UNDER_TEST" "$@" 2>&1)"
+	STATUS=$?
+}
+
+expect_status() {
+	local name="$1" want="$2"
+	if [ "$STATUS" -eq "$want" ]; then
+		ok "$name: exit $want"
+	else
+		not_ok "$name: expected exit $want, got $STATUS" "output was:
+$OUT"
+	fi
+}
+
+expect_output() {
+	local name="$1" needle="$2"
+	case "$OUT" in
+	*"$needle"*) ok "$name: output mentions '$needle'" ;;
+	*) not_ok "$name: output does not mention '$needle'" "output was:
+$OUT" ;;
+	esac
+}
+
+printf 'gen-openapi_test: %s\n' "$UNDER_TEST"
+printf 'gen-openapi_test: stripped PATH for missing-tool cases: %s\n\n' "$BASE_PATH"
+
+# ---------------------------------------------------------------------------
+printf 'case: both generators write -- must succeed (the over-fire control)\n'
+T="$(make_tree happy)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+run_case "$T" "$T"
+expect_status "happy" 0
+expect_output "happy" "regenerated $T/apps/api/internal/api/gen"
+expect_output "happy" "regenerated $T/packages/openapi-client/src/generated"
+expect_output "happy" "OK: both trees regenerated"
+
+# ---------------------------------------------------------------------------
+printf '\ncase: `go` missing -- must fail loudly, naming go, not skip\n'
+T="$(make_tree no_go)"
+write_shim "$T" pnpm write
+run_case "$T" "$T"
+expect_status "missing-go" 1
+expect_output "missing-go" "required tool 'go' was not found on PATH"
+expect_output "missing-go" "This step is never skipped"
+
+# ---------------------------------------------------------------------------
+printf '\ncase: `pnpm` missing -- must fail loudly, naming pnpm, not skip\n'
+T="$(make_tree no_pnpm)"
+write_shim "$T" go write
+run_case "$T" "$T"
+expect_status "missing-pnpm" 1
+expect_output "missing-pnpm" "required tool 'pnpm' was not found on PATH"
+
+# ---------------------------------------------------------------------------
+# The GH #511 defect itself, in both halves.
+printf '\ncase: go generator exits 0 and writes nothing -- must fail\n'
+T="$(make_tree go_noop)"
+write_shim "$T" go nothing
+write_shim "$T" pnpm write
+run_case "$T" "$T"
+expect_status "go-noop" 1
+expect_output "go-noop" "exited 0 but wrote nothing"
+expect_output "go-noop" "$T/apps/api/internal/api/gen"
+
+printf '\ncase: ts generator exits 0 and writes nothing -- must fail\n'
+T="$(make_tree ts_noop)"
+write_shim "$T" go write
+write_shim "$T" pnpm nothing
+run_case "$T" "$T"
+expect_status "ts-noop" 1
+expect_output "ts-noop" "exited 0 but wrote nothing"
+expect_output "ts-noop" "$T/packages/openapi-client/src/generated"
+
+# ---------------------------------------------------------------------------
+printf '\ncase: generator exits non-zero -- must fail, not continue\n'
+T="$(make_tree go_fail)"
+write_shim "$T" go fail
+write_shim "$T" pnpm write
+run_case "$T" "$T"
+expect_status "go-fail" 1
+expect_output "go-fail" "go/ogen generator failed"
+
+# ---------------------------------------------------------------------------
+printf '\ncase: spec missing -- must fail, naming the spec\n'
+T="$(make_tree no_spec)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+rm -f "$T/packages/openapi/openapi.yaml"
+run_case "$T" "$T"
+expect_status "no-spec" 1
+expect_output "no-spec" "the OpenAPI source of truth is missing"
+
+# ---------------------------------------------------------------------------
+printf '\ncase: output tree missing -- must fail, naming the tree\n'
+T="$(make_tree no_out)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+rm -rf "$T/packages/openapi-client/src/generated"
+run_case "$T" "$T"
+expect_status "no-out" 1
+expect_output "no-out" "the openapi-ts output tree is missing"
+
+# ---------------------------------------------------------------------------
+printf '\ncase: root does not exist -- must fail, not generate into nowhere\n'
+run_case "$WORKROOT/happy" "$WORKROOT/definitely-not-here"
+expect_status "bad-root" 1
+expect_output "bad-root" "root is not a directory"
+
+# ---------------------------------------------------------------------------
+printf '\ncase: unknown option -- must fail, not be ignored\n'
+T="$(make_tree bad_opt)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+run_case "$T" --nope "$T"
+expect_status "bad-opt" 2
+expect_output "bad-opt" "unknown option"
+
+# ---------------------------------------------------------------------------
+# --check: the drift half. Needs a real git repo, so these cases use a real
+# `git` from the stripped PATH.
+git_init() {
+	local root="$1"
+	(
+		cd "$root" || exit 1
+		PATH="$BASE_PATH" git init -q .
+		PATH="$BASE_PATH" git config user.email t@example.com
+		PATH="$BASE_PATH" git config user.name t
+		PATH="$BASE_PATH" git add apps packages
+		PATH="$BASE_PATH" git -c commit.gpgsign=false commit -qm seed
+	) >/dev/null 2>&1
+}
+
+# This is the over-fire control for --check. The shims rewrite both files with
+# the same bytes on every run, so mtimes move but content does not -- exactly
+# what an idempotent generator does against an in-sync tree. It must stay green,
+# or the drift job reddens correct work and gets switched off.
+printf '\ncase: --check, generated content identical to committed -- must pass\n'
+T="$(make_tree check_clean)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+run_case "$T" "$T" # generate once, so the tree holds generated content
+git_init "$T"      # commit that content
+run_case "$T" --check "$T"
+expect_status "check-clean" 0
+expect_output "check-clean" "committed generated trees match a fresh generation"
+
+# The stale-tree commit itself: what is committed is not what the spec now
+# generates.
+printf '\ncase: --check, generated content differs from committed -- must fail\n'
+T="$(make_tree check_drift)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+run_case "$T" "$T"
+git_init "$T"
+write_shim "$T" go write-b
+write_shim "$T" pnpm write-b
+run_case "$T" --check "$T"
+expect_status "check-drift" 1
+expect_output "check-drift" "do not match a fresh"
+expect_output "check-drift" "make gen"
+
+# ---------------------------------------------------------------------------
+printf '\n'
+printf 'gen-openapi_test: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+	exit 1
+fi
+exit 0

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -53,10 +53,11 @@ BASE_BIN="$WORKROOT/basebin"
 mkdir -p "$BASE_BIN"
 
 # bash runs the script under test; the rest are what the script itself calls
-# (mktemp/find/rm for the marker, cat for the drift message, git for --check,
-# ps/sleep/kill for the run_generator deadline watchdog -- kill is a bash
-# builtin so it needs no PATH entry, but ps and sleep are external).
-for tool in bash mktemp find rm cat git ps sleep; do
+# (mktemp/find/rm/touch for the marker, cat for the drift message, git for
+# --check, ps/sleep/kill for the run_generator deadline watchdog -- kill is a
+# bash builtin so it needs no PATH entry, but ps, sleep and touch are
+# external).
+for tool in bash mktemp find rm cat git ps sleep touch; do
 	resolved="$(command -v "$tool" 2>/dev/null || true)"
 	if [ -z "$resolved" ]; then
 		printf 'gen-openapi_test: FATAL: required utility %s not found on PATH.\n' "$tool" >&2

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -115,18 +115,26 @@ make_tree() {
 	printf '%s' "$root"
 }
 
-# Install a shim. $1=tree root, $2=name (go|pnpm|git), $3=behaviour:
+# Install a shim. $1=tree root, $2=name (go|pnpm|git), $3=behaviour, $4=extra
+# (only used by `hang`, see below):
 #   write    -- exit 0 after writing "generation A" into the output tree
 #   write-b  -- exit 0 after writing "generation B", i.e. different bytes
 #   nothing  -- exit 0 and touch nothing
 #   fail     -- exit 3 with a message
+#   hang     -- never returns: ignores SIGTERM itself, spawns a grandchild
+#               that also ignores SIGTERM, writes the grandchild's pid to
+#               $4, then blocks forever. This is the GH #511-follow-up
+#               shape: a stalled generator with a stalled child, and one
+#               that does not die on the deadline's first (TERM) signal, so
+#               reaching it proves the deadline's SIGKILL escalation and not
+#               just its happy path.
 #
 # `write` and `write-b` differ by content, not by a timestamp. An earlier
 # version of this file wrote `$(date)` and expected two runs to differ; both
 # runs landed in the same second, the bytes matched, and the drift case passed
 # by accident in the wrong direction.
 write_shim() {
-	local root="$1" name="$2" behaviour="$3" target="" shim="$1/bin/$2"
+	local root="$1" name="$2" behaviour="$3" extra="${4:-}" target="" shim="$1/bin/$2"
 	case "$name" in
 	go) target="$root/apps/api/internal/api/gen/oas_schemas_gen.go" ;;
 	pnpm) target="$root/packages/openapi-client/src/generated/types.gen.ts" ;;
@@ -139,6 +147,12 @@ write_shim() {
 		write-b) printf 'printf "generation B, from a changed spec\\n" > "%s"\nexit 0\n' "$target" ;;
 		nothing) printf 'exit 0\n' ;;
 		fail) printf 'printf "shim %s: boom\\n" >&2\nexit 3\n' "$name" ;;
+		hang)
+			printf 'trap "" TERM\n'
+			printf '( trap "" TERM; sleep 9999 ) &\n'
+			printf 'printf "%%s\\n" "$!" > "%s"\n' "$extra"
+			printf 'wait\n'
+			;;
 		esac
 	} >"$shim"
 	chmod +x "$shim"
@@ -311,6 +325,64 @@ run_case "$T" --check "$T"
 expect_status "check-drift" 1
 expect_output "check-drift" "do not match a fresh"
 expect_output "check-drift" "make gen"
+
+# ---------------------------------------------------------------------------
+# GH #511 follow-up: run_generator must not wait forever on a stalled
+# generator, or on a child it spawned. The `go` shim here ignores SIGTERM and
+# spawns a grandchild that also ignores SIGTERM, so reaching a failure here
+# proves the deadline's SIGKILL escalation, not just its TERM happy path.
+# GEN_OPENAPI_DEADLINE overrides the production default (120s) so this proves
+# the mechanism in a few seconds instead of two minutes.
+printf '\ncase: generator hangs -- must fail within the deadline, not hang\n'
+T="$(make_tree hang)"
+GRANDCHILD_PID_FILE="$WORKROOT/hang.grandchild.pid"
+rm -f "$GRANDCHILD_PID_FILE"
+write_shim "$T" go hang "$GRANDCHILD_PID_FILE"
+write_shim "$T" pnpm write
+START="$(date +%s)"
+OUT="$(GEN_OPENAPI_DEADLINE=2 PATH="$T/bin:$BASE_PATH" bash "$UNDER_TEST" "$T" 2>&1)"
+STATUS=$?
+ELAPSED=$(($(date +%s) - START))
+expect_status "hang" 1
+expect_output "hang" "exceeded its 2s deadline"
+expect_output "hang" "go/ogen"
+# Grace period in run_generator's watchdog is 2s (TERM, wait, then KILL), so
+# with a 2s deadline this must return in single-digit seconds, not the 9999s
+# the shim would otherwise sleep for.
+if [ "$ELAPSED" -le 20 ]; then
+	ok "hang: returned in ${ELAPSED}s, not hung (2s deadline, ignored SIGTERM)"
+else
+	not_ok "hang: took ${ELAPSED}s to return, expected well under 20s" "output was:
+$OUT"
+fi
+
+# Process-tree cleanup: the grandchild the hung shim spawned -- which also
+# ignores SIGTERM, forcing the SIGKILL escalation -- must not survive. This is
+# the concrete proof that the kill reaches the whole descendant tree, not just
+# the direct go/pnpm invocation. Demonstrated portably with plain `kill -0`
+# polling (works on both the BSD ps/kill this suite otherwise assumes and on
+# Linux); it is not a process-group proof, because run_generator deliberately
+# does not use process groups (see the comment in run_generator on why job
+# control hung this exact script when piped, which is how this suite invokes
+# it).
+if [ ! -s "$GRANDCHILD_PID_FILE" ]; then
+	not_ok "hang: grandchild pid file was never written" "the hang shim did not run as expected"
+else
+	GC_PID="$(cat "$GRANDCHILD_PID_FILE")"
+	GONE=0
+	for _ in 1 2 3 4 5 6 7 8; do
+		if ! kill -0 "$GC_PID" 2>/dev/null; then
+			GONE=1
+			break
+		fi
+		sleep 1
+	done
+	if [ "$GONE" -eq 1 ]; then
+		ok "hang: grandchild pid $GC_PID did not survive the deadline (descendant-tree kill)"
+	else
+		not_ok "hang: grandchild pid $GC_PID is still alive after the deadline" "descendant-tree kill did not reach it"
+	fi
+fi
 
 # ---------------------------------------------------------------------------
 printf '\n'

--- a/scripts/gen-openapi_test.sh
+++ b/scripts/gen-openapi_test.sh
@@ -53,11 +53,12 @@ BASE_BIN="$WORKROOT/basebin"
 mkdir -p "$BASE_BIN"
 
 # bash runs the script under test; the rest are what the script itself calls
-# (mktemp/find/rm/touch for the marker, cat for the drift message, git for
+# (mktemp/find/rm/touch for the marker and the wall-clock-bounded tick-advance
+# wait, date for that wait's budget, cat for the drift message, git for
 # --check, ps/sleep/kill for the run_generator deadline watchdog -- kill is a
-# bash builtin so it needs no PATH entry, but ps, sleep and touch are
+# bash builtin so it needs no PATH entry, but ps, sleep, touch and date are
 # external).
-for tool in bash mktemp find rm cat git ps sleep touch; do
+for tool in bash mktemp find rm cat git ps sleep touch date; do
 	resolved="$(command -v "$tool" 2>/dev/null || true)"
 	if [ -z "$resolved" ]; then
 		printf 'gen-openapi_test: FATAL: required utility %s not found on PATH.\n' "$tool" >&2
@@ -559,6 +560,43 @@ else
 			not_ok "tie-wait-before" "write after the wait was still not detected as newer"
 		fi
 	fi
+fi
+
+# ---------------------------------------------------------------------------
+# PR #512 review, gen-openapi.sh:227: the wait-before loop was bounded by a
+# fixed attempt count (2000 undelayed touch+find pairs), not by elapsed time.
+# On a fast host with coarse mtime granularity, all 2000 attempts can finish
+# inside a single tick with no sleep between them, so the clock never
+# advances, the count exhausts, and a perfectly healthy run fails before the
+# generator is even invoked -- the mirror image of the original unbounded-wait
+# defect: a wait bounded in the wrong unit. Simulated here by shimming `find`
+# to always report nothing (as if nothing is ever newer than anything, the
+# permanent-tie condition), which no attempt count can ever get past. If the
+# loop is genuinely bounded by wall-clock time, it must fail at approximately
+# GEN_OPENAPI_TICK_WAIT seconds regardless of how many attempts that allowed,
+# not run some huge, timing-dependent number of undelayed iterations first.
+printf '\ncase: clock never observably advances -- must fail within the wall-clock budget, not after N spins\n'
+T="$(make_tree tick_never_advances)"
+write_shim "$T" go write
+write_shim "$T" pnpm write
+printf '#!/bin/sh\nexit 0\n' >"$T/bin/find"
+chmod +x "$T/bin/find"
+TICK_START="$(date +%s)"
+OUT="$(GEN_OPENAPI_TICK_WAIT=2 PATH="$T/bin:$BASE_PATH" bash "$UNDER_TEST" "$T" 2>&1)"
+STATUS=$?
+TICK_ELAPSED=$(($(date +%s) - TICK_START))
+expect_status "tick-never-advances" 1
+expect_output "tick-never-advances" "did not observably advance"
+expect_output "tick-never-advances" "within 2s"
+expect_output "tick-never-advances" "go/ogen"
+# Bounded by the 2s budget, not instant (which would mean no real wait
+# happened) and not far beyond it (which would mean it is still spinning on
+# attempt count under the hood). A few seconds of slack for process overhead.
+if [ "$TICK_ELAPSED" -ge 1 ] && [ "$TICK_ELAPSED" -le 10 ]; then
+	ok "tick-never-advances: failed at ${TICK_ELAPSED}s, bounded by the 2s wall-clock budget"
+else
+	not_ok "tick-never-advances: took ${TICK_ELAPSED}s, expected close to the 2s budget" "output was:
+$OUT"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #511.

## The defect

`make gen` ran `scripts/gen-openapi.sh`, which was an `echo` and an `exit 0`:

```
$ bash scripts/gen-openapi.sh; echo "exit=$?"
OpenAPI codegen is wired in Phase 4. Source: packages/openapi/openapi.yaml
exit=0
```

Both generators had been wired and in daily use for months. So the documented
command reported success and regenerated nothing: you edited
`packages/openapi/openapi.yaml`, ran `make gen`, saw it pass, and committed a
stale generated tree. The spec and the clients diverged silently, and every
consumer coded against a contract the API no longer served.

The comment deferring to "Phase 4 (ADR-004, ADR-013)" was stale in the same way
and is gone.

## What changed

`scripts/gen-openapi.sh` now either performs both generations or fails loudly.

- **A missing tool fails, it does not skip.** `go` and `pnpm` are resolved with
  `command -v` *before* any generation runs; an empty result is a hard stop that
  names the binary and prints the `PATH` it searched.
- **One place, not two.** Each generator is driven through its own existing
  single source of truth — the `//go:generate` directive in
  `apps/api/internal/api/gen/generate.go` and the `generate` script in
  `packages/openapi-client` — so the flags are not copied into a second place.
  CI runs the same script, not a re-spelling of it.
- **Every step proves it wrote something.** A marker file is taken immediately
  before each generator runs; if nothing under the output tree is newer
  afterwards, that is an error. A generator that exits 0 and touches nothing is
  the #511 failure itself, and it can no longer pass.
- **`--check`** regenerates and then fails if the committed trees differ from
  the fresh generation.

`scripts/gen-openapi_test.sh` is the committed suite (30 assertions), following
the `check-version-surfaces.sh` pattern. It builds throwaway repo-shaped trees
and puts shims named `go` and `pnpm` on a stripped `PATH`, so it can drive the
"exited 0 and wrote nothing" branch that the real generators cannot produce — in
about a second, with no toolchain and no network. If the stripped `PATH` turns
out to contain a real `go`, it aborts rather than reporting a pass that proved
nothing.

`ci.yml` gains a `codegen-drift` job. The self-test runs **first**, so a guard
that has failed open cannot pass by finding nothing.

New targets: `make gen-check`, `make gen-test`.

## Why the CI check is in this change

It was worth judging separately, and the deciding number is cost: the full
regeneration of both trees takes **4.3 s** (`time make gen`, below). That is
noise next to the existing setup steps, and without it the fix relies on every
contributor running the right command — the same trust model that produced the
bug. It is a separate job, so it is off the critical path.

The drift comparison lives in the script rather than a YAML block scalar, and is
covered by the same suite.

## Proof

### 1. A spec change now reaches both trees

Planted a new `gh511Probe` property on the `Health` schema in
`packages/openapi/openapi.yaml`.

Old script, same plant:

```
$ git show origin/main:scripts/gen-openapi.sh > /tmp/old-gen-openapi.sh
$ bash /tmp/old-gen-openapi.sh; echo "old script exit=$?"
OpenAPI codegen is wired in Phase 4. Source: packages/openapi/openapi.yaml
old script exit=0
$ git status --porcelain -- apps/api/internal/api/gen packages/openapi-client/src/generated
                      <-- empty: exited 0, regenerated nothing
```

New script, same plant:

```
$ make gen; echo "exit=$?"
... exit=0
$ git diff --stat -- apps/api/internal/api/gen packages/openapi-client/src/generated
 apps/api/internal/api/gen/oas_json_gen.go            | 19 ++++++++++++++++++-
 apps/api/internal/api/gen/oas_schemas_gen.go         | 12 ++++++++++++
 packages/openapi-client/src/generated/schemas.gen.ts |  4 ++++
 packages/openapi-client/src/generated/types.gen.ts   |  4 ++++
 4 files changed, 38 insertions(+), 1 deletion(-)
```

Both trees move, Go and TS.

### 2. A missing generator fails, naming what is missing

```
$ PATH=/usr/bin:/bin ./scripts/gen-openapi.sh; echo "exit=$?"
gen-openapi: tools:
gen-openapi: ERROR: required tool 'go' was not found on PATH.
    It is needed to run ogen and regenerate .../apps/api/internal/api/gen.
    PATH=/usr/bin:/bin
    Install 'go' and re-run. This step is never skipped.
exit=1
```

```
$ PATH=/tmp/gh511-gobin:/usr/bin:/bin ./scripts/gen-openapi.sh; echo "exit=$?"
gen-openapi: tools:
gen-openapi:   go     /tmp/gh511-gobin/go
gen-openapi: ERROR: required tool 'pnpm' was not found on PATH.
    It is needed to run @hey-api/openapi-ts and regenerate .../packages/openapi-client/src/generated.
    PATH=/tmp/gh511-gobin:/usr/bin:/bin
    Install 'pnpm' and re-run. This step is never skipped.
exit=1
```

Both stop before any generation runs, so neither leaves a half-generated pair.

### 3. Idempotence

```
$ make gen; echo "exit=$?"          # first run
exit=0
$ make gen; echo "exit=$?"          # second run
exit=0
$ git status --porcelain -- apps/api/internal/api/gen packages/openapi-client/src/generated
                      <-- empty after the second run
```

### 4. Over-fire control: an unmodified checkout stays green

```
$ git status --porcelain -- apps/api/internal/api/gen packages/openapi-client/src/generated
                      <-- clean before
$ time make gen
gen-openapi: OK: both trees regenerated from .../packages/openapi/openapi.yaml
make gen  5.15s user 0.76s system 137% cpu 4.303 total
$ git status --porcelain -- apps/api/internal/api/gen packages/openapi-client/src/generated
                      <-- still clean: changed nothing
```

The committed trees on `main` were already in sync with the spec, so the new job
would not have reddened this checkout.

### 5. `--check` fires on a real stale-tree commit

Spec carrying the plant, generated trees reset to their committed state — i.e.
exactly the commit shape #511 allows:

```
$ make gen-check; echo "exit=$?"
gen-openapi: check: comparing committed trees against the fresh generation
 apps/api/internal/api/gen/oas_json_gen.go            | 19 ++++++++++++++++++-
 apps/api/internal/api/gen/oas_schemas_gen.go         | 12 ++++++++++++
 packages/openapi-client/src/generated/schemas.gen.ts |  4 ++++
 packages/openapi-client/src/generated/types.gen.ts   |  4 ++++
 4 files changed, 38 insertions(+), 1 deletion(-)

gen-openapi: ERROR: the committed generated trees do not match a fresh
    generation from packages/openapi/openapi.yaml. The spec and the generated
    clients have drifted apart.

    Fix it by committing the regeneration:

      make gen
      git add apps/api/internal/api/gen packages/openapi-client/src/generated
      git commit
exit=2
```

### 6. The suite

```
$ scripts/gen-openapi_test.sh
...
gen-openapi_test: 30 passed, 0 failed
```

Cases: both generators write (over-fire control) · `go` missing · `pnpm`
missing · go generator exits 0 and writes nothing · ts generator exits 0 and
writes nothing · generator exits non-zero · spec missing · output tree missing ·
root does not exist · unknown option · `--check` clean (over-fire control) ·
`--check` drifted.

The suite found two real defects while being written: a doubled-slash path in
the script's own echo, and a fixture that compared two `date` strings from the
same second and so passed the drift case in the wrong direction. Both are fixed
and commented.

### 7. CI evidence (the parts only a runner could prove)

**The suite's abort fired for real, on the first run.** The stripped PATH used
by the missing-tool cases was hard-coded as `/usr/bin:/bin:/usr/sbin:/sbin`,
which is genuinely stripped on macOS but not on a GitHub ubuntu runner, where Go
is installed at `/usr/bin/go`. Run 32484548243, job 96778034110:

```
gen-openapi_test: FATAL: `go` is on the stripped PATH (/usr/bin:/bin:/usr/sbin:/sbin), so the
  missing-tool cases cannot be tested honestly. Aborting rather than
  reporting a pass that proved nothing.
##[error]Process completed with exit code 1.
```

That is the guard refusing to report a pass over its own broken premise —
without it, six missing-tool assertions would have gone green while testing the
opposite of what they claim. Fixed in `ef87345c`: the PATH is now a directory of
symlinks to exactly the binaries needed (`bash`, `mktemp`, `find`, `rm`, `cat`,
`git`), each resolved with `command -v`, with a hard stop if any is missing, and
the abort now covers `pnpm` as well as `go`.

**Cross-platform determinism, which was the open over-fire risk.** The proofs
above ran on macOS; the concern was that ogen or prettier might emit different
bytes on Linux and redden every PR. The runner answers it (job 96778873685):

```
gen-openapi_test: 30 passed, 0 failed
gen-openapi: go/ogen: regenerated /home/runner/work/wpmgr/wpmgr/apps/api/internal/api/gen
gen-openapi: ts/openapi-ts: regenerated /home/runner/work/wpmgr/wpmgr/packages/openapi-client/src/generated
gen-openapi: OK: committed generated trees match a fresh generation
```

Both trees regenerate on Linux and match trees generated on macOS byte for byte.
`Codegen drift (OpenAPI -> Go + TS)` passes in **47s**, and every other `ci.yml`
job is green.

### Plants removed

```
$ git diff --stat
 .claude/rules/ci-and-build-logic.md |  ...
 .github/workflows/ci.yml            |  57 +++++++++++
 Makefile                            |  14 ++-
 scripts/gen-openapi.sh              | 243 +++++++++++++++++++++++++++++++++++-
```

No change to `packages/openapi/openapi.yaml` or to either generated tree. The
generated trees were never hand-edited; the script invokes the generators.

## Not fixed here

- `packages/openapi-client/openapi-ts.config.ts` carries a stale `NOTE (M5)`
  claiming the package "vendors a local copy" of the spec. Its `input` is
  `../openapi/openapi.yaml` and no local copy exists. Same stale-comment class,
  but `packages/**` is the frontend owner's path.
- `api-integration.yml` and `ci.yml` still hard-code "344 tests" in four places.
  Unrelated to #511.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable OpenAPI client generation for Go and TypeScript.
  * Added commands to regenerate clients, validate generated output, and run generator tests.
  * Added configurable generation deadlines to prevent stalled processes.

* **Bug Fixes**
  * Generation now clearly reports missing tools, inputs, outputs, failures, and no-op results.
  * Added drift detection to identify generated files that differ from committed output.
  * Added automated CI validation for generated code consistency.

* **Documentation**
  * Updated CI documentation to describe generated-code validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->