### PR TITLE
release: 0.61.145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.145] - 2026-08-26
+
+### Fixed
+
+- A database restore could silently drop the dump's last SQL statement while still reporting success. When the restorer could not tell whether the unterminated tail end of a dump was nothing but SQL comments, it treated that uncertainty as "yes, only comments" and discarded the fragment. Proven end to end against two otherwise byte-identical dumps that differed only in whether the final statement ended with a semicolon: the one that landed in the discarded tail lost a row, silently. A restore that cannot classify its own trailing fragment now aborts loudly instead of finishing and reporting success (GH #525).
+- The database tools' orphaned-data scan could fail outright with a fatal error every time it actually ran, calling a global function WordPress does not provide in place of the equivalent method it does provide. It now calls the correct one (GH #525).
+- Resending a failed outgoing email now actually works. The control plane and the agent had never agreed on what a resend command needs to carry, so every resend attempt failed with "missing required field: agent_seq," shown to the operator verbatim, on every connected site. A failed resend attempt no longer increments the "resent" counter or writes an audit entry claiming the email was resent; both now move only after a confirmed send (GH #520).
+- Editing a user's profile in wp-admin no longer fails with a critical error. WordPress does not always hand the agent's hooks the object type they expect on a profile edit, and five callbacks assumed one unconditionally; the crash hit every profile edit on every connected site, whether or not a password policy was configured (GH #521).
+- The disk-size probe behind Site Health's Directory sizes panel, the agent's own daily size walk, and every media upload on a multisite network no longer crashes when its cache is cold, which is any fresh install, any cache or object-cache flush, or the first read after either (GH #521).
+- The documented recovery constant for an admin locked out by this plugin's own auth policy (`WPMGR_DISABLE_SITE_2FA`) now also releases the unique-nickname rule. It previously silenced the password-policy crash above but still blocked recovery on that second rule (GH #521).
+- A parser-configuration bug had kept the agent's own static analysis from ever completing a run. Completing it for the first time is what surfaced the two fixes above, plus several smaller correctness fixes with no live symptom (GH #525).
+
 ## [0.61.144] - 2026-08-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.143**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.145**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.143
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.143
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.143
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.145
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.145
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.145
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.143   # omit to track :latest
+export WPMGR_VERSION=v0.61.145   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, security, performance, updates, site management
 Requires at least: 6.2
 Tested up to: 7.1
 Requires PHP: 8.1
-Stable tag: 0.61.139
+Stable tag: 0.61.145
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -275,6 +275,13 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 == Changelog ==
 
 The entries below summarize the notable changes since 0.31.1. This project ships frequently and not every intermediate patch release is listed here. Full history: https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md
+
+= 0.61.145 =
+* Fixed: a database restore could silently drop the dump's last SQL statement while still reporting success, when the restorer could not tell whether the very end of the dump was nothing but comments. It now aborts the restore instead of finishing on an uncertain guess.
+* Fixed: the database tools' orphaned-data scan could fail with a fatal error every time it ran, calling a function that does not exist outside of $wpdb. It now calls the correct one.
+* Fixed: editing a user's profile in wp-admin no longer fails with a critical error. WordPress does not always hand this plugin's hooks the object type they expect on a profile edit, and this plugin assumed one unconditionally.
+* Fixed: the disk-size probe behind Site Health's Directory sizes panel, this plugin's own daily size walk, and every media upload on a multisite network no longer crash when the size cache is cold, which is any fresh install, any cache flush, or the first read after either.
+* Fixed: the documented recovery constant for an admin locked out by this plugin's own auth policy (`WPMGR_DISABLE_SITE_2FA`) now also releases the unique-nickname rule, instead of leaving that one rule still blocking recovery.
 
 = 0.61.139 =
 * Added: this site now also reports an email delivery failure detected through WordPress's own mail-failure signal, not only failures on mail this site routes through WPMgr. Sites sending through their own SMTP setup are now covered too.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.139
+ * Version:           0.61.145
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.139');
+define('WPMGR_AGENT_VERSION', '0.61.145');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,119 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.145",
+    date: "2026-08-26",
+    summary:
+      "The most notable fix: a database restore could silently drop the dump's last SQL statement while still reporting success. It now aborts instead of guessing. Also fixed: resending a failed outgoing email, a WordPress agent crash on every user profile edit, and a crash in the disk-size check used by Site Health and multisite media uploads.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A database restore could silently drop the dump's last SQL statement while still reporting success, when the restorer could not tell whether the very end of the dump was nothing but comments. Proven against two otherwise identical dumps that differed only in whether the last statement ended with a semicolon: the one that landed in the discarded tail lost a row, silently. It now aborts the restore instead of finishing on an uncertain guess.",
+      },
+      {
+        tag: "Fixed",
+        text: "Resending a failed outgoing email now actually works. It previously failed on every attempt with an error shown verbatim to the operator. A failed attempt no longer inflates the resend counter or writes an audit entry claiming the email went out.",
+      },
+      {
+        tag: "Fixed",
+        text: "Editing a user's profile in wp-admin no longer crashes with a critical error, on every connected site.",
+      },
+      {
+        tag: "Fixed",
+        text: "The disk-size check behind Site Health's Directory sizes panel, the agent's own daily size walk, and multisite media uploads no longer crashes when its cache is cold, which is any fresh install or cache flush.",
+      },
+      {
+        tag: "Fixed",
+        text: "A database-cleanup scan for orphaned options could fail outright with a fatal error every time it ran. It now completes.",
+      },
+    ],
+    featureLinks: [{ label: "Email deliverability", href: "/features/email-deliverability" }],
+  },
+  {
+    version: "0.61.144",
+    date: "2026-08-22",
+    summary:
+      "An API key can now be scoped to exactly the access it needs instead of a whole role, and restricted to specific sites.",
+    items: [
+      {
+        tag: "Added",
+        text: "An API key can now be granted a specific set of capabilities instead of a whole role. Previously, a key that could read files could transitively manage members, mint further keys, read the audit log, and log into sites as a user. A key can now also be restricted to named sites. Existing keys keep exactly the access they have today.",
+      },
+      {
+        tag: "Fixed",
+        text: "The published API contract now correctly marks fields that can be null as nullable, instead of declaring them always present when the control plane can send a JSON null value.",
+      },
+    ],
+  },
+  {
+    version: "0.61.143",
+    date: "2026-08-20",
+    summary:
+      "Several control-plane reliability fixes: a stopped agent update run can no longer be reported as finished after the fact, a backup snapshot can no longer be left in an inconsistent state by two writes racing each other, and a rare bug that could leak a database connection's live-update subscription under load is fixed.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "An agent update run that was stopped by the kill switch or a withdrawn release could later be overwritten to show as completed if work already in flight finished afterward. Operators now see the stopped state as final.",
+      },
+      {
+        tag: "Fixed",
+        text: "A backup snapshot's claim and its final outcome are now protected against being written out of order, which previously could strand the storage a failed backup used, or leave a good backup marked unusable.",
+      },
+      {
+        tag: "Fixed",
+        text: "A shared database connection could stay subscribed to another request's live update notifications after that request ended, letting notifications cross between unrelated connections under load. Fixed.",
+      },
+    ],
+  },
+  {
+    version: "0.61.142",
+    date: "2026-08-20",
+    summary:
+      "Fleet uptime now has a 90-day history view. Also fixed: paused sites are correctly skipped by scheduled updates, database cleaning and vulnerability scans; a site with no monitoring data shows as unmeasured instead of 0% uptime; and a lock-release bug that could stall backups, per-tenant storage cleanup and organization deletion for up to 30 minutes.",
+    items: [
+      {
+        tag: "Added",
+        text: "Fleet uptime now has a 90-day availability view, one entry per day, in place of a single derived 7-day figure.",
+      },
+      {
+        tag: "Fixed",
+        text: "A site paused after an update run was already scheduled is no longer dispatched to. Scheduled database cleaning and the vulnerability digest now respect a paused site the same way.",
+      },
+      {
+        tag: "Fixed",
+        text: "A site with no uptime measurement yet now reports as unmeasured instead of showing 0% uptime.",
+      },
+      {
+        tag: "Fixed",
+        text: "A lock-release bug that could silently leak a database lock is fixed. While leaked, it could fleet-wide stall scheduled backups, stall per-tenant storage cleanup, and block organization deletion or restore for up to 30 minutes.",
+      },
+      {
+        tag: "Fixed",
+        text: "A cleanup worker for old webhook records is now actually running; it existed in code but was never wired in.",
+      },
+    ],
+  },
+  {
+    version: "0.61.141",
+    date: "2026-08-19",
+    summary:
+      "Scheduled update runs now actually wait for their scheduled time instead of firing immediately, and can be canceled before they run.",
+    items: [
+      {
+        tag: "Changed",
+        text: "Scheduled update runs now wait for their scheduled time instead of dispatching immediately. Runs and tasks show new statuses (scheduled, dispatching, expired), and a run whose start time passed more than two hours ago is marked expired rather than dispatched late.",
+      },
+      {
+        tag: "Added",
+        text: "A scheduled update run can now be canceled any time before dispatch claims it. Once dispatch has started, use the existing halt control instead.",
+      },
+      {
+        tag: "Fixed",
+        text: "The self-hosted setup script could report failure on a successful, fully configured re-run. It now exits cleanly as it should.",
+      },
+    ],
+  },
+  {
     version: "0.61.140",
     date: "2026-08-19",
     summary:

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -14,7 +14,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 // on every release: the agent version deliberately does not track the repo
 // release version, so a control-plane-only release leaves this alone and the
 // badge stays true.
-const AGENT_VERSION = "0.61.139";
+const AGENT_VERSION = "0.61.145";
 
 export const HOME_HERO = {
   badge: `v${AGENT_VERSION} / open source`,

--- a/docs/install.md
+++ b/docs/install.md
@@ -225,7 +225,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.143   # omit to track :latest
+export WPMGR_VERSION=v0.61.145   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.144
+  version: 0.61.145
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Cuts the release PR for 0.61.145. Based on `main` at `f646db18`, which carries:

- `b6f3efa5` fix(email): send agent_seq for resend_email, and count only successes (GH #520)
- `4b3b9de7` fix(agent): stop fatalling on the objects core actually passes to five hook callbacks (GH #521)
- `f646db18` fix(agent): repair PHPStan phpVersion parse abort (GH #525), which also fixed a database-restore bug that could silently drop the dump's last SQL statement while reporting success, and a fatal in the orphaned-data cleanup scan

**The agent changes in this release**, unlike 0.61.144, so its version triple and the marketing hero badge move to 0.61.145 alongside it.

## Surfaces updated

- `CHANGELOG.md`: new `[0.61.145]` entry, symptom-first
- `apps/agent/wpmgr-agent.php`: plugin header `Version` and `WPMGR_AGENT_VERSION` -> 0.61.145
- `apps/agent/readme.txt`: `Stable tag` -> 0.61.145, plus a new `= 0.61.145 =` changelog entry
- `apps/marketing/lib/content/home.ts`: `AGENT_VERSION` -> 0.61.145 (hero badge)
- `apps/marketing/app/(marketing)/changelog/page.tsx`: added 0.61.145, and backfilled 0.61.141 to 0.61.144, which the page had fallen four releases behind on
- `packages/openapi/openapi.yaml`: `info.version` -> 0.61.145
- `README.md` / `docs/install.md`: install pins -> v0.61.145

## Known issues, not fixed here

Filed during this work and still open, deliberately not listed as fixed: #522, #523, #528, #529, #531. #525 is closed by this release.

## Not in this release

PR #527 (the PHPStan CI gate) has not merged; a bot review is fixing a bug where a top-level analyser error was folded into ordinary findings. Not referenced as shipped anywhere in this PR.

## Gates

- `make check-versions-test`: 76 passed, 0 failed
- `make check-versions`: all surfaces consistent
- `node apps/marketing/scripts/check-copy.mjs`: passed, 390 files
- Docs vocabulary check (verbatim from `ci.yml`): no hits

No tag. Not merging this myself.
