### PR TITLE
fix(agent): declare Tested up to 7.1 to unblock the plugin-check gate

### DIFF
--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mosamlife
 Tags: backup, security, performance, updates, site management
 Requires at least: 6.2
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 8.1
 Stable tag: 0.61.139
 License: GPLv2 or later


### PR DESCRIPTION
WordPress 7.1 shipped on 2026-08-19. `apps/agent/readme.txt` still declared `Tested up to: 7.0`, so Plugin Check fails on `main` with:

```
0,0,ERROR,outdated_tested_upto_header,"Tested up to: 7.0 < 7.1. ..."
```

**This unblocks the plugin-check gate for every open PR.** `.github/workflows/plugincheck.yml` runs on any PR touching `apps/agent/**`, `tools/plugincheck/**`, `Makefile` or the workflow itself, and fails the PR on any ERROR row — so this one stale line is currently red on every such PR regardless of what that PR changes.

It is also a live listing problem, not just a red check. The published listing (`api.wordpress.org/plugins/info/1.0/fleet-agent-site-manager.json`) reads `tested: 7.0.4`, and wp.org filters plugins not documented as tested against the current release out of directory search.

## Compatibility was established, not assumed

The whole meaning of this field is "we tested this", so the number was not moved on its own.

Every breaking change in the [7.1 field guide](https://make.wordpress.org/core/2026/08/05/wordpress-7-1-field-guide/) is JavaScript/editor-side:

- the post editor is now always iframed
- jQuery UI 1.13.3 -> 1.14.2, dropping `$.fn._form`, `$.ui.ie`, `$.ui.safeActiveElement`, `$.ui.safeBlur`
- the `wp_classic_block_supports_inserter` filter is removed

A grep over `includes/` and `assets/` for jQuery UI handles, those four removed methods, that filter and the block editor packages returns **zero hits**. This plugin ships no editor JS and enqueues no jQuery UI, so none of the three can reach it.

Per subsystem:

| Subsystem | 7.1 status |
|---|---|
| libsodium / Ed25519 | `sodium`/`sodium_compat` absent from the revised-file list. PHP floor stays 7.4 (raised in 7.0, held in 7.1); ext-sodium is core since PHP 7.2. |
| REST registration | Additive only (JSON Schema preparation, Abilities API). No `register_rest_route` signature or `permission_callback` change. |
| Upgrader | `class-plugin-upgrader.php`, `class-theme-upgrader.php`, `class-core-upgrader.php` all absent from the revised list; `upgrader_process_complete` untouched. |
| Drop-ins | Drop-in loading unchanged, so `advanced-cache.php` and the object-cache drop-in are unaffected. |
| HTTP API / cron / options | One multisite-SSL ticket and one personal-data-cron ticket; no API change. |

Not verified, stated plainly: the diffs of `class-wp-upgrader.php`, the `WP_Filesystem` classes and `class-wp-http.php` (core.trac returns 403 to automated fetches; no dev note and untouched subclasses both point to docblock-only edits), and WP-CLI's 7.1 compatibility. No WordPress 7.1 runtime E2E was run — `e2e-agent.yml` pins no core version and is nightly/manual only, covering object cache rather than 7.1 compatibility.

## Floors rechecked

`Requires at least: 6.2` and `Requires PHP: 8.1` are both still accurate and unchanged. 8.1 is a genuine floor: the source uses `readonly` properties. A grep for post-6.2 core APIs found none — speculation rules are self-implemented rather than using core's 6.8 API.

## Gates

- `composer test` — 3265 tests, 17422 assertions, 0 failures (needs `memory_limit=-1`; see below)
- `make agent-check` — 8/8 files, 0 errors
- `make check-versions` — all 8 surfaces OK
- `make agent-plugincheck` — run locally the way `plugincheck.yml` runs it

## No version bump

`Stable tag` is deliberately unchanged at 0.61.139, so the agent version triple still agrees and the marketing hero badge does not move. `make check-versions` passes with only the readme changed.

## Separate findings (not fixed here)

1. `scripts/release-agent.sh:66` defaults `WPMGR_AGENT_TESTED` to **6.8**, feeding the `tested` field of the managed-channel manifest. `gh variable list` is empty, so that default is live. `scripts/**` routes to devops-engineer, so it is left alone here.
2. `apps/agent/tests/Backup/SqlInspectorTest.php` fatals under PHP's default 128M `memory_limit` (`gzgets($fh, 16777216)`); CI passes only because setup-php sets `-1`.