### PR TITLE
fix(perf): abort the cache toggle when the CDN credentials read fails (#522)

### DIFF
--- a/apps/api/internal/perf/cdn_creds_carryforward_test.go
+++ b/apps/api/internal/perf/cdn_creds_carryforward_test.go
@@ -1,0 +1,342 @@
+package perf
+
+// cdn_creds_carryforward_test.go — GH #522: toggling site cache silently
+// destroyed a site's stored CDN credentials and reported success.
+//
+// The three carry-forward call sites (EnableCache, DisableCache and the
+// beacon-key rotate, whose comment said it "mirrors EnableCache/DisableCache
+// exactly") discarded the error from GetCDNCredentialsCiphertext:
+//
+//	ct, _, _ := s.repo.GetCDNCredentialsCiphertext(ctx, tenantID, siteID)
+//
+// The repo returns (nil, "", err) on a genuine failure, so a read error was
+// indistinguishable from "no credentials stored". The nil then flowed into an
+// UPSERT that writes cdn_credentials_encrypted unconditionally
+// (db/query/perf.sql), replacing the age-encrypted blob with NULL while the
+// endpoint reported success.
+//
+// These tests pin BOTH directions:
+//   - a FAILED read aborts the write and the stored ciphertext survives;
+//   - a healthy read (with credentials, and with none) still toggles, keeps
+//     the credentials, and is never treated as an error.
+//
+// The fakeRepo's UpsertConfig assigns r.ciphertext = in.CDNCredentialsEncrypted,
+// which is exactly the unconditional column write the real SQL performs — so
+// "the stored ciphertext survived" is a real assertion here, not a stub.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// errCredRead stands in for a genuine infra failure inside the tenant tx
+// (pool exhausted, query error, RLS-scoped tx failure) — NOT ErrNotFound and
+// NOT "no credentials configured".
+var errCredRead = errors.New("tenant tx failed: connection reset")
+
+// storedCreds is a stand-in for the age-encrypted CDN credentials blob.
+var storedCreds = []byte("age-encrypted-cdn-credentials")
+
+func credsRepo(t *testing.T, tenantID, siteID uuid.UUID, ct []byte, readErr error) *fakeRepo {
+	t.Helper()
+	return &fakeRepo{
+		config:        Config{TenantID: tenantID, SiteID: siteID, ConfigVersion: 7, RumEnabled: true, BeaconKeySet: true},
+		configFound:   true,
+		ciphertext:    ct,
+		provider:      "cloudflare",
+		ciphertextErr: readErr,
+	}
+}
+
+func (r *fakeRepo) storedCiphertext() []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ciphertext
+}
+
+func (r *fakeRepo) upsertCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.upserts)
+}
+
+func (r *fakeRepo) lastUpsert(t *testing.T) UpsertConfigInput {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.upserts) == 0 {
+		t.Fatal("expected an UpsertConfig call, got none")
+	}
+	return r.upserts[len(r.upserts)-1]
+}
+
+// ---------------------------------------------------------------------------
+// RED: a failed credentials read must abort the write (all three call sites)
+// ---------------------------------------------------------------------------
+
+// TestEnableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext is the
+// regression for service.go EnableCache. Before the fix this returned
+// ("cache enabled", nil) after NULLing the stored ciphertext.
+func TestEnableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+	detail, err := svc.EnableCache(context.Background(), tenantID, siteID)
+	if err == nil {
+		t.Fatalf("EnableCache must FAIL when the credentials read fails; got detail=%q, err=nil", detail)
+	}
+	if !errors.Is(err, errCredRead) {
+		t.Errorf("error must carry the underlying read failure; got %v", err)
+	}
+	if detail == "cache enabled" {
+		t.Error("a failed read must never report success")
+	}
+	if n := repo.upsertCount(); n != 0 {
+		t.Errorf("no config write may happen after a failed credentials read; got %d upserts", n)
+	}
+	if got := repo.storedCiphertext(); string(got) != string(storedCreds) {
+		t.Fatalf("stored CDN ciphertext was destroyed: got %q, want %q", got, storedCreds)
+	}
+}
+
+// TestDisableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext is the
+// regression for service.go DisableCache.
+func TestDisableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+	detail, err := svc.DisableCache(context.Background(), tenantID, siteID)
+	if err == nil {
+		t.Fatalf("DisableCache must FAIL when the credentials read fails; got detail=%q, err=nil", detail)
+	}
+	if !errors.Is(err, errCredRead) {
+		t.Errorf("error must carry the underlying read failure; got %v", err)
+	}
+	if detail == "cache disabled" {
+		t.Error("a failed read must never report success")
+	}
+	if n := repo.upsertCount(); n != 0 {
+		t.Errorf("no config write may happen after a failed credentials read; got %d upserts", n)
+	}
+	if got := repo.storedCiphertext(); string(got) != string(storedCreds) {
+		t.Fatalf("stored CDN ciphertext was destroyed: got %q, want %q", got, storedCreds)
+	}
+}
+
+// TestRotateBeaconKey_CredentialsReadFails_AbortsWriteAndKeepsCiphertext is the
+// regression for the THIRD site (service.go RotateBeaconKey), which copied the
+// pattern deliberately. It also pins that the read happens BEFORE the mint, so
+// the failure cannot leave a rotated-but-unpushed hash behind.
+func TestRotateBeaconKey_CredentialsReadFails_AbortsWriteAndKeepsCiphertext(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	rotator := &fakeBeaconKeyRotator{}
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+	svc.SetAgentClient(&recordingAgent{}, &fakeSites{url: "https://example.com"})
+	svc.SetBeaconKeyRepo(rotator, "https://manage.example.com")
+
+	err := svc.RotateBeaconKey(context.Background(), tenantID, siteID)
+	if err == nil {
+		t.Fatal("RotateBeaconKey must FAIL when the credentials read fails")
+	}
+	if !errors.Is(err, errCredRead) {
+		t.Errorf("error must carry the underlying read failure; got %v", err)
+	}
+	if n := repo.upsertCount(); n != 0 {
+		t.Errorf("no config write may happen after a failed credentials read; got %d upserts", n)
+	}
+	if got := repo.storedCiphertext(); string(got) != string(storedCreds) {
+		t.Fatalf("stored CDN ciphertext was destroyed: got %q, want %q", got, storedCreds)
+	}
+	if n := rotator.calls(); n != 0 {
+		t.Errorf("the hash must not be rotated when a precondition read failed; got %d rotate calls", n)
+	}
+}
+
+// TestEnableCacheEndpoint_CredentialsReadFails_DoesNotReportSuccess drives the
+// real HTTP route (permission + site-access middleware included) and pins that
+// the response no longer says "cache enabled" while the credentials survive.
+// These two routes report non-domain failures as 200 {"ok":false,...} by house
+// convention; what matters is that ok is false, the detail is the failure, and
+// nothing was written.
+func TestEnableCacheEndpoint_CredentialsReadFails_DoesNotReportSuccess(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+	p := domain.Principal{TenantID: tenantID, Role: string(authz.RoleOperator)}
+	engine := buildRotateKeyEngine(t, svc, p)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sites/"+siteID.String()+"/perf/cache/enable", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, `"ok":true`) || strings.Contains(body, "cache enabled") {
+		t.Fatalf("endpoint reported success over a failed credentials read; body = %s", body)
+	}
+	if !strings.Contains(body, `"ok":false`) {
+		t.Fatalf("expected ok:false; body = %s", body)
+	}
+	if n := repo.upsertCount(); n != 0 {
+		t.Errorf("no config write may happen; got %d upserts", n)
+	}
+	if got := repo.storedCiphertext(); string(got) != string(storedCreds) {
+		t.Fatalf("stored CDN ciphertext was destroyed: got %q, want %q", got, storedCreds)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OVER-FIRE: a healthy read must still toggle, and keep the credentials
+// ---------------------------------------------------------------------------
+
+// TestEnableCache_HealthyRead_TogglesAndKeepsCredentials verifies the fix does
+// not block correct work: a site WITH stored credentials still enables cache,
+// and the ciphertext is carried forward byte-for-byte.
+func TestEnableCache_HealthyRead_TogglesAndKeepsCredentials(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, nil)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+	detail, err := svc.EnableCache(context.Background(), tenantID, siteID)
+	if err != nil {
+		t.Fatalf("EnableCache with a healthy read must succeed: %v", err)
+	}
+	if detail != "cache enabled" {
+		t.Errorf("detail = %q, want %q", detail, "cache enabled")
+	}
+	in := repo.lastUpsert(t)
+	if !in.Config.CacheEnabled {
+		t.Error("cache_enabled must be true after EnableCache")
+	}
+	if in.Config.ConfigVersion != 8 {
+		t.Errorf("config_version = %d, want 8 (bumped from 7)", in.Config.ConfigVersion)
+	}
+	if string(in.CDNCredentialsEncrypted) != string(storedCreds) {
+		t.Errorf("carried-forward ciphertext = %q, want %q", in.CDNCredentialsEncrypted, storedCreds)
+	}
+	if got := repo.storedCiphertext(); string(got) != string(storedCreds) {
+		t.Fatalf("stored CDN ciphertext changed: got %q, want %q", got, storedCreds)
+	}
+}
+
+// TestDisableCache_HealthyRead_TogglesAndKeepsCredentials — same, for disable.
+func TestDisableCache_HealthyRead_TogglesAndKeepsCredentials(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, nil)
+	repo.config.CacheEnabled = true
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+	detail, err := svc.DisableCache(context.Background(), tenantID, siteID)
+	if err != nil {
+		t.Fatalf("DisableCache with a healthy read must succeed: %v", err)
+	}
+	if detail != "cache disabled" {
+		t.Errorf("detail = %q, want %q", detail, "cache disabled")
+	}
+	in := repo.lastUpsert(t)
+	if in.Config.CacheEnabled {
+		t.Error("cache_enabled must be false after DisableCache")
+	}
+	if string(in.CDNCredentialsEncrypted) != string(storedCreds) {
+		t.Errorf("carried-forward ciphertext = %q, want %q", in.CDNCredentialsEncrypted, storedCreds)
+	}
+	if got := repo.storedCiphertext(); string(got) != string(storedCreds) {
+		t.Fatalf("stored CDN ciphertext changed: got %q, want %q", got, storedCreds)
+	}
+}
+
+// TestRotateBeaconKey_HealthyRead_RotatesAndKeepsCredentials — same, for the
+// third site: the rotate still mints, pushes and carries the ciphertext.
+func TestRotateBeaconKey_HealthyRead_RotatesAndKeepsCredentials(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, nil)
+	rotator := &fakeBeaconKeyRotator{}
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+	svc.SetAgentClient(&recordingAgent{}, &fakeSites{url: "https://example.com"})
+	svc.SetBeaconKeyRepo(rotator, "https://manage.example.com")
+
+	if err := svc.RotateBeaconKey(context.Background(), tenantID, siteID); err != nil {
+		t.Fatalf("RotateBeaconKey with a healthy read must succeed: %v", err)
+	}
+	if n := rotator.calls(); n != 1 {
+		t.Errorf("rotate calls = %d, want 1", n)
+	}
+	in := repo.lastUpsert(t)
+	if string(in.CDNCredentialsEncrypted) != string(storedCreds) {
+		t.Errorf("carried-forward ciphertext = %q, want %q", in.CDNCredentialsEncrypted, storedCreds)
+	}
+	if got := repo.storedCiphertext(); string(got) != string(storedCreds) {
+		t.Fatalf("stored CDN ciphertext changed: got %q, want %q", got, storedCreds)
+	}
+}
+
+// TestCarryForward_NoCredentialsStored_IsNeverAnError is the other over-fire
+// direction, and the one that would break every site without a CDN configured:
+// a genuine "no credentials" read returns (nil, "", nil) and must stay a
+// success on all three paths, writing a nil ciphertext as before.
+func TestCarryForward_NoCredentialsStored_IsNeverAnError(t *testing.T) {
+	t.Run("enable", func(t *testing.T) {
+		tenantID, siteID := uuid.New(), uuid.New()
+		repo := credsRepo(t, tenantID, siteID, nil, nil)
+		svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+		detail, err := svc.EnableCache(context.Background(), tenantID, siteID)
+		if err != nil {
+			t.Fatalf("a site with NO CDN credentials must still enable cache: %v", err)
+		}
+		if detail != "cache enabled" {
+			t.Errorf("detail = %q, want %q", detail, "cache enabled")
+		}
+		if in := repo.lastUpsert(t); in.CDNCredentialsEncrypted != nil {
+			t.Errorf("ciphertext = %q, want nil", in.CDNCredentialsEncrypted)
+		}
+	})
+
+	t.Run("disable", func(t *testing.T) {
+		tenantID, siteID := uuid.New(), uuid.New()
+		repo := credsRepo(t, tenantID, siteID, nil, nil)
+		svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+		detail, err := svc.DisableCache(context.Background(), tenantID, siteID)
+		if err != nil {
+			t.Fatalf("a site with NO CDN credentials must still disable cache: %v", err)
+		}
+		if detail != "cache disabled" {
+			t.Errorf("detail = %q, want %q", detail, "cache disabled")
+		}
+		if in := repo.lastUpsert(t); in.CDNCredentialsEncrypted != nil {
+			t.Errorf("ciphertext = %q, want nil", in.CDNCredentialsEncrypted)
+		}
+	})
+
+	t.Run("rotate", func(t *testing.T) {
+		tenantID, siteID := uuid.New(), uuid.New()
+		repo := credsRepo(t, tenantID, siteID, nil, nil)
+		rotator := &fakeBeaconKeyRotator{}
+		svc := NewService(repo, nil, &fakeEvents{}, nil)
+		svc.SetAgentClient(&recordingAgent{}, &fakeSites{url: "https://example.com"})
+		svc.SetBeaconKeyRepo(rotator, "https://manage.example.com")
+
+		if err := svc.RotateBeaconKey(context.Background(), tenantID, siteID); err != nil {
+			t.Fatalf("a site with NO CDN credentials must still rotate: %v", err)
+		}
+		if n := rotator.calls(); n != 1 {
+			t.Errorf("rotate calls = %d, want 1", n)
+		}
+		if in := repo.lastUpsert(t); in.CDNCredentialsEncrypted != nil {
+			t.Errorf("ciphertext = %q, want nil", in.CDNCredentialsEncrypted)
+		}
+	})
+}

