### PR TITLE
fix(release): derive agent tested/requires from source, not a literal (#515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,24 @@ jobs:
       - name: Version surface guard (openapi, changelog page, badge, agent, install pins)
         run: scripts/check-version-surfaces.sh
 
+      # ---- Agent release manifest guard ------------------------------------
+      # scripts/release-agent.sh is the trust boundary release.yml calls to
+      # build the agent's self-update manifest (GH #515: it used to publish a
+      # hard-coded "tested up to 6.8" regardless of what the plugin actually
+      # declared). scripts/release-agent_test.sh is its regression suite —
+      # `make agent-release-test` — and until now nothing ran it: release.yml
+      # invokes release-agent.sh directly, so a regression in the
+      # version/requires/requires_php/tested parsing merged green and reached
+      # the release path with no guard between it and a live compatibility
+      # floor. It needs only zip/unzip (both on this image already) — no PHP,
+      # no Go — and builds its own throwaway fixture repos, so it runs here
+      # rather than in the PHP (agent) job.
+      #
+      # Self-test first, same reasoning as the version surface guard above: a
+      # broken guard must fail here, not pass by failing open.
+      - name: Agent release manifest guard self-test (GH #515)
+        run: scripts/release-agent_test.sh
+
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26.6"

--- a/Makefile
+++ b/Makefile
@@ -512,6 +512,10 @@ agent-release: agent-zip ## Publish the agent release (zip + latest.json) to obj
 agent-release-dry-run: agent-zip ## Preview the agent release (build zip + print latest.json) without uploading
 	./scripts/release-agent.sh --dry-run
 
+.PHONY: agent-release-test
+agent-release-test: ## Run scripts/release-agent.sh's regression suite (GH #515: the tested/requires/requires_php defaults)
+	scripts/release-agent_test.sh
+
 .PHONY: gen
 gen: ## Regenerate OpenAPI clients (Go + TS) from packages/openapi/openapi.yaml
 	# Until GH #511 this target ran a script that echoed "wired in Phase 4" and

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -31,7 +31,9 @@
 #   WPMGR_RELEASE_BUCKET   (default: wpmgr-chunks-prod)
 #   WPMGR_RELEASE_PREFIX   (default: agent-releases)
 #   WPMGR_AGENT_MIN_VERSION(default: 0.0.0)   minimum on-disk version this applies to
-#   WPMGR_AGENT_TESTED     (default: 6.8)     "Tested up to" WP version for the UI
+#   WPMGR_AGENT_TESTED     (default: parsed from apps/agent/readme.txt's own
+#                            "Tested up to:" line; an explicit override skips
+#                            that parse entirely — see GH #515)
 #
 set -euo pipefail
 
@@ -63,7 +65,8 @@ cd "$repo_root"
 BUCKET="${WPMGR_RELEASE_BUCKET:-wpmgr-chunks-prod}"
 PREFIX="${WPMGR_RELEASE_PREFIX:-agent-releases}"
 MIN_VERSION="${WPMGR_AGENT_MIN_VERSION:-0.0.0}"
-TESTED="${WPMGR_AGENT_TESTED:-6.8}"
+# TESTED is resolved below, after the zip's own header is read — its default
+# is derived from apps/agent/readme.txt, not a literal (GH #515).
 
 ZIP="release/wpmgr-agent.zip"
 SLUG="wpmgr-agent"
@@ -89,11 +92,36 @@ top_dirs="$(unzip -Z1 "$ZIP" | sed 's#/.*##' | sort -u)"
 unzip -l "$ZIP" "$PLUGIN_FILE" >/dev/null 2>&1 || die "zip is missing $PLUGIN_FILE"
 
 # --- derive version + requirements from the zip's OWN main file --------------
+# Every extraction pipeline below ends in `|| true` so a non-match never trips
+# `set -o pipefail` before the explicit `[[ -n ... ]] || die` check gets to run
+# — without it, a failed grep mid-pipeline kills the script under `set -e`
+# with bash's own bare exit 1 and no message, which is silent in a different
+# costume. The explicit check is what actually produces the actionable error.
 header="$(unzip -p "$ZIP" "$PLUGIN_FILE")"
-VERSION="$(printf '%s\n' "$header" | grep -oE "WPMGR_AGENT_VERSION', *'[^']+'" | head -1 | sed -E "s/.*'([^']+)'.*/\1/")"
+VERSION="$(printf '%s\n' "$header" | grep -oE "WPMGR_AGENT_VERSION', *'[^']+'" | head -1 | sed -E "s/.*'([^']+)'.*/\1/" || true)"
 [[ -n "$VERSION" ]] || die "could not parse WPMGR_AGENT_VERSION from $PLUGIN_FILE"
