### PR TITLE
ci(agent): gate PHPStan, and fail an incomplete analysis distinctly (#525)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,18 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      # The guard's own regression suite. It needs php and nothing else, so a
+      # guard whose behaviour has regressed is caught here, before the composer
+      # install below, rather than after it. The suite runs FIRST for the same
+      # reason the version surface suite does: a broken guard must not be able
+      # to pass by failing open.
+      #
+      # working-directory is overridden because this job otherwise runs from
+      # apps/agent, and these two paths are repo relative.
+      - name: Agent PHPStan guard self-test
+        working-directory: ${{ github.workspace }}
+        run: scripts/check-agent-phpstan_test.sh
+
       - name: Get composer cache dir
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
@@ -510,3 +522,24 @@ jobs:
 
       - name: Test
         run: composer test
+
+      # PHPStan over the plugin. The plugin has owned a level 8 PHPStan config
+      # with the WordPress extension, the stubs and a baseline for a long time,
+      # and until this step existed nothing in CI ever invoked it, so it had
+      # never produced a result at all.
+      #
+      # Why a script and not `composer analyse`: the exit code is not the
+      # verdict. PHPStan exits 1 both when it analysed the whole plugin and
+      # found things and when it aborted in the parser having analysed almost
+      # nothing, and with --error-format=json the only thing distinguishing
+      # them is a line on stderr that the JSON report itself does not carry.
+      # Read carelessly, an aborted run looks like a short list of findings,
+      # and the obvious way to clear a short list of findings is to widen
+      # phpstan-baseline.neon, which turns this step green and leaves the
+      # analyser blind over the entire plugin. The guard reports an incomplete
+      # analysis as its own outcome, with its own exit code and a message that
+      # says not to baseline it, and scripts/check-agent-phpstan_test.sh holds
+      # that behaviour in place.
+      - name: Agent PHPStan static analysis
+        working-directory: ${{ github.workspace }}
+        run: scripts/check-agent-phpstan.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,12 +550,16 @@ jobs:
       # So findings are reported loudly and do not fail the build yet.
       #
       # This is NOT a soft gate. --allow-findings relaxes the findings outcome
-      # and nothing else. A parse abort, an unparseable report, a run that
-      # reports nothing while exiting non-zero, a missing binary, a missing
-      # vendor tree and a missing config all still fail this step with it set,
-      # and the guard's suite has a case pinning each of those. The parse abort
-      # is enforced from day one because it cannot be cleared by widening the
-      # baseline: PHPStan will not generate a baseline from a run that aborted.
+      # and nothing else. A parse abort, a top-level analysis error (an entry
+      # in PHPStan's own "errors" array, not attached to any file — the
+      # analyser saying part of the run itself failed), an unparseable report,
+      # a run that reports nothing while exiting non-zero, a missing binary, a
+      # missing vendor tree and a missing config all still fail this step with
+      # it set, and the guard's suite has a case pinning each of those. The
+      # parse abort and the top-level analysis error are both enforced from day
+      # one because neither can be cleared by widening the baseline: PHPStan
+      # will not generate a baseline entry from a run that aborted or a
+      # top-level error.
       #
       # TO MAKE IT FULLY BLOCKING: delete --allow-findings from the line below.
       # That is the whole change. Do it once the backlog has been triaged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,25 @@ jobs:
       # analysis as its own outcome, with its own exit code and a message that
       # says not to baseline it, and scripts/check-agent-phpstan_test.sh holds
       # that behaviour in place.
+      #
+      # WHY --allow-findings IS HERE, AND WHEN TO REMOVE IT. Repairing the
+      # parse abort does not reveal a clean plugin, it reveals a large backlog
+      # that was never visible because the analyser never ran. Making that
+      # backlog blocking on day one has one predictable outcome: the first red
+      # PR is cleared by regenerating the baseline, which swallows the genuine
+      # findings along with the known noise and leaves this step green forever.
+      # So findings are reported loudly and do not fail the build yet.
+      #
+      # This is NOT a soft gate. --allow-findings relaxes the findings outcome
+      # and nothing else. A parse abort, an unparseable report, a run that
+      # reports nothing while exiting non-zero, a missing binary, a missing
+      # vendor tree and a missing config all still fail this step with it set,
+      # and the guard's suite has a case pinning each of those. The parse abort
+      # is enforced from day one because it cannot be cleared by widening the
+      # baseline: PHPStan will not generate a baseline from a run that aborted.
+      #
+      # TO MAKE IT FULLY BLOCKING: delete --allow-findings from the line below.
+      # That is the whole change. Do it once the backlog has been triaged.
       - name: Agent PHPStan static analysis
         working-directory: ${{ github.workspace }}
-        run: scripts/check-agent-phpstan.sh
+        run: scripts/check-agent-phpstan.sh --allow-findings

--- a/Makefile
+++ b/Makefile
@@ -469,6 +469,9 @@ agent-check: ## Fast phpcs pass over apps/agent (committed phpcs.xml.dist). NOT 
 #
 # agent-phpstan-test is the guard's own regression suite; run it after editing
 # the guard. Needs a vendor tree: run `composer install` in apps/agent first.
+# This target is STRICTER than CI on purpose. CI passes --allow-findings while
+# the backlog is triaged; locally you want the truth, so this one fails on
+# findings too. Add --allow-findings by hand to see exactly what CI sees.
 .PHONY: agent-phpstan
 agent-phpstan: ## PHPStan static analysis over apps/agent (fails on findings AND on an incomplete analysis)
 	scripts/check-agent-phpstan.sh

--- a/Makefile
+++ b/Makefile
@@ -457,6 +457,26 @@ agent-check: ## Fast phpcs pass over apps/agent (committed phpcs.xml.dist). NOT 
 		|| composer update --no-interaction --quiet --ignore-platform-reqs)
 	cd apps/agent && vendor/bin/phpcs -d memory_limit=1G
 
+# The static analysis gate for the plugin, and the same one CI runs.
+#
+# It is a script rather than a `vendor/bin/phpstan` line because the decision is
+# not the exit code. PHPStan exits 1 both when it analysed everything and found
+# things and when it aborted in the parser having analysed almost nothing, and
+# in JSON mode the only signal telling those apart is on stderr. Answering the
+# second case by widening phpstan-baseline.neon turns the build green and leaves
+# the analyser blind, so the guard reports it as its own outcome with its own
+# exit code. See the header of the script.
+#
+# agent-phpstan-test is the guard's own regression suite; run it after editing
+# the guard. Needs a vendor tree: run `composer install` in apps/agent first.
+.PHONY: agent-phpstan
+agent-phpstan: ## PHPStan static analysis over apps/agent (fails on findings AND on an incomplete analysis)
+	scripts/check-agent-phpstan.sh
+
+.PHONY: agent-phpstan-test
+agent-phpstan-test: ## Run the agent PHPStan guard's regression suite
+	scripts/check-agent-phpstan_test.sh
+
 .PHONY: agent-format
 agent-format: ## phpcbf auto-fix over apps/agent, then re-lint
 	cd apps/agent && vendor/bin/phpcbf -d memory_limit=1G --report-summary --report-source || true

--- a/scripts/check-agent-phpstan.sh
+++ b/scripts/check-agent-phpstan.sh
@@ -65,6 +65,13 @@
 #      parser, it produced nothing parseable, or it reported no findings while
 #      exiting non-zero. THIS IS NOT A FINDING COUNT. Never respond to a 3 by
 #      editing the baseline.
+#   4  PHPStan reported a top-level analysis error: an entry in the report's
+#      "errors" array, not attached to any file. THIS IS ALSO NOT A FINDING
+#      COUNT. It is the analyser saying part of the run itself failed (an
+#      internal error, for instance), not that it examined the code and found
+#      something. Distinct from 3 because the two are diagnosed differently:
+#      3 means the source would not parse, 4 means the analyser broke while
+#      trying.
 #
 # Any non-zero exit fails the build. The codes exist to make the reason legible,
 # not to grade severity.
@@ -80,11 +87,11 @@
 #
 # So the findings outcome can be made advisory while the backlog is triaged.
 # What --allow-findings does NOT relax is everything that means the analysis is
-# not trustworthy: exit 2 and exit 3 still fail with it set. That split is the
-# whole reason the outcomes have separate exit codes. The parse abort in
-# particular is safe to enforce from day one, because it is unambiguous and
-# cannot be cleared by widening the baseline: PHPStan will not generate a
-# baseline from a run that aborted.
+# not trustworthy: exit 2, exit 3 and exit 4 all still fail with it set. That
+# split is the whole reason the outcomes have separate exit codes. The parse
+# abort and the top-level analysis error are both safe to enforce from day
+# one, because both are unambiguous and neither can be cleared by widening the
+# baseline: PHPStan will not generate a baseline entry for either one.
 #
 # This flag is temporary by design. Removing it from the CI step is the single
 # change that makes the gate fully blocking, and that should happen as soon as
@@ -130,6 +137,8 @@ Exit 1: the analysis completed and reported findings.
 Exit 2: the environment cannot run the analysis (php, PHPStan, vendor, config).
 Exit 3: the analysis ran but its result cannot be trusted (parse abort,
         unparseable output, or no findings alongside a non-zero exit).
+Exit 4: PHPStan reported a top-level analysis error (not tied to any file).
+        Never suppressible by --allow-findings or WPMGR_PHPSTAN_ALLOW_FINDINGS.
 USAGE
 }
 
@@ -170,6 +179,7 @@ EXIT_CLEAN=0
 EXIT_FINDINGS=1
 EXIT_ENV=2
 EXIT_UNTRUSTWORTHY=3
+EXIT_ANALYSIS_ERROR=4
 
 # The marker PHPStan prints to stderr when it gave up early. Matched as plain
 # ASCII on purpose: the real line is wrapped in warning emoji and may be
@@ -429,9 +439,6 @@ print_findings() {
   if [ "$MSG_ROWS" -gt "$MAX_LISTED" ]; then
     printf '  ... and %s more %s not listed.\n' "$((MSG_ROWS - MAX_LISTED))" "$_kind"
   fi
-  printf '%s\n' "$SUMMARY_OUT" | grep '^E	' | while IFS='	' read -r _tag _msg; do
-    printf '  [analysis error] %s\n' "$_msg"
-  done | sort
 }
 
 # --- Outcome: the analysis gave up. Checked before any count is reported, so
