### PR TITLE
fix(email): send agent_seq for resend_email, and count only successes (#520)

### DIFF
--- a/apps/api/internal/agentcmd/client.go
+++ b/apps/api/internal/agentcmd/client.go
@@ -935,12 +935,14 @@ func joinCommandURL(siteURL, command string) (string, error) {
 }
 
 // ResendEmail sends the signed `resend_email` command to the site's agent,
-// asking it to re-send a previously logged email using the stored body.
-// The gate (body_stored=true) is enforced by the CP service before this call.
+// asking it to re-send an email from its OWN log row, named by agent_seq.
+// The CP's near-end preconditions (row exists, body captured, agent_seq known)
+// are enforced by the email service before this call so a request that cannot
+// succeed never spends a signed command.
 //
-// Phase 4a: this command is DEFINED here but the agent does not yet implement
-// it (Phase 4b). Old agents will return a 404 from the REST router — the CP
-// surfaces that as ok=false + a descriptive detail rather than a hard error.
+// An agent too old to route the command answers 404, which post() returns as a
+// transport error; the CP surfaces that as ok=false with a descriptive detail
+// rather than a hard error.
 func (c *Client) ResendEmail(ctx context.Context, siteID uuid.UUID, siteURL string, req ResendEmailRequest) (ResendEmailResult, error) {
 	var out ResendEmailResult
 	if err := c.post(ctx, siteID, siteURL, "resend_email", req, &out); err != nil {

--- a/apps/api/internal/agentcmd/resend_email_contract.go
+++ b/apps/api/internal/agentcmd/resend_email_contract.go
@@ -1,47 +1,61 @@
 package agentcmd
 
-// resend_email_contract.go — CP->agent command contract for resending a stored
-// email from the CP-held email log body (Phase 4a definition; Phase 4b implementation).
+// resend_email_contract.go — CP->agent command contract for resending an email
+// the agent already holds in its own local log.
 //
-// The CP looks up the site_email_log row identified by log_id (UUID), reads the
-// stored body (requires body_stored=true, enforced by the service gate), and
-// dispatches the signed `resend_email` command to the agent. The agent re-sends
-// using its currently configured email provider (same config as the original send)
-// and returns the new provider Message-ID.
+// Wire contract (must match apps/agent/includes/commands/class-resend-email-command.php):
 //
-// The agent MUST implement the `resend_email` command handler in Phase 4b.
-// Until then, the CP stub returns ok=false with a descriptive detail.
+//	POST {siteURL}/wp-json/wpmgr/v1/command/resend_email
+//	Authorization: Bearer <Ed25519 JWT, cmd="resend_email", aud=<siteId>>
+//	Body: {"agent_seq": <int>}
+//
+// The agent looks the row up in its own wpmgr_email_log by that local row id,
+// refuses when the row is gone or its body was not captured, and otherwise
+// re-sends through its configured provider and returns the new Message-ID.
+//
+// GH #520: the CP used to send a log_id UUID plus an (unpopulated) copy of the
+// message itself. The agent has required agent_seq since the same commit that
+// shipped the CP side, so every resend, on every site, failed on the agent's
+// first validation branch. The agent's contract wins: it is already implemented
+// and tested, one CP deploy repairs the whole fleet without waiting for a
+// plugin update, and it keeps customer message bodies off the command channel.
+//
+// Consequence to keep in view: the agent prunes its log at 14 days / 50k rows
+// (class-email-logger.php), so a resend of an older entry legitimately returns
+// ResendDetailRowNotFound. That is an honest failure, not a silent empty send.
 
 // ResendEmailRequest is the POST body for the `resend_email` agent command.
+//
+// One field, deliberately. Everything the agent needs to rebuild the message
+// (recipients, from, subject, body, provider) it reads from its own log row —
+// the CP names the row and nothing more.
 type ResendEmailRequest struct {
-	// LogID is the CP-side site_email_log.id (UUID string). The agent uses it
-	// as a correlation identifier for the resend attempt — it does not need to
-	// query the CP to retrieve the body; the full message body is embedded in
-	// this request so the agent can re-send without a second round-trip.
-	LogID string `json:"log_id"`
-
-	// ToAddresses is the recipient list for the resend. Required.
-	// The CP copies the original log entry's to_addresses.
-	ToAddresses []string `json:"to_addresses"`
-
-	// FromAddress is the From: header value. Required.
-	FromAddress string `json:"from_address"`
-
-	// FromName is the From: display name. May be empty.
-	FromName string `json:"from_name,omitempty"`
-
-	// Subject is the email subject line. Required.
-	Subject string `json:"subject"`
-
-	// Body is the full email body (plain text or HTML, matching what was captured
-	// at the original send time). The CP only sends this when body_stored=true.
-	Body string `json:"body"`
-
-	// Provider is the provider slug used for the original send (smtp, ses,
-	// sendgrid, mailgun, postmark). The agent uses its currently configured
-	// provider; this field is informational for logging.
-	Provider string `json:"provider,omitempty"`
+	// AgentSeq is the agent-local wpmgr_email_log row id, mirrored into the CP
+	// as site_email_log.agent_seq at ingest. It is the only field the agent
+	// reads, and it must be a positive integer or the agent refuses.
+	AgentSeq int64 `json:"agent_seq"`
 }
+
+// Known `detail` values the agent returns with ok=false. These are contract
+// strings, not free text: callers map them to operator-facing wording rather
+// than showing them raw (a user saw "missing required field: agent_seq" in a
+// toast, which is how GH #520 was reported).
+const (
+	// ResendDetailRowNotFound — the agent's own log no longer holds the row,
+	// normally because its 14-day / 50k-row prune has passed over it.
+	ResendDetailRowNotFound = "log_row_not_found"
+	// ResendDetailBodyNotStored — the row exists but was logged without body
+	// capture, so there is nothing to re-send.
+	ResendDetailBodyNotStored = "body_not_stored"
+	// ResendDetailNoConfig — the agent has no email configuration yet; the CP
+	// must push sync_email_config first. Prefix, the agent appends guidance.
+	ResendDetailNoConfig = "no email config"
+	// ResendDetailMissingSeq — the agent rejected the request shape itself.
+	// Reachable only if the CP regresses to a pre-#520 payload.
+	ResendDetailMissingSeq = "missing required field: agent_seq"
+	// ResendDetailBadSeq — agent_seq was present but not a positive integer.
+	ResendDetailBadSeq = "agent_seq must be a positive integer"
+)
 
 // ResendEmailResult is the response body for the `resend_email` agent command.
 type ResendEmailResult struct {

--- a/apps/api/internal/agentcmd/resend_email_contract_test.go
+++ b/apps/api/internal/agentcmd/resend_email_contract_test.go
@@ -1,0 +1,73 @@
+package agentcmd
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestResendEmailRequest_WireShape pins the bytes that go on the command
+// channel for a resend.
+//
+// GH #520: this struct used to marshal to
+//
+//	{"log_id":"<uuid>","to_addresses":null,"from_address":"","subject":"","body":""}
+//
+// while apps/agent/includes/commands/class-resend-email-command.php rejects any
+// params array without agent_seq on the first line of execute(). Neither side's
+// tests looked at the other's, so the mismatch shipped and every resend failed.
+//
+// Exact equality, not a field check: an extra field here is message content
+// travelling on the command channel to a reader that ignores it.
+func TestResendEmailRequest_WireShape(t *testing.T) {
+	raw, err := json.Marshal(ResendEmailRequest{AgentSeq: 4242})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"agent_seq":4242}`
+	if string(raw) != want {
+		t.Errorf("resend_email request body = %s, want %s", raw, want)
+	}
+}
+
+// TestResendEmailResult_DecodesAgentResponses decodes the exact bodies the
+// agent's execute() returns, so a rename on either side is a test failure
+// rather than a silently empty result.
+func TestResendEmailResult_DecodesAgentResponses(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want ResendEmailResult
+	}{
+		{
+			name: "resent",
+			body: `{"ok":true,"detail":"resent","message_id":"<abc@site>"}`,
+			want: ResendEmailResult{OK: true, Detail: "resent", MessageID: "<abc@site>"},
+		},
+		{
+			name: "pruned from the agent log",
+			body: `{"ok":false,"detail":"log_row_not_found","message_id":""}`,
+			want: ResendEmailResult{OK: false, Detail: ResendDetailRowNotFound},
+		},
+		{
+			name: "body was never captured",
+			body: `{"ok":false,"detail":"body_not_stored","message_id":""}`,
+			want: ResendEmailResult{OK: false, Detail: ResendDetailBodyNotStored},
+		},
+		{
+			name: "the #520 rejection",
+			body: `{"ok":false,"detail":"missing required field: agent_seq","message_id":""}`,
+			want: ResendEmailResult{OK: false, Detail: ResendDetailMissingSeq},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ResendEmailResult
+			if err := json.Unmarshal([]byte(tc.body), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("decoded %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/api/internal/api/gen/oas_client_gen.go
+++ b/apps/api/internal/api/gen/oas_client_gen.go
@@ -2977,13 +2977,19 @@ type Invoker interface {
 	ResendAdminUserVerification(ctx context.Context, params ResendAdminUserVerificationParams) (ResendAdminUserVerificationRes, error)
 	// ResendEmailLog invokes resendEmailLog operation.
 	//
-	// Dispatches the `resend_email` agent command for the given log entry. Only available when
-	// `body_stored=true` on the log entry — returns 409 otherwise. The resend is best-effort: if the
-	// agent is offline or returns an error the response contains `ok=false` with the agent's detail
-	// message but HTTP 200 is returned (matching the test-email pattern).
+	// Dispatches the `resend_email` agent command for the given log entry. The command names the site's
+	// own log row, so the entry must have been reported by the site (`agent_seq`) and must have been
+	// logged with its body captured (`body_stored=true`) — 409 otherwise, with no command sent.
 	//
-	// The `resent_count` counter is incremented before the agent dispatch so operators can see how many
-	// resend attempts were made even if the agent was unavailable.
+	// The resend is best-effort past that point: if the site is offline or refuses, the response is HTTP
+	// 200 with `ok=false` and a `detail` explaining why (matching the test-email pattern).
+	//
+	// The site keeps its own email log for 14 days, or 50,000 messages, whichever comes first. An entry
+	// older than that is still listed here but can no longer be resent, and the attempt returns
+	// `ok=false`.
+	//
+	// `resent_count` and the `email.resent` audit entry record confirmed resends only; a refusal moves
+	// neither.
 	//
 	// Requires `site.email.manage` permission.
 	//
@@ -37266,13 +37272,19 @@ func (c *Client) sendResendAdminUserVerification(ctx context.Context, params Res
 
 // ResendEmailLog invokes resendEmailLog operation.
 //
-// Dispatches the `resend_email` agent command for the given log entry. Only available when
-// `body_stored=true` on the log entry — returns 409 otherwise. The resend is best-effort: if the
-// agent is offline or returns an error the response contains `ok=false` with the agent's detail
-// message but HTTP 200 is returned (matching the test-email pattern).
+// Dispatches the `resend_email` agent command for the given log entry. The command names the site's
+// own log row, so the entry must have been reported by the site (`agent_seq`) and must have been
+// logged with its body captured (`body_stored=true`) — 409 otherwise, with no command sent.
 //
-// The `resent_count` counter is incremented before the agent dispatch so operators can see how many
-// resend attempts were made even if the agent was unavailable.
+// The resend is best-effort past that point: if the site is offline or refuses, the response is HTTP
+// 200 with `ok=false` and a `detail` explaining why (matching the test-email pattern).
+//
+// The site keeps its own email log for 14 days, or 50,000 messages, whichever comes first. An entry
+// older than that is still listed here but can no longer be resent, and the attempt returns
+// `ok=false`.
+//
+// `resent_count` and the `email.resent` audit entry record confirmed resends only; a refusal moves
+// neither.
 //
 // Requires `site.email.manage` permission.
 //

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -40242,7 +40242,9 @@ func (*ResendEmailLogUnauthorized) resendEmailLogRes() {}
 // Ref: #/components/schemas/ResendEmailResult
 type ResendEmailResult struct {
 	Ok bool `json:"ok"`
-	// Agent response message or error detail.
+	// Why the resend did not happen, phrased for an operator. Known agent refusals (log pruned, body not
+	// captured, site not configured, plugin too old) are translated here; anything else is the provider's
+	// own error text, passed through. Safe to display as-is.
 	Detail OptNilString `json:"detail"`
 	// Provider message ID assigned to the resent email (if agent returned it).
 	MessageID OptNilString `json:"message_id"`

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -40244,7 +40244,9 @@ type ResendEmailResult struct {
 	Ok bool `json:"ok"`
 	// Why the resend did not happen, phrased for an operator. Known agent refusals (log pruned, body not
 	// captured, site not configured, plugin too old) are translated here; anything else is the provider's
-	// own error text, passed through. Safe to display as-is.
+	// own error text, passed through unmodified from the site's agent. Plain text, not markup: the
+	// passthrough case can carry arbitrary characters from a compromised site, so escape it before
+	// rendering.
 	Detail OptNilString `json:"detail"`
 	// Provider message ID assigned to the resent email (if agent returned it).
 	MessageID OptNilString `json:"message_id"`

--- a/apps/api/internal/email/handler.go
+++ b/apps/api/internal/email/handler.go
@@ -592,8 +592,50 @@ func (h *Handler) getFleetDeliverability(c *gin.Context) {
 // Phase 4a — resend + bulk delete log handlers
 // ---------------------------------------------------------------------------
 
+// resendAuditMeta decides whether a completed single resend has anything to
+// audit, and with what metadata.
+//
+// GH #520: ActionEmailResent used to be recorded unconditionally, immediately
+// after the service call, so an audit row saying an email had been resent was
+// written for every click — including the entire period in which the CP/agent
+// contract mismatch meant no resend could possibly have succeeded. An audit log
+// that records intentions is worse than one that records nothing, because it is
+// believed. Audit the send.
+func resendAuditMeta(logID uuid.UUID, res ResendResult) (map[string]any, bool) {
+	if !res.OK {
+		return nil, false
+	}
+	return map[string]any{
+		"log_id":     logID.String(),
+		"message_id": res.MessageID,
+	}, true
+}
+
+// bulkResendAuditMeta is the same decision for the bulk route.
+//
+// `count` is how many entries the site confirmed it resent, not how many were
+// asked for: N commands spent and zero emails sent used to leave one audit row
+// reading {"count": N}. `requested` is kept beside it so a partial batch stays
+// legible, and a batch that resent nothing writes no row at all.
+func bulkResendAuditMeta(requested int, results []BulkResendResult) (map[string]any, bool) {
+	resent := 0
+	for _, r := range results {
+		if r.OK {
+			resent++
+		}
+	}
+	if resent == 0 {
+		return nil, false
+	}
+	return map[string]any{
+		"count":     resent,
+		"requested": requested,
+	}, true
+}
+
 // resendLog handles POST /sites/:siteId/email/log/:logId/resend.
-// Gates on body_stored=true; returns 409 otherwise.
+// Refuses near-end (404/409) when the entry cannot be resent; otherwise returns
+// 200 with ok=true/false from the site. Audits only a confirmed resend.
 func (h *Handler) resendLog(c *gin.Context) {
 	p, _ := domain.PrincipalFromContext(c.Request.Context())
 	siteID, ok := parseSiteID(c)
@@ -610,7 +652,9 @@ func (h *Handler) resendLog(c *gin.Context) {
 		httpx.Error(c, serr)
 		return
 	}
-	h.record(c, p, audit.ActionEmailResent, siteID, map[string]any{"log_id": logID.String()})
+	if meta, ok := resendAuditMeta(logID, result); ok {
+		h.record(c, p, audit.ActionEmailResent, siteID, meta)
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"ok":         result.OK,
 		"detail":     result.Detail,
@@ -693,7 +737,9 @@ func (h *Handler) bulkResendLog(c *gin.Context) {
 		httpx.Error(c, serr)
 		return
 	}
-	h.record(c, p, audit.ActionEmailResent, siteID, map[string]any{"count": len(ids)})
+	if meta, ok := bulkResendAuditMeta(len(ids), results); ok {
+		h.record(c, p, audit.ActionEmailResent, siteID, meta)
+	}
 	dtos := make([]gin.H, 0, len(results))
 	for _, r := range results {
 		dtos = append(dtos, gin.H{

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -415,6 +415,18 @@ type LogDetail struct {
 	NextID *uuid.UUID
 }
 
+// ResendTarget is the slice of a log row a resend needs, and nothing else.
+//
+// AgentSeq is the agent-local wpmgr_email_log row id and the only thing the
+// resend_email command carries. It is a pointer because the column is nullable,
+// though IngestEmailLogEntry — the only production INSERT — always sets it
+// (repo.go IngestLogBatch takes &e.AgentSeq unconditionally). A nil here means
+// a row that arrived some other way, and a resend for it cannot be addressed.
+type ResendTarget struct {
+	AgentSeq   *int64
+	BodyStored bool
+}
+
 // IngestEntry is one entry from the agent's ingest push.
 type IngestEntry struct {
 	AgentSeq    int64

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -1708,14 +1708,25 @@ func (r *Repo) PruneWebhookDedup(ctx context.Context, cutoffTs time.Time) (int64
 // Log actions (Phase 4a)
 // ---------------------------------------------------------------------------
 
-// GetEmailLogBodyStored fetches the body_stored flag for a log entry (resend gate).
-func (r *Repo) GetEmailLogBodyStored(ctx context.Context, tenantID, siteID, id uuid.UUID) (bool, error) {
-	var bodyStored bool
+// GetResendTarget fetches everything a resend dispatch needs to decide whether
+// the command can succeed, and to name the row to the agent: the agent-local
+// row id (agent_seq) and the body_stored flag.
+//
+// GH #520: the resend gate used to read body_stored alone, because the CP
+// believed it was sending the body itself. The agent addresses its own log by
+// agent_seq, so agent_seq is now a precondition, not an afterthought — without
+// it there is nothing to ask the agent for.
+//
+// This reads through the existing GetEmailLog query rather than a narrower one.
+// That row carries the stored body; it stays in this process and never reaches
+// the command channel, which is the point of the agent-side contract.
+func (r *Repo) GetResendTarget(ctx context.Context, tenantID, siteID, id uuid.UUID) (ResendTarget, error) {
+	var target ResendTarget
 	err := r.scopedTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
-		row, qerr := sqlc.New(tx).GetEmailLogBodyStored(ctx, sqlc.GetEmailLogBodyStoredParams{
-			ID:       id,
+		row, qerr := sqlc.New(tx).GetEmailLog(ctx, sqlc.GetEmailLogParams{
 			TenantID: tenantID,
 			SiteID:   siteID,
+			ID:       id,
 		})
 		if qerr != nil {
 			if errors.Is(qerr, pgx.ErrNoRows) {
@@ -1723,10 +1734,11 @@ func (r *Repo) GetEmailLogBodyStored(ctx context.Context, tenantID, siteID, id u
 			}
 			return qerr
 		}
-		bodyStored = row.BodyStored
+		target.AgentSeq = row.AgentSeq
+		target.BodyStored = row.BodyStored
 		return nil
 	})
-	return bodyStored, err
+	return target, err
 }
 
 // IncrEmailLogResentCount increments resent_count on a log entry. Runs under scopedTenantTx.

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -313,7 +313,12 @@ func TestBulkResendEmail_MixedOutcomes(t *testing.T) {
 
 	wantOK := map[uuid.UUID]bool{okID: true, refusedID: false, noSeqID: false, missingID: false}
 	for _, r := range results {
-		if want := wantOK[r.LogID]; r.OK != want {
+		want, known := wantOK[r.LogID]
+		if !known {
+			t.Errorf("log %s: result carries an id that was never requested", r.LogID)
+			continue
+		}
+		if r.OK != want {
 			t.Errorf("log %s: ok=%v, want %v (detail %q)", r.LogID, r.OK, want, r.Detail)
 		}
 	}
@@ -321,6 +326,22 @@ func TestBulkResendEmail_MixedOutcomes(t *testing.T) {
 	// Only the two addressable rows may spend a signed command.
 	if agent.calls != 2 {
 		t.Errorf("agent dispatched %d command(s), want 2 (the unaddressable and missing rows must be refused near-end)", agent.calls)
+	}
+	// Each addressable row must be dispatched with its own agent_seq, in
+	// request order — proof that the bulk path addresses rows individually
+	// rather than resending one id (or one seq) for the whole batch.
+	wantSeqs := []int64{11, 12}
+	seqsMatch := len(agent.seqs) == len(wantSeqs)
+	if seqsMatch {
+		for i, want := range wantSeqs {
+			if agent.seqs[i] != want {
+				seqsMatch = false
+				break
+			}
+		}
+	}
+	if !seqsMatch {
+		t.Errorf("agent saw agent_seq sequence %v, want %v (each row must be addressed individually)", agent.seqs, wantSeqs)
 	}
 	if repo.incrCalls != 1 {
 		t.Errorf("resent_count incremented %d time(s), want 1", repo.incrCalls)

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -1,0 +1,434 @@
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentcmd"
+)
+
+// ---------------------------------------------------------------------------
+// GH #520 — the resend_email wire contract
+// ---------------------------------------------------------------------------
+//
+// This file exists because nothing asserted the payload the CP actually POSTs
+// for a resend. The Go fake declared
+//
+//	ResendEmail(_, _, _, _ agentcmd.ResendEmailRequest)
+//
+// and threw the request away with a blank identifier, while the agent's PHPUnit
+// test hand-built ['agent_seq' => N]. Each half tested its own idea of the
+// contract and nothing tested that the two agreed — so the CP shipped sending
+// log_id, the agent shipped requiring agent_seq, and every Resend on every site
+// failed with "missing required field: agent_seq" from commit 3f8e5765 onward.
+//
+// The assertion below is the whole point: the exact JSON object the agent
+// receives. It is compared as a key set plus values, not field-by-field, so an
+// EXTRA field is a failure too — an unread field on the command channel is how
+// stored message bodies would leak back onto the wire.
+//
+// The agent's reader is apps/agent/includes/commands/class-resend-email-command.php:
+// execute() rejects a params array without agent_seq before anything else runs.
+
+// wantResendKeys is the exact set of JSON keys the agent's resend_email handler
+// reads. Keep this in lockstep with class-resend-email-command.php::execute().
+var wantResendKeys = []string{"agent_seq"}
+
+// fakeResendAgent captures the ResendEmailRequest the service dispatches.
+type fakeResendAgent struct {
+	calls    int
+	lastReq  agentcmd.ResendEmailRequest
+	result   agentcmd.ResendEmailResult
+	resulErr error
+}
+
+func (f *fakeResendAgent) SyncEmailConfig(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.EmailConfigRequest) (agentcmd.EmailConfigResult, error) {
+	return agentcmd.EmailConfigResult{OK: true}, nil
+}
+
+func (f *fakeResendAgent) SendTestEmail(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.SendTestEmailRequest) (agentcmd.SendTestEmailResult, error) {
+	return agentcmd.SendTestEmailResult{OK: true}, nil
+}
+
+func (f *fakeResendAgent) ResendEmail(_ context.Context, _ uuid.UUID, _ string, req agentcmd.ResendEmailRequest) (agentcmd.ResendEmailResult, error) {
+	f.calls++
+	f.lastReq = req
+	if f.resulErr != nil {
+		return agentcmd.ResendEmailResult{OK: false, Detail: f.resulErr.Error()}, f.resulErr
+	}
+	return f.result, nil
+}
+
+// fakeResendRepo serves log rows by id and counts resent_count writes.
+type fakeResendRepo struct {
+	*fakeRepo
+	rows      map[uuid.UUID]ResendTarget
+	incrCalls int
+	incrIDs   []uuid.UUID
+}
+
+func newFakeResendRepo(logID uuid.UUID, agentSeq int64) *fakeResendRepo {
+	r := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	r.addRow(logID, agentSeq, true)
+	return r
+}
+
+func (r *fakeResendRepo) addRow(id uuid.UUID, agentSeq int64, bodyStored bool) {
+	t := ResendTarget{BodyStored: bodyStored}
+	if agentSeq != 0 {
+		seq := agentSeq
+		t.AgentSeq = &seq
+	}
+	r.rows[id] = t
+}
+
+func (r *fakeResendRepo) GetResendTarget(_ context.Context, _, _, id uuid.UUID) (ResendTarget, error) {
+	t, ok := r.rows[id]
+	if !ok {
+		return ResendTarget{}, ErrNotFound
+	}
+	return t, nil
+}
+
+func (r *fakeResendRepo) IncrEmailLogResentCount(_ context.Context, _, _, id uuid.UUID) error {
+	if _, ok := r.rows[id]; !ok {
+		return ErrNotFound
+	}
+	r.incrCalls++
+	r.incrIDs = append(r.incrIDs, id)
+	return nil
+}
+
+// newResendSvc wires a service over the two fakes above.
+func newResendSvc(repo repository, agent AgentEmailClient) *Service {
+	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
+	svc.repo = repo
+	svc.SetAgentClient(agent, &fakeSiteLookup{})
+	return svc
+}
+
+// TestResendEmail_DispatchedPayloadMatchesAgentContract is the regression test
+// for GH #520. It asserts the literal JSON the agent would receive.
+func TestResendEmail_DispatchedPayloadMatchesAgentContract(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	const agentSeq int64 = 4242
+
+	repo := newFakeResendRepo(logID, agentSeq)
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true, Detail: "resent", MessageID: "<m@site>"}}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("ResendEmail: expected ok=true, got ok=false detail=%q", res.Detail)
+	}
+	if agent.calls != 1 {
+		t.Fatalf("expected exactly 1 agent dispatch, got %d", agent.calls)
+	}
+
+	raw, err := json.Marshal(agent.lastReq)
+	if err != nil {
+		t.Fatalf("marshal dispatched request: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal dispatched request: %v", err)
+	}
+
+	// Exact key set — a missing key is the #520 bug, an extra key puts data on
+	// the command channel that the agent never reads.
+	if len(got) != len(wantResendKeys) {
+		t.Errorf("dispatched payload has %d field(s), want %d\n  got:  %s\n  want keys: %v",
+			len(got), len(wantResendKeys), raw, wantResendKeys)
+	}
+	for _, k := range wantResendKeys {
+		if _, ok := got[k]; !ok {
+			t.Errorf("dispatched payload is missing %q — the agent rejects this request\n  got: %s", k, raw)
+		}
+	}
+	// agent_seq must be the row's own local id, as a JSON number.
+	if n, ok := got["agent_seq"].(float64); !ok || int64(n) != agentSeq {
+		t.Errorf("agent_seq = %v, want %d\n  got: %s", got["agent_seq"], agentSeq, raw)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Accounting: resent_count and the audit row move on SUCCESS only
+// ---------------------------------------------------------------------------
+
+func TestResendEmail_Success_IncrementsCountOnce(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeResendRepo(logID, 7)
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true, Detail: "resent", MessageID: "<m@site>"}}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if !res.OK || res.MessageID != "<m@site>" {
+		t.Fatalf("expected ok=true with the agent's message id, got ok=%v id=%q", res.OK, res.MessageID)
+	}
+	if repo.incrCalls != 1 {
+		t.Errorf("resent_count incremented %d time(s), want 1", repo.incrCalls)
+	}
+	if meta, ok := resendAuditMeta(logID, res); !ok {
+		t.Error("a confirmed resend must be audited")
+	} else if meta["message_id"] != "<m@site>" {
+		t.Errorf("audit metadata message_id = %v, want <m@site>", meta["message_id"])
+	}
+}
+
+func TestResendEmail_AgentRefuses_NoCountNoAudit(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeResendRepo(logID, 7)
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: false, Detail: agentcmd.ResendDetailRowNotFound}}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if res.OK {
+		t.Fatal("expected ok=false when the agent refuses")
+	}
+	if repo.incrCalls != 0 {
+		t.Errorf("resent_count incremented %d time(s) on a refused resend, want 0", repo.incrCalls)
+	}
+	if _, ok := resendAuditMeta(logID, res); ok {
+		t.Error("a refused resend must not be audited as email.resent")
+	}
+	// The raw contract string must not reach the operator.
+	if strings.Contains(res.Detail, agentcmd.ResendDetailRowNotFound) {
+		t.Errorf("raw agent detail leaked to the caller: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "14 days") {
+		t.Errorf("expected the retention explanation in the detail, got %q", res.Detail)
+	}
+}
+
+func TestResendEmail_TransportError_NoCount(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeResendRepo(logID, 7)
+	agent := &fakeResendAgent{resulErr: errors.New("resend_email command rejected by agent: status 404 body=no route")}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if res.OK {
+		t.Fatal("expected ok=false on a transport failure")
+	}
+	if repo.incrCalls != 0 {
+		t.Errorf("resent_count incremented %d time(s) on a transport failure, want 0", repo.incrCalls)
+	}
+	if !strings.Contains(res.Detail, "too old") {
+		t.Errorf("expected the stale-plugin message for a 404, got %q", res.Detail)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions: refuse near-end rather than spend a signed command
+// ---------------------------------------------------------------------------
+
+func TestResendEmail_NoAgentSeq_RefusedBeforeDispatch(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeResendRepo(logID, 0) // body captured, but no agent_seq
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true}}
+	svc := newResendSvc(repo, agent)
+
+	_, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err == nil {
+		t.Fatal("expected a refusal when the row carries no agent_seq")
+	}
+	if !containsCode(err, "resend_agent_seq_missing") {
+		t.Errorf("expected code 'resend_agent_seq_missing', got: %v", err)
+	}
+	if agent.calls != 0 {
+		t.Errorf("a signed command was dispatched for an unaddressable row (%d call(s))", agent.calls)
+	}
+	if repo.incrCalls != 0 {
+		t.Errorf("resent_count incremented %d time(s) on a refused precondition, want 0", repo.incrCalls)
+	}
+}
+
+func TestResendEmail_BodyNotStored_RefusedBeforeDispatch(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRow(logID, 7, false) // agent_seq known, body never captured
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true}}
+	svc := newResendSvc(repo, agent)
+
+	_, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err == nil {
+		t.Fatal("expected a refusal when the body was not captured")
+	}
+	if !containsCode(err, "resend_body_not_stored") {
+		t.Errorf("expected code 'resend_body_not_stored', got: %v", err)
+	}
+	if agent.calls != 0 {
+		t.Errorf("a signed command was dispatched for a bodiless row (%d call(s))", agent.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bulk: per-entry outcomes, and one honest audit row
+// ---------------------------------------------------------------------------
+
+// TestBulkResendEmail_MixedOutcomes drives one batch containing an entry that
+// resends, an entry the site refuses, an entry with no agent_seq and an entry
+// that does not exist, and asserts that only the successful one is counted.
+func TestBulkResendEmail_MixedOutcomes(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	okID, refusedID, noSeqID, missingID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRow(okID, 11, true)
+	repo.addRow(refusedID, 12, true)
+	repo.addRow(noSeqID, 0, true)
+
+	// The agent resends the first row and refuses the second.
+	agent := &perSeqResendAgent{results: map[int64]agentcmd.ResendEmailResult{
+		11: {OK: true, Detail: "resent", MessageID: "<a@site>"},
+		12: {OK: false, Detail: agentcmd.ResendDetailBodyNotStored},
+	}}
+	svc := newResendSvc(repo, agent)
+
+	ids := []uuid.UUID{okID, refusedID, noSeqID, missingID}
+	results, err := svc.BulkResendEmail(context.Background(), tenantID, siteID, ids)
+	if err != nil {
+		t.Fatalf("BulkResendEmail: unexpected error: %v", err)
+	}
+	if len(results) != len(ids) {
+		t.Fatalf("got %d results for %d ids", len(results), len(ids))
+	}
+
+	wantOK := map[uuid.UUID]bool{okID: true, refusedID: false, noSeqID: false, missingID: false}
+	for _, r := range results {
+		if want := wantOK[r.LogID]; r.OK != want {
+			t.Errorf("log %s: ok=%v, want %v (detail %q)", r.LogID, r.OK, want, r.Detail)
+		}
+	}
+
+	// Only the two addressable rows may spend a signed command.
+	if agent.calls != 2 {
+		t.Errorf("agent dispatched %d command(s), want 2 (the unaddressable and missing rows must be refused near-end)", agent.calls)
+	}
+	if repo.incrCalls != 1 {
+		t.Errorf("resent_count incremented %d time(s), want 1", repo.incrCalls)
+	}
+	if len(repo.incrIDs) != 1 || repo.incrIDs[0] != okID {
+		t.Errorf("resent_count moved on the wrong rows: %v, want [%s]", repo.incrIDs, okID)
+	}
+
+	meta, ok := bulkResendAuditMeta(len(ids), results)
+	if !ok {
+		t.Fatal("a batch with one confirmed resend must be audited")
+	}
+	if meta["count"] != 1 {
+		t.Errorf("audit count = %v, want 1 (the number resent, not the number requested)", meta["count"])
+	}
+	if meta["requested"] != len(ids) {
+		t.Errorf("audit requested = %v, want %d", meta["requested"], len(ids))
+	}
+}
+
+// TestBulkResendEmail_AllFail_NoAuditRow is the N-commands-zero-emails case:
+// the batch used to write one audit row reading {"count": N}.
+func TestBulkResendEmail_AllFail_NoAuditRow(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	a, b := uuid.New(), uuid.New()
+
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRow(a, 21, true)
+	repo.addRow(b, 22, true)
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: false, Detail: agentcmd.ResendDetailRowNotFound}}
+	svc := newResendSvc(repo, agent)
+
+	results, err := svc.BulkResendEmail(context.Background(), tenantID, siteID, []uuid.UUID{a, b})
+	if err != nil {
+		t.Fatalf("BulkResendEmail: unexpected error: %v", err)
+	}
+	if repo.incrCalls != 0 {
+		t.Errorf("resent_count incremented %d time(s) for a batch that resent nothing, want 0", repo.incrCalls)
+	}
+	if _, ok := bulkResendAuditMeta(2, results); ok {
+		t.Error("a batch that resent nothing must not write an email.resent audit row")
+	}
+}
+
+// perSeqResendAgent answers per agent_seq, so a bulk test can prove the CP
+// addressed each row individually rather than sending one id repeatedly.
+type perSeqResendAgent struct {
+	calls   int
+	seqs    []int64
+	results map[int64]agentcmd.ResendEmailResult
+}
+
+func (f *perSeqResendAgent) SyncEmailConfig(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.EmailConfigRequest) (agentcmd.EmailConfigResult, error) {
+	return agentcmd.EmailConfigResult{OK: true}, nil
+}
+
+func (f *perSeqResendAgent) SendTestEmail(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.SendTestEmailRequest) (agentcmd.SendTestEmailResult, error) {
+	return agentcmd.SendTestEmailResult{OK: true}, nil
+}
+
+func (f *perSeqResendAgent) ResendEmail(_ context.Context, _ uuid.UUID, _ string, req agentcmd.ResendEmailRequest) (agentcmd.ResendEmailResult, error) {
+	f.calls++
+	f.seqs = append(f.seqs, req.AgentSeq)
+	res, ok := f.results[req.AgentSeq]
+	if !ok {
+		return agentcmd.ResendEmailResult{OK: false, Detail: agentcmd.ResendDetailRowNotFound}, nil
+	}
+	return res, nil
+}
+
+// ---------------------------------------------------------------------------
+// Operator-facing wording for the agent's contract strings
+// ---------------------------------------------------------------------------
+
+func TestResendFailureMessage(t *testing.T) {
+	cases := []struct {
+		name    string
+		detail  string
+		want    string // substring
+		wantRaw bool   // detail is returned unchanged
+	}{
+		{name: "row pruned", detail: agentcmd.ResendDetailRowNotFound, want: "no longer in the site's own email log"},
+		{name: "no body", detail: agentcmd.ResendDetailBodyNotStored, want: "did not keep a copy"},
+		{name: "unconfigured", detail: "no email config, run sync_email_config first", want: "no email configuration yet"},
+		{name: "the #520 string", detail: agentcmd.ResendDetailMissingSeq, want: "update the wpmgr plugin"},
+		{name: "bad seq", detail: agentcmd.ResendDetailBadSeq, want: "update the wpmgr plugin"},
+		{name: "old plugin", detail: "resend_email command rejected by agent: status 404 body=x", want: "too old"},
+		{name: "silent refusal", detail: "", want: "without giving a reason"},
+		{
+			name:    "provider error passes through",
+			detail:  "SMTP error: 550 5.7.1 relay access denied",
+			want:    "550 5.7.1 relay access denied",
+			wantRaw: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resendFailureMessage(tc.detail)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("resendFailureMessage(%q) = %q, want it to contain %q", tc.detail, got, tc.want)
+			}
+			if tc.wantRaw && got != tc.detail {
+				t.Errorf("an unrecognised detail must pass through unchanged: got %q, want %q", got, tc.detail)
+			}
+			// A mapped message must never be one of the agent's contract codes.
+			if !tc.wantRaw && got == tc.detail {
+				t.Errorf("detail %q reached the operator unmapped", tc.detail)
+			}
+		})
+	}
+}

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -80,7 +80,7 @@ type repository interface {
 	GetConfigByRouteTokenHashWithSecret(ctx context.Context, tokenHash []byte) (Config, []byte, error)
 	SetWebhookFields(ctx context.Context, tenantID, configID uuid.UUID, tokenHash, signingKeyCT []byte, setSigningKey bool, sesTopicArns []string) (Config, error)
 	PruneWebhookDedup(ctx context.Context, cutoffTs time.Time) (int64, error)
-	GetEmailLogBodyStored(ctx context.Context, tenantID, siteID, id uuid.UUID) (bool, error)
+	GetResendTarget(ctx context.Context, tenantID, siteID, id uuid.UUID) (ResendTarget, error)
 	IncrEmailLogResentCount(ctx context.Context, tenantID, siteID, id uuid.UUID) error
 	DeleteEmailLogsBulk(ctx context.Context, tenantID, siteID uuid.UUID, ids []uuid.UUID) (int64, error)
 	// m62 Area 2 — multi-connection CRUD
@@ -929,33 +929,51 @@ func (s *Service) PruneWebhookDedup(ctx context.Context, cutoffTs time.Time) (in
 // ---------------------------------------------------------------------------
 
 // ResendEmail dispatches the resend_email agent command for a single log entry.
-// Gate: body_stored must be true; returns 409 otherwise.
+//
+// The command names the agent's OWN log row by agent_seq and carries nothing
+// else — see agentcmd/resend_email_contract.go and GH #520, where the CP sent a
+// log_id UUID the agent has never read and every resend on every site failed.
+//
+// Near-end preconditions, all checked before a signed command is spent:
+//
+//   - the row exists for this tenant+site (404),
+//   - its body was captured (409), and
+//   - it carries an agent_seq to address (409).
+//
+// body_stored is KEPT as a gate. It is the agent's own flag for the same row,
+// mirrored at ingest, so it is a sound proxy for "the agent still has a body
+// too" and it refuses near-end what the agent would refuse far-end. It is not
+// the authority: the agent re-reads its live row and answers body_not_stored
+// itself, which is the check that counts.
+//
+// resent_count and the audit row move on SUCCESS only. They used to move on
+// every attempt, which meant every failed click — that is, every click, for as
+// long as #520 was live — inflated the counter and wrote an audit row saying an
+// email had been resent when none had.
 func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.UUID) (ResendResult, error) {
-	bodyStored, err := s.repo.GetEmailLogBodyStored(ctx, tenantID, siteID, logID)
+	target, err := s.repo.GetResendTarget(ctx, tenantID, siteID, logID)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return ResendResult{}, domain.NotFound("email_log_not_found", "email log entry not found")
 		}
 		return ResendResult{}, domain.Internal("resend_get_log", "failed to fetch log entry").WithCause(err)
 	}
-	if !bodyStored {
+	if !target.BodyStored {
 		return ResendResult{}, domain.Conflict("resend_body_not_stored",
 			"resend is only available when body was captured at send time (body_stored=true); "+
 				"this entry was sent without body capture enabled")
 	}
-
-	// Increment the resent_count counter before dispatching.
-	if err := s.repo.IncrEmailLogResentCount(ctx, tenantID, siteID, logID); err != nil {
-		return ResendResult{}, domain.Internal("resend_incr_count", "failed to increment resent_count").WithCause(err)
+	if target.AgentSeq == nil || *target.AgentSeq < 1 {
+		return ResendResult{}, domain.Conflict("resend_agent_seq_missing",
+			"this log entry has no agent sequence number, so the site cannot be told which "+
+				"message to resend; entries recorded before the site reported its own log ids "+
+				"cannot be resent")
 	}
 
-	// Dispatch the signed resend_email agent command (Phase 4b implements the
-	// agent side). Failure is non-fatal — the counter was already incremented
-	// so the operator knows a resend was attempted.
 	if s.agent == nil || s.siteLook == nil {
 		return ResendResult{
 			OK:     false,
-			Detail: "agent command client not configured; resend dispatched counter incremented but command not sent",
+			Detail: "agent command client not configured; the resend was not sent",
 		}, nil
 	}
 
@@ -964,15 +982,57 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 		return ResendResult{OK: false, Detail: "site not enrolled or unavailable"}, nil
 	}
 
-	res, err := s.agent.ResendEmail(ctx, siteID, siteURL, agentcmd.ResendEmailRequest{LogID: logID.String()})
+	res, err := s.agent.ResendEmail(ctx, siteID, siteURL, agentcmd.ResendEmailRequest{AgentSeq: *target.AgentSeq})
 	if err != nil {
-		return ResendResult{OK: false, Detail: err.Error()}, nil
+		return ResendResult{OK: false, Detail: resendFailureMessage(err.Error())}, nil
 	}
 	// DELIBERATE: the agent's ok=false is propagated as this call's OK rather than
 	// raised as an error. Every failure branch above returns the same shape, the
 	// handler renders OK plus Detail to the operator, and BulkResendEmail reports
 	// per-log outcomes from it. Nothing here reports success on a refusal.
-	return ResendResult{OK: res.OK, Detail: res.Detail, MessageID: res.MessageID}, nil
+	if !res.OK {
+		return ResendResult{OK: false, Detail: resendFailureMessage(res.Detail)}, nil
+	}
+
+	// The email is already out. A counter write that fails now must not turn a
+	// successful resend into a reported failure — log it and report the truth.
+	if err := s.repo.IncrEmailLogResentCount(ctx, tenantID, siteID, logID); err != nil {
+		s.log.Error("email resend: agent confirmed the send but resent_count was not incremented",
+			slog.String("site_id", siteID.String()),
+			slog.String("log_id", logID.String()),
+			slog.String("err", err.Error()),
+		)
+	}
+	return ResendResult{OK: true, Detail: res.Detail, MessageID: res.MessageID}, nil
+}
+
+// resendFailureMessage turns an agent-side refusal into a sentence an operator
+// can act on. The agent's contract strings are codes, not prose: one of them
+// ("missing required field: agent_seq") reached a user's toast verbatim and is
+// how GH #520 was reported.
+//
+// An unrecognised detail is returned unchanged — it is usually the provider's
+// own SMTP/API error, which is the most useful thing anyone could show.
+func resendFailureMessage(detail string) string {
+	switch {
+	case detail == "":
+		return "the site refused the resend without giving a reason"
+	case strings.Contains(detail, agentcmd.ResendDetailRowNotFound):
+		return "this message is no longer in the site's own email log, so it cannot be resent; " +
+			"WordPress keeps that log for 14 days (or 50,000 messages, whichever comes first)"
+	case strings.Contains(detail, agentcmd.ResendDetailBodyNotStored):
+		return "the site did not keep a copy of this message body, so there is nothing to resend"
+	case strings.Contains(detail, agentcmd.ResendDetailNoConfig):
+		return "this site has no email configuration yet; save its email settings to push the " +
+			"configuration to the site, then try the resend again"
+	case strings.Contains(detail, agentcmd.ResendDetailMissingSeq),
+		strings.Contains(detail, agentcmd.ResendDetailBadSeq):
+		return "the site rejected the resend request format; update the wpmgr plugin on this site"
+	case strings.Contains(detail, "status 404"):
+		return "this site's wpmgr plugin is too old to support resending; update the plugin and try again"
+	default:
+		return detail
+	}
 }
 
 // Bulk log-operation ceilings. These mirror the maxItems the OpenAPI schemas
@@ -985,7 +1045,15 @@ const (
 )
 
 // BulkResendEmail dispatches resend_email commands for multiple log entries.
-// Each entry is processed independently; per-entry body_stored gate is checked.
+//
+// Each entry is processed independently through ResendEmail, so each one gets
+// the same preconditions, the same success-only counter write, and the same
+// humanised failure detail. A per-entry refusal is reported in that entry's
+// result, never as a failure of the batch.
+//
+// The caller (the handler) audits the number of entries that actually came back
+// ok, not the number requested: a batch of 100 that resent nothing used to write
+// one audit row claiming 100.
 func (s *Service) BulkResendEmail(ctx context.Context, tenantID, siteID uuid.UUID, logIDs []uuid.UUID) ([]BulkResendResult, error) {
 	if len(logIDs) == 0 {
 		return nil, nil

--- a/apps/api/internal/email/service_test.go
+++ b/apps/api/internal/email/service_test.go
@@ -350,8 +350,8 @@ func (r *fakeRepo) PruneWebhookDedup(_ context.Context, _ time.Time) (int64, err
 	return 0, nil
 }
 
-func (r *fakeRepo) GetEmailLogBodyStored(_ context.Context, _, _, _ uuid.UUID) (bool, error) {
-	return false, ErrNotFound
+func (r *fakeRepo) GetResendTarget(_ context.Context, _, _, _ uuid.UUID) (ResendTarget, error) {
+	return ResendTarget{}, ErrNotFound
 }
 
 func (r *fakeRepo) IncrEmailLogResentCount(_ context.Context, _, _, _ uuid.UUID) error {
@@ -745,6 +745,9 @@ type fakeAgentClient struct {
 
 	sendTestCalled int
 	sendTestErr    error
+
+	resendCalled  int
+	resendLastReq agentcmd.ResendEmailRequest
 }
 
 func (f *fakeAgentClient) SyncEmailConfig(_ context.Context, _ uuid.UUID, _ string, req agentcmd.EmailConfigRequest) (agentcmd.EmailConfigResult, error) {
@@ -761,7 +764,12 @@ func (f *fakeAgentClient) SendTestEmail(_ context.Context, _ uuid.UUID, _ string
 	return agentcmd.SendTestEmailResult{OK: true, Detail: "sent"}, nil
 }
 
-func (f *fakeAgentClient) ResendEmail(_ context.Context, _ uuid.UUID, _ string, _ agentcmd.ResendEmailRequest) (agentcmd.ResendEmailResult, error) {
+// ResendEmail records the request. It used to discard it with a blank
+// identifier, which is precisely why GH #520 — a CP payload the agent could
+// never read — shipped and survived. Never take a command request as `_`.
+func (f *fakeAgentClient) ResendEmail(_ context.Context, _ uuid.UUID, _ string, req agentcmd.ResendEmailRequest) (agentcmd.ResendEmailResult, error) {
+	f.resendCalled++
+	f.resendLastReq = req
 	return agentcmd.ResendEmailResult{OK: true}, nil
 }
 

--- a/apps/api/internal/email/webhook_test.go
+++ b/apps/api/internal/email/webhook_test.go
@@ -684,7 +684,7 @@ func TestResendEmail_BodyNotStored_Conflict(t *testing.T) {
 	logID := uuid.New()
 
 	repo := newFakeRepo()
-	// fakeRepo.GetEmailLogBodyStored returns (false, ErrNotFound) by default.
+	// fakeRepo.GetResendTarget returns ErrNotFound by default.
 	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
 	svc.repo = repo
 
@@ -703,8 +703,8 @@ func TestResendEmail_BodyStored_Dispatches(t *testing.T) {
 	siteID := uuid.New()
 	logID := uuid.New()
 
-	// Extend fakeRepo with body_stored = true for this logID.
-	repo := &fakeRepoBodyStored{fakeRepo: newFakeRepo(), bodyStoredID: logID}
+	// A resendable row: body captured and an agent_seq to address it by.
+	repo := &fakeRepoBodyStored{fakeRepo: newFakeRepo(), bodyStoredID: logID, agentSeq: 17}
 	svc := NewService(&Repo{}, &fakeEncryptor{}, nil)
 	svc.repo = repo
 
@@ -712,24 +712,36 @@ func TestResendEmail_BodyStored_Dispatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResendEmail with body_stored=true: unexpected error: %v", err)
 	}
-	// Agent not wired → ok=false but no error.
+	// No agent client is wired here, so the service reports ok=false rather
+	// than pretending a command was sent.
 	if res.OK {
-		t.Log("ok=true is fine if agent is wired; here agent is nil so ok=false is expected")
+		t.Error("expected ok=false with no agent client wired")
+	}
+	if repo.incrCalls != 0 {
+		t.Errorf("resent_count incremented %d time(s) without an agent dispatch, want 0", repo.incrCalls)
 	}
 }
 
-// fakeRepoBodyStored wraps fakeRepo and overrides GetEmailLogBodyStored to
-// return true for a specific log ID, simulating an email stored with body capture.
+// fakeRepoBodyStored wraps fakeRepo and serves one resendable row, simulating an
+// email logged with body capture that the agent has since reported by agent_seq.
 type fakeRepoBodyStored struct {
 	*fakeRepo
 	bodyStoredID uuid.UUID
+	agentSeq     int64
+	incrCalls    int
 }
 
-func (r *fakeRepoBodyStored) GetEmailLogBodyStored(_ context.Context, _, _, id uuid.UUID) (bool, error) {
-	if id == r.bodyStoredID {
-		return true, nil
+func (r *fakeRepoBodyStored) GetResendTarget(_ context.Context, _, _, id uuid.UUID) (ResendTarget, error) {
+	if id != r.bodyStoredID {
+		return ResendTarget{}, ErrNotFound
 	}
-	return false, ErrNotFound
+	seq := r.agentSeq
+	return ResendTarget{AgentSeq: &seq, BodyStored: true}, nil
+}
+
+func (r *fakeRepoBodyStored) IncrEmailLogResentCount(_ context.Context, _, _, _ uuid.UUID) error {
+	r.incrCalls++
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -8952,7 +8952,8 @@ export const ResendEmailResultSchema = {
     },
     detail: {
       type: ["string", "null"],
-      description: "Agent response message or error detail.",
+      description:
+        "Why the resend did not happen, phrased for an operator. Known\nagent refusals (log pruned, body not captured, site not configured,\nplugin too old) are translated here; anything else is the provider's\nown error text, passed through. Safe to display as-is.\n",
     },
     message_id: {
       type: ["string", "null"],

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -8953,7 +8953,7 @@ export const ResendEmailResultSchema = {
     detail: {
       type: ["string", "null"],
       description:
-        "Why the resend did not happen, phrased for an operator. Known\nagent refusals (log pruned, body not captured, site not configured,\nplugin too old) are translated here; anything else is the provider's\nown error text, passed through. Safe to display as-is.\n",
+        "Why the resend did not happen, phrased for an operator. Known\nagent refusals (log pruned, body not captured, site not configured,\nplugin too old) are translated here; anything else is the provider's\nown error text, passed through unmodified from the site's agent.\nPlain text, not markup: the passthrough case can carry arbitrary\ncharacters from a compromised site, so escape it before rendering.\n",
     },
     message_id: {
       type: ["string", "null"],

--- a/packages/openapi-client/src/generated/sdk.gen.ts
+++ b/packages/openapi-client/src/generated/sdk.gen.ts
@@ -7489,14 +7489,20 @@ export const deleteFleetEmailSuppression = <
  * Resend a single email log entry
  *
  * Dispatches the `resend_email` agent command for the given log entry.
- * Only available when `body_stored=true` on the log entry — returns 409
- * otherwise. The resend is best-effort: if the agent is offline or returns
- * an error the response contains `ok=false` with the agent's detail message
- * but HTTP 200 is returned (matching the test-email pattern).
+ * The command names the site's own log row, so the entry must have been
+ * reported by the site (`agent_seq`) and must have been logged with its
+ * body captured (`body_stored=true`) — 409 otherwise, with no command sent.
  *
- * The `resent_count` counter is incremented before the agent dispatch so
- * operators can see how many resend attempts were made even if the agent
- * was unavailable.
+ * The resend is best-effort past that point: if the site is offline or
+ * refuses, the response is HTTP 200 with `ok=false` and a `detail`
+ * explaining why (matching the test-email pattern).
+ *
+ * The site keeps its own email log for 14 days, or 50,000 messages,
+ * whichever comes first. An entry older than that is still listed here but
+ * can no longer be resent, and the attempt returns `ok=false`.
+ *
+ * `resent_count` and the `email.resent` audit entry record confirmed
+ * resends only; a refusal moves neither.
  *
  * Requires `site.email.manage` permission.
  *

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5384,7 +5384,9 @@ export type ResendEmailResult = {
    * Why the resend did not happen, phrased for an operator. Known
    * agent refusals (log pruned, body not captured, site not configured,
    * plugin too old) are translated here; anything else is the provider's
-   * own error text, passed through. Safe to display as-is.
+   * own error text, passed through unmodified from the site's agent.
+   * Plain text, not markup: the passthrough case can carry arbitrary
+   * characters from a compromised site, so escape it before rendering.
    *
    */
   detail?: string | null;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5381,7 +5381,11 @@ export type AddSuppressionRequest = {
 export type ResendEmailResult = {
   ok: boolean;
   /**
-   * Agent response message or error detail.
+   * Why the resend did not happen, phrased for an operator. Known
+   * agent refusals (log pruned, body not captured, site not configured,
+   * plugin too old) are translated here; anything else is the provider's
+   * own error text, passed through. Safe to display as-is.
+   *
    */
   detail?: string | null;
   /**
@@ -18380,7 +18384,11 @@ export type ResendEmailLogErrors = {
    */
   404: Error;
   /**
-   * Body not stored — resend unavailable
+   * Resend unavailable for this entry, and no command was sent.
+   * `resend_body_not_stored`: the body was not captured at send time.
+   * `resend_agent_seq_missing`: the entry carries no site-side log id,
+   * so the site cannot be told which message to resend.
+   *
    */
   409: Error;
 };

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -10641,14 +10641,20 @@ paths:
       summary: Resend a single email log entry
       description: |
         Dispatches the `resend_email` agent command for the given log entry.
-        Only available when `body_stored=true` on the log entry — returns 409
-        otherwise. The resend is best-effort: if the agent is offline or returns
-        an error the response contains `ok=false` with the agent's detail message
-        but HTTP 200 is returned (matching the test-email pattern).
+        The command names the site's own log row, so the entry must have been
+        reported by the site (`agent_seq`) and must have been logged with its
+        body captured (`body_stored=true`) — 409 otherwise, with no command sent.
 
-        The `resent_count` counter is incremented before the agent dispatch so
-        operators can see how many resend attempts were made even if the agent
-        was unavailable.
+        The resend is best-effort past that point: if the site is offline or
+        refuses, the response is HTTP 200 with `ok=false` and a `detail`
+        explaining why (matching the test-email pattern).
+
+        The site keeps its own email log for 14 days, or 50,000 messages,
+        whichever comes first. An entry older than that is still listed here but
+        can no longer be resent, and the attempt returns `ok=false`.
+
+        `resent_count` and the `email.resent` audit entry record confirmed
+        resends only; a refusal moves neither.
 
         Requires `site.email.manage` permission.
       tags: [email]
@@ -10674,7 +10680,11 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Body not stored — resend unavailable
+          description: |
+            Resend unavailable for this entry, and no command was sent.
+            `resend_body_not_stored`: the body was not captured at send time.
+            `resend_agent_seq_missing`: the entry carries no site-side log id,
+            so the site cannot be told which message to resend.
           content:
             application/json:
               schema:
@@ -19576,7 +19586,11 @@ components:
           type: boolean
         detail:
           type: [string, "null"]
-          description: Agent response message or error detail.
+          description: |
+            Why the resend did not happen, phrased for an operator. Known
+            agent refusals (log pruned, body not captured, site not configured,
+            plugin too old) are translated here; anything else is the provider's
+            own error text, passed through. Safe to display as-is.
         message_id:
           type: [string, "null"]
           description: Provider message ID assigned to the resent email (if agent returned it).

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19590,7 +19590,9 @@ components:
             Why the resend did not happen, phrased for an operator. Known
             agent refusals (log pruned, body not captured, site not configured,
             plugin too old) are translated here; anything else is the provider's
-            own error text, passed through. Safe to display as-is.
+            own error text, passed through unmodified from the site's agent.
+            Plain text, not markup: the passthrough case can carry arbitrary
+            characters from a compromised site, so escape it before rendering.
         message_id:
           type: [string, "null"]
           description: Provider message ID assigned to the resent email (if agent returned it).


### PR DESCRIPTION
Fixes #520.

## The defect

The control plane and the agent were written to two different `resend_email` wire contracts and have never agreed. Every Resend on every site has always failed, unconditionally — not only on SMTP failures, not only for old entries.

The CP dispatched (this is the literal output of the regression test run against the unfixed tree):

```
{"log_id":"b4d7f58f-...","to_addresses":null,"from_address":"","subject":"","body":""}
```

`apps/agent/includes/commands/class-resend-email-command.php` rejects any params array without `agent_seq` on the first line of `execute()`, so the answer was always `missing required field: agent_seq` — which `apps/web` then displayed to the user verbatim. That string in a toast is how this was reported.

A second defect sat behind the first: the CP populated only `LogID` and left `Body`, `ToAddresses` and `Subject` at their Go zero values, contradicting the contract's own docblock. `Repo.GetLogEntry` existed and was never called. A rename alone would have sent an empty message to a null recipient list.

## The decision

**The control plane moves to the agent's contract.** One CP deploy repairs the entire fleet; the CP-authoritative alternative needs a plugin release and a fleet is only repaired when every site updates. The agent side is already implemented and tested, it keeps customer message bodies off the command channel, and past the agent's log retention it fails honestly rather than sending an empty message.

Accepted cost, not papered over: the agent prunes its log at 14 days / 50k rows, so resending an older entry legitimately fails. That now surfaces as *"this message is no longer in the site's own email log ... WordPress keeps that log for 14 days (or 50,000 messages, whichever comes first)"*, not as a raw code.

## What changed

- `agentcmd.ResendEmailRequest` carries `agent_seq` and nothing else. The agent's known `detail` strings are named constants in the same file.
- `GetResendTarget` reads `agent_seq` alongside `body_stored` through the **existing** `GetEmailLog` query, so nothing under `apps/api/db/**` moves. An entry with no `agent_seq` is refused 409 near-end rather than spending a signed command on a request that cannot succeed.
- `body_stored` is **kept** as a gate: it is the agent's own flag for the same row, mirrored at ingest, so it refuses near-end what the agent would refuse far-end. The agent re-reads its live row and remains the authority.
- **`resent_count` and the `email.resent` audit row move on a confirmed send only.** Both used to move on every attempt — so for as long as this bug was live, every failed click inflated the counter and wrote an audit row claiming an email had been resent. On the bulk path, N commands were spent, N counters bumped, one audit row written with the *requested* count, and zero emails sent.
- A counter write that fails *after* the agent confirms is logged, not reported as failure. The email is already out.
- Agent contract strings are mapped to operator-facing sentences at the API boundary; an unrecognised detail (usually the provider's own SMTP/API error) passes through unchanged.
- OpenAPI: the endpoint description promised the old "incremented before dispatch" behaviour. Corrected, both generated trees regenerated with it via `make gen` in the same commit.

## Proof

The reason this shipped is that **nothing asserted the dispatched payload**: the Go fake took the request as `_` and discarded it, while the agent's PHPUnit test hand-built its own `['agent_seq' => N]`. Each half tested its own idea of the contract.

`TestResendEmail_DispatchedPayloadMatchesAgentContract` asserts the exact JSON object the agent receives, through the real service dispatch path. It compares the whole key set, so an *extra* field fails it too — an unread field on the command channel is message content going somewhere nothing reads it. Both fakes now capture their request.

Red (unfixed tree) and green (fixed) output is in the task report, along with the over-fire cases: a legitimate resend still dispatches and increments exactly once; a refusal, a transport failure and a failed precondition each increment nothing and audit nothing; a mixed bulk batch dispatches only for addressable rows and audits `count: 1, requested: 4`.

## Follow-ups this PR does not do

- **`database-engineer`**: `apps/api/db/query/site_email.sql:249` still sets `resent_count = EXCLUDED.resent_count` on the ingest upsert, so an agent push can regress the CP's counter. Wants `GREATEST(EXCLUDED.resent_count, site_email_log.resent_count)`. The `GetEmailLogBodyStored` query also has no Go caller left.
- **`frontend-architect`**: `apps/web/src/.../use-email.ts:791` pipes `detail` straight to a toast. That is now safe and intended — the API sends a sentence — but a bulk result of all-`ok=false` should no longer read as a success.
- Not deployed or verified against the running system. The fleet is only repaired when the CP deploys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Email resends now use the original logged message and validate that it is available before sending.
  * Resend counts and audit records update only after confirmed successful delivery.
  * Bulk resend results accurately report successful and requested items.
  * Clearer error messages identify missing logs, unavailable content, configuration issues, and invalid requests.

* **Documentation**
  * Updated resend API documentation with retention limits, validation requirements, and failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->