### PR TITLE
fix(agent): stop fatalling on the objects core actually passes to five hook callbacks (#521)

### DIFF
--- a/apps/agent/includes/diagnostics/class-size-probe.php
+++ b/apps/agent/includes/diagnostics/class-size-probe.php
@@ -323,18 +323,33 @@ final class SizeProbe
      * so the value is accepted and ignored rather than normalised. Anything
      * added here that DOES read it must handle the false.
      *
-     * $maxExecTime is not guaranteed to be int either, for the same reason:
-     * recurse_dirsize() normalises a null budget from
-     * `ini_get( 'max_execution_time' )`, which returns a STRING, and only
-     * casts it to int via its own `-= 1` arithmetic when that value is > 10.
-     * A `max_execution_time` of 0 (unlimited — the PHP-CLI and WP-CLI
-     * default, so also the common case when this filter fires from a real
-     * cron running `wp cron event run` rather than wp-cron.php over HTTP) or
-     * anything <= 10 reaches this filter as the literal string PHP's
-     * ini_get() returned. A strict `int` hint under this file's
-     * `declare(strict_types=1)` is a TypeError on that string — the same
-     * defect class this file exists to close. Untyped here for the same
-     * reason $directoryCache is untyped: this callback never reads it.
+     * $maxExecTime is not guaranteed to be int either. recurse_dirsize()
+     * normalises a null budget from `ini_get( 'max_execution_time' )`, which
+     * returns a STRING, and only casts it to int via its own `-= 1`
+     * arithmetic when that value is > 10. A `max_execution_time` of 0
+     * (unlimited — the PHP-CLI and WP-CLI default, so also the common case
+     * when this filter fires from a real cron running `wp cron event run`
+     * rather than wp-cron.php over HTTP) or anything <= 10 reaches this
+     * filter as the literal numeric string PHP's ini_get() returned, e.g.
+     * "0".
+     *
+     * That does not fatal TODAY, and not because of this file's own
+     * `declare(strict_types=1)` — PHP's coercion mode for an argument is
+     * decided by the CALLING file, not the declaring one. The call into this
+     * callback is made by `WP_Hook::apply_filters()`'s
+     * `call_user_func_array()` in wp-includes/class-wp-hook.php, which
+     * declares no strict types, so a plain `int` hint here would still be
+     * evaluated in weak mode against that call: a well-formed numeric string
+     * like "0" coerces to int silently regardless of what this file declares.
+     *
+     * Relying on that coercion is fragile rather than already broken:
+     * `ini_get()` returns `false` if the directive is unknown, and can
+     * return a non-numeric string if the ini value is set but empty. A
+     * non-numeric string into an `int` parameter IS a TypeError even in weak
+     * mode — weak-mode coercion accepts well-formed numeric strings for
+     * int/float parameters, not arbitrary ones. `mixed` removes the
+     * dependence on that coercion entirely rather than trusting it to keep
+     * holding.
      *
      * @param false|int          $size           Existing filtered value.
      * @param string             $directory      Directory being measured.

--- a/apps/agent/includes/diagnostics/class-size-probe.php
+++ b/apps/agent/includes/diagnostics/class-size-probe.php
@@ -323,10 +323,25 @@ final class SizeProbe
      * so the value is accepted and ignored rather than normalised. Anything
      * added here that DOES read it must handle the false.
      *
+     * $maxExecTime is not guaranteed to be int either, for the same reason:
+     * recurse_dirsize() normalises a null budget from
+     * `ini_get( 'max_execution_time' )`, which returns a STRING, and only
+     * casts it to int via its own `-= 1` arithmetic when that value is > 10.
+     * A `max_execution_time` of 0 (unlimited — the PHP-CLI and WP-CLI
+     * default, so also the common case when this filter fires from a real
+     * cron running `wp cron event run` rather than wp-cron.php over HTTP) or
+     * anything <= 10 reaches this filter as the literal string PHP's
+     * ini_get() returned. A strict `int` hint under this file's
+     * `declare(strict_types=1)` is a TypeError on that string — the same
+     * defect class this file exists to close. Untyped here for the same
+     * reason $directoryCache is untyped: this callback never reads it.
+     *
      * @param false|int          $size           Existing filtered value.
      * @param string             $directory      Directory being measured.
      * @param array<string>|null $exclude        Exclusion list (WP core).
-     * @param int                $maxExecTime    Budget from WP (ignored here).
+     * @param mixed              $maxExecTime    Budget from WP (ignored here):
+     *                                           int, or a numeric string from
+     *                                           ini_get(), or null.
      * @param mixed              $directoryCache Cached dir paths: array, or
      *                                           false on a cold transient.
      * @return false|int
@@ -335,7 +350,7 @@ final class SizeProbe
         $size,
         string $directory,
         $exclude = null,
-        int $maxExecTime = 0,
+        mixed $maxExecTime = 0,
         mixed $directoryCache = false
     ) {
         if ($size !== false) {

--- a/apps/agent/includes/diagnostics/class-size-probe.php
+++ b/apps/agent/includes/diagnostics/class-size-probe.php
@@ -302,19 +302,41 @@ final class SizeProbe
     /**
      * Filter callback for pre_recurse_dirsize.
      *
-     * @param false|int            $size           Existing filtered value.
-     * @param string               $directory      Directory being measured.
-     * @param array<string>|null   $exclude        Exclusion list (WP core).
-     * @param int                  $maxExecTime    Budget from WP (ignored here).
-     * @param array<string,int>    $directoryCache WP's in-memory cache.
+     * $directoryCache is NOT always an array, whatever core's own docblock at
+     * wp-includes/functions.php says. recurse_dirsize() seeds it with
+     *
+     *     $directory_cache = get_transient( 'dirsize_cache' );
+     *
+     * and get_transient() returns FALSE when the transient is missing or
+     * expired, which is then handed straight to this filter. Core knows: it
+     * normalises with `if ( ! is_array( $directory_cache ) )` only AFTER
+     * apply_filters() has run. An `array` hint here is therefore a TypeError
+     * whenever the cache is cold — and this filter is registered
+     * unconditionally on every boot (Plugin::registerHooks), so it fired on
+     * fresh installs, after any transient or object-cache flush, on Site
+     * Health -> Info -> Directory sizes, and on multisite for every upload via
+     * get_space_used(). It could not self-heal either: the transient is only
+     * written after the walk the fatal prevented.
+     *
+     * This callback does not read the cache — it either short-circuits with a
+     * du(1) byte count or returns false and lets core do its own recursion —
+     * so the value is accepted and ignored rather than normalised. Anything
+     * added here that DOES read it must handle the false.
+     *
+     * @param false|int          $size           Existing filtered value.
+     * @param string             $directory      Directory being measured.
+     * @param array<string>|null $exclude        Exclusion list (WP core).
+     * @param int                $maxExecTime    Budget from WP (ignored here).
+     * @param mixed              $directoryCache Cached dir paths: array, or
+     *                                           false on a cold transient.
      * @return false|int
      */
     public function preRecurseDirsizeFilter(
         $size,
         string $directory,
-        $exclude,
-        int $maxExecTime,
-        array $directoryCache
+        $exclude = null,
+        int $maxExecTime = 0,
+        mixed $directoryCache = false
     ) {
         if ($size !== false) {
             return $size; // already handled upstream

--- a/apps/agent/includes/security/class-hardening-module.php
+++ b/apps/agent/includes/security/class-hardening-module.php
@@ -131,9 +131,26 @@ final class HardeningModule
      * (which identifier may be used to log in) and applyForceUniqueNickname()
      * (which can refuse a profile save). It does NOT gate the file-editor
      * block, xmlrpc mode, REST restriction, force-SSL, author-archive
-     * enumeration or the IP/user-agent bans. Those cannot lock anyone out, and
-     * silently dropping a site's IP bans because someone is recovering a login
-     * would turn a recovery step into a security regression.
+     * enumeration or the IP/user-agent bans.
+     *
+     * That exclusion is NOT because none of those six can lock anyone out —
+     * at least one demonstrably can. applyBanFilters() registers on `init`
+     * priority 1 with no gate at all; `init` fires on wp-login.php; the match
+     * is an unbounded case-insensitive substring
+     * (stripos($ua, $pattern) !== false) with no length or genericity check;
+     * and a match ends in exit('Access denied.'). A ban pattern of "Mozilla",
+     * "Chrome", "Safari", "AppleWebKit" or "Gecko" 403s the administrator's
+     * own login page along with everyone else's. That lockout risk is real,
+     * pre-existing, and tracked and scoped separately (#529) — it is not
+     * resolved by widening this constant's reach.
+     *
+     * The actual reason these six stay ungated is that silently dropping a
+     * site's file-editor lock, xmlrpc mode, REST restriction, forced SSL,
+     * author-archive block or IP/user-agent bans the moment someone sets a
+     * recovery constant would risk turning a recovery step into a worse
+     * regression than the lockout it is meant to fix. The scoping to just the
+     * two auth appliers is correct; only the "cannot lock anyone out"
+     * justification for it was.
      *
      * @return bool
      */

--- a/apps/agent/includes/security/class-hardening-module.php
+++ b/apps/agent/includes/security/class-hardening-module.php
@@ -325,14 +325,20 @@ final class HardeningModule
             return;
         }
 
-        add_action('user_profile_update_errors', static function (\WP_Error $errors, bool $update, \WP_User $user): void {
+        // $user is typed mixed, not \WP_User: core builds a bare stdClass in
+        // edit_user() and passes it by reference, so a \WP_User hint here is a
+        // TypeError at argument binding — a fatal on every user-edit screen for
+        // any site with this single toggle on, password policy or not.
+        // ProfileUpdateUser::resolve() also recovers user_login from the stored
+        // user, so an object without it cannot silently switch the check off.
+        add_action('user_profile_update_errors', static function (\WP_Error $errors, bool $update, mixed $user): void {
             if (!$update) {
                 return;
             }
             $nickname = isset($_POST['nickname']) && is_string($_POST['nickname']) // phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- nonce verified by WP core's profile-update handler before this hook fires; sanitized on the next line
                 ? sanitize_text_field(wp_unslash($_POST['nickname'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- same as above
                 : '';
-            $userLogin = $user->user_login;
+            $userLogin = ProfileUpdateUser::resolve($user)->user_login;
             if ($nickname !== '' && $userLogin !== '' && $nickname === $userLogin) {
                 $errors->add(
                     'wpmgr_nickname_conflict',

--- a/apps/agent/includes/security/class-hardening-module.php
+++ b/apps/agent/includes/security/class-hardening-module.php
@@ -116,6 +116,32 @@ final class HardeningModule
         $this->applyBanFilters($config);
     }
 
+    /**
+     * Whether the operator's recovery constant is set.
+     *
+     * `define('WPMGR_DISABLE_SITE_2FA', true)` is the documented escape hatch
+     * for an admin locked out by this plugin's auth policy. It was honoured by
+     * Site2faModule and PasswordPolicyModule but NOT here, so an operator who
+     * set it still hit HardeningModule's auth rules — an escape hatch that does
+     * not release everything it claims to is worse than none, because the
+     * person using it believes they are safe.
+     *
+     * DELIBERATELY SCOPED TO AUTH POLICY. This gates the two appliers that can
+     * keep an administrator out of their own site: applyLoginIdentifier()
+     * (which identifier may be used to log in) and applyForceUniqueNickname()
+     * (which can refuse a profile save). It does NOT gate the file-editor
+     * block, xmlrpc mode, REST restriction, force-SSL, author-archive
+     * enumeration or the IP/user-agent bans. Those cannot lock anyone out, and
+     * silently dropping a site's IP bans because someone is recovering a login
+     * would turn a recovery step into a security regression.
+     *
+     * @return bool
+     */
+    private static function authPolicyDisabled(): bool
+    {
+        return defined('WPMGR_DISABLE_SITE_2FA') && WPMGR_DISABLE_SITE_2FA;
+    }
+
     // -------------------------------------------------------------------------
     // Per-toggle appliers (all no-ops when the toggle is off)
     // -------------------------------------------------------------------------
@@ -296,6 +322,9 @@ final class HardeningModule
      */
     private function applyLoginIdentifier(HardeningConfig $config): void
     {
+        if (self::authPolicyDisabled()) {
+            return;
+        }
         if ($config->restrictLoginIdentifier === HardeningConfig::LOGIN_BOTH) {
             return;
         }
@@ -321,6 +350,9 @@ final class HardeningModule
      */
     private function applyForceUniqueNickname(HardeningConfig $config): void
     {
+        if (self::authPolicyDisabled()) {
+            return;
+        }
         if (!$config->forceUniqueNickname) {
             return;
         }

--- a/apps/agent/includes/security/class-password-policy-module.php
+++ b/apps/agent/includes/security/class-password-policy-module.php
@@ -110,12 +110,25 @@ final class PasswordPolicyModule
     /**
      * Validate password strength on profile update.
      *
+     * WordPress core does NOT pass a WP_User here. edit_user() builds a bare
+     * stdClass and passes it by reference (wp-admin/includes/user.php), so a
+     * \WP_User hint on this method throws a TypeError at argument binding —
+     * before any guard in the body can run, and outside validatePassword()'s
+     * catch(\Throwable). That is a fatal on every wp-admin route that edits a
+     * user, an administrator's own profile.php included.
+     *
+     * The object is deliberately NOT trusted for role-scoped decisions: it has
+     * no `roles` and no `caps`, so reading roles off it would silently
+     * under-enforce every role-scoped rule. ProfileUpdateUser::resolve()
+     * produces a real user to evaluate against instead.
+     *
      * @param \WP_Error $errors Error object to append to.
      * @param bool      $update Whether this is an update (vs. create).
-     * @param \WP_User  $user   User being updated.
+     * @param mixed     $user   User being updated. Core passes \stdClass; typed
+     *                          mixed because this is a hook boundary.
      * @return void
      */
-    public function validateOnProfileUpdate(\WP_Error $errors, bool $update, \WP_User $user): void
+    public function validateOnProfileUpdate(\WP_Error $errors, bool $update, mixed $user): void
     {
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce verified by WP core's profile-update handler before this hook fires
         $password = isset($_POST['pass1']) && is_string($_POST['pass1']) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- same
@@ -124,18 +137,33 @@ final class PasswordPolicyModule
         if ($password === '') {
             return;
         }
-        $this->validatePassword($password, $user, $errors);
+        // Resolved after the early return: no user load on the far more common
+        // profile save that does not touch the password.
+        $this->validatePassword($password, ProfileUpdateUser::resolve($user), $errors);
     }
 
     /**
      * Validate password strength on password reset.
      *
+     * Core documents this argument as `WP_User|WP_Error` — "WP_User object if
+     * the login and reset key match, WP_Error object otherwise" (wp-login.php).
+     * Core's own resetpass branch bails before firing the action when the key
+     * did not match, but the published contract is the contract, and any other
+     * caller firing `validate_password_reset` may hand us the WP_Error. A
+     * \WP_User hint would make that a fatal on the reset form.
+     *
+     * A WP_Error means there is no user whose password is being set — core will
+     * not call reset_password() either — so there is nothing to validate.
+     *
      * @param \WP_Error $errors
-     * @param \WP_User  $user
+     * @param mixed     $user   \WP_User on success, \WP_Error otherwise.
      * @return \WP_Error
      */
-    public function validateOnPasswordReset(\WP_Error $errors, \WP_User $user): \WP_Error
+    public function validateOnPasswordReset(\WP_Error $errors, mixed $user): \WP_Error
     {
+        if (!$user instanceof \WP_User) {
+            return $errors;
+        }
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- WP core verifies the reset key before this filter fires; no additional nonce is needed
         $password = isset($_POST['pass1']) && is_string($_POST['pass1']) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- same
             ? wp_unslash($_POST['pass1']) // phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- plaintext required for zxcvbn + HIBP SHA-1; sanitize_text_field alters special chars; never stored or echoed

--- a/apps/agent/includes/security/class-profile-update-user.php
+++ b/apps/agent/includes/security/class-profile-update-user.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * ProfileUpdateUser — resolves the object WordPress core hands to the
+ * `user_profile_update_errors` action into a real WP_User that carries the
+ * roles our role-scoped policy decisions depend on.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Core does NOT pass a WP_User to `user_profile_update_errors`. It builds a
+ * bare stdClass in edit_user() and passes it by reference:
+ *
+ *     wp-admin/includes/user.php
+ *       $user = new stdClass();          // plain stdClass, never a WP_User
+ *       if ( $user_id ) { $user->ID = $user_id; ... }   // ID ONLY on update
+ *       ...
+ *       $user->role = $new_role;         // only when the actor can promote_users
+ *       ...
+ *       do_action_ref_array( 'user_profile_update_errors', array( &$errors, $update, &$user ) );
+ *
+ * Two consequences drive everything below:
+ *
+ *   1. A callback that type-hints \WP_User throws a TypeError at argument
+ *      binding — before any guard inside the method body can run. That is a
+ *      hard fatal on every wp-admin route that edits a user, including an
+ *      administrator opening their own profile.php.
+ *
+ *   2. Merely widening the hint is NOT a fix. The stdClass has no `roles`
+ *      property and no `caps`, so every role-scoped rule
+ *      (SecurityPolicy::effectiveMinZxcvbnScore(), ::blockCompromisedFor())
+ *      would silently see an empty role list and fall back to the site
+ *      default. That converts a loud crash into silent under-enforcement of a
+ *      security policy, which is strictly worse. So we resolve a REAL user
+ *      instead of trusting the object the hook handed us.
+ *
+ * @package WPMgr\Agent\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Security;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolver for the `user_profile_update_errors` user argument.
+ */
+final class ProfileUpdateUser
+{
+    /**
+     * Resolve whatever the hook passed into a WP_User suitable for
+     * role-scoped policy evaluation.
+     *
+     * Total function: it never throws, for any input. It is called from a hook
+     * callback that sits OUTSIDE PasswordPolicyModule::validatePassword()'s
+     * catch(\Throwable) block, so a throw here would be a fatal — exactly the
+     * defect being fixed.
+     *
+     * Role resolution, stated explicitly because the wrong answer is silent:
+     *
+     *   UPDATE (ID present) — load the stored user with get_userdata() and take
+     *   its real roles. When the same submit also changes the role
+     *   ($user->role, set by core only when the actor can promote_users), take
+     *   the UNION of stored and submitted roles: the password must satisfy the
+     *   policy for every role the account holds or is about to hold. The union
+     *   is never weaker than either role alone, which is the safe direction for
+     *   a promotion (subscriber -> administrator must meet administrator rules).
+     *
+     *   CREATE (no ID) — there is no stored user to load. Core puts the
+     *   submitted role on the object; when it is absent (the actor could not
+     *   promote_users) wp_insert_user() will apply the site's `default_role`
+     *   option, so that is what we evaluate against. Either way we evaluate the
+     *   role the new account will ACTUALLY receive, not an empty list.
+     *
+     * The returned object is always a fresh stub, never the instance
+     * get_userdata() returned. get_userdata() hands back the request-cached
+     * WP_User, and writing a unioned role list onto it would corrupt that cache
+     * for the rest of the request.
+     *
+     * @param mixed $raw The third `user_profile_update_errors` argument. Typed
+     *                   mixed rather than object because this is a hook
+     *                   boundary: any plugin may fire the action with anything.
+     * @return \WP_User User to evaluate role-scoped rules against.
+     */
+    public static function resolve(mixed $raw): \WP_User
+    {
+        // A caller that already handed us a real user is trusted as-is; it
+        // carries its own roles and caps, and rebuilding it would only lose
+        // information.
+        if ($raw instanceof \WP_User) {
+            return $raw;
+        }
+
+        $id           = self::intProp($raw, 'ID');
+        $submittedRole = self::stringProp($raw, 'role');
+
+        $roles    = [];
+        $existing = null;
+
+        if ($id > 0 && function_exists('get_userdata')) {
+            $loaded = get_userdata($id);
+            if ($loaded instanceof \WP_User) {
+                $existing = $loaded;
+                if (isset($loaded->roles) && is_array($loaded->roles)) {
+                    $roles = array_values(array_filter(array_map('strval', $loaded->roles)));
+                }
+            }
+        }
+
+        if ($submittedRole !== '' && !in_array($submittedRole, $roles, true)) {
+            // Union, not replacement — see the docblock.
+            $roles[] = $submittedRole;
+        }
+
+        if ($roles === [] && $id === 0) {
+            // Create path with no submitted role: wp_insert_user() will apply
+            // the site default, so that is the role this password belongs to.
+            $default = function_exists('get_option') ? get_option('default_role') : '';
+            if (is_string($default) && $default !== '') {
+                $roles[] = $default;
+            }
+        }
+
+        $user             = new \WP_User();
+        $user->ID         = $id;
+        $user->roles      = $roles;
+        $user->user_login = self::firstNonEmpty(
+            self::stringProp($raw, 'user_login'),
+            $existing !== null ? self::stringProp($existing, 'user_login') : ''
+        );
+        $user->user_email = self::firstNonEmpty(
+            self::stringProp($raw, 'user_email'),
+            $existing !== null ? self::stringProp($existing, 'user_email') : ''
+        );
+        $user->display_name = self::firstNonEmpty(
+            self::stringProp($raw, 'display_name'),
+            $existing !== null ? self::stringProp($existing, 'display_name') : ''
+        );
+
+        return $user;
+    }
+
+    /**
+     * Read an int property from an arbitrary object without throwing.
+     *
+     * @param mixed  $obj
+     * @param string $prop
+     * @return int Zero when absent or not coercible.
+     */
+    private static function intProp(mixed $obj, string $prop): int
+    {
+        if (!is_object($obj) || !isset($obj->$prop)) {
+            return 0;
+        }
+        $value = $obj->$prop;
+        return is_int($value) || (is_string($value) && ctype_digit($value)) ? (int) $value : 0;
+    }
+
+    /**
+     * Read a string property from an arbitrary object without throwing.
+     *
+     * @param mixed  $obj
+     * @param string $prop
+     * @return string Empty string when absent or not a string.
+     */
+    private static function stringProp(mixed $obj, string $prop): string
+    {
+        if (!is_object($obj) || !isset($obj->$prop)) {
+            return '';
+        }
+        $value = $obj->$prop;
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * First non-empty of two strings.
+     *
+     * @param string $a
+     * @param string $b
+     * @return string
+     */
+    private static function firstNonEmpty(string $a, string $b): string
+    {
+        return $a !== '' ? $a : $b;
+    }
+}

--- a/apps/agent/includes/security/class-security-policy.php
+++ b/apps/agent/includes/security/class-security-policy.php
@@ -480,6 +480,15 @@ final class SecurityPolicy
      * list, conclude no role-scoped rule applies, and enforce nothing — with no
      * error and no log. Reading the submitted role keeps scoping alive there.
      *
+     * This fallback is a REPLACEMENT, not a union, and is strictly weaker than
+     * ProfileUpdateUser::resolve(): on the raw stdClass it can only ever see
+     * the single submitted `role`, never the account's stored role. Any future
+     * caller that reaches effectiveMinZxcvbnScore() or blockCompromisedFor()
+     * with that unresolved object on a demotion gets `['subscriber']` and
+     * silently skips the stored administrator rule — the exact defect class
+     * this fallback exists to catch, one level down. Do not rely on it for a
+     * role-scoped decision; resolve the user first.
+     *
      * @param object $user \WP_User, or the \stdClass core builds in edit_user().
      * @return list<string>
      */

--- a/apps/agent/includes/security/class-security-policy.php
+++ b/apps/agent/includes/security/class-security-policy.php
@@ -384,12 +384,18 @@ final class SecurityPolicy
     }
 
     /**
-     * Get the effective minimum zxcvbn score for a WP_User's role.
+     * Get the effective minimum zxcvbn score for a user's role.
      *
-     * @param \WP_User $user
+     * Accepts an object rather than a \WP_User because the
+     * `user_profile_update_errors` chain reaches here carrying whatever core
+     * passed, and core passes a bare stdClass. Callers on that path should
+     * resolve through ProfileUpdateUser::resolve() first; userRoles() below is
+     * the backstop for any that do not.
+     *
+     * @param object $user \WP_User, or the \stdClass core builds in edit_user().
      * @return int
      */
-    public function effectiveMinZxcvbnScore(\WP_User $user): int
+    public function effectiveMinZxcvbnScore(object $user): int
     {
         $roles = $this->userRoles($user);
 
@@ -439,12 +445,14 @@ final class SecurityPolicy
     }
 
     /**
-     * Get whether compromised-password blocking applies to a WP_User.
+     * Get whether compromised-password blocking applies to a user.
      *
-     * @param \WP_User $user
+     * Object-typed for the same reason as effectiveMinZxcvbnScore() above.
+     *
+     * @param object $user \WP_User, or the \stdClass core builds in edit_user().
      * @return bool
      */
-    public function blockCompromisedFor(\WP_User $user): bool
+    public function blockCompromisedFor(object $user): bool
     {
         if ($this->passwordBlockCompromised) {
             return true;
@@ -463,17 +471,27 @@ final class SecurityPolicy
     // -------------------------------------------------------------------------
 
     /**
-     * Extract the roles array from a WP_User safely.
+     * Extract the roles array from a user object safely.
      *
-     * @param \WP_User $user
+     * The `role` fallback is the backstop against silent under-enforcement: the
+     * stdClass core passes to `user_profile_update_errors` has no `roles`
+     * property, only the single submitted `role` string. Without this branch a
+     * caller that skipped ProfileUpdateUser::resolve() would read an empty role
+     * list, conclude no role-scoped rule applies, and enforce nothing — with no
+     * error and no log. Reading the submitted role keeps scoping alive there.
+     *
+     * @param object $user \WP_User, or the \stdClass core builds in edit_user().
      * @return list<string>
      */
-    private function userRoles(\WP_User $user): array
+    private function userRoles(object $user): array
     {
-        if (!isset($user->roles) || !is_array($user->roles)) {
-            return [];
+        if (isset($user->roles) && is_array($user->roles)) {
+            return array_values(array_filter(array_map('strval', $user->roles)));
         }
-        return array_values(array_filter(array_map('strval', $user->roles)));
+        if (isset($user->role) && is_string($user->role) && $user->role !== '') {
+            return [$user->role];
+        }
+        return [];
     }
 
     /**

--- a/apps/agent/includes/security/class-site-2fa-module.php
+++ b/apps/agent/includes/security/class-site-2fa-module.php
@@ -248,8 +248,15 @@ final class Site2faModule
         }
 
         // XML-RPC block for 2FA users.
+        //
+        // Deliberately NOT hooked: `xmlrpc_login_error`. Core fires it only
+        // from inside `if ( is_wp_error( $user ) )` in
+        // wp-includes/class-wp-xmlrpc-server.php, i.e. only once authentication
+        // has ALREADY failed, and its second argument is that WP_Error — never
+        // a WP_User. A callback there cannot block a successful login, which is
+        // the whole point of this control. `authenticate` is where the decision
+        // is actually made, and interceptXmlrpc2fa() makes it.
         if ($has2fa && $this->policy->blockXmlrpcFor2faUsers) {
-            add_filter('xmlrpc_login_error', [$this, 'blockXmlrpcFor2faUser'], 10, 2);
             add_filter('authenticate', [$this, 'interceptXmlrpc2fa'], 100, 3);
         }
 
@@ -1000,16 +1007,6 @@ final class Site2faModule
         }
 
         return $user;
-    }
-
-    /**
-     * @param mixed    $error
-     * @param \WP_User $user
-     * @return mixed
-     */
-    public function blockXmlrpcFor2faUser(mixed $error, \WP_User $user): mixed
-    {
-        return $error;
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/Security/UserProfileUpdateErrorsHookTest.php
+++ b/apps/agent/tests/Security/UserProfileUpdateErrorsHookTest.php
@@ -285,6 +285,40 @@ final class UserProfileUpdateErrorsHookTest extends TestCase
         );
     }
 
+    /**
+     * Demotion: the stored role is IN scope but the submitted role is out of
+     * scope. The union must still apply the STORED role's rule — a demotion
+     * must not be usable to smuggle a weak password past the policy the
+     * account is currently held to.
+     *
+     * This is the case that pins ProfileUpdateUser::resolve() as load-bearing
+     * rather than decorative: the raw core stdClass carries only the
+     * submitted `role` ('subscriber'), and SecurityPolicy::userRoles()'s
+     * `role` backstop would read that alone and see no in-scope role at all.
+     * Only resolve()'s union — which loads the STORED role via
+     * get_userdata() before folding in the submission — keeps the
+     * administrator rule alive here.
+     */
+    public function test_profile_update_demotion_still_applies_the_stored_role_rule(): void
+    {
+        $this->storeUser(11, ['administrator']);
+        $_POST['pass1'] = self::WEAK_PASSWORD;
+
+        $raw       = $this->coreUpdateObject(11);
+        $raw->role = 'subscriber';
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, true, $raw);
+
+        $this->assertArrayHasKey(
+            'wpmgr_password_strength',
+            $errors->errors,
+            'DEMOTION: the stored administrator rule must still apply when the same submit demotes the account'
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Site A — over-fire checks
     // -------------------------------------------------------------------------
@@ -439,8 +473,7 @@ final class UserProfileUpdateErrorsHookTest extends TestCase
      * Core sets user_login on the stdClass from the stored user, but a caller
      * that omits it must not silently disable the check — the login is
      * recovered from the stored user instead.
-     */
-    /**
+     *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */

--- a/apps/agent/tests/Security/UserProfileUpdateErrorsHookTest.php
+++ b/apps/agent/tests/Security/UserProfileUpdateErrorsHookTest.php
@@ -1,0 +1,583 @@
+<?php
+/**
+ * GH #521 regression: callbacks on `user_profile_update_errors` must accept the
+ * object WordPress core ACTUALLY passes, and must not lose role scoping doing it.
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM PasswordPolicyModuleTest
+ * -------------------------------------------------------------
+ * The existing suite is the reason this shipped. Its makeUser() helper returns
+ * a \WP_User, so every test handed the chain exactly the type the chain
+ * declared, and not one test entered through validateOnProfileUpdate(). The
+ * fatal lives at the hook boundary, one level ABOVE where that suite starts.
+ *
+ * Core does not pass a WP_User. wp-admin/includes/user.php builds a plain
+ * stdClass, gives it an ID only on update, and only sometimes gives it a role:
+ *
+ *     $user = new stdClass();
+ *     if ( $user_id ) { $user->ID = $user_id; ... }
+ *     ...
+ *     $user->role = $new_role;   // only when the actor can promote_users
+ *     do_action_ref_array( 'user_profile_update_errors', array( &$errors, $update, &$user ) );
+ *
+ * Every test below therefore constructs that object — a bare stdClass carrying
+ * only the properties core sets — and never a \WP_User, except where a
+ * legitimate \WP_User is deliberately being proven still to work.
+ *
+ * Two failure modes are covered, because fixing only the first produces the
+ * second:
+ *
+ *   1. TypeError at argument binding (the reported fatal). Thrown BEFORE any
+ *      early return inside the callback body, so no guard in the method can
+ *      save it, and it is not caught by validatePassword()'s catch(\Throwable).
+ *
+ *   2. Silent under-enforcement. The stdClass has no `roles` property, so
+ *      merely widening the type hints would make every role-scoped rule read
+ *      an empty role list and fall back to the site default — no crash, no
+ *      log, no enforcement. The role-scoped tests here fail loudly on that.
+ *
+ * @package WPMgr\Agent\Tests\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Security;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Security\CpUrlProvider;
+use WPMgr\Agent\Security\HardeningConfig;
+use WPMgr\Agent\Security\HardeningModule;
+use WPMgr\Agent\Security\PasswordPolicyModule;
+use WPMgr\Agent\Security\ProfileUpdateUser;
+use WPMgr\Agent\Security\RequestSigner;
+use WPMgr\Agent\Security\SecurityPolicy;
+use WPMgr\Agent\Security\Site2faModule;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Security\ProfileUpdateUser
+ * @covers \WPMgr\Agent\Security\PasswordPolicyModule
+ * @covers \WPMgr\Agent\Security\HardeningModule
+ * @covers \WPMgr\Agent\Security\SecurityPolicy
+ */
+final class UserProfileUpdateErrorsHookTest extends TestCase
+{
+    /** A password zxcvbn scores 0 against these user inputs. */
+    private const WEAK_PASSWORD = 'password1';
+
+    /** A password zxcvbn scores 4 against these user inputs. */
+    private const STRONG_PASSWORD = '7Kq!vZ3m#Xw9Lp2R@nT5';
+
+    /** @var array<int,\WP_User> Fake user store backing get_userdata(). */
+    private array $users = [];
+
+    /** @var array<string,mixed> Fake option store. */
+    private array $options = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->users   = [];
+        $this->options = [];
+
+        Functions\when('get_userdata')->alias(fn ($id) => $this->users[(int) $id] ?? false);
+        Functions\when('get_option')->alias(fn ($k, $d = false) => $this->options[$k] ?? $d);
+        Functions\when('get_user_meta')->justReturn('');
+        Functions\when('update_user_meta')->justReturn(true);
+        Functions\when('get_bloginfo')->justReturn('Test Site');
+        Functions\when('wp_unslash')->alias(fn ($v) => $v);
+        Functions\when('sanitize_text_field')->alias(fn ($v) => $v);
+        Functions\when('esc_html')->alias(fn ($t) => $t);
+        Functions\when('esc_html__')->alias(fn ($t, $d = '') => $t);
+        Functions\when('__')->alias(fn ($t, $d = '') => $t);
+        Functions\when('esc_url_raw')->alias(fn ($u) => $u);
+
+        unset($_POST['pass1'], $_POST['nickname']);
+    }
+
+    protected function tear_down(): void
+    {
+        unset($_POST['pass1'], $_POST['nickname']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    /**
+     * The object core actually passes on a user UPDATE: an ID, the stored
+     * login, and whatever the form submitted. No `roles`. No `caps`.
+     */
+    private function coreUpdateObject(int $id = 7): \stdClass
+    {
+        $u             = new \stdClass();
+        $u->ID         = $id;
+        $u->user_login = 'admin';
+        $u->user_email = 'admin@example.com';
+        return $u;
+    }
+
+    /**
+     * The object core actually passes on a user CREATE: no ID at all — core
+     * assigns ID only inside `if ( $user_id )`.
+     */
+    private function coreCreateObject(): \stdClass
+    {
+        $u             = new \stdClass();
+        $u->user_login = 'newbie';
+        $u->user_email = 'newbie@example.com';
+        return $u;
+    }
+
+    /** Register a stored user for get_userdata() to return. */
+    private function storeUser(int $id, array $roles, string $login = 'admin', string $email = 'admin@example.com'): \WP_User
+    {
+        $u               = new \WP_User();
+        $u->ID           = $id;
+        $u->roles        = $roles;
+        $u->user_login   = $login;
+        $u->user_email   = $email;
+        $u->display_name = 'Admin';
+        $this->users[$id] = $u;
+        return $u;
+    }
+
+    /**
+     * A policy whose strength rule applies ONLY to administrators. A fix that
+     * loses role resolution reads an empty role list, concludes the rule does
+     * not apply, and enforces nothing — which these tests catch.
+     */
+    private function adminScopedStrengthPolicy(): SecurityPolicy
+    {
+        return SecurityPolicy::fromArray([
+            'policy' => [
+                'password_min_zxcvbn_score' => 4,
+                'password_min_zxcvbn_roles' => ['administrator'],
+            ],
+        ]);
+    }
+
+    private function passwordModule(SecurityPolicy $policy): PasswordPolicyModule
+    {
+        $settings = new class implements CpUrlProvider {
+            public function controlPlaneUrl(): string
+            {
+                return '';
+            }
+        };
+        $signer = new class implements RequestSigner {
+            /** @return array<string,string> */
+            public function signHeaders(string $method, string $path, string $body): array
+            {
+                return [];
+            }
+        };
+        return new PasswordPolicyModule($policy, $settings, $signer);
+    }
+
+    // =========================================================================
+    // Site A — PasswordPolicyModule::validateOnProfileUpdate
+    // =========================================================================
+
+    /**
+     * The reported fatal. Before the fix this dies with
+     *   TypeError: ...validateOnProfileUpdate(): Argument #3 ($user) must be of
+     *   type WP_User, stdClass given
+     * at argument binding, on every profile.php / user-edit.php save.
+     *
+     * It also pins Trap 1: the administrator-scoped rule must still fire, which
+     * it cannot do if the fix simply widens the hint and reads roles off the
+     * role-less stdClass.
+     */
+    public function test_profile_update_on_update_enforces_role_scoped_rule(): void
+    {
+        $this->storeUser(7, ['administrator']);
+        $_POST['pass1'] = self::WEAK_PASSWORD;
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, true, $this->coreUpdateObject(7));
+
+        $this->assertArrayHasKey(
+            'wpmgr_password_strength',
+            $errors->errors,
+            'an administrator-scoped strength rule must reject a weak password when core passes its stdClass'
+        );
+    }
+
+    /**
+     * The create path. Core assigns no ID here at all, and puts the submitted
+     * role on the object. The rule must be evaluated against the role the new
+     * account is about to receive.
+     */
+    public function test_profile_update_on_create_uses_submitted_role(): void
+    {
+        $_POST['pass1'] = self::WEAK_PASSWORD;
+
+        $raw       = $this->coreCreateObject();
+        $raw->role = 'administrator';
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, false, $raw);
+
+        $this->assertArrayHasKey(
+            'wpmgr_password_strength',
+            $errors->errors,
+            'on create, the submitted role must drive the role-scoped rule'
+        );
+        $this->assertObjectNotHasProperty(
+            'ID',
+            $raw,
+            'guard against this fixture drifting: core assigns no ID on the create path'
+        );
+    }
+
+    /**
+     * Create path where the actor could not promote_users, so core set no role.
+     * wp_insert_user() will apply the site default_role, so that is the role
+     * the rule must be evaluated against — never an empty list.
+     */
+    public function test_profile_update_on_create_without_role_uses_site_default_role(): void
+    {
+        $_POST['pass1']                = self::WEAK_PASSWORD;
+        $this->options['default_role'] = 'administrator';
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, false, $this->coreCreateObject());
+
+        $this->assertArrayHasKey(
+            'wpmgr_password_strength',
+            $errors->errors,
+            'with no submitted role, the site default_role is the role the new user will get'
+        );
+    }
+
+    /**
+     * Promotion: the stored role is out of scope but the submitted role is in
+     * scope. The union must apply the stricter rule.
+     */
+    public function test_profile_update_promotion_applies_the_target_role_rule(): void
+    {
+        $this->storeUser(9, ['subscriber'], 'sub', 'sub@example.com');
+        $_POST['pass1'] = self::WEAK_PASSWORD;
+
+        $raw       = $this->coreUpdateObject(9);
+        $raw->role = 'administrator';
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, true, $raw);
+
+        $this->assertArrayHasKey(
+            'wpmgr_password_strength',
+            $errors->errors,
+            'promoting a subscriber to administrator must apply the administrator rule to the new password'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Site A — over-fire checks
+    // -------------------------------------------------------------------------
+
+    /** A password that satisfies the rule must still be accepted. */
+    public function test_profile_update_accepts_a_strong_password(): void
+    {
+        $this->storeUser(7, ['administrator']);
+        $_POST['pass1'] = self::STRONG_PASSWORD;
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, true, $this->coreUpdateObject(7));
+
+        $this->assertSame([], $errors->errors, 'a strong password must not be rejected');
+    }
+
+    /**
+     * A user whose role is OUT of the rule's scope must not be enforced against.
+     * This is the honest case the fix must not block: without it, "resolve a
+     * role" could degenerate into "enforce on everybody".
+     */
+    public function test_profile_update_does_not_enforce_on_out_of_scope_role(): void
+    {
+        $this->storeUser(8, ['subscriber'], 'sub', 'sub@example.com');
+        $_POST['pass1'] = self::WEAK_PASSWORD;
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, true, $this->coreUpdateObject(8));
+
+        $this->assertSame(
+            [],
+            $errors->errors,
+            'a subscriber must not be held to an administrator-scoped rule'
+        );
+    }
+
+    /** A caller that legitimately passes a real WP_User must keep working. */
+    public function test_profile_update_still_accepts_a_real_wp_user(): void
+    {
+        $user           = $this->storeUser(7, ['administrator']);
+        $_POST['pass1'] = self::WEAK_PASSWORD;
+
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, true, $user);
+
+        $this->assertArrayHasKey(
+            'wpmgr_password_strength',
+            $errors->errors,
+            'a genuine WP_User must still be evaluated with its own roles'
+        );
+    }
+
+    /** No password typed is still the cheap early return — no user load at all. */
+    public function test_profile_update_without_a_password_adds_no_error(): void
+    {
+        $mod    = $this->passwordModule($this->adminScopedStrengthPolicy());
+        $errors = new \WP_Error();
+
+        $mod->validateOnProfileUpdate($errors, true, $this->coreUpdateObject(7));
+
+        $this->assertSame([], $errors->errors, 'saving a profile without touching the password must add no error');
+    }
+
+    // =========================================================================
+    // Site B — HardeningModule force_unique_nickname closure
+    // =========================================================================
+
+    /**
+     * B is an independent toggle behind a different setting, so a site with no
+     * password policy at all still hits the identical crash. Capture the
+     * closure install() registers and invoke it with core's stdClass.
+     */
+    private function nicknameClosure(): callable
+    {
+        $captured = null;
+        Functions\expect('add_action')
+            ->once()
+            ->with('user_profile_update_errors', \Mockery::type('callable'), 10, 3)
+            ->andReturnUsing(function ($hook, $cb, $priority, $args) use (&$captured) {
+                $captured = $cb;
+                return true;
+            });
+
+        // No setAccessible(): it has been a no-op since PHP 8.1 and is
+        // deprecated as of 8.5, which phpunit reports as an issue.
+        $mod = new HardeningModule();
+        $ref = new \ReflectionMethod($mod, 'applyForceUniqueNickname');
+        $ref->invoke($mod, HardeningConfig::fromArray(['config' => ['force_unique_nickname' => true]]));
+
+        $this->assertIsCallable($captured, 'force_unique_nickname must register a user_profile_update_errors callback');
+        return $captured;
+    }
+
+    public function test_force_unique_nickname_accepts_core_stdclass(): void
+    {
+        $this->storeUser(7, ['administrator']);
+        $_POST['nickname'] = 'admin';
+
+        $cb     = $this->nicknameClosure();
+        $errors = new \WP_Error();
+
+        $cb($errors, true, $this->coreUpdateObject(7));
+
+        $this->assertArrayHasKey(
+            'wpmgr_nickname_conflict',
+            $errors->errors,
+            'a nickname equal to the login must still be rejected when core passes its stdClass'
+        );
+    }
+
+    public function test_force_unique_nickname_allows_a_distinct_nickname(): void
+    {
+        $this->storeUser(7, ['administrator']);
+        $_POST['nickname'] = 'Site Owner';
+
+        $cb     = $this->nicknameClosure();
+        $errors = new \WP_Error();
+
+        $cb($errors, true, $this->coreUpdateObject(7));
+
+        $this->assertSame([], $errors->errors, 'a nickname unlike the login must be accepted');
+    }
+
+    /**
+     * Core sets user_login on the stdClass from the stored user, but a caller
+     * that omits it must not silently disable the check — the login is
+     * recovered from the stored user instead.
+     */
+    public function test_force_unique_nickname_recovers_login_when_absent_from_the_object(): void
+    {
+        $this->storeUser(7, ['administrator'], 'admin');
+        $_POST['nickname'] = 'admin';
+
+        $raw     = new \stdClass();
+        $raw->ID = 7;
+
+        $cb     = $this->nicknameClosure();
+        $errors = new \WP_Error();
+
+        $cb($errors, true, $raw);
+
+        $this->assertArrayHasKey(
+            'wpmgr_nickname_conflict',
+            $errors->errors,
+            'a missing user_login on the hook object must not silently disable the check'
+        );
+    }
+
+    // =========================================================================
+    // Site C — Site2faModule and the xmlrpc_login_error hook
+    // =========================================================================
+
+    /**
+     * `xmlrpc_login_error` fires ONLY inside core's `if ( is_wp_error( $user ) )`
+     * branch (wp-includes/class-wp-xmlrpc-server.php), so its second argument is
+     * always a WP_Error and never a WP_User. A callback hinting \WP_User there
+     * could only ever fatal, and its body was `return $error;` — it never
+     * blocked anything. It is removed rather than widened.
+     */
+    public function test_xmlrpc_login_error_callback_is_gone(): void
+    {
+        $this->assertFalse(
+            method_exists(Site2faModule::class, 'blockXmlrpcFor2faUser'),
+            'the xmlrpc_login_error callback fires only on already-failed auth; it cannot block anything and must not exist'
+        );
+    }
+
+    /**
+     * The functional XML-RPC block lives on `authenticate`, which core calls
+     * with the resolved user. It must survive C's removal, and it must tolerate
+     * the WP_Error core hands it when authentication already failed.
+     */
+    public function test_xmlrpc_authenticate_block_tolerates_a_wp_error(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'         => true,
+                'block_xmlrpc_for_2fa_users' => true,
+            ],
+        ]);
+        $mod = new Site2faModule($policy, []);
+
+        $error  = new \WP_Error('incorrect_password', 'nope');
+        $result = $mod->interceptXmlrpc2fa($error, 'someone', 'secret');
+
+        $this->assertSame($error, $result, 'a failed authentication must pass straight through untouched');
+    }
+
+    // =========================================================================
+    // The chain — SecurityPolicy role resolution
+    // =========================================================================
+
+    /**
+     * Last line of defence for Trap 1. If a future caller bypasses the resolver
+     * and hands SecurityPolicy the raw core object, role scoping must still
+     * resolve from the submitted role rather than silently emptying out.
+     */
+    public function test_security_policy_resolves_roles_from_a_bare_core_object(): void
+    {
+        $policy = $this->adminScopedStrengthPolicy();
+
+        $raw       = new \stdClass();
+        $raw->role = 'administrator';
+
+        $this->assertSame(
+            4,
+            $policy->effectiveMinZxcvbnScore($raw),
+            'the submitted role must drive the role-scoped score, not the empty-role default'
+        );
+
+        $other       = new \stdClass();
+        $other->role = 'subscriber';
+
+        $this->assertSame(
+            0,
+            $policy->effectiveMinZxcvbnScore($other),
+            'an out-of-scope role must not pick up the administrator rule'
+        );
+    }
+
+    public function test_security_policy_block_compromised_resolves_group_role(): void
+    {
+        $policy = SecurityPolicy::fromArray([
+            'policy' => ['password_block_compromised' => false],
+            'groups' => [
+                ['role' => 'administrator', 'block_compromised' => true],
+            ],
+        ]);
+
+        $raw       = new \stdClass();
+        $raw->role = 'administrator';
+
+        $this->assertTrue(
+            $policy->blockCompromisedFor($raw),
+            'a group rule keyed on the submitted role must still apply'
+        );
+    }
+
+    // =========================================================================
+    // The resolver itself
+    // =========================================================================
+
+    public function test_resolver_returns_a_real_wp_user_untouched(): void
+    {
+        $user = $this->storeUser(7, ['administrator']);
+        $this->assertSame($user, ProfileUpdateUser::resolve($user));
+    }
+
+    /**
+     * get_userdata() returns the request-cached WP_User. Writing a unioned role
+     * list onto it would corrupt that cache for the rest of the request, so the
+     * resolver must always hand back a separate object.
+     */
+    public function test_resolver_never_mutates_the_cached_user(): void
+    {
+        $stored = $this->storeUser(9, ['subscriber'], 'sub', 'sub@example.com');
+
+        $raw       = $this->coreUpdateObject(9);
+        $raw->role = 'administrator';
+
+        $resolved = ProfileUpdateUser::resolve($raw);
+
+        $this->assertNotSame($stored, $resolved, 'the resolver must not hand back the cached instance');
+        $this->assertSame(['subscriber'], $stored->roles, 'the cached user must be left exactly as it was');
+        $this->assertSame(['subscriber', 'administrator'], $resolved->roles);
+        $this->assertSame(9, $resolved->ID);
+    }
+
+    /** Junk on a hook boundary must degrade, never throw. */
+    public function test_resolver_tolerates_junk(): void
+    {
+        foreach ([null, 'a string', 42, [], new \stdClass()] as $junk) {
+            $resolved = ProfileUpdateUser::resolve($junk);
+            $this->assertInstanceOf(\WP_User::class, $resolved);
+            $this->assertSame(0, $resolved->ID);
+        }
+    }
+
+    /** A stored user that no longer exists must not resurrect an empty role set silently. */
+    public function test_resolver_keeps_submitted_role_when_the_stored_user_is_gone(): void
+    {
+        $raw       = $this->coreUpdateObject(404);
+        $raw->role = 'editor';
+
+        $resolved = ProfileUpdateUser::resolve($raw);
+
+        $this->assertSame(['editor'], $resolved->roles);
+        $this->assertSame(404, $resolved->ID);
+    }
+}

--- a/apps/agent/tests/Security/UserProfileUpdateErrorsHookTest.php
+++ b/apps/agent/tests/Security/UserProfileUpdateErrorsHookTest.php
@@ -362,9 +362,22 @@ final class UserProfileUpdateErrorsHookTest extends TestCase
      * B is an independent toggle behind a different setting, so a site with no
      * password policy at all still hits the identical crash. Capture the
      * closure install() registers and invoke it with core's stdClass.
+     *
+     * Every caller of this helper runs in its own process. Site2faModuleTest
+     * defines WPMGR_DISABLE_SITE_2FA process-globally, and a constant cannot be
+     * undefined; applyForceUniqueNickname() now honours that constant, so in a
+     * whole-suite run these tests would register no closure, assert nothing and
+     * pass green — a regression test for a production fatal that silently stops
+     * running is worth less than no test. Verified: without isolation this
+     * helper returns null under `phpunit tests/Security/`, and the three
+     * callers fail on "null is of type callable".
      */
     private function nicknameClosure(): callable
     {
+        $this->assertFalse(
+            defined('WPMGR_DISABLE_SITE_2FA'),
+            'these tests need the recovery constant unset; process isolation has failed'
+        );
         $captured = null;
         Functions\expect('add_action')
             ->once()
@@ -384,6 +397,10 @@ final class UserProfileUpdateErrorsHookTest extends TestCase
         return $captured;
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_force_unique_nickname_accepts_core_stdclass(): void
     {
         $this->storeUser(7, ['administrator']);
@@ -401,6 +418,10 @@ final class UserProfileUpdateErrorsHookTest extends TestCase
         );
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_force_unique_nickname_allows_a_distinct_nickname(): void
     {
         $this->storeUser(7, ['administrator']);
@@ -419,6 +440,10 @@ final class UserProfileUpdateErrorsHookTest extends TestCase
      * that omits it must not silently disable the check — the login is
      * recovered from the stored user instead.
      */
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_force_unique_nickname_recovers_login_when_absent_from_the_object(): void
     {
         $this->storeUser(7, ['administrator'], 'admin');
@@ -436,6 +461,87 @@ final class UserProfileUpdateErrorsHookTest extends TestCase
             'wpmgr_nickname_conflict',
             $errors->errors,
             'a missing user_login on the hook object must not silently disable the check'
+        );
+    }
+
+    // =========================================================================
+    // The recovery constant must actually release the auth policy
+    // =========================================================================
+
+    /**
+     * `define('WPMGR_DISABLE_SITE_2FA', true)` is the documented escape hatch
+     * for an admin locked out by this plugin's auth policy. Site2faModule and
+     * PasswordPolicyModule honoured it; HardeningModule did not — so an
+     * operator who set it silenced the password-policy crash and was still
+     * refused by force_unique_nickname. An escape hatch that does not release
+     * everything it claims to is worse than none.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_recovery_constant_releases_the_nickname_rule(): void
+    {
+        define('WPMGR_DISABLE_SITE_2FA', true);
+
+        Functions\expect('add_action')->never();
+
+        $mod = new HardeningModule();
+        $ref = new \ReflectionMethod($mod, 'applyForceUniqueNickname');
+        $ref->invoke($mod, HardeningConfig::fromArray(['config' => ['force_unique_nickname' => true]]));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * The same hatch must release the login-identifier restriction, the other
+     * HardeningModule rule that can keep an administrator out.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_recovery_constant_releases_the_login_identifier_restriction(): void
+    {
+        define('WPMGR_DISABLE_SITE_2FA', true);
+
+        Functions\expect('add_action')->never();
+
+        $mod = new HardeningModule();
+        $ref = new \ReflectionMethod($mod, 'applyLoginIdentifier');
+        $ref->invoke($mod, HardeningConfig::fromArray(['config' => ['restrict_login_identifier' => 'username']]));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Over-fire guard on the hatch. It is scoped to auth policy on purpose:
+     * recovering a login must not silently drop the site's IP bans. If someone
+     * later widens authPolicyDisabled() to gate every applier, this reddens.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_recovery_constant_does_not_drop_ip_bans(): void
+    {
+        define('WPMGR_DISABLE_SITE_2FA', true);
+
+        $captured = null;
+        Functions\expect('add_action')
+            ->once()
+            ->andReturnUsing(function ($hook, $cb, $priority = 10, $args = 1) use (&$captured) {
+                $captured = $cb;
+                return true;
+            });
+
+        $mod    = new HardeningModule();
+        $config = HardeningConfig::fromArray([
+            'bans' => [['id' => 'b1', 'type' => 'user_agent', 'value' => 'EvilBot']],
+        ]);
+        $ref = new \ReflectionMethod($mod, 'applyBanFilters');
+        $ref->invoke($mod, $config);
+
+        $this->assertIsCallable(
+            $captured,
+            'the auth-policy recovery constant must not disable IP/user-agent bans'
         );
     }
 

--- a/apps/agent/tests/SizeProbeColdCacheTest.php
+++ b/apps/agent/tests/SizeProbeColdCacheTest.php
@@ -114,20 +114,34 @@ final class SizeProbeColdCacheTest extends TestCase
     }
 
     /**
-     * CodeRabbit review on PR #526: recurse_dirsize() normalises a null
-     * $max_execution_time from `ini_get( 'max_execution_time' )`, which
-     * returns a STRING, and only casts it to int via `-= 1` when that value
-     * is > 10. An ini value of "0" (unlimited — the PHP-CLI/WP-CLI default)
-     * reaches this filter as the literal string, never cast. Before the fix
-     * this dies with
+     * CodeRabbit review on PR #526 flagged that recurse_dirsize() can hand
+     * this filter a numeric string for $max_execution_time instead of an int
+     * (ini_get('max_execution_time') returns a STRING, cast to int only when
+     * the value is > 10 — see the callback's docblock). A well-formed numeric
+     * string like "0" does NOT fatal even under the old strict `int` hint:
+     * PHP's argument-coercion mode is decided by the CALLING file, not the
+     * declaring one, and the real caller — WP_Hook::apply_filters()'s
+     * call_user_func_array() in wp-includes/class-wp-hook.php — declares no
+     * strict types, so "0" coerces to int(0) silently there regardless of
+     * this file's own `declare(strict_types=1)`. (Verified directly: a
+     * throwaway weak-mode caller confirmed the coercion; this file's own
+     * strict_types would otherwise mask that.)
+     *
+     * The honest failure is a NON-numeric string, which ini_get() can return
+     * if the ini value is set but empty. Weak-mode coercion only accepts
+     * well-formed numeric strings for an int parameter — a non-numeric one is
+     * a TypeError in weak mode too, so this assertion holds the same whether
+     * this test calls the callback directly (as it does, from this file's own
+     * strict_types context) or WordPress calls it through its real weak-mode
+     * dispatch. Before the fix this dies with
      *   TypeError: ...preRecurseDirsizeFilter(): Argument #4 ($maxExecTime)
      *   must be of type int, string given
      */
-    public function test_numeric_string_max_exec_time_from_ini_get_does_not_fatal(): void
+    public function test_non_numeric_max_exec_time_does_not_fatal(): void
     {
         $probe = new SizeProbe();
 
-        $result = $probe->preRecurseDirsizeFilter(false, sys_get_temp_dir(), null, '0', false);
+        $result = $probe->preRecurseDirsizeFilter(false, sys_get_temp_dir(), null, '', false);
 
         $this->assertFalse($result);
     }

--- a/apps/agent/tests/SizeProbeColdCacheTest.php
+++ b/apps/agent/tests/SizeProbeColdCacheTest.php
@@ -114,6 +114,40 @@ final class SizeProbeColdCacheTest extends TestCase
     }
 
     /**
+     * CodeRabbit review on PR #526: recurse_dirsize() normalises a null
+     * $max_execution_time from `ini_get( 'max_execution_time' )`, which
+     * returns a STRING, and only casts it to int via `-= 1` when that value
+     * is > 10. An ini value of "0" (unlimited — the PHP-CLI/WP-CLI default)
+     * reaches this filter as the literal string, never cast. Before the fix
+     * this dies with
+     *   TypeError: ...preRecurseDirsizeFilter(): Argument #4 ($maxExecTime)
+     *   must be of type int, string given
+     */
+    public function test_numeric_string_max_exec_time_from_ini_get_does_not_fatal(): void
+    {
+        $probe = new SizeProbe();
+
+        $result = $probe->preRecurseDirsizeFilter(false, sys_get_temp_dir(), null, '0', false);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * recurse_dirsize()'s own default for $max_execution_time is null before
+     * normalisation. This filter must not assume a caller always normalises
+     * first — a plugin or a future core version applying this filter directly
+     * must not fatal on the parameter's own documented default.
+     */
+    public function test_null_max_exec_time_does_not_fatal(): void
+    {
+        $probe = new SizeProbe();
+
+        $result = $probe->preRecurseDirsizeFilter(false, sys_get_temp_dir(), null, null, false);
+
+        $this->assertFalse($result);
+    }
+
+    /**
      * Core marks arguments 3-5 optional. A third-party plugin applying the
      * filter with fewer arguments must not produce an ArgumentCountError.
      */

--- a/apps/agent/tests/SizeProbeColdCacheTest.php
+++ b/apps/agent/tests/SizeProbeColdCacheTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * GH #521 regression: SizeProbe's `pre_recurse_dirsize` callback must accept
+ * the FALSE that WordPress core passes as the fifth argument when the
+ * `dirsize_cache` transient is cold.
+ *
+ * Core seeds that argument from a transient and does not normalise it first:
+ *
+ *     // wp-includes/functions.php, recurse_dirsize()
+ *     if ( ! isset( $directory_cache ) ) {
+ *         $directory_cache = get_transient( 'dirsize_cache' );   // false when cold
+ *     }
+ *     ...
+ *     $size = apply_filters( 'pre_recurse_dirsize', false, $directory, $exclude, $max_execution_time, $directory_cache );
+ *     ...
+ *     if ( ! is_array( $directory_cache ) ) {   // normalised AFTER the filter
+ *         $directory_cache = array();
+ *     }
+ *
+ * get_transient() returns false when the transient is missing or expired, so an
+ * `array` hint on that parameter was an uncaught TypeError. This one is the
+ * worst of the set because it needs no setting at all: Plugin::registerHooks()
+ * registers the filter unconditionally on every boot, and it could not
+ * self-heal — the transient is only written after the directory walk that the
+ * fatal prevented, so it repeated on every request. Triggers included a fresh
+ * install, any transient or object-cache flush, Site Health -> Info ->
+ * Directory sizes, the agent's own daily size walk, and on multisite every
+ * media upload via get_space_used().
+ *
+ * The cases below bind exactly what core binds. No existing test constructed
+ * the cold-cache call at all.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Diagnostics\SizeProbe;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Diagnostics\SizeProbe
+ */
+final class SizeProbeColdCacheTest extends TestCase
+{
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        // '0' short-circuits execAvailable() to false, so the callback returns
+        // false and lets core do its own recursion. That keeps these tests
+        // deterministic and off the du(1) shell-out entirely: what is under
+        // test is argument binding, not the byte count.
+        Functions\when('get_transient')->justReturn('0');
+        Functions\when('set_transient')->justReturn(true);
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * The reported fatal. Before the fix this dies with
+     *   TypeError: ...preRecurseDirsizeFilter(): Argument #5 ($directoryCache)
+     *   must be of type array, bool given
+     */
+    public function test_cold_dirsize_transient_does_not_fatal(): void
+    {
+        $probe = new SizeProbe();
+
+        $result = $probe->preRecurseDirsizeFilter(false, sys_get_temp_dir(), null, 30, false);
+
+        $this->assertFalse(
+            $result,
+            'with exec unavailable the callback must hand the walk back to core, not throw'
+        );
+    }
+
+    /** A warm cache is an array, and that path must keep working unchanged. */
+    public function test_warm_dirsize_cache_still_works(): void
+    {
+        $probe = new SizeProbe();
+
+        $result = $probe->preRecurseDirsizeFilter(
+            false,
+            sys_get_temp_dir(),
+            null,
+            30,
+            ['/some/dir' => 1234]
+        );
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * A value already filtered upstream is passed straight through, cold cache
+     * or not — this callback must never clobber another plugin's answer.
+     */
+    public function test_upstream_size_is_returned_untouched_on_a_cold_cache(): void
+    {
+        $probe = new SizeProbe();
+
+        $this->assertSame(
+            4242,
+            $probe->preRecurseDirsizeFilter(4242, sys_get_temp_dir(), null, 30, false)
+        );
+    }
+
+    /**
+     * Core marks arguments 3-5 optional. A third-party plugin applying the
+     * filter with fewer arguments must not produce an ArgumentCountError.
+     */
+    public function test_filter_tolerates_being_applied_with_fewer_arguments(): void
+    {
+        $probe = new SizeProbe();
+
+        $this->assertFalse($probe->preRecurseDirsizeFilter(false, sys_get_temp_dir()));
+    }
+}


### PR DESCRIPTION
Fixes #521.

WordPress core does not pass a `WP_User` to `user_profile_update_errors`. `edit_user()` builds a bare `stdClass` and passes it by reference:

```php
// wp-admin/includes/user.php
$user = new stdClass();
if ( $user_id ) { $user->ID = $user_id; ... }   // ID only on update
...
$user->role = $new_role;                        // only if the actor can promote_users
do_action_ref_array( 'user_profile_update_errors', array( &$errors, $update, &$user ) );
```

Callbacks that demanded a `WP_User` threw a TypeError at argument binding — before any early return in the body, and outside `PasswordPolicyModule::validatePassword()`'s `catch(\Throwable)`. Blast radius was every wp-admin route that edits a user, an administrator opening their own `profile.php` included, whether or not a password was typed.

## The five fatals

| # | Site | Core passes | We demanded | Gate |
|---|---|---|---|---|
| A | `PasswordPolicyModule::validateOnProfileUpdate` | `stdClass` | `\WP_User` | any password rule |
| B | `HardeningModule` force_unique_nickname closure | `stdClass` | `\WP_User` | `forceUniqueNickname`, an independent toggle |
| C | `Site2faModule::blockXmlrpcFor2faUser` | `WP_Error` | `\WP_User` | 2FA + `blockXmlrpcFor2faUsers` |
| D | `SizeProbe::preRecurseDirsizeFilter` arg 5 | `false` | `array` | **none — every site, every boot** |
| E | `PasswordPolicyModule::validateOnPasswordReset` | `WP_User\|WP_Error` | `\WP_User` | any password rule |

**D is the most severe.** `recurse_dirsize()` seeds argument 5 from `get_transient( 'dirsize_cache' )`, which returns `false` when cold, and core normalises it only *after* `apply_filters()`. `Plugin::registerHooks()` binds that filter unconditionally, and it could not self-heal — the transient is written only after the walk the fatal prevented. Triggers: fresh install, any transient or object-cache flush, Site Health → Info → Directory sizes, the daily size walk, and on multisite every media upload via `get_space_used()`.

**B is why fixing the reported file was not enough** — a site with no password policy but that one hardening toggle crashed identically.

## Widening the hints alone would have been worse than the crash

The `stdClass` has no `roles`, no `caps`, and on create no `ID`. Relaxing the hints would have made every role-scoped rule (`SecurityPolicy::effectiveMinZxcvbnScore`, `::blockCompromisedFor`) read an empty role list and fall back to the site default — silent under-enforcement of a security policy, with no error and no log, sitting behind an exception swallow that only logs under `WP_DEBUG`.

So the hook object is not trusted for role decisions. `ProfileUpdateUser::resolve()` resolves a real user:

- **update** — load the stored user with `get_userdata()`. When the same submit also changes the role, take the **union** of stored and submitted roles, so a promotion is held to the target role's rule. Always returns a *fresh* object: `get_userdata()` hands back the request-cached `WP_User`, and writing a unioned role list onto it would corrupt that cache.
- **create** — no stored user exists. Use the submitted role, or the site's `default_role` option that `wp_insert_user()` is about to apply. Either way the rule is evaluated against the role the account will actually receive.

`SecurityPolicy::userRoles()` gains a `role` fallback as the backstop for any future caller that reaches it unresolved.

## C is removed, not widened

Core fires `xmlrpc_login_error` only from inside `if ( is_wp_error( $user ) )` in `class-wp-xmlrpc-server.php` — only once authentication has **already failed**, and its second argument is that `WP_Error`. The callback could not block a successful login, its body was `return $error;`, and it could only ever crash. The functional XML-RPC block already lives on `authenticate` in `interceptXmlrpc2fa()` and is untouched.

## The recovery constant now means what it says

`define('WPMGR_DISABLE_SITE_2FA', true)` is the documented escape hatch for an admin locked out by this plugin's auth policy. `Site2faModule` and `PasswordPolicyModule` honoured it; `HardeningModule` did not — so an operator who set it silenced A and was still refused by B.

Deliberately scoped to auth policy: it gates `applyLoginIdentifier()` and `applyForceUniqueNickname()`, the two rules that can keep an administrator out. It does **not** gate the file-editor block, xmlrpc mode, REST restriction, force-SSL, author-archive enumeration or the IP/user-agent bans. A test pins that boundary.

**Correction (post-review):** this paragraph originally said those six "cannot lock anyone out." That's false, and the security review disproved it by execution: `applyBanFilters()` registers on `init` priority 1 unconditionally (no gate, no flag), `init` fires on `wp-login.php`, the match is an unbounded case-insensitive substring (`stripos($ua, $pattern) !== false`) with no length or genericity check, and a match ends in `exit('Access denied.')`. A ban pattern of "Mozilla", "Chrome", "Safari", "AppleWebKit" or "Gecko" 403s the administrator's own login page exactly like everyone else's. The scoping above is still correct; only the justification was wrong. The true reason the other six stay ungated is that silently dropping a site's file-editor lock, xmlrpc mode, REST restriction, forced SSL, author-archive block or IP/user-agent bans the moment someone sets the recovery constant would risk a worse regression than the lockout it is meant to fix. That ban-filter lockout risk is real, pre-existing, and is now filed and scoped separately as #529 — it is not fixed by this PR. The docblock on `HardeningModule::authPolicyDisabled()` has been corrected to say the same thing; this comment corrects the claim here since the commit message that first stated it is not rewritten.

## Proof

Tests enter at the callback boundary and construct the object core actually passes, including the create case with no `ID`. The existing suite is why this shipped: `PasswordPolicyModuleTest`'s `makeUser()` returns a `WP_User`, so it handed the chain exactly the type the chain declared, and no test called `validateOnProfileUpdate` at all.

Red/green output for every callback is in the PR discussion. Over-fire coverage: a strong password is still accepted, an out-of-scope role is still not enforced against, a genuine `WP_User` still resolves with its own roles, a warm dirsize cache still works, and the recovery constant still leaves IP bans in place.

One test-isolation defect was found and fixed in the same change: `Site2faModuleTest` defines `WPMGR_DISABLE_SITE_2FA` process-globally, so once B honoured that constant the three `force_unique_nickname` regression tests registered no closure, asserted nothing and passed **green** in a whole-suite run while failing when the file ran alone. They now run in separate processes and assert the constant is unset before proceeding.

## Out of scope, filed separately

`class-site-2fa-module.php:247` registers on `wp_authenticate_application_password`, which in core is a **function** (`wp-includes/user.php:372`), not a filter — there is no `apply_filters()` by that name, so that app-password blocking control never runs. A silently dead security control, not a fatal. Needs its own change and a `security-reviewer` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with WordPress profile-update hooks, including varied user data formats and incomplete inputs.
  - Preserved password, nickname, login-identifier, and role-based security policy enforcement during user creation and updates.
  - Added safe recovery handling for configured authentication policy exceptions.
  - Prevented directory-size checks from failing when cached data is unavailable.
  - Improved XML-RPC two-factor authentication blocking during login.

- **Tests**
  - Added regression coverage for profile updates, security policies, XML-RPC authentication, and cold directory-size caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