@@ -495,15 +502,50 @@ if [ "$STATUS" != ok ]; then
   exit "$EXIT_UNTRUSTWORTHY"
 fi
 
+# TOP_FINDINGS: entries in the report's top level "errors" array. These are not
+# attached to any file, which is exactly what marks them out: PHPStan reports a
+# problem WITH THE CODE under a file in "files", and reports a problem WITH THE
+# RUN ITSELF here. An internal analyser error is the textbook case. This is the
+# same category as the parse abort above, not the ordinary-findings category
+# below it, and it is checked first and unconditionally for the same reason:
+# the one signal that says "do not trust this run" must never be the signal
+# --allow-findings suppresses.
+#
+# Believe whichever of the totals field and the actual row count is worse,
+# same reasoning as the ordinary-findings count further down.
+TOP_FINDINGS="$TOP_ERRORS"
+if [ "$TOP_ROWS" -gt "$TOP_FINDINGS" ]; then
+  TOP_FINDINGS="$TOP_ROWS"
+fi
+
+# --- Outcome: a top-level analysis error. Never a finding, never advisory.
+if [ "$TOP_FINDINGS" -gt 0 ]; then
+  err "PHPStan reported $TOP_FINDINGS top-level analysis error(s); the result cannot be trusted."
+  detail ''
+  detail 'THIS IS NOT A FINDING COUNT, AND --allow-findings DOES NOT REACH IT.'
+  detail 'A top-level error is not attached to any file: PHPStan is saying part of'
+  detail 'the run itself failed (an internal analyser error, for instance), not'
+  detail 'that it examined the code and found something to report. Whatever'
+  detail 'ordinary findings came back alongside it cannot be trusted either, so'
+  detail 'none of them are listed here.'
+  detail ''
+  detail 'What PHPStan reported:'
+  printf '%s\n' "$SUMMARY_OUT" | grep '^E	' | while IFS='	' read -r _tag _msg; do
+    printf '    %s\n' "$_msg"
+  done | sort >&2
+  exit "$EXIT_ANALYSIS_ERROR"
+fi
+
 # The count is computed here and printed from the computation. It is never
 # written down anywhere, in this script or in the workflow that calls it.
-FINDINGS=$((FILE_ERRORS + TOP_ERRORS))
-ROWS=$((MSG_ROWS + TOP_ROWS))
+# File-scoped only: a top-level analysis error is handled above, on its own
+# exit code, and must never be folded back in here.
+FINDINGS="$FILE_ERRORS"
 # If the totals and the reported messages disagree, believe whichever is worse.
 # A totals block that says zero over a non-empty message list is exactly the
 # shape of a zero that must not read as a pass.
-if [ "$ROWS" -gt "$FINDINGS" ]; then
-  FINDINGS="$ROWS"
+if [ "$MSG_ROWS" -gt "$FINDINGS" ]; then
+  FINDINGS="$MSG_ROWS"
 fi
 
 # --- Outcome: zero findings, but the run failed. Never a pass.

--- a/scripts/check-agent-phpstan.sh
+++ b/scripts/check-agent-phpstan.sh
@@ -36,6 +36,22 @@
 # its own exit code, distinct from "the analysis completed and found things",
 # and says in the failure message that the entries must not be baselined.
 #
+# THERE IS NO COVERAGE FIELD TO CHECK, SO DO NOT GO LOOKING FOR ONE. The obvious
+# way to detect an incomplete run is to compare files analysed against files
+# expected. The report format has no such field. Dumped from the installed
+# version, the document has exactly three top level keys, totals, files and
+# errors, and totals has exactly two, errors and file_errors. There is no
+# files_analysed, no scanned count, no coverage and no incomplete flag anywhere
+# in it. A completeness check written against a field like that cannot fire,
+# ever, and would sit in CI looking like protection while providing none.
+#
+# The two signals below are the only two that exist, and both are verified
+# against real output rather than assumed:
+#   1. the sentence PHPStan prints on stderr, which is not in the report at all;
+#   2. the phpstan.parse identifier on the individual messages, which is.
+# If a future PHPStan changes either, this guard must go red and be rewritten
+# against whatever replaced them, not quietly relaxed.
+#
 # EXIT CODES. Distinct on purpose, so CI logs and the regression suite can tell
 # the outcomes apart without matching on prose:
 #
@@ -52,6 +68,27 @@
 #
 # Any non-zero exit fails the build. The codes exist to make the reason legible,
 # not to grade severity.
+#
+# --allow-findings, AND WHY IT IS NOT A WEAKENING. Repairing the parse abort
+# does not reveal a clean plugin. It reveals a large backlog that was never
+# visible because the analyser never ran, a significant part of it the known
+# $wpdb and defensive-narrowing noise that phpstan.neon's own comment describes.
+# Landing a fully blocking gate on top of that backlog has one predictable
+# outcome: the first red PR is cleared by regenerating the baseline, which
+# swallows the genuine findings along with the noise and leaves a gate that is
+# green forever. A guard silenced on its first day guards nothing.
+#
+# So the findings outcome can be made advisory while the backlog is triaged.
+# What --allow-findings does NOT relax is everything that means the analysis is
+# not trustworthy: exit 2 and exit 3 still fail with it set. That split is the
+# whole reason the outcomes have separate exit codes. The parse abort in
+# particular is safe to enforce from day one, because it is unambiguous and
+# cannot be cleared by widening the baseline: PHPStan will not generate a
+# baseline from a run that aborted.
+#
+# This flag is temporary by design. Removing it from the CI step is the single
+# change that makes the gate fully blocking, and that should happen as soon as
+# the backlog has been triaged.
 #
 # RUN IT:
 #   make agent-phpstan          or  scripts/check-agent-phpstan.sh
@@ -79,12 +116,16 @@ set -uo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/check-agent-phpstan.sh [AGENT_DIR]
+Usage: scripts/check-agent-phpstan.sh [--allow-findings] [AGENT_DIR]
 
 AGENT_DIR defaults to apps/agent inside the repository this script lives in,
 or to $WPMGR_AGENT_DIR when that is set.
 
-Exit 0: the analysis completed and found nothing.
+  --allow-findings   Report findings loudly but exit 0 for them. An incomplete
+                     or unrunnable analysis STILL FAILS. See the header.
+
+Exit 0: the analysis completed and found nothing (or found things, under
+        --allow-findings).
 Exit 1: the analysis completed and reported findings.
 Exit 2: the environment cannot run the analysis (php, PHPStan, vendor, config).
 Exit 3: the analysis ran but its result cannot be trusted (parse abort,
@@ -92,15 +133,37 @@ Exit 3: the analysis ran but its result cannot be trusted (parse abort,
 USAGE
 }
 
-case "${1:-}" in
-  -h | --help)
-    usage
-    exit 0
-    ;;
-esac
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-AGENT_DIR_IN="${1:-${WPMGR_AGENT_DIR:-$SCRIPT_DIR/../apps/agent}}"
+ALLOW_FINDINGS=0
+if [ "${WPMGR_PHPSTAN_ALLOW_FINDINGS:-}" = "1" ]; then
+  ALLOW_FINDINGS=1
+fi
+AGENT_DIR_IN=''
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --allow-findings)
+      ALLOW_FINDINGS=1
+      ;;
+    -*)
+      printf 'ERROR: unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      AGENT_DIR_IN="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$AGENT_DIR_IN" ]; then
+  AGENT_DIR_IN="${WPMGR_AGENT_DIR:-$SCRIPT_DIR/../apps/agent}"
+fi
 
 # Exit codes, named so the branches below read as decisions.
 EXIT_CLEAN=0
@@ -459,6 +522,18 @@ fi
 
 # --- Outcome: the analysis completed and found things.
 if [ "$FINDINGS" -gt 0 ]; then
+  if [ "$ALLOW_FINDINGS" -eq 1 ]; then
+    # Advisory. Deliberately not the OK line: this is not a clean result, and a
+    # reader skimming for OK must not find one here.
+    printf 'ADVISORY: PHPStan completed and reported %s finding(s), which are not failing this build.\n' "$FINDINGS"
+    print_findings 'finding(s)'
+    printf '  \n'
+    printf '  These are real findings over the whole plugin, not a parse abort.\n'
+    printf '  They are advisory only while the backlog is triaged, and they are\n'
+    printf '  meant to be worked down, not baselined away in one command.\n'
+    printf '  An incomplete or unrunnable analysis still fails this build.\n'
+    exit "$EXIT_CLEAN"
+  fi
   err "PHPStan completed and reported $FINDINGS finding(s)."
   print_findings 'finding(s)' >&2
   detail ''

