### PR TITLE
fix(agent): fail closed when a restore cannot tell which table SQL targets (#531)

### DIFF
--- a/apps/agent/includes/backup/class-db-restorer.php
+++ b/apps/agent/includes/backup/class-db-restorer.php
@@ -91,9 +91,11 @@ final class DbRestorer
      *                                $tmpPrefix.
      * @param callable $progress     function(string $phase, array $detail): void
      * @return list<string> Names of the tmp tables that ended up populated.
-     * @throws \RuntimeException On fatal connection / read failure, or when
-     *      the dump's trailing fragment cannot be classified (see
-     *      looksLikeCommentOnly()) — aborting beats discarding SQL.
+     * @throws \RuntimeException On fatal connection / read failure; when the
+     *      dump's trailing fragment cannot be classified (see
+     *      looksLikeCommentOnly()) — aborting beats discarding SQL; and when a
+     *      statement's target table cannot be identified (see rewritePrefix())
+     *      — aborting beats replaying it at the live tables.
      */
     public function restore(string $sqlGzPath, string $tmpPrefix, string $sourcePrefix, callable $progress): array
     {
@@ -497,8 +499,19 @@ final class DbRestorer
                     'old_upload_url'   => '/# upload_url: (.*?) #/',
                     'old_table_prefix' => '/# table_prefix: (.*?) #/',
                 ];