--- a/apps/api/internal/perf/cdn_creds_carryforward_test.go
+++ b/apps/api/internal/perf/cdn_creds_carryforward_test.go
@@ -95,9 +95,10 @@ func TestEnableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext(t *testi
 	if err == nil {
 		t.Fatalf("EnableCache must FAIL when the credentials read fails; got detail=%q, err=nil", detail)
 	}
-	if !errors.Is(err, errCredRead) {
-		t.Errorf("error must carry the underlying read failure; got %v", err)
-	}
+	// Review follow-up (Greptile, PR #533): the raw repo error is no longer
+	// propagated verbatim — see cdn_creds_errormap_test.go for the sanitized-
+	// message + log-preservation proof. Here we only pin that SOME error
+	// aborts the write; the shape of that error is asserted there.
 	if detail == "cache enabled" {
 		t.Error("a failed read must never report success")
 	}
@@ -120,9 +121,8 @@ func TestDisableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext(t *test
 	if err == nil {
 		t.Fatalf("DisableCache must FAIL when the credentials read fails; got detail=%q, err=nil", detail)
 	}
-	if !errors.Is(err, errCredRead) {
-		t.Errorf("error must carry the underlying read failure; got %v", err)
-	}
+	// See EnableCache above — sanitized-message proof lives in
+	// cdn_creds_errormap_test.go.
 	if detail == "cache disabled" {
 		t.Error("a failed read must never report success")
 	}
@@ -150,9 +150,8 @@ func TestRotateBeaconKey_CredentialsReadFails_AbortsWriteAndKeepsCiphertext(t *t
 	if err == nil {
 		t.Fatal("RotateBeaconKey must FAIL when the credentials read fails")
 	}
-	if !errors.Is(err, errCredRead) {
-		t.Errorf("error must carry the underlying read failure; got %v", err)
-	}
+	// See EnableCache above — sanitized-message proof lives in
+	// cdn_creds_errormap_test.go.
 	if n := repo.upsertCount(); n != 0 {
 		t.Errorf("no config write may happen after a failed credentials read; got %d upserts", n)
 	}
@@ -167,9 +166,12 @@ func TestRotateBeaconKey_CredentialsReadFails_AbortsWriteAndKeepsCiphertext(t *t
 // TestEnableCacheEndpoint_CredentialsReadFails_DoesNotReportSuccess drives the
 // real HTTP route (permission + site-access middleware included) and pins that
 // the response no longer says "cache enabled" while the credentials survive.
-// These two routes report non-domain failures as 200 {"ok":false,...} by house
-// convention; what matters is that ok is false, the detail is the failure, and
-// nothing was written.
+// Since the review follow-up (see cdn_creds_errormap_test.go), resolveCDNCiphertext's
+// read-failure branch returns a domain.Error, so the handler's
+// `if isDomain { httpx.Error(...) }` branch fires: a 503 domain envelope, NOT
+// the old 200 {"ok":false,"detail":err.Error()} shape. The sanitized-message
+// and no-leak assertions live in cdn_creds_errormap_test.go; here we only
+// re-pin that success is never reported and nothing was written.
 func TestEnableCacheEndpoint_CredentialsReadFails_DoesNotReportSuccess(t *testing.T) {
 	tenantID, siteID := uuid.New(), uuid.New()
 	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
@@ -186,8 +188,8 @@ func TestEnableCacheEndpoint_CredentialsReadFails_DoesNotReportSuccess(t *testin
 	if strings.Contains(body, `"ok":true`) || strings.Contains(body, "cache enabled") {
 		t.Fatalf("endpoint reported success over a failed credentials read; body = %s", body)
 	}
-	if !strings.Contains(body, `"ok":false`) {
-		t.Fatalf("expected ok:false; body = %s", body)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected a non-200 status for a failed credentials read; got %d, body = %s", rec.Code, body)
 	}
 	if n := repo.upsertCount(); n != 0 {
 		t.Errorf("no config write may happen; got %d upserts", n)

--- a/apps/api/internal/perf/cdn_creds_errormap_test.go
+++ b/apps/api/internal/perf/cdn_creds_errormap_test.go
@@ -1,0 +1,252 @@
+package perf
+
+// cdn_creds_errormap_test.go — Greptile finding on PR #533 (GH #522 follow-up):
+// resolveCDNCiphertext's carry-forward branch returned the bare repo error
+// from GetCDNCredentialsCiphertext unchanged. EnableCache/DisableCache render
+// non-domain errors as HTTP 200 {"ok":false,"detail":err.Error()}, so an
+// operator saw e.g. `detail = "tenant tx failed: connection reset"` —
+// persistence-layer internals, indistinguishable from an ordinary rejection.
+//
+// These tests pin:
+//   - the raw string never reaches the client, on all three operator-facing
+//     call sites (EnableCache, DisableCache, RotateBeaconKey);
+//   - the raw diagnostic IS still captured, once, in the server log;
+//   - a genuine domain rejection (crypto unwired, validation) is untouched;
+//   - an agent-side refusal still surfaces with its own wording, unchanged;
+//   - the healthy/success path is untouched (already covered by
+//     cdn_creds_carryforward_test.go's "HealthyRead" cases).
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+const wantSanitizedMsg = "Could not read this site's stored CDN credentials, so nothing was changed. Your stored credentials are intact — please try again in a moment."
+
+// errAgentRefused stands in for the agent's own rejection wording (e.g. "cache
+// directory not writable"), NOT a CDN-credentials failure — this fix must
+// never touch this path.
+var errAgentRefused = errors.New("agent refused: cache directory not writable")
+
+// bufLogger returns a *slog.Logger writing to buf so a test can assert on the
+// server-side log line without touching stdout/stderr.
+func bufLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewTextHandler(&buf, nil)), &buf
+}
+
+// ---------------------------------------------------------------------------
+// RED/GREEN: the raw repo error must never reach the caller, on all three
+// operator-facing call sites, and must still be logged once, raw.
+// ---------------------------------------------------------------------------
+
+func TestEnableCache_CredentialsReadFails_SanitizesErrorAndLogsRaw(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	logger, logBuf := bufLogger()
+	svc := NewService(repo, nil, &fakeEvents{}, logger)
+
+	_, err := svc.EnableCache(context.Background(), tenantID, siteID)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "connection reset") {
+		t.Fatalf("raw repo error leaked into the returned error: %v", err)
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("expected a domain error, got %T: %v", err, err)
+	}
+	if de.Code != "perf_cdn_credentials_read_failed" {
+		t.Errorf("code = %q, want %q", de.Code, "perf_cdn_credentials_read_failed")
+	}
+	if de.Message != wantSanitizedMsg {
+		t.Errorf("message = %q, want %q", de.Message, wantSanitizedMsg)
+	}
+	if status := domain.HTTPStatus(err); status != http.StatusServiceUnavailable {
+		t.Errorf("HTTP status = %d, want %d", status, http.StatusServiceUnavailable)
+	}
+	if !strings.Contains(logBuf.String(), "connection reset") {
+		t.Errorf("raw diagnostic must still be logged; log = %q", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), siteID.String()) {
+		t.Errorf("log line must carry the site id; log = %q", logBuf.String())
+	}
+}
+
+func TestDisableCache_CredentialsReadFails_SanitizesErrorAndLogsRaw(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	repo.config.CacheEnabled = true
+	logger, logBuf := bufLogger()
+	svc := NewService(repo, nil, &fakeEvents{}, logger)
+
+	_, err := svc.DisableCache(context.Background(), tenantID, siteID)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "connection reset") {
+		t.Fatalf("raw repo error leaked into the returned error: %v", err)
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("expected a domain error, got %T: %v", err, err)
+	}
+	if de.Code != "perf_cdn_credentials_read_failed" {
+		t.Errorf("code = %q, want %q", de.Code, "perf_cdn_credentials_read_failed")
+	}
+	if !strings.Contains(logBuf.String(), "connection reset") {
+		t.Errorf("raw diagnostic must still be logged; log = %q", logBuf.String())
+	}
+}
+
+func TestRotateBeaconKey_CredentialsReadFails_SanitizesErrorAndLogsRaw(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	logger, logBuf := bufLogger()
+	svc := NewService(repo, nil, &fakeEvents{}, logger)
+	svc.SetAgentClient(&recordingAgent{}, &fakeSites{url: "https://example.com"})
+	svc.SetBeaconKeyRepo(&fakeBeaconKeyRotator{}, "https://manage.example.com")
+
+	err := svc.RotateBeaconKey(context.Background(), tenantID, siteID)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "connection reset") {
+		t.Fatalf("raw repo error leaked into the returned error: %v", err)
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("expected a domain error, got %T: %v", err, err)
+	}
+	if de.Code != "perf_cdn_credentials_read_failed" {
+		t.Errorf("code = %q, want %q", de.Code, "perf_cdn_credentials_read_failed")
+	}
+	if !strings.Contains(logBuf.String(), "connection reset") {
+		t.Errorf("raw diagnostic must still be logged; log = %q", logBuf.String())
+	}
+}
+
+// TestEnableCacheEndpoint_CredentialsReadFails_ResponseIsSanitized drives the
+// real HTTP route end to end and pins that the response body the operator
+// actually receives contains the sanitized message and NOT the raw string.
+func TestEnableCacheEndpoint_CredentialsReadFails_ResponseIsSanitized(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, errCredRead)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+	p := domain.Principal{TenantID: tenantID, Role: string(authz.RoleOperator)}
+	engine := buildRotateKeyEngine(t, svc, p)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sites/"+siteID.String()+"/perf/cache/enable", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "connection reset") {
+		t.Fatalf("raw repo error leaked into the HTTP response; body = %s", body)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusServiceUnavailable, body)
+	}
+	if !strings.Contains(body, "perf_cdn_credentials_read_failed") {
+		t.Fatalf("expected the stable code in the envelope; body = %s", body)
+	}
+	if !strings.Contains(body, "please try again in a moment") {
+		t.Fatalf("expected the operator-facing sanitized message; body = %s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OVER-FIRE: this must not flatten every failure into one opaque sentence.
+// ---------------------------------------------------------------------------
+
+// TestUpdateConfig_CryptoUnwired_MessageUnchanged: the raw != nil branch of
+// resolveCDNCiphertext (encrypting freshly supplied credentials) is untouched
+// by this fix — its existing domain error must read exactly as before.
+func TestUpdateConfig_CryptoUnwired_MessageUnchanged(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, nil, nil)
+	svc := NewService(repo, nil, &fakeEvents{}, nil) // decryptor: nil
+
+	_, err := svc.UpdateConfig(context.Background(), tenantID, siteID, UpdateConfigInput{
+		Config:            Config{CacheRefreshInterval: "2hours", JSDelayMethod: "defer"},
+		CDNCredentialsRaw: &CDNCredentials{APIToken: "tok"},
+	})
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("expected a domain error, got %T: %v", err, err)
+	}
+	if de.Code != "perf_crypto_unwired" {
+		t.Errorf("code = %q, want %q (unchanged by this fix)", de.Code, "perf_crypto_unwired")
+	}
+	if de.Message != "credential encryption is not configured" {
+		t.Errorf("message = %q, want unchanged %q", de.Message, "credential encryption is not configured")
+	}
+}
+
+// TestUpdateConfig_InvalidRefreshInterval_MessageUnchanged: an ordinary
+// validation rejection, unrelated to CDN credentials at all, must read
+// exactly as before.
+func TestUpdateConfig_InvalidRefreshInterval_MessageUnchanged(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, nil, nil)
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+
+	_, err := svc.UpdateConfig(context.Background(), tenantID, siteID, UpdateConfigInput{
+		Config: Config{CacheRefreshInterval: "bogus-interval", JSDelayMethod: "defer"},
+	})
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("expected a domain error, got %T: %v", err, err)
+	}
+	if de.Code != "invalid_cache_refresh_interval" {
+		t.Errorf("code = %q, want %q (unchanged by this fix)", de.Code, "invalid_cache_refresh_interval")
+	}
+	if !strings.Contains(de.Message, "bogus-interval") {
+		t.Errorf("message = %q, want it to still name the rejected value", de.Message)
+	}
+}
+
+// TestEnableCacheEndpoint_AgentRefusal_UnchangedDetail: an agent-side refusal
+// (a non-domain error from the agent push, downstream of a HEALTHY
+// credentials read) must keep surfacing exactly as before — HTTP 200
+// {"ok":false,"detail":"<agent's own wording>"} — because this fix only
+// touches resolveCDNCiphertext's error path, not the agent push's.
+func TestEnableCacheEndpoint_AgentRefusal_UnchangedDetail(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	repo := credsRepo(t, tenantID, siteID, storedCreds, nil) // healthy read
+	svc := NewService(repo, nil, &fakeEvents{}, nil)
+	svc.SetAgentClient(&fakeAgent{
+		cacheEnableErr: errAgentRefused,
+	}, &fakeSites{url: "https://example.com"})
+
+	p := domain.Principal{TenantID: tenantID, Role: string(authz.RoleOperator)}
+	engine := buildRotateKeyEngine(t, svc, p)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sites/"+siteID.String()+"/perf/cache/enable", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("agent refusal must still be a 200 {ok:false} envelope; status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"ok":false`) {
+		t.Fatalf("expected ok:false; body = %s", body)
+	}
+	if !strings.Contains(body, errAgentRefused.Error()) {
+		t.Fatalf("agent's own wording must pass through unchanged; body = %s", body)
+	}
+}

--- a/apps/api/internal/perf/service.go
+++ b/apps/api/internal/perf/service.go
@@ -480,7 +480,23 @@ func (s *Service) resolveCDNCiphertext(ctx context.Context, tenantID, siteID uui
 	// No new creds: carry forward the existing ciphertext.
 	prior, _, err := s.repo.GetCDNCredentialsCiphertext(ctx, tenantID, siteID)
 	if err != nil {
-		return nil, err
+		// GH #522 review follow-up: this used to return the bare repo error,
+		// which the handler renders verbatim (EnableCache/DisableCache render
+		// non-domain errors as HTTP 200 {"ok":false,"detail":err.Error()};
+		// UpdateConfig/RotateBeaconKey propagate it as a plain 500 message),
+		// leaking persistence-layer internals (e.g. "tenant tx failed:
+		// connection reset") to anyone who can click the button. Map it to a
+		// stable domain error here — the single chokepoint all four call
+		// sites (UpdateConfig, RotateBeaconKey, EnableCache, DisableCache)
+		// share — and log the raw diagnostic once, here, since this is the
+		// only place it should still be visible. Deliberately no
+		// .WithCause: handler.go's bulkConfig calls err.Error() on
+		// confirmed domain errors, and (*domain.Error).Error() appends the
+		// cause, which would re-open the identical leak through that path.
+		s.logger.Error("perf: CDN credentials read failed",
+			slog.String("site_id", siteID.String()), slog.Any("error", err))
+		return nil, domain.ServiceUnavailable("perf_cdn_credentials_read_failed",
+			"Could not read this site's stored CDN credentials, so nothing was changed. Your stored credentials are intact — please try again in a moment.")
 	}
 	return prior, nil
 }
@@ -715,8 +731,6 @@ func (s *Service) EnableCache(ctx context.Context, tenantID, siteID uuid.UUID) (
 	// "read failed" and "no credentials stored" are NOT the same nil.
 	ct, ctErr := s.resolveCDNCiphertext(ctx, tenantID, siteID, cfg, nil)
 	if ctErr != nil {
-		s.logger.Error("cache enable aborted: CDN credentials read failed (write skipped to preserve stored credentials)",
-			slog.String("site_id", siteID.String()), slog.Any("error", ctErr))
 		return "", ctErr
 	}
 	if _, err := s.repo.UpsertConfig(ctx, UpsertConfigInput{Config: cfg, CDNCredentialsEncrypted: ct}); err != nil {
@@ -768,8 +782,6 @@ func (s *Service) DisableCache(ctx context.Context, tenantID, siteID uuid.UUID) 
 	// silently NULLing cdn_credentials_encrypted (GH #522).
 	ct, ctErr := s.resolveCDNCiphertext(ctx, tenantID, siteID, cfg, nil)
 	if ctErr != nil {
-		s.logger.Error("cache disable aborted: CDN credentials read failed (write skipped to preserve stored credentials)",
-			slog.String("site_id", siteID.String()), slog.Any("error", ctErr))
 		return "", ctErr
 	}
 	if _, err := s.repo.UpsertConfig(ctx, UpsertConfigInput{Config: cfg, CDNCredentialsEncrypted: ct}); err != nil {

--- a/apps/api/internal/perf/service.go
+++ b/apps/api/internal/perf/service.go
@@ -418,6 +418,17 @@ func (s *Service) RotateBeaconKey(ctx context.Context, tenantID, siteID uuid.UUI
 	if lookupErr != nil {
 		return lookupErr
 	}
+	// Read the CDN ciphertext we must carry forward BEFORE minting, for the
+	// same fail-fast reason as the checks above: UpsertPerfConfig writes
+	// cdn_credentials_encrypted unconditionally, so a FAILED read must abort
+	// the whole rotate rather than blank a site's stored CDN credentials
+	// (GH #522). Reading it here means a read failure also never leaves a
+	// rotated-but-unpushed hash behind. A genuine "no credentials stored"
+	// still returns (nil, nil) and is not an error.
+	ct, ctErr := s.resolveCDNCiphertext(ctx, tenantID, siteID, cfg, nil)
+	if ctErr != nil {
+		return ctErr
+	}
 
 	freshKey, mintErr := s.mintAndRotateBeaconKey(ctx, tenantID, siteID)
 	if mintErr != nil {
@@ -430,7 +441,6 @@ func (s *Service) RotateBeaconKey(ctx context.Context, tenantID, siteID uuid.UUI
 	// forward unchanged (UpsertPerfConfig always writes the column — mirrors
 	// EnableCache/DisableCache exactly).
 	cfg.ConfigVersion++
-	ct, _, _ := s.repo.GetCDNCredentialsCiphertext(ctx, tenantID, siteID)
 	saved, err := s.repo.UpsertConfig(ctx, UpsertConfigInput{Config: cfg, CDNCredentialsEncrypted: ct})
 	if err != nil {
 		return err
@@ -699,7 +709,16 @@ func (s *Service) EnableCache(ctx context.Context, tenantID, siteID uuid.UUID) (
 	}
 	cfg.CacheEnabled = true
 	cfg.ConfigVersion = cfg.ConfigVersion + 1
-	ct, _, _ := s.repo.GetCDNCredentialsCiphertext(ctx, tenantID, siteID)
+	// Carry the stored CDN ciphertext forward. UpsertPerfConfig writes
+	// cdn_credentials_encrypted unconditionally, so a FAILED read must abort
+	// the toggle instead of blanking the site's credentials (GH #522) —
+	// "read failed" and "no credentials stored" are NOT the same nil.
+	ct, ctErr := s.resolveCDNCiphertext(ctx, tenantID, siteID, cfg, nil)
+	if ctErr != nil {
+		s.logger.Error("cache enable aborted: CDN credentials read failed (write skipped to preserve stored credentials)",
+			slog.String("site_id", siteID.String()), slog.Any("error", ctErr))
+		return "", ctErr
+	}
 	if _, err := s.repo.UpsertConfig(ctx, UpsertConfigInput{Config: cfg, CDNCredentialsEncrypted: ct}); err != nil {
 		return "", err
 	}
@@ -745,7 +764,14 @@ func (s *Service) DisableCache(ctx context.Context, tenantID, siteID uuid.UUID) 
 	}
 	cfg.CacheEnabled = false
 	cfg.ConfigVersion = cfg.ConfigVersion + 1
-	ct, _, _ := s.repo.GetCDNCredentialsCiphertext(ctx, tenantID, siteID)
+	// See EnableCache: a failed credentials read aborts the toggle rather than
+	// silently NULLing cdn_credentials_encrypted (GH #522).
+	ct, ctErr := s.resolveCDNCiphertext(ctx, tenantID, siteID, cfg, nil)
+	if ctErr != nil {
+		s.logger.Error("cache disable aborted: CDN credentials read failed (write skipped to preserve stored credentials)",
+			slog.String("site_id", siteID.String()), slog.Any("error", ctErr))
+		return "", ctErr
+	}
 	if _, err := s.repo.UpsertConfig(ctx, UpsertConfigInput{Config: cfg, CDNCredentialsEncrypted: ct}); err != nil {
 		return "", err
 	}

--- a/apps/api/internal/perf/service_test.go
+++ b/apps/api/internal/perf/service_test.go
@@ -27,6 +27,9 @@ type fakeRepo struct {
 	configFound bool
 	ciphertext  []byte
 	provider    string
+	// GH #522 — forces GetCDNCredentialsCiphertext to fail the way the real
+	// repo does (a tenant-tx/query error, NOT "no credentials stored").
+	ciphertextErr error
 	purges      []RecordPurgeInput
 	upserts     []UpsertConfigInput
 	markedKinds []string // kinds passed to MarkCachePurged
@@ -68,6 +71,11 @@ func (r *fakeRepo) UpsertConfig(_ context.Context, in UpsertConfigInput) (Config
 func (r *fakeRepo) GetCDNCredentialsCiphertext(_ context.Context, _, _ uuid.UUID) ([]byte, string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// GH #522: a genuine read failure must be distinguishable from "no
+	// credentials stored" — the real repo returns (nil, "", err) here.
+	if r.ciphertextErr != nil {
+		return nil, "", r.ciphertextErr
+	}
 	return r.ciphertext, r.provider, nil
 }
 

--- a/apps/api/internal/perf/service_test.go
+++ b/apps/api/internal/perf/service_test.go
@@ -240,15 +240,26 @@ type fakeAgent struct {
 	purgeErr        error
 	lastSnapshotReq agentcmd.DbSnapshotRequest
 	snapshotErr     error
+	// GH #522 review follow-up — over-fire proof: an agent-side refusal must
+	// keep surfacing as-is (200 {"ok":false,"detail":<agent detail>}), not get
+	// swept into the new CDN-credentials sanitization.
+	cacheEnableErr  error
+	cacheDisableErr error
 }
 
 func (a *fakeAgent) SyncPerfConfig(context.Context, uuid.UUID, string, agentcmd.PerfConfigRequest) (agentcmd.PerfConfigResult, error) {
 	return agentcmd.PerfConfigResult{OK: true}, nil
 }
 func (a *fakeAgent) CacheEnable(context.Context, uuid.UUID, string, agentcmd.CacheEnableRequest) (agentcmd.CacheEnableResult, error) {
+	if a.cacheEnableErr != nil {
+		return agentcmd.CacheEnableResult{}, a.cacheEnableErr
+	}
 	return agentcmd.CacheEnableResult{OK: true, Detail: "enabled"}, nil
 }
 func (a *fakeAgent) CacheDisable(context.Context, uuid.UUID, string, agentcmd.CacheDisableRequest) (agentcmd.CacheDisableResult, error) {
+	if a.cacheDisableErr != nil {
+		return agentcmd.CacheDisableResult{}, a.cacheDisableErr
+	}
 	return agentcmd.CacheDisableResult{OK: true, Detail: "disabled"}, nil
 }
 func (a *fakeAgent) CachePurge(_ context.Context, _ uuid.UUID, _ string, req agentcmd.CachePurgeRequest) (agentcmd.CachePurgeResult, error) {


### PR DESCRIPTION
Fixes #522.

## The defect

Three call sites carried the stored CDN ciphertext forward while discarding the read error:

- `EnableCache`
- `DisableCache`
- `RotateBeaconKey` — its comment said it "mirrors EnableCache/DisableCache exactly"

```go
ct, _, _ := s.repo.GetCDNCredentialsCiphertext(ctx, tenantID, siteID)
```

`GetCDNCredentialsCiphertext` returns `(nil, "", err)` on a genuine failure, so a read error was indistinguishable from "no credentials stored". That nil flowed into an upsert that writes `cdn_credentials_encrypted` unconditionally, so a transient read failure replaced a site's age-encrypted CDN credentials with NULL, the endpoint reported success, nothing was logged, `CDNHasCredentials` flipped false, and every later CDN purge silently did nothing. Recovery needs the operator to re-enter the key, with no signal that they have to.

## The fix

All three now use `resolveCDNCiphertext`, the helper that already existed in this file for exactly this carry-forward and which propagates the read error. A genuine "no credentials stored" still returns nil and is still not an error.

In the rotate path the read moved ahead of the mint, joining the preconditions that fail fast before the hash is touched, so a read failure cannot leave a rotated-but-unpushed hash behind either. Both toggles log at error level when they abort.

No schema, migration or generated-tree change.

## Proof

New `apps/api/internal/perf/cdn_creds_carryforward_test.go`. The fake repo's `UpsertConfig` assigns `r.ciphertext = in.CDNCredentialsEncrypted`, which is the same unconditional column write the real SQL performs, so "the stored ciphertext survived" is a real assertion rather than a stub.

Red, with only `service.go` reverted to the pre-fix version and the same tests run:

```
--- FAIL: TestEnableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext
    EnableCache must FAIL when the credentials read fails; got detail="cache enabled", err=nil
--- FAIL: TestDisableCache_CredentialsReadFails_AbortsWriteAndKeepsCiphertext
    DisableCache must FAIL when the credentials read fails; got detail="cache disabled", err=nil
--- FAIL: TestRotateBeaconKey_CredentialsReadFails_AbortsWriteAndKeepsCiphertext
    RotateBeaconKey must FAIL when the credentials read fails
--- FAIL: TestEnableCacheEndpoint_CredentialsReadFails_DoesNotReportSuccess
    endpoint reported success over a failed credentials read; body = {"detail":"cache enabled","ok":true}
FAIL
```

Green with the fix: every test in that file passes.

Over-fire — these passed against **both** versions, so the new tests redden only on the real defect:

- a site with credentials and a healthy read still toggles cache, and the ciphertext is carried forward byte-for-byte;
- a site with genuinely no credentials still toggles on all three paths and is never treated as an error.

## Checks

`go build ./...` exit 0, `go vet ./...` exit 0, `go test -count=1 ./internal/... ./cmd/...` exit 0 with every package `ok`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when enabling or disabling CDN caching and rotating beacon keys.
  * Operations now stop and report an error if CDN credential data cannot be read, preventing unintended configuration changes.
  * Existing CDN credentials are preserved during successful configuration updates.
  * Sites without stored CDN credentials continue to operate normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->