--- a/scripts/check-agent-phpstan.sh
+++ b/scripts/check-agent-phpstan.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+# scripts/check-agent-phpstan.sh
+#
+# Runs the agent plugin's PHPStan analysis and decides whether the result may
+# be trusted. Trust is the whole point of this script: PHPStan can exit 1 while
+# having analysed almost nothing, and telling that apart from "it analysed
+# everything and found some things" is a decision, not a line count.
+#
+# WHY THIS EXISTS. apps/agent has owned PHPStan at level 8 with the WordPress
+# extension, the WordPress stubs and a curated baseline for a long time, and
+# nothing in .github/workflows ever invoked it. When it was finally run by hand
+# it turned out to have been aborting in the parser, so the level-8 analysis
+# that the plugin was believed to be held to had never produced a result at all.
+# A gate that nobody runs is indistinguishable from no gate, which is why the
+# invocation now lives in CI and the decision logic lives here, in a file with
+# a committed regression suite, instead of in a YAML block scalar.
+#
+# THE FAILURE MODE THIS IS BUILT AGAINST. When PHPStan hits a syntax error it
+# cannot recover from, it reports the syntax errors as ordinary file errors,
+# gives up on the rest of the analysis, and says so. Read carelessly that looks
+# like a small, finite list of findings, and the obvious way to make a small
+# finite list of findings go away is to widen phpstan-baseline.neon. Do that and
+# the exit code goes green while the analyser stays blind, permanently, over the
+# entire plugin.
+#
+# What makes it genuinely easy to get wrong is where the signals are. With
+# --error-format=json, an aborted run puts the syntax errors in the normal
+# per-file structure, reports totals.errors as zero because that field counts
+# only non-file errors, leaves the top level "errors" array empty, and prints
+# the "Result is incomplete because of severe errors" warning to STDERR ONLY,
+# where nothing reading the JSON document will ever see it. So a gate that reads
+# stdout alone sees a handful of ordinary findings and no incompleteness signal
+# whatsoever. Both streams have to be read.
+#
+# This script therefore treats an incomplete analysis as its own outcome with
+# its own exit code, distinct from "the analysis completed and found things",
+# and says in the failure message that the entries must not be baselined.
+#
+# EXIT CODES. Distinct on purpose, so CI logs and the regression suite can tell
+# the outcomes apart without matching on prose:
+#
+#   0  The analysis completed and found nothing.
+#   1  The analysis completed and reported findings. Fix them, or baseline them
+#      deliberately.
+#   2  The environment is not able to run the analysis: no php, no PHPStan
+#      binary, no vendor tree, no config, no such directory. Nothing was
+#      analysed and nothing is claimed.
+#   3  The analysis ran but its result cannot be trusted: it aborted in the
+#      parser, it produced nothing parseable, or it reported no findings while
+#      exiting non-zero. THIS IS NOT A FINDING COUNT. Never respond to a 3 by
+#      editing the baseline.
+#
+# Any non-zero exit fails the build. The codes exist to make the reason legible,
+# not to grade severity.
+#
+# RUN IT:
+#   make agent-phpstan          or  scripts/check-agent-phpstan.sh
+#   make agent-phpstan-test     or  scripts/check-agent-phpstan_test.sh
+#   scripts/check-agent-phpstan.sh /path/to/some/other/agent/dir
+#
+# ENVIRONMENT OVERRIDES. All optional; empty is the same as unset.
+#   WPMGR_AGENT_PHP_BIN    php binary to use instead of the one on PATH.
+#   WPMGR_PHPSTAN_BIN      PHPStan binary to use instead of the vendored one.
+#   WPMGR_PHPSTAN_MEMORY   memory_limit for the analysis. Default below.
+#
+# THERE IS DELIBERATELY NO FALLBACK TO A PHPStan ON PATH. The plugin pins its
+# PHPStan, its WordPress extension and its stubs through composer, and the
+# config includes them by relative path out of vendor/. A PHPStan picked up from
+# PATH would be a different version analysing without the extension, and would
+# produce a confident answer that does not match the one CI produces. A wrong
+# answer from a gate is worse than an absent one, so an absent vendored binary
+# is an error that names the command to run, never a quiet substitution.
+#
+# PORTABILITY. bash 3.2 (what macOS ships) and POSIX tools, so it behaves the
+# same on a darwin laptop and on the ubuntu runner. No mapfile, no associative
+# arrays, no grep -P.
+
+set -uo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-agent-phpstan.sh [AGENT_DIR]
+
+AGENT_DIR defaults to apps/agent inside the repository this script lives in,
+or to $WPMGR_AGENT_DIR when that is set.
+
+Exit 0: the analysis completed and found nothing.
+Exit 1: the analysis completed and reported findings.
+Exit 2: the environment cannot run the analysis (php, PHPStan, vendor, config).
+Exit 3: the analysis ran but its result cannot be trusted (parse abort,
+        unparseable output, or no findings alongside a non-zero exit).
+USAGE
+}
+
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_DIR_IN="${1:-${WPMGR_AGENT_DIR:-$SCRIPT_DIR/../apps/agent}}"
+
+# Exit codes, named so the branches below read as decisions.
+EXIT_CLEAN=0
+EXIT_FINDINGS=1
+EXIT_ENV=2
+EXIT_UNTRUSTWORTHY=3
+
+# The marker PHPStan prints to stderr when it gave up early. Matched as plain
+# ASCII on purpose: the real line is wrapped in warning emoji and may be
+# colourised, and neither of those is anything to depend on.
+INCOMPLETE_MARKER='Result is incomplete because of severe errors'
+# The error identifier PHPStan attaches to a source file it could not parse.
+# These are reported with "ignorable": false, so they cannot be baselined away
+# even by someone trying to; their presence always means the run gave up.
+PARSE_IDENTIFIER='phpstan.parse'
+
+MEMORY="${WPMGR_PHPSTAN_MEMORY:-2G}"
+# How many findings to print in full before summarising the remainder. Only
+# affects the report, never the decision.
+MAX_LISTED=50
+
+err() { printf 'ERROR: %s\n' "$1" >&2; }
+detail() { printf '  %s\n' "$1" >&2; }
+ok() { printf 'OK: %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Preconditions. Each one names the thing that is missing and the command that
+# would fix it, and each one exits non-zero. Nothing here may fall through to
+# "well, no findings then": a check that cannot run has not passed.
+# ---------------------------------------------------------------------------
+
+if [ ! -d "$AGENT_DIR_IN" ]; then
+  err "the agent directory does not exist: $AGENT_DIR_IN"
+  detail 'Pass a directory, or run this from a checkout that has apps/agent.'
+  exit "$EXIT_ENV"
+fi
+
+# Physical path, so it matches the realpath-resolved paths PHPStan reports and
+# the prefix strip below actually strips. On macOS /tmp is a symlink into
+# /private/tmp, and a logical path would silently stop matching.
+AGENT_DIR="$(cd "$AGENT_DIR_IN" && pwd -P)" || exit "$EXIT_ENV"
+
+CONFIG=''
+for _candidate in phpstan.neon phpstan.neon.dist; do
+  if [ -f "$AGENT_DIR/$_candidate" ]; then
+    CONFIG="$_candidate"
+    break
+  fi
+done
+if [ -z "$CONFIG" ]; then
+  err "no PHPStan config in $AGENT_DIR (looked for phpstan.neon, phpstan.neon.dist)."
+  detail 'Without a config the analysis would silently run at defaults, which is not the gate.'
+  exit "$EXIT_ENV"
+fi
+
+if [ ! -d "$AGENT_DIR/vendor" ]; then
+  err "$AGENT_DIR/vendor does not exist, so the analysis cannot run."
+  detail 'The config includes the WordPress extension and stubs from vendor/.'
+  detail 'Run: composer install --prefer-dist --no-interaction   (in the agent directory)'
+  exit "$EXIT_ENV"
+fi
+
+# php, resolved at the point of use. Where a toolchain binary lives is a fact
+# about the machine, so it is looked up here rather than assumed, and an empty
+# answer stops the run instead of skipping it.
+PHP_BIN="${WPMGR_AGENT_PHP_BIN:-}"
+if [ -n "$PHP_BIN" ]; then
+  if ! command -v "$PHP_BIN" >/dev/null 2>&1; then
+    err "WPMGR_AGENT_PHP_BIN is set to '$PHP_BIN', which is not an executable command."
+    detail 'Unset it to use the php on PATH, or point it at a real php binary.'
+    exit "$EXIT_ENV"
+  fi
+else
+  PHP_BIN="$(command -v php 2>/dev/null || true)"
+  if [ -z "$PHP_BIN" ]; then
+    err 'no php binary found on PATH, so the analysis cannot run.'
+    detail 'Install PHP, or set WPMGR_AGENT_PHP_BIN to the binary to use.'
+    detail 'This step is never skipped: an unrunnable analysis is a failure, not a pass.'
+    exit "$EXIT_ENV"
+  fi
+fi
+
+PHPSTAN_BIN="${WPMGR_PHPSTAN_BIN:-}"
+if [ -n "$PHPSTAN_BIN" ]; then
+  if [ ! -f "$PHPSTAN_BIN" ]; then
+    err "WPMGR_PHPSTAN_BIN is set to '$PHPSTAN_BIN', which is not a file."
+    detail 'Unset it to use the vendored PHPStan, or point it at a real one.'
+    exit "$EXIT_ENV"
+  fi
+else
+  PHPSTAN_BIN="$AGENT_DIR/vendor/bin/phpstan"
+  if [ ! -f "$PHPSTAN_BIN" ]; then
+    err "no PHPStan binary at vendor/bin/phpstan in $AGENT_DIR."
+    detail 'A vendor/ built with --no-dev has no dev tools in it.'
+    detail 'Run: composer install --prefer-dist --no-interaction   (in the agent directory)'
+    detail 'There is no fallback to a PHPStan on PATH: see the header of this script.'
+    exit "$EXIT_ENV"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Run the analysis.
+# ---------------------------------------------------------------------------
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/wpmgr-agent-phpstan.XXXXXX")" || exit "$EXIT_ENV"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+OUT_FILE="$WORK/stdout"
+ERR_FILE="$WORK/stderr"
+
+# The JSON extractor. PHPStan's report is a JSON document and picking fields out
+# of it with grep would be guessing; php is already a hard requirement three
+# lines above, so the document is parsed by a parser. Key order in the document
+# is irrelevant to json_decode, which is what keeps this insensitive to how
+# PHPStan happens to order its output.
+SUMMARY_PHP="$WORK/summarise.php"
+cat >"$SUMMARY_PHP" <<'SUMMARY'
+<?php
+// Reads a PHPStan --error-format=json document and prints a flat, tab
+// separated summary for the shell. Prints STATUS=empty or STATUS=badjson
+// rather than guessing, so the caller can tell "nothing came back" apart from
+// "nothing was wrong".
+$path = isset($argv[1]) ? $argv[1] : '';
+$raw = @file_get_contents($path);
+if ($raw === false || trim($raw) === '') {
+    echo "STATUS=empty\n";
+    exit(0);
+}
+$doc = json_decode($raw, true);
+if (!is_array($doc) || !isset($doc['totals']) || !is_array($doc['totals'])) {
+    echo "STATUS=badjson\n";
+    exit(0);
+}
+$fileErrors = isset($doc['totals']['file_errors']) ? (int) $doc['totals']['file_errors'] : 0;
+$topErrors = isset($doc['totals']['errors']) ? (int) $doc['totals']['errors'] : 0;
+
+$flatten = function ($s) {
+    return str_replace(array("\t", "\r", "\n"), ' ', (string) $s);
+};
+
+$parse = 0;
+$rows = array();
+if (isset($doc['files']) && is_array($doc['files'])) {
+    foreach ($doc['files'] as $file => $info) {
+        if (!is_array($info) || !isset($info['messages']) || !is_array($info['messages'])) {
+            continue;
+        }
+        foreach ($info['messages'] as $m) {
+            if (!is_array($m)) {
+                continue;
+            }
+            $id = isset($m['identifier']) ? (string) $m['identifier'] : '';
+            if ($id === 'phpstan.parse') {
+                $parse++;
+            }
+            $rows[] = "F\t" . $flatten($file)
+                . "\t" . (isset($m['line']) ? $flatten($m['line']) : '?')
+                . "\t" . ($id === '' ? '-' : $flatten($id))
+                . "\t" . (isset($m['message']) ? $flatten($m['message']) : '');
+        }
+    }
+}
+
+$tops = array();
+if (isset($doc['errors']) && is_array($doc['errors'])) {
+    foreach ($doc['errors'] as $e) {
+        if (is_string($e)) {
+            $tops[] = "E\t" . $flatten($e);
+        } elseif (is_array($e) && isset($e['message'])) {
+            $tops[] = "E\t" . $flatten($e['message']);
+        } else {
+            $tops[] = "E\t" . $flatten(json_encode($e));
+        }
+    }
+}
+
+echo "STATUS=ok\n";
+echo "FILE_ERRORS=" . $fileErrors . "\n";
+echo "TOP_ERRORS=" . $topErrors . "\n";
+echo "PARSE_IDS=" . $parse . "\n";
+echo "MSG_ROWS=" . count($rows) . "\n";
+echo "TOP_ROWS=" . count($tops) . "\n";
+foreach ($rows as $r) {
+    echo $r . "\n";
+}
+foreach ($tops as $t) {
+    echo $t . "\n";
+}
+SUMMARY
+
+printf 'Running PHPStan over %s (config %s, memory_limit %s).\n' \
+  "$(basename "$AGENT_DIR")" "$CONFIG" "$MEMORY"
+printf '  php:     %s\n' "$PHP_BIN"
+printf '  phpstan: %s\n' "$PHPSTAN_BIN"
+
+# cd first so the config's relative includes and paths resolve exactly as they
+# do for a developer running composer analyse by hand.
+cd "$AGENT_DIR" || exit "$EXIT_ENV"
+
+# --no-ansi so the stderr marker is plain text. Nothing between the command and
+# reading $?: a single intervening builtin would overwrite it, which is a bug
+# this script was written with in mind.
+"$PHP_BIN" -d memory_limit="$MEMORY" "$PHPSTAN_BIN" analyse \
+  --no-progress --no-ansi --error-format=json --configuration "$CONFIG" \
+  >"$OUT_FILE" 2>"$ERR_FILE"
+PHPSTAN_EXIT=$?
+
+# ---------------------------------------------------------------------------
+# Interpret it.
+# ---------------------------------------------------------------------------
+
+# rel PATH -> the path with the agent directory prefix removed, so the report
+# is identical on a laptop and on a runner and never leaks a home directory.
+# Falls back to cutting at /apps/agent/ and then to printing what it was given;
+# it must never fail, because a path it cannot shorten is still a path worth
+# showing.
+rel() {
+  case "$1" in
+    "$AGENT_DIR"/*) printf '%s' "${1#"$AGENT_DIR"/}" ;;
+    */apps/agent/*) printf '%s' "${1#*/apps/agent/}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+SUMMARY_OUT="$("$PHP_BIN" "$SUMMARY_PHP" "$OUT_FILE" 2>/dev/null)"
+STATUS="$(printf '%s\n' "$SUMMARY_OUT" | sed -n 's/^STATUS=//p' | sed -n '1p')"
+
+# The stderr marker is read before anything else is believed. It is the only
+# thing either stream says about completeness, and it is only ever on stderr.
+#
+# Matched against stderr alone, never against stdout: a finding's message text
+# could quote this sentence, and a gate that reddened on a quoted sentence in a
+# report would be failing for a reason unrelated to the analysis.
+INCOMPLETE=0
+if grep -qF "$INCOMPLETE_MARKER" "$ERR_FILE" 2>/dev/null; then
+  INCOMPLETE=1
+fi
+
+FILE_ERRORS=0
+TOP_ERRORS=0
+PARSE_IDS=0
+MSG_ROWS=0
+TOP_ROWS=0
+if [ "$STATUS" = ok ]; then
+  FILE_ERRORS="$(printf '%s\n' "$SUMMARY_OUT" | sed -n 's/^FILE_ERRORS=//p' | sed -n '1p')"
+  TOP_ERRORS="$(printf '%s\n' "$SUMMARY_OUT" | sed -n 's/^TOP_ERRORS=//p' | sed -n '1p')"
+  PARSE_IDS="$(printf '%s\n' "$SUMMARY_OUT" | sed -n 's/^PARSE_IDS=//p' | sed -n '1p')"
+  MSG_ROWS="$(printf '%s\n' "$SUMMARY_OUT" | sed -n 's/^MSG_ROWS=//p' | sed -n '1p')"
+  TOP_ROWS="$(printf '%s\n' "$SUMMARY_OUT" | sed -n 's/^TOP_ROWS=//p' | sed -n '1p')"
+fi
+: "${FILE_ERRORS:=0}" "${TOP_ERRORS:=0}" "${PARSE_IDS:=0}" "${MSG_ROWS:=0}" "${TOP_ROWS:=0}"
+
+# print_findings KIND: the finding rows, agent relative, sorted. Sorted so the
+# report is byte identical between runs whatever order PHPStan walked the files
+# in; ordering is a property of the analyser, not a property of the codebase.
+print_findings() {
+  _kind="$1"
+  # Sorted BEFORE the cap, so the listed subset is the first N of a stable
+  # order rather than the first N of whatever order the analyser emitted.
+  printf '%s\n' "$SUMMARY_OUT" | grep '^F	' | while IFS='	' read -r _tag _file _line _id _msg; do
+    printf '  %s:%s  [%s] %s\n' "$(rel "$_file")" "$_line" "$_id" "$_msg"
+  done | sort | sed -n "1,${MAX_LISTED}p"
+  if [ "$MSG_ROWS" -gt "$MAX_LISTED" ]; then
+    printf '  ... and %s more %s not listed.\n' "$((MSG_ROWS - MAX_LISTED))" "$_kind"
+  fi
+  printf '%s\n' "$SUMMARY_OUT" | grep '^E	' | while IFS='	' read -r _tag _msg; do
+    printf '  [analysis error] %s\n' "$_msg"
+  done | sort
+}
+
+# --- Outcome: the analysis gave up. Checked before any count is reported, so
+# --- that no reader is ever handed a number that looks actionable.
+if [ "$INCOMPLETE" -eq 1 ] || [ "$PARSE_IDS" -gt 0 ]; then
+  err 'PHPStan did not complete: the analysis aborted on files it could not parse.'
+  detail ''
+  detail 'THIS IS NOT A FINDING COUNT, AND THESE MUST NOT BE BASELINED.'
+  detail 'PHPStan stopped early, so the files below are the ones it choked on,'
+  detail 'not the problems in this codebase. Everything it never reached is'
+  detail 'unanalysed and unreported. Baselining these would make the exit code'
+  detail 'green and leave the analyser blind over the whole plugin.'
+  detail ''
+  if [ "$INCOMPLETE" -eq 1 ]; then
+    detail "Signal: PHPStan printed \"$INCOMPLETE_MARKER\" on stderr."
+  fi
+  if [ "$PARSE_IDS" -gt 0 ]; then
+    detail "Signal: $PARSE_IDS finding(s) carry the $PARSE_IDENTIFIER identifier."
+  fi
+  detail ''
+  detail 'Files it could not parse:'
+  printf '%s\n' "$SUMMARY_OUT" | grep '^F	' | while IFS='	' read -r _tag _file _line _id _msg; do
+    case "$_id" in
+      "$PARSE_IDENTIFIER") printf '    %s:%s  %s\n' "$(rel "$_file")" "$_line" "$_msg" ;;
+    esac
+  done | sort >&2
+  detail ''
+  detail 'Usual cause: the parser is being asked to read the source as an older'
+  detail 'PHP language level than the source is written in, so modern syntax'
+  detail 'reads as a syntax error. Compare the phpVersion in the PHPStan config'
+  detail 'against the minimum php that composer.json requires; a phpVersion'
+  detail 'below it makes every use of newer syntax an unparseable file.'
+  detail 'Fixing the config is a change to the agent plugin, not to this gate.'
+  exit "$EXIT_UNTRUSTWORTHY"
+fi
+
+# --- Outcome: nothing usable came back.
+if [ "$STATUS" = empty ]; then
+  err "PHPStan produced no output at all (it exited $PHPSTAN_EXIT)."
+  detail 'A completed run always writes a JSON document, even a clean one.'
+  detail 'No document means the analysis did not run, so nothing is claimed about the code.'
+  if [ -s "$ERR_FILE" ]; then
+    detail 'What it wrote to stderr:'
+    sed 's/^/    /' "$ERR_FILE" >&2
+  else
+    detail 'It wrote nothing to stderr either.'
+  fi
+  exit "$EXIT_UNTRUSTWORTHY"
+fi
+
+if [ "$STATUS" != ok ]; then
+  err "PHPStan output could not be parsed as a JSON report (it exited $PHPSTAN_EXIT)."
+  detail 'Expected a JSON document with a totals object, from --error-format=json.'
+  detail 'First part of what it actually wrote to stdout:'
+  head -c 600 "$OUT_FILE" | sed 's/^/    /' >&2
+  printf '\n' >&2
+  if [ -s "$ERR_FILE" ]; then
+    detail 'What it wrote to stderr:'
+    sed 's/^/    /' "$ERR_FILE" >&2
+  fi
+  exit "$EXIT_UNTRUSTWORTHY"
+fi
+
+# The count is computed here and printed from the computation. It is never
+# written down anywhere, in this script or in the workflow that calls it.
+FINDINGS=$((FILE_ERRORS + TOP_ERRORS))
+ROWS=$((MSG_ROWS + TOP_ROWS))
+# If the totals and the reported messages disagree, believe whichever is worse.
+# A totals block that says zero over a non-empty message list is exactly the
+# shape of a zero that must not read as a pass.
+if [ "$ROWS" -gt "$FINDINGS" ]; then
+  FINDINGS="$ROWS"
+fi
+
+# --- Outcome: zero findings, but the run failed. Never a pass.
+if [ "$FINDINGS" -eq 0 ] && [ "$PHPSTAN_EXIT" -ne 0 ]; then
+  err "PHPStan reported no findings but exited $PHPSTAN_EXIT, so the result cannot be trusted."
+  detail 'A clean analysis exits 0. A non-zero exit with an empty report means'
+  detail 'the run failed for a reason it did not express as a finding.'
+  if [ -s "$ERR_FILE" ]; then
+    detail 'What it wrote to stderr:'
+    sed 's/^/    /' "$ERR_FILE" >&2
+  else
+    detail 'It wrote nothing to stderr.'
+  fi
+  exit "$EXIT_UNTRUSTWORTHY"
+fi
+
+# --- Outcome: the analysis completed and found things.
+if [ "$FINDINGS" -gt 0 ]; then
+  err "PHPStan completed and reported $FINDINGS finding(s)."
+  print_findings 'finding(s)' >&2
+  detail ''
+  detail 'The analysis completed, so this is a real count over the whole plugin.'
+  detail 'Fix them at the source. Baseline only what is deliberately accepted.'
+  exit "$EXIT_FINDINGS"
+fi
+
+# --- Outcome: clean.
+ok "PHPStan completed over the agent plugin and reported 0 findings (exit $PHPSTAN_EXIT)."
+exit "$EXIT_CLEAN"