-REQUIRES="$(printf '%s\n' "$header" | grep -oiE 'Requires at least: *[0-9.]+' | head -1 | grep -oE '[0-9.]+' || echo '6.0')"
-REQUIRES_PHP="$(printf '%s\n' "$header" | grep -oiE 'Requires PHP: *[0-9.]+' | head -1 | grep -oE '[0-9.]+' || echo '8.1')"
+REQUIRES="$(printf '%s\n' "$header" | grep -oiE 'Requires at least: *[0-9.]+' | head -1 | grep -oE '[0-9.]+' || true)"
+[[ -n "$REQUIRES" ]] || die "could not parse 'Requires at least' from $PLUGIN_FILE's header — refusing to publish a guessed minimum WordPress version"
+REQUIRES_PHP="$(printf '%s\n' "$header" | grep -oiE 'Requires PHP: *[0-9.]+' | head -1 | grep -oE '[0-9.]+' || true)"
+[[ -n "$REQUIRES_PHP" ]] || die "could not parse 'Requires PHP' from $PLUGIN_FILE's header — refusing to publish a guessed minimum PHP version"
+
+# --- derive "Tested up to" from readme.txt, the wordpress.org listing page --
+# GH #515: this used to be `${WPMGR_AGENT_TESTED:-6.8}` and nobody ever set the
+# override, so every published manifest claimed the agent was tested only up
+# to WordPress 6.8 regardless of what readme.txt actually declared. The
+# default is now the parsed value. WPMGR_AGENT_TESTED remains available as an
+# explicit override (and, when set, skips the readme parse entirely); when it
+# is unset, a missing file or an unparseable line is a hard error — a wrong
+# compatibility floor published silently is the defect being fixed, so a
+# fallback here would only reintroduce it in a new costume.
+if [[ -n "${WPMGR_AGENT_TESTED:-}" ]]; then
+  TESTED="$WPMGR_AGENT_TESTED"
+else
+  README_FILE="apps/agent/readme.txt"
+  [[ -f "$README_FILE" ]] || die "missing $README_FILE — cannot derive 'Tested up to'; refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)"
+  TESTED="$(grep -iE '^Tested up to:' "$README_FILE" | head -1 | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 || true)"
+  [[ -n "$TESTED" ]] || die "could not parse a 'Tested up to:' version from $README_FILE — refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)"
+fi
 
 SHA256="$(sha256_of "$ZIP")"
 SIZE="$(wc -c < "$ZIP" | tr -d ' ')"

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -31,9 +31,11 @@
 #   WPMGR_RELEASE_BUCKET   (default: wpmgr-chunks-prod)
 #   WPMGR_RELEASE_PREFIX   (default: agent-releases)
 #   WPMGR_AGENT_MIN_VERSION(default: 0.0.0)   minimum on-disk version this applies to
-#   WPMGR_AGENT_TESTED     (default: parsed from apps/agent/readme.txt's own
-#                            "Tested up to:" line; an explicit override skips
-#                            that parse entirely — see GH #515)
+#   WPMGR_AGENT_TESTED     (default: parsed from the ZIP's own readme.txt
+#                            "Tested up to:" line — the same archive VERSION,
+#                            REQUIRES and REQUIRES_PHP already come from, not
+#                            the working tree; an explicit override skips that
+#                            parse entirely — see GH #515)
 #
 set -euo pipefail
 
@@ -66,7 +68,8 @@ BUCKET="${WPMGR_RELEASE_BUCKET:-wpmgr-chunks-prod}"
 PREFIX="${WPMGR_RELEASE_PREFIX:-agent-releases}"
 MIN_VERSION="${WPMGR_AGENT_MIN_VERSION:-0.0.0}"
 # TESTED is resolved below, after the zip's own header is read — its default
-# is derived from apps/agent/readme.txt, not a literal (GH #515).
+# is derived from the zip's own readme.txt, not a literal and not the
+# working-tree copy (GH #515).
 
 ZIP="release/wpmgr-agent.zip"
 SLUG="wpmgr-agent"
@@ -105,22 +108,34 @@ REQUIRES="$(printf '%s\n' "$header" | grep -oiE 'Requires at least: *[0-9.]+' | 
 REQUIRES_PHP="$(printf '%s\n' "$header" | grep -oiE 'Requires PHP: *[0-9.]+' | head -1 | grep -oE '[0-9.]+' || true)"
 [[ -n "$REQUIRES_PHP" ]] || die "could not parse 'Requires PHP' from $PLUGIN_FILE's header — refusing to publish a guessed minimum PHP version"
 
