### PR TITLE
docs(adr): amend ADR-061 (A1-A13), close ADR-062's principal blocker, add ADR-063

### DIFF
--- a/docs/adr/ADR-061-assistant-surface-phase-1.md
+++ b/docs/adr/ADR-061-assistant-surface-phase-1.md
@@ -1,7 +1,7 @@
 # ADR-061 — Assistant surface, Phase 1: control-plane server and out-of-band approval
 
-**Status:** Accepted (amended 2026-08-23) · **Date:** 2026-08-22
-**Supersedes/relates:** ADR-060 (this work sits in its "constrained automation" phase, ahead of differentiation), ADR-057 (unaffected; the capability model here is a separate axis from per-site security policy), ADR-062 (Proposed — supersedes Decision 7 below, per amendment A7).
+**Status:** Accepted (amended 2026-08-23 and 2026-08-24) · **Date:** 2026-08-22
+**Supersedes/relates:** ADR-060 (this work sits in its "constrained automation" phase, ahead of differentiation — and its freeze clause fixes the ordering *inside* this phase, per amendment A9), ADR-057 (unaffected; the capability model here is a separate axis from per-site security policy), ADR-062 (Proposed — supersedes Decision 7 below, per amendment A7), ADR-063 (licensing and third-party reuse — its conclusion independently supports Decision 1's siting).
 
 This ADR records the locked Phase 1 design for the assistant surface: an
 endpoint on the control plane that lets an AI assistant read a fleet and
@@ -18,6 +18,15 @@ on Decisions 1, 6 or 7.** The status stays Accepted and no decision text below
 was rewritten. Eight amendments are recorded at the end of this file: Decision 1
 is clarified rather than changed, Decision 6 is amended, Decision 7 is
 superseded by ADR-062, and four items ADR-061 was silent on are decided.
+
+**Amended again 2026-08-24 — read [Amendments](#amendments-2026-08-24) before
+planning any Phase 1 work.** Five further amendments, A9 through A13. **A9 is the
+one to read first**: ADR-060's freeze clause fixes the ordering *inside* Phase 1,
+so the gate work closes before the endpoint ships. The rest make the audit posture
+fail-closed for this surface, put site scoping in v1 as named work, settle three
+protocol-header cases the code must not conflate, and state the rule that skill
+and prompt content is data and never permission. No decision text below is
+rewritten by any of them.
 
 ---
 
@@ -923,3 +932,194 @@ A vendor documenting the limit of its own containment, on its own flagship
 feature, is better evidence than any argument we could construct: it is the
 claim's author conceding it. The exclusion stands unamended, and A3's Layer C is
 not a route back to it.
+
+---
+
+## Amendments (2026-08-24)
+
+A second review pass — over the whole assistant surface, the connection
+experience, the tool and capability model, the skill and prompt content model,
+the client setup formats and this repository's own licence position — produced
+five further amendments. A9 is the most consequential: it fixes an **ordering**
+inside Phase 1 that this record left free, and the ordering is not a preference.
+
+The 2026-08-23 amendments above stand unchanged, and so does every decision above
+them. As before, the earlier text is not rewritten; the correction is recorded
+next to it.
+
+### A9 — Sequencing inside Phase 1 is fixed by ADR-060's freeze clause, and this is the most consequential sequencing fact in the plan
+
+ADR-060 carries one absolute prohibition, and it is the only absolute in that
+record:
+
+> No new externally-reachable surface ships while an auth-boundary item is open.
+
+Three facts meet in Phase 1 and the conclusion follows from them without judgement
+being involved:
+
+1. **The MCP endpoint is a new externally-reachable surface.** A9 does not need to
+   argue this; A6 already records the protocol, the transport and the fact that
+   the endpoint answers on the existing API host. Something that a third-party
+   client connects to from the public internet is the case the clause is about.
+2. **The site-scope chokepoint is an auth-boundary item, and it is open.**
+   Decision 4 records that the application-layer chokepoint is the boundary in v1,
+   and the chokepoint does not exist yet. A10 and A11 below say what is left.
+3. **The audit posture on this surface is an auth-boundary item, and it is open.**
+   The audit path is documented as best-effort and fails open by default, and A10
+   changes that for this surface. Until the helper exists, the surface's own
+   record of who was denied what is not reliable, which is the boundary's evidence.
+
+**Therefore the Phase-1 gate work closes before the MCP endpoint ships.** Not
+"should", not "ideally in the same release" — the clause is absolute and it is
+narrow precisely so that it can be held rather than informally suspended. Anything
+that renders a Phase 1 plan renders the gate work ahead of the endpoint, and a
+plan that shows them shipping together is wrong on its face rather than optimistic.
+
+**Why this needs stating at all.** The connection wizard, the endpoint and the
+capability hub are the visible part of Phase 1 and the chokepoint is not visible
+at all. That asymmetry is exactly the pressure ADR-060 exists to resist, and it
+resolves silently in the visible direction unless the ordering is written where a
+planner will hit it.
+
+### A10 — Audit is fail-closed for this surface, and opting in is deliberate
+
+**On the assistant surface the audit trail is the point: every AI-originated
+read, proposal, approval, denial and execution writes its record in the same
+transaction as its effect, and if the record cannot be written the operation
+fails — no AI action is ever performed whose record was lost.**
+
+The existing write helper is documented as **best-effort and fail-open**: callers
+are told to log an audit error and continue, *except where the audit trail is
+itself the point*. That default is right for the rest of the product, and there is
+no existing helper that implements the exception — the fail-closed branch exists as
+a sentence in a doc comment and not as a function.
+
+Three things follow, and each is work rather than a caveat:
+
+- **The helper has to be built**, and it becomes the only audit path this surface
+  may use. A surface that can reach the fail-open helper will eventually reach it.
+- **Reads are included.** *Which sites a connection read, and when* is the record
+  a customer needs when they ask what the assistant saw. Reads may be batched or
+  sampled for volume, but the batching rule is written down with a stated
+  retention. An omission dressed as an optimisation is how a read log becomes
+  absent.
+- **The chain lock becomes a throughput ceiling, and it must be measured.** Audit
+  appends take a per-tenant advisory lock. Fail-closed plus a per-tenant
+  serialisation point means audit contention bounds this surface's throughput,
+  under A4's per-organization step ceiling. That is the correct trade and it is
+  still a number somebody has to take, before production takes it for us.
+
+This is an opt-in to a stricter posture than the codebase's default, chosen for
+one surface, and named as such so that nobody later reads the difference as an
+inconsistency to be tidied away.
+
+### A11 — Site scoping is in v1, as an application-layer chokepoint, and it must be built rather than assumed
+
+Decision 4 is unchanged and this amendment does not soften it. What it adds is
+that site scoping is **in v1** — an organization-wide assistant key is not a
+product that can be sold to an operator who answers to someone else for the sites
+they touch — together with the specific work that makes it true.
+
+The current state is that the capability-set migration **stores** a site scope and
+a site allowlist on an API key and **enforces neither**; its own header says so.
+Storage is not a boundary. Six things:
+
+1. **The chokepoint.** One function taking the principal and the requested site
+   id, returning either a scoped context or a typed denial. It is the only way
+   this surface names a site.
+2. **It uses the scoped transaction helper, not the plain tenant one**, so the
+   restrictive site-scope policies that *do* exist actually engage. Today that
+   helper has a handful of call sites; Decision 4 gives the commands for counting
+   them and they are the commands to re-run, not the figures to quote. This
+   surface making it the default is also the honest way to prove it works.
+3. **A scope of "site" with an empty allowlist resolves to zero sites, not all
+   sites.** The scope column exists precisely so that "restricted to nothing" is
+   expressible, and a test proves it fails closed. This is the single most likely
+   place for a fail-open default to survive review.
+4. **A containment test that fails CI.** No handler on this surface may take a
+   site id from a request and pass it anywhere but the chokepoint. Plant a bypass,
+   watch it go red, restore, watch it go green, paste both outputs with their
+   commands.
+5. **Every denial is audited**, under the established action / action-denied
+   naming convention, through A10's fail-closed path.
+6. **The proof runs as the role every install runs as, through the same code path
+   production uses.** A proof that opens its own connection leaves the policies
+   inert while every test passes, which has already happened in this repository
+   once.
+
+**Reaffirmed, and it binds every artifact and not only this one:** database-level
+site scoping for API-key principals is **v2**. The v1 boundary is this
+application-layer chokepoint plus the restrictive policies that already exist.
+**No document, wireframe, marketing page or reviewer-facing summary may imply the
+database enforces it.** The presence of a scope column and an allowlist column is
+not a boundary, and the most likely way this goes wrong is a reviewer reading the
+columns as one.
+
+### A12 — Protocol: three header cases the code must not conflate, and logging from the first request
+
+A6 fixed the target at 2025-11-25 and the floor at 2025-03-26. It did not say what
+happens to the version **header** on an ordinary request, which is a different
+question from what happens at `initialize`, and conflating the three cases below
+produces a server that rejects compliant clients.
+
+1. **Header absent → assume the floor, 2025-03-26. Do not return 400.** This is
+   not leniency and it is not a compatibility concession; the specification says
+   the server should assume that version when the header is not received.
+   Returning 400 here rejects a client that is behaving correctly.
+2. **Header present but unsupported or unparseable → 400 Bad Request.** The
+   specification requires it. The response names the floor and the target so the
+   operator has something to act on, per A6's rule that a version-mismatch error
+   the operator cannot act on is the same defect as a silent downgrade arriving
+   one screen later.
+3. **The negotiated version governs.** Not the header, not the newest version
+   either side supports, not a per-request override. The header is transport
+   metadata about the request; negotiation at `initialize` is what decides the
+   contract.
+
+**Log the received header from day one, on every request, alongside the client
+name and version reported at `initialize`.** No AI client's public documentation
+mentions this header at all, so the real distribution of what clients actually
+send is unknowable from documentation and can only be observed. That log is the
+only route to an answer, and it is the same instrumentation the tool-selection
+measurement in A3 needs.
+
+One consequence follows immediately and constrains scope rather than describing
+it: **no Phase 1 capability may depend on a feature that exists only at
+2025-11-25.** Header-less clients are floor clients by definition, so the whole
+Phase 1 tool surface has to be expressible at 2025-03-26. Anything richer is gated
+and degrades with an explicit message, never with a silent absence.
+
+### A13 — Skill and prompt content is data, never permission
+
+**Authorization resolves outside the model loop. Instruction text that asks for an
+approval to be skipped is therefore denied identically to text that does not ask,
+because the text is not consulted when the question is decided.**
+
+This is not a new decision — it is Decision 2's architecture stated as a rule
+about *content*, because the content is where it will be tested. A skill, a
+prompt, a page body, a plugin error string and a site name are all the same kind
+of object to this surface: material the model may read, and material that can
+never widen what the model may do. There is no phrasing, no framing and no claimed
+authority inside that material which changes the answer, and the reason is
+structural rather than a matter of the model being well-behaved.
+
+**The fencing rule is Phase 1, even though the skill store itself is later.** Every
+site-originated string reaching the model arrives inside a fenced envelope, under
+a standing preamble stating that the enclosed material is reference text that
+cannot change what is permitted, with a provenance attribute we emit from our own
+database and never from the content itself, and with the delimiter escaped so the
+content cannot close its own fence.
+
+The ordering argument is the whole of A13's point: **the fence must predate the
+first untrusted string, not the first skill.** Site names, plugin-supplied error
+strings and — under ADR-062 — page content all reach the model in Phase 1,
+regardless of whether any skill exists. If the fence arrives with the store, then
+every string that reached the model before the store did so naked, and the first
+skill inherits a precedent that instructions arrive unfenced. Likewise the
+structural rule above is Phase 1, because a rule that is not true in Phase 1 is
+decoration.
+
+The ship gate is a **planted hostile site name**: a site whose name is an injection
+payload must produce an approval surface that still renders correctly and a set of
+permitted actions that is unchanged. A fence nobody has watched fail is not known
+to fence anything.

--- a/docs/adr/ADR-061-assistant-surface-phase-1.md
+++ b/docs/adr/ADR-061-assistant-surface-phase-1.md
@@ -1,7 +1,7 @@
 # ADR-061 — Assistant surface, Phase 1: control-plane server and out-of-band approval
 
-**Status:** Accepted · **Date:** 2026-08-22
-**Supersedes/relates:** ADR-060 (this work sits in its "constrained automation" phase, ahead of differentiation), ADR-057 (unaffected; the capability model here is a separate axis from per-site security policy).
+**Status:** Accepted (amended 2026-08-23) · **Date:** 2026-08-22
+**Supersedes/relates:** ADR-060 (this work sits in its "constrained automation" phase, ahead of differentiation), ADR-057 (unaffected; the capability model here is a separate axis from per-site security policy), ADR-062 (Proposed — supersedes Decision 7 below, per amendment A7).
 
 This ADR records the locked Phase 1 design for the assistant surface: an
 endpoint on the control plane that lets an AI assistant read a fleet and
@@ -12,6 +12,12 @@ It records the decisions and the reasoning behind them, not the build plan.
 **Phase 2 — content operations and page-builder work — is out of scope for
 this record and gets its own ADR.** Nothing here should be read as approving
 any part of it.
+
+**Amended 2026-08-23 — read [Amendments](#amendments-2026-08-23) before acting
+on Decisions 1, 6 or 7.** The status stays Accepted and no decision text below
+was rewritten. Eight amendments are recorded at the end of this file: Decision 1
+is clarified rather than changed, Decision 6 is amended, Decision 7 is
+superseded by ADR-062, and four items ADR-061 was silent on are decided.
 
 ---
 
@@ -42,6 +48,10 @@ model applies nothing directly.
 ---
 
 ## Decision 1 — The server lives on the control plane, not on managed sites
+
+*Clarified 2026-08-23 by amendment A1. The text below is unchanged. The
+clarification scopes the fan-out argument and activates the second clause of the
+first Consequences bullet; it does not weaken the credential argument.*
 
 **The assistant endpoint is a route on the existing API host. It is not a
 surface on the WordPress agent, and it does not route through the WordPress
@@ -407,6 +417,12 @@ caught all of them.
 
 ## Decision 6 — The tool surface is fleet-level questions, not per-site commands
 
+*Amended 2026-08-23 by amendment A3. The text below is unchanged and its flat
+fleet-read set stands. What changed: the revisit threshold is now measured
+rather than a round number, a three-layer registry is recorded, and the second
+of the three arguments against a facade is retired as not binding on this
+architecture.*
+
 **A small flat set of fleet-level tools. No meta-tool facade, no per-site
 command mirror of the product's action surface.**
 
@@ -444,7 +460,14 @@ prompt-level safety is not a boundary.
 
 ---
 
-## Decision 7 — Site generation is conceded
+## Decision 7 — Site generation is conceded — SUPERSEDED
+
+*Superseded 2026-08-23 by ADR-062 (Proposed), via amendment A7. The text below
+is kept as written and is no longer the standing decision. Its factual premise
+survives — Phase 1 writes no content, and no content write path exists in either
+process — but the conclusion drawn from that premise does not. Read
+[ADR-062](./ADR-062-assistant-surface-phase-2-content-operations.md) instead;
+until ADR-062 is Accepted, no Phase 2 content code ships.*
 
 **Content writes and site generation are not scheduled, and this is a
 concession rather than a deferral.**
@@ -524,6 +547,14 @@ sustained 0% decline rate is read as a kill signal rather than as success.
   configuration; that requires the deferred migration and its own decision.
 - Content and page-builder operations are outside this design entirely.
 
+*Three items in that list were amended on 2026-08-23 and must be read with the
+Amendments section below. The second sentence of the first bullet — per-site
+capability dispatched through the existing signed-command path — is activated
+rather than hypothetical (A1). The second bullet is bounded against scheduling:
+a scheduler that only proposes is permitted, and nothing scheduled may approve
+(A5). The last bullet is retired (A7); it remains true of Phase 1's scope and is
+no longer a statement about the product.*
+
 **What it costs.**
 
 - Site scoping in v1 is an application-layer property, which is a weaker
@@ -571,3 +602,293 @@ sustained 0% decline rate is read as a kill signal rather than as success.
 surface exists. The assistant route must answer 401 rather than 404 to an
 unauthenticated request against the deployed revision, because a missed
 constructor leaves every route 404 while the build and the package tests pass.
+
+---
+
+## Amendments (2026-08-23)
+
+A design review over the whole assistant surface — the decisions above, the
+published Phase 1 and Phase 2 design surfaces, and the agent's actual command
+surface — found that this record contradicts our own published design work in
+four places, decides three things it never states, and rests one argument on a
+premise that a later decision had already discharged.
+
+**These are amendments, not a rewrite.** Every decision above keeps its original
+text. This section records what changed and why, in the pattern `CLAUDE.md`
+already uses for its own corrections: the wrong or incomplete version stays
+visible, because the next person to reason about it quickly will re-derive the
+same version and needs to find the correction rather than the argument.
+
+**What these amendments do not change.** Decisions 2, 3, 4 and 5 are untouched.
+So is *Two things that were expensive to learn*, and in particular the corrected
+statement at the top of it: per-command signing gives **forgery and tampering
+resistance while the signing authority remains trusted**, and does **not**
+protect a site from a compromised control plane or a stolen key. Nothing in A2
+or A4 below is a claim about the signing key, and nothing below turns signing
+into a safety property it does not have.
+
+---
+
+### A1 — Decision 1 stands. The fan-out argument is scoped, and the per-site clause is activated
+
+Decision 1 gave two arguments and they have different reach.
+
+**The credential argument (Decision 1, paragraph 3) is untouched and is the
+load-bearing half.** A per-site *inbound* assistant path would still require a
+privileged WordPress user and a standing credential on every managed site,
+multiplied by the size of the fleet. Nothing here reopens that, and no amendment
+below creates an inbound path to a site.
+
+**The fan-out argument is narrower than it reads.** Its subject is *fleet
+questions* — "Sending them to individual sites turns one Postgres query into an
+unbounded fan-out". The antecedent is fleet-aggregate queries, and the argument
+was never applied to a targeted single-site action, which is a different traffic
+shape: one round trip to one named site, not N.
+
+Decision 6's "Per-site commands are an unbounded fan-out of round trips" looks
+like a counter-example and is not, for a reason neither decision noticed.
+"Unbounded" describes a tool whose site parameter is a *set*. And more
+decisively: **under Decision 2 a per-site tool call does not execute anything.**
+It writes a proposal row. Its cost at tool-call time is one INSERT and zero
+network round trips. Dispatch happens afterwards, on a worker, after a human
+approves, outside any first-byte deadline. Decision 6's response-time argument
+assumes the tool call executes; it does not, and that assumption is the only
+thing holding it up.
+
+**What this activates.** The second sentence of the first Consequences bullet —
+"Any future per-site capability is dispatched by the control plane through the
+existing signed-command path" — was written as a hypothetical. It is hereby the
+sanctioned and only route: per-site capability reaches a site as a signed command
+dispatched by the control plane after a human approval, and never as an inbound
+connection to the site. A future per-site capability therefore does **not**
+require superseding Decision 1. Opening an inbound path still does.
+
+### A2 — The agent already has a large action surface, and this record reads as though it does not
+
+Measured in the working tree at the time of writing, from `apps/agent`:
+
+```sh
+ls includes/commands/*.php | wc -l
+#   68
+
+grep -rhoE 'command/[a-z0-9_]+' includes/commands/*.php \
+  | sed 's#command/##' | sort -u | wc -l
+#   55
+```
+
+Sixty-eight command classes implementing fifty-five distinct signed command
+names ship today, over the outbound signed-command channel: the filesystem
+surface, database maintenance, search-and-replace, media, cache, backup, restore,
+rollback, scan and update. Re-run both commands rather than citing these
+figures; they move with the plugin.
+
+This corrects a **reading**, not a decision. "The agent plugin does not move for
+this feature" is a statement about Phase 1 and stays true — Phase 1 adds no
+command. But the surrounding framing reads as though the agent has no action
+surface at all, and every downstream design artifact inherited that reading. The
+consequence is the single largest correction in the review: for most per-site
+work an assistant might propose, **what is missing is model-facing exposure, not
+capability.**
+
+Decision 7's premise — "no post, page, block, taxonomy or menu write path exists
+in the control plane or in the agent" — is about *content* write paths
+specifically and remains true. It was re-verified against the same command's
+output this pass: no name in the set is a content verb.
+
+One property of that channel is worth recording here because A3 and A4 lean on
+it. Each command is authorized by its own short-lived Ed25519 bearer token bound
+to a single command name and a single site, so a token minted for one command
+cannot invoke another (`apps/api/internal/agentcmd/jwt.go`); confirmation for a
+dangerous write is a body field the agent enforces server-side rather than a
+prose instruction; and a file write that would overwrite an existing file copies
+it to a staging area first (`apps/agent/includes/commands/class-file-write-command.php`).
+That is a description of the wire contract. It is not a claim about the signing
+key, and the paragraph above still governs what signing does and does not buy.
+
+### A3 — Decision 6: a measured threshold, a three-layer registry, and one retired argument
+
+Decision 6's flat fleet-read set is right and stays. Three things change.
+
+**The threshold is measured, and it is measured against `tools/list` size
+specifically.** "Revisit a facade if the flat set approaches roughly 25 entries"
+is replaced by: *revisit at the measured point at which tool-selection accuracy
+degrades, measured against the size of the list the client actually receives,
+re-measured per release.* Two reasons. Registry size and `tools/list` size are
+different quantities and the original conflated them — a registry of hundreds
+behind a handful of exposed tools does not test the exposed-list claim at all.
+And a round number in an ADR is a guess wearing a decision's clothes; `CLAUDE.md`
+already requires that a performance question be settled by measurement before a
+fix, and tool-selection accuracy is that kind of question. Until the measurement
+exists, Layer A ships and instrumenting tool-selection correctness is a Phase 1
+deliverable.
+
+**The registry has three layers, and the boundary between them is enforced by
+what is registered rather than by a flag.**
+
+- **Layer A — flat fleet-read tools.** Decision 6 as written, unchanged. A small
+  set, each wearing its own name, each answered from control-plane inventory with
+  its own staleness stamp in the same object as the answer.
+- **Layer B — curated per-site *proposal* tools, named by intent rather than by
+  command.** Not a mirror of the command surface. Most of that surface is
+  operator plumbing — inventory refresh, cache preload queueing, agent
+  self-update, object cache and performance config — that no model should ever be
+  asked to choose between. A Layer B tool resolves to one or more signed
+  commands, and it wears its own name **on our approval surface**, which renders
+  the resolved command names from control-plane-derived facts and never a generic
+  "execute".
+- **Layer C — at most one dispatcher, and only if Layer B exceeds the measured
+  cap.** Permitted only over a positively enumerated, per-site-gated registry
+  whose argument is constrained by an enum generated from what a given site
+  actually has. Never over an open tail.
+
+**The facade objection is retained in one half and retired in the other.**
+Decision 6 cut the facade on two grounds.
+
+The first — "a tail defined only by what is absent from it is not a registry" —
+is **retained**, and it is exactly why Layer C is confined to a positively
+enumerated registry with a generated argument enum. A facade over an enumerated,
+per-target-gated, runtime-verified registry is a different object from a facade
+over an undefined tail, and only the second is what that sentence rejects.
+
+The second — "every action should wear its own name in the client's approval UI"
+— is **retired as not binding on this architecture**, and the reasoning matters
+more than the conclusion. That argument protects a property Decision 2 does not
+rely on. Decision 2 removed the client's approval UI from our trust model
+entirely: approval happens on a control-plane surface the model cannot reach, the
+proposing and approving credential classes are disjoint, and the confirmation
+phrase is never sent to the model. In an architecture whose *only* gate is the
+client's tool-approval prompt, a generic invoke tool is a real and serious cost —
+the operator is shown one tool name standing in for every action the surface can
+take, and that is the whole of what they get to approve. We are not that
+architecture. The name that carries our approval decision is the one **our**
+surface renders, and Decision 3 already requires that surface to derive it from
+inventory rather than from anything the model sends. The argument is sound; it
+binds a different product.
+
+**Unchanged by this amendment:** shell execution and command-runner tools remain
+excluded from this product line permanently, and Layer C is not a route back to
+them. The byte-capped, record-boundary output rule is also unchanged.
+
+### A4 — Concurrency: a per-organization ceiling and a per-site exclusive lock
+
+ADR-061 was silent on concurrency, and two published surfaces filled the silence
+differently — one rendering several operations running at once, another
+disabling an action because another operation holds its sites. Both are correct
+under one rule, and nothing said so.
+
+**Two mechanisms, both in force.**
+
+1. **A per-organization fleet-wide ceiling on concurrently dispatching steps,
+   default 4.** It is configured as the `MaxWorkers` of the assistant dispatch
+   River queue, sharded per tenant the way `apps/api/internal/update` already
+   shards its task queue (`const tenantQueueShards = 8`,
+   `apps/api/internal/update/worker.go:60`), so one organization's burst fills
+   only its own shard and cannot starve another tenant. The default of 4 is a
+   starting value, not a measurement: it is the same bounded default the RUCSS
+   queue already uses (`apps/api/internal/rucss/worker/worker.go:405`), and it is
+   expected to move once real dispatch load exists. It is stated here so that
+   there is a number with a decision behind it.
+2. **A per-site exclusive advisory lock, held for the duration of that site's
+   step.** `pg_advisory_xact_lock(hashtext(<namespace>), hashtext(<site id>))`,
+   released by commit or rollback — the same discipline
+   `apps/api/internal/update/agent_repo.go` and `apps/api/internal/org` already
+   use, and not a new locking mechanism.
+
+The ceiling bounds fleet-wide load. The lock is what makes "another operation
+holds these sites" true without taking a global lock, so unrelated sites keep
+moving while one site is busy.
+
+Reads are freely concurrent and take no lock. A proposal is an INSERT and is
+concurrency-safe, which is A1's point restated: the thing that needs serializing
+is dispatch, and dispatch happens after approval.
+
+**Recorded so it is not cited again: the "3 concurrent" figure in the Phase 1
+design surfaces is mock copy.** No decision stood behind it; it was invented to
+fill a wireframe. It is not the ceiling, and the surfaces render whatever this
+decision sets.
+
+### A5 — A scheduler that only proposes is permitted; nothing scheduled may approve
+
+"No automation may ever approve" is unchanged and absolute. It does not forbid
+automation that only proposes.
+
+A scheduler may assemble a proposal on a timetable and enqueue it. That proposal
+enters the same queue, is rendered on the same approval surface, and waits for
+the same human decision as any other. Nothing scheduled may approve; no timeout,
+escalation or policy may approve; and a run that waits forever waits forever,
+visibly. The operative words in the foreclosure are "with no human in the loop",
+and without this sentence the bullet reads as foreclosing scheduled dispatch
+entirely, which was not the decision.
+
+### A6 — The protocol is MCP, and this record now says so
+
+This is a decision record for a connector that never named its protocol.
+Before this amendment,
+`grep -ric 'MCP\|Model Context Protocol' docs/adr/ADR-061-assistant-surface-phase-1.md`
+returned `0`, while the published Phase 1 design surfaces already show users an
+`/mcp` endpoint on the app host. The UI encoded a protocol decision the ADR did
+not record. Closing that gap:
+
+- **Protocol: MCP (Model Context Protocol).**
+- **Target version: 2025-11-25**, with a compatibility window for clients that
+  negotiate an earlier version. Version negotiation happens at `initialize`, and
+  a version we cannot serve is refused with a named error rather than silently
+  downgraded into unspecified behaviour.
+- **Transport: Streamable HTTP**, on the existing API host, inside the existing
+  TLS boundary and auth path. That is Decision 1's consequence restated: one
+  origin, one boundary. There is no stdio transport, because there is nothing on
+  a customer machine for us to run.
+- **Resources: out of scope for Phase 1.** Every fleet answer is a tool result
+  that carries its own staleness stamp in the same object as the answer, and a
+  resource has nowhere to put one.
+- **Prompts: out of scope for Phase 1.**
+- **Elicitation and sampling are never on the approval path.** Neither is a
+  substitute for the Decision 2 surface, and an elicitation round trip that
+  looked like an approval would produce precisely the ambiguity Decision 2 exists
+  to remove — a confirmation the model could have satisfied itself.
+- **Server instructions are delivered in the first tool result rather than
+  relying on the `initialize` handshake, and prepended rather than appended.**
+  Client handling of handshake instructions varies, and where an instruction
+  budget is capped it is the tail that gets cut.
+
+### A7 — Decision 7 is superseded by ADR-062
+
+Decision 7 conceded content writes and site generation, and recorded the
+concession as permanent specifically so it would not be re-proposed each planning
+cycle by someone who had not read the reasoning. The reasoning is what failed.
+
+Its premise was a fact about this tree — no content write path exists in either
+process — and that half is still true (A2). What Decision 7 drew from it was a
+*market* conclusion: that building one is "a product bet about entering a
+different market". That conclusion does not survive. Fleet content operations are
+already designed in this product's own published Phase 2 design surfaces, against
+a locked decision that forbids them; and the technical objection underneath the
+concession rested on a test that was the wrong test, which ADR-062 states and
+replaces.
+
+**Decision 7 is superseded by
+[ADR-062](./ADR-062-assistant-surface-phase-2-content-operations.md).** ADR-062
+is **Proposed**, not Accepted, and no Phase 2 content code ships until it is
+accepted. "Conceded rather than deferred" is retired and replaced by a scoped
+commitment recorded there.
+
+The Consequences bullet "Content and page-builder operations are outside this
+design entirely" is retired with it. It remains an accurate statement of *this*
+ADR's scope — Phase 1 writes no content — and it is no longer a statement about
+the product.
+
+### A8 — Added to *Two things that were expensive to learn*
+
+**"Prompt-level safety is not a boundary" now has external corroboration, and
+the strongest kind.** The exclusion of shell execution and command-runner tools
+was recorded above as reasoning. A shipping product in this category exposes
+arbitrary code execution inside the WordPress process to a model, and the entire
+safety mechanism around it is a short prose instruction asking the model to
+behave. Its own published documentation states that the containment appearing to
+surround that feature is not a security boundary, and that code execution passes
+straight through it.
+
+A vendor documenting the limit of its own containment, on its own flagship
+feature, is better evidence than any argument we could construct: it is the
+claim's author conceding it. The exclusion stands unamended, and A3's Layer C is
+not a route back to it.

--- a/docs/adr/ADR-061-assistant-surface-phase-1.md
+++ b/docs/adr/ADR-061-assistant-surface-phase-1.md
@@ -798,6 +798,24 @@ The ceiling bounds fleet-wide load. The lock is what makes "another operation
 holds these sites" true without taking a global lock, so unrelated sites keep
 moving while one site is busy.
 
+**The unit of the ceiling is the per-site step, and "runs" and "operations" are
+not synonyms for it.** A step is the smallest unit of work that touches one site;
+it is what occupies a worker and makes one outbound request, so it is what
+`MaxWorkers` counts and the only unit in which a concurrency limit means
+anything here. **A run is not capped.** An organization may have any number of
+multi-site runs in flight; what is capped is how many of their steps dispatch at
+once. Counting the ceiling in runs would understate fleet load by roughly the
+size of the fleet — one run across forty sites is a single run and forty steps,
+so a ceiling of four *runs* permits up to forty concurrent site dispatches while
+reading on screen as four.
+
+The conversion between the two, since it is meaningful: **a run over N sites
+contributes at most `min(N, ceiling)` concurrently dispatching steps, and never
+more than one step per site at a time**, because mechanism 2 serializes a site's
+own steps whatever the ceiling allows. Every surface that renders this limit
+renders it in steps and uses that word: three nouns for one limit is how the
+withdrawn figure above survived as long as it did.
+
 Reads are freely concurrent and take no lock. A proposal is an INSERT and is
 concurrency-safe, which is A1's point restated: the thing that needs serializing
 is dispatch, and dispatch happens after approval.
@@ -830,10 +848,23 @@ returned `0`, while the published Phase 1 design surfaces already show users an
 not record. Closing that gap:
 
 - **Protocol: MCP (Model Context Protocol).**
-- **Target version: 2025-11-25**, with a compatibility window for clients that
-  negotiate an earlier version. Version negotiation happens at `initialize`, and
-  a version we cannot serve is refused with a named error rather than silently
-  downgraded into unspecified behaviour.
+- **Target version: 2025-11-25.** This is what we implement against and what a
+  current client negotiates. It is corroborated against the WordPress project's
+  published MCP schema package, whose typed protocol DTOs are described as MCP
+  2025-11-25.
+- **Floor: 2025-03-26, and it is a floor rather than a preference.** Below it the
+  protocol drops fields the approval flow depends on, and the approval flow is
+  the product — ADR-061 exists to make "a named human approved this" checkable,
+  and a negotiated version that cannot carry the fields that claim rests on
+  cannot serve it. A compatibility window is therefore bounded below by
+  2025-03-26 and not by whatever the oldest client in the field happens to speak.
+- **Below the floor: refuse, and say why.** Version negotiation happens at
+  `initialize`; a version below the floor is refused rather than silently
+  downgraded into unspecified behaviour, and the refusal reaches the operator as
+  the reason rather than as a bare version mismatch — this client speaks an older
+  revision of the protocol, that revision cannot carry the approval fields, and
+  the remedy is a newer client. A version-mismatch error the operator cannot act
+  on is the same defect as a silent downgrade, arriving one screen later.
 - **Transport: Streamable HTTP**, on the existing API host, inside the existing
   TLS boundary and auth path. That is Decision 1's consequence restated: one
   origin, one boundary. There is no stdio transport, because there is nothing on

--- a/docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md
+++ b/docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md
@@ -1,14 +1,19 @@
 # ADR-062 — Assistant surface, Phase 2: governed fleet content operations
 
-**Status:** Proposed · **Date:** 2026-08-23
-**Supersedes/relates:** Supersedes ADR-061 Decision 7 (site generation conceded), via ADR-061 amendment A7. Relates to ADR-061 (Phase 1, as amended 2026-08-23 — Decision 1 siting, Decision 2 out-of-band approval, Decision 3 control-plane-derived approval facts, amendment A3's tool registry, amendment A4's concurrency rule) and ADR-060 (this work sits in the differentiation phase and does not outbid anything above it).
+**Status:** Proposed · **Date:** 2026-08-23 · **Amended:** 2026-08-24
+**Supersedes/relates:** Supersedes ADR-061 Decision 7 (site generation conceded), via ADR-061 amendment A7. Relates to ADR-061 (Phase 1, as amended 2026-08-23 and 2026-08-24 — Decision 1 siting, Decision 2 out-of-band approval, Decision 3 control-plane-derived approval facts, Decision 4 application-layer site scoping, amendment A3's tool registry, amendment A4's concurrency rule, amendment A9's sequencing, amendment A13's fencing rule), ADR-060 (this work sits in the differentiation phase and does not outbid anything above it) and ADR-063 (licensing and third-party reuse).
 
 **This ADR is Proposed and it blocks Phase 2.** No content-write code ships in
-`apps/agent` or in the control plane until it is Accepted. The nine items in
+`apps/agent` or in the control plane until it is Accepted. The items in
 [The nine things this ADR must establish](#the-nine-things-this-adr-must-establish)
-are its acceptance checklist, and item 2 — which WordPress principal a content
-write executes as — is currently unanswered and is a hard blocker rather than a
-detail to settle during the build.
+are its acceptance checklist.
+
+**What the 2026-08-24 amendment changes.** Item 2 — which WordPress principal a
+content write executes as — was named here as *"Open, and a hard blocker"*. It is
+now decided, in [The principal question](#the-principal-question). Items 5 and 7
+are decided with it, and the raw-content fork in *Other open questions* is decided
+too. **The ADR stays Proposed**, and the reasons are named rather than left to
+inference: [Why this is still Proposed](#why-this-is-still-proposed).
 
 ---
 
@@ -95,35 +100,68 @@ Nothing in this ADR raises the floor on a heterogeneous fleet.
 
 ## The nine things this ADR must establish
 
-This is the acceptance checklist. Every unchecked item is a reason this ADR is
-still Proposed.
+This is the acceptance checklist, revised 2026-08-24. `[x]` means the decision is
+recorded in this ADR; `[ ]` means it is not, and every `[ ]` is a reason this ADR
+is still Proposed.
 
-- [ ] **1. Where the write executes, and by what channel.** On-site, in-process,
+The count in this heading is not a figure to trust from a heading. Verify it, and
+verify how many are still open, from the list itself:
+
+```sh
+f=docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md
+[ -f "$f" ] || { echo "FAIL: $f missing -- the checklist moved, which is not an empty checklist" >&2; exit 1; }
+total=$(grep -cE '^- \[[ x]\] \*\*[0-9]+\.' "$f")
+[ "$total" -gt 0 ] || { echo "FAIL: no checklist items matched -- the list was reformatted, which is not zero items" >&2; exit 1; }
+echo "checklist items $total"
+echo "still open      $(grep -cE '^- \[ \] \*\*[0-9]+\.' "$f")"
+```
+
+The refusal on zero is the point of writing it this way. A reformatted list that
+matched nothing would otherwise print `0 open` and read as an ADR ready to accept.
+
+- [x] **1. Where the write executes, and by what channel.** On-site, in-process,
       in `apps/agent`, reached only over the existing outbound signed-command
-      channel, as the four separately signed command names above. Drafted in
-      [Where the write executes](#where-the-write-executes). **Needs:**
+      channel, as the four separately signed command names above. Recorded in
+      [Where the write executes](#where-the-write-executes). **Still needs:**
       `security-reviewer` sign-off on the four-name split and its token scoping.
-- [ ] **2. Which WordPress principal a content write executes as.** **Open, and
-      a hard blocker.** See [The principal question](#the-principal-question).
-      No content code is written before this closes.
+      That review is a build gate, not an acceptance gate — the decision is made,
+      the proof is not.
+- [x] **2. Which WordPress principal a content write executes as.** **Decided
+      2026-08-24:** a dedicated WordPress service user with a custom role, created
+      by the agent, with no password, no login path, no session, and deliberately
+      no `unfiltered_html`. See
+      [The principal question](#the-principal-question). Its attack-test suite is
+      a **ship gate**, not a review item.
 - [ ] **3. Own or delegate, per integration — with verify-and-rollback as a
-      shared primitive rather than a per-integration one.** See
-      [Own or delegate](#own-or-delegate-and-why-the-guard-is-a-platform-property).
+      shared primitive rather than a per-integration one.** The rule is recorded
+      in [Own or delegate](#own-or-delegate-and-why-the-guard-is-a-platform-property);
+      **the per-integration table that applies it is not written**, and it cannot
+      be written for Wave 2 until the Wave 1 machinery has been proved once.
 - [ ] **4. Snapshot before every destructive write, mandatory, at the platform
-      layer.** See
+      layer.** The rule is recorded in
       [Snapshot is a platform property](#snapshot-is-a-platform-property-not-an-integration-feature).
-- [ ] **5. The block-editor fork, taken deliberately.** Two branches, each with
-      its cost, one of which must be chosen before Phase 2 scope is fixed. See
-      [The block-editor fork](#the-block-editor-fork).
+      **Open because the file version stack does not cover content**, and
+      extending it is named work that has not started. Snapshot-as-a-rule is
+      cheap; snapshot-as-a-mechanism for post rows is the build.
+- [x] **5. The block-editor fork, taken deliberately.** **Decided 2026-08-24:**
+      Branch A for third-party and core *static* blocks, as a stated absence, plus
+      a narrow Branch B. See [The block-editor fork](#the-block-editor-fork).
 - [ ] **6. Dynamic-data binding as the primary write-reduction strategy.** See
-      [Bind once, then write fields](#bind-once-then-write-fields).
-- [ ] **7. Scope: which page builders and field plugins are in v1**, on stated
-      evidence about the cost of each, with everything outside v1 named as absent
-      rather than silently missing.
+      [Bind once, then write fields](#bind-once-then-write-fields). Recorded as a
+      design goal; **the binding operation itself is unscoped** and it lands with
+      the one builder in Wave 2, so it cannot close ahead of that wave.
+- [x] **7. Scope: which page builders and field plugins are in v1**, with
+      everything outside v1 named as absent rather than silently missing.
+      **Decided 2026-08-24** in [Scope: the wave plan](#scope-the-wave-plan) —
+      and decided on **reasoned** criteria, not on measured fleet data. That
+      caveat travels with the plan wherever the plan is rendered.
 - [ ] **8. How the Layer B / Layer C tool budget accommodates content.**
       Cross-references ADR-061 amendment A3: content proposal tools are Layer B,
       named by intent, and the measured `tools/list` threshold from A3 — not a
-      round number — decides whether Layer C is needed at all.
+      round number — decides whether Layer C is needed at all. **Open by
+      construction:** A3 requires a measurement that cannot be taken until Layer A
+      is serving live traffic. This item closes with a number, not with an
+      argument.
 - [ ] **9. Formal retirement of ADR-061 Decision 7 and its Consequences bullet**,
       with "conceded rather than deferred" replaced by the scoped commitment this
       ADR records. Done in ADR-061 amendment A7; this item closes when this ADR
@@ -260,6 +298,138 @@ everything else it knows about the site. Two rules follow:
 The same rule covers core-version-gated capability: a site below a version floor
 sees a row stating the requirement and its own version, not an empty space.
 
+## Scope: the wave plan
+
+**Decided 2026-08-24.** This closes checklist item 7. Read the two honesty
+statements that follow it before acting on the ordering; they are part of the
+decision, not a caveat attached to it.
+
+### Wave 1 — no page builder, and no block-editor writes
+
+Wave 1 deliberately contains **no page builder at all** and **no Gutenberg
+writes**. It is four capabilities:
+
+| # | Capability | Scope | Why it is here |
+|---|---|---|---|
+| 1a | **Capability detection across every integration target.** Read-only, always registered, never gated off below a version floor. | Zero writes | The cheapest item in the plan and the highest leverage. *"Which of my four hundred sites run a page builder below its floor"* is a question operators have today and nothing answers. One schema across all integrations, with per-integration detail confined to a typed detail object. |
+| 1b | **SEO metadata — one canonical document, adapters per plugin.** Post-level and term-level only: title, meta description, canonical, robots, social tags, focus keyword. | **Excluded:** site-wide settings, redirects, structured data | Externally verifiable (below). Documented storage. Reversible by read-then-write. One canonical document with several adapters is the highest value-per-line abstraction in the whole surface. |
+| 1c | **Commerce catalog — reads in full, writes narrow.** Writes limited to product and variation stock, stock status and post status. | **Excluded:** every price write, every delete, orders, customers, refunds, coupons, tax, gateways | Everything goes through the commerce plugin's own product API and never through raw post meta, which is the same rule this ADR already states for field values. |
+| 1d | **Custom-field values — read and write. No structure.** | **Excluded:** field-group and field creation | A documented plugin write API that maintains the value/definition pair, reversible, and friendly to the signed-command channel. |
+
+**Why SEO leads, in one sentence an operator can repeat:** it is the only
+capability in the entire surface whose result can be proved **from outside the
+site** — fetch the public URL from the control plane and read the title and
+description out of the response.
+
+That is the standing rule about verifying the thing rather than the pipeline's
+report of it, applied to a roadmap. Every other Wave 1 candidate — a stock write,
+a field write, a theme option write — is verifiable only by asking the same agent
+again, which *is* the pipeline's report. We already run outbound uptime probes, so
+the verification path exists in shape. **It exists in shape, not in fact:** whether
+that prober can be reused for arbitrary URL fetches has not been checked, and the
+entire external-verifiability argument rests on it. Confirming that is a
+pre-development task, below.
+
+**Price writes carry a typed confirmation, permanently, whenever they land.** Not
+a boolean asserted by the caller, and not a consequence of a risk flag: the typed
+confirmation string shape the agent already uses for its most destructive database
+command. A consent gate keyed on a per-author risk flag is a gate whose meaning
+drifts per author. Wave 1 does not include price writes at all.
+
+**Every risk flag in the catalogue gets a written definition and a check that
+fails CI**, built as a repo script with a committed self-test, per the standing
+rule that build-gating logic never lives in a YAML block scalar. A risk flag
+without a definition means four things to four engineers, and a consent gate keyed
+on it inherits all four.
+
+### Wave 2 — exactly one page builder
+
+- **Elementor, and only Elementor, of the page builders.** Its document is a
+  hand-owned post-meta blob whose real schema lives in editor JavaScript, so it
+  requires the semantic verification primitive plus the platform snapshot and the
+  ownership precondition to **already exist and already be proved**. This narrows
+  the prior planning round's "three to four builders in v1" to one: three builders
+  is three reverse-engineered formats, three signature functions and three
+  maintenance liabilities tracking three release schedules, all bought before the
+  machinery that contains them has been proved once.
+- **Theme settings for a small set of themes**, late in the wave, and only because
+  of a structural accident that makes them unusually safe: several of them keep
+  everything in a single serialized option, so snapshot-and-restore is one option
+  read and one option write — the cleanest rollback available anywhere in this
+  surface. Any theme whose storage mode varies is detected before it is supported.
+  A theme operation that imports content or can install plugins is excluded
+  outright.
+- **Form reads only.** The canonical-document abstraction earns its keep on the
+  read side, where several mappers collapse into one comparable document. It is
+  not attempted on the write side, where each mapper would have to be exactly
+  right and a shared abstraction becomes a liability.
+- **Dynamic-data discovery reads** — enumerate what is bindable, validate it,
+  evaluate it. Cheap, idempotent, no writes. This is the read half of
+  [Bind once, then write fields](#bind-once-then-write-fields).
+
+### Wave 3 — only if the fleet query justifies it
+
+Gutenberg **static** blocks (subject to the block-editor fork above and its
+planted failing test), Bricks, form writes, and content modelling. Each carries a
+detection-signature seeding task as an explicit prerequisite, surfaced in the
+backlog up front rather than discovered mid-build — several Wave 3 targets are
+genuinely absent from our detection corpus today, and Wave 1 depends on none of
+them.
+
+### Out of scope, each with its one-line reason
+
+- **Divi** — the document is written into the post body, and a mismatched writer
+  destroys the page on first editor open. The failure is silent until someone
+  opens the editor.
+- **Avada** — the format is owned by hand at the SQL level, with far more raw
+  database call sites than any other integration measured. We would be adopting
+  someone else's schema, not their API.
+- **Oxygen and Breakdance** — one codebase behind a mode constant, so supporting
+  either means supporting both and telling them apart correctly every time.
+- **WPBakery** — older branches are fatal on PHP 8, so touching a site below the
+  floor takes the site down rather than failing the write.
+- **Beaver Builder, Etch, Voxel, Mosaic** — no evidence they are on this fleet,
+  and nothing in the criteria promotes them ahead of the targets above.
+- **Any translation push to a vendor cloud** — permanently. It is the only
+  operation in the surveyed surface that mutates state **outside the customer's
+  server**, which means we cannot roll it back at all, and this ADR's whole
+  premise is that every write has a snapshot and a way back. Translation *reads*
+  are fine.
+
+### Two honesty statements that travel with this plan
+
+**1. The ordering is reasoned, not measured — say so wherever the plan is
+rendered.** No installed-base numbers were used to produce it, deliberately, since
+there is no command that produces them and an installed-base figure is exactly the
+kind of number that gets repeated for a year after it stops being true. The
+criteria are: can we verify the result from outside the site, can we put it back,
+is the storage documented, and does it fit the signed-command channel. Installed
+base is deliberately last. **A reasoned ordering must never be read as an
+evidenced one**, and it will be, if a wave table is rendered on a screen with no
+such line on it.
+
+**2. The fleet-inventory query is a pre-development task, and it has not been
+run.** For each integration target: how many of our sites have it, and its version
+distribution against that target's vendor floor. The data is already there — the
+per-site component inventory, the active theme, the plugin-signature corpus and
+the wordpress.org checksum tables. Running it costs an afternoon and turns this
+section from an opinion into a plan. **The criteria do not change if the query
+surprises us. The ordering does.**
+
+Two further pre-development checks gate Wave 1, and both are about detection
+honesty rather than capability:
+
+- **Confirm the outbound prober can fetch arbitrary URLs**, because the whole
+  external-verifiability argument for leading with SEO rests on it and it was
+  never checked.
+- **Audit how the plugin-signature corpus is matched against per-site component
+  inventory.** Wave 1 leans on SEO and SEO leans on detecting a handful of
+  plugins. At least one corpus key does not match that plugin's real
+  wordpress.org directory slug. Either the corpus is keyed on something other
+  than the slug and this is noise, or it is keyed on the slug and that plugin has
+  never been detected on any site and nobody has noticed. One look at the match
+  path settles it, and it is a cheap look with an expensive wrong answer.
+
 ## The block-editor fork
 
 The core block editor is a genuine fork in the road and this ADR must take one
@@ -290,11 +460,148 @@ it puts a human in the middle of the mechanical part of the operation while
 ADR-061 deliberately puts them in the middle of the *decision*. Whichever branch
 is taken, it is taken here and recorded, not discovered during the build.
 
+### The fork, taken — 2026-08-24
+
+**Branch A for third-party and core *static* blocks, recorded as a stated
+absence. Plus a narrow Branch B, limited to blocks whose serialization we can make
+exact server-side.** Branch B is precisely two things and nothing that resembles
+them:
+
+1. **Dynamic blocks we register ourselves in `apps/agent`, with no saved
+   markup.** A block that saves nothing serializes to a comment delimiter plus its
+   JSON attributes, so PHP serialization is exact rather than approximately right.
+   This buys real authoring capability with no browser and no new mechanism, and
+   it is the best value available anywhere in the content surface.
+2. **A positively enumerated set of core blocks** whose serialization is stable
+   and expressible in PHP. Anything outside the set is refused **by name**, with
+   the name in the refusal — the same absence-not-a-flag rule that governs
+   capability detection above.
+
+**A machine-held browser session is also refused, and it is not a third branch.**
+This ADR already forecloses any content operation needing a human-held browser
+session per site. Driving a hidden editor from our own cloud through a one-time
+login link is the machine-held variant of the same posture change, and it is
+worse rather than better, because it means we hold a session for the customer's
+admin account. Refused permanently.
+
+**If a later wave revisits static-block authoring, one test is planted first, and
+it must fail before anything is built.** An implementation that stops at
+constructing blocks and serializing them produces markup that *passes* block
+validation and renders broken on the front end, for exactly the blocks that mint a
+unique id in an edit-time effect — which is exactly the population of blocks
+customers care about. A build that cannot demonstrate that failure first has not
+understood the problem it is solving, and the passing-validation part is what
+makes it dangerous: the obvious check goes green.
+
 ---
 
 ## The principal question
 
-**Open. This is the blocker.**
+**Decided 2026-08-24. This was the blocker; it is now the decision.**
+
+> **A dedicated WordPress service user with a custom role, created by the agent:
+> no password, no login path, no session, and deliberately no
+> `unfiltered_html`.**
+
+This is candidate (b) below, taken with its cost stated and its cheap alternative
+refused. The three candidates and their trade-offs are left in place underneath,
+because the next person to reason about this quickly will re-derive candidate (c)
+— it has the best-sounding audit story — and needs to find the reason it was
+rejected rather than the argument for it.
+
+### What is created, and what it can do
+
+- **One WordPress user per site, created by the agent idempotently at enrolment**,
+  and re-created if it is found missing. It has no password, no application
+  password, no interactive login path and no session. It exists to be the
+  `current_user` for the duration of one signed content command and nothing else.
+- **Its role is ours, not `editor` and not `administrator`.** It carries exactly
+  the WordPress capabilities the enabled content commands need, and it never
+  carries `manage_options`, `edit_users`, `install_plugins`, `edit_files`,
+  `edit_themes` or `unfiltered_html`.
+- **The command sets the current user for the handler's duration and clears it
+  afterwards**, so a `current_user_can()` inside a builder's save path or a
+  third-party `save_post` hook resolves against a real, correctly-scoped
+  principal instead of against nobody.
+- **`post_author` on a new post, and the author on every revision, is that user**,
+  so a site owner opening the WordPress editor sees a legible actor rather than a
+  blank.
+- **A post-meta stamp links the WordPress revision back to the control plane** —
+  change-set id, proposal id, and the approving human's identity as recorded in
+  the audit chain. The site's own history and ours resolve to the same event.
+
+This satisfies the three required properties stated at the end of this section:
+one principal for authorship and authorization, recorded on the proposal row so
+the approval screen can render it as a control-plane-derived fact per ADR-061
+Decision 3, and stated per site on the capability panel — because a site whose
+service user was deleted or whose role was stripped legitimately answers
+differently, and an operator must see that before approving rather than afterwards
+in a partial-failure report.
+
+### What it costs, stated plainly
+
+**It puts a privileged object on every managed site.** That is the honest
+objection and it is the same one this ADR raised against candidate (b) in the
+first place: it is adjacent to the shape ADR-061 Decision 1 removed. The answer is
+that it has no password, no inbound authentication, no standing session and no
+route by which anything outside a command we signed can become it.
+
+**But "not really privileged" is an argument, and an argument is not a property.**
+The distinction has to be *proved*, and the proof is a specific attack-test suite
+that is a **ship gate** — no content-write code ships without it green, and it is
+not a line item on a reviewer's checklist that a busy review can wave through:
+
+- Authenticate as the user by password → must fail, because no password hash
+  exists.
+- Mint an application password for it → must be refused.
+- Reach it through the autologin path → must be refused; the target allowlist
+  excludes it.
+- Establish a REST or admin session as it → must fail.
+- Enumerate its capabilities → must equal the declared role exactly, with
+  `unfiltered_html`, `manage_options`, `edit_files` and `install_plugins` all
+  absent.
+
+Each of those is planted as a *passing* attack first, watched go red, restored,
+and watched go green, with both outputs pasted alongside their commands. A suite
+nobody has seen fail is not known to test anything, and this is the suite the
+whole "not really privileged" claim rests on.
+
+**It is deletable by the site's own admin, and that breaks content writes.** That
+is correct behaviour — the site owner is sovereign over their own users — and the
+failure must surface as a typed `principal_missing` refusal with a one-click
+recreate remedy. Never a silent fallback to a different principal: a write that
+quietly executes as somebody else is worse than a write that refuses.
+
+**It is a new visible row on the customer's Users screen** and it will generate
+support questions. That is a documentation cost, and a small one.
+
+### What it forecloses, deliberately
+
+**It forecloses making an AI change look human-authored.** Attribution is legible
+by construction, and some operators will want the post author to be their own
+editor's account. We are choosing legibility of automation over invisibility of
+automation: a fleet where AI-authored changes cannot be told apart from human ones
+is a fleet nobody can audit, and that is the property this whole product line
+sells. If human attribution is ever genuinely needed, the shape is a per-site
+overridable `post_author` while the executing principal stays fixed — attribution
+and execution become two fields, and only the display field moves. It never
+becomes a second execution principal.
+
+**It forecloses writing arbitrary HTML.** Without `unfiltered_html`,
+`wp_kses_post` runs over the content, so a content write cannot introduce a
+script tag, an iframe or an arbitrary embed. Two consequences, and both are
+features. The assistant cannot place a tracking pixel or a third-party embed into
+a page — if that capability is ever wanted it arrives as its own decision, with
+its own gate, not as a side effect of a content write. And a prompt-injection
+payload that reaches the content path cannot become executable markup on the
+site: the last conversion step from text to script is missing. This is worth
+saying in the product copy, in the terms ADR-061 Decision 4 permits — describe
+what runs on a write, do not claim a boundary.
+
+**It forecloses candidate (c) as the v1 answer**, and candidate (a) entirely for
+content. Both reasons are below.
+
+### The candidates, kept for the record
 
 A signed command arrives at a site with no authenticated WordPress session.
 Nothing in the request corresponds to a logged-in user, and that is deliberate —
@@ -335,31 +642,71 @@ operator on every site, needs a fallback that is one of the two above anyway, an
 it makes a control-plane approval mint site-side authorship for someone who never
 touched the site.
 
+**Why (a) is rejected for content specifically.** "No user" is an honest answer
+for a filesystem, option or raw-SQL write, and it is the answer every command
+shipped so far gives. For a content write it is a bug generator: this ADR's own
+cost line for (a) — capability checks that "fail or behave unpredictably" inside
+builder save paths and third-party hooks — describes a class of defect that
+surfaces on someone else's plugin, on a customer's site, days later. There is no
+version of that failure we can debug from the control plane.
+
+**Why (c) is rejected as the v1 answer.** The mapping it depends on does not
+exist, would not exist for every operator on every site if it did, and would need
+a fallback that is (a) or (b) anyway — so choosing (c) is choosing (b) plus a
+mapping. Worse, it makes a control-plane approval mint site-side authorship for a
+person who never touched the site, which is a *worse* audit story than the one it
+was chosen for. Not deferred, rejected.
+
 **Whatever is chosen, three properties are required of the answer.** It is the
 same principal the revision records and every capability check sees — not one
 answer for authorship and another for authorization. It is recorded on the
 proposal row, so the approval screen can render it as a control-plane-derived
 fact before a human approves, per ADR-061 Decision 3. And it is stated on the
 capability panel per site, because on a fleet the answer may legitimately differ
-between sites and an operator must not have to guess which.
+between sites and an operator must not have to guess which. The decision above
+satisfies all three; a future revision of it must satisfy them too.
 
-This question routes to `security-reviewer` before any content code is written.
-It touches the agent protocol and site-side privilege, both of which are on that
-list.
+**Routing.** `security-reviewer` with `model: "opus"` **before any content code is
+written** — this is a new principal, and it touches the agent protocol and
+site-side privilege, both of which are on that list. Then the build order is
+`database-engineer` (proposal and staging schema) → `backend-architect`
+(control-plane half) → `wp-agent-engineer` (`apps/agent`), per the rule that a
+change spanning a migration and code is agents in sequence and never one agent
+doing both.
 
 ## Other open questions
 
-**Does raw content ever cross to the model?** ADR-061's threat model assumes
+**Does raw content ever cross to the model? Decided 2026-08-24: yes, inside the
+fence, with provenance, never as instructions.** ADR-061's threat model assumes
 prompt injection succeeds and constrains blast radius, and one of the constraints
 is that the highest-density carriers — raw file contents, raw log bodies, raw
 command output — are returned by no Phase 1 tool at all. Content operations put
 that under direct pressure: the moment a content tool returns post bodies or
 builder documents to the model, the densest injection carrier is back, sourced
-from exactly the population ADR-061 names as attacker-controlled. The fork is
+from exactly the population ADR-061 names as attacker-controlled. The fork was
 structured, control-plane-derived summaries only, or raw content with the
-sanitizers doing the work. The first materially limits what a content assistant
-can do; the second reopens a threat the design already assumes succeeds. This
-ADR must decide it, and it is not decided here.
+sanitizers doing the work.
+
+The first branch is refused because it produces a content assistant that cannot
+read content, which is not the product. The second is taken because the threat it
+would be defending against is one this architecture **already assumes succeeds**:
+ADR-061 puts the real boundary at structural authorization outside the model loop,
+precisely so that a successful injection changes nothing about what is permitted.
+We cannot make the model safe by starving it; we make it safe by ensuring nothing
+it reads can change what it is allowed to do.
+
+The bound is exact. Page content, plugin-supplied error strings, site names and
+every other site-originated string reach the model inside a fenced envelope whose
+provenance attribute is emitted from **our** database and never from the content
+itself, under a standing preamble stating that the enclosed material is reference
+text that cannot change what is permitted. **That envelope is an ADR-061 Phase 1
+deliverable, not a Phase 2 one** — see ADR-061 amendment A13 — because site names
+and plugin error strings reach the model in Phase 1 regardless, and a fence that
+arrives after the first untrusted string has already conceded the precedent.
+
+The ship gate travels with the decision: a **planted hostile site name**. A site
+whose name is an injection payload must produce an approval screen that still
+renders correctly and a set of permitted actions that is unchanged.
 
 **Does Phase 2 write content, or also model content?** Editing what exists across
 many sites is what the published Phase 2 design work actually describes. Creating
@@ -376,6 +723,45 @@ edge.
 
 ---
 
+## Why this is still Proposed
+
+The hard blocker closed on 2026-08-24 and this ADR did **not** move to Accepted.
+Recording why, because "the blocker closed" is exactly the moment a status line
+gets changed on momentum:
+
+1. **Its own gate is what would lift.** Accepting this ADR releases the sentence
+   at the top — *no content-write code ships until it is Accepted*. That sentence
+   is the only thing standing between the wave plan above and someone starting
+   Wave 1. It should be released when the work is ready to start, not when the
+   argument is finished.
+2. **ADR-060's precedence puts this behind open rank-1 work.** Content operations
+   are differentiation, rank 5. The site-scope chokepoint and the fail-closed
+   audit helper are auth-boundary items and both are open (ADR-061 amendments A9
+   through A11). Accepting a rank-5 ADR while rank-1 items are open does not
+   violate the freeze clause — this ADR adds no externally-reachable surface by
+   itself — but it advertises readiness that the precedence order does not
+   support, and precedence is reversed by exactly this kind of drift.
+3. **Checklist items remain genuinely open, and two of them cannot close on
+   argument.** Item 8 needs a measurement that cannot be taken until Layer A is
+   serving live traffic. Item 4 needs a snapshot mechanism for post rows that does
+   not exist, because the existing version stack covers files and posts do not
+   live on the filesystem. Neither closes by anyone thinking harder.
+4. **The wave plan is provisional on a query nobody has run.** Item 7 is decided
+   on criteria, and the criteria do not move when the numbers arrive — but the
+   ordering does, and the query costs an afternoon. Accepting the ADR before it
+   runs converts "we reasoned this" into "we decided this" in every downstream
+   reading.
+5. **`security-reviewer` has not seen the principal or the four-command token
+   scoping.** Both are on the standing list, both route with `model: "opus"`, and
+   the attack-test suite that the whole "not really privileged" claim rests on has
+   not been written, let alone watched go red.
+
+**What closes it.** The five above, in that order. Items 3 and 6 are expected to
+close *inside* their waves rather than before them, and this ADR should say so
+when it is accepted rather than carry them as permanent open marks.
+
+---
+
 ## Consequences
 
 **What this forecloses.**
@@ -387,7 +773,16 @@ edge.
   verify. An integration cannot opt out of either, because neither is the
   integration's to take.
 - No raw post meta write for a field-plugin-managed value.
-- No content operation that requires a human-held browser session per site.
+- No content operation that requires a human-held browser session per site, and
+  none that requires a machine-held one either.
+- **No content write that can produce executable markup.** The execution principal
+  has no `unfiltered_html`, so content passes through core's post-content
+  sanitizer. Script, iframes and arbitrary embeds are out of reach of this
+  surface, and putting them back in reach is a separate decision with its own
+  gate — never a side effect of a content feature.
+- **No AI-authored change that looks human-authored.** The executing principal is
+  fixed and the revision names it. A future per-site `post_author` override moves
+  the display field only.
 - ADR-061's approval architecture is unchanged and is not relaxed for content:
   no automation may approve, and a content proposal is a proposal like any other.
 
@@ -401,14 +796,25 @@ edge.
 - Fleet-wide content operations are constrained by ADR-061 amendment A4's
   per-organization ceiling and per-site exclusive lock, so a large fleet change
   is a wave that takes time rather than a single instant.
-- The principal answer, whichever it is, adds something to defend: a new site-side
-  object, an unattributed revision, or a mapping.
+- The principal answer adds something to defend: a new site-side object on every
+  managed site, deletable by the site's own admin, visible on the Users screen,
+  and carrying a support-documentation cost.
+- The wave plan buys the narrowest builder capability first and defers the rest.
+  That is the intended trade, and the cost is that operators on the deferred
+  builders see a named absence for longer.
 
 **What has to exist before any Phase 2 content code is written.**
 
-- All nine checklist items closed, item 2 first.
-- `security-reviewer` on the principal decision, on the four-command token
-  scoping, and on the snapshot and revert paths.
+- Every checklist item closed. Item 2 closed on 2026-08-24; the rest are listed
+  with their reason in [Why this is still Proposed](#why-this-is-still-proposed).
+- The **pre-development tasks** in
+  [Scope: the wave plan](#scope-the-wave-plan): the fleet-inventory query, the
+  outbound-prober confirmation, and the signature-corpus match audit.
+- The **service-principal attack-test suite** green, with each attack planted as
+  passing first and both outputs pasted alongside their commands. This is a ship
+  gate; it is not satisfied by a reviewer agreeing that the principal looks safe.
+- `security-reviewer` with `model: "opus"` on the principal decision, on the
+  four-command token scoping, and on the snapshot and revert paths.
 - `database-engineer` on the proposal and staging schema before any Go or PHP,
   per the routing rule that a change spanning a migration and code is two agents
   in sequence.

--- a/docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md
+++ b/docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md
@@ -1,0 +1,421 @@
+# ADR-062 — Assistant surface, Phase 2: governed fleet content operations
+
+**Status:** Proposed · **Date:** 2026-08-23
+**Supersedes/relates:** Supersedes ADR-061 Decision 7 (site generation conceded), via ADR-061 amendment A7. Relates to ADR-061 (Phase 1, as amended 2026-08-23 — Decision 1 siting, Decision 2 out-of-band approval, Decision 3 control-plane-derived approval facts, amendment A3's tool registry, amendment A4's concurrency rule) and ADR-060 (this work sits in the differentiation phase and does not outbid anything above it).
+
+**This ADR is Proposed and it blocks Phase 2.** No content-write code ships in
+`apps/agent` or in the control plane until it is Accepted. The nine items in
+[The nine things this ADR must establish](#the-nine-things-this-adr-must-establish)
+are its acceptance checklist, and item 2 — which WordPress principal a content
+write executes as — is currently unanswered and is a hard blocker rather than a
+detail to settle during the build.
+
+---
+
+## Context
+
+ADR-061 Decision 7 recorded content writes and site generation as **conceded
+rather than deferred**, and gave a reason for the framing: a deferred item gets
+re-proposed every planning cycle by whoever has not read the reasoning. That
+instinct was right. The reasoning is what did not hold.
+
+**Its premise was a fact about this repository, and that half is still true.**
+No post, page, block, taxonomy or menu write path exists in the control plane or
+in the agent. Re-verified this pass against the agent's full command list — ADR-061
+amendment A2 carries the two commands that produce it — and no signed command
+name in that list is a content verb.
+
+**What it drew from that premise was a claim about the market, and that half
+fails.** Decision 7 concluded that building a content model to serve an
+assistant is "a product bet about entering a different market". Two things
+contradict it.
+
+We are already designing that market's product. A published Phase 2 wireframe
+set and a published Phase 2 plan both design fleet content operations in detail —
+blast radius across a fleet, coverage by page builder, waves, per-site status
+vocabulary, undo across sites, partial-failure and halted-run states — against a
+locked decision that forbids them. That is the largest governance gap the design
+review found, and an ADR is how it closes.
+
+And the technical objection underneath the concession rested on the wrong test.
+The experiment that produced it round-tripped page-builder documents and compared
+the result to the original **byte for byte**. Byte comparison fails for reasons
+that have nothing to do with correctness, so it produced a verdict of
+intractability that the evidence does not support. The correct test is stated
+below and is one function's worth of work.
+
+## What this is, and what it is not
+
+**The unit of work is the fleet, not the document.** This ADR governs *content
+operations across many sites* — apply a change to a set of sites, know which of
+them can accept it, stage it, have a human approve it once, dispatch it in waves,
+report per-site outcomes honestly including the partial ones, and undo it across
+the set. Every concept in that sentence has an N in it.
+
+That is a different product from single-site authoring, which has no N and
+therefore needs none of it. Authoring tools optimize the round trip between one
+person and one document. Nothing here is aimed at that, and the design should not
+drift toward it: a feature that only makes sense with one site open is out of
+scope by construction.
+
+The buyer is the same one ADR-060 and ADR-061 are built for — an operator who
+answers to someone about sites they do not personally own. What that operator
+needs from content operations is not expressive power over a single page. It is
+the ability to say what changed, on which of forty sites, who approved it, and
+how to put it back.
+
+## Where the write executes
+
+**On the site, in the WordPress process, in `apps/agent`, reached only over the
+existing outbound signed-command channel as new command names.**
+
+This **re-affirms** ADR-061 Decision 1; it does not bend it. The site opens
+nothing, holds no model-facing credential and gains no inbound AI surface. What
+it gains is command classes, on a mechanism that already exists and already
+carries a large set of them (ADR-061 amendment A2 measures it, with its
+commands).
+
+It has to execute in-process because a content write needs the runtime. A page
+builder's document object, a field plugin's write API and the live block registry
+are reachable only from inside a WordPress request. A control plane cannot call
+any of them, and a content write assembled anywhere else is a guess about what
+those objects would have done.
+
+**Four separately signed command names, not one.** `content_read`,
+`content_stage`, `content_promote`, `content_revert`. The split is not
+organizational. Each command is authorized by its own bearer token bound to that
+one command name, so a token minted to stage a change **cannot promote it**, and
+the revert path is reachable without holding anything that can write. Collapsing
+the four into a single `content_write` would discard that property for nothing.
+
+The WordPress floor stays at **6.2** for content work
+(`apps/agent/readme.txt:4`, `Requires at least: 6.2`). A builder write needs the
+builder's own classes, which are shipped by the builder, not a newer core API.
+Nothing in this ADR raises the floor on a heterogeneous fleet.
+
+## The nine things this ADR must establish
+
+This is the acceptance checklist. Every unchecked item is a reason this ADR is
+still Proposed.
+
+- [ ] **1. Where the write executes, and by what channel.** On-site, in-process,
+      in `apps/agent`, reached only over the existing outbound signed-command
+      channel, as the four separately signed command names above. Drafted in
+      [Where the write executes](#where-the-write-executes). **Needs:**
+      `security-reviewer` sign-off on the four-name split and its token scoping.
+- [ ] **2. Which WordPress principal a content write executes as.** **Open, and
+      a hard blocker.** See [The principal question](#the-principal-question).
+      No content code is written before this closes.
+- [ ] **3. Own or delegate, per integration — with verify-and-rollback as a
+      shared primitive rather than a per-integration one.** See
+      [Own or delegate](#own-or-delegate-and-why-the-guard-is-a-platform-property).
+- [ ] **4. Snapshot before every destructive write, mandatory, at the platform
+      layer.** See
+      [Snapshot is a platform property](#snapshot-is-a-platform-property-not-an-integration-feature).
+- [ ] **5. The block-editor fork, taken deliberately.** Two branches, each with
+      its cost, one of which must be chosen before Phase 2 scope is fixed. See
+      [The block-editor fork](#the-block-editor-fork).
+- [ ] **6. Dynamic-data binding as the primary write-reduction strategy.** See
+      [Bind once, then write fields](#bind-once-then-write-fields).
+- [ ] **7. Scope: which page builders and field plugins are in v1**, on stated
+      evidence about the cost of each, with everything outside v1 named as absent
+      rather than silently missing.
+- [ ] **8. How the Layer B / Layer C tool budget accommodates content.**
+      Cross-references ADR-061 amendment A3: content proposal tools are Layer B,
+      named by intent, and the measured `tools/list` threshold from A3 — not a
+      round number — decides whether Layer C is needed at all.
+- [ ] **9. Formal retirement of ADR-061 Decision 7 and its Consequences bullet**,
+      with "conceded rather than deferred" replaced by the scoped commitment this
+      ADR records. Done in ADR-061 amendment A7; this item closes when this ADR
+      is Accepted.
+
+---
+
+## Verify after write, and why byte comparison is the wrong test
+
+Re-serializing a page-builder document and comparing the bytes to the original
+fails on documents that are semantically identical. Encoder profiles differ; key
+ordering differs; whitespace, escaping and numeric formatting differ; generated
+element ids, timestamps and revision counters change on every save by design. A
+byte comparison reports all of that as damage. Used as an acceptance test it does
+not measure whether the write was correct — it measures whether our serializer
+happens to be byte-compatible with whatever wrote the document last, which is not
+a property any writer can hold across a plugin's own version history.
+
+**The correct test is a semantic signature over observed post-write state.**
+Read the document back after the write, parse it, **strip the fields known to be
+volatile**, canonicalize what remains, and compare the signature of that against
+the signature computed from what we intended to write. A mismatch is a real
+defect and triggers the rollback in item 4. A match is meaningful in a way a byte
+match never was.
+
+Two supporting techniques make the signature stable, and both belong in the
+platform layer rather than in each integration:
+
+- **Write the whole document rather than patching part of it.** When the writer
+  emits the entire structure, the encoder profile becomes a property of our
+  writer instead of a property of the document's history, and an entire class of
+  spurious differences stops existing.
+- **Guard the encode/decode depth asymmetry by decoding our own output before
+  committing it.** Deeply nested structures can encode successfully and then fail
+  to decode, because the encoder and decoder do not enforce the same depth limit.
+  A structure that cannot be read back is not a document, and the place to
+  discover that is before the write commits, not on the next page load.
+
+## Snapshot is a platform property, not an integration feature
+
+**Every destructive content write is preceded by a snapshot, taken by the
+platform, before the integration is asked to do anything.**
+
+This is not a new capability and it should not be re-litigated per integration.
+The agent already does exactly this for file writes: an existing file is copied
+to a per-op staging area before any mutation, and restoring a previous version is
+itself a first-class command
+(`apps/agent/includes/commands/class-file-write-command.php`). Content extends
+that mechanism.
+
+The reason it must sit at the platform layer is a failure mode worth stating
+plainly. **A guard that each integration implements for itself is a guard some
+integration will not implement.** Where two integrations are built on the same
+engine from near-identical code, one can carry the snapshot and its sibling can
+carry only a depth check, and nothing in review catches it, because each file
+reads as complete on its own terms. The asymmetry is invisible until the day the
+unguarded one is asked to roll back. Put the snapshot where an integration cannot
+forget it: the promote path takes it, and an integration that wants to write is
+handed a target that has already been snapshotted.
+
+The same argument applies to the verify step above. Verify-and-rollback is one
+primitive, invoked by the promote path, parameterized by the integration's
+signature function — not a thing each integration is trusted to remember.
+
+## Own or delegate, and why the guard is a platform property
+
+For each supported integration this ADR records one of two postures, with its
+reason:
+
+- **Delegate** — call the integration's own save API and let it own its storage
+  format. Lower risk, bounded capability, and it breaks when the plugin's API
+  does not expose what the operation needs.
+- **Own** — write the integration's storage format directly. Necessary where the
+  save API cannot express the operation or requires a request context we do not
+  have, and it makes us responsible for that format across the plugin's version
+  history.
+
+Owning a format is viable — that was the objection the byte test manufactured —
+but it is only viable **with** the verify-and-rollback primitive above. Own with
+verification, or delegate. Owning without a semantic verify is the posture this
+ADR forbids.
+
+**Field values are written through the field plugin's own API, never as raw post
+meta.** This is not a preference. A custom field's value is stored as a *pair*:
+the value under the field's name, and a companion row that ties that name to the
+field's definition key. Writing the value row alone leaves the pair inconsistent —
+the value is present in the database and the field no longer resolves to its
+definition, so it stops appearing in the editor, stops being returned by the
+plugin's own read functions, and starts differing between the front end and the
+admin. A raw-meta write looks like it worked, and the defect surfaces later, on a
+different screen, to someone who did not make the change. The plugin's write API
+maintains both rows; use it. Where a target site has the field plugin but not a
+version whose API can express the operation, that is a capability refusal (below),
+not a reason to reach past it.
+
+## Bind once, then write fields
+
+**Dynamic-data binding is the primary write-reduction strategy, and it is a
+design goal rather than an optimization.**
+
+A page-builder element can be bound once to a field, after which every subsequent
+content change is a *field* write and the builder document is not touched at all.
+That converts the risky operation — a large, structurally unstable rewrite of a
+proprietary document, repeated on every update — into a stable, small, verifiable
+one, repeated instead.
+
+The consequence for the roadmap is that the expensive builder-document work is
+concentrated in a one-time binding operation per element, and the recurring fleet
+operation afterward is field writes through the field plugin's API. Design the
+binding operation carefully and the ongoing operation is cheap and safe. Invert
+that and every routine content update carries the full risk of a document
+rewrite.
+
+## Per-site capability detection
+
+**A site reports its own content capability surface over the signed channel, and
+the control plane never proposes an operation the target cannot serve.**
+
+The agent reports which page builders and field plugins are installed and active
+and at what version; the control plane holds that in inventory alongside
+everything else it knows about the site. Two rules follow:
+
+- **A tool a site cannot serve is not offered for that site.** Absence, not a
+  flag. This is ADR-061 Decision 5's mechanism applied to content: an
+  unregistered capability cannot be reached by a schema-guessing model or by a
+  future grant bug.
+- **A refusal names the requirement and the site's actual version.** Not "not
+  supported". A capability panel row reads, for example, *"Requires Elementor
+  3.2 or later — this site has 2.9"*, with the site named. Absent, named and
+  explained, never silently missing. The operator planning a fleet change needs
+  to know which sites will not accept it **before** approving, not afterwards
+  from a partial-failure report.
+
+The same rule covers core-version-gated capability: a site below a version floor
+sees a row stating the requirement and its own version, not an empty space.
+
+## The block-editor fork
+
+The core block editor is a genuine fork in the road and this ADR must take one
+branch explicitly, because both branches have a cost and drifting between them
+produces a feature that half exists.
+
+The constraint: serialization of static block markup is performed client-side by
+the editor's own JavaScript. A write path that must produce byte-correct block
+markup for arbitrary blocks therefore needs that JavaScript to run, which means a
+browser session per site, held open for the duration, driving a hidden editor and
+managed by something that can survive a tab closing.
+
+**Branch A — block-editor writes are out of scope for Phase 2.** Content
+operations cover page-builder documents and field values; core block content is
+read-only. Cost: a real capability gap on sites that use the core editor and no
+page builder, which is a large share of any fleet, and it must be surfaced as a
+named absence per the capability rule above rather than left to be discovered.
+
+**Branch B — find a route that does not need a browser.** Server-side
+construction restricted to a positively enumerated set of blocks whose
+serialization is stable and expressible in PHP, with anything outside that set
+refused by name. Cost: the enumerated set is small, it is maintenance that tracks
+core, and the refusal surface has to be honest about what it will not do.
+
+**A browser-held session per site is not a viable third branch for a fleet.** It
+does not survive the tab closing, it cannot run in a wave across forty sites, and
+it puts a human in the middle of the mechanical part of the operation while
+ADR-061 deliberately puts them in the middle of the *decision*. Whichever branch
+is taken, it is taken here and recorded, not discovered during the build.
+
+---
+
+## The principal question
+
+**Open. This is the blocker.**
+
+A signed command arrives at a site with no authenticated WordPress session.
+Nothing in the request corresponds to a logged-in user, and that is deliberate —
+it is the property ADR-061 Decision 1 exists to preserve. For every command
+shipped so far this has not mattered. For a content write it matters immediately,
+because WordPress content APIs read the current user:
+
+- Post and revision authorship is attributed to the current user, so revision
+  history either names a principal or names nobody.
+- Capability checks inside builder save paths and inside third-party save hooks
+  consult the current user, and behave unpredictably when there is not one.
+- Other plugins observe the write through save hooks and may act on who made it.
+
+So "which principal" is not a cosmetic question about an audit column. It
+determines what the site's own revision history says, which save paths succeed,
+and what every other plugin on that site sees. Three candidate answers, each with
+its cost:
+
+**(a) No user at all.** Truthful about what happened — the control plane wrote
+this, not a person on the site — and it needs no new object on the site.
+Capability checks inside builder save paths and third-party save hooks will fail
+or behave unpredictably, and the revision carries no author, so the site's own
+history cannot show where the change came from.
+
+**(b) A dedicated agent-owned WordPress user, created at enrolment.** Revisions
+attribute to a named principal an auditor can see on the site, and capability
+checks pass predictably. The cost is that a privileged user object now exists on
+every managed site — adjacent to the shape Decision 1 removed. It is not the same
+shape (no password, no interactive login, no standing session, nothing that
+authenticates inbound), but that distinction has to be **designed and proved**,
+not asserted, and it is exactly the kind of claim ADR-061 Decision 4's copy rule
+forbids stating as a guarantee.
+
+**(c) The approving operator's mapped site user, where a mapping exists.** The
+best audit story: the person who approved is the person the site's history names.
+The cost is that the mapping does not exist today, will not exist for every
+operator on every site, needs a fallback that is one of the two above anyway, and
+it makes a control-plane approval mint site-side authorship for someone who never
+touched the site.
+
+**Whatever is chosen, three properties are required of the answer.** It is the
+same principal the revision records and every capability check sees — not one
+answer for authorship and another for authorization. It is recorded on the
+proposal row, so the approval screen can render it as a control-plane-derived
+fact before a human approves, per ADR-061 Decision 3. And it is stated on the
+capability panel per site, because on a fleet the answer may legitimately differ
+between sites and an operator must not have to guess which.
+
+This question routes to `security-reviewer` before any content code is written.
+It touches the agent protocol and site-side privilege, both of which are on that
+list.
+
+## Other open questions
+
+**Does raw content ever cross to the model?** ADR-061's threat model assumes
+prompt injection succeeds and constrains blast radius, and one of the constraints
+is that the highest-density carriers — raw file contents, raw log bodies, raw
+command output — are returned by no Phase 1 tool at all. Content operations put
+that under direct pressure: the moment a content tool returns post bodies or
+builder documents to the model, the densest injection carrier is back, sourced
+from exactly the population ADR-061 names as attacker-controlled. The fork is
+structured, control-plane-derived summaries only, or raw content with the
+sanitizers doing the work. The first materially limits what a content assistant
+can do; the second reopens a threat the design already assumes succeeds. This
+ADR must decide it, and it is not decided here.
+
+**Does Phase 2 write content, or also model content?** Editing what exists across
+many sites is what the published Phase 2 design work actually describes. Creating
+the content model itself — post types, taxonomies, field groups — is a third
+product with its own internal representation problem, and folding it in
+unannounced is how scope arrives without a decision. Recorded so it arrives, if
+it arrives, on purpose.
+
+**One internal content-model representation, adapted at the edges.** Where more
+than one integration is supported, the temptation is a bespoke content model per
+integration, and the cost lands later, on the first operation that has to span
+two of them. Define one internal representation and adapt at each integration's
+edge.
+
+---
+
+## Consequences
+
+**What this forecloses.**
+
+- No inbound content path to a site, now or later. Content reaches a site the
+  same way everything else does: a signed command the control plane dispatches
+  after a human approval. Anything else supersedes ADR-061 Decision 1.
+- No destructive content write without a platform-taken snapshot and a semantic
+  verify. An integration cannot opt out of either, because neither is the
+  integration's to take.
+- No raw post meta write for a field-plugin-managed value.
+- No content operation that requires a human-held browser session per site.
+- ADR-061's approval architecture is unchanged and is not relaxed for content:
+  no automation may approve, and a content proposal is a proposal like any other.
+
+**What it costs.**
+
+- Owning a page-builder storage format is a standing maintenance liability that
+  tracks someone else's release schedule. The verify primitive bounds the damage;
+  it does not remove the work.
+- Whichever branch of the block-editor fork is taken leaves a named capability
+  gap, and naming it on a capability panel is part of the cost.
+- Fleet-wide content operations are constrained by ADR-061 amendment A4's
+  per-organization ceiling and per-site exclusive lock, so a large fleet change
+  is a wave that takes time rather than a single instant.
+- The principal answer, whichever it is, adds something to defend: a new site-side
+  object, an unattributed revision, or a mapping.
+
+**What has to exist before any Phase 2 content code is written.**
+
+- All nine checklist items closed, item 2 first.
+- `security-reviewer` on the principal decision, on the four-command token
+  scoping, and on the snapshot and revert paths.
+- `database-engineer` on the proposal and staging schema before any Go or PHP,
+  per the routing rule that a change spanning a migration and code is two agents
+  in sequence.
+- The verify primitive with its planted-failure proof: a write that is corrupted
+  on purpose must be caught by the semantic signature and rolled back, with the
+  red and green outputs pasted alongside their commands — and then the honest
+  cases it must not block, so a correct write with a changed timestamp does not
+  trigger a rollback.
+- `make test-integration` run locally before merge, since content proposals carry
+  site scoping and `ci.yml` does not run that package.

--- a/docs/adr/ADR-063-licensing-and-third-party-reuse.md
+++ b/docs/adr/ADR-063-licensing-and-third-party-reuse.md
@@ -1,0 +1,306 @@
+# ADR-063 — Repository licensing, and the rules for third-party reuse
+
+**Status:** Accepted · **Date:** 2026-08-24
+**Supersedes/relates:** Relates to ADR-061 (its Decision 1 sites the assistant surface on the control plane; §3 below reaches the same siting from licensing alone) and ADR-062 (Phase 2 content operations, which is where new agent-side dependencies would otherwise be proposed).
+
+This ADR records what this repository is actually licensed under, what follows
+from that for anyone adding a dependency, and the rules an engineer applies when
+they want to reuse something they did not write. It exists because the licence
+position was assumed wrong in a planning round, in the direction that costs the
+most: the constraint everyone was defending against does not apply here, and the
+one that does apply was undocumented.
+
+---
+
+## Context
+
+Two questions kept being answered from memory and being answered differently:
+what licence is the control plane under, and what may be added to the WordPress
+plugin. Both have exact answers that live in files at the repository root, and
+neither answer is where an engineer looks when they are about to run
+`composer require`.
+
+The specific failure worth recording: a planning pass reasoned from the premise
+that the control plane is closed-source, and therefore that adding copyleft code
+to it would be fatal. **The premise is false**, and reasoning from it produces
+two errors at once — it refuses adoptions that are in fact permitted, and it
+never surfaces the real constraint, which sits on the plugin rather than on the
+control plane. A wrong licence premise does not fail loudly. It just quietly
+makes every downstream row of the decision table wrong in the same direction.
+
+---
+
+## 1. What this repository is licensed under
+
+Two licence files exist in the tracked tree, and no more. The command, and what
+it returned when this ADR was written:
+
+```sh
+git ls-files | grep -iE '(^|/)LICENSE' \
+  | grep -c . \
+  || { echo "FAIL: no tracked LICENSE file matched -- moved or renamed, which is not 'unlicensed'" >&2; exit 1; }
+#   2
+```
+
+Re-run it rather than trusting the figure; a third licence file appearing is
+exactly the event this ADR needs someone to notice. The refusal on zero is
+deliberate for the standing reason: `grep … | wc -l` takes its exit status from
+`wc`, so a renamed path prints `0` and exits `0`, and "this repository has no
+licence" is not a claim to arrive at by accident.
+
+**The root `LICENSE` is AGPL-3.0, and it covers `apps/api`.**
+
+```sh
+grep -nE 'GNU AFFERO GENERAL PUBLIC LICENSE|Version 3, 19 November 2007' LICENSE | head -2
+#   1:                    GNU AFFERO GENERAL PUBLIC LICENSE
+#   2:                       Version 3, 19 November 2007
+```
+
+There is no separate licence file under `apps/api/`, so the root file governs it,
+along with `apps/web`, `apps/marketing` and `packages/**` — everything the
+carve-out below does not name.
+
+**`LICENSE-AGENT` is MIT, and it covers `apps/agent` and `apps/tracker`.**
+
+```sh
+grep -nE '^MIT License|^Applies to:|^The rest of this repository' LICENSE-AGENT
+#   1:MIT License
+#   5:Applies to: apps/agent (WordPress plugin) and apps/tracker (JS web-vitals).
+#   6:The rest of this repository is licensed under AGPL-3.0 (see LICENSE).
+```
+
+`NOTICE.md` states the same split in one sentence:
+
+```sh
+grep -n 'control plane is AGPL' NOTICE.md
+#   3:WPMgr's control plane is AGPL-3.0; the WordPress agent is MIT-licensed. See the
+```
+
+**The plugin as distributed is offered under GPLv2-or-later**, which its
+wordpress.org listing page declares:
+
+```sh
+grep -nE '^License' apps/agent/readme.txt
+#   8:License: GPLv2 or later
+#   9:License URI: https://www.gnu.org/licenses/gpl-2.0.html
+```
+
+while the plugin header declares MIT:
+
+```sh
+grep -nE '^ \* License' apps/agent/wpmgr-agent.php
+#   10: * License:           MIT
+#   11: * License URI:       https://opensource.org/licenses/MIT
+```
+
+That is two different strings in two files a user reads side by side. It is not a
+violation — see [Open for an owner ruling](#open-for-an-owner-ruling), F1 — but it
+is recorded here rather than left for the next reviewer to rediscover.
+
+**The repository is public.** Public is not permissive: publishing source grants
+nothing beyond what the licence files grant, and it gives this project no
+additional right to anyone else's code either. What being public *does* do is
+discharge the AGPL's source-offer obligation conveniently, and make every commit
+message, comment and committed document permanently visible.
+
+---
+
+## 2. What follows: the constraint is on the plugin, not on the control plane
+
+**Adding AGPL-3.0-or-later code to `apps/api` creates no new licence obligation.**
+The network clause extends copyleft past distribution to network interaction, and
+for a proprietary hosted service that is fatal — it would compel publication of
+the whole service. This service is already AGPL-3.0 and its source is already
+public, so the obligation is already discharged. This is the single most
+important licensing fact in this record and it points the opposite way from the
+one everybody expects.
+
+**Adding GPL-2.0-or-later or AGPL code to `apps/agent` relicenses the plugin.**
+MIT is permissive; a copyleft dependency makes the combined distributed work
+carry the copyleft licence. The result is that `LICENSE-AGENT` and the plugin
+header become false, the wordpress.org listing changes what it promises, and a
+carve-out that two other files depend on stops being true. That is a strategic
+change to a plugin published in a public directory, not an engineering detail
+that belongs inside a dependency-bump PR.
+
+**So the direction that is safe for `apps/api` is unsafe for `apps/agent`.** The
+asymmetry is the whole content of this section, and it is why the reuse rules
+below are stated per destination rather than per package.
+
+### This independently supports siting the MCP surface in the control plane
+
+ADR-061 Decision 1 puts the assistant server on the control plane, and it argues
+that from credentials and fan-out: a per-site inbound path would need a
+privileged WordPress user and a standing credential on every managed site.
+
+**Licensing reaches the same siting by a different route, and that is worth
+recording because two independent arguments for one decision are harder to
+overturn than one.** The mature open-source MCP components for WordPress —
+`wordpress/mcp-adapter` and `wordpress/php-mcp-schema`, both from the WordPress
+project — are GPL-2.0-or-later. Adopting either into `apps/agent` relicenses the
+plugin, per §2. Adopting either into `apps/api` is not a licence event at all.
+An architecture that keeps the MCP surface in the control plane and lets the agent
+keep speaking the existing signed-command protocol is therefore also the cheapest
+licensing outcome, and the two arguments do not depend on each other.
+
+The point of writing this down is narrower than it looks: it stops a licence
+consideration from being discovered *by* a `composer require` in the agent's
+`composer.json`, at which point the change has already been made and the argument
+becomes about reverting rather than about deciding.
+
+---
+
+## 3. The reuse rules
+
+Four dispositions, and every reuse decision resolves to exactly one of them.
+
+### ADOPT UPSTREAM
+
+**Take the package from its own upstream, at its own version, as an ordinary
+dependency.** This is the right answer whenever the thing wanted is a library
+that exists independently of wherever it was first seen.
+
+- Check the licence against the **destination** first, per §2. MIT and BSD are
+  fine anywhere. GPL-2.0-or-later and AGPL are fine in `apps/api` and are a
+  relicensing event in `apps/agent`.
+- Retain the package's own notice text, and add an entry to `NOTICE.md` **and**
+  the third-party section of `apps/agent/readme.txt` in the same PR. The existing
+  `matthiasmullie/minify` entries in both files are the template.
+- Where an independently-licensed artifact is taken and modified, mark it with a
+  sidecar file naming the upstream and its SPDX identifier. Apache-2.0 also
+  requires stating significant changes in modified files, and a sidecar satisfies
+  both obligations in one place.
+- Never copy a package out of a local reference tree. Fetch it from its own
+  upstream, so what is in the lockfile is what the upstream published.
+
+### INTERFACE-COMPATIBLE ONLY
+
+**Implement the published contract from the contract's own documentation.** MCP,
+OAuth 2.1 and its RFCs, the WordPress Abilities API, and a page builder's storage
+format are all in this class.
+
+Copyright protects **expression** — the particular source text somebody wrote —
+not the interface, not the wire format, not the field names a protocol mandates,
+and not the facts of how a third-party product stores its data. Implementing the
+same protocol from its own specification is not copying even when the result is
+necessarily similar, and no attribution is owed for it. A storage format is a fact
+about a third product, discoverable by opening any site that uses it.
+
+Two practical rules follow. Derive from the specification, the vendor's own
+documentation, or a real install — never from somebody else's implementation of
+the same specification, because at that point what is being read is expression.
+And in the PR description, cite the specification: *"implements the published X
+specification"*, with a link to X.
+
+### REIMPLEMENT FROM BEHAVIOUR
+
+**Take the design insight; write the implementation.** This is the disposition for
+an idea observed working somewhere — a pattern, an architecture, an error-handling
+posture — where what is valuable is one or two sentences of understanding and the
+code is incidental.
+
+Almost everything worth having lands here, including where a licence would in
+principle permit more, and the reason is not licensing at all. Honest copyleft
+attribution requires naming the source. The house rule forbids naming a competitor
+product in code, a comment, a commit message or a committed document, and this
+repository is public so a commit message cannot be recalled. Those two obligations
+cannot both be satisfied, so the reuse does not happen and the understanding is
+what carries over. State the design in your own words, build it against this
+codebase's own primitives, and route anything touching auth, tokens, tenancy,
+capability checks or the command protocol to `security-reviewer` regardless of how
+small it looks.
+
+A note on porting, because it is the shape most likely to be mistaken for
+reimplementation: **a translation is a derivative work.** Rewriting somebody's PHP
+as Go line by line carries the original's licence with it. Reading it to
+understand what it does, then writing Go that behaves the same way, does not. The
+difference is whether the source is open next to yours while you type.
+
+### DO NOT USE
+
+**Prose.** Consent-screen text, error messages, admin-screen copy, tooltips,
+hint strings. Prose is the most copyrightable material in any tree and copied
+prose is the easiest infringement to detect and the hardest to explain. Read
+somebody else's consent screen for the *checklist* of what a user must be told —
+scope, grantee, revocation, duration — and then write every sentence fresh.
+
+---
+
+## 4. Standing rules for engineers
+
+1. **Check the licence against the destination before adding any dependency.**
+   `apps/agent` is MIT and a copyleft dependency relicenses it. `apps/api` is
+   AGPL-3.0 and has no such conflict.
+2. **Add every new dependency to `NOTICE.md` and to `apps/agent/readme.txt`'s
+   third-party section in the same PR**, following the existing entries.
+3. **Take libraries from their own upstream**, never out of a local reference
+   copy.
+4. **Never name a competitor product** in code, a comment, a commit message, a
+   committed document, a tracked ignore file or a PR title. `apps/marketing/**`
+   is the only carve-out and nothing in the rules above goes there.
+   `apps/agent/readme.txt` is the public wordpress.org listing page and stays
+   under the strict rule.
+5. **Never write a defensive disclaimer.** No "not derived from", no "original
+   implementation". Saying it implies the question arose, which reads worse than
+   describing what was built.
+6. **Reference material is used and then deleted, never ignored.** A tracked
+   ignore file is committed, so a line naming a local reference directory
+   publishes the reference. There is no correct entry; there is only deleting the
+   directory.
+7. **When unsure, ask before writing the code**, not after. An unrouted commit to
+   a public repository cannot be recalled.
+
+---
+
+## Open for an owner ruling
+
+Two items are recorded here as **open**. Neither is resolved by this ADR, and
+neither is a session's to resolve.
+
+**F1 — the agent declares two different licences.** The plugin header says `MIT`
+(`apps/agent/wpmgr-agent.php:10`) and the wordpress.org listing says
+`GPLv2 or later` (`apps/agent/readme.txt:8`). This is **not a violation**: MIT is
+GPL-compatible, so an MIT-licensed plugin may legitimately be distributed under
+GPLv2-or-later, and the readme is an accurate statement of what the distributed
+*package* is offered under. It is still two different strings a user reads side by
+side, and it costs one sentence to fix — the plugin's own code is MIT, the package
+as distributed is GPLv2-or-later. **Recommendation: fix it now rather than during
+a release**, routed to `wp-agent-engineer` since the path is `apps/agent/**`.
+Cosmetic, cheap, and it stops recurring in every future review.
+
+**F2 — keeping the MCP surface out of the plugin for licence reasons.** §2 sets
+out why this is also the architecture already chosen, but the *decision* has three
+real options and the owner picks one:
+
+- **(b) Keep the entire MCP surface in `apps/api`** and let the agent keep
+  speaking the existing signed-command protocol. Cheapest licensing outcome,
+  changes nothing about `apps/agent`, and matches ADR-061 Decision 1.
+  **This is the recommendation.**
+- **(a) Accept the relicence** and update `LICENSE-AGENT` and the plugin header
+  to GPL-2.0-or-later. This also resolves F1. It is a strategic licence change to
+  a plugin listed in a public directory.
+- **(c) Implement the MCP wire protocol in the agent from the published
+  specification** and bundle neither package. Permitted — the protocol is not
+  copyrightable expression — but it is real work for no benefit given (b).
+
+**This blocks the start of MCP work**, and it is a short ruling rather than a
+long one. The reason it is written down before anyone needs it is that the
+alternative is discovering it from a lockfile diff, after the choice has already
+been made by whoever was in a hurry.
+
+---
+
+## Consequences
+
+- The licence position is now citable from one file, with the commands that
+  verify it. A future planning pass that reasons from a remembered premise can be
+  checked against this in one command rather than one argument.
+- Adding a dependency to `apps/agent` acquires a mandatory licence check against
+  MIT. This is a small cost paid on every dependency bump, and it is the only
+  mechanism that catches the relicensing case before it ships.
+- The reuse dispositions give a PR description a vocabulary: a PR says which of
+  the four it is doing, which makes a review about the right question.
+- ADR-061's Decision 1 gains a second, independent supporting argument. If the
+  credential argument were ever revisited, the licensing one would still stand.
+- F1 and F2 stay open until an owner rules, and F2 gates the start of MCP work.
+  A later ADR supersedes this section when they close; they are not edited away.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,7 +42,8 @@ each file (see "Status line formats" below — the tree is not normalized).
 | 057 | Security Suite Foundation: Per-Site Policy Model | Accepted | 2026-06-20 | [ADR-057-security-suite-foundation.md](./ADR-057-security-suite-foundation.md) |
 | 059 | Site-User Authentication Policy (2FA + Password Policy) | Accepted — 2026-06-20 | 2026-06-20 | [ADR-059-site-user-auth-policy.md](./ADR-059-site-user-auth-policy.md) |
 | 060 | Phase order: safety and truth before capability | Accepted | 2026-08-18 | [ADR-060-phase-order-safety-before-capability.md](./ADR-060-phase-order-safety-before-capability.md) |
-| 061 | Assistant surface, Phase 1: control-plane server and out-of-band approval | Accepted | 2026-08-22 | [ADR-061-assistant-surface-phase-1.md](./ADR-061-assistant-surface-phase-1.md) |
+| 061 | Assistant surface, Phase 1: control-plane server and out-of-band approval | Accepted (amended 2026-08-23) | 2026-08-22 | [ADR-061-assistant-surface-phase-1.md](./ADR-061-assistant-surface-phase-1.md) |
+| 062 | Assistant surface, Phase 2: governed fleet content operations | Proposed | 2026-08-23 | [ADR-062-assistant-surface-phase-2-content-operations.md](./ADR-062-assistant-surface-phase-2-content-operations.md) |
 
 Not part of the numbering: [`font-subsetting-phase2-plan.md`](./font-subsetting-phase2-plan.md)
 is a build plan, not a decision record. It lives in this directory because it
@@ -71,7 +72,7 @@ Two files don't fit any of the three and are findings, not table artifacts:
 ## Numbering
 
 Numbers are allocated in this file and are never reused, including the ones
-below that have no file. **The next free number is 062.**
+below that have no file. **The next free number is 063.**
 
 | Number(s) | What happened |
 |---|---|

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,8 +42,9 @@ each file (see "Status line formats" below — the tree is not normalized).
 | 057 | Security Suite Foundation: Per-Site Policy Model | Accepted | 2026-06-20 | [ADR-057-security-suite-foundation.md](./ADR-057-security-suite-foundation.md) |
 | 059 | Site-User Authentication Policy (2FA + Password Policy) | Accepted — 2026-06-20 | 2026-06-20 | [ADR-059-site-user-auth-policy.md](./ADR-059-site-user-auth-policy.md) |
 | 060 | Phase order: safety and truth before capability | Accepted | 2026-08-18 | [ADR-060-phase-order-safety-before-capability.md](./ADR-060-phase-order-safety-before-capability.md) |
-| 061 | Assistant surface, Phase 1: control-plane server and out-of-band approval | Accepted (amended 2026-08-23) | 2026-08-22 | [ADR-061-assistant-surface-phase-1.md](./ADR-061-assistant-surface-phase-1.md) |
-| 062 | Assistant surface, Phase 2: governed fleet content operations | Proposed | 2026-08-23 | [ADR-062-assistant-surface-phase-2-content-operations.md](./ADR-062-assistant-surface-phase-2-content-operations.md) |
+| 061 | Assistant surface, Phase 1: control-plane server and out-of-band approval | Accepted (amended 2026-08-23 and 2026-08-24) | 2026-08-22 | [ADR-061-assistant-surface-phase-1.md](./ADR-061-assistant-surface-phase-1.md) |
+| 062 | Assistant surface, Phase 2: governed fleet content operations | Proposed (amended 2026-08-24) | 2026-08-23 | [ADR-062-assistant-surface-phase-2-content-operations.md](./ADR-062-assistant-surface-phase-2-content-operations.md) |
+| 063 | Repository licensing, and the rules for third-party reuse | Accepted | 2026-08-24 | [ADR-063-licensing-and-third-party-reuse.md](./ADR-063-licensing-and-third-party-reuse.md) |
 
 Not part of the numbering: [`font-subsetting-phase2-plan.md`](./font-subsetting-phase2-plan.md)
 is a build plan, not a decision record. It lives in this directory because it
@@ -56,7 +57,7 @@ normalized:
 
 1. **Bold inline**, its own line near the top — `**Status:** <value>`, e.g.
    ADR-037 through ADR-047 (except the ADR-045 appendices), ADR-055–057,
-   ADR-059, ADR-060.
+   ADR-059 through ADR-063.
 2. **Plain inline**, no bold — `Status: <value> (<date>)`, e.g.
    ADR-051–054.
 3. **Bold bullet**, inside a metadata list — `- **Status:** <value> (<date>) —
@@ -72,7 +73,7 @@ Two files don't fit any of the three and are findings, not table artifacts:
 ## Numbering
 
 Numbers are allocated in this file and are never reused, including the ones
-below that have no file. **The next free number is 063.**
+below that have no file. **The next free number is 064.**
 
 | Number(s) | What happened |
 |---|---|


### PR DESCRIPTION
Records an architecture decision that has already been made and evidenced. Documentation only; no code paths touched.

## ADR-061 — amended in place, Status stays Accepted

No decision text was rewritten. A new `## Amendments (2026-08-23)` section carries eight items, and each amended decision carries a pointer to it where a reader will hit it.

| # | Change |
|---|---|
| A1 | Clarifies Decision 1 without amending it. The fan-out argument is scoped to fleet-aggregate questions; under Decision 2 a per-site tool call writes a proposal row, so it costs one INSERT and zero round trips, and dispatch happens later on a worker after a human approves. The per-site clause in Consequences is activated as the sanctioned route. The credential argument is untouched and remains load-bearing. |
| A2 | Records the agent's existing signed-command surface, with the two commands that measure it. Corrects a reading, not a decision: what is missing for per-site work is model-facing exposure, not capability. Decision 7's content-write premise is re-verified and remains true. |
| A3 | Amends Decision 6. The revisit threshold is measured against `tools/list` size specifically and re-measured per release, replacing a round number. Records the three-layer registry. Retires the client-approval-UI argument, with the reasoning: Decision 2 removed that UI from the trust model, so the argument binds a different architecture. The tail-is-not-a-registry half is retained and confines Layer C. |
| A4 | Decides concurrency: a per-organization ceiling (default 4) on the assistant dispatch queue plus a per-site exclusive advisory lock, both following patterns already in `internal/update` and `internal/org`. Fixes the **unit** as the per-site step, records that runs are not capped at all, and gives the conversion. Records that the withdrawn wireframe figure was mock copy with no decision behind it. |
| A5 | Bounds the no-automation-may-approve foreclosure against the scheduler: a scheduler that only proposes is permitted, nothing scheduled may approve. |
| A6 | Names the protocol. MCP, **target 2025-11-25, floor 2025-03-26**, refuse below the floor with the reason surfaced, transport, and resources/prompts scoped out of Phase 1. The ADR previously never said MCP while the shipped surfaces already published an `/mcp` endpoint. |
| A7 | Marks Decision 7 superseded by ADR-062 and retires its Consequences bullet. |
| A8 | Adds one line under *Two things that were expensive to learn*: prompt-level safety is not a boundary now has external corroboration. |

The signing statement ADR-061 already corrects is not reintroduced — signing gives forgery and tampering resistance while the key is trusted, and nothing in A2 or A4 claims more.

## ADR-062 — new, Status Proposed

`docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md`. **Proposed, not Accepted — it blocks Phase 2 code.** Carries the nine-item acceptance checklist and records why Decision 7's market conclusion failed, why byte comparison was the wrong verify test and what replaces it, that the unit of work is fleet content operations rather than single-site authoring, snapshot-before-destructive-write and verify-and-rollback as platform primitives rather than per-integration ones, capability detection over the signed channel with refusals naming the requirement and the site's actual version, dynamic-data binding as the write-reduction strategy, field writes through the field plugin's own API rather than raw meta, and the block-editor fork with both branches costed.

Item 2 — **which WordPress principal a content write executes as** — is open and recorded as a hard blocker with three candidate answers and their costs. It routes to `security-reviewer` before any content code.

## Second commit — two under-specifications closed

An adversarial cross-artifact consistency check found two places where published artifacts disagreed with each other and the ADR arbitrated neither. Both were the ADR being under-specified rather than wrong, so both fixes are additions.

**A6 had a target version and no floor.** One artifact accepted a pre-floor protocol revision in its negotiation window; another drew a refusal screen for that same revision and gave a reason tied to the approval flow. The refusal wins, because its reason is tied to the product: below the floor the protocol drops fields the approval flow depends on, and this ADR exists to make a named human's approval checkable. A6 now records **three** values — target `2025-11-25`, floor `2025-03-26`, and refuse-below-the-floor with the reason surfaced to the operator rather than a bare version mismatch. The target version is now corroborated against the WordPress project's published MCP schema package rather than asserted.

**A4 stated its ceiling in steps while artifacts rendered it as run slots and as operations.** Three nouns for one limit is how the withdrawn ceiling figure survived. A4 now fixes the unit as the **per-site step**, states that runs are not capped at all, and gives the conversion: a run over N sites contributes at most `min(N, ceiling)` concurrently dispatching steps and never more than one step per site, because the per-site lock serializes a site's own steps whatever the ceiling allows. Counting the ceiling in runs would understate fleet load by roughly the size of the fleet.

## Third commit — ADR-062's blocker closed, five more ADR-061 amendments, and ADR-063

### ADR-062 — the principal is decided, and the ADR stays Proposed

**Item 2 is closed.** The WordPress execution principal is a dedicated service user with a custom role, created by the agent: no password, no login path, no session, and deliberately **no `unfiltered_html`**, so `wp_kses_post` runs and a content write cannot inject script.

The cost is stated rather than argued away. It is a privileged object on every managed site, and the ADR does not let "not really privileged" stand as an assertion — it specifies an **attack-test suite as a ship gate**, not a review item: authenticate by password, mint an application password, reach it through the autologin path, establish a REST or admin session, and enumerate its capabilities. Each is planted as a *passing* attack first and watched go red before it is watched go green. Two other costs are on the record: the site's own admin can delete it, which must surface as a typed `principal_missing` refusal with a recreate remedy and never a silent fallback to a different principal; and it is a new visible row on the customer's Users screen.

What it forecloses is recorded as deliberate: **making an AI change look human-authored** (attribution is legible by construction; a future per-site `post_author` override moves the display field only, never the executing principal), and **arbitrary embed or HTML writes** (without `unfiltered_html` a prompt-injection payload reaching the content path cannot become executable markup).

**The checklist now marks decided against open**, and the ADR carries the command that counts both — refusing on zero, so a reformatted list cannot print `0 open` and read as an ADR ready to accept.

**The wave plan closes item 7.** Wave 1 has **no page builder and no Gutenberg writes**. Wave 2 gets **exactly one builder, Elementor**. Wave 3 is Gutenberg static blocks and Bricks, gated on the fleet query. Everything else is out of scope with a one-line reason each. Two honesty statements travel with the plan wherever it is rendered: **the ordering is reasoned, not measured**, and **the fleet-inventory query that would measure it is a pre-development task nobody has run**. The criteria do not change if the query surprises us; the ordering does.

**ADR-062 stays Proposed**, and the ADR now carries a `Why this is still Proposed` section rather than leaving it to inference: accepting it lifts its own gate on content-write code, ADR-060's precedence puts it behind open rank-1 work, two checklist items need a measurement and a mechanism rather than an argument, the wave plan is provisional on a query nobody has run, and `security-reviewer` has not seen the principal or the four-command token scoping.

### ADR-061 — amendments A9 through A13

| # | Change |
|---|---|
| A9 | **The most consequential sequencing fact in the plan.** ADR-060's freeze clause fixes ordering *inside* Phase 1: the MCP endpoint is a new externally-reachable surface, and the site-scope chokepoint and the audit fail-open are open auth-boundary items, so they close **before** the endpoint ships. Not "should" — the clause is absolute and it is ADR-060's only absolute. |
| A10 | Audit is **fail-closed for this surface**, in one sentence, noting the existing write helper is documented fail-open and that opting in is deliberate. Reads are included; the chain lock becomes a throughput ceiling that must be measured rather than discovered. |
| A11 | **Site scoping is in v1** as an application-layer chokepoint, with the six pieces of work listed. Reaffirms that no document may imply the database enforces it — the scope and allowlist columns are stored and enforced by nothing today. |
| A12 | **Protocol**: the three cases the code must not conflate. An absent `MCP-Protocol-Version` header means assume the floor `2025-03-26`, **not** a 400; an unsupported or unparseable value MUST get a 400; the negotiated version governs. No AI client's public documentation mentions the header, so the server logs what it actually receives from day one. |
| A13 | **Skill and prompt content is data, never permission.** Authorization resolves outside the model loop, so instruction text asking to skip approval is denied identically to text that does not. The fencing rule is Phase 1 even though the store itself is later: the fence must predate the first untrusted string, not the first skill. |

### ADR-063 — new, Status Accepted

`docs/adr/ADR-063-licensing-and-third-party-reuse.md`. Records repository licensing as it actually is, verified by commands the file carries rather than quoted from memory: the root `LICENSE` is **AGPL-3.0** and covers `apps/api`; `LICENSE-AGENT` is **MIT** and covers `apps/agent` and `apps/tracker`.

The consequence is an asymmetry that points the opposite way from the one people expect: **GPL-2.0-or-later components cannot enter the MIT plugin without relicensing it**, while the AGPL control plane has no such conflict, because the repository is already public and already AGPL. **This independently supports siting the MCP surface in the control plane** — a second argument for ADR-061 Decision 1 that does not depend on the credential one.

Adds the four reuse dispositions for engineers (adopt upstream, interface-compatible only, reimplement from behaviour, do not use), and records that a protocol, a published specification and a public API shape are not copyrightable expression the way source code is. Two items are left **open for an owner ruling**: the plugin header declares `License: MIT` while `readme.txt` declares `GPLv2 or later`, and the decision to keep MCP out of the plugin for licence reasons.

`docs/adr/README.md` is kept in step: ADR-063 registered, next free number advanced, amended statuses transcribed.

## Gates run

- Docs vocabulary check, copied out of `.github/workflows/ci.yml` in this pass and run over `docs/**.md` and root markdown: no output, all three commits. **Proved it fires** rather than trusting a silent pass: planted a banned name in a scratch file under `docs/`, watched it go red naming the file, removed it, watched it go green.
- `make hooks-status`: pre-push installed and current.
- `make check-versions-test` then `make check-versions`: pass, self-test first.
- `node apps/marketing/scripts/check-copy.mjs`: pass.
- Every count in either document is the output of a command run while writing it, with the command beside it. Neither ADR hard-codes a checklist count; ADR-062 carries the command that prints it.

Draft. Please do not merge before review.