--- a/scripts/check-agent-phpstan_test.sh
+++ b/scripts/check-agent-phpstan_test.sh
@@ -62,10 +62,14 @@ FAILED=0
 SKIPPED=0
 FAILED_NAMES=''
 
-# Per case environment overrides, reset by case_run after every case so one
-# case can never leak an override into the next.
+# Per case switches, reset by case_run after every case so one case can never
+# leak a setting into the next. ALLOW_FINDINGS passes --allow-findings on the
+# command line; ALLOW_FINDINGS_ENV sets the environment variable instead, so
+# both routes into the same behaviour are covered.
 ENV_PHP_BIN=''
 ENV_PHPSTAN_BIN=''
+ALLOW_FINDINGS=0
+ALLOW_FINDINGS_ENV=0
 
 # ---------------------------------------------------------------------------
 # Fixtures: real PHPStan 2.x output shapes.
@@ -191,15 +195,29 @@ case_run() {
         SKIPPED=$((SKIPPED + 1))
         ENV_PHP_BIN=''
         ENV_PHPSTAN_BIN=''
+        ALLOW_FINDINGS=0
+        ALLOW_FINDINGS_ENV=0
         return 0
         ;;
     esac
   fi
 
-  _out="$(WPMGR_AGENT_PHP_BIN="$ENV_PHP_BIN" WPMGR_PHPSTAN_BIN="$ENV_PHPSTAN_BIN" "$GUARD" "$_dir" 2>&1)"
-  _code=$?
+  if [ "$ALLOW_FINDINGS" -eq 1 ]; then
+    _out="$(WPMGR_AGENT_PHP_BIN="$ENV_PHP_BIN" WPMGR_PHPSTAN_BIN="$ENV_PHPSTAN_BIN" \
+      "$GUARD" --allow-findings "$_dir" 2>&1)"
+    _code=$?
+  elif [ "$ALLOW_FINDINGS_ENV" -eq 1 ]; then
+    _out="$(WPMGR_AGENT_PHP_BIN="$ENV_PHP_BIN" WPMGR_PHPSTAN_BIN="$ENV_PHPSTAN_BIN" \
+      WPMGR_PHPSTAN_ALLOW_FINDINGS=1 "$GUARD" "$_dir" 2>&1)"
+    _code=$?
+  else
+    _out="$(WPMGR_AGENT_PHP_BIN="$ENV_PHP_BIN" WPMGR_PHPSTAN_BIN="$ENV_PHPSTAN_BIN" "$GUARD" "$_dir" 2>&1)"
+    _code=$?
+  fi
   ENV_PHP_BIN=''
   ENV_PHPSTAN_BIN=''
+  ALLOW_FINDINGS=0
+  ALLOW_FINDINGS_ENV=0
   _problems=''
 
   if [ "$_code" -ne "$_want" ]; then
@@ -453,6 +471,66 @@ stub "$t2" "$JSON_TWO_FINDINGS_REORDERED" '' 1
 case_same "no over-fire: the report is identical whichever order the files come back in" "$t" "$t2"
 
 case_run "no over-fire: --help exits 0" 0 --help
+
+case_run "no over-fire: an unknown option is refused rather than ignored" 2 --nonsense-flag
+
+# ===========================================================================
+# ADVISORY MODE. --allow-findings exists so the gate can land before the
+# backlog is triaged without inviting a one-command baseline regeneration that
+# would swallow the real findings. It must relax the FINDINGS outcome and
+# NOTHING ELSE. Every case below is the proof of that boundary: if any of them
+# starts passing, the flag has become a way to switch the guard off.
+# ===========================================================================
+
+t="$(tree advisory-findings)"
+stub "$t" "$JSON_TWO_FINDINGS" "$STDERR_INSTRUCTIONS" 1
+ALLOW_FINDINGS=1
+case_run "advisory: findings are reported loudly but do not fail the build" \
+  0 "$t" "+ADVISORY" "+reported 2 finding(s)" \
+  "+includes/class-alpha.php:9" "-OK:"
+
+t="$(tree advisory-parse-abort)"
+stub "$t" "$JSON_PARSE_ABORT" "$STDERR_INCOMPLETE" 1
+ALLOW_FINDINGS=1
+case_run "advisory: a parse abort STILL fails, the flag does not reach it" \
+  3 "$t" "+did not complete" "+MUST NOT BE BASELINED" "-ADVISORY"
+
+t="$(tree advisory-parse-abort-identifier)"
+stub "$t" "$JSON_PARSE_ABORT" "$STDERR_NOTE" 1
+ALLOW_FINDINGS=1
+case_run "advisory: a parse abort seen only via the identifier STILL fails" \
+  3 "$t" "+did not complete" "-ADVISORY"
+
+t="$(tree advisory-zero-findings-nonzero)"
+stub "$t" "$JSON_CLEAN" "$STDERR_NOTE" 1
+ALLOW_FINDINGS=1
+case_run "advisory: zero findings with a non-zero exit STILL fails" \
+  3 "$t" "+cannot be trusted" "-ADVISORY"
+
+t="$(tree advisory-empty-output)"
+stub "$t" '' '' 1
+ALLOW_FINDINGS=1
+case_run "advisory: no parseable output STILL fails" \
+  3 "$t" "+produced no output at all" "-ADVISORY"
+
+t="$(tree advisory-no-vendor)"
+rm -rf "$t/vendor"
+ALLOW_FINDINGS=1
+case_run "advisory: a missing vendor tree STILL fails" \
+  2 "$t" "+vendor does not exist" "-ADVISORY"
+
+t="$(tree advisory-clean)"
+stub "$t" "$JSON_CLEAN" '' 0
+ALLOW_FINDINGS=1
+case_run "advisory: a genuinely clean run is still reported as clean, not as advisory" \
+  0 "$t" "+OK:" "-ADVISORY"
+
+# The env var is the same switch as the flag, so a CI step can set either.
+t="$(tree advisory-env-var)"
+stub "$t" "$JSON_TWO_FINDINGS" '' 1
+ALLOW_FINDINGS_ENV=1
+case_run "advisory: WPMGR_PHPSTAN_ALLOW_FINDINGS=1 behaves the same as the flag" \
+  0 "$t" "+ADVISORY" "+reported 2 finding(s)"
 
 # ---------------------------------------------------------------------------
 printf '\n'

--- a/scripts/check-agent-phpstan_test.sh
+++ b/scripts/check-agent-phpstan_test.sh
@@ -104,6 +104,11 @@ JSON_NO_TOTALS='{"files":{},"errors":[]}'
 
 JSON_TOP_LEVEL_ERROR='{"totals":{"errors":1,"file_errors":0},"files":{},"errors":["Internal error: something went wrong in the analyser."]}'
 
+# A per-file finding whose MESSAGE TEXT mentions an analysis error, with the
+# top level "errors" array itself empty. A guard that keyed off the words
+# rather than the array would misread this as the untrustworthy outcome above.
+JSON_FINDING_MENTIONS_ANALYSIS_ERROR='{"totals":{"errors":0,"file_errors":1},"files":{"@@CWD@@/includes/class-doc.php":{"errors":1,"messages":[{"message":"Catches and logs an analysis error from the remote API gracefully.","line":22,"ignorable":true,"identifier":"return.type"}]}},"errors":[]}'
+
 NOT_JSON='PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted in /vendor/phpstan/phpstan/phpstan.phar on line 1'
 
 STDERR_EMPTY=''
@@ -336,6 +341,19 @@ stub "$t" "$JSON_PARSE_ABORT" "$STDERR_INCOMPLETE" 0
 case_run "parse: an incomplete analysis that exits 0 still fails" 3 "$t" "+did not complete"
 
 # ===========================================================================
+# TOP-LEVEL ANALYSIS ERRORS. An entry in PHPStan's "errors" array is not tied
+# to any file: it is the analyser saying part of the run itself failed, not
+# that it examined code and found something. Same untrustworthy category as
+# the parse abort above, on its own exit code, never a finding count.
+# ===========================================================================
+
+t="$(tree top-level-error)"
+stub "$t" "$JSON_TOP_LEVEL_ERROR" '' 1
+case_run "top-level: an analysis error is its own outcome, not a finding" \
+  4 "$t" "+top-level analysis error" "+Internal error" \
+  "-reported 1 finding(s)" "-OK:"
+
+# ===========================================================================
 # NOTHING USABLE CAME BACK. A guard that finds nothing goes red.
 # ===========================================================================
 
@@ -414,11 +432,6 @@ case_run "findings: two findings are reported as two, with the count computed no
   "+includes/class-alpha.php:9" "+includes/class-beta.php:14" \
   "+[return.type]" "-did not complete"
 
-t="$(tree findings-top-level)"
-stub "$t" "$JSON_TOP_LEVEL_ERROR" '' 1
-case_run "findings: a top level analysis error counts as a finding" \
-  1 "$t" "+reported 1 finding(s)" "+Internal error"
-
 # The count is printed from the data, so a different number of findings prints
 # a different number without anybody editing the guard.
 _msgs=''
@@ -463,6 +476,14 @@ stub "$t" "$JSON_FINDING_QUOTING_MARKER" "$STDERR_INSTRUCTIONS" 1
 case_run "no over-fire: a finding whose message quotes the incompleteness sentence is a finding, not an abort" \
   1 "$t" "+reported 1 finding(s)" "-did not complete" "-MUST NOT BE BASELINED"
 
+# The equivalent over-fire for the top-level-error check: the array is what
+# means it, not the words. A finding whose message text merely mentions an
+# analysis error must still be read as an ordinary finding.
+t="$(tree finding-mentions-analysis-error)"
+stub "$t" "$JSON_FINDING_MENTIONS_ANALYSIS_ERROR" '' 1
+case_run "no over-fire: a finding whose message mentions an analysis error is a finding, not a top-level error" \
+  1 "$t" "+reported 1 finding(s)" "-top-level analysis error"
+
 # Ordering is a property of the analyser, not of the codebase.
 t="$(tree order-a)"
 stub "$t" "$JSON_TWO_FINDINGS" '' 1
@@ -500,6 +521,18 @@ stub "$t" "$JSON_PARSE_ABORT" "$STDERR_NOTE" 1
 ALLOW_FINDINGS=1
 case_run "advisory: a parse abort seen only via the identifier STILL fails" \
   3 "$t" "+did not complete" "-ADVISORY"
+
+t="$(tree advisory-top-level-error)"
+stub "$t" "$JSON_TOP_LEVEL_ERROR" '' 1
+ALLOW_FINDINGS=1
+case_run "advisory: a top level analysis error STILL fails, the flag does not reach it" \
+  4 "$t" "+top-level analysis error" "-ADVISORY"
+
+t="$(tree advisory-env-top-level-error)"
+stub "$t" "$JSON_TOP_LEVEL_ERROR" '' 1
+ALLOW_FINDINGS_ENV=1
+case_run "advisory: WPMGR_PHPSTAN_ALLOW_FINDINGS=1 does not reach a top level analysis error either" \
+  4 "$t" "+top-level analysis error" "-ADVISORY"
 
 t="$(tree advisory-zero-findings-nonzero)"
 stub "$t" "$JSON_CLEAN" "$STDERR_NOTE" 1

--- a/scripts/check-agent-phpstan_test.sh
+++ b/scripts/check-agent-phpstan_test.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# scripts/check-agent-phpstan_test.sh
+#
+# The regression suite for scripts/check-agent-phpstan.sh.
+#
+# WHAT IT TESTS AND WHAT IT DOES NOT. It tests the guard's decision: given what
+# PHPStan wrote to stdout, what it wrote to stderr, and the code it exited with,
+# does the guard reach the right verdict and say a useful thing about it. It
+# does not re-test PHPStan. Every fixture below is a real shape observed from
+# PHPStan 2.x with --error-format=json, including the one that matters most:
+# an aborted run reports the syntax errors as ordinary per-file entries, leaves
+# totals.errors at zero and the top level errors array empty, and puts the
+# "Result is incomplete because of severe errors" warning on STDERR ONLY.
+#
+# HOW THE ANALYSER IS FAKED, AND WHY THAT IS HONEST. Each case builds a
+# complete little agent directory with a phpstan.neon, a vendor/ tree, and a
+# vendor/bin/phpstan that is a real PHP script. The guard resolves it, invokes
+# it through the same php command line it uses in production, and reads the two
+# streams and the exit code exactly as it would from the real analyser. Only
+# the analysis itself is canned. Nothing about the guard is stubbed, no
+# function is overridden, and no code path is special cased for tests.
+#
+# The real analyser is exercised too, but by CI running the guard against
+# apps/agent for real, which is the other half of the same gate.
+#
+# RUN IT:
+#   scripts/check-agent-phpstan_test.sh          # everything
+#   scripts/check-agent-phpstan_test.sh parse    # only cases matching "parse"
+#
+# Point it at a different implementation to prove the suite is not vacuous
+# (break a copy of the guard, watch the suite go red):
+#   WPMGR_AGENT_PHPSTAN_SCRIPT=/tmp/guard-with-hole.sh \
+#     scripts/check-agent-phpstan_test.sh
+#
+# PORTABILITY. bash 3.2 and POSIX tools, same as the guard. Needs php, because
+# the thing under test needs php; a missing php stops the suite loudly rather
+# than reporting a green run over nothing.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${WPMGR_AGENT_PHPSTAN_SCRIPT:-$HERE/check-agent-phpstan.sh}"
+FILTER="${1:-}"
+
+if [ ! -f "$GUARD" ]; then
+  echo "no guard script at $GUARD" >&2
+  exit 2
+fi
+
+PHP_BIN="$(command -v php 2>/dev/null || true)"
+if [ -z "$PHP_BIN" ]; then
+  echo 'no php on PATH, and this suite cannot test a php tool without it.' >&2
+  echo 'Refusing to report a pass over tests that did not run.' >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/wpmgr-agent-phpstan-test.XXXXXX")" || exit 2
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+FAILED_NAMES=''
+
+# Per case environment overrides, reset by case_run after every case so one
+# case can never leak an override into the next.
+ENV_PHP_BIN=''
+ENV_PHPSTAN_BIN=''
+
+# ---------------------------------------------------------------------------
+# Fixtures: real PHPStan 2.x output shapes.
+#
+# @@CWD@@ is replaced by the stub with its own working directory, which is the
+# agent directory the guard cd'd into. That reproduces the real thing, where
+# PHPStan reports absolute realpath'd file names, and it is what lets the
+# "no machine specific paths in the report" case below mean something.
+# ---------------------------------------------------------------------------
+
+JSON_CLEAN='{"totals":{"errors":0,"file_errors":0},"files":{},"errors":[]}'
+
+# An aborted run. Note totals.errors is 0 and the errors array is empty: read
+# from stdout alone this is indistinguishable from a couple of ordinary
+# findings, which is the entire reason this guard exists.
+JSON_PARSE_ABORT='{"totals":{"errors":0,"file_errors":2},"files":{"@@CWD@@/includes/cache/class-admin-bar-purge.php":{"errors":1,"messages":[{"message":"Syntax error, unexpected T_STRING, expecting T_VARIABLE on line 36","line":36,"ignorable":false,"identifier":"phpstan.parse"}]},"@@CWD@@/includes/security/class-security-policy.php":{"errors":1,"messages":[{"message":"Syntax error, unexpected T_STRING, expecting T_VARIABLE on line 41","line":41,"ignorable":false,"identifier":"phpstan.parse"}]}},"errors":[]}'
+
+JSON_TWO_FINDINGS='{"totals":{"errors":0,"file_errors":2},"files":{"@@CWD@@/includes/class-alpha.php":{"errors":1,"messages":[{"message":"Method alpha() should return string but returns int.","line":9,"ignorable":true,"identifier":"return.type"}]},"@@CWD@@/includes/class-beta.php":{"errors":1,"messages":[{"message":"Call to an undefined method Beta::missing().","line":14,"ignorable":true,"identifier":"method.notFound"}]}},"errors":[]}'
+
+# The same two findings, files emitted in the opposite order.
+JSON_TWO_FINDINGS_REORDERED='{"totals":{"file_errors":2,"errors":0},"files":{"@@CWD@@/includes/class-beta.php":{"errors":1,"messages":[{"message":"Call to an undefined method Beta::missing().","line":14,"ignorable":true,"identifier":"method.notFound"}]},"@@CWD@@/includes/class-alpha.php":{"errors":1,"messages":[{"message":"Method alpha() should return string but returns int.","line":9,"ignorable":true,"identifier":"return.type"}]}},"errors":[]}'
+
+# A finding whose MESSAGE TEXT quotes the incompleteness sentence. A guard that
+# grepped stdout for that sentence would call this a parse abort and redden a
+# build for a reason that has nothing to do with the analysis.
+JSON_FINDING_QUOTING_MARKER='{"totals":{"errors":0,"file_errors":1},"files":{"@@CWD@@/includes/class-doc.php":{"errors":1,"messages":[{"message":"Result is incomplete because of severe errors is a string this method returns.","line":22,"ignorable":true,"identifier":"return.type"}]}},"errors":[]}'
+
+# totals claims nothing is wrong while the per-file messages say otherwise.
+JSON_ZERO_TOTALS_WITH_MESSAGES='{"totals":{"errors":0,"file_errors":0},"files":{"@@CWD@@/includes/class-liar.php":{"errors":1,"messages":[{"message":"Something real is wrong here.","line":3,"ignorable":true,"identifier":"return.type"}]}},"errors":[]}'
+
+JSON_NO_TOTALS='{"files":{},"errors":[]}'
+
+JSON_TOP_LEVEL_ERROR='{"totals":{"errors":1,"file_errors":0},"files":{},"errors":["Internal error: something went wrong in the analyser."]}'
+
+NOT_JSON='PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted in /vendor/phpstan/phpstan/phpstan.phar on line 1'
+
+STDERR_EMPTY=''
+STDERR_NOTE='Note: Using configuration file /somewhere/apps/agent/phpstan.neon.'
+STDERR_INCOMPLETE='Note: Using configuration file /somewhere/apps/agent/phpstan.neon.
+ !  Result is incomplete because of severe errors.  !
+   Fix these errors first and then re-run PHPStan
+   to get all reported errors.'
+# PHPStan 2.x prints this whenever there are findings. It is ordinary stderr
+# noise and must never be mistaken for a failure signal.
+#
+# The backticks below are part of the fixture text, copied from what PHPStan
+# actually prints. Single quotes are what keeps them literal.
+# shellcheck disable=SC2016
+STDERR_INSTRUCTIONS='Instructions for interpreting errors
+---------
+
+Each error has an associated identifier, like `argument.type`.
+Each error identifier has documentation at URL https://phpstan.org/error-identifiers/<identifier>
+The error usually indicates a real bug or incorrect type in the code.'
+
+# ---------------------------------------------------------------------------
+# Tree construction
+# ---------------------------------------------------------------------------
+
+# The fake analyser. Reads its canned streams and exit code from files beside
+# it, so a case can change the analyser's behaviour without rewriting any PHP.
+write_stub_binary() {
+  cat >"$1" <<'STUB'
+<?php
+// Stands in for vendor/bin/phpstan. Reads canned output from files beside it.
+$dir = __DIR__;
+$read = function ($name) use ($dir) {
+    $v = @file_get_contents($dir . '/' . $name);
+    return $v === false ? '' : $v;
+};
+$out = str_replace('@@CWD@@', getcwd(), $read('stub-stdout'));
+$err = str_replace('@@CWD@@', getcwd(), $read('stub-stderr'));
+$code = (int) trim($read('stub-exit'));
+if ($out !== '') {
+    fwrite(STDOUT, $out);
+}
+if ($err !== '') {
+    fwrite(STDERR, $err);
+}
+exit($code);
+STUB
+  chmod +x "$1"
+}
+
+# tree NAME [CONFIG_NAME] -> path to a complete, runnable fixture agent dir.
+tree() {
+  _dir="$WORK/$1"
+  _config="${2:-phpstan.neon}"
+  mkdir -p "$_dir/includes" "$_dir/vendor/bin"
+  printf 'parameters:\n    level: 8\n    paths:\n        - includes\n' >"$_dir/$_config"
+  printf '{"name":"wpmgr/agent","require":{"php":">=8.1"}}\n' >"$_dir/composer.json"
+  write_stub_binary "$_dir/vendor/bin/phpstan"
+  # A default so a tree is always runnable; cases override with stub().
+  stub "$_dir" "$JSON_CLEAN" "$STDERR_EMPTY" 0
+  printf '%s' "$_dir"
+}
+
+# stub DIR STDOUT STDERR EXITCODE
+stub() {
+  printf '%s' "$2" >"$1/vendor/bin/stub-stdout"
+  printf '%s' "$3" >"$1/vendor/bin/stub-stderr"
+  printf '%s' "$4" >"$1/vendor/bin/stub-exit"
+}
+
+# ---------------------------------------------------------------------------
+# Assertions
+#
+#   case_run NAME EXPECTED_EXIT DIR [+MUST-CONTAIN ...] [-MUST-NOT-CONTAIN ...]
+#
+# The exit code is asserted exactly, not as pass/fail, because telling 1 from 3
+# IS the thing this guard exists to do.
+# ---------------------------------------------------------------------------
+case_run() {
+  _name="$1"
+  _want="$2"
+  _dir="$3"
+  shift 3
+
+  if [ -n "$FILTER" ]; then
+    case "$_name" in
+      *"$FILTER"*) : ;;
+      *)
+        SKIPPED=$((SKIPPED + 1))
+        ENV_PHP_BIN=''
+        ENV_PHPSTAN_BIN=''
+        return 0
+        ;;
+    esac
+  fi
+
+  _out="$(WPMGR_AGENT_PHP_BIN="$ENV_PHP_BIN" WPMGR_PHPSTAN_BIN="$ENV_PHPSTAN_BIN" "$GUARD" "$_dir" 2>&1)"
+  _code=$?
+  ENV_PHP_BIN=''
+  ENV_PHPSTAN_BIN=''
+  _problems=''
+
+  if [ "$_code" -ne "$_want" ]; then
+    _problems="$_problems
+    expected exit $_want, got $_code"
+  fi
+
+  for _a in "$@"; do
+    case "$_a" in
+      +*)
+        _needle="${_a#+}"
+        if ! printf '%s\n' "$_out" | grep -qF "$_needle"; then
+          _problems="$_problems
+    expected the output to contain: $_needle"
+        fi
+        ;;
+      -*)
+        _needle="${_a#-}"
+        if printf '%s\n' "$_out" | grep -qF "$_needle"; then
+          _problems="$_problems
+    expected the output NOT to contain: $_needle"
+        fi
+        ;;
+    esac
+  done
+
+  if [ -n "$_problems" ]; then
+    FAILED=$((FAILED + 1))
+    FAILED_NAMES="$FAILED_NAMES  $_name
+"
+    printf 'FAIL %s%s\n' "$_name" "$_problems"
+    printf '%s\n' "$_out" | sed 's/^/      | /'
+  else
+    PASSED=$((PASSED + 1))
+    printf 'ok   %s\n' "$_name"
+  fi
+}
+
+# case_same NAME DIR_A DIR_B: the two runs must produce identical finding lines.
+case_same() {
+  _name="$1"
+  if [ -n "$FILTER" ]; then
+    case "$_name" in
+      *"$FILTER"*) : ;;
+      *)
+        SKIPPED=$((SKIPPED + 1))
+        return 0
+        ;;
+    esac
+  fi
+  _a="$("$GUARD" "$2" 2>&1 | grep '  includes/' | sort)"
+  _b="$("$GUARD" "$3" 2>&1 | grep '  includes/' | sort)"
+  if [ -z "$_a" ]; then
+    FAILED=$((FAILED + 1))
+    FAILED_NAMES="$FAILED_NAMES  $_name
+"
+    printf 'FAIL %s\n    no finding lines at all, so the compare proves nothing\n' "$_name"
+  elif [ "$_a" = "$_b" ]; then
+    PASSED=$((PASSED + 1))
+    printf 'ok   %s\n' "$_name"
+  else
+    FAILED=$((FAILED + 1))
+    FAILED_NAMES="$FAILED_NAMES  $_name
+"
+    printf 'FAIL %s\n    the two reports differ:\n%s\n    ---\n%s\n' "$_name" "$_a" "$_b"
+  fi
+}
+
+# ===========================================================================
+# THE PARSE ABORT. The defect this guard was built for. An incomplete analysis
+# must never read as a finding count, and must never be answered by baselining.
+# ===========================================================================
+
+t="$(tree parse-abort-both-signals)"
+stub "$t" "$JSON_PARSE_ABORT" "$STDERR_INCOMPLETE" 1
+case_run "parse: both signals present is an incomplete analysis, not a finding count" \
+  3 "$t" \
+  "+did not complete" "+MUST NOT BE BASELINED" \
+  "+Result is incomplete because of severe errors" \
+  "+phpstan.parse" \
+  "-completed and reported"
+
+# The stderr marker is the ONLY completeness signal in a JSON run, and it is on
+# a stream nothing reading the report would look at.
+t="$(tree parse-abort-stderr-only)"
+stub "$t" "$JSON_TWO_FINDINGS" "$STDERR_INCOMPLETE" 1
+case_run "parse: the stderr marker alone is enough, even when stdout looks like ordinary findings" \
+  3 "$t" \
+  "+did not complete" "+MUST NOT BE BASELINED" \
+  "-completed and reported"
+
+# And the identifier alone is enough, in case a future PHPStan stops printing
+# the sentence or prints it somewhere else.
+t="$(tree parse-abort-identifier-only)"
+stub "$t" "$JSON_PARSE_ABORT" "$STDERR_NOTE" 1
+case_run "parse: the phpstan.parse identifier alone is enough, with a clean stderr" \
+  3 "$t" \
+  "+did not complete" "+phpstan.parse" \
+  "-completed and reported"
+
+t="$(tree parse-abort-lists-files)"
+stub "$t" "$JSON_PARSE_ABORT" "$STDERR_INCOMPLETE" 1
+case_run "parse: the report names the files it could not parse" \
+  3 "$t" \
+  "+includes/cache/class-admin-bar-purge.php:36" \
+  "+includes/security/class-security-policy.php:41"
+
+t="$(tree parse-abort-no-machine-paths)"
+stub "$t" "$JSON_PARSE_ABORT" "$STDERR_INCOMPLETE" 1
+case_run "parse: the report is free of machine specific absolute paths" \
+  3 "$t" "+includes/cache/class-admin-bar-purge.php" "-$t/includes"
+
+# A parse abort that somehow exits 0 is still a parse abort.
+t="$(tree parse-abort-exit-zero)"
+stub "$t" "$JSON_PARSE_ABORT" "$STDERR_INCOMPLETE" 0
+case_run "parse: an incomplete analysis that exits 0 still fails" 3 "$t" "+did not complete"
+
+# ===========================================================================
+# NOTHING USABLE CAME BACK. A guard that finds nothing goes red.
+# ===========================================================================
+
+t="$(tree empty-output-nonzero)"
+stub "$t" '' "$STDERR_NOTE" 1
+case_run "empty: no output at all with a non-zero exit fails" \
+  3 "$t" "+produced no output at all"
+
+# The one that would fail open: a run that wrote nothing and claimed success.
+t="$(tree empty-output-zero)"
+stub "$t" '' '' 0
+case_run "empty: no output at all with a ZERO exit still fails, it never reads as clean" \
+  3 "$t" "+produced no output at all" "-OK:"
+
+t="$(tree not-json)"
+stub "$t" "$NOT_JSON" '' 255
+case_run "unparseable: a fatal error on stdout instead of a report fails" \
+  3 "$t" "+could not be parsed as a JSON report" "+Allowed memory size"
+
+t="$(tree json-without-totals)"
+stub "$t" "$JSON_NO_TOTALS" '' 0
+case_run "unparseable: valid JSON with no totals object fails" \
+  3 "$t" "+could not be parsed as a JSON report"
+
+t="$(tree zero-findings-nonzero-exit)"
+stub "$t" "$JSON_CLEAN" "$STDERR_NOTE" 1
+case_run "untrusted: zero findings alongside a non-zero exit never reads as a pass" \
+  3 "$t" "+no findings but exited 1" "-OK:"
+
+t="$(tree zero-totals-with-messages)"
+stub "$t" "$JSON_ZERO_TOTALS_WITH_MESSAGES" '' 0
+case_run "untrusted: totals claiming zero over a non-empty message list is believed as findings" \
+  1 "$t" "+reported 1 finding(s)" "-OK:"
+
+# ===========================================================================
+# THE ENVIRONMENT CANNOT RUN THE ANALYSIS. Each one names what is missing and
+# what to run, and none of them may pass.
+# ===========================================================================
+
+case_run "env: a directory that does not exist fails and names it" \
+  2 "$WORK/no-such-agent-dir" "+does not exist"
+
+t="$(tree env-no-config)"
+rm -f "$t/phpstan.neon"
+case_run "env: no PHPStan config at all fails and names what it looked for" \
+  2 "$t" "+no PHPStan config" "+phpstan.neon.dist"
+
+t="$(tree env-no-vendor)"
+rm -rf "$t/vendor"
+case_run "env: a missing vendor tree fails and names the command that fixes it" \
+  2 "$t" "+vendor does not exist" "+composer install"
+
+t="$(tree env-no-phpstan-binary)"
+rm -f "$t/vendor/bin/phpstan"
+case_run "env: a vendor tree with no PHPStan binary fails and names the command that fixes it" \
+  2 "$t" "+no PHPStan binary" "+composer install"
+
+t="$(tree env-bad-phpstan-override)"
+ENV_PHPSTAN_BIN="$WORK/definitely-not-a-phpstan"
+case_run "env: WPMGR_PHPSTAN_BIN pointing at nothing fails and names the variable" \
+  2 "$t" "+WPMGR_PHPSTAN_BIN"
+
+t="$(tree env-bad-php-override)"
+ENV_PHP_BIN="$WORK/definitely-not-a-php"
+case_run "env: WPMGR_AGENT_PHP_BIN pointing at nothing fails and names the variable" \
+  2 "$t" "+WPMGR_AGENT_PHP_BIN"
+
+# ===========================================================================
+# FINDINGS. A completed analysis that found things, counted at runtime.
+# ===========================================================================
+
+t="$(tree findings-two)"
+stub "$t" "$JSON_TWO_FINDINGS" "$STDERR_INSTRUCTIONS" 1
+case_run "findings: two findings are reported as two, with the count computed not assumed" \
+  1 "$t" "+reported 2 finding(s)" \
+  "+includes/class-alpha.php:9" "+includes/class-beta.php:14" \
+  "+[return.type]" "-did not complete"
+
+t="$(tree findings-top-level)"
+stub "$t" "$JSON_TOP_LEVEL_ERROR" '' 1
+case_run "findings: a top level analysis error counts as a finding" \
+  1 "$t" "+reported 1 finding(s)" "+Internal error"
+
+# The count is printed from the data, so a different number of findings prints
+# a different number without anybody editing the guard.
+_msgs=''
+_i=1
+while [ "$_i" -le 60 ]; do
+  _msgs="$_msgs{\"message\":\"Finding number $_i.\",\"line\":$_i,\"ignorable\":true,\"identifier\":\"return.type\"},"
+  _i=$((_i + 1))
+done
+_msgs="${_msgs%,}"
+JSON_SIXTY="{\"totals\":{\"errors\":0,\"file_errors\":60},\"files\":{\"@@CWD@@/includes/big.php\":{\"errors\":60,\"messages\":[$_msgs]}},\"errors\":[]}"
+
+t="$(tree findings-many)"
+stub "$t" "$JSON_SIXTY" '' 1
+case_run "findings: a long list prints the real total and says how many it did not list" \
+  1 "$t" "+reported 60 finding(s)" "+and 10 more"
+
+# ===========================================================================
+# CLEAN, and the things that must not break it. A guard that reddens correct
+# work gets switched off, and then it guards nothing.
+# ===========================================================================
+
+t="$(tree clean-quiet)"
+stub "$t" "$JSON_CLEAN" '' 0
+case_run "clean: an empty report with a zero exit passes" 0 "$t" "+OK:" "+0 findings"
+
+t="$(tree clean-with-note)"
+stub "$t" "$JSON_CLEAN" "$STDERR_NOTE" 0
+case_run "clean: the routine 'Using configuration file' note on stderr does not redden it" \
+  0 "$t" "+OK:"
+
+t="$(tree clean-with-instructions)"
+stub "$t" "$JSON_CLEAN" "$STDERR_INSTRUCTIONS" 0
+case_run "clean: PHPStan's stderr instructions block does not redden it" 0 "$t" "+OK:"
+
+t="$(tree clean-dist-config phpstan.neon.dist)"
+stub "$t" "$JSON_CLEAN" '' 0
+case_run "clean: a phpstan.neon.dist config is accepted" 0 "$t" "+OK:" "+phpstan.neon.dist"
+
+# The over-fire that a stdout grep for the marker sentence would cause.
+t="$(tree finding-quotes-the-marker)"
+stub "$t" "$JSON_FINDING_QUOTING_MARKER" "$STDERR_INSTRUCTIONS" 1
+case_run "no over-fire: a finding whose message quotes the incompleteness sentence is a finding, not an abort" \
+  1 "$t" "+reported 1 finding(s)" "-did not complete" "-MUST NOT BE BASELINED"
+
+# Ordering is a property of the analyser, not of the codebase.
+t="$(tree order-a)"
+stub "$t" "$JSON_TWO_FINDINGS" '' 1
+t2="$(tree order-b)"
+stub "$t2" "$JSON_TWO_FINDINGS_REORDERED" '' 1
+case_same "no over-fire: the report is identical whichever order the files come back in" "$t" "$t2"
+
+case_run "no over-fire: --help exits 0" 0 --help
+
+# ---------------------------------------------------------------------------
+printf '\n'
+if [ -n "$FILTER" ]; then
+  printf 'filter: %s (%s skipped)\n' "$FILTER" "$SKIPPED"
+fi
+printf '%s passed, %s failed\n' "$PASSED" "$FAILED"
+if [ "$FAILED" -ne 0 ]; then
+  printf 'failing cases:\n%s' "$FAILED_NAMES"
+  exit 1
+fi
+exit 0