-# --- derive "Tested up to" from readme.txt, the wordpress.org listing page --
+# --- derive "Tested up to" from the zip's OWN readme.txt --------------------
 # GH #515: this used to be `${WPMGR_AGENT_TESTED:-6.8}` and nobody ever set the
 # override, so every published manifest claimed the agent was tested only up
 # to WordPress 6.8 regardless of what readme.txt actually declared. The
-# default is now the parsed value. WPMGR_AGENT_TESTED remains available as an
-# explicit override (and, when set, skips the readme parse entirely); when it
-# is unset, a missing file or an unparseable line is a hard error — a wrong
-# compatibility floor published silently is the defect being fixed, so a
-# fallback here would only reintroduce it in a new costume.
+# default is now the parsed value.
+#
+# It is parsed from readme.txt INSIDE THE ZIP, not the working-tree copy at
+# apps/agent/readme.txt — the same rule already applied to VERSION, REQUIRES
+# and REQUIRES_PHP above. This script can publish an already-built zip after
+# the working tree has moved on (that is the whole point of separating build
+# from publish), and version/requires/requires_php were already reading the
+# archive; a working-tree read here would make `tested` describe a DIFFERENT
+# build than its three manifest neighbours (GH #515 follow-up). One source of
+# truth per manifest: the artefact actually being published.
+#
+# WPMGR_AGENT_TESTED remains available as an explicit override (and, when
+# set, skips the readme read entirely); when it is unset, a missing readme in
+# the zip or an unparseable line is a hard error — a wrong compatibility
+# floor published silently is the defect being fixed, so a fallback here
+# would only reintroduce it in a new costume.
 if [[ -n "${WPMGR_AGENT_TESTED:-}" ]]; then
   TESTED="$WPMGR_AGENT_TESTED"
 else
-  README_FILE="apps/agent/readme.txt"
-  [[ -f "$README_FILE" ]] || die "missing $README_FILE — cannot derive 'Tested up to'; refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)"
-  TESTED="$(grep -iE '^Tested up to:' "$README_FILE" | head -1 | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 || true)"
-  [[ -n "$TESTED" ]] || die "could not parse a 'Tested up to:' version from $README_FILE — refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)"
+  README_IN_ZIP="${SLUG}/readme.txt"
+  unzip -l "$ZIP" "$README_IN_ZIP" >/dev/null 2>&1 || die "missing $README_IN_ZIP inside $ZIP — cannot derive 'Tested up to'; refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)"
+  readme="$(unzip -p "$ZIP" "$README_IN_ZIP")"
+  TESTED="$(printf '%s\n' "$readme" | grep -iE '^Tested up to:' | head -1 | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 || true)"
+  [[ -n "$TESTED" ]] || die "could not parse a 'Tested up to:' version from $README_IN_ZIP inside $ZIP — refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)"
 fi
 
 SHA256="$(sha256_of "$ZIP")"

--- a/scripts/release-agent_test.sh
+++ b/scripts/release-agent_test.sh
@@ -88,10 +88,28 @@ build_zip() {
   ( cd "$_dir" && zip -X -q -r release/wpmgr-agent.zip wpmgr-agent )
 }
 
+# write_readme FILE -> writes a readme.txt declaring "Tested up to: 7.1" to FILE.
+write_readme() {
+  _file="$1"
+  {
+    echo '=== WPMgr Agent ==='
+    echo 'Requires at least: 6.2'
+    echo 'Tested up to: 7.1'
+    echo 'Requires PHP: 8.1'
+    echo 'Stable tag: 1.2.3'
+  } >"$_file"
+}
+
 # fixture NAME -> path to a fresh scratch repo root with:
 #   scripts/release-agent.sh   (a copy of $GUARD, so repo-root detection
 #                                lands here, not on this checkout)
