### PR TITLE
release: 0.61.144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.144] - 2026-08-22
+
+### Added
+
+- An API key can now be granted least privilege instead of a whole role. Keys previously carried a single rank-ordered role, so granting an assistant permission to read files transitively granted managing members, minting further API keys, reading the audit log, and logging into sites as a user. A key now carries an explicit capability set, and can additionally be restricted to named sites (GH #510). Existing keys are unchanged and keep exactly the access they have today. The site restriction is enforced in the application, not in the database; the migration says so in place, and database-level scoping is a separate change that has not shipped.
+
+### Fixed
+
+- The API contract no longer declares nullability with a keyword the spec version it claims does not have. `packages/openapi/openapi.yaml` declares OpenAPI 3.1.0, which removed `nullable`, and used it in 163 places. The TypeScript generator ignored the keyword outright, so those fields were published to consumers of the generated client as always present when the control plane genuinely sends JSON null. All of them now use the forms 3.1 does have: the union `type: [x, "null"]` for scalars, and an `anyOf` with a null branch for the `$ref` and `allOf` shapes the union form cannot reach. Anyone generating a client from this spec was being told a value would always exist when it might not (GH #479).
+- `make gen` regenerates both client trees or fails loudly (GH #511). It previously printed a message about being wired in a later phase and exited 0 without generating anything, so editing the spec and running the documented command left a stale generated tree that looked correct. Each generator is now proved to have written, each is bounded by a deadline, and a new CI job fails when the committed trees do not match a fresh generation. Affects contributors to this repository, not the running system.
+- The plugin now declares compatibility with WordPress 7.1 (GH #514). The listing said 7.0, which wordpress.org treats as grounds for excluding a plugin from search results. This is listing metadata only: no plugin code changed and the agent version does not move. The declaration reaches the public listing when the plugin is next published to wordpress.org, which this release does not do.
+
 ## [0.61.143] - 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.142**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.143**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.142
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.142
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.142
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.143
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.143
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.143
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.142   # omit to track :latest
+export WPMGR_VERSION=v0.61.143   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -225,7 +225,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.142   # omit to track :latest
+export WPMGR_VERSION=v0.61.143   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.143
+  version: 0.61.144
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Cuts the 0.61.144 release surfaces.

## Release type: control plane, and why the agent does not move

`apps/agent` **did** change since `v0.61.143`, but only `readme.txt`'s `Tested up to:` line:

```
$ git diff --stat v0.61.143..origin/main -- apps/agent/
 apps/agent/readme.txt | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

That is wordpress.org listing metadata rather than plugin code, and `Tested up to` is not one of the surfaces `scripts/check-version-surfaces.sh` tracks. So the agent version triple stays on 0.61.139, and the marketing hero badge, which names the **agent** version, stays on 0.61.139 with it. That is confirmed by the guard rather than asserted:

```
OK: the marketing hero badge names agent 0.61.139, matching apps/agent/wpmgr-agent.php.
OK: the agent version triple agrees (0.61.139).
```

**The WordPress 7.1 declaration only reaches the public wordpress.org listing when the plugin is published there. This release does not publish it.** The remedy is a wordpress.org publish of the agent, which is a separate action.

## Surfaces moved

| Surface | From | To |
|---|---|---|
| `CHANGELOG.md` top entry | 0.61.143 | **0.61.144** |
| `packages/openapi/openapi.yaml` `info.version` | 0.61.143 | **0.61.144** |
| Install pins, `README.md` and `docs/install.md` | v0.61.142 | **v0.61.143** |
| Agent triple, marketing hero badge | 0.61.139 | *unchanged* |

The install pins stay one release behind the top entry per policy, since the 0.61.144 images do not exist yet. All three v0.61.143 images were confirmed pullable with `docker manifest inspect` before the pin moved.

## Changelog contents

Four changes, one per commit in `v0.61.143..main`:

- **#479** the API contract no longer declares nullability with a keyword its declared spec version removed. The count is recounted, not inherited: `git show v0.61.143:packages/openapi/openapi.yaml | grep -cE 'nullable:[[:space:]]*true'` prints **163**, and the same grep on this branch prints **0**.
- **#510** API keys carry an explicit capability set and an optional site restriction. The entry states plainly that the site restriction is enforced in the application and not the database, and that database-level scoping has not shipped.
- **#511** `make gen` regenerates both client trees or fails loudly.
- **#514** the plugin declares compatibility with WordPress 7.1.

## Gates, all run on this branch

| Gate | Result |
|---|---|
| `make check-versions-test` | 76 passed, 0 failed |
| `make check-versions` | all 8 checks OK |
| `node apps/marketing/scripts/check-copy.mjs` | passed across 389 files |
| `ci.yml` Docs vocabulary check, copied from the workflow | printed nothing, exit 0 |

The vocabulary check was run byte-identical to `ci.yml` lines 365 to 371, verified with `diff` against the extracted block, and its file set was confirmed non-empty (79 markdown files) so the pass is not vacuous.

## Known follow-up, not fixed here

The marketing `/changelog` page's newest entry is still 0.61.140. `check-versions` measures that as **4 releases behind 0.61.144 against a tolerance of 5**, so it passes with one release of headroom. It needs a backfill covering 0.61.141 through 0.61.144 before 0.61.146, and that is deliberately not done in this PR: writing user-facing framing for three releases this PR was not briefed on is how invented copy gets shipped.