--- a/scripts/check-agent-phpstan_test.sh
+++ b/scripts/check-agent-phpstan_test.sh
@@ -571,6 +571,22 @@ if [ -n "$FILTER" ]; then
   printf 'filter: %s (%s skipped)\n' "$FILTER" "$SKIPPED"
 fi
 printf '%s passed, %s failed\n' "$PASSED" "$FAILED"
+
+# A guard that finds nothing must go red, not green. "0 passed, 0 failed" is
+# not a clean run, it is proof nothing was checked: either FILTER matched no
+# case name (a typo, or a case renamed without updating an invocation), or
+# every case_run/case_same call above was removed. Either way this suite has
+# verified nothing and must not exit 0.
+if [ "$((PASSED + FAILED))" -eq 0 ]; then
+  if [ -n "$FILTER" ]; then
+    echo "no case matched filter '$FILTER' ($SKIPPED skipped, 0 run)." >&2
+  else
+    echo 'no case ran at all.' >&2
+  fi
+  echo 'Refusing to report a pass over tests that did not run.' >&2
+  exit 2
+fi
+
 if [ "$FAILED" -ne 0 ]; then
   printf 'failing cases:\n%s' "$FAILED_NAMES"
   exit 1


### PR DESCRIPTION
Closes part of #525.