-#   apps/agent/readme.txt      (default: declares "Tested up to: 7.1")
+#   apps/agent/readme.txt      (the WORKING-TREE copy; default: "Tested up to: 7.1")
+#   wpmgr-agent/readme.txt     (the ARCHIVE copy that actually gets zipped —
+#                                release-agent.sh reads THIS one, mirroring
+#                                `make agent-zip`'s rsync of apps/agent/ into
+#                                release/wpmgr-agent/. Starts identical to the
+#                                working-tree copy; a case that wants to prove
+#                                the two may diverge edits only one of them.)
 #   release/wpmgr-agent.zip    (default: version 1.2.3, requires 6.2/8.1)
 fixture() {
   _t="$WORK/$1"
@@ -99,14 +117,9 @@ fixture() {
   mkdir -p "$_t/scripts" "$_t/apps/agent"
   cp "$GUARD" "$_t/scripts/release-agent.sh"
   chmod +x "$_t/scripts/release-agent.sh"
-  {
-    echo '=== WPMgr Agent ==='
-    echo 'Requires at least: 6.2'
-    echo 'Tested up to: 7.1'
-    echo 'Requires PHP: 8.1'
-    echo 'Stable tag: 1.2.3'
-  } >"$_t/apps/agent/readme.txt"
+  write_readme "$_t/apps/agent/readme.txt"
   write_plugin_php "$_t" "1.2.3" "6.2" "8.1"
+  cp "$_t/apps/agent/readme.txt" "$_t/wpmgr-agent/readme.txt"
   build_zip "$_t"
   printf '%s' "$_t"
 }
@@ -205,34 +218,52 @@ run_case "honest: tested is parsed from readme.txt's Tested up to line, not defa
   pass "$t" -- '+"tested": "7.1"' -'"tested": "6.8"'
 
 t="$(fixture tested-override-wins-and-skips-readme)"
-rm -f "$t/apps/agent/readme.txt" # prove the override needs no readme at all
+rm -f "$t/apps/agent/readme.txt" "$t/wpmgr-agent/readme.txt" # prove the override needs no readme at all, in the archive or the working tree
+build_zip "$t"
 run_case "tested: an explicit WPMGR_AGENT_TESTED override wins and never touches readme.txt" \
   pass "$t" "WPMGR_AGENT_TESTED=6.5" -- '+"tested": "6.5"'
 
 t="$(fixture tested-readme-missing-fails-loud)"
-rm -f "$t/apps/agent/readme.txt"
-run_case "tested: a missing readme.txt with no override is a hard error, not a fallback" \
+rm -f "$t/wpmgr-agent/readme.txt" # the ARCHIVE copy is what release-agent.sh reads
+build_zip "$t"
+run_case "tested: a missing readme.txt in the archive with no override is a hard error, not a fallback" \
   fail "$t" -- '+missing' '+readme.txt' '+refusing to publish a guessed'
 
 t="$(fixture tested-line-absent-fails-loud)"
-sub "$t/apps/agent/readme.txt" '/^Tested up to:/d'
-run_case "tested: a readme.txt with no Tested up to line is a hard error" \
+sub "$t/wpmgr-agent/readme.txt" '/^Tested up to:/d'
+build_zip "$t"
+run_case "tested: an archive readme.txt with no Tested up to line is a hard error" \
   fail "$t" -- "+could not parse a 'Tested up to:'"
 
 t="$(fixture tested-line-unparseable-fails-loud)"
-sub "$t/apps/agent/readme.txt" 's/^Tested up to: .*/Tested up to: latest/'
+sub "$t/wpmgr-agent/readme.txt" 's/^Tested up to: .*/Tested up to: latest/'
+build_zip "$t"
 run_case "tested: a non-numeric Tested up to value is a hard error, not silently coerced" \
   fail "$t" -- "+could not parse a 'Tested up to:'"
 
 t="$(fixture tested-tolerates-case-and-spacing)"
-sub "$t/apps/agent/readme.txt" 's/^Tested up to: 7\.1/tested up to:   7.2   /'
+sub "$t/wpmgr-agent/readme.txt" 's/^Tested up to: 7\.1/tested up to:   7.2   /'
+build_zip "$t"
 run_case "tested: label case and extra whitespace do not disable the parse (no over-fire)" \
   pass "$t" -- '+"tested": "7.2"'
 
 t="$(fixture tested-old-default-never-appears)"
-sub "$t/apps/agent/readme.txt" 's/^Tested up to: 7\.1/Tested up to: 6.3/'
-run_case "regress: the old 6.8 literal cannot reappear when readme says something else" \
+sub "$t/wpmgr-agent/readme.txt" 's/^Tested up to: 7\.1/Tested up to: 6.3/'
+build_zip "$t"
+run_case "regress: the old 6.8 literal cannot reappear when the archive says something else" \
   pass "$t" -- '+"tested": "6.3"' -'"tested": "6.8"'
+
+# ===========================================================================
+# GH #515 follow-up (this fix): the manifest must describe the ARCHIVE, not
+# the working tree it happened to be published from. version/requires/
+# requires_php already read the zip's own plugin file; tested now reads the
+# zip's own readme.txt the same way. Prove the working tree can diverge from
+# the archive WITHOUT moving the manifest.
+# ===========================================================================
+t="$(fixture tested-archive-is-source-not-working-tree)"
+sub "$t/apps/agent/readme.txt" 's/^Tested up to: 7\.1/Tested up to: 9.9/' # working tree only; archive untouched, zip NOT rebuilt
+run_case "tested: a working-tree readme.txt that disagrees with the archive is ignored" \
+  pass "$t" -- '+"tested": "7.1"' -'"tested": "9.9"'
 
 # ===========================================================================
 # Siblings found during the audit: requires / requires_php / version had the

--- a/scripts/release-agent_test.sh
+++ b/scripts/release-agent_test.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# scripts/release-agent_test.sh
+#
+# The regression suite for scripts/release-agent.sh.
+#
+# WHY THIS EXISTS (GH #515). `tested` in the published manifest used to be
+# `${WPMGR_AGENT_TESTED:-6.8}`. Nobody ever set the override, so every release
+# published a WordPress compatibility floor of 6.8 regardless of what
+# apps/agent/readme.txt actually declared. The fix makes the default the
+# value parsed from readme.txt's own "Tested up to:" line, and turns a
+# missing file or an unparseable line into a hard failure instead of a new
+# silent default. `requires` and `requires_php` had the same defect in their
+# error path (`|| echo '6.0'` / `|| echo '8.1'`); they are fixed the same way.
+# This suite is the proof that survives after the terminal scrollback does.
+#
+# HOW IT WORKS. release-agent.sh derives its own repo root from its own
+# script path (dirname "$0"/..), not from an argument or an env var, so each
+# case builds a full miniature repo under a scratch dir — scripts/,
+# apps/agent/readme.txt, release/wpmgr-agent.zip — and runs a COPY of the
+# real script placed at <fixture>/scripts/release-agent.sh, so its repo-root
+# detection lands on the fixture instead of this checkout. No mocking: the
+# real script reads real files and a real zip built with the real `zip`.
+#
+# RUN IT:
+#   scripts/release-agent_test.sh            # everything
+#   scripts/release-agent_test.sh tested     # only cases matching "tested"
+#
+# Point it at a different implementation to prove the suite is not vacuous:
+#   WPMGR_RELEASE_AGENT_SCRIPT=/tmp/guard-with-hole.sh \
+#     scripts/release-agent_test.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${WPMGR_RELEASE_AGENT_SCRIPT:-$HERE/release-agent.sh}"
+FILTER="${1:-}"
+
+if [ ! -f "$GUARD" ]; then
+  echo "no script at $GUARD" >&2
+  exit 2
+fi
+command -v zip >/dev/null 2>&1 || { echo "zip is required to build fixture packages" >&2; exit 2; }
+command -v unzip >/dev/null 2>&1 || { echo "unzip is required (release-agent.sh depends on it too)" >&2; exit 2; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/wpmgr-release-agent.XXXXXX")" || exit 2
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+FAILED_NAMES=''
+
+# ---------------------------------------------------------------------------
+# Fixture construction
+# ---------------------------------------------------------------------------
+
+# write_plugin_php DIR VERSION_LINE REQUIRES_LINE REQUIRES_PHP_LINE
+#   Each *_LINE is the literal header line, or "" to omit it entirely, so a
+#   case can simulate a plugin header that is missing one field.
+#   VERSION_LINE additionally controls the WPMGR_AGENT_VERSION define; pass
+#   "" to omit both the header Version line and the define.
+write_plugin_php() {
+  _dir="$1"; _version="$2"; _requires="$3"; _requires_php="$4"
+  mkdir -p "$_dir/wpmgr-agent"
+  {
+    echo '<?php'
+    echo '/**'
+    echo ' * Plugin Name: WPMgr Agent'
+    [ -n "$_version" ] && echo " * Version:     $_version"
+    [ -n "$_requires" ] && echo " * Requires at least: $_requires"
+    [ -n "$_requires_php" ] && echo " * Requires PHP:      $_requires_php"
+    echo ' */'
+    echo ''
+    echo "if (!defined('ABSPATH')) { exit; }"
+    if [ -n "$_version" ]; then
+      echo ""
+      echo "define('WPMGR_AGENT_VERSION', '$_version');"
+    fi
+  } >"$_dir/wpmgr-agent/wpmgr-agent.php"
+}
+
+# build_zip DIR -> zips $_dir/wpmgr-agent/ into $_dir/release/wpmgr-agent.zip
+# with the mandatory "wpmgr-agent/" top-level entry.
+build_zip() {
+  _dir="$1"
+  mkdir -p "$_dir/release"
+  rm -f "$_dir/release/wpmgr-agent.zip"
+  ( cd "$_dir" && zip -X -q -r release/wpmgr-agent.zip wpmgr-agent )
+}
+
+# fixture NAME -> path to a fresh scratch repo root with:
+#   scripts/release-agent.sh   (a copy of $GUARD, so repo-root detection
+#                                lands here, not on this checkout)
+#   apps/agent/readme.txt      (default: declares "Tested up to: 7.1")
+#   release/wpmgr-agent.zip    (default: version 1.2.3, requires 6.2/8.1)
+fixture() {
+  _t="$WORK/$1"
+  rm -rf "$_t"
+  mkdir -p "$_t/scripts" "$_t/apps/agent"
+  cp "$GUARD" "$_t/scripts/release-agent.sh"
+  chmod +x "$_t/scripts/release-agent.sh"
+  {
+    echo '=== WPMgr Agent ==='
+    echo 'Requires at least: 6.2'
+    echo 'Tested up to: 7.1'
+    echo 'Requires PHP: 8.1'
+    echo 'Stable tag: 1.2.3'
+  } >"$_t/apps/agent/readme.txt"
+  write_plugin_php "$_t" "1.2.3" "6.2" "8.1"
+  build_zip "$_t"
+  printf '%s' "$_t"
+}
+
+sub() { # sub FILE SED-EXPR
+  sed -E "$2" "$1" >"$1.tmp" && mv "$1.tmp" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# run NAME pass|fail FIXTURE_DIR [ENV=VAL ...] -- [+MUST-CONTAIN ...] [-MUST-NOT-CONTAIN ...]
+#
+# Runs the fixture's own copy of the script with --dry-run against
+# <fixture>/out/latest.json. On a `pass` case the manifest must exist; on a
+# `fail` case it must NOT exist (a refusal must not leave a half-written
+# manifest behind).
+# ---------------------------------------------------------------------------
+run_case() {
+  _name="$1"; _want="$2"; _dir="$3"; shift 3
+
+  if [ -n "$FILTER" ]; then
+    case "$_name" in
+      *"$FILTER"*) : ;;
+      *) SKIPPED=$((SKIPPED + 1)); return 0 ;;
+    esac
+  fi
+
+  _envs=()
+  while [ "$#" -gt 0 ] && [ "$1" != '--' ]; do
+    _envs+=("$1")
+    shift
+  done
+  [ "$#" -gt 0 ] && shift # drop the --
+
+  _out="$_dir/out/latest.json"
+  rm -rf "$_dir/out"
+  # "${_envs[@]+"${_envs[@]}"}" (not the plain "${_envs[@]}") because bash 3.2
+  # — what macOS ships, and what this suite must run under — treats expanding
+  # an EMPTY array under `set -u` as an unbound-variable error.
+  _result="$(env "${_envs[@]+"${_envs[@]}"}" "$_dir/scripts/release-agent.sh" --dry-run --out "$_out" 2>&1)"
+  _code=$?
+  _problems=''
+
+  if [ "$_want" = pass ] && [ "$_code" -ne 0 ]; then
+    _problems="$_problems
+    expected exit 0, got $_code"
+  fi
+  if [ "$_want" = fail ] && [ "$_code" -eq 0 ]; then
+    _problems="$_problems
+    expected a non-zero exit, got 0"
+  fi
+  if [ "$_want" = pass ] && [ ! -f "$_out" ]; then
+    _problems="$_problems
+    expected a manifest to be written at $_out, found none"
+  fi
+  if [ "$_want" = fail ] && [ -f "$_out" ]; then
+    _problems="$_problems
+    expected NO manifest on a refusal, but $_out exists"
+  fi
+
+  for _a in "$@"; do
+    case "$_a" in
+      +*)
+        _needle="${_a#+}"
+        if ! printf '%s\n' "$_result" | grep -qF "$_needle"; then
+          _problems="$_problems
+    expected the output to contain: $_needle"
+        fi
+        ;;
+      -*)
+        _needle="${_a#-}"
+        if printf '%s\n' "$_result" | grep -qF "$_needle"; then
+          _problems="$_problems
+    expected the output NOT to contain: $_needle"
+        fi
+        ;;
+    esac
+  done
+
+  if [ -n "$_problems" ]; then
+    FAILED=$((FAILED + 1))
+    FAILED_NAMES="$FAILED_NAMES  $_name
+"
+    printf 'FAIL %s%s\n' "$_name" "$_problems"
+    printf '%s\n' "$_result" | sed 's/^/      | /'
+  else
+    PASSED=$((PASSED + 1))
+    printf 'ok   %s\n' "$_name"
+  fi
+}
+
+# ===========================================================================
+# GH #515: the core defect and its fix.
+# ===========================================================================
+t="$(fixture honest-tested-parsed-from-readme)"
+run_case "honest: tested is parsed from readme.txt's Tested up to line, not defaulted" \
+  pass "$t" -- '+"tested": "7.1"' -'"tested": "6.8"'
+
+t="$(fixture tested-override-wins-and-skips-readme)"
+rm -f "$t/apps/agent/readme.txt" # prove the override needs no readme at all
+run_case "tested: an explicit WPMGR_AGENT_TESTED override wins and never touches readme.txt" \
+  pass "$t" "WPMGR_AGENT_TESTED=6.5" -- '+"tested": "6.5"'
+
+t="$(fixture tested-readme-missing-fails-loud)"
+rm -f "$t/apps/agent/readme.txt"
+run_case "tested: a missing readme.txt with no override is a hard error, not a fallback" \
+  fail "$t" -- '+missing' '+readme.txt' '+refusing to publish a guessed'
+
+t="$(fixture tested-line-absent-fails-loud)"
+sub "$t/apps/agent/readme.txt" '/^Tested up to:/d'
+run_case "tested: a readme.txt with no Tested up to line is a hard error" \
+  fail "$t" -- "+could not parse a 'Tested up to:'"
+
+t="$(fixture tested-line-unparseable-fails-loud)"
+sub "$t/apps/agent/readme.txt" 's/^Tested up to: .*/Tested up to: latest/'
+run_case "tested: a non-numeric Tested up to value is a hard error, not silently coerced" \
+  fail "$t" -- "+could not parse a 'Tested up to:'"
+
+t="$(fixture tested-tolerates-case-and-spacing)"
+sub "$t/apps/agent/readme.txt" 's/^Tested up to: 7\.1/tested up to:   7.2   /'
+run_case "tested: label case and extra whitespace do not disable the parse (no over-fire)" \
+  pass "$t" -- '+"tested": "7.2"'
+
+t="$(fixture tested-old-default-never-appears)"
+sub "$t/apps/agent/readme.txt" 's/^Tested up to: 7\.1/Tested up to: 6.3/'
+run_case "regress: the old 6.8 literal cannot reappear when readme says something else" \
+  pass "$t" -- '+"tested": "6.3"' -'"tested": "6.8"'
+
+# ===========================================================================
+# Siblings found during the audit: requires / requires_php / version had the
+# same "silent fallback on parse failure" shape in their error path.
+# ===========================================================================
+t="$(fixture requires-missing-fails-loud)"
+write_plugin_php "$t" "1.2.3" "" "8.1"
+build_zip "$t"
+run_case "requires: a plugin header missing 'Requires at least' is a hard error, not 6.0" \
+  fail "$t" -- "+could not parse 'Requires at least'"
+
+t="$(fixture requires-php-missing-fails-loud)"
+write_plugin_php "$t" "1.2.3" "6.2" ""
+build_zip "$t"
+run_case "requires_php: a plugin header missing 'Requires PHP' is a hard error, not 8.1" \
+  fail "$t" -- "+could not parse 'Requires PHP'"
+
+t="$(fixture version-missing-fails-loud-with-message)"
+write_plugin_php "$t" "" "6.2" "8.1"
+build_zip "$t"
+run_case "version: a missing WPMGR_AGENT_VERSION define fails WITH the die message (not a bare pipefail exit)" \
+  fail "$t" -- "+could not parse WPMGR_AGENT_VERSION"
+
+# ===========================================================================
+# Honest trees: the fix must not over-fire on a normal release.
+# ===========================================================================
+t="$(fixture honest-complete-manifest)"
+run_case "honest: a normal release produces every manifest field" \
+  pass "$t" -- \
+  '+"slug": "wpmgr-agent"' \
+  '+"plugin": "wpmgr-agent/wpmgr-agent.php"' \
+  '+"version": "1.2.3"' \
+  '+"min_version": "0.0.0"' \
+  '+"requires": "6.2"' \
+  '+"requires_php": "8.1"' \
+  '+"tested": "7.1"' \
+  '+"sections"' \
+  '+"description"'
+
+t="$(fixture honest-min-version-override-still-works)"
+run_case "honest: WPMGR_AGENT_MIN_VERSION still overrides independently of the tested fix" \
+  pass "$t" "WPMGR_AGENT_MIN_VERSION=0.55.0" -- '+"min_version": "0.55.0"'
+
+t="$(fixture honest-missing-zip-still-an-error)"
+rm -f "$t/release/wpmgr-agent.zip"
+run_case "honest: the pre-existing missing-zip guard still fires" \
+  fail "$t" -- "+run 'make agent-zip' first"
+
+# ---------------------------------------------------------------------------
+printf '\n'
+if [ -n "$FILTER" ]; then
+  printf 'filter: %s (%s skipped)\n' "$FILTER" "$SKIPPED"
+fi
+printf '%s passed, %s failed\n' "$PASSED" "$FAILED"
+if [ "$FAILED" -ne 0 ]; then
+  printf 'failing cases:\n%s' "$FAILED_NAMES"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- `scripts/release-agent.sh` published `"tested": "6.8"` in every agent release manifest via `TESTED="${WPMGR_AGENT_TESTED:-6.8}"`. Nobody ever set the override, so every release told self-hosted control planes the agent was tested only up to WordPress 6.8, regardless of what `apps/agent/readme.txt` actually declared (7.1 as of this writing).
- The default is now the value parsed from readme.txt's own `Tested up to:` line. `WPMGR_AGENT_TESTED` still works as an explicit override (and skips the readme parse entirely when set). When it is unset, a missing readme.txt or an unparseable `Tested up to:` line is now a hard failure — the script refuses to publish rather than guessing.
- `requires`/`requires_php` already parsed dynamically from the zip's own plugin header, but their *failure* path fell back to the same kind of hardcoded literal (`|| echo '6.0'` / `|| echo '8.1'`) instead of refusing to publish. Fixed the same way: a missing header field is now a hard error naming the field.
- Found and fixed a latent, related bug while auditing: the `WPMGR_AGENT_VERSION` extraction's failure path relied on a `sed` at the end of the pipeline "absorbing" an earlier failed `grep`, but under `set -o pipefail` a failed `grep` earlier in the pipe still fails the whole pipeline, so a parse failure there silently killed the script with bash's own bare `exit 1` and never printed the script's own `die()` message. Fixed by adding `|| true` before the `[[ -n ... ]] || die` check, matching the pattern already used correctly elsewhere in the file.

