### PR TITLE
fix(agent): repair PHPStan phpVersion parse abort (#525)

### DIFF
--- a/apps/agent/includes/backup/class-backup-janitor.php
+++ b/apps/agent/includes/backup/class-backup-janitor.php
@@ -228,9 +228,9 @@ class BackupJanitor
         if (!is_object($wpdb)) {
             return false;
         }
+        /** @var \wpdb $wpdb */
 
         $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
-        // @phpstan-ignore-next-line — dynamic wpdb.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct read on plugin-owned task-state table; identifier is prefix+constant; live liveness check, not cacheable
         $row = $wpdb->get_row($wpdb->prepare("SELECT phase, last_progress_at FROM {$table} WHERE snapshot_id = %s", $snapshotId), ARRAY_A);
         if (!is_array($row)) {

--- a/apps/agent/includes/backup/class-db-restorer.php
+++ b/apps/agent/includes/backup/class-db-restorer.php
@@ -91,7 +91,9 @@ final class DbRestorer
      *                                $tmpPrefix.
      * @param callable $progress     function(string $phase, array $detail): void
      * @return list<string> Names of the tmp tables that ended up populated.
-     * @throws \RuntimeException On fatal connection / read failure.
+     * @throws \RuntimeException On fatal connection / read failure, or when
+     *      the dump's trailing fragment cannot be classified (see
+     *      looksLikeCommentOnly()) — aborting beats discarding SQL.
      */
     public function restore(string $sqlGzPath, string $tmpPrefix, string $sourcePrefix, callable $progress): array
     {
@@ -1146,13 +1148,43 @@ final class DbRestorer
     /**
      * Whether a buffer tail looks like only whitespace and SQL comments — in
      * which case we don't need to flush it as a "statement" at EOF.
+     *
+     * A `true` here makes the caller DISCARD the dump's final fragment, so
+     * this method must never answer `true` out of ignorance. The two regex
+     * calls below are therefore treated asymmetrically, on purpose.
+     *
+     * @throws \RuntimeException When the tail cannot be classified at all.
      */
     private static function looksLikeCommentOnly(string $tail): bool
     {
         // Strip /* */ block comments and -- line comments / # line comments.
+        //
+        // A preg_replace() failure is safe to absorb. Falling back to the
+        // unstripped tail can only make a line look like real SQL, never like
+        // a comment, so the worst case is flushing a comment-only tail to the
+        // server as a statement. That errs towards KEEPING data, which is the
+        // safe direction on a restore.
         $stripped = preg_replace('#/\*.*?\*/#s', '', $tail) ?? $tail;
-        $lines    = preg_split('/\r?\n/', $stripped);
-        $lines    = $lines === false ? [] : $lines;
+
+        // A preg_split() failure is NOT safe to absorb. Coercing `false` to an
+        // empty list would skip the loop below entirely and fall through to
+        // `return true` — telling the caller "only comments here, safe to
+        // drop" and silently discarding the dump's last SQL statement while
+        // the restore still reports success. A regex failure is not evidence
+        // that the tail is comment-only; it is evidence that we cannot tell,
+        // and "cannot tell" must never resolve to "safe to discard". Abort
+        // instead: restore()'s transaction is left uncommitted and the caller
+        // fails the restore rather than committing a partial database.
+        $lines = preg_split('/\r?\n/', $stripped);
+        if ($lines === false) {
+            throw new \RuntimeException(
+                'DbRestorer: cannot classify the trailing SQL fragment of the dump (preg_split failed: '
+                . esc_html(preg_last_error_msg()) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to server log/SSE, not browser output
+                . '). Aborting the restore rather than risk discarding SQL. Raise pcre.backtrack_limit'
+                . ' / pcre.recursion_limit on this host and retry the restore.'
+            );
+        }
+
         foreach ($lines as $line) {
             $t = trim($line);
             if ($t === '' || strpos($t, '--') === 0 || strpos($t, '#') === 0) {

--- a/apps/agent/includes/backup/class-db-restorer.php
+++ b/apps/agent/includes/backup/class-db-restorer.php
@@ -1151,7 +1151,8 @@ final class DbRestorer
     {
         // Strip /* */ block comments and -- line comments / # line comments.
         $stripped = preg_replace('#/\*.*?\*/#s', '', $tail) ?? $tail;
-        $lines    = preg_split('/\r?\n/', $stripped) ?? [];
+        $lines    = preg_split('/\r?\n/', $stripped);
+        $lines    = $lines === false ? [] : $lines;
         foreach ($lines as $line) {
             $t = trim($line);
             if ($t === '' || strpos($t, '--') === 0 || strpos($t, '#') === 0) {

--- a/apps/agent/includes/backup/class-restore-health-check.php
+++ b/apps/agent/includes/backup/class-restore-health-check.php
@@ -163,6 +163,7 @@ final class RestoreHealthCheck
         if (!is_object($wpdb)) {
             return ['ok' => false, 'failures' => ['DB probe: $wpdb is not available']];
         }
+        /** @var \wpdb $wpdb */
 
         $failures = [];
 
@@ -182,9 +183,7 @@ final class RestoreHealthCheck
             if (isset($wpdb->options) && is_string($wpdb->options) && $wpdb->options !== '') {
                 $optionsTable = $wpdb->options;
             }
-            /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
             $siteurl = $wpdb->get_var("SELECT option_value FROM {$optionsTable} WHERE option_name = 'siteurl' LIMIT 1"); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,PluginCheck.Security.DirectDB.UnescapedDBParameter -- $optionsTable is either the real $wpdb->options property or prefix+the literal 'options', never user input; a fresh uncached read of the just-swapped live table is the entire point of this probe
-            /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
             $lastError = (string) $wpdb->last_error;
             if ($lastError !== '') {
                 $failures[] = 'DB probe: siteurl query error: ' . substr($lastError, 0, 200);
@@ -205,9 +204,7 @@ final class RestoreHealthCheck
                 if (isset($wpdb->{$core}) && is_string($wpdb->{$core}) && $wpdb->{$core} !== '') {
                     $table = $wpdb->{$core};
                 }
-                /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
                 $wpdb->get_var("SELECT 1 FROM {$table} LIMIT 1"); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,PluginCheck.Security.DirectDB.UnescapedDBParameter -- $table is either the real $wpdb->users/$wpdb->posts property or prefix+a literal from the hardcoded ['users','posts'] loop, never user input; a fresh uncached read of the just-swapped live table is the entire point of this probe
-                /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
                 $lastError = (string) $wpdb->last_error;
                 if ($lastError !== '') {
                     $failures[] = 'DB probe: ' . $core . ' table query error: ' . substr($lastError, 0, 200);

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -1833,17 +1833,16 @@ final class RestoreRunner
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $dbName = $this->dbCreds()['name'] ?? '';
         if ($dbName === '') {
             return 0;
         }
         try {
-            /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
             $prepared = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
                 'SELECT SUM(data_length + index_length) FROM information_schema.tables WHERE table_schema = %s',
                 $dbName
             );
-            /** @phpstan-ignore-next-line */
             $bytes = $wpdb->get_var($prepared); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- information_schema size probe; no core helper exists; not a cacheable value (must reflect live size right before the dump)
             return is_numeric($bytes) ? (int) $bytes : 0;
         } catch (\Throwable $e) {
@@ -2553,6 +2552,7 @@ final class RestoreRunner
         if (!is_object($wpdb)) {
             return null;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return null;
@@ -2563,7 +2563,6 @@ final class RestoreRunner
                 WHERE snapshot_id = %s AND restore_id = %s LIMIT 1";
         /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
         $prepared = $wpdb->prepare($sql, $this->snapshotId(), $this->restoreId()); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
-        /** @phpstan-ignore-next-line */
         $row = $wpdb->get_row($prepared, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,PluginCheck.Security.DirectDB.UnescapedDBParameter -- direct query on plugin-owned table; correctness requires a live read; already prepared above; value is the output of $wpdb->prepare()
 
         if (!is_array($row)) {
@@ -2593,6 +2592,7 @@ final class RestoreRunner
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return;
@@ -2602,7 +2602,6 @@ final class RestoreRunner
         $sql = "INSERT IGNORE INTO {$table}
                 (snapshot_id, restore_id, kind, phase, sub_state, started_at, last_progress_at, resume_count, max_resumes)
                 VALUES (%s, %s, %s, %s, %s, %d, %d, %d, %d)";
-        /** @phpstan-ignore-next-line */
         $prepared = $wpdb->prepare(
             $sql, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- identifier validated against information_schema / prefix+constant; values bound via placeholders
             $this->snapshotId(),
@@ -2628,6 +2627,7 @@ final class RestoreRunner
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return;
@@ -2647,7 +2647,6 @@ final class RestoreRunner
         }
         $this->lastDbUpdate = $now;
 
-        /** @phpstan-ignore-next-line */
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; correctness requires a live read
         $wpdb->update(
             $table,
@@ -2675,13 +2674,13 @@ final class RestoreRunner
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return;
         }
         $this->lastDbUpdate = $now;
 
-        /** @phpstan-ignore-next-line */
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; correctness requires a live read
         $wpdb->update(
             $table,
@@ -2765,7 +2764,6 @@ final class RestoreRunner
         global $wpdb;
         if (is_object($wpdb)) {
             $runsTable = $this->prefix() . Schema::BACKUP_RESTORE_RUNS_TABLE;
-            /** @phpstan-ignore-next-line */
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; correctness requires a live read
             $wpdb->delete(
                 $runsTable,

--- a/apps/agent/includes/backup/class-restore-watchdog.php
+++ b/apps/agent/includes/backup/class-restore-watchdog.php
@@ -65,8 +65,8 @@ final class RestoreWatchdog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_RESTORE_TASKS_TABLE;
-        // @phpstan-ignore-next-line — dynamic wpdb.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; no core $wpdb helper exists; correctness requires a live read (anti-replay/locking)
         $row = $wpdb->get_row($wpdb->prepare(
             "SELECT * FROM {$table} WHERE snapshot_id = %s AND restore_id = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); values bound via placeholders
@@ -94,7 +94,6 @@ final class RestoreWatchdog
         $resumeCount = (int) ($row['resume_count'] ?? 0);
         $maxResumes  = (int) ($row['max_resumes'] ?? 6);
         if ($resumeCount >= $maxResumes) {
-            // @phpstan-ignore-next-line
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; no core $wpdb helper exists; correctness requires a live read (anti-replay/locking)
             @$wpdb->update(
                 $table,
@@ -112,7 +111,6 @@ final class RestoreWatchdog
             return;
         }
 
-        // @phpstan-ignore-next-line
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; no core $wpdb helper exists; correctness requires a live read (anti-replay/locking)
         @$wpdb->update(
             $table,
@@ -163,8 +161,8 @@ final class RestoreWatchdog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_RESTORE_TASKS_TABLE;
-        // @phpstan-ignore-next-line — dynamic wpdb.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; no core $wpdb helper exists; correctness requires a live read (anti-replay/locking)
         $row = $wpdb->get_row($wpdb->prepare(
             "SELECT * FROM {$table} WHERE snapshot_id = %s AND restore_id = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); values bound via placeholders

--- a/apps/agent/includes/backup/class-task-runner.php
+++ b/apps/agent/includes/backup/class-task-runner.php
@@ -660,8 +660,8 @@ final class TaskRunner
         if (!is_object($wpdb)) {
             return null;
         }
+        /** @var \wpdb $wpdb */
         try {
-            /** @phpstan-ignore-next-line */
             $result = $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, 0)', $this->lockName())); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- advisory run-lock probe; anti-double-fire correctness read, not a cacheable value
         } catch (\Throwable $e) {
             return null;
@@ -680,8 +680,8 @@ final class TaskRunner
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         try {
-            /** @phpstan-ignore-next-line */
             $wpdb->get_var($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $this->lockName())); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- advisory run-lock release; no core helper exists
         } catch (\Throwable $e) {
             // Swallow — MySQL releases the lock automatically on connection close.
@@ -858,6 +858,7 @@ final class TaskRunner
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return;
@@ -868,7 +869,6 @@ final class TaskRunner
             $sql      = "SELECT sub_state FROM {$table} WHERE snapshot_id = %s LIMIT 1";
             /** @phpstan-ignore-next-line */
             $prepared = $wpdb->prepare($sql, $this->snapshotId()); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
-            /** @phpstan-ignore-next-line */
             $raw = $wpdb->get_var($prepared); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.UnescapedDBParameter, PluginCheck.Security.DirectDB.UnescapedDBParameter -- direct read on plugin-owned table; value is the output of $wpdb->prepare(); $table comes from tableName() (prefix+constant), opaque to static analysis but not user input
 
             $envelope = [];
@@ -884,7 +884,6 @@ final class TaskRunner
                 return;
             }
 
-            /** @phpstan-ignore-next-line */
             $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; breadcrumb-only write, phase column untouched
                 $table,
                 ['sub_state' => $encoded],
@@ -1725,6 +1724,7 @@ final class TaskRunner
         if (!is_object($wpdb)) {
             return null;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return null;
@@ -1734,7 +1734,6 @@ final class TaskRunner
         $sql = "SELECT phase, kind, sub_state, resume_count, max_resumes FROM {$table} WHERE snapshot_id = %s LIMIT 1";
         /** @phpstan-ignore-next-line — $wpdb is a runtime interface. */
         $prepared = $wpdb->prepare($sql, $this->snapshotId()); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
-        /** @phpstan-ignore-next-line */
         $row      = $wpdb->get_row($prepared, ARRAY_A); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.UnescapedDBParameter, PluginCheck.Security.DirectDB.UnescapedDBParameter -- direct query on plugin-owned table; value is the output of $wpdb->prepare()
 
         if (!is_array($row)) {
@@ -1762,6 +1761,7 @@ final class TaskRunner
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return;
@@ -1775,7 +1775,6 @@ final class TaskRunner
         $sql = "INSERT IGNORE INTO {$table}
                 (snapshot_id, kind, phase, sub_state, started_at, last_progress_at, resume_count, max_resumes)
                 VALUES (%s, %s, %s, %s, %d, %d, %d, %d)";
-        /** @phpstan-ignore-next-line */
         $prepared = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on this line via $wpdb->prepare()
             $sql, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- identifier validated against information_schema / prefix+constant; values bound via placeholders
             $this->snapshotId(),
@@ -1872,6 +1871,7 @@ final class TaskRunner
         if (!is_object($wpdb)) {
             return false;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return false;
@@ -1913,7 +1913,6 @@ final class TaskRunner
             }
         }
 
-        /** @phpstan-ignore-next-line */
         $result = $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; no core helper exists; correctness requires a live write
             $table,
             [
@@ -1956,13 +1955,13 @@ final class TaskRunner
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->tableName();
         if ($table === '') {
             return;
         }
         $this->lastDbUpdate = $now;
 
-        /** @phpstan-ignore-next-line */
         $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; throttled liveness ping; no core helper exists
             $table,
             ['last_progress_at' => $now],

--- a/apps/agent/includes/backup/class-watchdog.php
+++ b/apps/agent/includes/backup/class-watchdog.php
@@ -113,9 +113,9 @@ final class Watchdog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
 
         $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
-        // @phpstan-ignore-next-line — dynamic wpdb.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct query on plugin-owned table; identifier is prefix+constant; no caching on live task-state read
         $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE snapshot_id = %s", $snapshotId), ARRAY_A);
         if (!is_array($row)) {
@@ -127,7 +127,6 @@ final class Watchdog
             // Terminal. Best-effort DELETE the row so a future stale
             // wpmgr_backup_watchdog event can't even find it. (Defensive
             // cleanup — the TaskRunner success path now also DELETEs.)
-            // @phpstan-ignore-next-line — dynamic wpdb.
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; correctness requires a live write
             return;
         }
@@ -162,7 +161,6 @@ final class Watchdog
             // last legitimate /progress post made it; if it's already
             // 'completed' on the CP, this guard prevents the phantom 'failed'
             // event that would otherwise overwrite it.
-            // @phpstan-ignore-next-line — dynamic wpdb.
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; stale-row cleanup
             DebugLog::write(sprintf(
                 'WPMgr Backup: watchdog refusing to re-enter stale task for snapshot %s (started %ds ago, phase=%s); deleted row without re-entry',
@@ -214,7 +212,6 @@ final class Watchdog
             // for why this is now gated on the run-lock rather than on
             // $stalledFor alone.
             self::reclaimRunScratch($row);
-            // @phpstan-ignore-next-line — dynamic wpdb.
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; late-phase stale-row cleanup
             DebugLog::write(sprintf(
                 'WPMgr Backup: watchdog refusing to re-enter late-phase stalled task for snapshot %s (phase=%s, stalled %ds); deleted row',
@@ -274,13 +271,11 @@ final class Watchdog
             // local troubleshooting, and the CP's own progress-watchdog
             // independently times the snapshot out on its side regardless.
             self::reclaimRunScratch($row);
-            // @phpstan-ignore-next-line
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; terminal give-up, no further recovery is ever attempted for this row
             DebugLog::write(sprintf('WPMgr Backup: snapshot %s exhausted %d resume attempts; reclaimed scratch and deleted row. %s', $snapshotId, $maxResumes, $failureReason));
             return;
         }
 
-        // @phpstan-ignore-next-line
         @$wpdb->update($table, ['resume_count' => $resumeCount + 1, 'last_progress_at' => time()], ['snapshot_id' => $snapshotId], ['%d', '%d'], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; watchdog resume-count must be written live
         DebugLog::write(sprintf('WPMgr Backup: watchdog resuming snapshot %s (attempt %d/%d) — stalled for %ds in phase=%s',
             $snapshotId, $resumeCount + 1, $maxResumes, $stalledFor, $phase));
@@ -426,8 +421,8 @@ final class Watchdog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
-        // @phpstan-ignore-next-line — dynamic wpdb.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct query on plugin-owned table; identifier is prefix+constant; no caching on live task-state read
         $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE snapshot_id = %s", $snapshotId), ARRAY_A);
         if (!is_array($row)) {
@@ -450,7 +445,6 @@ final class Watchdog
             // Terminal. DELETE the row so this and any future stale
             // wpmgr_backup_run firings short-circuit at the "row missing"
             // check above. Mirrors the success-path cleanup in TaskRunner.
-            // @phpstan-ignore-next-line — dynamic wpdb.
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; terminal cleanup
             return;
         }
@@ -475,7 +469,6 @@ final class Watchdog
             // file when a live runner still holds it, deferring to
             // BackupJanitor::gcRuns(). See reclaimRunScratch()'s own doc.
             self::reclaimRunScratch($row);
-            // @phpstan-ignore-next-line — dynamic wpdb.
             @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned table; stale dispatch cleanup
             DebugLog::write(sprintf(
                 'WPMgr Backup: dispatch refusing to start stale task for snapshot %s (started %ds ago, phase=%s); deleted row',
@@ -544,6 +537,7 @@ final class Watchdog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
 
         $table     = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
         $cutoff    = time() - self::STALL_THRESHOLD_SECONDS;
@@ -555,7 +549,6 @@ final class Watchdog
                     WHERE phase NOT IN (%s, %s) AND last_progress_at < %d
                     ORDER BY started_at ASC
                     LIMIT %d";
-            /** @phpstan-ignore-next-line — dynamic wpdb. */
             $prepared = $wpdb->prepare(
                 // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is a hard-coded query template with placeholders only; values are bound by this very prepare() call
                 $sql,
@@ -564,7 +557,6 @@ final class Watchdog
                 $cutoff,
                 $safeLimit
             );
-            /** @phpstan-ignore-next-line — dynamic wpdb. */
             $rows = $wpdb->get_col($prepared); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- direct read on plugin-owned table; value is the output of $wpdb->prepare()
         } catch (\Throwable $e) {
             DebugLog::write('WPMgr Backup: sweepStalled query failed: ' . $e->getMessage());
@@ -616,6 +608,7 @@ final class Watchdog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
 
         try {
@@ -623,7 +616,6 @@ final class Watchdog
             $sql = "SELECT sub_state FROM {$table} WHERE snapshot_id = %s LIMIT 1";
             /** @phpstan-ignore-next-line — dynamic wpdb. */
             $prepared = $wpdb->prepare($sql, $snapshotId); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- already prepared on the preceding line
-            /** @phpstan-ignore-next-line — dynamic wpdb. */
             $raw = $wpdb->get_var($prepared); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- direct read on plugin-owned table; value is the output of $wpdb->prepare()
 
             $envelope = [];
@@ -639,7 +631,6 @@ final class Watchdog
                 return;
             }
 
-            /** @phpstan-ignore-next-line — dynamic wpdb. */
             @$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; breadcrumb write, correctness requires a live write
                 $table,
                 ['sub_state' => $encoded, 'last_progress_at' => time()],

--- a/apps/agent/includes/cache/class-preload-queue.php
+++ b/apps/agent/includes/cache/class-preload-queue.php
@@ -212,6 +212,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $url = trim($url);
         if ($url === '') {
             return 0;
@@ -268,6 +269,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return null;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
 
         try {
@@ -438,6 +440,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
         try {
             return (int) $wpdb->get_var( // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- value is the output of $wpdb->prepare(); not attacker-controlled
@@ -486,6 +489,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
         try {
             return (int) $wpdb->get_var( // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- value is the output of $wpdb->prepare(); not attacker-controlled
@@ -514,6 +518,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return [];
         }
+        /** @var \wpdb $wpdb */
         $limit = min(200, max(1, $limit));
         $table = $this->table();
         try {
@@ -548,6 +553,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
         try {
             $wpdb->query( // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- value is the output of $wpdb->prepare(); not attacker-controlled
@@ -577,6 +583,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
         try {
             $wpdb->query( // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- value is the output of $wpdb->prepare(); not attacker-controlled
@@ -631,6 +638,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
         try {
             return (int) $wpdb->get_var( // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- value is the output of $wpdb->prepare(); not attacker-controlled
@@ -660,6 +668,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
         try {
             return (int) $wpdb->get_var( // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- value is the output of $wpdb->prepare(); not attacker-controlled
@@ -688,6 +697,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return false;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
         try {
             $count = (int) $wpdb->get_var( // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- value is the output of $wpdb->prepare(); not attacker-controlled
@@ -891,6 +901,7 @@ final class PreloadQueue
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $this->table();
 
         // Table-missing guard: a fresh install before dbDelta ran.

--- a/apps/agent/includes/class-replay-cache.php
+++ b/apps/agent/includes/class-replay-cache.php
@@ -68,7 +68,6 @@ class ReplayCache
 
         // $table is built from a class constant + the trusted wpdb prefix
         // (no user input), so interpolating it ahead of prepare() is safe.
-        // @phpstan-ignore-next-line
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); values bound via placeholders
         $sql = $wpdb->prepare("SELECT 1 FROM {$table} WHERE jti_hash = %s AND expires_at >= %d LIMIT 1", $hash, $now);
         if (!is_string($sql)) {
@@ -179,7 +178,6 @@ class ReplayCache
         $now   = $now ?? time();
         $table = $this->tableName();
 
-        // @phpstan-ignore-next-line
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); values bound via placeholders
         $sql = $wpdb->prepare("DELETE FROM {$table} WHERE expires_at < %d", $now);
         if (!is_string($sql)) {

--- a/apps/agent/includes/class-schema.php
+++ b/apps/agent/includes/class-schema.php
@@ -121,6 +121,7 @@ class Schema
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
 
         // dbDelta lives in wp-admin/includes/upgrade.php and is not loaded by
         // default on the frontend. require_once is safe to call multiple times.

--- a/apps/agent/includes/commands/class-backup-command.php
+++ b/apps/agent/includes/commands/class-backup-command.php
@@ -374,6 +374,7 @@ final class BackupCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return true; // No DB seam — allow the run (single-process dev).
         }
+        /** @var \wpdb $wpdb */
         $table  = $wpdb->prefix . Schema::BACKUP_RUNS_TABLE;
         $now    = time();
         $cutoff = $now - self::DEDUP_WINDOW_SECONDS;
@@ -384,11 +385,9 @@ final class BackupCommand implements CommandInterface
             return false;
         }
         if (is_object($existing)) {
-            // @phpstan-ignore-next-line
             $wpdb->update($table, ['pid' => getmypid() ?: 0, 'started_at' => $now], ['snapshot_id' => $snapshotId], ['%d', '%d'], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned dedup table; no core helper exists
             return true;
         }
-        // @phpstan-ignore-next-line
         $inserted = $wpdb->insert($table, ['snapshot_id' => $snapshotId, 'pid' => getmypid() ?: 0, 'started_at' => $now], ['%s', '%d', '%d']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- direct insert on plugin-owned dedup table; no core helper exists
         return $inserted !== false;
     }
@@ -399,8 +398,8 @@ final class BackupCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_RUNS_TABLE;
-        // @phpstan-ignore-next-line
         @$wpdb->delete($table, ['snapshot_id' => $snapshotId], ['%s']); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct delete on plugin-owned dedup table; no core helper exists
     }
 
@@ -443,6 +442,7 @@ final class BackupCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
         $now   = time();
         $subState = (string) wp_json_encode(['params' => $runnerParams]);
@@ -701,8 +701,8 @@ final class BackupCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return null;
         }
+        /** @var \wpdb $wpdb */
         try {
-            // @phpstan-ignore-next-line
             $value = $wpdb->get_var('SELECT @@max_allowed_packet'); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- preflight max_allowed_packet probe; informational session variable read; no suitable cached alternative
         } catch (\Throwable $e) {
             return null;
@@ -800,6 +800,7 @@ final class BackupCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_TASKS_TABLE;
         $now   = time();
         $subState = (string) wp_json_encode([

--- a/apps/agent/includes/commands/class-db-snapshot-command.php
+++ b/apps/agent/includes/commands/class-db-snapshot-command.php
@@ -541,6 +541,7 @@ final class DbSnapshotCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         try {
             $count = $wpdb->get_var("SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE'"); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- static literal query on information_schema; direct query; no caching appropriate for a live count
             return is_numeric($count) ? (int) $count : 0;

--- a/apps/agent/includes/commands/class-file-extract-command.php
+++ b/apps/agent/includes/commands/class-file-extract-command.php
@@ -721,6 +721,7 @@ final class FileExtractCommand implements CommandInterface {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- headless agent; WP_Filesystem never initialized; direct writability probe
 			&& is_writable( $tmpBaseReal );
 
+		$quarantineDir = '';
 		if ( $useSystemTmp ) {
 			// Create a per-job subdirectory with restrictive permissions.
 			$quarantineDir = (string) $tmpBaseReal . '/wpmgr-extract-' . bin2hex( random_bytes( 8 ) );

--- a/apps/agent/includes/commands/class-file-list-command.php
+++ b/apps/agent/includes/commands/class-file-list-command.php
@@ -246,7 +246,7 @@ final class FileListCommand implements CommandInterface
      *
      * @param string $jailRoot Absolute jail root (no trailing slash, realpath'd).
      * @param string $relPath  Site-relative forward-slash path.
-     * @return array{ok:bool,abs?:string,rel?:string,code?:string,message?:string}
+     * @return array{ok:true,abs:string,rel:string}|array{ok:false,code:string,message:string}
      */
     public static function jailPath(string $jailRoot, string $relPath): array
     {

--- a/apps/agent/includes/commands/class-media-sync-command.php
+++ b/apps/agent/includes/commands/class-media-sync-command.php
@@ -72,6 +72,7 @@ final class MediaSyncCommand implements CommandInterface
         if (!isset($wpdb) || !is_object($wpdb)) {
             return ['ok' => false, 'detail' => 'WP not available'];
         }
+        /** @var \wpdb $wpdb */
 
         // A mega library can enumerate thousands of rows across many pages; this
         // runs in the command's REST request, so lift PHP's per-request caps
@@ -193,6 +194,7 @@ final class MediaSyncCommand implements CommandInterface
         if (!isset($wpdb) || !is_object($wpdb)) {
             return [];
         }
+        /** @var \wpdb $wpdb */
 
         // $wpdb->posts is a trusted core table name; 'image/%' passes through
         // prepare() as a literal value whose % stays a SQL LIKE wildcard.

--- a/apps/agent/includes/commands/class-resend-email-command.php
+++ b/apps/agent/includes/commands/class-resend-email-command.php
@@ -122,6 +122,7 @@ final class ResendEmailCommand implements CommandInterface {
 		if ( ! is_object( $wpdb ) ) {
 			return null;
 		}
+		/** @var \wpdb $wpdb */
 
 		$table = $wpdb->prefix . Schema::EMAIL_LOG_TABLE;
 
@@ -209,6 +210,7 @@ final class ResendEmailCommand implements CommandInterface {
 		if ( ! is_object( $wpdb ) ) {
 			return;
 		}
+		/** @var \wpdb $wpdb */
 
 		$table = $wpdb->prefix . Schema::EMAIL_LOG_TABLE;
 

--- a/apps/agent/includes/commands/class-restore-command.php
+++ b/apps/agent/includes/commands/class-restore-command.php
@@ -329,11 +329,11 @@ final class RestoreCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return true;
         }
+        /** @var \wpdb $wpdb */
         $table  = $wpdb->prefix . Schema::BACKUP_RESTORE_RUNS_TABLE;
         $now    = time();
         $cutoff = $now - self::DEDUP_WINDOW_SECONDS;
 
-        // @phpstan-ignore-next-line
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; no core $wpdb helper exists; correctness requires a live read (anti-replay/locking)
         $existing = $wpdb->get_row($wpdb->prepare(
             "SELECT pid, started_at FROM {$table} WHERE snapshot_id = %s AND restore_id = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- interpolated identifier is prefix+constant (trusted); values bound via placeholders
@@ -344,7 +344,6 @@ final class RestoreCommand implements CommandInterface
             return false;
         }
         if (is_object($existing)) {
-            // @phpstan-ignore-next-line
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; no core $wpdb helper exists
             $wpdb->update(
                 $table,
@@ -355,7 +354,6 @@ final class RestoreCommand implements CommandInterface
             );
             return true;
         }
-        // @phpstan-ignore-next-line
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- direct query on plugin-owned table; no core $wpdb helper exists
         $inserted = $wpdb->insert(
             $table,
@@ -376,8 +374,8 @@ final class RestoreCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_RESTORE_RUNS_TABLE;
-        // @phpstan-ignore-next-line
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct query on plugin-owned table; no core $wpdb helper exists
         @$wpdb->delete($table, ['snapshot_id' => $snapshotId, 'restore_id' => $restoreId], ['%s', '%s']);
     }
@@ -433,6 +431,7 @@ final class RestoreCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_RESTORE_TASKS_TABLE;
         $now   = time();
         $subState = (string) wp_json_encode(['params' => $runnerParams]);
@@ -528,7 +527,6 @@ final class RestoreCommand implements CommandInterface
         global $wpdb;
         if (is_object($wpdb)) {
             try {
-                // @phpstan-ignore-next-line — runtime wpdb seam.
                 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- connectivity probe on core WP connection; no core helper exists; adding cache would defeat the purpose
                 $probe = $wpdb->get_var('SELECT 1');
                 if ((string) $probe !== '1') {
@@ -594,8 +592,8 @@ final class RestoreCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return null;
         }
+        /** @var \wpdb $wpdb */
         try {
-            // @phpstan-ignore-next-line
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- reads a MySQL system variable; no caching applicable; no core $wpdb helper exists
             $value = $wpdb->get_var('SELECT @@max_allowed_packet');
         } catch (\Throwable $e) {
@@ -618,6 +616,7 @@ final class RestoreCommand implements CommandInterface
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . Schema::BACKUP_RESTORE_TASKS_TABLE;
         $now   = time();
         $subState = (string) wp_json_encode([

--- a/apps/agent/includes/commands/class-search-replace-command.php
+++ b/apps/agent/includes/commands/class-search-replace-command.php
@@ -186,6 +186,7 @@ final class SearchReplaceCommand implements CommandInterface
         if (!isset($wpdb) || !is_object($wpdb)) {
             throw new \RuntimeException('wpdb not available');
         }
+        /** @var \wpdb $wpdb */
 
         $prefix        = (string) ($wpdb->prefix ?? '');
         $mysqli        = $this->openMysqli();

--- a/apps/agent/includes/diagnostics/class-size-probe.php
+++ b/apps/agent/includes/diagnostics/class-size-probe.php
@@ -489,6 +489,7 @@ final class SizeProbe
         if (!is_object($wpdb)) {
             return null;
         }
+        /** @var \wpdb $wpdb */
         try {
             $bytes = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- information_schema aggregate size query; no caching (live read required for accurate size probe)
                 "SELECT SUM(data_length + index_length)

--- a/apps/agent/includes/email/class-email-log-reporter.php
+++ b/apps/agent/includes/email/class-email-log-reporter.php
@@ -122,6 +122,7 @@ final class EmailLogReporter {
 		if ( ! is_object( $wpdb ) ) {
 			return;
 		}
+		/** @var \wpdb $wpdb */
 
 		$base = $this->settings->controlPlaneUrl();
 		if ( $base === '' ) {

--- a/apps/agent/includes/email/class-email-logger.php
+++ b/apps/agent/includes/email/class-email-logger.php
@@ -59,6 +59,7 @@ class EmailLogger {
 		if ( ! is_object( $wpdb ) ) {
 			return false;
 		}
+		/** @var \wpdb $wpdb */
 
 		$table = $wpdb->prefix . Schema::EMAIL_LOG_TABLE;
 
@@ -151,6 +152,7 @@ class EmailLogger {
 		if ( ! is_object( $wpdb ) ) {
 			return 0;
 		}
+		/** @var \wpdb $wpdb */
 
 		$days  = max( 1, $retention_days );
 		$table = $wpdb->prefix . Schema::EMAIL_LOG_TABLE;

--- a/apps/agent/includes/email/handlers/class-mailgun-handler.php
+++ b/apps/agent/includes/email/handlers/class-mailgun-handler.php
@@ -135,7 +135,7 @@ final class MailgunHandler implements ProviderHandlerInterface {
 				}
 			}
 			if ( $att_names !== array() && $body_text !== '' ) {
-				$body['text'] .= "\n\n[Attachments: " . implode( ', ', $att_names ) . ']';
+				$body['text'] = ( $body['text'] ?? '' ) . "\n\n[Attachments: " . implode( ', ', $att_names ) . ']';
 			}
 		}
 

--- a/apps/agent/includes/media/class-attachment-meta.php
+++ b/apps/agent/includes/media/class-attachment-meta.php
@@ -498,7 +498,6 @@ final class AttachmentMeta
         }
         $ext  = $this->rename->extensionOf($url);
         $mime = $ext === 'jpg' ? 'image/jpeg' : ('image/' . $ext);
-        // @phpstan-ignore-next-line — wpdb runtime seam.
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on core posts table; correctness requires live write; no plugin-helper wraps $wpdb->update for GUID+mime_type
         $wpdb->update($wpdb->posts, ['guid' => $url, 'post_mime_type' => $mime], ['ID' => $attachmentId]);
     }

--- a/apps/agent/includes/object-cache/class-object-cache-dropin-installer.php
+++ b/apps/agent/includes/object-cache/class-object-cache-dropin-installer.php
@@ -289,6 +289,7 @@ final class ObjectCacheDropinInstaller
 		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) ) {
 			return 0;
 		}
+		/** @var \wpdb $wpdb */
 		$count = 0;
 
 		// Identifier defense in depth: $wpdb->options is a trusted core property,

--- a/apps/agent/includes/optimizer/class-bloat.php
+++ b/apps/agent/includes/optimizer/class-bloat.php
@@ -59,7 +59,10 @@ final class Bloat
             add_action('wp_enqueue_scripts', [$this, 'dequeueDashicons'], 100);
         }
         if ($this->config->bloatDisableJqueryMigrate) {
-            add_filter('wp_default_scripts', [$this, 'removeJqueryMigrate']);
+            // wp_default_scripts is fired via do_action_ref_array() in core — an
+            // action, not a filter. $scripts is mutated by reference; the
+            // callback has nothing to return.
+            add_action('wp_default_scripts', [$this, 'removeJqueryMigrate']);
         }
         if ($this->config->bloatDisableXmlRpc) {
             add_filter('xmlrpc_enabled', '__return_false');

--- a/apps/agent/includes/optimizer/class-db-cleanup.php
+++ b/apps/agent/includes/optimizer/class-db-cleanup.php
@@ -106,7 +106,9 @@ final class DbCleanup
     public function __construct(?PerfConfig $config = null, ?object $wpdb = null)
     {
         $this->config = $config ?? PerfConfig::load();
-        $this->wpdb   = $wpdb ?? (isset($GLOBALS['wpdb']) && is_object($GLOBALS['wpdb']) ? $GLOBALS['wpdb'] : null);
+        /** @var \wpdb|null $resolvedWpdb */
+        $resolvedWpdb = $wpdb ?? (isset($GLOBALS['wpdb']) && is_object($GLOBALS['wpdb']) ? $GLOBALS['wpdb'] : null);
+        $this->wpdb   = $resolvedWpdb;
     }
 
     /**
@@ -620,7 +622,7 @@ final class DbCleanup
         $offset = 0;
 
         while (true) {
-            if ($this->wpdb === null || !method_exists($this->wpdb, 'prepare') || !method_exists($this->wpdb, 'get_results')) {
+            if ($this->wpdb === null || !method_exists($this->wpdb, 'prepare') || !method_exists($this->wpdb, 'get_results') || !method_exists($this->wpdb, 'esc_like')) {
                 break;
             }
 
@@ -631,8 +633,8 @@ final class DbCleanup
             // _transient_* rows to pass all subsequent attribution passes and surface
             // as false-positive orphans. The esc_like() + '%' suffix matches the same
             // pattern that scanExpiredTransients uses for the timeout LIKE.
-            $transientPat     = esc_like('_transient_')     . '%';
-            $siteTransientPat = esc_like('_site_transient_') . '%';
+            $transientPat     = $this->wpdb->esc_like('_transient_')     . '%';
+            $siteTransientPat = $this->wpdb->esc_like('_site_transient_') . '%';
 
             $sql = "SELECT option_name, autoload, LENGTH(option_value) AS size_bytes
                     FROM {$options}

--- a/apps/agent/includes/optimizer/class-font.php
+++ b/apps/agent/includes/optimizer/class-font.php
@@ -302,7 +302,7 @@ final class Font
     private function transcodeWoff2InlineStyles(string $html): string
     {
         if ($this->transcodeClient === null) {
-            return $html; // @phpstan-ignore-line — guard re-checked for clarity
+            return $html;
         }
         return (string) preg_replace_callback(
             '/<style\b[^>]*>(.*?)<\/style>/is',
@@ -557,7 +557,6 @@ final class Font
      */
     private function walkFontDir(string $dir, string $baseDir): void
     {
-        // @phpstan-ignore-next-line
         $entries = @scandir($dir);
         if ($entries === false) {
             return;

--- a/apps/agent/includes/security/class-profile-update-user.php
+++ b/apps/agent/includes/security/class-profile-update-user.php
@@ -102,7 +102,14 @@ final class ProfileUpdateUser
             $loaded = get_userdata($id);
             if ($loaded instanceof \WP_User) {
                 $existing = $loaded;
-                if (isset($loaded->roles) && is_array($loaded->roles)) {
+                // No isset() here: WP_User::$roles is populated by the
+                // constructor on every real instance (core's WP_User and this
+                // suite's stub both declare it with a `[]` default), so once
+                // $loaded is confirmed instanceof \WP_User the property is
+                // always set. is_array() stays as the actual runtime guard —
+                // a plugin filtering user data could still hand back something
+                // that is not an array despite the declared type.
+                if (is_array($loaded->roles)) {
                     $roles = array_values(array_filter(array_map('strval', $loaded->roles)));
                 }
             }

--- a/apps/agent/includes/support/class-activity-log.php
+++ b/apps/agent/includes/support/class-activity-log.php
@@ -811,6 +811,7 @@ final class ActivityLog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
 
         try {
             $table = $wpdb->prefix . self::TABLE;
@@ -985,6 +986,7 @@ final class ActivityLog
         if (!is_object($wpdb)) {
             return self::GENESIS_HASH;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . self::TABLE;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct read on plugin-owned table; identifier is prefix+constant; no caching (live chain-head needed)
         $hash = $wpdb->get_var("SELECT this_hash FROM {$table} ORDER BY seq DESC LIMIT 1");
@@ -1007,6 +1009,7 @@ final class ActivityLog
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . self::TABLE;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct count on plugin-owned table; identifier is prefix+constant; live read needed
         $count = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table}");
@@ -1055,6 +1058,7 @@ final class ActivityLog
         if (!is_object($wpdb)) {
             return [];
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . self::TABLE;
         // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct query on plugin-owned table; identifier is prefix+constant; no caching (live unshipped rows needed)
         $rows = $wpdb->get_results(

--- a/apps/agent/includes/support/class-error-monitor.php
+++ b/apps/agent/includes/support/class-error-monitor.php
@@ -388,6 +388,7 @@ final class ErrorMonitor
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $md5 = md5($code . ':' . $file . ':' . $line . ':' . $message);
 
         // --- S1.2 ignore-list + level gating ---
@@ -497,6 +498,7 @@ final class ErrorMonitor
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . self::TABLE;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- direct count on plugin-owned table; identifier is prefix+constant; live read needed
         $count = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table}");
@@ -624,6 +626,7 @@ final class ErrorMonitor
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
         $table = $wpdb->prefix . self::TABLE;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- direct update on plugin-owned table; correctness requires a live write
         $result = $wpdb->update(
@@ -655,6 +658,7 @@ final class ErrorMonitor
         if (!is_object($wpdb)) {
             return [];
         }
+        /** @var \wpdb $wpdb */
         $table    = $wpdb->prefix . self::TABLE;
         $sinceId  = (int) (function_exists('get_option') ? get_option(self::OPTION_SHIP_CURSOR, 0) : 0);
         $sinceTs  = (int) (function_exists('get_option') ? get_option(self::OPTION_SHIP_TS, 0) : 0);

--- a/apps/agent/includes/support/class-login-protection.php
+++ b/apps/agent/includes/support/class-login-protection.php
@@ -321,6 +321,7 @@ final class LoginProtection
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
 
         try {
             $table = $wpdb->prefix . self::TABLE;
@@ -494,6 +495,7 @@ final class LoginProtection
         if (!is_object($wpdb)) {
             return [];
         }
+        /** @var \wpdb $wpdb */
 
         $sinceId = (int) (function_exists('get_option') ? get_option(self::OPTION_SHIP_CURSOR, 0) : 0);
         $table   = $wpdb->prefix . self::TABLE;
@@ -573,6 +575,7 @@ final class LoginProtection
         if (!is_object($wpdb)) {
             return 0;
         }
+        /** @var \wpdb $wpdb */
 
         $cutoff = $now - $gap;
         $table  = $wpdb->prefix . self::TABLE;
@@ -820,6 +823,7 @@ final class LoginProtection
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
 
         try {
             $table = $wpdb->prefix . self::TABLE;
@@ -858,6 +862,7 @@ final class LoginProtection
         if (!is_object($wpdb)) {
             return;
         }
+        /** @var \wpdb $wpdb */
 
         try {
             $table = $wpdb->prefix . self::TABLE;

--- a/apps/agent/phpstan-baseline.neon
+++ b/apps/agent/phpstan-baseline.neon
@@ -1,6 +1,24 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Parameter \#1 \$params of class WPMgr\\Agent\\Backup\\TaskRunner constructor expects array\{snapshot_id\: string, kind\: string, age_recipient\: string, presign_endpoint\: string, manifest_endpoint\: string, progress_endpoint\: string, chunk_bytes\: int, scratch_dir\: string, \.\.\.\}, array\{snapshot_id\: non\-falsy\-string, scratch_dir\: non\-falsy\-string\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/backup/class-backup-janitor.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/backup/class-backup-janitor.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: includes/backup/class-backup-janitor.php
+
+		-
 			message: '#^Cannot call method fetch_array\(\) on mysqli_result\|true\.$#'
 			identifier: method.nonObject
 			count: 2
@@ -37,22 +55,16 @@ parameters:
 			path: includes/backup/class-db-dumper.php
 
 		-
-			message: '#^Parameter \#3 \$length of function substr expects int\|null, int\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/backup/class-db-dumper.php
-
-		-
 			message: '#^Property WPMgr\\Agent\\Backup\\DbDumper\:\:\$opts is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: includes/backup/class-db-dumper.php
 
 		-
-			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
+			message: '#^Strict comparison using \!\=\= between numeric\-string and '''' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
 			count: 1
-			path: includes/backup/class-db-restorer.php
+			path: includes/backup/class-db-dumper.php
 
 		-
 			message: '#^Cannot call method close\(\) on mysqli_result\|true\.$#'
@@ -76,12 +88,6 @@ parameters:
 			message: '#^Cannot call method free\(\) on mysqli_result\|true\.$#'
 			identifier: method.nonObject
 			count: 5
-			path: includes/backup/class-db-restorer.php
-
-		-
-			message: '#^Expression on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.expr
-			count: 1
 			path: includes/backup/class-db-restorer.php
 
 		-
@@ -111,7 +117,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$array \(list\<\(int\|string\)\>\) of array_values is already a list, call has no effect\.$#'
 			identifier: arrayValues.list
-			count: 1
+			count: 3
 			path: includes/backup/class-files-archiver.php
 
 		-
@@ -119,6 +125,24 @@ parameters:
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 2
 			path: includes/backup/class-files-restorer.php
+
+		-
+			message: '#^Property wpdb\:\:\$options \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: includes/backup/class-restore-health-check.php
+
+		-
+			message: '#^Property wpdb\:\:\$prefix \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: includes/backup/class-restore-health-check.php
+
+		-
+			message: '#^Call to an undefined method object\:\:delete\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/backup/class-restore-runner.php
 
 		-
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
@@ -271,14 +295,44 @@ parameters:
 			path: includes/backup/class-restore-runner.php
 
 		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: includes/backup/class-restore-runner.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/backup/class-restore-runner.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and '''' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/backup/class-restore-runner.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/backup/class-restore-runner.php
+
+		-
 			message: '#^Ternary operator condition is always false\.$#'
 			identifier: ternary.alwaysFalse
 			count: 1
 			path: includes/backup/class-restore-runner.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$prefix\.$#'
-			identifier: property.notFound
+			message: '#^Variable \$age on left side of \?\?\= always exists and is always null\.$#'
+			identifier: nullCoalesce.variable
+			count: 1
+			path: includes/backup/class-restore-runner.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
 			count: 2
 			path: includes/backup/class-restore-watchdog.php
 
@@ -289,16 +343,46 @@ parameters:
 			path: includes/backup/class-sql-inspector.php
 
 		-
+			message: '#^Parameter \#1 \$array of function array_values contains unresolvable type\.$#'
+			identifier: argument.unresolvableType
+			count: 1
+			path: includes/backup/class-task-runner.php
+
+		-
 			message: '#^Parameter \#1 \$entries of method WPMgr\\Agent\\Backup\\EncryptAndUpload\:\:submitManifest\(\) expects list\<array\<string, mixed\>\>, non\-empty\-array\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/backup/class-task-runner.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$prefix\.$#'
-			identifier: property.notFound
-			count: 2
-			path: includes/backup/class-watchdog.php
+			message: '#^Parameter \#1 \$entries of method WPMgr\\Agent\\Backup\\TaskRunner\:\:appendTombstoneEntries\(\) expects list\<array\<string, mixed\>\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/backup/class-task-runner.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/backup/class-task-runner.php
+
+		-
+			message: '#^Return type of call to function array_values contains unresolvable type\.$#'
+			identifier: function.unresolvableReturnType
+			count: 1
+			path: includes/backup/class-task-runner.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between array\{\} and array\{\} will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: includes/backup/class-task-runner.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and '''' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/backup/class-task-runner.php
 
 		-
 			message: '#^Method WPMgr\\Agent\\Backup\\Watchdog\:\:decodeSubState\(\) has parameter \$raw with no type specified\.$#'
@@ -319,10 +403,100 @@ parameters:
 			path: includes/backup/class-watchdog.php
 
 		-
+			message: '#^Parameter \#1 \$params of class WPMgr\\Agent\\Backup\\TaskRunner constructor expects array\{snapshot_id\: string, kind\: string, age_recipient\: string, presign_endpoint\: string, manifest_endpoint\: string, progress_endpoint\: string, chunk_bytes\: int, scratch_dir\: string, \.\.\.\}, non\-empty\-array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/backup/class-watchdog.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: includes/backup/class-watchdog.php
+
+		-
 			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: includes/backup/destinations/class-local-destination.php
+
+		-
+			message: '#^Constant WPMgr\\Agent\\Backup\\Destinations\\LocalDestination\:\:BASE_DIR_NAME is unused\.$#'
+			identifier: classConstant.unused
+			count: 1
+			path: includes/backup/destinations/class-local-destination.php
+
+		-
+			message: '#^Parameter \#1 \$args of method WP_Admin_Bar\:\:add_node\(\) expects array\{id\?\: string, title\?\: string, parent\?\: string, href\?\: string, group\?\: bool, meta\?\: array\}, array\{id\: ''wpmgr\-cache'', title\: ''WPMgr Cache'', href\: false\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/cache/class-admin-bar-purge.php
+
+		-
+			message: '#^Cannot cast int\|WP_Post to int\.$#'
+			identifier: cast.int
+			count: 1
+			path: includes/cache/class-cache-manager.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/cache/class-cache-writer.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between non\-falsy\-string and '''' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: includes/cache/class-cacheability.php
+
+		-
+			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: includes/cache/class-preload-queue.php
+
+		-
+			message: '#^Call to an undefined method object\:\:query\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: includes/cache/class-preload-queue.php
+
+		-
+			message: '#^Offset 0 on array\{float, float, float\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: includes/cache/class-preload-queue.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 13
+			path: includes/cache/class-preload-queue.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 5
+			path: includes/cache/class-preload-queue.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: includes/cache/class-purge.php
+
+		-
+			message: '#^Parameter \#1 \$hook_name of function do_action expects non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/cache/class-purge.php
+
+		-
+			message: '#^Found usage of constant DOING_AJAX\. Use wp_doing_ajax\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: includes/class-heartbeat-catchup.php
 
 		-
 			message: '#^Call to function is_string\(\) with ''/var/keys/wpmgr…'' will always evaluate to true\.$#'
@@ -333,8 +507,32 @@ parameters:
 		-
 			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 3
+			count: 4
 			path: includes/class-keystore.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\MediaKeystore\:\:get\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/class-media-keystore.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\MediaKeystore\:\:reduceAfterRestore\(\) has parameter \$sizesUnoptimized with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/class-media-keystore.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\MediaKeystore\:\:set\(\) has parameter \$blob with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/class-media-keystore.php
+
+		-
+			message: '#^Action callback returns bool but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: includes/class-plugin.php
 
 		-
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
@@ -343,22 +541,40 @@ parameters:
 			path: includes/class-plugin.php
 
 		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/class-replay-cache.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: includes/class-scheduler.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: includes/class-scheduler.php
+
+		-
 			message: '#^Call to function property_exists\(\) with WP_User and ''roles'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: includes/commands/class-autologin-command.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$prefix\.$#'
-			identifier: property.notFound
-			count: 4
-			path: includes/commands/class-backup-command.php
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: includes/commands/class-autologin-command.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$started_at\.$#'
-			identifier: property.notFound
+			message: '#^Offset ''type'' on array\{type\: int, message\: string, file\: string, line\: int\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
 			count: 1
-			path: includes/commands/class-backup-command.php
+			path: includes/commands/class-autologin-command.php
 
 		-
 			message: '#^Call to function method_exists\(\) with ''ZipArchive'' and ''addFile'' will always evaluate to true\.$#'
@@ -367,22 +583,64 @@ parameters:
 			path: includes/commands/class-backup-command.php
 
 		-
-			message: '#^Method WPMgr\\Agent\\Commands\\BackupCommand\:\:execute\(\) should return array\{ok\: bool, detail\: string\} but returns array\.$#'
-			identifier: return.type
-			count: 8
-			path: includes/commands/class-backup-command.php
-
-		-
-			message: '#^Method WPMgr\\Agent\\Commands\\BackupCommand\:\:refuse\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/commands/class-backup-command.php
-
-		-
 			message: '#^Method WPMgr\\Agent\\Commands\\BackupCommand\:\:seedTaskRow\(\) has parameter \$runnerParams with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: includes/commands/class-backup-command.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/commands/class-backup-command.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Commands\\CacheEnableCommand\:\:execute\(\) should return array\{ok\: bool, detail\: string, steps\?\: array\<string, bool\>, stats\?\: array\<string, mixed\>\} but returns array\<string, mixed\>\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/commands/class-cache-enable-command.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: includes/commands/class-db-clean-command.php
+
+		-
+			message: '#^Offset ''message'' on array\{type\: int, message\: string, file\: string, line\: int\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: includes/commands/class-db-clean-command.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_var\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/commands/class-db-orphan-delete-command.php
+
+		-
+			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/commands/class-db-orphan-delete-command.php
+
+		-
+			message: '#^Call to function is_callable\(\) with ''get_plugins'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/commands/class-db-orphan-delete-command.php
+
+		-
+			message: '#^Property WPMgr\\Agent\\Commands\\DbOrphanDeleteCommand\:\:\$settings is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: includes/commands/class-db-orphan-delete-command.php
+
+		-
+			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
+			identifier: method.notFound
+			count: 10
+			path: includes/commands/class-db-table-action-command.php
 
 		-
 			message: '#^Call to an undefined method object\:\:get_row\(\)\.$#'
@@ -409,14 +667,122 @@ parameters:
 			path: includes/commands/class-diagnostics-command.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$prefix\.$#'
-			identifier: property.notFound
-			count: 4
-			path: includes/commands/class-restore-command.php
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-file-archive-create-command.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$started_at\.$#'
-			identifier: property.notFound
+			message: '#^Call to function is_float\(\) with float will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/commands/class-file-chmod-command.php
+
+		-
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/commands/class-media-clean-command.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Commands\\MediaCleanCommand\:\:allFilePathsForAttachment\(\) has parameter \$meta with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/commands/class-media-clean-command.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Commands\\MediaCleanCommand\:\:optimizerManagedPaths\(\) has parameter \$meta with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/commands/class-media-clean-command.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Commands\\MediaCleanCommand\:\:requireJobId\(\) has parameter \$params with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/commands/class-media-clean-command.php
+
+		-
+			message: '#^Parameter \#1 \$job of method WPMgr\\Agent\\Commands\\MediaDeleteOriginalsCommand\:\:processJob\(\) expects array\{job_id\: string, wp_attachment_id\: int\}, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-media-delete-originals-command.php
+
+		-
+			message: '#^Parameter \#1 \$job of method WPMgr\\Agent\\Commands\\MediaDeleteOriginalsCommand\:\:processJob\(\) expects array\{job_id\: string, wp_attachment_id\: int\}, array\<string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-media-delete-originals-command.php
+
+		-
+			message: '#^Parameter \#1 \$job of method WPMgr\\Agent\\Commands\\MediaOptimizeCommand\:\:processJob\(\) expects array\{job_id\: string, wp_attachment_id\: int\}, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-media-optimize-command.php
+
+		-
+			message: '#^Parameter \#1 \$job of method WPMgr\\Agent\\Commands\\MediaOptimizeCommand\:\:processJob\(\) expects array\{job_id\: string, wp_attachment_id\: int\}, array\<string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-media-optimize-command.php
+
+		-
+			message: '#^Parameter \#1 \$job of method WPMgr\\Agent\\Commands\\MediaRestoreCommand\:\:processJob\(\) expects array\{job_id\: string, wp_attachment_id\: int\}, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-media-restore-command.php
+
+		-
+			message: '#^Parameter \#1 \$job of method WPMgr\\Agent\\Commands\\MediaRestoreCommand\:\:processJob\(\) expects array\{job_id\: string, wp_attachment_id\: int\}, array\<string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-media-restore-command.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-media-sync-command.php
+
+		-
+			message: '#^Dead catch \- Throwable is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: includes/commands/class-objectcache-test-command.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: includes/commands/class-objectcache-test-command.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Commands\\PerfConfigUpdateCommand\:\:execute\(\) should return array\{ok\: bool, detail\: string, stats\?\: array\<string, mixed\>\} but returns array\<string, mixed\>\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/commands/class-perf-config-update-command.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and '''' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/commands/class-record-managed-files-command.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/commands/class-resend-email-command.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/commands/class-resend-email-command.php
+
+		-
+			message: '#^Call to an undefined method object\:\:get_var\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: includes/commands/class-restore-command.php
 
@@ -427,10 +793,40 @@ parameters:
 			path: includes/commands/class-restore-command.php
 
 		-
-			message: '#^Call to an undefined method object\:\:get_var\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: includes/commands/class-restore-command.php
+
+		-
+			message: '#^Cannot call method fetch_assoc\(\) on mysqli_result\|true\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: includes/commands/class-search-replace-command.php
+
+		-
+			message: '#^Cannot call method fetch_row\(\) on mysqli_result\|true\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: includes/commands/class-search-replace-command.php
+
+		-
+			message: '#^Cannot call method free\(\) on mysqli_result\|true\.$#'
+			identifier: method.nonObject
+			count: 7
+			path: includes/commands/class-search-replace-command.php
+
+		-
+			message: '#^Property wpdb\:\:\$prefix \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
 			count: 1
-			path: includes/diagnostics/class-size-probe.php
+			path: includes/commands/class-search-replace-command.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between non\-empty\-string and '''' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: includes/commands/class-update-command.php
 
 		-
 			message: '#^Strict comparison using \!\=\= between non\-empty\-string and '''' will always evaluate to true\.$#'
@@ -439,10 +835,604 @@ parameters:
 			path: includes/diagnostics/class-size-probe.php
 
 		-
+			message: '#^Call to an undefined method object\:\:get_results\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/email/class-email-log-reporter.php
+
+		-
+			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/email/class-email-log-reporter.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/email/class-email-logger.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/email/class-email-logger.php
+
+		-
+			message: '#^Comparison operation "\>\=" between int\<0, max\> and 0 is always true\.$#'
+			identifier: greaterOrEqual.alwaysTrue
+			count: 1
+			path: includes/email/class-mail-router.php
+
+		-
+			message: '#^Parameter \#1 \$array \(list\<string\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 3
+			path: includes/email/class-mail-router.php
+
+		-
+			message: '#^Parameter \#1 \$array \(non\-empty\-list\<mixed\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: includes/email/class-provider-router.php
+
+		-
+			message: '#^Cannot cast array\|string to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: includes/email/handlers/class-sendgrid-handler.php
+
+		-
+			message: '#^Cannot call method getPathname\(\) on SplFileInfo\|string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/integrations/class-cloudpanel.php
+
+		-
+			message: '#^Cannot call method isDir\(\) on SplFileInfo\|string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/integrations/class-cloudpanel.php
+
+		-
+			message: '#^Cannot call method isFile\(\) on SplFileInfo\|string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/integrations/class-cloudpanel.php
+
+		-
+			message: '#^Cannot call method isLink\(\) on SplFileInfo\|string\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: includes/integrations/class-cloudpanel.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Integrations\\CloudPanel\:\:urlPart\(\) should return int\|string\|false\|null but returns array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\|int\<0, 65535\>\|string\|false\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/integrations/class-cloudpanel.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\Breeze_CloudFlare…'' and ''is_cloudflare…'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-cloudways.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\Breeze_CloudFlare…'' and ''purge_cloudflare…'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-cloudways.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\Breeze_CloudFlare…'' and ''reset_all_cache'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-cloudways.php
+
+		-
+			message: '#^Call to static method purge_cloudflare_cache_urls\(\) on an unknown class Breeze_CloudFlare_Helper\.$#'
+			identifier: class.notFound
+			count: 1
+			path: includes/integrations/class-cloudways.php
+
+		-
+			message: '#^Call to static method reset_all_cache\(\) on an unknown class Breeze_CloudFlare_Helper\.$#'
+			identifier: class.notFound
+			count: 1
+			path: includes/integrations/class-cloudways.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\CDN_Clear_Cache…'' and ''purge_cache'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-rocketnet.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\CDN_Clear_Cache…'' and ''purge_cache_url'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-rocketnet.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\RunCloud_Hub'' and ''purge_cache_all'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-runcloud.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\RunCloud_Hub'' and ''purge_cache_all…'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-runcloud.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\RunCloud_Hub'' and ''purge_cache_object'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-runcloud.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\SiteGround…'' and ''get_instance'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-siteground.php
+
+		-
+			message: '#^PHPDoc tag @var for constant WPMgr\\Agent\\Integrations\\SiteGround\:\:SUPERCACHER with type class\-string is incompatible with value ''\\\\SiteGround…''\.$#'
+			identifier: classConstant.phpDocType
+			count: 1
+			path: includes/integrations/class-siteground.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\WpeCommon'' and ''clear_maxcdn_cache''\|''purge_memcached''\|''purge_varnish_cache'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: includes/integrations/class-wpengine.php
+
+		-
+			message: '#^Call to an undefined method object\:\:update\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: includes/media/class-attachment-meta.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/media/class-db-rewriter.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaQuarantine\:\:loadManifest\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-quarantine.php
+
+		-
+			message: '#^Property WPMgr\\Agent\\Media\\MediaQuarantine\:\:\$openManifests type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-quarantine.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:allPathsForAttachment\(\) has parameter \$meta with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:extractFromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:extractFromArrayAttributed\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:extractFromJsonMeta\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:extractFromSerialized\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:isReferenced\(\) has parameter \$attachmentMeta with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Property WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:\$ids type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Property WPMgr\\Agent\\Media\\MediaReferenceIndex\:\:\$paths type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between non\-empty\-string and '''' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: includes/media/class-media-reference-index.php
+
+		-
+			message: '#^Parameter \#1 \$array \(non\-empty\-list\<mixed\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: includes/media/class-media-run-store.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Media\\MediaUploader\:\:jobStatus\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/media/class-media-uploader.php
+
+		-
+			message: '#^PHPDoc tag @return with type bool is incompatible with native type array\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: includes/media/class-media-uploader.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/object-cache/class-object-cache-dropin-installer.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/object-cache/class-object-cache-dropin-installer.php
+
+		-
+			message: '#^Property wpdb\:\:\$options \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: includes/object-cache/class-object-cache-dropin-installer.php
+
+		-
+			message: '#^Anonymous function has an unused use \$results\.$#'
+			identifier: closure.unusedUse
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method del\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method get\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method mget\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method pipeline\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method set\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 11
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method setex\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method ttl\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Cannot call method unlink\(\) on Redis\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Comparison operation "\<" between 0\|1 and 2 is always true\.$#'
+			identifier: smaller.alwaysTrue
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Parameter \#1 \$redis of static method WPMgr\\Agent\\ObjectCache\\RedisConnection\:\:probeCapabilities\(\) expects Redis, Redis\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Property WPMgr_Object_Cache\:\:\$failbackFlushed is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Property WPMgr_Object_Cache\:\:\$globalGroups \(array\<string\>\) does not accept array\<bool\|string\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Property WPMgr_Object_Cache\:\:\$globalGroups \(array\<string\>\) does not accept array\<string, int\>\.$#'
+			identifier: assign.propertyType
+			count: 2
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Property WPMgr_Object_Cache\:\:\$nonPersistentGroups \(array\<string\>\) does not accept array\<bool\|string\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Property WPMgr_Object_Cache\:\:\$nonPersistentGroups \(array\<string\>\) does not accept array\<string, int\>\.$#'
+			identifier: assign.propertyType
+			count: 2
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Property WPMgr_Object_Cache\:\:\$nonPrefetchableGroups is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between Redis and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: includes/object-cache/class-object-cache-engine.php
+
+		-
+			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/object-cache/class-object-cache-heartbeat.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Redis and ''connect'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/object-cache/class-redis-connection.php
+
+		-
+			message: '#^Constant WPMgr\\Agent\\ObjectCache\\RedisConnection\:\:JITTER_BASE_US is unused\.$#'
+			identifier: classConstant.unused
+			count: 1
+			path: includes/object-cache/class-redis-connection.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\ObjectCache\\RedisConnection\:\:acquire\(\) should return Redis but returns Redis\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/object-cache/class-redis-connection.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: includes/object-cache/class-redis-connection.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between int\<min, 3\> and 4 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/object-cache/class-redis-connection.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Optimizer\\DbCleanup\:\:buildInstalledPluginsSnapshot\(\) should return list\<array\{slug\: string, name\: string, active\: bool, source\: string\}\> but returns list\<array\{active\: true, source\: ''network''\}\|array\{slug\: non\-empty\-string, name\: non\-empty\-string, active\: bool, source\: ''dropin''\|''mu\-plugin''\|''network''\|''plugin''\}\>\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Optimizer\\DbCleanup\:\:directQuery\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Optimizer\\DbCleanup\:\:ids\(\) should return list\<int\> but returns array\<int\>\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Offset 1 on array\{string, non\-falsy\-string\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 2
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, string given\.$#'
+			identifier: argument.type
+			count: 4
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between object and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/optimizer/class-db-cleanup.php
+
+		-
+			message: '#^Offset ''otf''\|''ttf''\|''woff'' on array\{woff\: ''woff'', ttf\: ''truetype'', otf\: ''opentype''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: includes/optimizer/class-font.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''opentype''\|''truetype''\|''woff'' and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: includes/optimizer/class-font.php
+
+		-
+			message: '#^Offset 0 on array\{0\: int\<0, max\>, 1\: int\<0, max\>, 2\: int, 3\: string, mime\: string, channels\?\: int, bits\?\: int\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: includes/optimizer/class-images-html.php
+
+		-
+			message: '#^Offset 1 on array\{0\: int\<0, max\>, 1\: int\<0, max\>, 2\: int, 3\: string, mime\: string, channels\?\: int, bits\?\: int\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: includes/optimizer/class-images-html.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: includes/optimizer/class-optimizer.php
+
+		-
+			message: '#^Call to function is_array\(\) with list\<non\-empty\-string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/optimizer/class-rum-injector.php
+
+		-
+			message: '#^Call to function is_string\(\) with non\-empty\-string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/optimizer/class-rum-injector.php
+
+		-
 			message: '#^Property WPMgr\\Agent\\Phpbu\\ProgressClient\:\:\$snapshotId is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: includes/phpbu/class-progress-client.php
+
+		-
+			message: '#^Constant WPMgr\\Agent\\Security\\HardeningModule\:\:AGENT_AUTOLOGIN_PATH is unused\.$#'
+			identifier: classConstant.unused
+			count: 1
+			path: includes/security/class-hardening-module.php
+
+		-
+			message: '#^Found usage of constant DOING_CRON\. Use wp_doing_cron\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: includes/security/class-hardening-module.php
+
+		-
+			message: '#^Parameter \#1 \$array \(list\<string\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: includes/security/class-hardening-module.php
+
+		-
+			message: '#^Found usage of constant DOING_CRON\. Use wp_doing_cron\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: includes/security/class-hide-backend-module.php
+
+		-
+			message: '#^Found usage of constant WP_INSTALLING\. Use wp_installing\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: includes/security/class-hide-backend-module.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arg1 of function max expects non\-empty\-array, list\<int\<0, max\>\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/security/class-qr-encoder.php
+
+		-
+			message: '#^Static property WPMgr\\Agent\\Security\\QrEncoder\:\:\$gfExp \(list\<int\>\) does not accept non\-empty\-array\<int\<0, max\>, int\>\.$#'
+			identifier: assign.propertyType
+			count: 2
+			path: includes/security/class-qr-encoder.php
+
+		-
+			message: '#^Parameter \#1 \$array \(non\-empty\-list\<string\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: includes/security/class-security-policy.php
+
+		-
+			message: '#^Property WP_User\:\:\$roles \(array\<string\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: includes/security/class-security-policy.php
+
+		-
+			message: '#^Call to function method_exists\(\) with WP_REST_Request and ''get_route'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/security/class-site-2fa-module.php
+
+		-
+			message: '#^Parameter \#1 \$object_or_class of function is_a expects object, WP_Error\|WP_User\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/security/class-site-2fa-module.php
+
+		-
+			message: '#^Property WP_Roles\:\:\$role_names \(array\<string\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: includes/security/class-site-roles.php
+
+		-
+			message: '#^Property WP_Roles\:\:\$roles \(array\<array\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: includes/security/class-site-roles.php
+
+		-
+			message: '#^Method WPMgr\\Agent\\Security\\TotpProvider\:\:storeSecret\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: includes/security/class-totp-provider.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$options\.$#'
@@ -453,23 +1443,11 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$prefix\.$#'
 			identifier: property.notFound
-			count: 5
-			path: includes/support/class-activity-log.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_results\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: includes/support/class-activity-log.php
 
 		-
 			message: '#^Call to an undefined method object\:\:get_var\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: includes/support/class-activity-log.php
-
-		-
-			message: '#^Call to an undefined method object\:\:insert\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: includes/support/class-activity-log.php
@@ -477,13 +1455,13 @@ parameters:
 		-
 			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
 			identifier: method.notFound
-			count: 6
+			count: 3
 			path: includes/support/class-activity-log.php
 
 		-
 			message: '#^Call to an undefined method object\:\:query\(\)\.$#'
 			identifier: method.notFound
-			count: 4
+			count: 2
 			path: includes/support/class-activity-log.php
 
 		-
@@ -496,6 +1474,18 @@ parameters:
 			message: '#^Offset ''status'' on \*NEVER\* on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.offset
 			count: 1
+			path: includes/support/class-activity-log.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: includes/support/class-activity-log.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 2
 			path: includes/support/class-activity-log.php
 
 		-
@@ -523,43 +1513,25 @@ parameters:
 			path: includes/support/class-blake3.php
 
 		-
+			message: '#^Trying to invoke string but it might not be a callable\.$#'
+			identifier: callable.nonCallable
+			count: 1
+			path: includes/support/class-connection-finisher.php
+
+		-
 			message: '#^Access to an undefined property object\:\:\$prefix\.$#'
 			identifier: property.notFound
-			count: 5
-			path: includes/support/class-error-monitor.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_results\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/support/class-error-monitor.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_var\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/support/class-error-monitor.php
-
-		-
-			message: '#^Call to an undefined method object\:\:insert\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: includes/support/class-error-monitor.php
 
 		-
 			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
 			identifier: method.notFound
-			count: 4
+			count: 1
 			path: includes/support/class-error-monitor.php
 
 		-
 			message: '#^Call to an undefined method object\:\:query\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: includes/support/class-error-monitor.php
-
-		-
-			message: '#^Call to an undefined method object\:\:update\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: includes/support/class-error-monitor.php
@@ -595,6 +1567,18 @@ parameters:
 			path: includes/support/class-error-monitor.php
 
 		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: includes/support/class-error-monitor.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/support/class-error-monitor.php
+
+		-
 			message: '#^Strict comparison using \=\=\= between non\-empty\-string and '''' will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
@@ -607,40 +1591,40 @@ parameters:
 			path: includes/support/class-file-scanner.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$prefix\.$#'
-			identifier: property.notFound
-			count: 5
-			path: includes/support/class-login-protection.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_results\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Method WPMgr\\Agent\\Support\\FileScanner\:\:scan\(\) has parameter \$excludeTopDirs with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
-			path: includes/support/class-login-protection.php
+			path: includes/support/class-file-scanner.php
 
 		-
-			message: '#^Call to an undefined method object\:\:get_var\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: includes/support/class-login-protection.php
-
-		-
-			message: '#^Call to an undefined method object\:\:insert\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Method WPMgr\\Agent\\Support\\FileScanner\:\:scan\(\) has parameter \$resumeCursor with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
-			path: includes/support/class-login-protection.php
+			path: includes/support/class-file-scanner.php
 
 		-
-			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
-			identifier: method.notFound
-			count: 5
-			path: includes/support/class-login-protection.php
+			message: '#^Offset ''mode'' on array\{path\: array\|string, size\: int, md5\: '''', mtime\: int, mode\: mixed, is_link\: bool, uid\?\: mixed, gid\?\: mixed\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: includes/support/class-file-scanner.php
 
 		-
-			message: '#^Call to an undefined method object\:\:query\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: includes/support/class-login-protection.php
+			message: '#^Offset ''mtime'' on array\{path\: array\|string, size\: int, md5\: '''', mtime\: mixed, mode\: mixed, is_link\: bool, uid\?\: mixed, gid\?\: mixed\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: includes/support/class-file-scanner.php
+
+		-
+			message: '#^Offset ''size'' on array\{path\: array\|string, size\: mixed, md5\: '''', mtime\: mixed, mode\: mixed, is_link\: bool, uid\?\: mixed, gid\?\: mixed\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: includes/support/class-file-scanner.php
+
+		-
+			message: '#^Parameter \#2 \$traversalStack of method WPMgr\\Agent\\Support\\FileScanner\:\:buildBasePath\(\) expects list\<array\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/support/class-file-scanner.php
 
 		-
 			message: '#^Parameter \#1 \$array \(list\<non\-falsy\-string\>\) of array_values is already a list, call has no effect\.$#'
@@ -649,7 +1633,79 @@ parameters:
 			path: includes/support/class-login-protection.php
 
 		-
-			message: '#^Property WPMgr\\Agent\\Support\\LoginProtection\:\:\$configCache \(array\{mode\: string, thresholds\: array\{captcha_limit\: int, temp_block_limit\: int, block_all_limit\: int, failed_login_gap\: int, success_login_gap\: int, all_blocked_gap\: int\}, ip_header\: string, allow_cidrs\: array\<int, string\>, deny_cidrs\: array\<int, string\>\}\|null\) does not accept array\{mode\: string, thresholds\: array\<string, int\>, ip_header\: string, allow_cidrs\: array\<int, string\>, deny_cidrs\: array\<int, string\>\}\.$#'
-			identifier: assign.propertyType
-			count: 1
+			message: '#^Parameter \#1 \$query of method wpdb\:\:prepare\(\) expects literal\-string, non\-falsy\-string given\.$#'
+			identifier: argument.type
+			count: 5
 			path: includes/support/class-login-protection.php
+
+		-
+			message: '#^Parameter \#1 \$query of method wpdb\:\:query\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 2
+			path: includes/support/class-login-protection.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 3
+			path: includes/support/class-mu-plugin-installer.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\WP_Upgrader'' and ''create_lock'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: includes/support/class-site-update-lock.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\WP_Upgrader'' and ''release_lock'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/support/class-site-update-lock.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: includes/support/class-snapshot-manager.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: includes/support/class-storage-paths.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$no_update\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/support/class-update-checker.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$response\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/support/class-update-checker.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\WP_Upgrader'' and ''release_lock'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/support/class-update-checker.php
+
+		-
+			message: '#^Cannot access offset ''filename'' on array\{headers\: WpOrg\\Requests\\Utility\\CaseInsensitiveDictionary, body\: string, response\: array\{code\: int, message\: string\}, cookies\: array\<int, WP_Http_Cookie\>, filename\: string\|null, http_response\: WP_HTTP_Requests_Response\}\|WP_Error\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: includes/support/class-update-checker.php
+
+		-
+			message: '#^Call to function method_exists\(\) with WP_Error and ''get_error_message'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/support/class-update-runner.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\<mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: includes/webhooks/class-media-modal-injector.php

--- a/apps/agent/phpstan-baseline.neon
+++ b/apps/agent/phpstan-baseline.neon
@@ -1399,12 +1399,6 @@ parameters:
 			path: includes/security/class-security-policy.php
 
 		-
-			message: '#^Property WP_User\:\:\$roles \(array\<string\>\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
-			path: includes/security/class-security-policy.php
-
-		-
 			message: '#^Call to function method_exists\(\) with WP_REST_Request and ''get_route'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/apps/agent/phpstan.neon
+++ b/apps/agent/phpstan.neon
@@ -78,6 +78,28 @@ includes:
     # It is baselined so CI can gate future regressions against today's count
     # instead of staying unenforced, not asserted as false-positive-free.
     # Working it down is tracked as follow-up, not closed by this baseline.
+    #
+    # 2026-08-26 (#530): re-baselined against `main` after #526 merged in,
+    # which touched several of the files this baseline already covered (their
+    # line numbers moved, which does not affect matching — entries key on
+    # message/identifier/path/count, never on line) and added one new file,
+    # includes/security/class-profile-update-user.php. That file surfaced a
+    # genuine finding rather than noise, so it was fixed in source instead of
+    # baselined: line 105 read `isset($loaded->roles) && is_array(...)` right
+    # after `$loaded instanceof \WP_User` was already confirmed on the branch
+    # above it. WP_User::$roles has no nullable path — core's constructor and
+    # this suite's own WP_User test double (tests/bootstrap.php) both declare
+    # it with a `[]` default — so the isset() half could never be false and
+    # was dead. Removed the isset(), kept is_array() as the real guard (a
+    # filter can still hand back a non-array despite the declared type). This
+    # merge also made one existing ignore-pattern entry for the identical
+    # message stale (it used to match a since-refactored check in
+    # class-security-policy.php's userRoles(), which now takes a generic
+    # `object` and no longer emits this identifier); regenerating dropped it
+    # rather than leaving it to rot as an ignore.unmatched failure. Net effect
+    # on the baseline is exactly those two changes — regenerate and diff
+    # against the previous commit's phpstan-baseline.neon to see it, rather
+    # than trusting a count written here.
     - phpstan-baseline.neon
 
 parameters:

--- a/apps/agent/phpstan.neon
+++ b/apps/agent/phpstan.neon
@@ -10,6 +10,74 @@ includes:
     #     LoginProtection::emitBlockEvent — corrected to the 5-arg shape.
     #   - a stale @phpstan-ignore-next-line in EncryptAndUpload::submitManifest
     #     (2.x infers the manifest-entry type cleanly) — removed.
+    #
+    # 2026-08-25 (#525): phpVersion was pinned at 80000 (PHP 8.0) against code
+    # that requires 8.1 and uses `readonly` properties. PHPStan parsed 8.1
+    # syntax under 8.0 rules, hit a syntax error, and aborted before analysing
+    # anything — composer analyse had never once produced a result. Corrected
+    # to 80100 and regenerated this baseline against a completed run for the
+    # first time. Six GENUINE bugs the completed run surfaced were fixed in
+    # source, not baselined: a bare esc_like() call (that function does not
+    # exist in WordPress — $wpdb->esc_like() does — so this was a live fatal
+    # on the code path that runs it) in DbCleanup; a hook registered with
+    # add_filter() for wp_default_scripts, which core actually fires via
+    # do_action_ref_array() — add_action() is the same registration and
+    # matches what the hook is; an uninitialized-variable risk in
+    # FileExtractCommand one refactor away from a real bug; a compound-assign
+    # into an optional array offset in the Mailgun handler that only stayed
+    # safe by two unenforced guards agreeing; a `preg_split() ?? []` that can
+    # never fire because preg_split() fails with false, not null; and
+    # FileListCommand::jailPath()'s @return docblock, which declared every key
+    # of both outcomes optional instead of the discriminated union the six
+    # return statements actually produce — fixing the docblock alone resolved
+    # 65 offsetAccess.notFound findings across the 14 file-command classes
+    # that consume it.
+    #
+    # The other large false-positive class fixed at the root rather than
+    # baselined: `global $wpdb;` has no declared type anywhere in scope, so
+    # PHPStan treats it as mixed, and the pervasive
+    # `if (!is_object($wpdb)) { return ...; }` guard then narrows the
+    # surviving branch to the bare `object` pseudo-type — every $wpdb->method()
+    # call after that read as undefined-method-on-object. Fixed with a
+    # `/** @var \wpdb $wpdb */` annotation placed immediately after the
+    # existing guard (the same idiom already used in class-connector.php,
+    # class-replay-cache.php and class-backup-source.php), applied only where
+    # the guard was a clean, immediate early-return.
+    #
+    # What's captured in the regenerated baseline below, confirmed by reading
+    # the flagged source rather than assumed from the message text:
+    #   - wpdb/mysqli_result runtime seams, extended: wpdb::prepare()'s
+    #     declared `literal-string` parameter type rejects any query built
+    #     with interpolated (but program-controlled, not user-controlled)
+    #     identifiers, and both prepare() and mysqli::query() carry
+    #     nullable/bool return types for failure modes that can't occur when
+    #     the placeholder count and the query text are fixed at the call site.
+    #   - Redis|null closure-capture: ObjectCacheEngine's redisOp() checks
+    #     `$this->redis !== null` before invoking its $op closure, but that
+    #     guarantee doesn't reach into the closure body's own analysis —
+    #     PHPStan re-evaluates $this->redis's declared type independently
+    #     inside each closure.
+    #   - optional third-party integration classes (e.g.
+    #     Breeze_CloudFlare_Helper in Cloudways) guarded by method_exists()
+    #     at runtime; PHPStan has no stub for a class it doesn't ship with and
+    #     can't credit the guard.
+    #   - list<T> vs array<K,V> strictness in bit/array-manipulation code
+    #     (Blake3, QrEncoder, object-cache group config) where the array is a
+    #     list at every runtime call site but PHPStan's inference through
+    #     array manipulation loses the sequential-key guarantee statically.
+    #   - dynamic invocation of a function named by a string variable
+    #     (ConnectionFinisher's default $invoke), which PHPStan cannot verify
+    #     names a real function without running it.
+    #
+    # The remainder is this plugin's first level-8 analysis to ever complete.
+    # It is triaged above by identifier/file distribution, not verified line
+    # by line — count it yourself with (from apps/agent, config with the
+    # `- phpstan-baseline.neon` line above temporarily removed):
+    #   php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress \
+    #     --error-format=raw | grep -cE ':[0-9]+:'
+    # It is baselined so CI can gate future regressions against today's count
+    # instead of staying unenforced, not asserted as false-positive-free.
+    # Working it down is tracked as follow-up, not closed by this baseline.
     - phpstan-baseline.neon
 
 parameters:

--- a/apps/agent/phpstan.neon
+++ b/apps/agent/phpstan.neon
@@ -14,7 +14,7 @@ includes:
 
 parameters:
     level: 8
-    phpVersion: 80000
+    phpVersion: 80100
     paths:
         - includes
         - wpmgr-agent.php

--- a/apps/agent/tests/Backup/DbRestorerCommentTailTest.php
+++ b/apps/agent/tests/Backup/DbRestorerCommentTailTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * DbRestorerCommentTailTest — locks the fail-closed contract of
+ * `DbRestorer::looksLikeCommentOnly()`.
+ *
+ * At EOF `DbRestorer::restore()` holds whatever bytes were left in the read
+ * buffer after the last `;` — the dump's trailing fragment. It asks
+ * `looksLikeCommentOnly()` whether that fragment is nothing but whitespace and
+ * SQL comments, and DISCARDS it when the answer is `true`. So a spurious
+ * `true` does not merely mis-parse: it drops the dump's final SQL statement
+ * and lets the restore commit and report success. That is silent data loss on
+ * the recovery path.
+ *
+ * The method reaches its verdict through `preg_split()`. `preg_split()`
+ * returns `false` when PCRE gives up — a backtrack/recursion limit exhausted
+ * on a host with tight `pcre.*` ini values, for instance. The failure used to
+ * be coerced to an empty list, which made the classification loop iterate zero
+ * times and fall through to `return true`: PCRE failing was read as "only
+ * comments here". A regex failure is not evidence that a fragment is
+ * comment-only, it is evidence that we cannot tell, and "cannot tell" must
+ * never resolve to "safe to discard".
+ *
+ * The failure is forced here by setting `pcre.backtrack_limit` to 0, which is
+ * how the real defect reproduces: PCRE aborts the match and `preg_split()`
+ * returns `false`. Note that the subject MUST contain a newline. PCRE's
+ * start-of-match optimisation finds the required `\n` code unit with a plain
+ * scan and returns NOMATCH without ever entering the match engine, so a
+ * single-line subject never touches the backtrack limit and never fails. Real
+ * dumps put multi-line statements in the tail routinely (extended INSERTs,
+ * CREATE TABLE bodies), so the multi-line subject is the realistic case, not a
+ * contrived one.
+ *
+ * `pcre.backtrack_limit` is process-global, so every test that lowers it
+ * restores it in a `finally` — a leaked limit of 0 would break every later
+ * test in the suite.
+ *
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use WPMgr\Agent\Backup\DbRestorer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\DbRestorer
+ */
+final class DbRestorerCommentTailTest extends TestCase
+{
+    /**
+     * A two-line INSERT with no trailing `;` — exactly what lands in the tail
+     * when a dump's final statement is unterminated.
+     */
+    private const REAL_SQL_TAIL = "INSERT INTO `wp_options` (option_name, option_value)\nVALUES ('siteurl', 'https://example.test')";
+
+    /**
+     * Invoke the private classifier. No setAccessible() call — since PHP 8.1
+     * ReflectionMethod::invoke() reaches private methods on its own, and
+     * setAccessible() is deprecated as of 8.5 (which would trip
+     * phpunit.xml.dist's failOnWarning).
+     */
+    private function classify(string $tail): bool
+    {
+        $method = new \ReflectionMethod(DbRestorer::class, 'looksLikeCommentOnly');
+
+        return (bool) $method->invoke(null, $tail);
+    }
+
+    /**
+     * Run $fn with pcre.backtrack_limit forced to 0, restoring it afterwards
+     * whatever happens.
+     *
+     * @param callable():mixed $fn
+     * @return mixed
+     */
+    private function withBrokenPcre(callable $fn)
+    {
+        $previous = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '0');
+        try {
+            return $fn();
+        } finally {
+            ini_set('pcre.backtrack_limit', $previous === false ? '1000000' : $previous);
+        }
+    }
+
+    /**
+     * The mechanism this whole test class depends on: with the backtrack limit
+     * exhausted, preg_split() really does return false on a multi-line
+     * subject. If this ever stops being true the tests below would pass
+     * vacuously, so assert it explicitly rather than assume it.
+     */
+    public function test_preg_split_really_fails_when_the_backtrack_limit_is_exhausted(): void
+    {
+        $result = $this->withBrokenPcre(static fn () => preg_split('/\r?\n/', "first\nsecond"));
+
+        $this->assertFalse(
+            $result,
+            'preg_split() must return false under an exhausted backtrack limit — '
+            . 'without that, every other test here proves nothing'
+        );
+    }
+
+    /**
+     * THE REGRESSION LOCK. A preg_split() failure must abort, never be read as
+     * "this tail is only comments". Before the fix this returned true, and the
+     * caller then skipped the dump's final statement and committed the restore
+     * as a success.
+     */
+    public function test_preg_split_failure_aborts_instead_of_discarding_the_tail(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/cannot classify the trailing SQL fragment/');
+
+        $this->withBrokenPcre(fn () => $this->classify(self::REAL_SQL_TAIL));
+    }
+
+    /**
+     * The abort message has to tell an operator what happened and what to do,
+     * not just fail. It names the restore, the reason, and the ini knobs.
+     */
+    public function test_abort_message_is_actionable(): void
+    {
+        try {
+            $this->withBrokenPcre(fn () => $this->classify(self::REAL_SQL_TAIL));
+            $this->fail('expected a RuntimeException');
+        } catch (\RuntimeException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('DbRestorer', $message);
+            $this->assertStringContainsString('preg_split failed', $message);
+            $this->assertStringContainsString('Aborting the restore', $message);
+            $this->assertStringContainsString('pcre.backtrack_limit', $message);
+        }
+    }
+
+    /**
+     * OVER-FIRE GUARD. A genuinely comment-only tail must still be recognised
+     * as comment-only when PCRE is healthy. A fix that aborts real restores is
+     * worse than the bug it fixes.
+     *
+     * @dataProvider provide_comment_only_tails
+     */
+    public function test_genuine_comment_only_tails_are_still_discarded(string $tail, string $why): void
+    {
+        $this->assertTrue($this->classify($tail), $why);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function provide_comment_only_tails(): array
+    {
+        return [
+            'empty string'          => ['', 'an empty tail is nothing to flush'],
+            'whitespace only'       => ["  \n\t\n  ", 'whitespace is not a statement'],
+            'double-dash comment'   => ['-- End of dump', 'the canonical dump trailer'],
+            'hash comment'          => ['# MySQL-style line comment', 'MySQL accepts # line comments'],
+            'multiple line comments' => ["-- one\n-- two\n\n", 'several comment lines plus blanks'],
+            'block comment'         => ["/* multi\n   line\n   block */", 'block comments are stripped first'],
+            'block then line'       => ["/* banner */\n-- trailer", 'mixed comment styles'],
+        ];
+    }
+
+    /**
+     * OVER-FIRE GUARD, the other direction. Real SQL in the tail must be
+     * reported as NOT comment-only so the caller flushes it, and that must
+     * happen without throwing when PCRE is healthy.
+     *
+     * @dataProvider provide_real_sql_tails
+     */
+    public function test_real_sql_tails_are_never_treated_as_comments(string $tail, string $why): void
+    {
+        $this->assertFalse($this->classify($tail), $why);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function provide_real_sql_tails(): array
+    {
+        return [
+            'single-line insert' => ["INSERT INTO `wp_options` VALUES (1, 'a')", 'a bare unterminated INSERT'],
+            'multi-line insert'  => [self::REAL_SQL_TAIL, 'the realistic extended-INSERT tail'],
+            'sql after comment'  => ["-- trailing note\nINSERT INTO `wp_posts` VALUES (1)", 'a comment must not shadow the SQL under it'],
+            'sql after block'    => ["/* banner */\nUPDATE `wp_options` SET option_value = '1'", 'a block comment must not shadow the SQL under it'],
+        ];
+    }
+}

--- a/apps/agent/tests/OptimizerDbOrphanScanTest.php
+++ b/apps/agent/tests/OptimizerDbOrphanScanTest.php
@@ -970,4 +970,10 @@ final class OrphanFakeWpdb
         $this->writes[] = $sql;
         return 0;
     }
+
+    /** Mirrors real wpdb::esc_like(): escape \, %, _ for a SQL LIKE clause. */
+    public function esc_like(string $text): string
+    {
+        return addcslashes($text, '_%\\');
+    }
 }


### PR DESCRIPTION
## Summary

Closes the first half of #525: `phpstan.neon` pinned `phpVersion: 80000` while `composer.json` requires `php: >=8.1` and the code uses `readonly` properties, an 8.1 feature. PHPStan parsed 8.1 syntax under 8.0 rules, hit a syntax error on all three `readonly` declarations, and aborted the whole analysis before producing a result. `composer analyse` had never completed a run.

- **Config fix**: `phpVersion` corrected to `80100`.
- **Root-cause fix #1**: the largest false-positive category the repaired analyser reported was `global $wpdb;` collapsing to the bare `object` pseudo-type across the existing `if (!is_object($wpdb)) { return ...; }` guard, because `$wpdb` has no declared type anywhere in scope. Fixed with the same `/** @var \wpdb $wpdb */` idiom already used in `class-connector.php`/`class-replay-cache.php`/`class-backup-source.php`, applied only where the guard is a clean, immediate early-return (66 sites across 24 files).
- **Stale-ignore cleanup**: that fix surfaced 52 `@phpstan-ignore*` comments PHPStan reports as matching nothing. None were ever evaluated before this PR (the parse abort meant the whole analyser was blind), so each was individually confirmed dead against a real run and removed rather than guessed at.
- **Root-cause fix #2**: `FileListCommand::jailPath()`'s `@return` docblock declared every key of both outcomes as optional, instead of the discriminated union the six return statements actually produce. Retyping it as `array{ok:true,abs:string,rel:string}|array{ok:false,code:string,message:string}` alone resolved 65 `offsetAccess.notFound` findings across all 14 file-command classes that consume it.
- **Six genuine bugs** found once the analyser could see the whole plugin (full detail in the relevant commits): a bare `esc_like()` call to a function that doesn't exist in WordPress (fatal if that code path ever ran — confirmed with a fake-wpdb test fixture fix in the same commit range), a hook registered via `add_filter()` for what core fires as an action, an uninitialized-variable risk one refactor away from a real bug, a compound-assign into an optional array key, a property-type mismatch between a native `?object` param and a `\wpdb|null` docblock, and a `preg_split() ?? []` that can never fire because `preg_split()` fails with `false`, not `null`.
- **Baseline**: regenerated against the now-completed run (`412` findings — reproduce with `php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress --error-format=raw | grep -cE ':[0-9]+:'` from `apps/agent` with the baseline include temporarily removed). `phpstan.neon`'s header comment documents, by category and with source evidence, the noise confirmed by reading the flagged code (wpdb/mysqli_result runtime seams extended to `literal-string`/nullable-return, `Redis|null` closure-capture in `ObjectCacheEngine`, optional third-party integration classes guarded by `method_exists()`, `list<T>` vs `array<K,V>` strictness in bit-manipulation code, dynamic invocation by string). It also says plainly that the remainder of the 412 is this plugin's *first ever completed* level-8 run, triaged by identifier/file distribution rather than verified line by line — baselined so CI can gate regressions against today's count, not asserted as false-positive-free.

## Explicitly out of scope

This does **not** address the hook-contract defect class from #521 (parameter *type* mismatches against what a hook actually passes). `szepeviktor/phpstan-wordpress`'s `HookCallbackRule` only validates parameter count and return-type void-ness against `accepted_args` — nothing here compares callback parameter types to what a named hook delivers. That gap is untouched.

## Dependency

PR #527 (CI gating for `composer analyse`, currently draft) depends on this landing first. **Verified**: fetched `scripts/check-agent-phpstan.sh` from #527's branch and ran it standalone against this repaired tree — `OK: PHPStan completed over the agent plugin and reported 0 findings (exit 0)`. Do not merge #527 before this.

## Test plan

- [x] `composer install` restores phpstan/phpcs/phpunit (previously wiped by `composer install --no-dev`)
- [x] Before fix: `php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress --error-format=raw` → parse abort on the 3 documented lines, `EXIT=1`
- [x] After fix: same command completes a full analysis, `EXIT=1` while findings existed, `composer analyse` → `EXIT=0` after baseline regeneration
- [x] PR #527's `scripts/check-agent-phpstan.sh` run standalone against this tree → `EXIT=0`
- [x] `composer test` (phpunit): 3265 tests, 0 failures, `EXIT=0`
- [x] `make agent-check` (phpcs): `EXIT=0`
- [ ] `make agent-plugincheck` — not run; no wp.org-facing surface changed (internal correctness fixes, test fixture, and static-analysis config only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email attachment-note handling when no text body is provided.
  - Corrected script optimization hook registration for more reliable jQuery Migrate removal.
  - Improved database cleanup escaping for transient prefixes.

- **Refactor**
  - Updated database and file-operation handling for clearer validation and more reliable static analysis.
  - Clarified success and error return documentation for file path validation.

- **Chores**
  - Updated PHP 8.1 analysis configuration and refreshed quality checks across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->