## What this does

Adds a gate that runs the agent plugin's static analysis in CI, plus its own committed self-test, following the `scripts/check-version-surfaces.sh` + `_test.sh` pattern — the self-test runs first, so a broken guard cannot pass by failing open.

**Two outcomes, deliberately separated:**

| Condition | Exit | Blocking? |
|---|---|---|
| Parse abort — the analyser could not read the source | 3 | **Yes** |
| Findings — the analyser ran and reported problems | 1 | Advisory for now |
| Missing binary / missing vendor / no parseable output / zero findings with a non-zero exit | non-zero | **Yes** |

## Why findings are advisory rather than blocking

Measured in a scratch copy, with the config's `phpVersion` corrected:

- `phpVersion: 80000` (as shipped) → 3 parse errors, "Result is incomplete because of severe errors"
- `phpVersion: 80100` → parse abort gone. **483 findings with the committed baseline, 649 without.**

Turning findings into a blocking gate today would make the next PR red for 483 reasons, most of them the documented `$wpdb` narrowing and defensive `is_*()` noise the baseline comment already describes. The escape hatch — regenerate a baseline that swallows everything — is one command away, and taking it would bury the genuine findings permanently. A guard silenced on day one guards nothing.

The parse abort is safe to block immediately, because it cannot be baselined away: the baseline generator refuses to run during one.