## Audit of every other field in the manifest (per the issue's ask)

| Field | Verdict |
|---|---|
| `slug`, `plugin` | Literal, but validated at runtime against the real zip structure (`top_dirs == SLUG`, `unzip -l` checks the plugin file exists) — correct-by-construction, not a stale default. |
| `version` | Parsed from the zip's own `WPMGR_AGENT_VERSION` define. Already correct; fixed a latent pipefail bug in its failure path (see above). |
| `min_version` | `${WPMGR_AGENT_MIN_VERSION:-0.0.0}`. This is a release-rollout policy parameter ("the floor this manifest update applies to"), not a fact derivable from source — `0.0.0` means "no floor", a legitimate default. Left unchanged. |
| `requires`, `requires_php` | Parsed from the zip's own plugin header (already correct-by-construction); the failure-path literal is fixed in this PR. |
| `tested` | Was the bug this issue reports. Fixed. |
| `sections.description` | Hardcoded marketing-style prose (with `${VERSION}` interpolated). Not a compatibility fact, so it can't silently redefine what WordPress versions are supported — but it is authored text that isn't derived from readme.txt and could drift from the actual feature set over time. Left unchanged; flagging as a possible follow-up, out of scope here. |

## Proof (commands + output in the PR description below)

Red (pre-fix script against the real zip + readme.txt, which says `Tested up to: 7.1`):
```
"tested": "6.8"
```

