### PR TITLE
feat(db): m120 — capability set, key kind and site allowlist for API keys (#510)

### DIFF
--- a/apps/api/db/query/api_keys.sql
+++ b/apps/api/db/query/api_keys.sql
@@ -1,6 +1,20 @@
+-- CreateAPIKey is the ONLY INSERT path for api_keys, deliberately. m120 (#510)
+-- extended it in place rather than adding a second capability-aware INSERT
+-- alongside it: two INSERT statements over a table whose CHECK constraints
+-- encode an authorization contract is one statement that can forget a column,
+-- and the column it forgets defaults to the permissive legacy value.
+--
+-- Callers pass auth_model='role' + capabilities=NULL for a legacy role key, or
+-- auth_model='capability' + a non-NULL (possibly empty) set for a least-
+-- privilege key. api_keys_auth_model_capabilities_check refuses every other
+-- combination, so an inconsistent pair fails 23514 here rather than
+-- authenticating with surprise authority later.
 -- name: CreateAPIKey :one
-INSERT INTO api_keys (tenant_id, name, prefix, key_hash, role)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO api_keys (
+    tenant_id, name, prefix, key_hash, role,
+    kind, auth_model, capabilities, site_scope, allowed_site_ids
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING *;
 
 -- name: GetAPIKey :one

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -571,7 +571,65 @@ CREATE TABLE api_keys (
     role         text        NOT NULL DEFAULT 'operator',
     created_at   timestamptz NOT NULL DEFAULT now(),
     last_used_at timestamptz,
-    revoked_at   timestamptz
+    revoked_at   timestamptz,
+    -- m120 (#510): explicit capability set + site allowlist, so a machine
+    -- principal can be granted least privilege instead of a whole role rank.
+    -- What sort of principal this key represents. Closed discriminator.
+    kind             text   NOT NULL DEFAULT 'integration',
+    -- How permissions are computed: 'role' (legacy, authz.Allows over role) or
+    -- 'capability' (the capabilities set is authoritative and role is NOT
+    -- consulted). Deliberately redundant with `capabilities IS NOT NULL` and
+    -- held in lockstep by api_keys_auth_model_capabilities_check: SQL NULL and
+    -- '{}' both scan into a zero-length []string in Go, and that collapse is
+    -- the fail-open this column exists to prevent.
+    auth_model       text   NOT NULL DEFAULT 'role',
+    -- Nullable, NO default. '{}' as a default would give every pre-existing key
+    -- a zero-length capability set and strip the fleet's authority at boot.
+    capabilities     text[],
+    -- 'org' (tenant-wide, the existing behaviour) or 'site'. Values are exactly
+    -- domain.ScopeOrg / domain.ScopeSite.
+    site_scope       text   NOT NULL DEFAULT 'org',
+    -- Site allowlist. STORED HERE, NOT ENFORCED HERE: no RLS policy reads it.
+    -- The boundary is application-enforced in Go at one audited chokepoint in
+    -- v1; database-level site scoping for API-key principals is v2. NOT NULL
+    -- with an empty default because site_scope carries the "is restricted"
+    -- signal, so this column never needs NULL to mean "unrestricted".
+    allowed_site_ids uuid[] NOT NULL DEFAULT '{}'::uuid[],
+
+    -- m120: closed structural discriminators ARE constrained here.
+    CONSTRAINT api_keys_kind_check       CHECK (kind IN ('integration', 'agent')),
+    CONSTRAINT api_keys_auth_model_check CHECK (auth_model IN ('role', 'capability')),
+    CONSTRAINT api_keys_site_scope_check CHECK (site_scope IN ('org', 'site')),
+    -- Shape of the capability set only. The 30-string permission vocabulary is
+    -- owned by internal/authz/role.go and grows with ordinary feature work;
+    -- enumerating it in a CHECK would make every new permission fail 23514 in
+    -- production until a migration caught up, and migrations apply inside
+    -- main() at boot. Uses IMMUTABLE primitives exclusively (array_to_string is
+    -- STABLE, so a whole-array regex is not available here).
+    CONSTRAINT api_keys_capabilities_shape_check CHECK (
+        capabilities IS NULL
+        OR (
+            coalesce(array_ndims(capabilities), 1) = 1
+            AND cardinality(capabilities) <= 64
+            AND array_position(capabilities, NULL) IS NULL
+            AND NOT ('' = ANY (capabilities))
+        )
+    ),
+    -- Keeps auth_model and capabilities from ever diverging.
+    CONSTRAINT api_keys_auth_model_capabilities_check CHECK (
+        (auth_model = 'capability' AND capabilities IS NOT NULL)
+        OR (auth_model = 'role' AND capabilities IS NULL)
+    ),
+    -- An org-scoped key must not carry an allowlist: that half-state invites two
+    -- readers to disagree about where the boundary is.
+    CONSTRAINT api_keys_site_scope_allowlist_check CHECK (
+        site_scope = 'site' OR cardinality(allowed_site_ids) = 0
+    ),
+    -- The least-privilege guarantee in the database: an agent key can never
+    -- fall back to whole-role authority.
+    CONSTRAINT api_keys_agent_capability_check CHECK (
+        kind <> 'agent' OR auth_model = 'capability'
+    )
 );
 
 -- prefix is globally unique so the auth middleware can look a key up by prefix

--- a/apps/api/internal/apikey/apikey.go
+++ b/apps/api/internal/apikey/apikey.go
@@ -29,6 +29,15 @@ const keyPrefix = "wpmgr"
 
 var b32 = base32.StdEncoding.WithPadding(base32.NoPadding)
 
+// KindIntegration is an ordinary operator-minted key. Default; may use either
+// authorization model.
+const KindIntegration = "integration"
+
+// KindAgent is a machine principal minted for an automated caller. m120's
+// api_keys_agent_capability_check refuses an agent key on the role model, so
+// these are always least-privilege.
+const KindAgent = "agent"
+
 // APIKey is a stored key record (never includes the secret).
 type APIKey struct {
 	ID         uuid.UUID
@@ -39,6 +48,38 @@ type APIKey struct {
 	CreatedAt  time.Time
 	LastUsedAt *time.Time
 	RevokedAt  *time.Time
+
+	// Kind is KindIntegration or KindAgent.
+	Kind string
+	// AuthModel is domain.AuthModelRole or domain.AuthModelCapability. It is
+	// the sole discriminator for how this key's permissions are computed, and
+	// it is NOT derivable from Capabilities: a NULL capabilities column and an
+	// empty one both scan into a zero-length slice.
+	AuthModel string
+	// Capabilities is the explicit permission set, non-nil exactly when
+	// AuthModel is domain.AuthModelCapability. Nil for a role key.
+	Capabilities []string
+	// SiteScope is domain.ScopeOrg or domain.ScopeSite.
+	SiteScope string
+	// AllowedSiteIDs is the site allowlist, non-empty only when SiteScope is
+	// domain.ScopeSite. STORED, NOT ENFORCED BY RLS: no policy reads the
+	// column (see the m120 header). The site boundary for these principals is
+	// enforced in Go, and the enforcement chokepoint is NOT yet wired — see
+	// PrincipalFor.
+	AllowedSiteIDs []uuid.UUID
+}
+
+// CapabilitySpec describes a least-privilege key to be minted.
+type CapabilitySpec struct {
+	// Kind is KindIntegration or KindAgent. Empty defaults to KindIntegration.
+	Kind string
+	// Capabilities is the explicit permission set. It MUST be non-nil; an
+	// empty non-nil set is legal and means zero authority. Nil is refused,
+	// because nil is how a role key is represented and accepting it here would
+	// mint a role key wearing a capability label.
+	Capabilities []string
+	// AllowedSiteIDs restricts the key to these sites. Empty means org scope.
+	AllowedSiteIDs []uuid.UUID
 }
 
 // Created bundles a freshly created key with its one-time plaintext token.
@@ -86,12 +127,17 @@ func NewService(pool *db.Pool) *Service {
 
 func toModel(k sqlc.ApiKey) APIKey {
 	m := APIKey{
-		ID:        k.ID,
-		TenantID:  k.TenantID,
-		Name:      k.Name,
-		Prefix:    k.Prefix,
-		Role:      authz.Role(k.Role),
-		CreatedAt: k.CreatedAt,
+		ID:             k.ID,
+		TenantID:       k.TenantID,
+		Name:           k.Name,
+		Prefix:         k.Prefix,
+		Role:           authz.Role(k.Role),
+		CreatedAt:      k.CreatedAt,
+		Kind:           k.Kind,
+		AuthModel:      k.AuthModel,
+		Capabilities:   k.Capabilities,
+		SiteScope:      k.SiteScope,
+		AllowedSiteIDs: k.AllowedSiteIds,
 	}
 	if k.LastUsedAt.Valid {
 		t := k.LastUsedAt.Time
@@ -116,24 +162,123 @@ func (s *Service) Create(ctx context.Context, tenantID uuid.UUID, name string, r
 	if role == authz.RoleClient {
 		return Created{}, domain.Validation("apikey_role_invalid", "client role cannot be assigned to an API key")
 	}
-	prefix, err := randomToken(6)
+	prefix, secret, err := newTokenParts()
 	if err != nil {
-		return Created{}, domain.Internal("apikey_gen_failed", "failed to generate key").WithCause(err)
+		return Created{}, err
 	}
-	secret, err := randomToken(24)
-	if err != nil {
-		return Created{}, domain.Internal("apikey_gen_failed", "failed to generate key").WithCause(err)
-	}
-	token := keyPrefix + "_" + prefix + "_" + secret
+	// m120 (#510): the three discriminator columns and the two array columns are
+	// passed EXPLICITLY. Leaving them off a keyed literal is not a compile
+	// error — it silently sends "" for the strings and SQL NULL for the arrays,
+	// which the CHECK and NOT NULL constraints then refuse at runtime. Keep
+	// every column named here even where the value equals the column default.
+	return s.insert(ctx, tenantID, name, prefix, secret, insertSpec{
+		role:      role,
+		kind:      KindIntegration,
+		authModel: domain.AuthModelRole,
+		// nil, not []string{}: SQL NULL is what the role model requires, and
+		// api_keys_auth_model_capabilities_check enforces the pairing.
+		capabilities: nil,
+		siteScope:    domain.ScopeOrg,
+		// Non-nil empty, not nil: the column is NOT NULL DEFAULT '{}', and a
+		// nil slice encodes as SQL NULL, which fails 23502.
+		allowedSiteIDs: []uuid.UUID{},
+	})
+}
 
+// CreateCapability mints a least-privilege key whose authority is an explicit
+// capability set. The stored role is deliberately RoleClient — the one role
+// that holds zero permissions in the matrix — so that if any future code path
+// ever reaches this key's role instead of its capabilities, the answer is "no"
+// rather than a silent grant. The capability model does not consult it, and
+// nothing should, but a fail-safe value costs nothing here.
+func (s *Service) CreateCapability(ctx context.Context, tenantID uuid.UUID, name string, spec CapabilitySpec) (Created, error) {
+	if name == "" {
+		return Created{}, domain.Validation("apikey_name_required", "API key name is required")
+	}
+	kind := spec.Kind
+	if kind == "" {
+		kind = KindIntegration
+	}
+	if kind != KindIntegration && kind != KindAgent {
+		return Created{}, domain.Validation("apikey_kind_invalid", "invalid API key kind")
+	}
+	// Vocabulary and per-element format live here because the database
+	// deliberately does not enumerate the permission strings; see
+	// authz.ValidateCapabilities. An unknown capability is refused, not dropped.
+	if err := authz.ValidateCapabilities(spec.Capabilities); err != nil {
+		return Created{}, err
+	}
+
+	// Normalise the capability set to non-nil so it reaches Postgres as '{}'
+	// rather than NULL. ValidateCapabilities already refused a nil set, so this
+	// only ever converts an empty-but-non-nil slice that pgx would still encode
+	// correctly — it is belt-and-braces against a future caller path.
+	caps := spec.Capabilities
+	if caps == nil {
+		caps = []string{}
+	}
+
+	siteScope := domain.ScopeOrg
+	allowed := []uuid.UUID{}
+	if len(spec.AllowedSiteIDs) > 0 {
+		siteScope = domain.ScopeSite
+		allowed = append(allowed, spec.AllowedSiteIDs...)
+	}
+
+	prefix, secret, err := newTokenParts()
+	if err != nil {
+		return Created{}, err
+	}
+	return s.insert(ctx, tenantID, name, prefix, secret, insertSpec{
+		role:           authz.RoleClient,
+		kind:           kind,
+		authModel:      domain.AuthModelCapability,
+		capabilities:   caps,
+		siteScope:      siteScope,
+		allowedSiteIDs: allowed,
+	})
+}
+
+// insertSpec carries the full api_keys column set for one INSERT. It exists so
+// that both mint paths go through a single struct literal that names every
+// m120 column, making an omission a compile error at the one place it is built
+// rather than a silent zero value at each call site.
+type insertSpec struct {
+	role           authz.Role
+	kind           string
+	authModel      string
+	capabilities   []string
+	siteScope      string
+	allowedSiteIDs []uuid.UUID
+}
+
+func newTokenParts() (prefix, secret string, err error) {
+	prefix, err = randomToken(6)
+	if err != nil {
+		return "", "", domain.Internal("apikey_gen_failed", "failed to generate key").WithCause(err)
+	}
+	secret, err = randomToken(24)
+	if err != nil {
+		return "", "", domain.Internal("apikey_gen_failed", "failed to generate key").WithCause(err)
+	}
+	return prefix, secret, nil
+}
+
+func (s *Service) insert(ctx context.Context, tenantID uuid.UUID, name, prefix, secret string, spec insertSpec) (Created, error) {
+	token := keyPrefix + "_" + prefix + "_" + secret
 	var created Created
-	err = s.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+	err := s.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		row, err := sqlc.New(tx).CreateAPIKey(ctx, sqlc.CreateAPIKeyParams{
-			TenantID: tenantID,
-			Name:     name,
-			Prefix:   prefix,
-			KeyHash:  hashSecret(secret),
-			Role:     string(role),
+			TenantID:       tenantID,
+			Name:           name,
+			Prefix:         prefix,
+			KeyHash:        hashSecret(secret),
+			Role:           string(spec.role),
+			Kind:           spec.kind,
+			AuthModel:      spec.authModel,
+			Capabilities:   spec.capabilities,
+			SiteScope:      spec.siteScope,
+			AllowedSiteIds: spec.allowedSiteIDs,
 		})
 		if err != nil {
 			return domain.Internal("apikey_create_failed", "failed to create API key").WithCause(err)
@@ -142,6 +287,38 @@ func (s *Service) Create(ctx context.Context, tenantID uuid.UUID, name string, r
 		return nil
 	})
 	return created, err
+}
+
+// PrincipalFor builds the request principal for an authenticated key. The
+// stored site_scope values are exactly domain.ScopeOrg / domain.ScopeSite and
+// the auth_model values exactly domain.AuthModelRole /
+// domain.AuthModelCapability, so this is an assignment, not a translation.
+//
+// NOTE (out of scope for the #510 Go half, deliberately): populating
+// Scope/AllowedSiteIDs here makes authz.RequireSiteAccess enforce the allowlist
+// on every by-id route that already calls it, because that middleware keys on
+// Scope == domain.ScopeSite. Routes that do NOT call it — and the bulk routes
+// that fan out over many sites in the handler — are not covered by this change.
+func PrincipalFor(k APIKey) domain.Principal {
+	p := domain.Principal{
+		Type:         domain.PrincipalAPIKey,
+		APIKeyID:     k.ID,
+		TenantID:     k.TenantID,
+		Role:         string(k.Role),
+		Scope:        k.SiteScope,
+		AuthModel:    k.AuthModel,
+		Capabilities: k.Capabilities,
+	}
+	if p.Scope == "" {
+		p.Scope = domain.ScopeOrg
+	}
+	if p.AuthModel == "" {
+		p.AuthModel = domain.AuthModelRole
+	}
+	if p.Scope == domain.ScopeSite {
+		p.AllowedSiteIDs = append([]uuid.UUID(nil), k.AllowedSiteIDs...)
+	}
+	return p
 }
 
 // List returns a tenant's API keys.

--- a/apps/api/internal/authz/capability.go
+++ b/apps/api/internal/authz/capability.go
@@ -1,0 +1,162 @@
+package authz
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// MaxCapabilities caps a single key's capability set. It mirrors the
+// cardinality bound in the m120 CHECK (api_keys_capabilities_shape_check) so a
+// set refused by the database is refused here first, with a domain error the
+// caller can render, rather than as a 23514 surfacing from the repo layer.
+const MaxCapabilities = 64
+
+// permissionVocabulary is the set of every permission the control plane knows.
+//
+// It is DERIVED from minRoleFor rather than maintained as a second list, so it
+// cannot drift from the role matrix: a permission that is not in minRoleFor is
+// one that Allows() already returns false for unconditionally, and admitting it
+// as a capability string would mint a key holding an authority no role can
+// grant and no route checks. TestCapabilityVocabularyCoversEveryDeclaredPermission
+// reads the declarations out of role.go and fails if a constant is declared
+// without a matching minRoleFor entry, which is the drift this derivation
+// cannot detect on its own.
+//
+// The database deliberately does NOT enumerate these strings. Migrations apply
+// inside main() at boot, so a CHECK listing the vocabulary would make a new
+// binary's writes fail 23514 against a database that has not caught up yet —
+// exactly when a feature ships. Vocabulary validation is therefore Go's, and
+// only Go's, which is why it has to actually happen here.
+var permissionVocabulary = func() map[Permission]struct{} {
+	m := make(map[Permission]struct{}, len(minRoleFor))
+	for p := range minRoleFor {
+		m[p] = struct{}{}
+	}
+	return m
+}()
+
+// AllPermissions returns every permission in the vocabulary, sorted, so tests
+// and admin surfaces can enumerate the capability space deterministically.
+func AllPermissions() []Permission {
+	out := make([]Permission, 0, len(permissionVocabulary))
+	for p := range permissionVocabulary {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// KnownPermission reports whether p is in the control plane's vocabulary.
+func KnownPermission(p Permission) bool {
+	_, ok := permissionVocabulary[p]
+	return ok
+}
+
+// validCapabilityFormat reports whether s has the shape of a permission string:
+// lowercase alphanumerics separated by '.', '_', ':' or '-', with no leading,
+// trailing or doubled separator and no surrounding whitespace.
+//
+// The vocabulary check below subsumes this — nothing malformed can be in the
+// vocabulary — but the two failures are reported separately on purpose. A
+// malformed string is a caller bug (a trailing space, a copy-paste artefact, a
+// capitalised constant name); an unknown well-formed string is a version skew
+// between the caller and this binary. Collapsing them into one error makes the
+// first indistinguishable from the second at exactly the moment someone is
+// debugging why their key will not mint.
+func validCapabilityFormat(s string) bool {
+	if s == "" || len(s) > 128 {
+		return false
+	}
+	if s != strings.TrimSpace(s) {
+		return false
+	}
+	prevSep := true // treat position 0 as following a separator: forbids a leading one
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			prevSep = false
+		case c == '.' || c == '_' || c == ':' || c == '-':
+			if prevSep {
+				return false // leading or doubled separator
+			}
+			prevSep = true
+		default:
+			return false // uppercase, whitespace, punctuation, non-ASCII
+		}
+	}
+	return !prevSep // forbids a trailing separator
+}
+
+// ValidateCapabilities checks a capability set for shape and vocabulary and
+// returns a domain validation error describing the first problem it finds.
+//
+// A nil slice is rejected: the caller must pass a non-nil (possibly empty) set
+// when minting a capability key, because nil is how a ROLE key is represented
+// and silently accepting it here would mint a role key under a capability
+// label. That is the same NULL/'{}' collapse the auth_model column exists to
+// prevent, arriving through the front door instead.
+//
+// An unknown capability is REFUSED, never dropped. Silently skipping it would
+// mint a key its owner believes holds a permission it does not, and the gap
+// only surfaces as a 403 at some unpredictable later moment.
+func ValidateCapabilities(caps []string) error {
+	if caps == nil {
+		return domain.Validation("apikey_capabilities_required",
+			"a capability key requires an explicit capability set (use an empty set for zero authority)")
+	}
+	if len(caps) > MaxCapabilities {
+		return domain.Validation("apikey_capabilities_too_many",
+			fmt.Sprintf("a capability set may hold at most %d capabilities, got %d", MaxCapabilities, len(caps)))
+	}
+	seen := make(map[string]struct{}, len(caps))
+	for _, c := range caps {
+		if !validCapabilityFormat(c) {
+			return domain.Validation("apikey_capability_malformed",
+				fmt.Sprintf("malformed capability %q", c))
+		}
+		if _, dup := seen[c]; dup {
+			return domain.Validation("apikey_capability_duplicate",
+				fmt.Sprintf("capability %q listed more than once", c))
+		}
+		seen[c] = struct{}{}
+		if !KnownPermission(Permission(c)) {
+			return domain.Validation("apikey_capability_unknown",
+				fmt.Sprintf("unknown capability %q", c))
+		}
+	}
+	return nil
+}
+
+// PrincipalAllows reports whether principal p may perform perm.
+//
+// For an AuthModelCapability principal the capability set is the ONLY input:
+// the role is not consulted, not as a fallback, not when the set is empty, and
+// not when the set is nil. That is the entire point of #510. api_keys.role is a
+// rank in a totally ordered hierarchy, so granting a machine principal one
+// admin-tier permission grants it every admin-and-below permission too; a
+// capability key exists precisely to escape that coupling, and any fallback
+// path would silently restore it.
+//
+// For every other principal — sessions, legacy keys, anything whose AuthModel
+// is the empty zero value — this is exactly Allows(Role, perm), unchanged.
+func PrincipalAllows(p domain.Principal, perm Permission) bool {
+	if p.IsCapabilityScoped() {
+		// An unknown permission is denied before the set is even scanned, so a
+		// stale capability string that happens to match a retired permission
+		// name cannot authorise anything.
+		if !KnownPermission(perm) {
+			return false
+		}
+		for _, c := range p.Capabilities {
+			if Permission(c) == perm {
+				return true
+			}
+		}
+		return false
+	}
+	return Allows(Role(p.Role), perm)
+}

--- a/apps/api/internal/authz/capability_test.go
+++ b/apps/api/internal/authz/capability_test.go
@@ -1,0 +1,214 @@
+package authz
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+var permDeclRe = regexp.MustCompile(`Permission = "([^"]+)"`)
+
+// TestCapabilityVocabularyCoversEveryDeclaredPermission is the drift guard for
+// the derivation in capability.go. permissionVocabulary is built from
+// minRoleFor, which means a permission constant declared in role.go but never
+// added to the role matrix would be invisible to it — and a capability naming
+// that permission would be refused at mint time with "unknown capability",
+// which is a confusing way to discover an incomplete matrix.
+//
+// This reads the declarations out of the source file rather than trusting a
+// hard-coded count, and REFUSES to pass when it matches nothing: a renamed
+// declaration style or a moved file must redden here, not silently assert
+// nothing over an empty set.
+func TestCapabilityVocabularyCoversEveryDeclaredPermission(t *testing.T) {
+	src, err := os.ReadFile("role.go")
+	if err != nil {
+		t.Fatalf("read role.go: %v", err)
+	}
+	matches := permDeclRe.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatal("matched zero permission declarations in role.go — the pattern or the path is wrong; " +
+			"an empty match set must not read as 'nothing to check'")
+	}
+
+	declared := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		declared[m[1]] = struct{}{}
+	}
+
+	for p := range declared {
+		if !KnownPermission(Permission(p)) {
+			t.Errorf("permission %q is declared in role.go but missing from minRoleFor, "+
+				"so it is absent from the capability vocabulary and cannot be granted to a key", p)
+		}
+	}
+	if len(declared) != len(permissionVocabulary) {
+		t.Errorf("declared permissions = %d, vocabulary = %d — the two must match exactly",
+			len(declared), len(permissionVocabulary))
+	}
+	// Every element of the format check must accept every real permission; if a
+	// future permission uses a character the format rejects, minting a key with
+	// it would fail even though it is legitimate.
+	for p := range declared {
+		if !validCapabilityFormat(p) {
+			t.Errorf("declared permission %q is rejected by validCapabilityFormat", p)
+		}
+	}
+}
+
+func TestValidateCapabilities(t *testing.T) {
+	tests := []struct {
+		name     string
+		caps     []string
+		wantCode string // "" means accept
+	}{
+		{"empty set is valid — zero authority", []string{}, ""},
+		{"single known", []string{"site.files.read"}, ""},
+		{"several known", []string{"site:read", "site.files.read", "member:read"}, ""},
+		{"nil is refused", nil, "apikey_capabilities_required"},
+		{"unknown string", []string{"site:superuser"}, "apikey_capability_unknown"},
+		{"plausible but undeclared", []string{"site.files.read_all"}, "apikey_capability_unknown"},
+		{"uppercase", []string{"Site.Files.Read"}, "apikey_capability_malformed"},
+		{"trailing space", []string{"site.files.read "}, "apikey_capability_malformed"},
+		{"leading space", []string{" site.files.read"}, "apikey_capability_malformed"},
+		{"empty element", []string{""}, "apikey_capability_malformed"},
+		{"leading separator", []string{".site.files.read"}, "apikey_capability_malformed"},
+		{"trailing separator", []string{"site.files.read."}, "apikey_capability_malformed"},
+		{"doubled separator", []string{"site..files.read"}, "apikey_capability_malformed"},
+		{"duplicate", []string{"site:read", "site:read"}, "apikey_capability_duplicate"},
+		{"one bad among good", []string{"site:read", "nope:nope"}, "apikey_capability_unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCapabilities(tt.caps)
+			if tt.wantCode == "" {
+				if err != nil {
+					t.Fatalf("ValidateCapabilities(%v) = %v, want accept", tt.caps, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateCapabilities(%v) accepted, want refusal %q", tt.caps, tt.wantCode)
+			}
+			de, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("error is not a domain error: %v", err)
+			}
+			if de.Code != tt.wantCode {
+				t.Fatalf("code = %q, want %q", de.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestValidateCapabilitiesRejectsOversizedSet(t *testing.T) {
+	caps := make([]string, 0, MaxCapabilities+1)
+	// Use distinct malformed-free strings; the size check must fire before the
+	// vocabulary check so the error names the real problem.
+	for i := 0; i <= MaxCapabilities; i++ {
+		caps = append(caps, "site:read")
+	}
+	err := ValidateCapabilities(caps)
+	if err == nil {
+		t.Fatal("oversized capability set accepted")
+	}
+	de, _ := domain.AsDomain(err)
+	if de == nil || de.Code != "apikey_capabilities_too_many" {
+		t.Fatalf("got %v, want apikey_capabilities_too_many", err)
+	}
+}
+
+// TestPrincipalAllowsRoleModelUnchanged is the over-fire control at the unit
+// level: for every role and every permission in the vocabulary, PrincipalAllows
+// over a role principal must equal Allows exactly. If this reddens, existing
+// authority moved.
+func TestPrincipalAllowsRoleModelUnchanged(t *testing.T) {
+	roles := []Role{RoleClient, RoleViewer, RoleOperator, RoleAdmin, RoleOwner}
+	for _, r := range roles {
+		for _, perm := range AllPermissions() {
+			// Explicit role model.
+			p := domain.Principal{Role: string(r), AuthModel: domain.AuthModelRole}
+			if got, want := PrincipalAllows(p, perm), Allows(r, perm); got != want {
+				t.Errorf("role=%s perm=%s: explicit-model got %v want %v", r, perm, got, want)
+			}
+			// Zero-value AuthModel — every principal built before m120.
+			z := domain.Principal{Role: string(r)}
+			if got, want := PrincipalAllows(z, perm), Allows(r, perm); got != want {
+				t.Errorf("role=%s perm=%s: zero-value-model got %v want %v", r, perm, got, want)
+			}
+		}
+	}
+}
+
+// TestCapabilityPrincipalNeverConsultsRole is the assertion #510 exists for.
+func TestCapabilityPrincipalNeverConsultsRole(t *testing.T) {
+	// An owner-role principal — the maximum role rank — carrying exactly one
+	// capability. If role were consulted at all, this principal would hold
+	// every permission in the vocabulary.
+	p := domain.Principal{
+		Type:         domain.PrincipalAPIKey,
+		APIKeyID:     uuid.New(),
+		Role:         string(RoleOwner),
+		AuthModel:    domain.AuthModelCapability,
+		Capabilities: []string{string(PermSiteFilesRead)},
+	}
+
+	if !PrincipalAllows(p, PermSiteFilesRead) {
+		t.Fatal("capability principal denied its own granted capability")
+	}
+	if PrincipalAllows(p, PermMemberManage) {
+		t.Fatal("capability principal with only site.files.read was allowed member:manage — role fallback")
+	}
+	for _, perm := range AllPermissions() {
+		want := perm == PermSiteFilesRead
+		if got := PrincipalAllows(p, perm); got != want {
+			t.Errorf("perm=%s: got %v want %v (role=owner must be ignored)", perm, got, want)
+		}
+	}
+}
+
+// TestEmptyCapabilitySetIsZeroAuthority proves the NULL/'{}' collapse is not a
+// fail-open in Go either: an owner-role principal on the capability model with
+// an empty set holds nothing, while the same principal on the role model holds
+// everything. Both have len(Capabilities) == 0.
+func TestEmptyCapabilitySetIsZeroAuthority(t *testing.T) {
+	empty := domain.Principal{
+		Role:         string(RoleOwner),
+		AuthModel:    domain.AuthModelCapability,
+		Capabilities: []string{},
+	}
+	nilCaps := domain.Principal{
+		Role:      string(RoleOwner),
+		AuthModel: domain.AuthModelCapability,
+		// Capabilities nil — indistinguishable from the above by length.
+	}
+	roleKey := domain.Principal{Role: string(RoleOwner), AuthModel: domain.AuthModelRole}
+
+	for _, perm := range AllPermissions() {
+		if PrincipalAllows(empty, perm) {
+			t.Errorf("empty capability set allowed %s", perm)
+		}
+		if PrincipalAllows(nilCaps, perm) {
+			t.Errorf("nil capability set on capability model allowed %s", perm)
+		}
+	}
+	if !PrincipalAllows(roleKey, PermMemberManage) {
+		t.Fatal("owner role principal lost member:manage — discriminator read backwards")
+	}
+}
+
+// TestPrincipalAllowsDeniesUnknownPermission guards the check-time half: a
+// capability string is only ever honoured when it names a permission this
+// binary actually knows.
+func TestPrincipalAllowsDeniesUnknownPermission(t *testing.T) {
+	p := domain.Principal{
+		AuthModel:    domain.AuthModelCapability,
+		Capabilities: []string{"site:retired_permission"},
+	}
+	if PrincipalAllows(p, Permission("site:retired_permission")) {
+		t.Fatal("a capability naming a permission outside the vocabulary authorised an action")
+	}
+}

--- a/apps/api/internal/authz/middleware.go
+++ b/apps/api/internal/authz/middleware.go
@@ -164,7 +164,10 @@ func RequirePermission(perm Permission) gin.HandlerFunc {
 				return
 			}
 		}
-		if !Allows(Role(p.Role), perm) {
+		// m120 (#510): PrincipalAllows, not Allows. For a capability principal
+		// the explicit set is authoritative and the role is never consulted;
+		// for every other principal this is identical to Allows(Role, perm).
+		if !PrincipalAllows(p, perm) {
 			abort(c, domain.Forbidden("insufficient_permission", "your role does not permit this action"))
 			return
 		}

--- a/apps/api/internal/authz/middleware.go
+++ b/apps/api/internal/authz/middleware.go
@@ -12,9 +12,10 @@ import (
 // allowlist for site-scoped principals. It must be applied AFTER RequireAuth
 // and RequireTenant (and typically after RequirePermission) on per-site routes.
 //
-// Behaviour:
-//   - Scope == "org" (or ""): no-op; full org members pass unconditionally.
-//   - Scope == "site": the :siteId path parameter is parsed and checked against
+// Behaviour, keyed on domain.IsSiteConstrained and not on the scope label:
+//   - unconstrained (org member, tenant-wide key, legacy zero-value scope):
+//     no-op; they pass unconditionally.
+//   - site constrained: the :siteId path parameter is parsed and checked against
 //     p.AllowedSiteIDs. If siteId is absent from the allowlist, the request is
 //     aborted with 404 (not 403, to avoid confirming site existence to a caller
 //     who has no access to this tenant at all).
@@ -140,10 +141,10 @@ func RequireRole(min Role) gin.HandlerFunc {
 	}
 }
 
-// orgLevelPerms is the set of permissions that require Scope=="org". A
-// site-scoped collaborator (Scope=="site") must never be able to exercise any
-// of these, regardless of the role they were granted on a specific site. This
-// is the belt-and-braces guard at the permission layer; the RLS restrictive
+// orgLevelPerms is the set of permissions no site-constrained principal may
+// exercise, regardless of the role it was granted on a specific site. "Site
+// constrained" is domain.IsSiteConstrained, not the scope label alone. This is
+// the belt-and-braces guard at the permission layer; the RLS restrictive
 // policies on the underlying tables are the database-level guard.
 var orgLevelPerms = map[Permission]struct{}{
 	PermMemberManage:  {},
@@ -158,19 +159,27 @@ var orgLevelPerms = map[Permission]struct{}{
 }
 
 // RequirePermission aborts unless the principal's role holds the permission.
-// FIX 1 (CRITICAL): if the requested permission is org-level AND the principal's
-// Scope != "org", the request is rejected with 403 (code 'org_scope_required')
-// REGARDLESS of role. This prevents a site-scoped collaborator from ever
-// reaching member management, API keys, audit log, or tenant management.
+//
+// If the requested permission is org-level AND the principal is site
+// constrained, the request is rejected with 403 (code 'org_scope_required')
+// REGARDLESS of role. This is what stops a site-scoped collaborator, or a
+// site-scoped capability key, from reaching member management, API keys, the
+// audit log or tenant management.
 func RequirePermission(perm Permission) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		p, ok := principalWithTenant(c)
 		if !ok {
 			return
 		}
-		// Org-level permission guard: reject site-scoped principals unconditionally.
+		// Org-level permission guard: reject site-constrained principals
+		// unconditionally. This asks domain.IsSiteConstrained, the same single
+		// predicate as RequireSiteAccess, RequireOrgScope and the RLS dispatch
+		// in db.RunTenantTx — a bare Scope compare here would have let a
+		// principal carrying an allowlist without the label reach member
+		// management, API keys, the audit log and tenant settings while every
+		// other gate treated it as constrained.
 		if _, isOrgLevel := orgLevelPerms[perm]; isOrgLevel {
-			if p.Scope == domain.ScopeSite {
+			if p.IsSiteConstrained() {
 				abort(c, domain.Forbidden("org_scope_required", "this action requires full organisation membership"))
 				return
 			}

--- a/apps/api/internal/authz/middleware.go
+++ b/apps/api/internal/authz/middleware.go
@@ -31,8 +31,11 @@ func RequireSiteAccess(siteIDParam string) gin.HandlerFunc {
 			return
 		}
 
-		// Org-scoped (or legacy zero-value) principals: no site allowlist check.
-		if p.Scope != domain.ScopeSite {
+		// Unconstrained principals (org members, tenant-wide keys, legacy
+		// zero-value scope) pass: no allowlist to check. IsSiteConstrained is
+		// the shared predicate — see its doc comment for why a bare "no scope"
+		// is not treated as a restriction and why a populated allowlist is.
+		if !p.IsSiteConstrained() {
 			c.Next()
 			return
 		}
@@ -73,7 +76,15 @@ func RequireOrgScope() gin.HandlerFunc {
 			abort(c, domain.Unauthorized("unauthenticated", "authentication required"))
 			return
 		}
-		if p.Scope == domain.ScopeSite {
+		// IsSiteConstrained, not a bare Scope compare: this middleware IS the
+		// whole boundary for the fleet rollups that carry it (the email fleet
+		// group, /vulnerabilities, /perf/db/fleet-health, /perf/rum/fleet,
+		// /fleet/agents), none of which filter per site in the handler because
+		// none of them can — they aggregate the tenant. A principal that is
+		// constrained by an allowlist but whose scope label is missing would
+		// have walked straight through the old compare into a tenant-wide
+		// aggregate.
+		if p.IsSiteConstrained() {
 			abort(c, domain.Forbidden("org_scope_required", "this resource is not available to site-scoped access"))
 			return
 		}

--- a/apps/api/internal/authz/nobypass_test.go
+++ b/apps/api/internal/authz/nobypass_test.go
@@ -1,0 +1,148 @@
+package authz_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoDirectAllowsOutsideAuthz makes the capability bypass unrepresentable.
+//
+// authz.Allows takes a Role and nothing else. For a capability principal the
+// role is a placeholder — the authority is the explicit set — so any call site
+// outside this package that reaches for Allows hands a capability-limited key
+// its full role rank. That is precisely the hole #510 exists to close, and it
+// had opened twice already (internal/files/handler.go and
+// internal/perf/handler.go, both in a private `allows` helper that read as
+// boilerplate). The correct call is authz.PrincipalAllows.
+//
+// Allows stays exported because the role matrix is genuinely useful to admin
+// and introspection surfaces; this test is what keeps it from being used as an
+// authorization decision outside the package that owns the model.
+func TestNoDirectAllowsOutsideAuthz(t *testing.T) {
+	root := repoAPIRoot(t)
+
+	// The sentinel proves the scanner can actually see source. It is a string
+	// this test knows exists in the tree: PrincipalAllows is the replacement
+	// every converted call site now uses, so if the walk finds zero of them the
+	// walk is broken — wrong root, wrong extension filter, an empty checkout —
+	// and a "no violations" result would be a false pass. A guard that cannot
+	// find its inputs must fail, not pass.
+	const sentinel = "authz.PrincipalAllows("
+	const forbidden = "authz.Allows("
+
+	var (
+		goFilesScanned int
+		sentinelHits   int
+		violations     []string
+	)
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "gen", "sqlc", "testdata", "vendor", "node_modules":
+				return filepath.SkipDir
+			}
+			// The authz package owns Allows; calls inside it are the point.
+			if path != root && filepath.Base(filepath.Dir(path)) == "internal" && d.Name() == "authz" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// _test.go is excluded deliberately, and this is the honest case the
+		// guard must not block. A role-model test computes the EXPECTED answer
+		// with Allows(role, perm) and asserts PrincipalAllows agrees — see
+		// tests/apikey_capability_integration_test.go, which is the proof that
+		// the role model did not move. Reddening that is reddening correct
+		// work, and a guard that reddens correct work gets switched off and
+		// then guards nothing. Only non-test source makes authorization
+		// decisions in a request path, and only non-test source is scanned.
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		b, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		goFilesScanned++
+		src := string(b)
+		sentinelHits += strings.Count(src, sentinel)
+
+		for i, line := range strings.Split(src, "\n") {
+			if !strings.Contains(line, forbidden) {
+				continue
+			}
+			// authz.PrincipalAllows( does not contain authz.Allows(, so no
+			// exclusion is needed for the correct call; anything matching here
+			// is a genuine role-only decision.
+			rel, _ := filepath.Rel(root, path)
+			violations = append(violations, rel+":"+itoa(i+1)+": "+strings.TrimSpace(line))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+
+	// Fail loudly when the search found nothing to search. Both of these are
+	// "the guard is blind", not "the code is clean".
+	if goFilesScanned == 0 {
+		t.Fatalf("scanned 0 .go files under %s — the guard is blind, not clean", root)
+	}
+	if sentinelHits == 0 {
+		t.Fatalf("found 0 occurrences of the sentinel %q across %d .go files under %s — "+
+			"the guard cannot see the call sites it is meant to police, so a clean result is meaningless",
+			sentinel, goFilesScanned, root)
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("%d call site(s) use %s outside the authz package; use authz.PrincipalAllows so a "+
+			"capability key is not handed its role rank:\n  %s",
+			len(violations), forbidden, strings.Join(violations, "\n  "))
+	}
+
+	t.Logf("scanned %d .go files, %d PrincipalAllows call sites, 0 direct Allows call sites",
+		goFilesScanned, sentinelHits)
+}
+
+// repoAPIRoot returns apps/api, located by walking up from this test file's
+// package directory until go.mod is found. It fails the test rather than
+// falling back to a guessed path.
+func repoAPIRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate go.mod above %s — cannot determine the scan root", dir)
+	return ""
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/apps/api/internal/authz/siteaccess.go
+++ b/apps/api/internal/authz/siteaccess.go
@@ -9,23 +9,34 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
-// This file is the single place that answers "which sites may this principal
-// touch?" for a route that handles MANY sites at once.
+// STATUS: this file is scaffolding, not a boundary that is currently load
+// bearing. AuthorizeSites has no production call site yet, and no route mints a
+// site-scoped capability key, so no principal that it would filter exists
+// outside a test. Read every claim below as "what this shape is for", not as a
+// description of what the running server does. It ships ahead of its callers so
+// that the routes converted next have one place to go; the conversion of those
+// routes, and the wiring of SetSiteAccessAuditor in cmd/wpmgr/main.go, is the
+// work that makes this a chokepoint. Until then it enforces nothing.
 //
-// The by-id routes are already covered: RequireSiteAccess sits in front of them
-// and keys on the same predicate. What that middleware cannot cover is a bulk
-// or fleet route that takes one request and fans out over a set of sites
-// resolved inside the handler — no :siteId is in the path, so no middleware
-// ever sees the ids. Those handlers were each doing their own filtering, or
-// none, and "or none" is not visible in review because the missing code is
-// missing.
+// The intent: one place that answers "which sites may this principal touch?"
+// for a route that handles MANY sites at once.
 //
-// The fix is not another helper that a handler may remember to call. It is a
-// value the fan-out cannot proceed without: AuthorizedSites carries the
+// The by-id routes are already covered, today, by RequireSiteAccess, which keys
+// on the same predicate. What that middleware cannot cover is a bulk or fleet
+// route that takes one request and fans out over a set of sites resolved inside
+// the handler — no :siteId is in the path, so no middleware ever sees the ids.
+// Those handlers each do their own filtering, or none, and "or none" is not
+// visible in review because the missing code is missing. RequireOrgScope is
+// what stands in front of the fleet rollups meanwhile; it refuses a constrained
+// principal outright rather than filtering for it.
+//
+// The intended fix is not another helper that a handler may remember to call.
+// It is a value the fan-out cannot proceed without: AuthorizedSites carries the
 // filtered set, its fields are unexported so only this package can populate
-// one, and its zero value authorises nothing. A handler that skips the
-// chokepoint has no token to iterate, so the omission is a compile error or an
-// empty loop, not a silent tenant-wide fan-out.
+// one, and its zero value authorises nothing. A handler that takes the token
+// has no way to iterate a set it did not filter, so the omission becomes a
+// compile error or an empty loop rather than a silent tenant-wide fan-out —
+// once handlers take it.
 
 // AuthorizedSites is the result of the site-authorization chokepoint: the
 // subset of a requested site set that the principal is actually permitted to
@@ -95,9 +106,14 @@ var (
 )
 
 // SetSiteAccessAuditor installs the process-wide auditor for chokepoint
-// denials. Call it once during server wiring. A nil auditor is allowed and
-// means denials are filtered but not recorded — the filtering is the security
-// boundary, the audit trail is the evidence.
+// denials. It is meant to be called once during server wiring, and as of #513
+// cmd/wpmgr/main.go does not call it: the auditor is nil in the running binary
+// and no denial is recorded. That is not yet a gap in the audit trail, because
+// AuthorizeSites has no production caller to deny anything; wiring it belongs
+// with the first route that does.
+//
+// A nil auditor is allowed and means denials are filtered but not recorded —
+// the filtering is the security boundary, the audit trail is the evidence.
 func SetSiteAccessAuditor(a SiteAccessAuditor) {
 	auditorMu.Lock()
 	defer auditorMu.Unlock()
@@ -110,9 +126,11 @@ func currentAuditor() SiteAccessAuditor {
 	return auditor
 }
 
-// AuthorizeSites is THE chokepoint. Given the sites a bulk request wants to
-// operate on, it returns the subset the principal may actually touch, plus the
-// ids that were refused so the caller can shape its response.
+// AuthorizeSites is the intended chokepoint for bulk routes — intended, because
+// it has no production caller yet; see the STATUS note at the top of this file.
+// Given the sites a bulk request wants to operate on, it returns the subset the
+// principal may actually touch, plus the ids that were refused so the caller can
+// shape its response.
 //
 // Semantics, and each one is deliberate:
 //
@@ -134,9 +152,10 @@ func currentAuditor() SiteAccessAuditor {
 // Duplicates in requested are collapsed. Order is preserved so a response can
 // be zipped against the request.
 //
-// The denials are recorded through the installed SiteAccessAuditor before the
-// token is returned, so every refusal at a fan-out route leaves a trail without
-// each handler having to remember to write one.
+// Denials are passed to the installed SiteAccessAuditor before the token is
+// returned, so that once an auditor is wired every refusal at a fan-out route
+// leaves a trail without each handler having to remember to write one. No
+// auditor is installed today, so the call is a no-op.
 func AuthorizeSites(ctx context.Context, p domain.Principal, requested []uuid.UUID) (AuthorizedSites, []uuid.UUID) {
 	allowed := make([]uuid.UUID, 0, len(requested))
 	var denied []uuid.UUID

--- a/apps/api/internal/authz/siteaccess.go
+++ b/apps/api/internal/authz/siteaccess.go
@@ -1,0 +1,178 @@
+package authz
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// This file is the single place that answers "which sites may this principal
+// touch?" for a route that handles MANY sites at once.
+//
+// The by-id routes are already covered: RequireSiteAccess sits in front of them
+// and keys on the same predicate. What that middleware cannot cover is a bulk
+// or fleet route that takes one request and fans out over a set of sites
+// resolved inside the handler — no :siteId is in the path, so no middleware
+// ever sees the ids. Those handlers were each doing their own filtering, or
+// none, and "or none" is not visible in review because the missing code is
+// missing.
+//
+// The fix is not another helper that a handler may remember to call. It is a
+// value the fan-out cannot proceed without: AuthorizedSites carries the
+// filtered set, its fields are unexported so only this package can populate
+// one, and its zero value authorises nothing. A handler that skips the
+// chokepoint has no token to iterate, so the omission is a compile error or an
+// empty loop, not a silent tenant-wide fan-out.
+
+// AuthorizedSites is the result of the site-authorization chokepoint: the
+// subset of a requested site set that the principal is actually permitted to
+// touch.
+//
+// It can only be produced by AuthorizeSites. Both fields are unexported, so no
+// other package can construct a populated one — `authz.AuthorizedSites{}` is
+// declarable but inert, because the zero value has ok=false and no ids, and
+// every accessor on it reports "nothing authorized". That is the point: the
+// unforgeable-token shape turns "the handler forgot to filter" from a review
+// comment into an empty result set at runtime and, where a function signature
+// demands the token, into a compile error.
+type AuthorizedSites struct {
+	ids []uuid.UUID
+	ok  bool
+}
+
+// IDs returns the authorized site ids, in the order they were requested, with
+// duplicates removed. The returned slice is a copy; mutating it cannot widen
+// the token. The zero value returns nil.
+func (a AuthorizedSites) IDs() []uuid.UUID {
+	if !a.ok || len(a.ids) == 0 {
+		return nil
+	}
+	out := make([]uuid.UUID, len(a.ids))
+	copy(out, a.ids)
+	return out
+}
+
+// Len is the number of authorized sites. The zero value is 0.
+func (a AuthorizedSites) Len() int {
+	if !a.ok {
+		return 0
+	}
+	return len(a.ids)
+}
+
+// Contains reports whether a specific site survived authorization. The zero
+// value returns false for every id, including uuid.Nil.
+func (a AuthorizedSites) Contains(id uuid.UUID) bool {
+	if !a.ok {
+		return false
+	}
+	for _, s := range a.ids {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}
+
+// Authorized reports whether this token came from AuthorizeSites at all. A
+// false result means the value is a zero literal someone declared rather than a
+// filtered set, which is never a state a real fan-out should act on.
+func (a AuthorizedSites) Authorized() bool { return a.ok }
+
+// SiteAccessAuditor receives one record per denied site. It is a local
+// interface, not a dependency on internal/audit, so wiring the real auditor in
+// cannot create an import cycle.
+type SiteAccessAuditor interface {
+	RecordSiteAccessDenied(ctx context.Context, p domain.Principal, siteIDs []uuid.UUID)
+}
+
+var (
+	auditorMu sync.RWMutex
+	auditor   SiteAccessAuditor
+)
+
+// SetSiteAccessAuditor installs the process-wide auditor for chokepoint
+// denials. Call it once during server wiring. A nil auditor is allowed and
+// means denials are filtered but not recorded — the filtering is the security
+// boundary, the audit trail is the evidence.
+func SetSiteAccessAuditor(a SiteAccessAuditor) {
+	auditorMu.Lock()
+	defer auditorMu.Unlock()
+	auditor = a
+}
+
+func currentAuditor() SiteAccessAuditor {
+	auditorMu.RLock()
+	defer auditorMu.RUnlock()
+	return auditor
+}
+
+// AuthorizeSites is THE chokepoint. Given the sites a bulk request wants to
+// operate on, it returns the subset the principal may actually touch, plus the
+// ids that were refused so the caller can shape its response.
+//
+// Semantics, and each one is deliberate:
+//
+//   - An unconstrained principal (org member, tenant-wide key) is authorized
+//     for everything it requested. This is not a widening: the tenant filter in
+//     every query and the tenant RLS policies still bound it to its own tenant.
+//     AuthorizeSites answers the site question only, and a site id from another
+//     tenant survives this filter — it dies at the tenant boundary instead.
+//
+//   - A constrained principal keeps only the requested ids that are on its
+//     allowlist. An empty allowlist authorizes nothing, which is the
+//     fail-closed state m120's site_scope column exists to keep expressible.
+//
+//   - An empty request authorizes nothing and denies nothing. It does NOT mean
+//     "all sites". A caller that wants the principal's full reach must pass the
+//     candidate set it resolved; there is no expansion path here, because
+//     silence must not mean everything.
+//
+// Duplicates in requested are collapsed. Order is preserved so a response can
+// be zipped against the request.
+//
+// The denials are recorded through the installed SiteAccessAuditor before the
+// token is returned, so every refusal at a fan-out route leaves a trail without
+// each handler having to remember to write one.
+func AuthorizeSites(ctx context.Context, p domain.Principal, requested []uuid.UUID) (AuthorizedSites, []uuid.UUID) {
+	allowed := make([]uuid.UUID, 0, len(requested))
+	var denied []uuid.UUID
+	seen := make(map[uuid.UUID]struct{}, len(requested))
+
+	constrained := p.IsSiteConstrained()
+	for _, id := range requested {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		if !constrained || p.CanAccessSite(id) {
+			allowed = append(allowed, id)
+			continue
+		}
+		denied = append(denied, id)
+	}
+
+	if len(denied) > 0 {
+		if a := currentAuditor(); a != nil {
+			a.RecordSiteAccessDenied(ctx, p, denied)
+		}
+	}
+
+	// ok is true whenever this function produced the value, even when the
+	// filtered set is empty. "Authorized for zero sites" and "never went
+	// through the chokepoint" are different states and must stay
+	// distinguishable — collapsing them is how a zero literal would start
+	// passing for a real, if empty, authorization.
+	return AuthorizedSites{ids: allowed, ok: true}, denied
+}
+
+// AuthorizeSite is the single-site form, for a fan-out that has already
+// narrowed to one id and wants the same audited path. It is exactly
+// AuthorizeSites with a one-element slice.
+func AuthorizeSite(ctx context.Context, p domain.Principal, siteID uuid.UUID) bool {
+	tok, _ := AuthorizeSites(ctx, p, []uuid.UUID{siteID})
+	return tok.Contains(siteID)
+}

--- a/apps/api/internal/authz/siteaccess_test.go
+++ b/apps/api/internal/authz/siteaccess_test.go
@@ -1,0 +1,201 @@
+package authz_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// TestAuthorizeSitesRefusesSiteOutsideAllowlist is proof 2: a key allowlisted
+// to site A, reaching a route that fans out over {A, B} inside the handler,
+// gets A and only A. No middleware runs on this path — there is no :siteId in
+// a bulk route — so the chokepoint is the entire boundary.
+func TestAuthorizeSitesRefusesSiteOutsideAllowlist(t *testing.T) {
+	siteA, siteB := uuid.New(), uuid.New()
+
+	capKey := domain.Principal{
+		Type:           domain.PrincipalAPIKey,
+		APIKeyID:       uuid.New(),
+		TenantID:       uuid.New(),
+		Role:           string(authz.RoleOwner),
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{siteA},
+		AuthModel:      domain.AuthModelCapability,
+		Capabilities:   []string{string(authz.PermSiteFilesRead)},
+	}
+
+	if !capKey.IsSiteConstrained() {
+		t.Fatal("precondition failed: the key under test is not site-constrained, so the filter below proves nothing")
+	}
+
+	tok, denied := authz.AuthorizeSites(context.Background(), capKey, []uuid.UUID{siteA, siteB})
+
+	if !tok.Contains(siteA) {
+		t.Errorf("site A (%s) is on the allowlist but was refused", siteA)
+	}
+	if tok.Contains(siteB) {
+		t.Errorf("BYPASS: site B (%s) is NOT on the allowlist but the fan-out was authorized for it", siteB)
+	}
+	if tok.Len() != 1 {
+		t.Errorf("authorized set = %d sites, want 1 (%v)", tok.Len(), tok.IDs())
+	}
+	if len(denied) != 1 || denied[0] != siteB {
+		t.Errorf("denied = %v, want exactly [%s]", denied, siteB)
+	}
+}
+
+// TestZeroAuthorizedSitesAuthorizesNothing is what makes the chokepoint hard to
+// skip: a handler that declares the token instead of calling AuthorizeSites
+// gets a value that admits nothing, so the omission is an empty fan-out rather
+// than a tenant-wide one.
+func TestZeroAuthorizedSitesAuthorizesNothing(t *testing.T) {
+	var zero authz.AuthorizedSites
+	if zero.Authorized() {
+		t.Error("zero AuthorizedSites reports Authorized() == true")
+	}
+	if zero.Len() != 0 {
+		t.Errorf("zero AuthorizedSites Len() = %d, want 0", zero.Len())
+	}
+	if zero.IDs() != nil {
+		t.Errorf("zero AuthorizedSites IDs() = %v, want nil", zero.IDs())
+	}
+	for _, id := range []uuid.UUID{uuid.New(), uuid.Nil} {
+		if zero.Contains(id) {
+			t.Errorf("zero AuthorizedSites Contains(%s) = true", id)
+		}
+	}
+	// A real but empty authorization is distinguishable from the zero value.
+	empty, _ := authz.AuthorizeSites(context.Background(), domain.Principal{
+		Scope: domain.ScopeSite,
+	}, []uuid.UUID{uuid.New()})
+	if !empty.Authorized() {
+		t.Error("a real AuthorizeSites result reports Authorized() == false")
+	}
+	if empty.Len() != 0 {
+		t.Errorf("site-scoped principal with an empty allowlist authorized %d sites, want 0", empty.Len())
+	}
+}
+
+// TestEmptyRequestDoesNotMeanEverything: silence must not widen.
+func TestEmptyRequestDoesNotMeanEverything(t *testing.T) {
+	orgUser := domain.Principal{
+		Type:     domain.PrincipalUser,
+		UserID:   uuid.New(),
+		TenantID: uuid.New(),
+		Role:     string(authz.RoleOwner),
+		Scope:    domain.ScopeOrg,
+	}
+	tok, denied := authz.AuthorizeSites(context.Background(), orgUser, nil)
+	if tok.Len() != 0 {
+		t.Errorf("an empty request authorized %d sites — it was read as 'all'", tok.Len())
+	}
+	if len(denied) != 0 {
+		t.Errorf("an empty request denied %v, want nothing", denied)
+	}
+}
+
+// TestOrgPrincipalsUnchanged is proof 3 for the site gate: every principal
+// shape that exists today and is NOT site-scoped keeps tenant-wide site reach,
+// through both CanAccessSite and the chokepoint. This is the over-fire control
+// for finding 2 — it must be green before and after the change.
+func TestOrgPrincipalsUnchanged(t *testing.T) {
+	siteX, siteY := uuid.New(), uuid.New()
+
+	cases := []struct {
+		name string
+		p    domain.Principal
+	}{
+		{"org-scoped session user", domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: uuid.New(),
+			Role: string(authz.RoleOwner), Scope: domain.ScopeOrg,
+		}},
+		{"legacy zero-value scope session user", domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: uuid.New(),
+			Role: string(authz.RoleOperator), // Scope deliberately unset
+		}},
+		{"legacy pre-m120 API key", domain.Principal{
+			Type: domain.PrincipalAPIKey, APIKeyID: uuid.New(), TenantID: uuid.New(),
+			Role: string(authz.RoleAdmin), // Scope and AuthModel both unset
+		}},
+		{"m120 org-scoped capability key", domain.Principal{
+			Type: domain.PrincipalAPIKey, APIKeyID: uuid.New(), TenantID: uuid.New(),
+			Role: string(authz.RoleClient), Scope: domain.ScopeOrg,
+			AuthModel: domain.AuthModelCapability, Capabilities: []string{string(authz.PermSiteFilesRead)},
+		}},
+		{"org-scoped viewer", domain.Principal{
+			Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: uuid.New(),
+			Role: string(authz.RoleViewer), Scope: domain.ScopeOrg,
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.p.IsSiteConstrained() {
+				t.Fatalf("REGRESSION: %s is now site-constrained; it was tenant-wide before #510", tc.name)
+			}
+			for _, id := range []uuid.UUID{siteX, siteY, uuid.New()} {
+				if !tc.p.CanAccessSite(id) {
+					t.Errorf("REGRESSION: %s was refused site %s", tc.name, id)
+				}
+			}
+			tok, denied := authz.AuthorizeSites(context.Background(), tc.p, []uuid.UUID{siteX, siteY})
+			if tok.Len() != 2 {
+				t.Errorf("REGRESSION: %s authorized for %d of 2 requested sites", tc.name, tok.Len())
+			}
+			if len(denied) != 0 {
+				t.Errorf("REGRESSION: %s was denied %v", tc.name, denied)
+			}
+		})
+	}
+}
+
+// TestSiteScopedCollaboratorUnchanged: the existing site-share collaborator —
+// the only principal that WAS constrained before #510 — behaves identically.
+func TestSiteScopedCollaboratorUnchanged(t *testing.T) {
+	siteA, siteB := uuid.New(), uuid.New()
+	collab := domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: uuid.New(),
+		Role: string(authz.RoleOperator), Scope: domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{siteA},
+	}
+	if !collab.CanAccessSite(siteA) {
+		t.Errorf("collaborator was refused its allowlisted site %s", siteA)
+	}
+	if collab.CanAccessSite(siteB) {
+		t.Errorf("collaborator reached non-allowlisted site %s", siteB)
+	}
+}
+
+// TestRunTenantTxDispatchMatchesDomainPredicate cross-checks the predicate that
+// internal/db/db.go restates inline (it cannot import domain — domain imports
+// db) against domain.Principal.IsSiteConstrained, over every combination that
+// matters. If the two ever disagree, a principal is constrained at the HTTP
+// gate and tenant-wide inside the transaction, or the reverse.
+func TestRunTenantTxDispatchMatchesDomainPredicate(t *testing.T) {
+	site := uuid.New()
+	cases := []struct {
+		name    string
+		scope   string
+		allowed []uuid.UUID
+	}{
+		{"unset scope, no allowlist", "", nil},
+		{"org scope, no allowlist", domain.ScopeOrg, nil},
+		{"site scope, no allowlist", domain.ScopeSite, nil},
+		{"site scope, with allowlist", domain.ScopeSite, []uuid.UUID{site}},
+		{"unset scope, with allowlist", "", []uuid.UUID{site}},
+		{"org scope, with allowlist", domain.ScopeOrg, []uuid.UUID{site}},
+	}
+	for _, tc := range cases {
+		p := domain.Principal{Scope: tc.scope, AllowedSiteIDs: tc.allowed}
+		// This expression is the literal condition in db.RunTenantTx.
+		dbDispatchesScoped := tc.scope == "site" || len(p.GetAllowedSiteIDs()) > 0
+		if got := p.IsSiteConstrained(); got != dbDispatchesScoped {
+			t.Errorf("DRIFT (%s): domain.IsSiteConstrained=%v but db.RunTenantTx would dispatch scoped=%v",
+				tc.name, got, dbDispatchesScoped)
+		}
+	}
+}

--- a/apps/api/internal/authz/siteaccess_test.go
+++ b/apps/api/internal/authz/siteaccess_test.go
@@ -2,8 +2,12 @@ package authz_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
@@ -170,32 +174,107 @@ func TestSiteScopedCollaboratorUnchanged(t *testing.T) {
 	}
 }
 
-// TestRunTenantTxDispatchMatchesDomainPredicate cross-checks the predicate that
-// internal/db/db.go restates inline (it cannot import domain — domain imports
-// db) against domain.Principal.IsSiteConstrained, over every combination that
-// matters. If the two ever disagree, a principal is constrained at the HTTP
-// gate and tenant-wide inside the transaction, or the reverse.
-func TestRunTenantTxDispatchMatchesDomainPredicate(t *testing.T) {
+// TestIsSiteConstrainedSemantics pins what the shared predicate MEANS, case by
+// case, in literal booleans rather than by restating the expression.
+//
+// It replaces TestRunTenantTxDispatchMatchesDomainPredicate, which claimed to
+// cross-check db.RunTenantTx's dispatch and never called into internal/db at
+// all: it restated the dispatch condition in its own body and compared that
+// restatement to IsSiteConstrained, so it compared two copies that both lived
+// outside db.go. Gutting the dispatch — `if false` around the InScopedTenantTx
+// branch — routed every site-scoped principal through InTenantTx with
+// app.site_scope unset, and it passed.
+//
+// #513 removed the reason for a drift test: internal/db now calls
+// domain.IsSiteConstrained, so there is only one copy left to drift. What the
+// dispatch DOES with the answer is proved by TestDispatchTenantTxRoutes in
+// internal/db, which drives the real routing against a recorder and asserts
+// which transaction helper ran.
+func TestIsSiteConstrainedSemantics(t *testing.T) {
 	site := uuid.New()
 	cases := []struct {
 		name    string
 		scope   string
 		allowed []uuid.UUID
+		want    bool
 	}{
-		{"unset scope, no allowlist", "", nil},
-		{"org scope, no allowlist", domain.ScopeOrg, nil},
-		{"site scope, no allowlist", domain.ScopeSite, nil},
-		{"site scope, with allowlist", domain.ScopeSite, []uuid.UUID{site}},
-		{"unset scope, with allowlist", "", []uuid.UUID{site}},
-		{"org scope, with allowlist", domain.ScopeOrg, []uuid.UUID{site}},
+		{"unset scope, no allowlist: legacy org principal, tenant-wide", "", nil, false},
+		{"org scope, no allowlist: org member, tenant-wide", domain.ScopeOrg, nil, false},
+		{"site scope, no allowlist: restricted to zero sites, fail-closed", domain.ScopeSite, nil, true},
+		{"site scope, with allowlist: the collaborator case", domain.ScopeSite, []uuid.UUID{site}, true},
+		{"unset scope, with allowlist: backstop, label missing", "", []uuid.UUID{site}, true},
+		{"org scope, with allowlist: backstop, label wrong", domain.ScopeOrg, []uuid.UUID{site}, true},
 	}
 	for _, tc := range cases {
-		p := domain.Principal{Scope: tc.scope, AllowedSiteIDs: tc.allowed}
-		// This expression is the literal condition in db.RunTenantTx.
-		dbDispatchesScoped := tc.scope == "site" || len(p.GetAllowedSiteIDs()) > 0
-		if got := p.IsSiteConstrained(); got != dbDispatchesScoped {
-			t.Errorf("DRIFT (%s): domain.IsSiteConstrained=%v but db.RunTenantTx would dispatch scoped=%v",
-				tc.name, got, dbDispatchesScoped)
+		t.Run(tc.name, func(t *testing.T) {
+			if got := domain.IsSiteConstrained(tc.scope, tc.allowed); got != tc.want {
+				t.Errorf("domain.IsSiteConstrained(%q, %v) = %v, want %v", tc.scope, tc.allowed, got, tc.want)
+			}
+			p := domain.Principal{Scope: tc.scope, AllowedSiteIDs: tc.allowed}
+			if got := p.IsSiteConstrained(); got != tc.want {
+				t.Errorf("Principal.IsSiteConstrained() = %v, want %v — the method must hold no logic of its own", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRequirePermissionOrgGateUsesSharedPredicate is the F2 regression. The
+// org-level permission gate was the last site gate still on a bare
+// `p.Scope == domain.ScopeSite`, and it guards member:manage, apikey:manage,
+// audit:read, tenant:manage and billing:manage. A principal carrying a site
+// allowlist without the scope label was constrained by RequireSiteAccess and by
+// the RLS dispatch, and waved through here.
+func TestRequirePermissionOrgGateUsesSharedPredicate(t *testing.T) {
+	site := uuid.New()
+	backstop := domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: uuid.New(),
+		Role: string(authz.RoleOwner), Scope: domain.ScopeOrg,
+		AllowedSiteIDs: []uuid.UUID{site},
+	}
+	if !backstop.IsSiteConstrained() {
+		t.Fatalf("precondition: an allowlist-carrying principal must be site-constrained")
+	}
+
+	for _, perm := range []authz.Permission{
+		authz.PermMemberManage, authz.PermAPIKeyManage, authz.PermAuditRead,
+		authz.PermTenantManage, authz.PermBillingManage,
+	} {
+		t.Run(string(perm), func(t *testing.T) {
+			rec := runRequirePermission(t, backstop, perm)
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("org-level %s returned %d for a site-constrained principal, want 403", perm, rec.Code)
+			}
+			if !strings.Contains(rec.Body.String(), "org_scope_required") {
+				t.Errorf("org-level %s: body %q, want code org_scope_required", perm, rec.Body.String())
+			}
+		})
+	}
+
+	// And the honest case it must not block: a real owner, no allowlist.
+	owner := domain.Principal{
+		Type: domain.PrincipalUser, UserID: uuid.New(), TenantID: uuid.New(),
+		Role: string(authz.RoleOwner), Scope: domain.ScopeOrg,
+	}
+	for _, perm := range []authz.Permission{authz.PermMemberManage, authz.PermTenantManage} {
+		if rec := runRequirePermission(t, owner, perm); rec.Code != http.StatusOK {
+			t.Errorf("OVER-FIRE: unconstrained owner refused %s with %d: %s", perm, rec.Code, rec.Body.String())
 		}
 	}
+}
+
+// runRequirePermission drives the real gin middleware over a real request, so
+// the gate is reached the same way a route reaches it.
+func runRequirePermission(t *testing.T, p domain.Principal, perm authz.Permission) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) {
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), p))
+		c.Next()
+	}, authz.RequirePermission(perm), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	return rec
 }

--- a/apps/api/internal/backup/service.go
+++ b/apps/api/internal/backup/service.go
@@ -650,7 +650,12 @@ func (s *Service) ListSnapshots(ctx context.Context, tenantID, siteID uuid.UUID,
 // fleet queries. For org-scoped principals it returns all site IDs in the
 // tenant; for site-scoped principals it returns p.AllowedSiteIDs.
 func (s *Service) FleetSiteIDs(ctx context.Context, tenantID uuid.UUID, p domain.Principal) ([]uuid.UUID, error) {
-	if p.Scope == domain.ScopeSite {
+	// IsSiteConstrained, not a bare Scope compare: this function IS the
+	// "which sites may this principal touch?" question for the fleet routes,
+	// which have no :siteId for RequireSiteAccess to read. A principal carrying
+	// an allowlist whose scope label was missing would fall through to the full
+	// tenant site list here. See domain.Principal.IsSiteConstrained.
+	if p.IsSiteConstrained() {
 		return p.AllowedSiteIDs, nil
 	}
 	return s.sites.ListSiteIDs(ctx, tenantID)
@@ -671,8 +676,8 @@ func (s *Service) FleetListSnapshots(ctx context.Context, p domain.Principal, te
 	if tenantID == uuid.Nil {
 		return FleetSnapshotPage{}, domain.Forbidden("tenant_required", "a tenant context is required")
 	}
-	// Fail-closed: site-scoped principal with zero accessible sites → empty page.
-	if p.Scope == domain.ScopeSite && len(f.SiteIDs) == 0 {
+	// Fail-closed: constrained principal with zero accessible sites → empty page.
+	if p.IsSiteConstrained() && len(f.SiteIDs) == 0 {
 		return FleetSnapshotPage{Items: []Snapshot{}}, nil
 	}
 	const (
@@ -701,8 +706,8 @@ func (s *Service) FleetBackupHealth(ctx context.Context, p domain.Principal, ten
 	if tenantID == uuid.Nil {
 		return nil, domain.Forbidden("tenant_required", "a tenant context is required")
 	}
-	// Fail-closed: site-scoped principal with zero accessible sites → empty list.
-	if p.Scope == domain.ScopeSite && len(siteIDs) == 0 {
+	// Fail-closed: constrained principal with zero accessible sites → empty list.
+	if p.IsSiteConstrained() && len(siteIDs) == 0 {
 		return []FleetBackupHealthItem{}, nil
 	}
 	if len(siteIDs) == 0 {

--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -636,7 +636,16 @@ func (p *Pool) RunTenantTx(ctx context.Context, principal ScopedPrincipal, fn fu
 	tenantID := principal.GetTenantID()
 	userID := principal.GetUserID()
 
-	if scope == "site" {
+	// This condition is domain.Principal.IsSiteConstrained, restated. db cannot
+	// import domain (domain imports db), so the predicate is duplicated here
+	// rather than shared, and TestRunTenantTxDispatchMatchesDomainPredicate in
+	// internal/authz cross-checks the two over a table of cases so they cannot
+	// drift apart. The second disjunct is the fail-closed backstop: a principal
+	// carrying an allowlist must reach InScopedTenantTx — which is what sets
+	// app.site_scope and app.allowed_site_ids — even if its scope label is
+	// missing, because falling through would run the whole transaction
+	// tenant-wide with the site-scope GUCs unset.
+	if scope == "site" || len(principal.GetAllowedSiteIDs()) > 0 {
 		return p.InScopedTenantTx(ctx, tenantID, userID, principal.GetAllowedSiteIDs(), fn)
 	}
 	// "org" or "" (backward compat for existing flows that never set Scope)

--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // Pool wraps a pgxpool and exposes tenant-scoped transaction helpers.
@@ -609,8 +611,10 @@ func (p *Pool) InInviteLookupTx(ctx context.Context, fn func(tx pgx.Tx) error) e
 
 // ScopedPrincipal is the interface RunTenantTx requires from a principal. It
 // is implemented by domain.Principal and any test double that carries the four
-// scope fields. Using an interface here avoids a circular import between db and
-// domain (domain cannot import db; db cannot import domain).
+// scope fields. The interface, not the concrete type, is what keeps db from
+// depending on the shape of domain.Principal; db does import domain for the
+// shared site-constraint predicate, which is safe because domain imports
+// nothing from this package.
 type ScopedPrincipal interface {
 	GetScope() string
 	GetUserID() uuid.UUID
@@ -618,39 +622,60 @@ type ScopedPrincipal interface {
 	GetAllowedSiteIDs() []uuid.UUID
 }
 
-// RunTenantTx is the central dispatch helper that chooses the correct
-// transaction wrapper based on the principal's Scope. Repos and services
-// MUST use this instead of calling InTenantTx / InTenantTxAsUser /
-// InScopedTenantTx directly, so that a forgotten call-site cannot silently
-// bypass the site-scope RLS.
+// tenantTxHelpers is the set of transaction wrappers the dispatch chooses
+// between. *Pool implements it. It exists so the dispatch can be driven by a
+// unit test that records WHICH helper ran without needing a database — the
+// only kind of test that can catch the branch being gutted.
+//
+// Before #513 the guard on this dispatch compared two restatements of the
+// predicate, both outside this file. Replacing the scoped branch with
+// `if false` left every site-scoped principal running under InTenantTx with
+// app.site_scope and app.allowed_site_ids unset, and the guard still passed.
+type tenantTxHelpers interface {
+	InTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error
+	InTenantTxAsUser(ctx context.Context, tenantID, userID uuid.UUID, fn func(tx pgx.Tx) error) error
+	InScopedTenantTx(ctx context.Context, tenantID, userID uuid.UUID, allowedSiteIDs []uuid.UUID, fn func(tx pgx.Tx) error) error
+}
+
+// dispatchTenantTx holds the whole routing decision for RunTenantTx. It is a
+// free function over tenantTxHelpers rather than a method so that
+// TestDispatchTenantTxRoutes in this package can run it against a recorder and
+// assert the helper it actually called.
 //
 // Dispatch rules:
-//   - Scope == "site": InScopedTenantTx with p.AllowedSiteIDs
-//   - Scope == "org" (or empty, for backward compat): InTenantTxAsUser when
-//     UserID is non-nil, InTenantTx otherwise (API-key principals have no
-//     UserID; they don't need the memberships_self_read policy)
-//
-// The fn receives the raw pgx.Tx. Callers wrap it with sqlc.New(tx) as usual.
-func (p *Pool) RunTenantTx(ctx context.Context, principal ScopedPrincipal, fn func(tx pgx.Tx) error) error {
-	scope := principal.GetScope()
+//   - site-constrained (domain.IsSiteConstrained): InScopedTenantTx with the
+//     principal's allowlist
+//   - otherwise: InTenantTxAsUser when UserID is non-nil, InTenantTx otherwise
+//     (API-key principals have no UserID; they don't need the
+//     memberships_self_read policy)
+func dispatchTenantTx(ctx context.Context, h tenantTxHelpers, principal ScopedPrincipal, fn func(tx pgx.Tx) error) error {
 	tenantID := principal.GetTenantID()
 	userID := principal.GetUserID()
+	allowed := principal.GetAllowedSiteIDs()
 
-	// This condition is domain.Principal.IsSiteConstrained, restated. db cannot
-	// import domain (domain imports db), so the predicate is duplicated here
-	// rather than shared, and TestRunTenantTxDispatchMatchesDomainPredicate in
-	// internal/authz cross-checks the two over a table of cases so they cannot
-	// drift apart. The second disjunct is the fail-closed backstop: a principal
+	// domain.IsSiteConstrained is THE predicate; this package no longer keeps a
+	// copy of it. Its second disjunct is the fail-closed backstop: a principal
 	// carrying an allowlist must reach InScopedTenantTx — which is what sets
 	// app.site_scope and app.allowed_site_ids — even if its scope label is
 	// missing, because falling through would run the whole transaction
 	// tenant-wide with the site-scope GUCs unset.
-	if scope == "site" || len(principal.GetAllowedSiteIDs()) > 0 {
-		return p.InScopedTenantTx(ctx, tenantID, userID, principal.GetAllowedSiteIDs(), fn)
+	if domain.IsSiteConstrained(principal.GetScope(), allowed) {
+		return h.InScopedTenantTx(ctx, tenantID, userID, allowed, fn)
 	}
 	// "org" or "" (backward compat for existing flows that never set Scope)
 	if userID != uuid.Nil {
-		return p.InTenantTxAsUser(ctx, tenantID, userID, fn)
+		return h.InTenantTxAsUser(ctx, tenantID, userID, fn)
 	}
-	return p.InTenantTx(ctx, tenantID, fn)
+	return h.InTenantTx(ctx, tenantID, fn)
+}
+
+// RunTenantTx is the central dispatch helper that chooses the correct
+// transaction wrapper based on the principal's scope. Repos and services
+// MUST use this instead of calling InTenantTx / InTenantTxAsUser /
+// InScopedTenantTx directly, so that a forgotten call-site cannot silently
+// bypass the site-scope RLS. The routing itself lives in dispatchTenantTx.
+//
+// The fn receives the raw pgx.Tx. Callers wrap it with sqlc.New(tx) as usual.
+func (p *Pool) RunTenantTx(ctx context.Context, principal ScopedPrincipal, fn func(tx pgx.Tx) error) error {
+	return dispatchTenantTx(ctx, p, principal, fn)
 }

--- a/apps/api/internal/db/sqlc/api_keys.sql.go
+++ b/apps/api/internal/db/sqlc/api_keys.sql.go
@@ -12,19 +12,38 @@ import (
 )
 
 const createAPIKey = `-- name: CreateAPIKey :one
-INSERT INTO api_keys (tenant_id, name, prefix, key_hash, role)
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, tenant_id, name, prefix, key_hash, role, created_at, last_used_at, revoked_at
+INSERT INTO api_keys (
+    tenant_id, name, prefix, key_hash, role,
+    kind, auth_model, capabilities, site_scope, allowed_site_ids
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+RETURNING id, tenant_id, name, prefix, key_hash, role, created_at, last_used_at, revoked_at, kind, auth_model, capabilities, site_scope, allowed_site_ids
 `
 
 type CreateAPIKeyParams struct {
-	TenantID uuid.UUID `json:"tenant_id"`
-	Name     string    `json:"name"`
-	Prefix   string    `json:"prefix"`
-	KeyHash  string    `json:"key_hash"`
-	Role     string    `json:"role"`
+	TenantID       uuid.UUID   `json:"tenant_id"`
+	Name           string      `json:"name"`
+	Prefix         string      `json:"prefix"`
+	KeyHash        string      `json:"key_hash"`
+	Role           string      `json:"role"`
+	Kind           string      `json:"kind"`
+	AuthModel      string      `json:"auth_model"`
+	Capabilities   []string    `json:"capabilities"`
+	SiteScope      string      `json:"site_scope"`
+	AllowedSiteIds []uuid.UUID `json:"allowed_site_ids"`
 }
 
+// CreateAPIKey is the ONLY INSERT path for api_keys, deliberately. m120 (#510)
+// extended it in place rather than adding a second capability-aware INSERT
+// alongside it: two INSERT statements over a table whose CHECK constraints
+// encode an authorization contract is one statement that can forget a column,
+// and the column it forgets defaults to the permissive legacy value.
+//
+// Callers pass auth_model='role' + capabilities=NULL for a legacy role key, or
+// auth_model='capability' + a non-NULL (possibly empty) set for a least-
+// privilege key. api_keys_auth_model_capabilities_check refuses every other
+// combination, so an inconsistent pair fails 23514 here rather than
+// authenticating with surprise authority later.
 func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (ApiKey, error) {
 	row := q.db.QueryRow(ctx, createAPIKey,
 		arg.TenantID,
@@ -32,6 +51,11 @@ func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (Api
 		arg.Prefix,
 		arg.KeyHash,
 		arg.Role,
+		arg.Kind,
+		arg.AuthModel,
+		arg.Capabilities,
+		arg.SiteScope,
+		arg.AllowedSiteIds,
 	)
 	var i ApiKey
 	err := row.Scan(
@@ -44,12 +68,17 @@ func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (Api
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.Kind,
+		&i.AuthModel,
+		&i.Capabilities,
+		&i.SiteScope,
+		&i.AllowedSiteIds,
 	)
 	return i, err
 }
 
 const getAPIKey = `-- name: GetAPIKey :one
-SELECT id, tenant_id, name, prefix, key_hash, role, created_at, last_used_at, revoked_at FROM api_keys
+SELECT id, tenant_id, name, prefix, key_hash, role, created_at, last_used_at, revoked_at, kind, auth_model, capabilities, site_scope, allowed_site_ids FROM api_keys
 WHERE id = $1 AND tenant_id = $2
 `
 
@@ -71,12 +100,17 @@ func (q *Queries) GetAPIKey(ctx context.Context, arg GetAPIKeyParams) (ApiKey, e
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.Kind,
+		&i.AuthModel,
+		&i.Capabilities,
+		&i.SiteScope,
+		&i.AllowedSiteIds,
 	)
 	return i, err
 }
 
 const getAPIKeyByPrefix = `-- name: GetAPIKeyByPrefix :one
-SELECT api_keys.id, api_keys.tenant_id, api_keys.name, api_keys.prefix, api_keys.key_hash, api_keys.role, api_keys.created_at, api_keys.last_used_at, api_keys.revoked_at FROM api_keys
+SELECT api_keys.id, api_keys.tenant_id, api_keys.name, api_keys.prefix, api_keys.key_hash, api_keys.role, api_keys.created_at, api_keys.last_used_at, api_keys.revoked_at, api_keys.kind, api_keys.auth_model, api_keys.capabilities, api_keys.site_scope, api_keys.allowed_site_ids FROM api_keys
 JOIN tenants t ON t.id = api_keys.tenant_id
 WHERE api_keys.prefix = $1 AND t.deleted_at IS NULL
 `
@@ -105,12 +139,17 @@ func (q *Queries) GetAPIKeyByPrefix(ctx context.Context, prefix string) (ApiKey,
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.Kind,
+		&i.AuthModel,
+		&i.Capabilities,
+		&i.SiteScope,
+		&i.AllowedSiteIds,
 	)
 	return i, err
 }
 
 const listAPIKeys = `-- name: ListAPIKeys :many
-SELECT id, tenant_id, name, prefix, key_hash, role, created_at, last_used_at, revoked_at FROM api_keys
+SELECT id, tenant_id, name, prefix, key_hash, role, created_at, last_used_at, revoked_at, kind, auth_model, capabilities, site_scope, allowed_site_ids FROM api_keys
 WHERE tenant_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -141,6 +180,11 @@ func (q *Queries) ListAPIKeys(ctx context.Context, arg ListAPIKeysParams) ([]Api
 			&i.CreatedAt,
 			&i.LastUsedAt,
 			&i.RevokedAt,
+			&i.Kind,
+			&i.AuthModel,
+			&i.Capabilities,
+			&i.SiteScope,
+			&i.AllowedSiteIds,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -51,15 +51,20 @@ type AlertConfig struct {
 }
 
 type ApiKey struct {
-	ID         uuid.UUID          `json:"id"`
-	TenantID   uuid.UUID          `json:"tenant_id"`
-	Name       string             `json:"name"`
-	Prefix     string             `json:"prefix"`
-	KeyHash    string             `json:"key_hash"`
-	Role       string             `json:"role"`
-	CreatedAt  time.Time          `json:"created_at"`
-	LastUsedAt pgtype.Timestamptz `json:"last_used_at"`
-	RevokedAt  pgtype.Timestamptz `json:"revoked_at"`
+	ID             uuid.UUID          `json:"id"`
+	TenantID       uuid.UUID          `json:"tenant_id"`
+	Name           string             `json:"name"`
+	Prefix         string             `json:"prefix"`
+	KeyHash        string             `json:"key_hash"`
+	Role           string             `json:"role"`
+	CreatedAt      time.Time          `json:"created_at"`
+	LastUsedAt     pgtype.Timestamptz `json:"last_used_at"`
+	RevokedAt      pgtype.Timestamptz `json:"revoked_at"`
+	Kind           string             `json:"kind"`
+	AuthModel      string             `json:"auth_model"`
+	Capabilities   []string           `json:"capabilities"`
+	SiteScope      string             `json:"site_scope"`
+	AllowedSiteIds []uuid.UUID        `json:"allowed_site_ids"`
 }
 
 type AppAlertRollout struct {

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -515,6 +515,17 @@ type Querier interface {
 	// Count registered WebAuthn credentials for a user. Used to recompute
 	// two_factor_enabled after credential deletion.
 	CountWebAuthnCredentials(ctx context.Context, userID uuid.UUID) (int64, error)
+	// CreateAPIKey is the ONLY INSERT path for api_keys, deliberately. m120 (#510)
+	// extended it in place rather than adding a second capability-aware INSERT
+	// alongside it: two INSERT statements over a table whose CHECK constraints
+	// encode an authorization contract is one statement that can forget a column,
+	// and the column it forgets defaults to the permissive legacy value.
+	//
+	// Callers pass auth_model='role' + capabilities=NULL for a legacy role key, or
+	// auth_model='capability' + a non-NULL (possibly empty) set for a least-
+	// privilege key. api_keys_auth_model_capabilities_check refuses every other
+	// combination, so an inconsistent pair fails 23514 here rather than
+	// authenticating with surprise authority later.
 	CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (ApiKey, error)
 	// M4 backup queries. Every statement is tenant-scoped both explicitly
 	// (tenant_id in the WHERE/VALUES) and by RLS (the app.tenant_id policy).

--- a/apps/api/internal/db/tenant_tx_dispatch_test.go
+++ b/apps/api/internal/db/tenant_tx_dispatch_test.go
@@ -1,0 +1,207 @@
+// tenant_tx_dispatch_test.go: the behavioural guard on RunTenantTx's routing.
+//
+// This replaces TestRunTenantTxDispatchMatchesDomainPredicate, which lived in
+// internal/authz and never called into this package at all. It restated the
+// dispatch condition in its own body and compared that restatement to
+// domain.Principal.IsSiteConstrained — two copies, both outside db.go. Replacing
+// the scoped branch in RunTenantTx with `if false` routed every site-scoped
+// principal through InTenantTx, with app.site_scope and app.allowed_site_ids
+// unset and every m112 RESTRICTIVE policy inert, and that test still passed.
+//
+// Two changes close it, and the first matters more than the second:
+//
+//  1. There is now exactly one copy of the predicate. db.go calls
+//     domain.IsSiteConstrained; drift is not something a test has to detect
+//     because it is no longer expressible.
+//
+//  2. This test drives the real dispatch — dispatchTenantTx, the function
+//     RunTenantTx delegates to — against a recorder that reports WHICH helper
+//     ran. Gutting the branch changes the recorded helper, so the mutation that
+//     the old guard slept through reddens here.
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// recordingHelpers implements tenantTxHelpers and records the call instead of
+// touching a database.
+type recordingHelpers struct {
+	called   string
+	tenantID uuid.UUID
+	userID   uuid.UUID
+	allowed  []uuid.UUID
+	ranFn    bool
+}
+
+func (r *recordingHelpers) InTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	r.called, r.tenantID = "InTenantTx", tenantID
+	return fn(nil)
+}
+
+func (r *recordingHelpers) InTenantTxAsUser(ctx context.Context, tenantID, userID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	r.called, r.tenantID, r.userID = "InTenantTxAsUser", tenantID, userID
+	return fn(nil)
+}
+
+func (r *recordingHelpers) InScopedTenantTx(ctx context.Context, tenantID, userID uuid.UUID, allowedSiteIDs []uuid.UUID, fn func(tx pgx.Tx) error) error {
+	r.called, r.tenantID, r.userID, r.allowed = "InScopedTenantTx", tenantID, userID, allowedSiteIDs
+	return fn(nil)
+}
+
+// *Pool must satisfy the interface the dispatch is written against, or this
+// test would be exercising a seam production does not use.
+var _ tenantTxHelpers = (*Pool)(nil)
+
+// domain.Principal must satisfy ScopedPrincipal, or the cases below would be
+// proving something about a test double only.
+var _ ScopedPrincipal = domain.Principal{}
+
+// TestDispatchTenantTxRoutes asserts, for every combination of scope, allowlist
+// and user id that matters, which transaction helper the dispatch actually
+// calls. The principals are real domain.Principal values, so the predicate
+// under test is reached the same way a request reaches it.
+func TestDispatchTenantTxRoutes(t *testing.T) {
+	tenant := uuid.New()
+	user := uuid.New()
+	site := uuid.New()
+
+	cases := []struct {
+		name        string
+		principal   domain.Principal
+		wantHelper  string
+		wantAllowed []uuid.UUID
+	}{
+		{
+			name:       "unset scope, no allowlist, no user (API key): plain tenant tx",
+			principal:  domain.Principal{TenantID: tenant},
+			wantHelper: "InTenantTx",
+		},
+		{
+			name:       "unset scope, no allowlist, with user: tenant tx as user",
+			principal:  domain.Principal{TenantID: tenant, UserID: user},
+			wantHelper: "InTenantTxAsUser",
+		},
+		{
+			name:       "org scope, no allowlist, no user: plain tenant tx",
+			principal:  domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg},
+			wantHelper: "InTenantTx",
+		},
+		{
+			name:       "org scope, no allowlist, with user: tenant tx as user",
+			principal:  domain.Principal{TenantID: tenant, UserID: user, Scope: domain.ScopeOrg},
+			wantHelper: "InTenantTxAsUser",
+		},
+		{
+			// The fail-CLOSED case m120 keeps expressible: restricted to zero
+			// sites must still activate the site-scope GUCs, not fall through
+			// to a tenant-wide transaction.
+			name:        "site scope, empty allowlist: scoped tx with no sites",
+			principal:   domain.Principal{TenantID: tenant, UserID: user, Scope: domain.ScopeSite},
+			wantHelper:  "InScopedTenantTx",
+			wantAllowed: nil,
+		},
+		{
+			name:        "site scope, with allowlist: scoped tx carrying the allowlist",
+			principal:   domain.Principal{TenantID: tenant, UserID: user, Scope: domain.ScopeSite, AllowedSiteIDs: []uuid.UUID{site}},
+			wantHelper:  "InScopedTenantTx",
+			wantAllowed: []uuid.UUID{site},
+		},
+		{
+			// The backstop disjunct. Unreachable for any principal built by
+			// apikey.PrincipalFor or the session path, and the point is that it
+			// stays fail-closed if a future constructor forgets the label.
+			name:        "unset scope, with allowlist: scoped tx anyway",
+			principal:   domain.Principal{TenantID: tenant, UserID: user, AllowedSiteIDs: []uuid.UUID{site}},
+			wantHelper:  "InScopedTenantTx",
+			wantAllowed: []uuid.UUID{site},
+		},
+		{
+			name:        "org scope, with allowlist: scoped tx anyway",
+			principal:   domain.Principal{TenantID: tenant, UserID: user, Scope: domain.ScopeOrg, AllowedSiteIDs: []uuid.UUID{site}},
+			wantHelper:  "InScopedTenantTx",
+			wantAllowed: []uuid.UUID{site},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingHelpers{}
+			fnRan := false
+			err := dispatchTenantTx(context.Background(), rec, tc.principal, func(tx pgx.Tx) error {
+				fnRan = true
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("dispatchTenantTx returned %v", err)
+			}
+			if !fnRan {
+				t.Errorf("the caller's fn never ran")
+			}
+			if rec.called != tc.wantHelper {
+				t.Errorf("dispatched to %s, want %s — a site-scoped principal in the wrong helper runs with app.site_scope unset",
+					rec.called, tc.wantHelper)
+			}
+			if rec.tenantID != tc.principal.TenantID {
+				t.Errorf("helper got tenant %s, want %s", rec.tenantID, tc.principal.TenantID)
+			}
+			if len(rec.allowed) != len(tc.wantAllowed) {
+				t.Fatalf("helper got allowlist %v, want %v", rec.allowed, tc.wantAllowed)
+			}
+			for i := range tc.wantAllowed {
+				if rec.allowed[i] != tc.wantAllowed[i] {
+					t.Errorf("allowlist[%d] = %s, want %s", i, rec.allowed[i], tc.wantAllowed[i])
+				}
+			}
+			// The dispatch must hand the user id to the helpers that take one,
+			// or the audit hash chain and the memberships_self_read policy lose
+			// app.user_id.
+			if tc.wantHelper != "InTenantTx" && rec.userID != tc.principal.UserID {
+				t.Errorf("helper got user %s, want %s", rec.userID, tc.principal.UserID)
+			}
+		})
+	}
+}
+
+// TestDispatchTenantTxPropagatesError proves the dispatch is a pass-through and
+// does not swallow the helper's error, in every branch.
+func TestDispatchTenantTxPropagatesError(t *testing.T) {
+	sentinel := errors.New("boom")
+	principals := []domain.Principal{
+		{TenantID: uuid.New()},
+		{TenantID: uuid.New(), UserID: uuid.New()},
+		{TenantID: uuid.New(), UserID: uuid.New(), Scope: domain.ScopeSite},
+	}
+	for _, p := range principals {
+		rec := &recordingHelpers{}
+		err := dispatchTenantTx(context.Background(), rec, p, func(tx pgx.Tx) error { return sentinel })
+		if !errors.Is(err, sentinel) {
+			t.Errorf("%s: got %v, want the sentinel back", rec.called, err)
+		}
+	}
+}
+
+// TestRunTenantTxUsesTheDispatch pins RunTenantTx to dispatchTenantTx. The
+// method needs a real pool to run, so what is asserted here is the wiring: a
+// nil *Pool reaches the dispatch, which selects a helper and panics inside it
+// on the nil receiver rather than returning. A RunTenantTx that stopped
+// delegating — or that grew a second copy of the routing — would not panic
+// where this expects.
+func TestRunTenantTxUsesTheDispatch(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Errorf("RunTenantTx on a nil pool returned instead of reaching a tx helper; it is no longer delegating to dispatchTenantTx")
+		}
+	}()
+	var p *Pool
+	_ = p.RunTenantTx(context.Background(), domain.Principal{
+		TenantID: uuid.New(), Scope: domain.ScopeSite, AllowedSiteIDs: []uuid.UUID{uuid.New()},
+	}, func(tx pgx.Tx) error { return nil })
+}

--- a/apps/api/internal/domain/principal.go
+++ b/apps/api/internal/domain/principal.go
@@ -122,16 +122,53 @@ func (p Principal) GetTenantID() uuid.UUID { return p.TenantID }
 // It satisfies the db.Pool.RunTenantTx principal interface.
 func (p Principal) GetAllowedSiteIDs() []uuid.UUID { return p.AllowedSiteIDs }
 
+// IsSiteConstrained reports whether this principal's site access is limited to
+// an explicit allowlist rather than being tenant-wide. It is the SINGLE
+// predicate behind every site gate — CanAccessSite, authz.RequireSiteAccess,
+// authz.AuthorizeSites and db.RunTenantTx's dispatch all ask this one question,
+// so a principal cannot be constrained by one gate and tenant-wide at the next.
+//
+// Two disjuncts, and the second is the fail-closed backstop:
+//
+//   - Scope == ScopeSite is authoritative and is the ONLY condition that can
+//     fire for a principal loaded from the database. m120's
+//     api_keys_site_scope_check pins site_scope to 'org' | 'site', and
+//     api_keys_site_scope_allowlist_check forbids the half-state (site_scope
+//     'org' carrying a populated allowed_site_ids). site_scope, not the
+//     emptiness of the list, is what says "restricted", because "restricted to
+//     zero sites" is a legitimate fail-CLOSED state that must stay expressible.
+//
+//   - A non-empty AllowedSiteIDs constrains regardless of the Scope label. For
+//     any principal built by apikey.PrincipalFor or by the session path this
+//     disjunct is UNREACHABLE — PrincipalFor copies the allowlist only when
+//     Scope == ScopeSite, and the DB CHECK makes the stored half-state
+//     impossible — so it changes no existing behaviour by one bit. It exists so
+//     that a hand-built Principal, or a future constructor that populates the
+//     allowlist and forgets the label, fails CLOSED instead of silently
+//     widening to the whole tenant.
+//
+// Note what is deliberately NOT here: a bare "no scope set" does not constrain.
+// The zero-value Scope means org, and org-scoped user principals are legitimately
+// tenant-wide today. Refusing them would break real access for real members,
+// which is why the predicate keys on an expressed restriction, not on silence.
+func (p Principal) IsSiteConstrained() bool {
+	return p.Scope == ScopeSite || len(p.AllowedSiteIDs) > 0
+}
+
 // CanAccessSite reports whether this principal may access the given site.
-// Org-scoped (and API-key) principals are tenant-wide, so RLS + the tenant
-// filter already constrain them — this returns true. Site-scoped principals
-// (outside collaborators) are constrained to their explicit allowlist. This is
-// the canonical app-layer gate for by-id resource routes whose site is only
-// known after the resource is loaded (the path-based RequireSiteAccess
-// middleware cannot cover those); call it after resolving the resource's
-// site_id and 403/404 when it returns false.
+// Unconstrained principals (org members, tenant-wide API keys) are bounded by
+// the tenant filter and RLS, so this returns true for them. Constrained
+// principals are held to their explicit allowlist — including the empty
+// allowlist, which admits nothing.
+//
+// This is the canonical app-layer gate for a by-id resource whose site is only
+// known after the row is loaded, which the path-based RequireSiteAccess
+// middleware cannot cover. Call it after resolving the resource's site_id and
+// 404 when it returns false. For a route that fans out over MANY sites, use
+// authz.AuthorizeSites instead: it returns a token that carries the filtered
+// set, so the fan-out cannot proceed on an unfiltered list.
 func (p Principal) CanAccessSite(siteID uuid.UUID) bool {
-	if p.Scope != ScopeSite {
+	if !p.IsSiteConstrained() {
 		return true
 	}
 	for _, allowed := range p.AllowedSiteIDs {

--- a/apps/api/internal/domain/principal.go
+++ b/apps/api/internal/domain/principal.go
@@ -122,15 +122,24 @@ func (p Principal) GetTenantID() uuid.UUID { return p.TenantID }
 // It satisfies the db.Pool.RunTenantTx principal interface.
 func (p Principal) GetAllowedSiteIDs() []uuid.UUID { return p.AllowedSiteIDs }
 
-// IsSiteConstrained reports whether this principal's site access is limited to
-// an explicit allowlist rather than being tenant-wide. It is the SINGLE
-// predicate behind every site gate — CanAccessSite, authz.RequireSiteAccess,
-// authz.AuthorizeSites and db.RunTenantTx's dispatch all ask this one question,
-// so a principal cannot be constrained by one gate and tenant-wide at the next.
+// IsSiteConstrained reports whether a principal's site access is limited to an
+// explicit allowlist rather than being tenant-wide. It is the SINGLE predicate
+// behind every site gate — Principal.CanAccessSite, authz.RequireSiteAccess,
+// authz.RequirePermission's org-level guard, authz.AuthorizeSites,
+// db.RunTenantTx's RLS dispatch and email.Repo.scopedTenantTx all call THIS
+// function, so a principal cannot be constrained by one gate and tenant-wide at
+// the next.
+//
+// It takes the two fields rather than a Principal so that packages which cannot
+// hold a domain.Principal can still call it. internal/db reaches it through the
+// db.ScopedPrincipal interface accessors; that is why this exists as a
+// package-level function and not only as a method. Before #513 internal/db
+// restated the expression inline and a test restated it a third time, so the
+// test compared two copies and neither was the shipped dispatch.
 //
 // Two disjuncts, and the second is the fail-closed backstop:
 //
-//   - Scope == ScopeSite is authoritative and is the ONLY condition that can
+//   - scope == ScopeSite is authoritative and is the ONLY condition that can
 //     fire for a principal loaded from the database. m120's
 //     api_keys_site_scope_check pins site_scope to 'org' | 'site', and
 //     api_keys_site_scope_allowlist_check forbids the half-state (site_scope
@@ -138,7 +147,7 @@ func (p Principal) GetAllowedSiteIDs() []uuid.UUID { return p.AllowedSiteIDs }
 //     emptiness of the list, is what says "restricted", because "restricted to
 //     zero sites" is a legitimate fail-CLOSED state that must stay expressible.
 //
-//   - A non-empty AllowedSiteIDs constrains regardless of the Scope label. For
+//   - A non-empty allowedSiteIDs constrains regardless of the scope label. For
 //     any principal built by apikey.PrincipalFor or by the session path this
 //     disjunct is UNREACHABLE — PrincipalFor copies the allowlist only when
 //     Scope == ScopeSite, and the DB CHECK makes the stored half-state
@@ -151,8 +160,15 @@ func (p Principal) GetAllowedSiteIDs() []uuid.UUID { return p.AllowedSiteIDs }
 // The zero-value Scope means org, and org-scoped user principals are legitimately
 // tenant-wide today. Refusing them would break real access for real members,
 // which is why the predicate keys on an expressed restriction, not on silence.
+func IsSiteConstrained(scope string, allowedSiteIDs []uuid.UUID) bool {
+	return scope == ScopeSite || len(allowedSiteIDs) > 0
+}
+
+// IsSiteConstrained reports whether this principal's site access is limited to
+// an explicit allowlist rather than being tenant-wide. It is the method form of
+// the package-level IsSiteConstrained and holds no logic of its own.
 func (p Principal) IsSiteConstrained() bool {
-	return p.Scope == ScopeSite || len(p.AllowedSiteIDs) > 0
+	return IsSiteConstrained(p.Scope, p.AllowedSiteIDs)
 }
 
 // CanAccessSite reports whether this principal may access the given site.

--- a/apps/api/internal/domain/principal.go
+++ b/apps/api/internal/domain/principal.go
@@ -19,6 +19,18 @@ const (
 // ScopeOrg is the scope value for a full org member (existing behaviour).
 const ScopeOrg = "org"
 
+// AuthModelRole is the legacy authorization model: permissions are derived from
+// the principal's role through the totally ordered role hierarchy. It is the
+// meaning of the zero value, so a Principal built by code that predates m120
+// (#510) behaves exactly as it did before.
+const AuthModelRole = "role"
+
+// AuthModelCapability is the least-privilege authorization model: the explicit
+// capability set is authoritative and the role is NEVER consulted, not even as
+// a fallback when the set is empty. These strings match the api_keys.auth_model
+// column values exactly (see migration m120).
+const AuthModelCapability = "capability"
+
 // ScopeSite is the scope value for an outside collaborator who has been granted
 // access to one or more specific sites via site_shares, but has no membership
 // row in the active tenant.
@@ -45,10 +57,44 @@ type Principal struct {
 	// auth time from non-expired site_shares rows. It is empty for Scope=="org".
 	AllowedSiteIDs []uuid.UUID
 
+	// AuthModel selects how this principal's permissions are computed:
+	// AuthModelRole (the default, and the zero value's meaning) consults Role
+	// through the totally ordered hierarchy; AuthModelCapability consults
+	// Capabilities ONLY and never falls back to Role.
+	//
+	// This field is deliberately redundant with `Capabilities != nil`, and it
+	// is the reason the collapse below is not a fail-open. The database column
+	// capabilities is nullable and sqlc generates it as a plain []string with
+	// no validity flag, so SQL NULL and '{}' both arrive here as a zero-length
+	// slice: len(Capabilities) == 0 cannot distinguish "no capability set, use
+	// the role" from "a real capability set containing nothing, allow nothing".
+	// Reading AuthModel instead of the slice length is what keeps a
+	// zero-capability key at zero authority rather than handing it its role.
+	//
+	// The empty string means AuthModelRole, so every principal built before
+	// m120 (#510) — and every session principal, which has no key row at all —
+	// keeps exactly the authority it had.
+	AuthModel string
+
+	// Capabilities is the explicit permission set for an AuthModelCapability
+	// principal. Each element is an authz.Permission string validated against
+	// the vocabulary at mint time. Empty (or nil) means zero authority when
+	// AuthModel == AuthModelCapability; it is meaningless and ignored when
+	// AuthModel is AuthModelRole.
+	Capabilities []string
+
 	// ClientIDs holds the client UUIDs the principal belongs to as a portal
 	// member. Populated only when Role == "client" (resolved via client_members).
 	// Empty for every non-portal principal.
 	ClientIDs []uuid.UUID
+}
+
+// IsCapabilityScoped reports whether this principal's authority comes from an
+// explicit capability set rather than from its role rank. Call this instead of
+// testing len(Capabilities) — see the AuthModel doc comment for why the slice
+// length is not a safe discriminator.
+func (p Principal) IsCapabilityScoped() bool {
+	return p.AuthModel == AuthModelCapability
 }
 
 // ActorID returns the stable identifier of the principal for audit logging.

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -563,9 +563,20 @@ func NewRepo(pool *db.Pool) *Repo { return &Repo{pool: pool} }
 // rows; scoping that transaction to the inherited principal's site allowlist
 // would filter the wrong tenant's data. When the principal is not the owner of
 // the tenant being queried, it tells us nothing and is ignored.
+//
+// The "is this principal restricted" half of the condition is
+// domain.IsSiteConstrained, reached through Principal.IsSiteConstrained — the
+// same single predicate as db.RunTenantTx and every HTTP site gate. This
+// package must not restate it: #513 found this file deciding the RLS dispatch
+// on a bare `Scope == ScopeSite`, so a principal carrying an allowlist without
+// the label was constrained at the gate and tenant-wide over every email row.
+// Which helper actually runs is proved behaviourally by
+// repo_site_scope_integration_test.go against real policies, and the structural
+// guard in repo_tx_dispatch_test.go refuses a new method that skips this
+// wrapper.
 func (r *Repo) scopedTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
 	if p, ok := domain.PrincipalFromContext(ctx); ok &&
-		p.Scope == domain.ScopeSite &&
+		p.IsSiteConstrained() &&
 		p.TenantID == tenantID {
 		return r.pool.InScopedTenantTx(ctx, tenantID, p.UserID, p.AllowedSiteIDs, fn)
 	}

--- a/apps/api/internal/email/repo_tx_dispatch_test.go
+++ b/apps/api/internal/email/repo_tx_dispatch_test.go
@@ -139,9 +139,23 @@ func TestScopedTenantTxStillDispatchesOnSiteScope(t *testing.T) {
 		t.Fatal("Repo.scopedTenantTx no longer calls InScopedTenantTx, so nothing sets " +
 			"app.site_scope on the email path and the m112 policies never activate")
 	}
-	if !mentionsIdent(body, "ScopeSite") {
-		t.Fatal("Repo.scopedTenantTx no longer tests for domain.ScopeSite, so its dispatch " +
-			"cannot be selecting site-scoped principals")
+	// The dispatch must ask the SHARED predicate, not a local restatement.
+	// #513 found this helper deciding on a bare `p.Scope == domain.ScopeSite`
+	// while every other site gate had moved to IsSiteConstrained, which left a
+	// principal carrying an allowlist without the scope label constrained at
+	// the HTTP gate and tenant-wide over every email row. mentionsIdent matches
+	// the selector name, so this accepts p.IsSiteConstrained() and
+	// domain.IsSiteConstrained(...) alike and rejects a copy of the expression.
+	if !mentionsIdent(body, "IsSiteConstrained") {
+		t.Fatal("Repo.scopedTenantTx no longer asks IsSiteConstrained. That predicate is the " +
+			"single definition of \"this principal is restricted to an allowlist\" — shared " +
+			"with db.RunTenantTx and every HTTP site gate. A restatement here (a bare " +
+			"Scope == ScopeSite, say) drifts silently and sends a constrained principal " +
+			"into a tenant-wide transaction.")
+	}
+	if mentionsIdent(body, "ScopeSite") {
+		t.Fatal("Repo.scopedTenantTx compares against domain.ScopeSite directly again. Ask " +
+			"IsSiteConstrained instead; the scope label is only one of its two disjuncts.")
 	}
 }
 

--- a/apps/api/internal/files/capability_bypass_test.go
+++ b/apps/api/internal/files/capability_bypass_test.go
@@ -1,0 +1,127 @@
+package files
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ctxWith builds a *gin.Context carrying p exactly the way the auth middleware
+// does — on the request context, not on gin's key/value bag — so h.allows is
+// exercised through the same retrieval path a live request uses.
+func ctxWith(p domain.Principal) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest("GET", "/api/v1/sites/x/files", nil)
+	c.Request = req.WithContext(domain.WithPrincipal(req.Context(), p))
+	return c
+}
+
+// TestCapabilityKeyDeniedRoleOnlyPermissionThroughFilesHandler is proof 1 for
+// #510 finding 1, taken at the real call site: (*Handler).allows, the private
+// helper that gates every sensitive branch in this package — reading a
+// sensitive file, writing code, deleting a file. Before the fix it read
+// authz.Allows(authz.Role(p.Role), perm), which consults the role hierarchy and
+// ignores the capability set entirely.
+//
+// The key under test holds exactly one capability, site.files.read, and carries
+// role "owner". Owner outranks every permission in the matrix, so if the role
+// is consulted at all every assertion below flips.
+func TestCapabilityKeyDeniedRoleOnlyPermissionThroughFilesHandler(t *testing.T) {
+	h := &Handler{}
+
+	capKey := domain.Principal{
+		Type:      domain.PrincipalAPIKey,
+		APIKeyID:  uuid.New(),
+		TenantID:  uuid.New(),
+		Role:      string(authz.RoleOwner), // deliberately the highest role
+		Scope:     domain.ScopeOrg,
+		AuthModel: domain.AuthModelCapability,
+		Capabilities: []string{
+			string(authz.PermSiteFilesRead),
+		},
+	}
+
+	// Sanity: the role really would grant these, so the denials below are the
+	// capability model working and not an artefact of a weak role.
+	for _, perm := range []authz.Permission{
+		authz.PermSiteFilesReadSensitive,
+		authz.PermSiteFilesWriteCode,
+		authz.PermSiteFilesDelete,
+	} {
+		if !authz.Allows(authz.RoleOwner, perm) {
+			t.Fatalf("precondition failed: role owner does not grant %q, so the denial below proves nothing", perm)
+		}
+	}
+
+	c := ctxWith(capKey)
+
+	// Granted: the one capability the key actually holds.
+	if !h.allows(c, authz.PermSiteFilesRead) {
+		t.Errorf("capability key holding %q was denied it through the files handler", authz.PermSiteFilesRead)
+	}
+
+	// Denied: everything the ROLE would have granted but the capability set does not.
+	for _, perm := range []authz.Permission{
+		authz.PermSiteFilesReadSensitive,
+		authz.PermSiteFilesWriteCode,
+		authz.PermSiteFilesDelete,
+	} {
+		if h.allows(c, perm) {
+			t.Errorf("BYPASS: capability key (caps=%v, role=owner) was granted %q through the files handler — "+
+				"the role was consulted", capKey.Capabilities, perm)
+		}
+	}
+}
+
+// TestRoleKeyBehaviourUnchangedThroughFilesHandler is the over-fire control for
+// proof 3: a legacy role principal — a session user and a pre-m120 API key,
+// both with the zero-value AuthModel — must get byte-identical answers from
+// h.allows and from the role matrix, for every permission in the vocabulary.
+// If the fix narrowed anything for existing principals, this reddens.
+func TestRoleKeyBehaviourUnchangedThroughFilesHandler(t *testing.T) {
+	perms := authz.AllPermissions()
+	if len(perms) == 0 {
+		t.Fatal("authz.AllPermissions() returned an empty vocabulary — this control proves nothing")
+	}
+
+	roles := []authz.Role{
+		authz.RoleOwner, authz.RoleAdmin, authz.RoleOperator, authz.RoleViewer, authz.RoleClient,
+	}
+
+	for _, role := range roles {
+		for _, principalType := range []domain.PrincipalType{domain.PrincipalUser, domain.PrincipalAPIKey} {
+			p := domain.Principal{
+				Type:     principalType,
+				TenantID: uuid.New(),
+				Role:     string(role),
+				// AuthModel deliberately left at the zero value: this is
+				// exactly how every principal built before m120 arrives.
+			}
+			if principalType == domain.PrincipalUser {
+				p.UserID = uuid.New()
+			} else {
+				p.APIKeyID = uuid.New()
+			}
+			c := ctxWith(p)
+
+			for _, perm := range perms {
+				want := authz.Allows(role, perm)
+				got := h0().allows(c, perm)
+				if got != want {
+					t.Errorf("REGRESSION: %s principal role=%s perm=%q: handler allows=%v, role matrix=%v — "+
+						"existing behaviour moved", principalType, role, perm, got, want)
+				}
+			}
+		}
+	}
+	t.Logf("checked %d permissions x %d roles x 2 principal types = %d assertions, all unchanged",
+		len(perms), len(roles), len(perms)*len(roles)*2)
+}
+
+func h0() *Handler { return &Handler{} }

--- a/apps/api/internal/files/handler.go
+++ b/apps/api/internal/files/handler.go
@@ -1370,12 +1370,18 @@ func bindJSON(c *gin.Context, dst any) error {
 	return nil
 }
 
+// allows answers the in-handler permission question for conditional behaviour
+// (a field the caller may not see, a branch it may not take). It MUST route
+// through authz.PrincipalAllows, never authz.Allows: the latter takes only the
+// role, so a capability key — whose role is a placeholder and whose authority
+// is the explicit set — would be handed its full role rank here. That was the
+// bypass #510 exists to close, and TestNoDirectAllowsOutsideAuthz keeps it shut.
 func (h *Handler) allows(c *gin.Context, perm authz.Permission) bool {
 	p, ok := domain.PrincipalFromContext(c.Request.Context())
 	if !ok {
 		return false
 	}
-	return authz.Allows(authz.Role(p.Role), perm)
+	return authz.PrincipalAllows(p, perm)
 }
 
 func (h *Handler) record(c *gin.Context, p domain.Principal, action string, siteID uuid.UUID, meta map[string]any) {

--- a/apps/api/internal/middleware/auth.go
+++ b/apps/api/internal/middleware/auth.go
@@ -92,13 +92,13 @@ func (a *Authenticator) Authenticate() gin.HandlerFunc {
 			// write leaves a key untraced, and a hard tenant purge cascades
 			// audit_log away with the tenant. An unknown/invalid stored role
 			// fails closed on its own: rank 0 fails every AtLeast.
-			p := domain.Principal{
-				Type:     domain.PrincipalAPIKey,
-				APIKeyID: key.ID,
-				TenantID: key.TenantID,
-				Role:     string(key.Role),
-				Scope:    domain.ScopeOrg,
-			}
+			// m120 (#510): built by apikey.PrincipalFor so auth_model, the
+			// capability set, site_scope and the allowlist all reach the
+			// principal from one place. A key minted before m120 carries kind
+			// 'integration', auth_model 'role', capabilities NULL and
+			// site_scope 'org', so PrincipalFor reproduces exactly the literal
+			// this replaced and such a key's authority is bit-identical.
+			p := apikey.PrincipalFor(key)
 			c.Request = c.Request.WithContext(domain.WithPrincipal(ctx, p))
 			c.Next()
 			return

--- a/apps/api/internal/perf/capability_bypass_test.go
+++ b/apps/api/internal/perf/capability_bypass_test.go
@@ -1,0 +1,89 @@
+package perf
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+func capCtx(p domain.Principal) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest("POST", "/api/v1/sites/x/perf/cache/purge", nil)
+	c.Request = req.WithContext(domain.WithPrincipal(req.Context(), p))
+	return c
+}
+
+// TestCapabilityKeyDeniedRoleOnlyPermissionThroughPerfHandler is the perf-side
+// half of proof 1. (*Handler).allows here gates cache purge-all and the media
+// clean delete — both destructive — and it read the role only until #510.
+func TestCapabilityKeyDeniedRoleOnlyPermissionThroughPerfHandler(t *testing.T) {
+	h := &Handler{}
+
+	capKey := domain.Principal{
+		Type:      domain.PrincipalAPIKey,
+		APIKeyID:  uuid.New(),
+		TenantID:  uuid.New(),
+		Role:      string(authz.RoleOwner),
+		Scope:     domain.ScopeOrg,
+		AuthModel: domain.AuthModelCapability,
+		// Read-only capability: it must not reach either destructive branch.
+		Capabilities: []string{string(authz.PermSiteFilesRead)},
+	}
+
+	for _, perm := range []authz.Permission{
+		authz.PermSiteCacheDeleteAll,
+		authz.PermMediaCleanDelete,
+	} {
+		if !authz.Allows(authz.RoleOwner, perm) {
+			t.Fatalf("precondition failed: role owner does not grant %q, so the denial below proves nothing", perm)
+		}
+	}
+
+	c := capCtx(capKey)
+	for _, perm := range []authz.Permission{
+		authz.PermSiteCacheDeleteAll,
+		authz.PermMediaCleanDelete,
+	} {
+		if h.allows(c, perm) {
+			t.Errorf("BYPASS: capability key (caps=%v, role=owner) was granted %q through the perf handler",
+				capKey.Capabilities, perm)
+		}
+	}
+}
+
+// TestRoleBehaviourUnchangedThroughPerfHandler is the perf-side over-fire
+// control: legacy role principals must be answered exactly as the role matrix
+// answers, across the whole vocabulary.
+func TestRoleBehaviourUnchangedThroughPerfHandler(t *testing.T) {
+	h := &Handler{}
+	perms := authz.AllPermissions()
+	if len(perms) == 0 {
+		t.Fatal("authz.AllPermissions() returned an empty vocabulary — this control proves nothing")
+	}
+	roles := []authz.Role{authz.RoleOwner, authz.RoleAdmin, authz.RoleOperator, authz.RoleViewer, authz.RoleClient}
+
+	n := 0
+	for _, role := range roles {
+		p := domain.Principal{
+			Type:     domain.PrincipalAPIKey,
+			APIKeyID: uuid.New(),
+			TenantID: uuid.New(),
+			Role:     string(role),
+		}
+		c := capCtx(p)
+		for _, perm := range perms {
+			want := authz.Allows(role, perm)
+			if got := h.allows(c, perm); got != want {
+				t.Errorf("REGRESSION: role=%s perm=%q: handler allows=%v, role matrix=%v", role, perm, got, want)
+			}
+			n++
+		}
+	}
+	t.Logf("%d role-model assertions, all unchanged", n)
+}

--- a/apps/api/internal/perf/handler.go
+++ b/apps/api/internal/perf/handler.go
@@ -1640,12 +1640,18 @@ func (h *Handler) mediaCleanDelete(c *gin.Context) {
 	})
 }
 
+// allows answers the in-handler permission question for conditional behaviour
+// (a field the caller may not see, a branch it may not take). It MUST route
+// through authz.PrincipalAllows, never authz.Allows: the latter takes only the
+// role, so a capability key — whose role is a placeholder and whose authority
+// is the explicit set — would be handed its full role rank here. That was the
+// bypass #510 exists to close, and TestNoDirectAllowsOutsideAuthz keeps it shut.
 func (h *Handler) allows(c *gin.Context, perm authz.Permission) bool {
 	p, ok := domain.PrincipalFromContext(c.Request.Context())
 	if !ok {
 		return false
 	}
-	return authz.Allows(authz.Role(p.Role), perm)
+	return authz.PrincipalAllows(p, perm)
 }
 
 func (h *Handler) record(c *gin.Context, p domain.Principal, action string, siteID uuid.UUID, meta map[string]any) {

--- a/apps/api/internal/uptime/service.go
+++ b/apps/api/internal/uptime/service.go
@@ -229,7 +229,9 @@ func (s *Service) GetAlertConfig(ctx context.Context, tenantID uuid.UUID) (Alert
 // queries. For org-scoped principals it returns all tenant site IDs; for
 // site-scoped principals it returns p.AllowedSiteIDs.
 func (s *Service) FleetSiteIDs(ctx context.Context, tenantID uuid.UUID, p domain.Principal) ([]uuid.UUID, error) {
-	if p.Scope == domain.ScopeSite {
+	// IsSiteConstrained, not a bare Scope compare — see the identical note on
+	// backup.Service.FleetSiteIDs and domain.Principal.IsSiteConstrained.
+	if p.IsSiteConstrained() {
 		return p.AllowedSiteIDs, nil
 	}
 	return s.verifier.ListSiteIDs(ctx, tenantID)

--- a/apps/api/migrations/20260822000000_m120_apikey_capability_principals.sql
+++ b/apps/api/migrations/20260822000000_m120_apikey_capability_principals.sql
@@ -1,0 +1,294 @@
+-- m120 - GH #510: give an API key an EXPLICIT capability set, a key kind and a
+-- site allowlist, so a non-human principal can be granted least privilege.
+--
+-- THE DEFECT
+-- ----------
+-- api_keys.role is a single rank in a totally ordered hierarchy
+-- (internal/authz/role.go: client 1 < viewer 2 < operator 3 < admin 4 < owner 5)
+-- and authz.Allows() is `r.AtLeast(minRoleFor[p])`. Granting an assistant the
+-- admin-tier "site.files.read" therefore also grants every other admin-and-below
+-- permission in the same map, including member:manage, apikey:manage,
+-- audit:read and site:autologin. There is no way to say "read files, manage
+-- nothing". api_keys also carries no site column at all, so a key is tenant-wide
+-- by construction.
+--
+-- WHAT THIS MIGRATION DOES *NOT* DO — READ THIS BEFORE TRUSTING A COLUMN
+-- ---------------------------------------------------------------------
+-- allowed_site_ids stores an allowlist. It does NOT enforce one. There is no
+-- RLS policy in this migration that reads it, and adding these columns widens
+-- nothing: RLS in PostgreSQL is row-level, so api_keys_tenant_isolation and
+-- api_keys_prefix_lookup (20260527130000_auth_multitenancy.sql) already govern
+-- every column on the row, the new ones included.
+--
+-- Per the #510 design, database-level site scoping for API-key principals is
+-- explicitly v2. In v1 the boundary is APPLICATION-ENFORCED, at one audited
+-- chokepoint in Go. Until that chokepoint exists and is proven, these columns
+-- are inert metadata and a reviewer must not read their presence as a boundary.
+--
+-- What v2 would add, for the record: api_keys has no site_id, so it is not a
+-- site-keyed table and the RESTRICTIVE <table>_site_scope policy the site-keyed
+-- siblings carry (see 20260531050000_m19_orgs_sharing.sql and
+-- 20260814000000_m112_email_site_scope_rls.sql) does not apply to api_keys
+-- itself. v2 is the mirror image: the auth layer sets app.site_scope='on' plus
+-- the resolved allowlist GUC for a site-scoped API-key principal exactly as it
+-- already does for a site-scoped human collaborator, and every site-keyed table
+-- then refuses out-of-allowlist rows through the RESTRICTIVE policy it ALREADY
+-- has. That is a Go change in the dispatch layer plus proofs, not new DDL here.
+--
+-- COEXISTENCE WITH role: role IS RETAINED, NOT DERIVED, NOT REPLACED
+-- ------------------------------------------------------------------
+-- Every column below is additive with a default that reproduces present-day
+-- behaviour exactly, so a key that exists before this migration runs neither
+-- gains nor loses a single permission:
+--
+--   kind             -> 'integration'   (what every existing key is)
+--   auth_model       -> 'role'          (resolve permissions from role, as now)
+--   capabilities     -> NULL            (no set; role is authoritative)
+--   site_scope       -> 'org'           (tenant-wide, as now)
+--   allowed_site_ids -> '{}'            (empty; meaningless while site_scope='org')
+--
+-- role remains the authority for auth_model='role'. For auth_model='capability'
+-- the capability set is the authority and role must NOT be consulted for any
+-- permission decision. role stays on the row regardless, for display, audit
+-- attribution and the non-permission role-rank checks — it is never dropped.
+--
+-- WHY auth_model EXISTS WHEN `capabilities IS NOT NULL` SAYS THE SAME THING
+-- ------------------------------------------------------------------------
+-- It is deliberately redundant, and constraint (5) below keeps the redundancy
+-- from ever diverging. It exists because the NULL-vs-'{}' distinction does not
+-- survive the round trip into Go: sqlc/pgx scan both SQL NULL and the empty
+-- array into a zero-length []string, and `len(caps) == 0` is the idiom any
+-- reviewer writes. Collapsing those two states is precisely the fail-open this
+-- ticket is about — an empty capability set read as "fall back to role" hands a
+-- deliberately-restricted key its full role authority. A NOT NULL text
+-- discriminator cannot be collapsed by a driver, by JSON, or by len().
+--
+-- The same reasoning gives site_scope its own column rather than inferring
+-- restriction from `allowed_site_ids <> '{}'`: "restricted to zero sites" is a
+-- legitimate, fail-CLOSED state and must be expressible. site_scope's two values
+-- are the exact string constants domain.ScopeOrg and domain.ScopeSite already
+-- use, so the Go mapping is an assignment and not a translation table.
+--
+-- CONSTRAINT POLICY: SHAPE IS THE DATABASE'S, VOCABULARY IS GO'S
+-- --------------------------------------------------------------
+-- There is deliberately NO CHECK enumerating the permission strings.
+-- `grep -hoE 'Permission = "[^"]+"' internal/authz/role.go | sort -u | grep -c .`
+-- returns 30 today and has only ever grown; the vocabulary is owned by Go and
+-- extended by ordinary feature work. A CHECK listing them inverts that: adding
+-- a permission in Go would require a migration before any key could hold it,
+-- and until that migration applied, INSERTs would fail 23514 in production at
+-- the exact moment a feature rolls out. Migrations here apply inside main() at
+-- boot, so a lagging database fails a NEW binary's writes closed. This repeats
+-- the reasoning that already rejected a status CHECK on the same grounds.
+--
+-- The kind and auth_model and site_scope CHECKs are NOT the same call, and the
+-- asymmetry is the point: those are closed structural discriminators that
+-- change how authorization is computed, not an open vocabulary. A third kind
+-- cannot be honoured without a new Go branch shipping anyway, so the migration
+-- rides the same release; and an unconstrained free-text kind lets a typo
+-- ('agnet') fall through a Go switch's default branch, which is the fail-OPEN
+-- direction. Constrain closed discriminators; never constrain an open
+-- vocabulary the application owns.
+--
+-- The capabilities CHECK constrains shape only, using exclusively IMMUTABLE
+-- primitives. Verified on this server, not assumed:
+--   select proname, provolatile from pg_proc
+--    where proname in ('array_ndims','cardinality','array_position','array_to_string');
+--   -> array_ndims i | cardinality i | array_position i | array_to_string s
+-- array_to_string is STABLE, so the tempting whole-array regex format check
+-- does not belong in a CHECK; per-element format and vocabulary validation is
+-- Go's, at the same place that already validates role.
+--
+-- IDEMPOTENCE: every statement is guarded, so this file applies twice with no
+-- error. That is the intended contract, matching the surrounding migrations.
+
+-- ---------------------------------------------------------------------------
+-- 1. Columns. All additive, all with backward-compatible defaults.
+-- ---------------------------------------------------------------------------
+ALTER TABLE "public"."api_keys"
+  ADD COLUMN IF NOT EXISTS "kind" text NOT NULL DEFAULT 'integration';
+
+ALTER TABLE "public"."api_keys"
+  ADD COLUMN IF NOT EXISTS "auth_model" text NOT NULL DEFAULT 'role';
+
+-- No DEFAULT, and nullable on purpose. A DEFAULT of '{}' would give every
+-- pre-existing key a zero-length capability set, which under a
+-- capabilities-are-authoritative reading strips all authority from every key in
+-- the fleet at boot. NULL means "this key has no capability set at all".
+ALTER TABLE "public"."api_keys"
+  ADD COLUMN IF NOT EXISTS "capabilities" text[];
+
+ALTER TABLE "public"."api_keys"
+  ADD COLUMN IF NOT EXISTS "site_scope" text NOT NULL DEFAULT 'org';
+
+-- NOT NULL with an empty-array default: the presence of a restriction is
+-- site_scope's job, so this column never needs a NULL to mean "unrestricted"
+-- and can therefore never be read ambiguously.
+ALTER TABLE "public"."api_keys"
+  ADD COLUMN IF NOT EXISTS "allowed_site_ids" uuid[] NOT NULL DEFAULT '{}'::uuid[];
+
+-- ---------------------------------------------------------------------------
+-- 2. Constraints. Each is guarded so a re-run is a no-op rather than a 42710.
+-- ---------------------------------------------------------------------------
+
+-- (1) Closed discriminator: what sort of principal this key represents.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.api_keys'::regclass
+       AND conname  = 'api_keys_kind_check'
+  ) THEN
+    ALTER TABLE "public"."api_keys"
+      ADD CONSTRAINT "api_keys_kind_check"
+      CHECK ("kind" IN ('integration', 'agent'));
+  END IF;
+END
+$$;
+
+-- (2) Closed discriminator: how permissions are computed for this key.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.api_keys'::regclass
+       AND conname  = 'api_keys_auth_model_check'
+  ) THEN
+    ALTER TABLE "public"."api_keys"
+      ADD CONSTRAINT "api_keys_auth_model_check"
+      CHECK ("auth_model" IN ('role', 'capability'));
+  END IF;
+END
+$$;
+
+-- (3) Closed discriminator, reusing domain.ScopeOrg / domain.ScopeSite verbatim.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.api_keys'::regclass
+       AND conname  = 'api_keys_site_scope_check'
+  ) THEN
+    ALTER TABLE "public"."api_keys"
+      ADD CONSTRAINT "api_keys_site_scope_check"
+      CHECK ("site_scope" IN ('org', 'site'));
+  END IF;
+END
+$$;
+
+-- (4) Shape of the capability set. Vocabulary is NOT checked here (see header).
+--     - 1-dimensional: PostgreSQL will happily store a 2-D text[] otherwise,
+--       which unnest() would silently flatten into capabilities nobody granted.
+--     - bounded cardinality: a capability set is a hand-picked grant, not a
+--       bulk column; 64 is far above the 30 permissions that exist.
+--     - no NULL element: array_position(arr, NULL) finds the first NULL, so
+--       `IS NULL` here means "no NULL element present".
+--     - no empty-string element: '' is not a permission and would otherwise sit
+--       in the set looking like one.
+--     An empty array IS permitted and means exactly "zero capabilities", the
+--     fail-closed state; only cardinality > 64 and malformed elements are refused.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.api_keys'::regclass
+       AND conname  = 'api_keys_capabilities_shape_check'
+  ) THEN
+    ALTER TABLE "public"."api_keys"
+      ADD CONSTRAINT "api_keys_capabilities_shape_check"
+      CHECK (
+        "capabilities" IS NULL
+        OR (
+          coalesce(array_ndims("capabilities"), 1) = 1
+          AND cardinality("capabilities") <= 64
+          AND array_position("capabilities", NULL) IS NULL
+          AND NOT ('' = ANY ("capabilities"))
+        )
+      );
+  END IF;
+END
+$$;
+
+-- (5) The biconditional that stops auth_model and capabilities diverging. This
+--     is what makes auth_model safe to trust as the sole discriminator in Go:
+--     auth_model='capability' guarantees a non-NULL set (possibly empty, which
+--     is zero authority), and auth_model='role' guarantees there is no set to
+--     misread.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.api_keys'::regclass
+       AND conname  = 'api_keys_auth_model_capabilities_check'
+  ) THEN
+    ALTER TABLE "public"."api_keys"
+      ADD CONSTRAINT "api_keys_auth_model_capabilities_check"
+      CHECK (
+        ("auth_model" = 'capability' AND "capabilities" IS NOT NULL)
+        OR ("auth_model" = 'role' AND "capabilities" IS NULL)
+      );
+  END IF;
+END
+$$;
+
+-- (6) An org-scoped key must not carry an allowlist. A row with site_scope='org'
+--     and a populated allowed_site_ids is an ambiguous half-state: one reader
+--     treats the list as restrictive, another ignores it, and the two disagree
+--     about the boundary. Forbid it rather than document it.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.api_keys'::regclass
+       AND conname  = 'api_keys_site_scope_allowlist_check'
+  ) THEN
+    ALTER TABLE "public"."api_keys"
+      ADD CONSTRAINT "api_keys_site_scope_allowlist_check"
+      CHECK (
+        "site_scope" = 'site'
+        OR cardinality("allowed_site_ids") = 0
+      );
+  END IF;
+END
+$$;
+
+-- (7) The least-privilege guarantee, in the database. An 'agent' key is the
+--     principal this ticket exists for; it must never be able to fall back to
+--     whole-role authority. Creating one without a capability set is refused
+--     here, not merely discouraged in a handler.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.api_keys'::regclass
+       AND conname  = 'api_keys_agent_capability_check'
+  ) THEN
+    ALTER TABLE "public"."api_keys"
+      ADD CONSTRAINT "api_keys_agent_capability_check"
+      CHECK (
+        "kind" <> 'agent'
+        OR "auth_model" = 'capability'
+      );
+  END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Indexes: none added, on purpose.
+-- ---------------------------------------------------------------------------
+-- A GIN index on capabilities would serve a capability-predicate sweep ("revoke
+-- every key holding site.files.read"). No such query exists in
+-- db/query/api_keys.sql today; every current read path is by primary key, by the
+-- unique prefix index, or a per-tenant list over a table bounded at tens of rows
+-- per tenant. The index lands with the query that needs it, not before.
+--
+-- 4. RLS: no policy changes. api_keys already has ENABLE + FORCE ROW LEVEL
+-- SECURITY, api_keys_tenant_isolation (USING + WITH CHECK on app.tenant_id) and
+-- the SELECT-only api_keys_prefix_lookup gated on app.apikey_lookup='on'. Row
+-- policies cover every column, so these columns are exactly as protected as
+-- key_hash already is, and nothing a tenant can see has widened. No
+-- api_keys_site_scope policy is added: see the header — api_keys has no site_id
+-- and is not a site-keyed table, and the site boundary for these principals is
+-- v2 and application-enforced today. No new GRANT is needed either; the
+-- table-level grants to wpmgr_app from the original migration apply to columns
+-- added later.

--- a/apps/api/tests/apikey_capability_integration_test.go
+++ b/apps/api/tests/apikey_capability_integration_test.go
@@ -1,0 +1,273 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/apikey"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// TestAPIKeyCreateSendsDiscriminatorColumns is the red-first proof for the
+// #510 Go half. m120 added five columns to api_keys, three of them constrained
+// by CHECKs that encode an authorization contract. apikey.Service.Create builds
+// sqlc.CreateAPIKeyParams as a KEYED literal, so the three new string columns
+// silently took the Go zero value "" once sqlc regenerated the params struct —
+// which compiles, vets and unit-tests clean, and then fails every single key
+// creation at runtime with SQLSTATE 23514.
+//
+// This is the hazard GH #458 predicted: a generated params struct gaining a
+// field still compiles at every keyed-literal call site while sending nothing.
+// The build being green is not evidence that the callers were updated.
+//
+// Before the fix this test fails with 23514 (api_keys_kind_check). After it,
+// Create round-trips and the row carries the legacy-equivalent defaults.
+func TestAPIKeyCreateSendsDiscriminatorColumns(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "apikey-cap-create")
+
+	svc := apikey.NewService(pool)
+
+	created, err := svc.Create(ctx, tenant, "legacy role key", authz.RoleOperator)
+	if err != nil {
+		t.Fatalf("Create failed — this is the m120 caller gap if the error is 23514: %v", err)
+	}
+
+	// The row must reproduce present-day behaviour exactly.
+	if created.Key.Kind != apikey.KindIntegration {
+		t.Errorf("kind = %q, want %q", created.Key.Kind, apikey.KindIntegration)
+	}
+	if created.Key.AuthModel != domain.AuthModelRole {
+		t.Errorf("auth_model = %q, want %q", created.Key.AuthModel, domain.AuthModelRole)
+	}
+	if created.Key.Capabilities != nil {
+		t.Errorf("capabilities = %v, want nil (SQL NULL) for a role key", created.Key.Capabilities)
+	}
+	if created.Key.SiteScope != domain.ScopeOrg {
+		t.Errorf("site_scope = %q, want %q", created.Key.SiteScope, domain.ScopeOrg)
+	}
+	if len(created.Key.AllowedSiteIDs) != 0 {
+		t.Errorf("allowed_site_ids = %v, want empty", created.Key.AllowedSiteIDs)
+	}
+	if created.Key.Role != authz.RoleOperator {
+		t.Errorf("role = %q, want %q", created.Key.Role, authz.RoleOperator)
+	}
+}
+
+// TestPreExistingRoleKeyAuthorityUnchanged is the over-fire control. A key
+// created through the ordinary role path must resolve to EXACTLY the permission
+// set it resolved to before m120 — not one permission more, not one fewer.
+// The reference set is computed straight from authz.Allows over the stored
+// role, which is the pre-m120 behaviour by construction.
+//
+// This test must be green both before and after the capability work. If it ever
+// reddens, an existing key's authority moved, which the #510 brief forbids.
+func TestPreExistingRoleKeyAuthorityUnchanged(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "apikey-cap-unchanged")
+
+	svc := apikey.NewService(pool)
+
+	for _, role := range []authz.Role{authz.RoleViewer, authz.RoleOperator, authz.RoleAdmin, authz.RoleOwner} {
+		t.Run(string(role), func(t *testing.T) {
+			created, err := svc.Create(ctx, tenant, "role key "+string(role), role)
+			if err != nil {
+				t.Fatalf("Create(%s): %v", role, err)
+			}
+
+			// Resolve through the real authentication path.
+			key, err := svc.Authenticate(ctx, created.Token)
+			if err != nil {
+				t.Fatalf("Authenticate(%s): %v", role, err)
+			}
+			p := apikey.PrincipalFor(key)
+
+			if p.AuthModel != domain.AuthModelRole {
+				t.Fatalf("auth_model = %q, want %q — a legacy key must stay on the role model",
+					p.AuthModel, domain.AuthModelRole)
+			}
+
+			// Every permission in the vocabulary, compared against pre-m120 semantics.
+			for _, perm := range authz.AllPermissions() {
+				want := authz.Allows(role, perm)
+				got := authz.PrincipalAllows(p, perm)
+				if got != want {
+					t.Errorf("permission %q: PrincipalAllows = %v, authz.Allows(%s) = %v — authority moved",
+						perm, got, role, want)
+				}
+			}
+		})
+	}
+}
+
+// TestCapabilityKeyDoesNotFallBackToRole is the assertion the whole issue
+// exists for. api_keys.role is a rank in a totally ordered hierarchy, so a
+// machine principal granted an admin-tier permission is granted every
+// admin-and-below permission with it. site.files.read is admin-tier
+// (authz.PermSiteFilesRead -> RoleAdmin), and member:manage is also admin-tier
+// (authz.PermMemberManage -> RoleAdmin). Under the role model those two are
+// inseparable. Under the capability model they must not be.
+func TestCapabilityKeyDoesNotFallBackToRole(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "apikey-cap-nofallback")
+
+	svc := apikey.NewService(pool)
+	siteID := uuid.New()
+
+	created, err := svc.CreateCapability(ctx, tenant, "files reader", apikey.CapabilitySpec{
+		Kind:           apikey.KindAgent,
+		Capabilities:   []string{string(authz.PermSiteFilesRead)},
+		AllowedSiteIDs: []uuid.UUID{siteID},
+	})
+	if err != nil {
+		t.Fatalf("CreateCapability: %v", err)
+	}
+
+	key, err := svc.Authenticate(ctx, created.Token)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	p := apikey.PrincipalFor(key)
+
+	// The granted capability is held.
+	if !authz.PrincipalAllows(p, authz.PermSiteFilesRead) {
+		t.Fatalf("capability key does NOT hold its own granted capability %q", authz.PermSiteFilesRead)
+	}
+
+	// THE assertion: the same-rank permission it was never granted is denied.
+	if authz.PrincipalAllows(p, authz.PermMemberManage) {
+		t.Fatalf("capability key holding only %q was allowed %q — it fell back to role authority",
+			authz.PermSiteFilesRead, authz.PermMemberManage)
+	}
+
+	// And it holds for every other permission in the vocabulary too: exactly
+	// one capability means exactly one permission.
+	for _, perm := range authz.AllPermissions() {
+		want := perm == authz.PermSiteFilesRead
+		if got := authz.PrincipalAllows(p, perm); got != want {
+			t.Errorf("permission %q: got %v, want %v", perm, got, want)
+		}
+	}
+
+	// The site allowlist reached the principal, so the site chokepoint has
+	// something to enforce against.
+	if p.Scope != domain.ScopeSite {
+		t.Errorf("scope = %q, want %q", p.Scope, domain.ScopeSite)
+	}
+	if len(p.AllowedSiteIDs) != 1 || p.AllowedSiteIDs[0] != siteID {
+		t.Errorf("allowed_site_ids = %v, want [%s]", p.AllowedSiteIDs, siteID)
+	}
+}
+
+// TestUnknownCapabilityRefusedAtCreation proves the vocabulary guard fires.
+// The database deliberately does NOT enumerate the permission vocabulary (it
+// would fail new writes closed against a lagging database at boot), so this
+// validation is Go's and only Go's. An unknown string must be refused, not
+// silently stored and then silently ignored at check time.
+func TestUnknownCapabilityRefusedAtCreation(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "apikey-cap-unknown")
+
+	svc := apikey.NewService(pool)
+
+	cases := []struct {
+		name string
+		caps []string
+	}{
+		{"not in vocabulary", []string{"site.files.read", "site:superuser"}},
+		{"plausible but undeclared", []string{"site.files.read_all"}},
+		{"malformed — uppercase", []string{"Site.Files.Read"}},
+		{"malformed — whitespace", []string{"site.files.read "}},
+		{"malformed — empty element", []string{""}},
+		{"duplicate element", []string{"site.files.read", "site.files.read"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.CreateCapability(ctx, tenant, "bad caps", apikey.CapabilitySpec{
+				Kind:         apikey.KindIntegration,
+				Capabilities: tc.caps,
+			})
+			if err == nil {
+				t.Fatalf("CreateCapability accepted %v — an unknown or malformed capability must be refused", tc.caps)
+			}
+			de, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("error is not a domain error (so it is an infra failure, not a refusal): %v", err)
+			}
+			if !strings.HasPrefix(de.Code, "apikey_capabilit") {
+				t.Fatalf("code = %q, want an apikey_capabilit* validation code", de.Code)
+			}
+		})
+	}
+}
+
+// TestEmptyCapabilitySetHasZeroAuthority closes the fail-open that auth_model
+// exists to prevent. sqlc generates Capabilities []string with no validity
+// flag, so SQL NULL and '{}' both arrive as a zero-length slice: len(caps)==0
+// cannot tell "no capability set, use role" from "zero capabilities, allow
+// nothing". Collapsing them would hand a zero-capability key its full role
+// authority, which is the worst possible direction for the failure.
+func TestEmptyCapabilitySetHasZeroAuthority(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "apikey-cap-empty")
+
+	svc := apikey.NewService(pool)
+
+	created, err := svc.CreateCapability(ctx, tenant, "zero authority", apikey.CapabilitySpec{
+		Kind:         apikey.KindIntegration,
+		Capabilities: []string{}, // non-nil, empty: a real set with nothing in it
+	})
+	if err != nil {
+		t.Fatalf("CreateCapability with empty set: %v", err)
+	}
+
+	key, err := svc.Authenticate(ctx, created.Token)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	p := apikey.PrincipalFor(key)
+
+	// Distinguishable from a role key even though both have len(Capabilities)==0.
+	if p.AuthModel != domain.AuthModelCapability {
+		t.Fatalf("auth_model = %q, want %q — the discriminator collapsed and this key would fall back to role",
+			p.AuthModel, domain.AuthModelCapability)
+	}
+	if len(p.Capabilities) != 0 {
+		t.Fatalf("capabilities = %v, want empty", p.Capabilities)
+	}
+
+	// Zero authority, across the entire vocabulary.
+	for _, perm := range authz.AllPermissions() {
+		if authz.PrincipalAllows(p, perm) {
+			t.Errorf("empty-capability key was allowed %q — zero capabilities must mean zero authority", perm)
+		}
+	}
+
+	// And the contrast: a role key with the same zero-length Capabilities slice
+	// keeps its full role authority. This is the pair that proves the two
+	// zero-length slices are NOT being treated alike.
+	roleCreated, err := svc.Create(ctx, tenant, "contrast role key", authz.RoleAdmin)
+	if err != nil {
+		t.Fatalf("Create role key: %v", err)
+	}
+	roleKey, err := svc.Authenticate(ctx, roleCreated.Token)
+	if err != nil {
+		t.Fatalf("Authenticate role key: %v", err)
+	}
+	rp := apikey.PrincipalFor(roleKey)
+	if len(rp.Capabilities) != 0 {
+		t.Fatalf("precondition: role key should also have a zero-length capability slice, got %v", rp.Capabilities)
+	}
+	if !authz.PrincipalAllows(rp, authz.PermMemberManage) {
+		t.Fatal("role key lost its authority — the discriminator is being read backwards")
+	}
+}


### PR DESCRIPTION
Schema half of GH #510. **Draft: the Go half lands before this is reviewable.**

`api_keys.role` is a single rank in a totally ordered hierarchy, and
`authz.Allows` is `r.AtLeast(minRoleFor[p])`. Granting a machine principal the
admin-tier `site.files.read` therefore also grants `member:manage`,
`apikey:manage`, `audit:read` and `site:autologin`. m120 adds the columns that
let a key carry an explicit capability set instead, plus a site allowlist and a
key-kind discriminator.

## Columns

| column | default | meaning |
|---|---|---|
| `kind` | `'integration'` | agent vs ordinary integration key |
| `auth_model` | `'role'` | how permissions are computed |
| `capabilities` | `NULL` (no default) | the explicit set |
| `site_scope` | `'org'` | `domain.ScopeOrg` / `domain.ScopeSite` verbatim |
| `allowed_site_ids` | `'{}'` | the allowlist |

Every default reproduces present-day behaviour, so an existing key neither gains
nor loses a permission. `role` is **retained**, not derived and not replaced: it
stays authoritative when `auth_model='role'`.

## `allowed_site_ids` is stored, NOT enforced

No RLS policy reads it. Per the #510 design, database-level site scoping for
these principals is **v2**; v1 enforces in Go at one audited chokepoint. The
migration header says this in full, so a reviewer cannot mistake the column's
presence for a boundary.

## Why `auth_model` is deliberately redundant

sqlc generates `Capabilities []string` — a plain slice with no validity flag.
SQL `NULL` and `'{}'` both arrive as a zero-length slice, and `len(caps) == 0`
is the idiom any reviewer writes. Collapsing "no capability set" into "zero
capabilities" is exactly the fail-open this ticket exists to close, so the
discriminator is a `NOT NULL text` no driver can collapse. A CHECK holds the two
in lockstep. `site_scope` carries the same signal for the allowlist, so
"restricted to zero sites" stays expressible and fail-closed.

## Constraint policy: shape is the database's, vocabulary is Go's

There is **no CHECK enumerating the permission strings**.
`grep -hoE 'Permission = "[^"]+"' apps/api/internal/authz/role.go | sort -u | grep -c .`
returns 30, and the set only grows. Migrations apply inside `main()` at boot, so
enumerating the vocabulary would fail a new binary's writes closed on a lagging
database at the exact moment a feature rolls out. The closed structural
discriminators (`kind`, `auth_model`, `site_scope`) *are* constrained — a third
kind needs a new Go branch shipping anyway, and unconstrained free text lets a
typo fall through a `switch` default, which is the fail-**open** direction.

The `capabilities` CHECK constrains shape only, using IMMUTABLE primitives
exclusively. `array_to_string` is STABLE on this server (verified via
`pg_proc.provolatile`), so the tempting whole-array regex does not belong in a
CHECK; per-element format validation is Go's.

## RLS

None changed. `api_keys` already has `ENABLE` + `FORCE ROW LEVEL SECURITY`,
`api_keys_tenant_isolation` and `api_keys_prefix_lookup`. Row policies cover
every column, so the new columns are exactly as protected as `key_hash`. No
`api_keys_site_scope` policy was added: `api_keys` has no `site_id` and is not a
site-keyed table.

## Proof

Real Postgres 16.4, as `wpmgr_app` (`rolsuper=f`, `rolbypassrls=f`), against a
database built by applying the real migrations. 13 checks, both directions:
pre-existing key keeps identical authority; capability key round-trips intact; a
permission string that does not exist in Go today is **accepted** (the
over-fire check); an empty set is accepted as zero authority; and 8 malformed
rows are each rejected by their named constraint. The migration applies twice
with no error (second run: `NOTICE ... skipping`, exit 0).

## Expected breakage — the next brief, not fixed here

`apps/api/internal/apikey/apikey.go:131` builds `sqlc.CreateAPIKeyParams` as a
**named** literal, so it still compiles while sending `''` for the three
discriminators. That row is now **rejected** by CHECK (fail-closed, proof 12) —
`apikey.Service.Create` fails at runtime until the Go half lands. `toModel` also
silently drops all five new columns.