## What this does NOT do

It does **not** catch the defect class from #521 — hook callbacks whose declared parameter types do not match what WordPress actually passes. Measured: a repaired analyser catches **zero of the five** known instances.

The reason is structural, not a misconfiguration. `szepeviktor/phpstan-wordpress`'s `HookCallbackRule` validates only the *count* of parameters against `accepted_args`, and whether the return type is void. No code path compares a callback's parameter *types* against what a named hook passes. Both wrong-typed callbacks declared the correct argument count, so both existing checks were silently satisfied.

That class needs a purpose-built hook-signature check, tracked separately in #525.

## Proof

Red, against the tree as it stands (`bash scripts/check-agent-phpstan.sh`, exit 3):

```
Signal: PHPStan printed "Result is incomplete because of severe errors" on stderr.
Signal: 3 finding(s) carry the phpstan.parse identifier.

Files it could not parse:
  includes/cache/class-admin-bar-purge.php:36  Syntax error, unexpected T_STRING, expecting T_VARIABLE
  includes/security/class-hardening-config.php:60  Syntax error, unexpected T_STRING, expecting T_VARIABLE
  includes/security/class-security-policy.php:41  Syntax error, unexpected T_STRING, expecting T_VARIABLE
```

This is a genuine red against the real defect, not a simulated one.