Green (fixed script, same inputs):
```
"tested": "7.1"
```

Fail-loud (readme.txt missing):
```
release-agent: missing apps/agent/readme.txt — cannot derive 'Tested up to'; refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)
```
exit 1, no manifest written.

Fail-loud (readme.txt present, `Tested up to:` line absent):
```
release-agent: could not parse a 'Tested up to:' version from apps/agent/readme.txt — refusing to publish a guessed WordPress compatibility floor (set WPMGR_AGENT_TESTED to override explicitly)
```
exit 1, no manifest written.

Over-fire check: a normal dry run still produces a complete, valid manifest with every field populated (see full JSON in the issue thread / commit description).

`scripts/release-agent_test.sh` (new, 13 cases) builds fixture plugin zips and readme.txt files and runs the real script against them — no mocking. Pointing it at the pre-fix script via `WPMGR_RELEASE_AGENT_SCRIPT=...` reproduces exactly 10 of 13 cases failing, which is the proof the suite is not vacuous:
```
./scripts/release-agent_test.sh
13 passed, 0 failed
```

`make agent-release-test` runs the same suite.

## Explicitly out of scope

Did not publish, tag, or run `make agent-release`. The already-published 0.61.145 manifest still carries `"tested": "6.8"`. Republishing it would mean re-running `scripts/release-agent.sh` (now fixed) against the existing 0.61.145 zip — the versioned package object at `gs://wpmgr-chunks-prod/agent-releases/0.61.145/wpmgr-agent.zip` doesn't need to change, only `latest.json` needs to be rewritten and re-uploaded with `cache-control: no-store` (it already carries that header, so a fresh upload takes effect immediately for anyone who re-checks). That decision is the owner's call.

## Test plan

- [x] `make hooks-status` — pre-push hook installed and current
- [x] Red/green/fail-loud/over-fire proofs above, run against a real built `release/wpmgr-agent.zip` and the real `apps/agent/readme.txt` (never against `main`'s published manifest)
- [x] `scripts/release-agent_test.sh` — 13/13 passing, and meta-tested against the pre-fix script to confirm it's not vacuous
- [x] `shellcheck` clean on both `scripts/release-agent.sh` and `scripts/release-agent_test.sh`
- [ ] CI (`ci.yml`) — pending