+                // A preg_match() failure here is safe to absorb, unlike the
+                // one in rewritePrefix(). Nothing this method returns decides
+                // where data is written: the source/target table prefixes come
+                // from the CP params and the live $wpdb (RestoreRunner::
+                // sourcePrefix() / targetPrefix()), never from the banner. A
+                // missed banner field only leaves the OLD urls unknown, and the
+                // rewrite pass then falls back to the CP-supplied source_* URLs
+                // or short-circuits to a no-op — the restored site can end up
+                // still serving the source URLs, which is visible, recoverable
+                // and non-destructive. Failing the whole restore over an
+                // unreadable comment banner would be the worse trade.
                 foreach ($matchers as $key => $pattern) {
-                    if ($out[$key] === '' && preg_match($pattern, $line, $m)) {
+                    if ($out[$key] === '' && preg_match($pattern, $line, $m) === 1) {
                         $out[$key] = trim($m[1]);
                     }
                 }
@@ -1015,6 +1028,9 @@ final class DbRestorer
      * @param string $tmpPrefix    Replacement prefix (e.g. `tmpAB12_`).
      * @param string $currentTable In/out — current table name (updated).
      * @return string Rewritten statement. Empty string skips the statement.
+     * @throws \RuntimeException When PCRE cannot decide whether a statement
+     *      names a table — see the keyword loop below. Aborting beats
+     *      replaying an unrewritten statement against the LIVE tables.
      */
     public static function rewritePrefix(string $stmt, string $sourcePrefix, string $tmpPrefix, string &$currentTable): string
     {
@@ -1056,7 +1072,36 @@ final class DbRestorer
         ];
 
         foreach ($patterns as $p) {
-            if (!preg_match($p, $body, $m, PREG_OFFSET_CAPTURE)) {
+            // preg_match() has THREE outcomes and they are not interchangeable
+            // here: 1 = this statement names a table, 0 = it does not, false =
+            // PCRE gave up and we do not know. `!preg_match(...)` collapsed
+            // `false` into `0` — a PCRE failure was read as "no table name".
+            //
+            // That is the worst possible reading. Every pattern would fail the
+            // same way, the loop would fall through to the tail below, and the
+            // statement would be returned VERBATIM — still naming `wp_posts`
+            // instead of `tmp<rand>_posts`. The dump then replays straight
+            // into the LIVE tables, outside the staging discipline the tmp
+            // prefix exists to provide. $currentTable is never set either, so
+            // $touchedTbls stays empty, swap() takes its `$tmpTables === []`
+            // branch, emits 'done' => true, and the whole restore reports
+            // Completed having overwritten the live database and swapped
+            // nothing. The staging mechanism exists precisely so that a failed
+            // restore is non-destructive; this defeated it silently.
+            //
+            // "Cannot tell" must never resolve to "route it at the live
+            // tables". Abort: restore() never reaches its COMMIT, the caller
+            // fails the restore, and the live database is left alone.
+            $matched = preg_match($p, $body, $m, PREG_OFFSET_CAPTURE);
+            if ($matched === false) {
+                throw new \RuntimeException(
+                    'DbRestorer: cannot determine which table a dump statement targets (preg_match failed: '
+                    . esc_html(preg_last_error_msg()) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to server log/SSE, not browser output
+                    . '). Aborting the restore rather than replay unrewritten SQL against the live tables.'
+                    . ' Raise pcre.backtrack_limit / pcre.recursion_limit on this host and retry the restore.'
+                );
+            }
+            if ($matched === 0) {
                 continue;
             }
             $tableName = $m[2][0];

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -2600,10 +2600,20 @@ final class RestoreRunner
             // armGuardOnce()'s rollback callback would "roll back" an empty
             // sub-state — each of them reporting success over work that never
             // happened. Fail loudly instead: the caller marks the restore
-            // failed and an operator retries, which is recoverable. The
-            // is_array() check below still stands for a well-formed payload
-            // that simply is not an object (`null`, a scalar); that decodes
-            // cleanly and genuinely carries no state.
+            // failed and an operator retries, which is recoverable.
+            //
+            // The is_array() check below still stands for a payload that
+            // decodes cleanly but is not an object (`null`, a scalar), and
+            // that case is deliberately left as it was. Not because a scalar
+            // means "no state" — `null` arguably does, `5` or `"text"` is
+            // corruption wearing valid JSON, and by the reasoning above
+            // corruption ought to abort too — but because no writer of this
+            // column can produce one: seedTask() writes the literal '{}',
+            // saveTaskState() always encodes an array, and RestoreCommand
+            // seeds wp_json_encode(['params' => ...]). Reaching it means the
+            // row was edited outside this plugin. Tightening it to a throw
+            // changes resume behaviour and belongs in a change reviewed as
+            // such, not in this one.
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new \RuntimeException(
                     'RestoreRunner: persisted sub_state is unreadable (json_decode failed: '

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -1372,7 +1372,22 @@ final class RestoreRunner
         // Classify before the FilesArchiver generic check so 'core' is never
         // misclassified as 'file' (the legacy fallback) even when componentKindFromPartName
         // cannot match it (COMPONENT_PARTITIONS does not include 'core').
-        if (preg_match('/^core\.(g\d+\.)?part\d+\.zip$/i', $lower) === 1) {
+        $isCorePart = preg_match('/^core\.(g\d+\.)?part\d+\.zip$/i', $lower);
+        if ($isCorePart === false) {
+            // Same shape as rewritePrefix(): this call ROUTES data. A `false`
+            // absorbed as "not a core part" does not merely mis-label — the
+            // fallthrough below lands every unrecognised `.zip` on the legacy
+            // 'file' entry_kind, so a WordPress core part would be overlaid by
+            // the whole-wp-content swap path instead of the core path. Route
+            // nothing on a guess.
+            throw new \RuntimeException(
+                'RestoreRunner: cannot classify restore artifact "' . esc_html($logical) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to server log/SSE, not browser output
+                . '" (preg_match failed: ' . esc_html(preg_last_error_msg()) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to server log/SSE, not browser output
+                . '). Aborting rather than routing it to the wrong restore path.'
+                . ' Raise pcre.backtrack_limit / pcre.recursion_limit on this host and retry the restore.'
+            );
+        }
+        if ($isCorePart === 1) {
             return 'core';
         }
         // Track 5 per-component archives. FilesArchiver emits generation-
@@ -2546,6 +2561,10 @@ final class RestoreRunner
     /**
      * @return array{phase:string,kind:string,sub_state:array<string,mixed>,resume_count:int,max_resumes:int}|null
      */
+    /**
+     * @throws \RuntimeException When a persisted sub_state exists but cannot
+     *      be decoded — resuming from a blank slate silently skips phases.
+     */
     private function loadTask(): ?array
     {
         global $wpdb;
@@ -2572,6 +2591,28 @@ final class RestoreRunner
         $sub = [];
         if (isset($row['sub_state']) && is_string($row['sub_state']) && $row['sub_state'] !== '') {
             $decoded = json_decode($row['sub_state'], true);
+            // A decode FAILURE is not "no resume state", it is "we cannot read
+            // the resume state", and the two must not be conflated. Silently
+            // substituting [] hands every caller a blank slate over a run that
+            // is demonstrably mid-flight: run() would re-derive a fresh
+            // tmp_prefix and lose the tmp tables the previous pass populated,
+            // runUrlRewrite() would no-op, swap() would take its empty-list
+            // branch and report 'done' => true having swapped nothing, and
+            // armGuardOnce()'s rollback callback would "roll back" an empty
+            // sub-state — each of them reporting success over work that never
+            // happened. Fail loudly instead: the caller marks the restore
+            // failed and an operator retries, which is recoverable. The
+            // is_array() check below still stands for a well-formed payload
+            // that simply is not an object (`null`, a scalar); that decodes
+            // cleanly and genuinely carries no state.
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \RuntimeException(
+                    'RestoreRunner: persisted sub_state is unreadable (json_decode failed: '
+                    . esc_html(json_last_error_msg()) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- thrown exception; message goes to server log/SSE, not browser output
+                    . '). Refusing to resume from a blank slate — an empty sub-state would skip the'
+                    . ' table swap and report the restore complete.'
+                );
+            }
             if (is_array($decoded)) {
                 $sub = $decoded;
             }

--- a/apps/agent/includes/backup/class-restore-runner.php
+++ b/apps/agent/includes/backup/class-restore-runner.php
@@ -2560,8 +2560,7 @@ final class RestoreRunner
 
     /**
      * @return array{phase:string,kind:string,sub_state:array<string,mixed>,resume_count:int,max_resumes:int}|null
-     */
-    /**
+     *
      * @throws \RuntimeException When a persisted sub_state exists but cannot
      *      be decoded — resuming from a blank slate silently skips phases.
      */

--- a/apps/agent/tests/Backup/DbRestorerPrefixRewriteFailClosedTest.php
+++ b/apps/agent/tests/Backup/DbRestorerPrefixRewriteFailClosedTest.php
@@ -1,8 +1,24 @@
 <?php
 /**
  * DbRestorerPrefixRewriteFailClosedTest — locks the fail-closed contract of
- * `DbRestorer::rewritePrefix()`, proven END-TO-END through the public
- * `DbRestorer::restore()` path against a live scratch MariaDB/MySQL.
+ * `DbRestorer::rewritePrefix()`, in two tiers.
+ *
+ *  - UNIT tier, no server, ALWAYS RUNS. `rewritePrefix()` is `static` and the
+ *    abort is raised inside it, so the defect and its repair are both a pure
+ *    function call away. This tier is what holds the line in CI.
+ *  - END-TO-END tier, through the public `DbRestorer::restore()` path against
+ *    a live scratch MariaDB/MySQL. It proves the abort reaches `restore()` and
+ *    that the live tables survive untouched — the part no unit test can fake,
+ *    since DDL is not transactional in MySQL. Each of these calls
+ *    `requireLiveMysql()` and skips individually when `WPMGR_TEST_MYSQL_*` is
+ *    unset.
+ *
+ * The tiering is deliberate and is itself a fix. With the scratch-database
+ * bootstrap in `set_up()`, the skip covered the whole class, and since
+ * `ci.yml` runs `composer test` with no MySQL env, this file reported
+ * `Tests: 6, Assertions: 0, Skipped: 6` and exit 0 on every CI run — the
+ * regression lock for a data-loss defect announcing success over its own
+ * absence, which is the same defect class the code under test commits.
  *
  * `rewritePrefix()` is the single point at which a dump statement naming
  * `wp_posts` becomes a statement naming `tmp<rand>_posts`. That rewrite IS the
@@ -42,7 +58,11 @@
  * restores it in a `finally` — a leaked limit of 0 would break the rest of the
  * suite.
  *
- * @group integration
+ * `@group integration` is applied PER METHOD, to the end-to-end tier only.
+ * Tagging the class would put the unit tier one `--exclude-group integration`
+ * away from silently vanishing again, which is the failure this file just came
+ * back from.
+ *
  * @package WPMgr\Agent\Tests\Backup
  */
 
@@ -78,21 +98,34 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
 
     private string $dumpPath = '';
 
+    /** Per-run namespace for every identifier this test creates. */
+    private string $suffix = '';
+
     /** @var array{host:string,user:string,password:string,name:string,prefix:string} */
     private array $db = [];
 
+    /**
+     * MySQL-FREE. Everything here works with no server, because most of what
+     * this file locks needs none: `rewritePrefix()` is `static`, and the abort
+     * is raised inside it, so the defect and its repair are both reachable as
+     * a pure function call.
+     *
+     * The scratch-database bootstrap deliberately does NOT live here. It did
+     * once, and the cost was the whole guard: `ci.yml` runs `composer test`
+     * and sets no `WPMGR_TEST_MYSQL_*`, so the `markTestSkipped()` in `set_up()`
+     * fired for every test in the class and the file reported
+     * `Tests: 6, Assertions: 0, Skipped: 6` with exit 0 — the regression lock
+     * for a proven data-loss defect announcing success over its own absence,
+     * which is precisely the defect class this file exists to guard against.
+     *
+     * Moving the bootstrap into `requireLiveMysql()`, called by the end-to-end
+     * tests only, is what lets the unit-level tests below run unconditionally.
+     * Failing hard on absent env instead would have reddened every developer's
+     * `composer test`, and a guard that reddens correct work gets switched off.
+     */
     protected function set_up(): void
     {
         parent::set_up();
-
-        $host = getenv('WPMGR_TEST_MYSQL_HOST');
-        $user = getenv('WPMGR_TEST_MYSQL_USER');
-        $pass = getenv('WPMGR_TEST_MYSQL_PASSWORD');
-        $name = getenv('WPMGR_TEST_MYSQL_DATABASE');
-
-        if ($host === false || $user === false || $name === false) {
-            $this->markTestSkipped('WPMGR_TEST_MYSQL_* env vars not set.');
-        }
 
         $suffix = bin2hex(random_bytes(4));
         // Stands in for the live install's `wp_` prefix. Namespaced per run so
@@ -102,6 +135,31 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
         $this->livePrefix   = 'live' . $suffix . '_';
         $this->tmpPrefix    = 'tmp' . $suffix . '_';
         $this->foreignTable = 'other' . $suffix . '_widgets';
+        $this->suffix       = $suffix;
+    }
+
+    /**
+     * Bring up the live scratch database, seed the pre-restore live tables and
+     * write the fixture dump — or skip THIS test alone.
+     *
+     * Called as the first line of the end-to-end tests, never from `set_up()`.
+     * The skip is still correct for those: they assert on real DDL against a
+     * real server, and there is no honest way to fake that. What is no longer
+     * correct is letting the skip reach the tests that need no server.
+     */
+    private function requireLiveMysql(): void
+    {
+        $host = getenv('WPMGR_TEST_MYSQL_HOST');
+        $user = getenv('WPMGR_TEST_MYSQL_USER');
+        $pass = getenv('WPMGR_TEST_MYSQL_PASSWORD');
+        $name = getenv('WPMGR_TEST_MYSQL_DATABASE');
+
+        if ($host === false || $user === false || $name === false) {
+            $this->markTestSkipped(
+                'WPMGR_TEST_MYSQL_* env vars not set — end-to-end restore case skipped. '
+                . 'The unit-level fail-closed assertions in this class run regardless.'
+            );
+        }
 
         $this->db = [
             'host'     => (string) $host,
@@ -119,7 +177,7 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
 
         $this->seedLiveTables();
 
-        $this->dumpPath = sys_get_temp_dir() . '/wpmgr-dbrestorer-531-' . $suffix . '.sql.gz';
+        $this->dumpPath = sys_get_temp_dir() . '/wpmgr-dbrestorer-531-' . $this->suffix . '.sql.gz';
         file_put_contents($this->dumpPath, (string) gzencode($this->buildFixtureDump()));
     }
 
@@ -180,7 +238,154 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
     }
 
     // -----------------------------------------------------------------
+    // RED -> GREEN, unit level. NO SERVER REQUIRED, so this runs in CI.
+    //
+    // The abort is raised inside the static rewritePrefix(), which is also
+    // where the defect lived, so the whole red-to-green transition is
+    // observable without MySQL. The end-to-end cases below prove the abort
+    // reaches restore() and spares the live tables; THIS one proves the abort
+    // happens at all, and it is the assertion that carries the lock in CI.
+    // -----------------------------------------------------------------
+
+    /**
+     * THE REGRESSION LOCK, unit level.
+     *
+     * With PCRE unable to answer, `rewritePrefix()` must throw rather than
+     * return. The defect was `if (!preg_match(...)) { continue; }`: `false`
+     * collapsed into `0`, every pattern "did not match", the loop fell through
+     * and the statement came back VERBATIM — still naming the live table, with
+     * `$currentTable` never set. Both halves of that are asserted here, so
+     * restoring the old line reddens this test with no database in sight.
+     */
+    public function test_rewrite_prefix_aborts_instead_of_returning_a_live_prefixed_statement(): void
+    {
+        $stmt = 'CREATE TABLE `' . $this->livePrefix . "posts` (\n"
+            . "  `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n"
+            . "  `post_title` text NOT NULL,\n"
+            . "  PRIMARY KEY (`ID`)\n"
+            . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4';
+
+        $currentTable = '';
+        $returned     = null;
+        $thrown       = null;
+
+        try {
+            $returned = $this->withBrokenPcre(function () use ($stmt, &$currentTable) {
+                return DbRestorer::rewritePrefix($stmt, $this->livePrefix, $this->tmpPrefix, $currentTable);
+            });
+        } catch (\RuntimeException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull(
+            $thrown,
+            'rewritePrefix() must ABORT when PCRE cannot tell which table the statement targets. '
+            . 'Returning at all is the defect — the returned SQL still names the live table and '
+            . 'gets replayed straight into the live database.'
+        );
+
+        // The specific shape of the old failure, asserted rather than implied:
+        // it did not merely fail to abort, it handed back live-prefixed SQL.
+        $this->assertNull(
+            $returned,
+            'nothing may be returned on a PCRE failure; the verbatim live-prefixed statement is '
+            . 'exactly what overwrote the live database'
+        );
+        $this->assertSame(
+            '',
+            $currentTable,
+            '$currentTable must stay unset — the empty $touchedTbls it produced is what made swap() '
+            . "report 'done' => true having swapped nothing"
+        );
+    }
+
+    /**
+     * The abort message must tell an operator what happened and what to do.
+     * Asserted against `rewritePrefix()` directly — the message is built there,
+     * so this needs no server, and its propagation out through `restore()` is
+     * covered by the end-to-end case below.
+     */
+    public function test_abort_message_is_actionable(): void
+    {
+        $stmt = 'INSERT INTO `' . $this->livePrefix . "options` VALUES\n"
+            . "(1,'siteurl','https://old-site.example'),\n"
+            . "(2,'home','https://old-site.example'),\n"
+            . "(3,'blogname','WPMgr Fixture Site')";
+
+        $currentTable = '';
+        $thrown       = null;
+
+        // Captured, never asserted from inside the catch: PHPUnit's own
+        // AssertionFailedError extends RuntimeException, so a `fail()` in the
+        // try block lands in the catch and gets re-reported as a nonsense
+        // string assertion against the failure message itself.
+        try {
+            $this->withBrokenPcre(function () use ($stmt, &$currentTable) {
+                return DbRestorer::rewritePrefix($stmt, $this->livePrefix, $this->tmpPrefix, $currentTable);
+            });
+        } catch (\RuntimeException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'rewritePrefix() must throw when preg_match() fails');
+
+        $message = $thrown->getMessage();
+        $this->assertStringContainsString('DbRestorer', $message);
+        $this->assertStringContainsString('cannot determine which table a dump statement targets', $message);
+        $this->assertStringContainsString('preg_match failed', $message);
+        $this->assertStringContainsString('Aborting the restore', $message);
+        $this->assertStringContainsString('live tables', $message);
+        $this->assertStringContainsString('pcre.backtrack_limit', $message);
+        $this->assertStringContainsString('pcre.recursion_limit', $message);
+    }
+
+    /**
+     * OVER-FIRE GUARD, unit level, and NO SERVER REQUIRED. `0` and `false` are
+     * now distinct and only `false` aborts, so a statement that legitimately
+     * does not match must still be handled exactly as it was before the fix.
+     *
+     * This pairs with the lock above: together they are what makes the CI-side
+     * assertions a real guard rather than a one-directional tripwire.
+     */
+    public function test_legitimately_unmatched_statements_still_pass_through_untouched(): void
+    {
+        // Names a table, but not one of OURS: still skipped outright, because
+        // replaying it would corrupt an unrelated plugin's data.
+        $current = '';
+        $this->assertSame(
+            '',
+            DbRestorer::rewritePrefix(
+                'CREATE TABLE `' . $this->foreignTable . "` (\n  `id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`)\n)",
+                $this->livePrefix,
+                $this->tmpPrefix,
+                $current
+            ),
+            'a statement naming a table outside the source prefix must still be skipped entirely'
+        );
+        $this->assertSame('', $current, 'a foreign table must not become the current table');
+
+        // Names no table at all (SET / START TRANSACTION / COMMIT): still
+        // passes through verbatim rather than aborting.
+        $current = '';
+        $this->assertSame(
+            'SET NAMES utf8mb4',
+            DbRestorer::rewritePrefix('SET NAMES utf8mb4', $this->livePrefix, $this->tmpPrefix, $current),
+            'a prefix-free statement must still pass through verbatim'
+        );
+        $this->assertSame('', $current, 'a prefix-free statement must not claim a current table');
+
+        // The context-switching statements are still refused.
+        $current = '';
+        $this->assertSame(
+            '',
+            DbRestorer::rewritePrefix('USE some_other_database', $this->livePrefix, $this->tmpPrefix, $current),
+            'context-switching statements must still be dropped'
+        );
+    }
+
+    // -----------------------------------------------------------------
     // RED -> GREEN. The end-to-end proof through the public restore() path.
+    // These need a live scratch server and skip individually without one.
     // -----------------------------------------------------------------
 
     /**
@@ -197,9 +402,12 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
      * proof: DDL is not transactional in MySQL, so had the unrewritten
      * `DROP TABLE IF EXISTS `<live>_options`` executed, no rollback could have
      * brought it back.
+     *
+     * @group integration
      */
     public function test_pcre_failure_aborts_before_writing_to_the_live_tables(): void
     {
+        $this->requireLiveMysql();
         $restorer = new DbRestorer($this->db);
 
         $thrown = null;
@@ -249,35 +457,6 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
         );
     }
 
-    /**
-     * The abort message must tell an operator what happened and what to do.
-     */
-    public function test_abort_message_is_actionable(): void
-    {
-        $restorer = new DbRestorer($this->db);
-
-        try {
-            $this->withBrokenPcre(function () use ($restorer) {
-                return $restorer->restore(
-                    $this->dumpPath,
-                    $this->tmpPrefix,
-                    $this->livePrefix,
-                    static function (string $phase, array $detail): void {
-                    }
-                );
-            });
-            $this->fail('expected a RuntimeException');
-        } catch (\RuntimeException $e) {
-            $message = $e->getMessage();
-            $this->assertStringContainsString('DbRestorer', $message);
-            $this->assertStringContainsString('preg_match failed', $message);
-            $this->assertStringContainsString('Aborting the restore', $message);
-            $this->assertStringContainsString('live tables', $message);
-            $this->assertStringContainsString('pcre.backtrack_limit', $message);
-            $this->assertStringContainsString('pcre.recursion_limit', $message);
-        }
-    }
-
     // -----------------------------------------------------------------
     // OVER-FIRE. A fix that aborts real restores is worse than the bug.
     // -----------------------------------------------------------------
@@ -286,9 +465,12 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
      * OVER-FIRE GUARD. With PCRE healthy the identical dump restores in full:
      * every statement rewritten to the tmp prefix, every row present, the live
      * tables still untouched, and both tmp tables reported back to swap().
+     *
+     * @group integration
      */
     public function test_a_normal_restore_still_completes_with_every_row(): void
     {
+        $this->requireLiveMysql();
         $restorer = new DbRestorer($this->db);
 
         $tmpTables = $restorer->restore(
@@ -329,13 +511,18 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
     }
 
     /**
-     * OVER-FIRE GUARD, the other direction. A statement that legitimately does
-     * not match must still be handled exactly as before — skipped when it
-     * names someone else's table, passed through when it names no table at
-     * all. `0` and `false` are now distinct, and only `false` aborts.
+     * OVER-FIRE GUARD, the other direction, end to end: a foreign table named
+     * in the dump is skipped by a real restore rather than created. The
+     * unit-level half of this assertion — that `rewritePrefix()` returns `''`
+     * for it — is in
+     * `test_legitimately_unmatched_statements_still_pass_through_untouched`
+     * and runs without a server; this proves `restore()` acts on that `''`.
+     *
+     * @group integration
      */
-    public function test_legitimately_unmatched_statements_are_still_handled_as_before(): void
+    public function test_a_foreign_table_in_the_dump_is_never_created(): void
     {
+        $this->requireLiveMysql();
         $restorer = new DbRestorer($this->db);
 
         $restorer->restore(
@@ -353,24 +540,6 @@ final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
         $this->assertFalse(
             $this->tableExists($this->foreignTable),
             'a statement naming a table outside the source prefix must still be skipped entirely'
-        );
-
-        // And a statement naming no table at all (SET / START TRANSACTION /
-        // COMMIT) still passes through untouched rather than aborting.
-        $current = '';
-        $this->assertSame(
-            'SET NAMES utf8mb4',
-            DbRestorer::rewritePrefix('SET NAMES utf8mb4', $this->livePrefix, $this->tmpPrefix, $current),
-            'a prefix-free statement must still pass through verbatim'
-        );
-        $this->assertSame('', $current, 'a prefix-free statement must not claim a current table');
-
-        // The context-switching statements are still refused.
-        $current = '';
-        $this->assertSame(
-            '',
-            DbRestorer::rewritePrefix('USE some_other_database', $this->livePrefix, $this->tmpPrefix, $current),
-            'context-switching statements must still be dropped'
         );
     }
 

--- a/apps/agent/tests/Backup/DbRestorerPrefixRewriteFailClosedTest.php
+++ b/apps/agent/tests/Backup/DbRestorerPrefixRewriteFailClosedTest.php
@@ -1,0 +1,545 @@
+<?php
+/**
+ * DbRestorerPrefixRewriteFailClosedTest — locks the fail-closed contract of
+ * `DbRestorer::rewritePrefix()`, proven END-TO-END through the public
+ * `DbRestorer::restore()` path against a live scratch MariaDB/MySQL.
+ *
+ * `rewritePrefix()` is the single point at which a dump statement naming
+ * `wp_posts` becomes a statement naming `tmp<rand>_posts`. That rewrite IS the
+ * staging discipline: it is the only reason a restore can fail without
+ * damaging the live database.
+ *
+ * The decision was made with `if (!preg_match($p, $body, $m, ...)) continue;`.
+ * `preg_match()` returns 1 on match, 0 on no match, and `false` when PCRE
+ * gives up — a backtrack/recursion limit exhausted on a host with tight
+ * `pcre.*` ini values. The `!` collapsed `false` into `0`, so PCRE failing was
+ * read as "this statement does not name a table". Every pattern failed the
+ * same way, the loop fell through, and the statement was returned VERBATIM:
+ *
+ *   PCRE healthy:  CREATE TABLE `tmp1234_posts` (   currentTable = 'tmp1234_posts'
+ *   PCRE failing:  CREATE TABLE `wp_posts` (        currentTable = ''
+ *
+ * The dump then replayed straight into the LIVE tables. `$currentTable` was
+ * never set, so `$touchedTbls` stayed empty, `swap()` took its
+ * `$tmpTables === []` branch, emitted `'done' => true` and returned. The live
+ * database was overwritten outside the staging discipline, nothing was
+ * swapped, and the restore reported Completed.
+ *
+ * The failure is forced here with `pcre.backtrack_limit = 0`, which is how the
+ * real defect reproduces. TWO traps govern that:
+ *
+ *  1. PCRE's start-of-match optimisation. A subject that cannot match at all
+ *     returns NOMATCH from a plain first-byte scan without ever entering the
+ *     match engine, so the limit is never consulted and `preg_match()` returns
+ *     0, not `false`. Every subject here is therefore one the pattern can
+ *     genuinely begin to match, on a realistic multi-line body (a wide CREATE
+ *     TABLE, an extended INSERT) rather than a contrived one-liner.
+ *  2. A test that never proves PCRE actually failed proves nothing at all, so
+ *     `test_pcre_really_fails_...` asserts the mechanism directly against the
+ *     production patterns.
+ *
+ * `pcre.backtrack_limit` is process-global, so every test that lowers it
+ * restores it in a `finally` — a leaked limit of 0 would break the rest of the
+ * suite.
+ *
+ * @group integration
+ * @package WPMgr\Agent\Tests\Backup
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Backup;
+
+use WPMgr\Agent\Backup\DbRestorer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Backup\DbRestorer
+ */
+final class DbRestorerPrefixRewriteFailClosedTest extends TestCase
+{
+    /**
+     * The first pattern in rewritePrefix()'s list, copied verbatim. Asserting
+     * against the production regex (not a stand-in) is what makes the forced
+     * failure evidence about this code rather than about PCRE in general.
+     */
+    private const CREATE_TABLE_PATTERN = '/^(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?)`?([A-Za-z0-9_\$]+)`?/i';
+
+    private ?\mysqli $mysqli = null;
+
+    /** The prefix standing in for the LIVE site's tables. */
+    private string $livePrefix = '';
+
+    /** The staging prefix the restore is supposed to write to instead. */
+    private string $tmpPrefix = '';
+
+    /** A table belonging to some OTHER plugin — must never be touched. */
+    private string $foreignTable = '';
+
+    private string $dumpPath = '';
+
+    /** @var array{host:string,user:string,password:string,name:string,prefix:string} */
+    private array $db = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+
+        $host = getenv('WPMGR_TEST_MYSQL_HOST');
+        $user = getenv('WPMGR_TEST_MYSQL_USER');
+        $pass = getenv('WPMGR_TEST_MYSQL_PASSWORD');
+        $name = getenv('WPMGR_TEST_MYSQL_DATABASE');
+
+        if ($host === false || $user === false || $name === false) {
+            $this->markTestSkipped('WPMGR_TEST_MYSQL_* env vars not set.');
+        }
+
+        $suffix = bin2hex(random_bytes(4));
+        // Stands in for the live install's `wp_` prefix. Namespaced per run so
+        // the test can never collide with a real table in a shared scratch DB,
+        // while playing exactly the role `wp_` plays in production: the prefix
+        // the dump names and the prefix the live site reads.
+        $this->livePrefix   = 'live' . $suffix . '_';
+        $this->tmpPrefix    = 'tmp' . $suffix . '_';
+        $this->foreignTable = 'other' . $suffix . '_widgets';
+
+        $this->db = [
+            'host'     => (string) $host,
+            'user'     => (string) $user,
+            'password' => $pass === false ? '' : (string) $pass,
+            'name'     => (string) $name,
+            'prefix'   => $this->livePrefix,
+        ];
+
+        [$connHost, $connPort] = $this->splitHostPort((string) $host);
+        $this->mysqli = @new \mysqli($connHost, (string) $user, $pass === false ? '' : (string) $pass, (string) $name, $connPort ?? 3306); // phpcs:ignore WordPress.DB.RestrictedClasses.mysql__mysqli -- test-side verification connection, mirrors DbRestorerLiveTest's live-MySQL setup
+        if ($this->mysqli->connect_errno) {
+            $this->markTestSkipped('Cannot connect to scratch MySQL: ' . $this->mysqli->connect_error);
+        }
+
+        $this->seedLiveTables();
+
+        $this->dumpPath = sys_get_temp_dir() . '/wpmgr-dbrestorer-531-' . $suffix . '.sql.gz';
+        file_put_contents($this->dumpPath, (string) gzencode($this->buildFixtureDump()));
+    }
+
+    protected function tear_down(): void
+    {
+        if ($this->mysqli instanceof \mysqli) {
+            foreach (['options', 'posts'] as $t) {
+                @$this->mysqli->query('DROP TABLE IF EXISTS `' . $this->livePrefix . $t . '`');
+                @$this->mysqli->query('DROP TABLE IF EXISTS `' . $this->tmpPrefix . $t . '`');
+            }
+            @$this->mysqli->query('DROP TABLE IF EXISTS `' . $this->foreignTable . '`');
+            @$this->mysqli->close();
+        }
+        if ($this->dumpPath !== '' && is_file($this->dumpPath)) {
+            @unlink($this->dumpPath);
+        }
+        parent::tear_down();
+    }
+
+    // -----------------------------------------------------------------
+    // The mechanism. Without this, every other test here passes vacuously.
+    // -----------------------------------------------------------------
+
+    /**
+     * With the backtrack limit exhausted, `preg_match()` against
+     * rewritePrefix()'s OWN first pattern really does return `false` on a
+     * realistic multi-line CREATE TABLE body — and returns plain `0`, not
+     * `false`, on a subject the start-of-match optimisation rejects outright.
+     * Both halves matter: the first is the defect's trigger, the second is why
+     * a one-line harness reports a false pass.
+     */
+    public function test_pcre_really_fails_when_the_backtrack_limit_is_exhausted(): void
+    {
+        $matchable = "CREATE TABLE `" . $this->livePrefix . "posts` (\n  `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `post_title` text NOT NULL,\n  PRIMARY KEY (`ID`)\n) ENGINE=InnoDB";
+
+        $result = $this->withBrokenPcre(function () use ($matchable) {
+            return preg_match(self::CREATE_TABLE_PATTERN, $matchable, $m, PREG_OFFSET_CAPTURE);
+        });
+
+        $this->assertFalse(
+            $result,
+            'preg_match() must return false under an exhausted backtrack limit — '
+            . 'without that, every other test in this class proves nothing'
+        );
+
+        // The trap, asserted rather than described: a subject the pattern
+        // cannot start to match never reaches the match engine, so it yields a
+        // truthful 0 even with the limit at 0.
+        $unmatchable = $this->withBrokenPcre(function () {
+            return preg_match(self::CREATE_TABLE_PATTERN, "SET NAMES utf8mb4", $m, PREG_OFFSET_CAPTURE);
+        });
+        $this->assertSame(
+            0,
+            $unmatchable,
+            "PCRE's start-of-match optimisation should return a genuine NOMATCH here — "
+            . 'this is why a single-line or non-matching subject cannot be used to force the failure'
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // RED -> GREEN. The end-to-end proof through the public restore() path.
+    // -----------------------------------------------------------------
+
+    /**
+     * THE REGRESSION LOCK, end to end.
+     *
+     * Before the fix this run completed "successfully": the dump's
+     * `DROP TABLE IF EXISTS` / `CREATE TABLE` / `INSERT` statements were
+     * replayed unrewritten, so the LIVE tables were dropped and repopulated,
+     * restore() returned an empty tmp-table list, and swap() reported done
+     * over that empty list.
+     *
+     * After the fix the same bytes abort before a single statement reaches the
+     * server, and the live data is exactly as it was. The sentinel row is the
+     * proof: DDL is not transactional in MySQL, so had the unrewritten
+     * `DROP TABLE IF EXISTS `<live>_options`` executed, no rollback could have
+     * brought it back.
+     */
+    public function test_pcre_failure_aborts_before_writing_to_the_live_tables(): void
+    {
+        $restorer = new DbRestorer($this->db);
+
+        $thrown = null;
+        try {
+            $this->withBrokenPcre(function () use ($restorer) {
+                return $restorer->restore(
+                    $this->dumpPath,
+                    $this->tmpPrefix,
+                    $this->livePrefix,
+                    static function (string $phase, array $detail): void {
+                    }
+                );
+            });
+        } catch (\RuntimeException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull(
+            $thrown,
+            'restore() must ABORT when PCRE cannot tell which table a statement targets. '
+            . 'Returning normally is the defect: it means the dump was replayed unrewritten.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/cannot determine which table a dump statement targets/',
+            $thrown->getMessage()
+        );
+
+        // --- The live database is untouched. --------------------------------
+        $this->assertTrue(
+            $this->tableExists($this->livePrefix . 'options'),
+            'the LIVE options table must still exist — an unrewritten DROP TABLE would have removed it'
+        );
+        $this->assertSame(
+            'https://live-site.example',
+            $this->readOptionValue($this->livePrefix . 'options', 'siteurl'),
+            'the LIVE siteurl row must still hold its pre-restore value — '
+            . 'reading the dump value here means the restore wrote to the live table'
+        );
+        $this->assertSame(
+            'sentinel',
+            $this->readOptionValue($this->livePrefix . 'options', 'wpmgr_sentinel'),
+            'the sentinel row must survive; a DROP+CREATE replay would have erased it'
+        );
+        $this->assertFalse(
+            $this->tableExists($this->livePrefix . 'posts'),
+            'the dump\'s CREATE TABLE must not have created a live posts table'
+        );
+    }
+
+    /**
+     * The abort message must tell an operator what happened and what to do.
+     */
+    public function test_abort_message_is_actionable(): void
+    {
+        $restorer = new DbRestorer($this->db);
+
+        try {
+            $this->withBrokenPcre(function () use ($restorer) {
+                return $restorer->restore(
+                    $this->dumpPath,
+                    $this->tmpPrefix,
+                    $this->livePrefix,
+                    static function (string $phase, array $detail): void {
+                    }
+                );
+            });
+            $this->fail('expected a RuntimeException');
+        } catch (\RuntimeException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('DbRestorer', $message);
+            $this->assertStringContainsString('preg_match failed', $message);
+            $this->assertStringContainsString('Aborting the restore', $message);
+            $this->assertStringContainsString('live tables', $message);
+            $this->assertStringContainsString('pcre.backtrack_limit', $message);
+            $this->assertStringContainsString('pcre.recursion_limit', $message);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // OVER-FIRE. A fix that aborts real restores is worse than the bug.
+    // -----------------------------------------------------------------
+
+    /**
+     * OVER-FIRE GUARD. With PCRE healthy the identical dump restores in full:
+     * every statement rewritten to the tmp prefix, every row present, the live
+     * tables still untouched, and both tmp tables reported back to swap().
+     */
+    public function test_a_normal_restore_still_completes_with_every_row(): void
+    {
+        $restorer = new DbRestorer($this->db);
+
+        $tmpTables = $restorer->restore(
+            $this->dumpPath,
+            $this->tmpPrefix,
+            $this->livePrefix,
+            static function (string $phase, array $detail): void {
+            }
+        );
+
+        sort($tmpTables);
+        $this->assertSame(
+            [$this->tmpPrefix . 'options', $this->tmpPrefix . 'posts'],
+            $tmpTables,
+            'restore() must report every tmp table it populated — an empty list is what makes '
+            . 'swap() report done having swapped nothing'
+        );
+
+        // Every row from the dump landed, in the STAGING tables.
+        $this->assertSame(
+            'https://old-site.example',
+            $this->readOptionValue($this->tmpPrefix . 'options', 'siteurl')
+        );
+        $this->assertSame(
+            'WPMgr Fixture Site',
+            $this->readOptionValue($this->tmpPrefix . 'options', 'blogname')
+        );
+        $this->assertSame(3, $this->countRows($this->tmpPrefix . 'options'), 'all three option rows must be present');
+        $this->assertSame(2, $this->countRows($this->tmpPrefix . 'posts'), 'both post rows must be present');
+
+        // And the live tables are still the live tables.
+        $this->assertSame(
+            'https://live-site.example',
+            $this->readOptionValue($this->livePrefix . 'options', 'siteurl'),
+            'a healthy restore must stage, never write through to the live tables'
+        );
+        $this->assertSame('sentinel', $this->readOptionValue($this->livePrefix . 'options', 'wpmgr_sentinel'));
+    }
+
+    /**
+     * OVER-FIRE GUARD, the other direction. A statement that legitimately does
+     * not match must still be handled exactly as before — skipped when it
+     * names someone else's table, passed through when it names no table at
+     * all. `0` and `false` are now distinct, and only `false` aborts.
+     */
+    public function test_legitimately_unmatched_statements_are_still_handled_as_before(): void
+    {
+        $restorer = new DbRestorer($this->db);
+
+        $restorer->restore(
+            $this->dumpPath,
+            $this->tmpPrefix,
+            $this->livePrefix,
+            static function (string $phase, array $detail): void {
+            }
+        );
+
+        // The dump contains a CREATE TABLE for a table belonging to another
+        // plugin. rewritePrefix() returns '' for it (it names a table, but not
+        // one of ours) and restore() skips it — replaying it would corrupt an
+        // unrelated plugin's data.
+        $this->assertFalse(
+            $this->tableExists($this->foreignTable),
+            'a statement naming a table outside the source prefix must still be skipped entirely'
+        );
+
+        // And a statement naming no table at all (SET / START TRANSACTION /
+        // COMMIT) still passes through untouched rather than aborting.
+        $current = '';
+        $this->assertSame(
+            'SET NAMES utf8mb4',
+            DbRestorer::rewritePrefix('SET NAMES utf8mb4', $this->livePrefix, $this->tmpPrefix, $current),
+            'a prefix-free statement must still pass through verbatim'
+        );
+        $this->assertSame('', $current, 'a prefix-free statement must not claim a current table');
+
+        // The context-switching statements are still refused.
+        $current = '';
+        $this->assertSame(
+            '',
+            DbRestorer::rewritePrefix('USE some_other_database', $this->livePrefix, $this->tmpPrefix, $current),
+            'context-switching statements must still be dropped'
+        );
+    }
+
+    /**
+     * OVER-FIRE GUARD, unit level: the rewrite itself is unchanged. This is
+     * the exact comparison from the defect report, asserted on the healthy
+     * side so a future "fix" that abandons the rewrite cannot pass.
+     */
+    public function test_healthy_pcre_still_rewrites_to_the_tmp_prefix(): void
+    {
+        $current = '';
+        $out     = DbRestorer::rewritePrefix(
+            'CREATE TABLE `' . $this->livePrefix . "posts` (\n  `ID` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`ID`)\n)",
+            $this->livePrefix,
+            $this->tmpPrefix,
+            $current
+        );
+
+        $this->assertStringStartsWith('CREATE TABLE `' . $this->tmpPrefix . 'posts`', $out);
+        $this->assertSame($this->tmpPrefix . 'posts', $current);
+        $this->assertStringNotContainsString(
+            '`' . $this->livePrefix . 'posts`',
+            $out,
+            'the live identifier must not survive the rewrite'
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Harness.
+    // -----------------------------------------------------------------
+
+    /**
+     * Run $fn with pcre.backtrack_limit forced to 0, restoring it afterwards
+     * whatever happens. The limit is process-global; a leaked 0 would break
+     * every later test in the suite.
+     *
+     * @param callable():mixed $fn
+     * @return mixed
+     */
+    private function withBrokenPcre(callable $fn)
+    {
+        $previous = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '0');
+        try {
+            return $fn();
+        } finally {
+            ini_set('pcre.backtrack_limit', $previous === false ? '1000000' : $previous);
+        }
+    }
+
+    /**
+     * The pre-restore live database: the tables a real restore is staging
+     * AWAY from. The sentinel row exists so "the live table was rewritten" is
+     * provable and not merely likely.
+     */
+    private function seedLiveTables(): void
+    {
+        $t = $this->livePrefix . 'options';
+        $this->mustQuery('DROP TABLE IF EXISTS `' . $t . '`');
+        $this->mustQuery(
+            'CREATE TABLE `' . $t . '` ('
+            . '`option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,'
+            . '`option_name` varchar(191) NOT NULL DEFAULT \'\','
+            . '`option_value` longtext NOT NULL,'
+            . 'PRIMARY KEY (`option_id`), UNIQUE KEY `option_name` (`option_name`)'
+            . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+        );
+        $this->mustQuery(
+            'INSERT INTO `' . $t . '` (option_name, option_value) VALUES '
+            . "('siteurl','https://live-site.example'),"
+            . "('blogname','The LIVE Site'),"
+            . "('wpmgr_sentinel','sentinel')"
+        );
+    }
+
+    /**
+     * A minimal-but-real mysqldump-shaped fixture, prefixed with the LIVE
+     * prefix exactly as a real snapshot of this site would be. The bodies are
+     * deliberately multi-line: PCRE's start-of-match optimisation means a
+     * one-line subject would never reach the match engine and the forced
+     * failure would not fire — a false pass. Real dumps are multi-line
+     * anyway.
+     */
+    private function buildFixtureDump(): string
+    {
+        $live = $this->livePrefix;
+
+        return "-- WPMgr fixture dump\n"
+            . "SET NAMES utf8mb4;\n"
+            . 'DROP TABLE IF EXISTS `' . $live . "options`;\n"
+            . 'CREATE TABLE `' . $live . "options` (\n"
+            . "  `option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n"
+            . "  `option_name` varchar(191) NOT NULL DEFAULT '',\n"
+            . "  `option_value` longtext NOT NULL,\n"
+            . "  PRIMARY KEY (`option_id`),\n"
+            . "  UNIQUE KEY `option_name` (`option_name`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
+            . 'INSERT INTO `' . $live . "options` VALUES\n"
+            . "(1,'siteurl','https://old-site.example'),\n"
+            . "(2,'home','https://old-site.example'),\n"
+            . "(3,'blogname','WPMgr Fixture Site');\n"
+            . 'DROP TABLE IF EXISTS `' . $live . "posts`;\n"
+            . 'CREATE TABLE `' . $live . "posts` (\n"
+            . "  `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n"
+            . "  `post_title` text NOT NULL,\n"
+            . "  `post_content` longtext NOT NULL,\n"
+            . "  `guid` varchar(255) NOT NULL DEFAULT '',\n"
+            . "  PRIMARY KEY (`ID`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
+            . 'INSERT INTO `' . $live . "posts` VALUES\n"
+            . "(1,'Hello World','Welcome to https://old-site.example/ — enjoy your stay.','https://old-site.example/?p=1'),\n"
+            . "(2,'Second Post','More content here.','https://old-site.example/?p=2');\n"
+            // A table belonging to some other plugin. Names a table, but not
+            // one of ours — rewritePrefix() must still skip it outright.
+            . 'CREATE TABLE `' . $this->foreignTable . "` (\n"
+            . "  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n"
+            . "  `payload` longtext NOT NULL,\n"
+            . "  PRIMARY KEY (`id`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n";
+    }
+
+    private function mustQuery(string $sql): void
+    {
+        $ok = $this->mysqli->query($sql);
+        $this->assertNotFalse($ok, 'fixture query failed: ' . $this->mysqli->error);
+    }
+
+    private function readOptionValue(string $table, string $optionName): ?string
+    {
+        $escaped = $this->mysqli->real_escape_string($optionName);
+        $res     = $this->mysqli->query('SELECT option_value FROM `' . $table . "` WHERE option_name = '" . $escaped . "'");
+        if ($res === false) {
+            return null;
+        }
+        $row = $res->fetch_assoc();
+        $res->free();
+        return is_array($row) ? (string) ($row['option_value'] ?? '') : null;
+    }
+
+    private function countRows(string $table): int
+    {
+        $res = $this->mysqli->query('SELECT COUNT(*) AS c FROM `' . $table . '`');
+        $this->assertNotFalse($res, 'COUNT against ' . $table . ' failed: ' . $this->mysqli->error);
+        $row = $res->fetch_assoc();
+        $res->free();
+        return is_array($row) ? (int) $row['c'] : -1;
+    }
+
+    private function tableExists(string $table): bool
+    {
+        $escaped = $this->mysqli->real_escape_string($table);
+        $res     = $this->mysqli->query("SHOW TABLES LIKE '" . $escaped . "'");
+        if ($res === false) {
+            return false;
+        }
+        $found = $res->fetch_row() !== null;
+        $res->free();
+        return $found;
+    }
+
+    /**
+     * @return array{0:string,1:int|null}
+     */
+    private function splitHostPort(string $host): array
+    {
+        if (strpos($host, ':') !== false) {
+            [$h, $p] = explode(':', $host, 2);
+            return [$h, ctype_digit($p) ? (int) $p : null];
+        }
+        return [$host, null];
+    }
+}


### PR DESCRIPTION
Fixes #531.

## The defect

`DbRestorer::rewritePrefix()` is the single point at which a dump statement naming `wp_posts` becomes one naming `tmp<rand>_posts`. That rewrite **is** the staging discipline — it is the only reason a restore can fail without damaging the live database.

The decision was made at `class-db-restorer.php:1059` with:

```php
if (!preg_match($p, $body, $m, PREG_OFFSET_CAPTURE)) { continue; }
```

`preg_match()` has three outcomes — `1` names a table, `0` does not, `false` means PCRE gave up (a backtrack or recursion limit exhausted on a host with tight `pcre.*` ini values). The `!` collapsed `false` into `0`, so PCRE failing was read as *"this statement has no table name"*:

```
PCRE healthy:  CREATE TABLE `tmp1234_posts` (   currentTable = 'tmp1234_posts'
PCRE failing:  CREATE TABLE `wp_posts` (        currentTable = ''
```

Every pattern in the list failed the same way, the loop fell through, and the statement was returned verbatim — still naming the live table. `$currentTable` was never set either, so `$touchedTbls` stayed empty, `swap()` took its `$tmpTables === []` branch at `:244`, emitted `'done' => true` and returned. **The live database was overwritten outside the staging discipline, nothing was swapped, and the restore reported Completed.**

## The fix

All three returns are now distinguished, and `false` throws `\RuntimeException` — the shape landed in 334e3d84 for the trailing-SQL path. The message names the cause and the ini knobs to raise, `restore()` never reaches its `COMMIT`, and the caller fails the restore instead of writing to the live tables.

## Red

`restore()` driven through its public path against a scratch MariaDB (`docker run mariadb:11`) with `pcre.backtrack_limit=0`, against the **pre-fix** source:

```
=== restore() under a forced PCRE failure (pcre.backtrack_limit=0) ===
preg_match against rewritePrefix's own CREATE TABLE pattern returns: false  (false == PCRE gave up)

restore() RETURNED NORMALLY.
  tmp tables reported: array (
)
  final progress event: restore_db {"done":true,"statements_done":4,"errors":0,"tables_touched":0}

=== state of the LIVE table `live0f5c6b2d_options` ===
  table exists: true
  siteurl          = https://old-site.example
  wpmgr_sentinel   = (absent)
  blogname         = WPMgr Fixture Site

  tmp table `tmp0f5c6b2d_options` exists: false

=== swap() with the tmp-table list restore() returned ===
  swap_db {"done":true,"tables_done":0,"tables_total":0}
```

The live table was dropped, recreated and repopulated from the dump; the pre-restore sentinel row is gone; no tmp table was ever created; `swap()` reported done over an empty list; `errors: 0`.

## Green

Same bytes, same forced limit, fixed source:

```
restore() ABORTED: RuntimeException
  DbRestorer: cannot determine which table a dump statement targets (preg_match failed:
  Backtrack limit exhausted). Aborting the restore rather than replay unrewritten SQL
  against the live tables. Raise pcre.backtrack_limit / pcre.recursion_limit on this host
  and retry the restore.

=== state of the LIVE table `live73c91153_options` ===
  table exists: true
  siteurl          = https://live-site.example
  wpmgr_sentinel   = sentinel
  blogname         = (absent)
```

DDL is not transactional in MySQL, so the surviving sentinel is real evidence — no rollback could have brought it back.

## Over-fire

`tests/Backup/DbRestorerPrefixRewriteFailClosedTest.php`, end to end through `restore()`:

- a healthy restore still stages every row of both tables (`3` option rows, `2` post rows) and leaves the live rows untouched;
- a statement naming another plugin's table is still skipped outright;
- a statement naming no table at all still passes through verbatim, and `USE <db>` is still dropped;
- the rewrite itself still produces the tmp identifier and sets `$currentTable`.

One test asserts the forced limit really does make `preg_match()` return `false` against `rewritePrefix()`'s own pattern, so the other cases cannot pass vacuously — and asserts the converse, that a subject PCRE's start-of-match optimisation rejects returns a truthful `0`. That optimisation is why a single-line harness reports a false pass, so every subject here is multi-line, as real dumps are.

```
$ WPMGR_TEST_MYSQL_HOST=127.0.0.1:33061 ... vendor/bin/phpunit tests/Backup/DbRestorerPrefixRewriteFailClosedTest.php
OK (6 tests, 48 assertions)
EXIT=0
```

## The sweep

Third instance of this shape in this neighbourhood, so both files were swept for every `preg_*` / `json_decode` whose failure is coerced into a benign default on a path that decides whether to keep, discard, or route data.

**Fixed — same defect:**

- `class-restore-runner.php:2574` `json_decode($row['sub_state'], true)`. A decode *failure* yielding `[]` conflates "no resume state" with "cannot read the resume state". A blank slate over a run that is demonstrably mid-flight makes `run()` re-derive a fresh `tmp_prefix` and orphan the populated tmp tables, makes `runUrlRewrite()` no-op, makes `swap()` take its empty-list branch and report done having swapped nothing, and makes `armGuardOnce()`'s rollback callback "roll back" an empty sub-state — each reporting success over work that never happened. Now throws on `json_last_error()`. A well-formed payload that simply is not an object (`null`, a scalar) still decodes cleanly to the empty default, so a fresh task is unaffected.
- `class-restore-runner.php:1375` `preg_match('/^core\.(g\d+\.)?part\d+\.zip$/i', ...)`. Absorbed as "not a core part", and the fallthrough lands every unrecognised `.zip` on the legacy `'file'` entry_kind — a WordPress core part routed to the whole-wp-content swap path. This call routes data; it now throws rather than routing on a guess.

**Left, deliberately, with the reason now in the code:**

- `class-db-restorer.php:501` banner parse. Nothing this method returns decides *where* data is written — the source and target prefixes come from the CP params and the live `$wpdb` (`RestoreRunner::sourcePrefix()` / `targetPrefix()`), never from the banner. A missed field only leaves the old URLs unknown, and the rewrite pass then falls back to the CP-supplied `source_*` URLs or short-circuits to a no-op; the restored site can end up still serving the source URLs, which is visible, recoverable and non-destructive. Failing a whole restore over an unreadable comment banner is the worse trade. Tightened to an explicit `=== 1` and commented so the asymmetry with `rewritePrefix()` is stated rather than implied.

**Checked, already fail-closed or benign:** `class-restore-runner.php:2954` and `:2991` (`preg_split === false` → reject the path — correct direction for a traversal guard); `:1076` and `:2917` (`preg_replace(...) ?? ''` → falls through to a random 8-hex value, still a valid non-empty prefix, never an empty one).

## Review follow-ups (8e33264d, 3ee3b996)

Two blocking findings from the security review, neither in the fail-closed fix's logic. The fix itself is unchanged.

**B1 — PHPStan was red, on the gate this branch's own base commit added.** `loadTask()` carried **two consecutive docblocks**. PHP attaches only the last, so the `@return array{phase:...,sub_state:array<string,mixed>,...}` shape was silently discarded:

```
$ cd apps/agent && php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress
 2568  Method WPMgr\Agent\Backup\RestoreRunner::loadTask() return type has
       no value type specified in iterable type array.   missingType.iterableValue
 [ERROR] Found 1 error
EXIT=1
```

Base commit `c5a29c5` is *"ci(agent): gate PHPStan, and fail an incomplete analysis distinctly (#525)"*, so this reddened that gate on its first real outing — and the task-row shape was no longer checked at any `loadTask()` call site on the restore state machine. Merged into one docblock, keeping both the `@return` shape and the `@throws`; nothing else in the method changed. Now `[OK] No errors`, exit 0.

**B2 — the regression lock never ran in CI.** The scratch-MySQL bootstrap sat in `set_up()`, so its `markTestSkipped()` covered the whole class, and `ci.yml` runs `composer test` with no `WPMGR_TEST_MYSQL_*` set anywhere (`grep -rn 'WPMGR_TEST_MYSQL' .github/ Makefile apps/agent/phpunit.xml*` → no matches). The file reported **6 tests, 0 assertions, exit 0** on every CI run — the guard for a proven data-loss defect announcing success over its own absence, which is structurally the same mistake as the bug under test.

Split into two tiers. `rewritePrefix()` is `static` and raises the abort itself, so the whole red-to-green transition is observable with no server:

- **unit tier, always runs.** PCRE really returns `false` under an exhausted backtrack limit; `rewritePrefix()` aborts instead of returning the live-prefixed statement with `$currentTable` unset; the abort message is actionable; and the over-fire direction still holds.
- **end-to-end tier**, `@group integration` per method, each calling `requireLiveMysql()` and skipping alone: the abort reaches `restore()`, the live tables and their sentinel row survive, a healthy restore still stages every row.

`@group integration` moved off the class onto those three methods — on the class it left the unit tier one `--exclude-group` away from vanishing again.

Under CI conditions, no MySQL env:

```
before:  Tests: 6, Assertions: 0,  Skipped: 6   EXIT=0
after:   Tests: 8, Assertions: 21, Skipped: 3   EXIT=0
```

And it reddens on the defect — `rewritePrefix()` reverted to `if (!preg_match($p, $body, $m, PREG_OFFSET_CAPTURE)) { continue; }`, still no MySQL env:

```
Tests: 8, Assertions: 12, Failures: 2, Skipped: 3   EXIT=1
  x Rewrite prefix aborts instead of returning a live prefixed statement
  x Abort message is actionable
```

CodeRabbit's proposed patch — fail hard when the env is absent — was **not** taken: it reddens every developer's `composer test`, and a guard that reddens correct work gets switched off, at which point it guards nothing. Wiring a MySQL service into the agent CI job is filed separately.

`3ee3b996` corrects a code comment only, closing the Greptile P1 thread on non-array `sub_state`. No behaviour change; the reasoning is in the thread.

## Gates

```
$ make hooks-status
pre-push INSTALLED and current: .../.git/hooks/pre-push

$ make agent-check
cd apps/agent && vendor/bin/phpcs -d memory_limit=1G
........ 8 / 8 (100%)
Time: 132ms; Memory: 8MB
# (the "8 / 8" is phpcs's parallel-batch counter, not a file count —
#  vendor/bin/phpcs --no-cache --report=json reports
#  251 files scanned; errors=0; warnings=0)

$ cd apps/agent && php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress
[OK] No errors
PHPSTAN_EXIT=0

$ cd apps/agent && php -d memory_limit=1024M vendor/bin/phpunit --colors=never --no-progress
Tests: 3316, Assertions: 17361, Deprecations: 59, PHPUnit Deprecations: 1, Skipped: 10.
SUITE_EXIT_NO_MYSQL_ENV=0
```

With the live-MySQL env vars supplied, the suite was `Tests: 3314, Assertions: 17467, Errors: 1` **as measured on `d64fecf1`** — the counts above have since moved by the two tests added in `8e33264d`, and that env-supplied run has not been repeated on the current head. The one error was `DbDumperTest::test_dump_against_live_mysql_produces_sql_gz`, **pre-existing and unrelated**. Verified by reverting both changed source files to `c5a29c54` and re-running that file under the same env: it still errored (`BASE_DBDUMPER_EXIT=2`). Neither changed file appears in its stack; it fails inside `class-db-dumper.php`.

```
$ make agent-plugincheck        # on 3ee3b996
Plugin Check: 0 errors. (Review any WARNING rows above.)
```

Neither changed file appears in any row. The WARNING rows are all pre-existing and untouched by this PR: four `readme.txt` metadata items, and six `PluginCheck.CodeAnalysis.WriteFile.ABSPATHDetected` in `class-file-upload-apply-command.php`, `class-file-write-command.php` and `class-file-version-restore-command.php`.

> **Correction.** An earlier revision of this section said `make agent-plugincheck` was not run, on the grounds that "`phpcs` covers the sniffs that apply". The conclusion was right — it has now been run twice, 0 errors both times, nothing in either changed file — but the stated reason was false and is worth killing so it is not reused. The two tools run **disjoint** sniff sets:
>
> ```
> $ cd apps/agent && vendor/bin/phpcs -i
> The installed coding standards are MySource, PEAR, PSR1, PSR2, PSR12, Squiz,
> Zend, Modernize, NormalizedArrays, Universal, PHPCSUtils, WordPress,
> WordPress-Core, WordPress-Docs and WordPress-Extra
> ```
>
> No `PluginCheck` standard is installed, so `phpcs` never runs a single `PluginCheck.*` sniff, never runs the META checks (`trademarks`, `plugin_updater`, `plugin_readme`), and misses `set_time_limit`/`ini_set`. It also over-reports in the other direction, flagging calls Plugin Check permits. phpcs is the fast linter; Plugin Check is the gate, and "phpcs was clean" is never a reason to skip it.

## Review

This is the restore path — `security-reviewer` should take it before merge. Not merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backup restores now stop safely when SQL target detection or table-prefix rewriting fails.
  - Invalid backup metadata and archive formats are rejected instead of triggering unsafe fallback behavior.
  - Improved error handling prevents incomplete or incorrectly targeted data from being written to live tables.
  - Backup restore errors now provide clearer, more actionable feedback.

- **Reliability**
  - Valid restores continue to preserve table data and expected prefix rewriting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