Self-test: `bash scripts/check-agent-phpstan_test.sh` → `37 passed, 0 failed`, exit 0.

Mutation test — the suite takes a `WPMGR_AGENT_PHPSTAN_SCRIPT` override for exactly this. Neutering the parse-abort detection in a copy reddens **8 tests**, precisely the parse and advisory ones:

```
parse: the phpstan.parse identifier alone is enough, with a clean stderr
parse: an incomplete analysis that exits 0 still fails
advisory: a parse abort STILL fails, the flag does not reach it
advisory: a parse abort seen only via the identifier STILL fails
```

Restoring the guard returns `37 passed, 0 failed`.

Over-fire coverage in the suite includes: a finding whose message merely *quotes* the incompleteness sentence is treated as a finding and not an abort; the report is stable whichever order files come back in; `--help` exits 0; an unknown option is refused rather than ignored; and machine-specific absolute paths are kept out of the report.

## Must land before findings can become blocking

1. The `phpstan.neon` `phpVersion` repair — a change inside `apps/agent`, so it belongs to `wp-agent-engineer` and is not in this PR.
2. Triage of the 483 findings: fix the root cause of the narrowing false positives, re-point or delete stale ignore comments, then baseline the remainder with a written reason rather than a blanket regeneration.

Draft until at least (1) lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PHPStan analysis commands for local development.
  * Added automated checks that distinguish clean results, findings, environment issues, and analysis errors.
  * Findings can be reported as advisory while critical analysis failures still block validation.

* **Tests**
  * Added comprehensive regression coverage for PHPStan result handling, malformed output, configuration errors, and command-line validation.
  * Integrated the regression suite and analysis guard into continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->