### PR TITLE
fix(agent): register the app-password 2FA block on a hook core fires (#523)

### DIFF
--- a/apps/agent/includes/security/class-site-2fa-module.php
+++ b/apps/agent/includes/security/class-site-2fa-module.php
@@ -65,9 +65,28 @@
  * hook dispatched with core's own argument list, in
  * tests/Security/Site2faHookRegistrationTest.php.
  *
- * The agent's own /wpmgr/v1 REST channel and the autologin path are
- * explicitly exempted -- they carry their own Ed25519 credential and never
- * rely on application passwords.
+ * NO REQUEST-URI EXEMPTION:
+ * An earlier revision of this control exempted the agent's own REST channel by
+ * testing str_contains($_SERVER['REQUEST_URI'], '/wpmgr/v1/'). REQUEST_URI is
+ * the raw, client-supplied request target, and that was an unanchored
+ * substring match over the whole of it, query string included, so anyone
+ * holding a stolen application password for a 2FA-required administrator
+ * walked past the control by appending one unused parameter:
+ *
+ *     GET /wp-json/wp/v2/users/1?wpmgr=/wpmgr/v1/
+ *
+ * The exemption was deleted rather than repaired, because it was guarding
+ * nothing: the agent's /wpmgr/v1 routes authenticate with an Ed25519 signature
+ * verified in the REST permission callback, autologin treats the signed JWT
+ * itself as the authorization, and no application-password API is referenced
+ * anywhere in includes/ outside this file. Repairing the matcher would have
+ * kept a client-controlled input inside an auth decision for no benefit --
+ * and an anchored path/query matcher is itself reachable with
+ * `?x=rest_route=/wpmgr/v1/`. The only exemption left is the user-shaped one:
+ * a user who neither requires 2FA nor has a non-email method enrolled.
+ *
+ * The bypass and its regression guard are in
+ * tests/Security/Site2faHookRegistrationTest.php.
  *
  * FORCED-CHANGE INTERSTITIAL (H2 fix):
  * When PasswordPolicyModule sets META_FORCE_CHANGE on a user, onWpLogin
@@ -321,9 +340,11 @@ final class Site2faModule
      * argument list down to it before calling.
      *
      * EXEMPTED (must not be blocked):
-     *  - The agent's own /wpmgr/v1 REST routes (Ed25519-signed; never use app passwords).
-     *  - The autologin path (POST /wp-json/wpmgr/v1/autologin; also REST, also Ed25519).
      *  - Any user who does NOT require 2FA and has no non-email method enrolled.
+     *
+     * That is the ONLY exemption, and it is decided purely from the WP_User
+     * core hands us. There is deliberately no request-shape exemption: see
+     * NO REQUEST-URI EXEMPTION in the class docblock.
      *
      * Application passwords do NOT satisfy the second factor: they carry only
      * password-equivalent credentials and bypass wp_login entirely, so the 2FA
@@ -347,13 +368,6 @@ final class Site2faModule
             return;
         }
 
-        // Exempt the agent's own REST namespace (/wpmgr/v1/*). Those routes
-        // are authenticated via Ed25519 signatures at the REST permission callback
-        // and never rely on application passwords.
-        if ($this->isAgentRestRequest()) {
-            return;
-        }
-
         // Block if the user requires 2FA.
         if ($this->policy->requires2fa($user)) {
             $error->add(
@@ -372,34 +386,6 @@ final class Site2faModule
                 esc_html__('Application passwords are disabled for accounts with two-factor authentication enrolled. Use an alternative authentication method.', 'wpmgr-agent')
             );
         }
-    }
-
-    /**
-     * Check whether the current request targets the agent's own REST namespace.
-     * The agent's /wpmgr/v1 routes are exempted from app-password blocking.
-     *
-     * REQUEST_URI is the only signal available here: core fires
-     * wp_authenticate_application_password_errors with no WP_REST_Request, and
-     * on the determine_current_user path REST routing has not run yet, so
-     * neither a WP_REST_Request nor the REST_REQUEST constant exists to consult.
-     * Both URI forms carry the namespace as a literal path segment
-     * (/wp-json/wpmgr/v1/... and ?rest_route=/wpmgr/v1/...), and the rest_route
-     * form is checked decoded as well because a client may percent-encode it.
-     *
-     * @return bool
-     */
-    private function isAgentRestRequest(): bool
-    {
-        if (!isset($_SERVER['REQUEST_URI']) || !is_string($_SERVER['REQUEST_URI'])) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- presence/type check only; sanitized below
-            return false;
-        }
-
-        $uri = sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI'])); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized on this line
-        if (str_contains($uri, '/wpmgr/v1/')) {
-            return true;
-        }
-
-        return str_contains(rawurldecode($uri), '/wpmgr/v1/');
     }
 
     /**

--- a/apps/agent/includes/security/class-site-2fa-module.php
+++ b/apps/agent/includes/security/class-site-2fa-module.php
@@ -37,12 +37,34 @@
  * It is ONLY written to META_SECRET by activatePendingSecret() when the user proves
  * a valid code. An abandoned setup never activates the secret.
  *
- * APPLICATION-PASSWORD BYPASS BLOCK (H1 fix):
- * WordPress Application Passwords authenticate via HTTP Basic or the
- * wp_authenticate_application_password filter WITHOUT firing wp_login,
- * so the interstitial hook above never sees them. For any user who requires
- * 2FA (or who has a non-email method enrolled), application-password auth is
- * rejected outright via the wp_authenticate_application_password filter.
+ * APPLICATION-PASSWORD BYPASS BLOCK (H1 fix; hook corrected for #523):
+ * WordPress Application Passwords authenticate over HTTP Basic WITHOUT firing
+ * wp_login, so the interstitial hook above never sees them. For any user who
+ * requires 2FA (or who has a non-email method enrolled), application-password
+ * auth is rejected.
+ *
+ * The interception point is core's wp_authenticate_application_password_errors
+ * ACTION (wp-includes/user.php), fired as
+ *     do_action( '...', $error, $user, $item, $password )
+ * once a supplied password has matched a stored application-password hash and
+ * before core records the password's use. Core documents it as the place "for
+ * plugins to add additional constraints to prevent an application password
+ * from being used": add to the passed WP_Error and core abandons the
+ * authentication and hands that error back to the caller. It is the only hook
+ * that fires on BOTH app-password entry points -- the `authenticate` filter
+ * chain and wp_validate_application_password() on determine_current_user --
+ * and it fires for no other credential type, so an ordinary wp-login.php form
+ * post never reaches it.
+ *
+ * There is no `wp_authenticate_application_password` FILTER. That name is a
+ * core function (wp-includes/user.php), which core registers on `authenticate`
+ * at priority 20 in wp-includes/default-filters.php. Until #523 the block was
+ * added to it as though it were a filter: add_filter() against a name nothing
+ * fires stores the callback, warns about nothing, and never invokes it, so the
+ * control had never executed on any site. Registration is asserted, and the
+ * hook dispatched with core's own argument list, in
+ * tests/Security/Site2faHookRegistrationTest.php.
+ *
  * The agent's own /wpmgr/v1 REST channel and the autologin path are
  * explicitly exempted -- they carry their own Ed25519 credential and never
  * rely on application passwords.
@@ -241,10 +263,15 @@ final class Site2faModule
         }
 
         // H1 fix: block application-password auth for 2FA-required users.
-        // This filter fires when WP resolves an HTTP-Basic / app-password credential.
-        // We gate it on twoFactorEnabled to avoid overhead when 2FA is off.
+        //
+        // wp_authenticate_application_password_errors is a core ACTION fired with
+        // ($error, $user, $item, $password) once a supplied password has matched a
+        // stored application-password hash; adding to $error makes core reject the
+        // credential. See the class docblock for why this is the interception point
+        // -- and for the filter name, corrected in #523, that core never fires.
+        // Gated on twoFactorEnabled to avoid overhead when 2FA is off.
         if ($has2fa) {
-            add_filter('wp_authenticate_application_password', [$this, 'blockAppPasswordFor2faUser'], 10, 5);
+            add_action('wp_authenticate_application_password_errors', [$this, 'blockAppPasswordFor2faUser'], 10, 4);
         }
 
         // XML-RPC block for 2FA users.
@@ -278,6 +305,21 @@ final class Site2faModule
      * Reject application-password authentication for users who require 2FA
      * or who have a non-email (real) 2FA method enrolled.
      *
+     * Registered on core's wp_authenticate_application_password_errors action
+     * (wp-includes/user.php), which core fires with ($error, $user, $item,
+     * $password) after the supplied password has matched a stored
+     * application-password hash. $error is a fresh WP_Error; if it carries any
+     * error when the action returns, core abandons the authentication and
+     * returns that WP_Error to the caller. WP_Error is an object, so mutating
+     * it here is what core observes -- this callback returns nothing, and a
+     * `return` is how it ALLOWS the credential.
+     *
+     * $item and $password are declared with defaults purely for robustness on
+     * hosts where some other plugin re-fires this action with a short argument
+     * list; core always passes all four. The declared arity (4) is asserted in
+     * tests/Security/Site2faHookRegistrationTest.php, because core slices the
+     * argument list down to it before calling.
+     *
      * EXEMPTED (must not be blocked):
      *  - The agent's own /wpmgr/v1 REST routes (Ed25519-signed; never use app passwords).
      *  - The autologin path (POST /wp-json/wpmgr/v1/autologin; also REST, also Ed25519).
@@ -287,89 +329,77 @@ final class Site2faModule
      * password-equivalent credentials and bypass wp_login entirely, so the 2FA
      * interstitial never fires for them.
      *
-     * @param \WP_Error|\WP_User|null $user        Result from earlier authenticate filters.
-     * @param \WP_User|false          $inputUser   Resolved user (or false).
-     * @param string                  $appPassword The raw application password.
-     * @param array<mixed>|null       $item        Application-password DB record.
-     * @param \WP_REST_Request|null   $request     The current REST request.
-     * @return \WP_Error|\WP_User|null
+     * @param mixed $error    WP_Error collecting extra constraints; mutated in place.
+     * @param mixed $user     WP_User the application password belongs to.
+     * @param mixed $item     Application-password DB record.
+     * @param mixed $password The raw application password (unused; never logged or stored).
+     * @return void
      */
     public function blockAppPasswordFor2faUser(
+        mixed $error,
         mixed $user,
-        mixed $inputUser,
-        string $appPassword,
-        ?array $item,
-        mixed $request
-    ): mixed {
-        // If a prior filter already produced an error, pass it through.
-        if (is_a($user, 'WP_Error')) {
-            return $user;
-        }
-
-        // Resolve the user we will be acting on.
-        $resolvedUser = ($user instanceof \WP_User) ? $user : $inputUser;
-        if (!($resolvedUser instanceof \WP_User)) {
-            return $user;
+        mixed $item = null,
+        mixed $password = ''
+    ): void {
+        // The action's whole contract is mutation of a WP_Error for a WP_User.
+        // Anything else is a caller that is not core: do nothing rather than guess.
+        if (!($error instanceof \WP_Error) || !($user instanceof \WP_User)) {
+            return;
         }
 
         // Exempt the agent's own REST namespace (/wpmgr/v1/*). Those routes
         // are authenticated via Ed25519 signatures at the REST permission callback
-        // and never reach application-password resolution.
-        if ($this->isAgentRestRequest($request)) {
-            return $user;
+        // and never rely on application passwords.
+        if ($this->isAgentRestRequest()) {
+            return;
         }
 
         // Block if the user requires 2FA.
-        if ($this->policy->requires2fa($resolvedUser)) {
-            return new \WP_Error(
+        if ($this->policy->requires2fa($user)) {
+            $error->add(
                 'wpmgr_2fa_app_password_blocked',
                 esc_html__('Application passwords are disabled for accounts that require two-factor authentication. Use an alternative authentication method.', 'wpmgr-agent')
             );
+            return;
         }
 
         // Block if the user has any non-email 2FA method enrolled.
         // Email is intentionally excluded: it is always "configured" for any user
         // with an email address and therefore cannot indicate deliberate 2FA enrollment.
-        if ($this->hasNonEmailMethodConfigured($resolvedUser)) {
-            return new \WP_Error(
+        if ($this->hasNonEmailMethodConfigured($user)) {
+            $error->add(
                 'wpmgr_2fa_app_password_blocked',
                 esc_html__('Application passwords are disabled for accounts with two-factor authentication enrolled. Use an alternative authentication method.', 'wpmgr-agent')
             );
         }
-
-        return $user;
     }
 
     /**
-     * Check whether the current REST request targets the agent's own namespace.
+     * Check whether the current request targets the agent's own REST namespace.
      * The agent's /wpmgr/v1 routes are exempted from app-password blocking.
      *
-     * @param mixed $request The WP_REST_Request or null.
+     * REQUEST_URI is the only signal available here: core fires
+     * wp_authenticate_application_password_errors with no WP_REST_Request, and
+     * on the determine_current_user path REST routing has not run yet, so
+     * neither a WP_REST_Request nor the REST_REQUEST constant exists to consult.
+     * Both URI forms carry the namespace as a literal path segment
+     * (/wp-json/wpmgr/v1/... and ?rest_route=/wpmgr/v1/...), and the rest_route
+     * form is checked decoded as well because a client may percent-encode it.
+     *
      * @return bool
      */
-    private function isAgentRestRequest(mixed $request): bool
+    private function isAgentRestRequest(): bool
     {
-        // WP_REST_Request carries the route; check it if available.
-        if ($request instanceof \WP_REST_Request) {
-            $route = '';
-            if (method_exists($request, 'get_route')) {
-                $route = (string) $request->get_route();
-            }
-            if (str_contains($route, '/wpmgr/v1/')) {
-                return true;
-            }
+        if (!isset($_SERVER['REQUEST_URI']) || !is_string($_SERVER['REQUEST_URI'])) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- presence/type check only; sanitized below
+            return false;
         }
 
-        // Fallback: inspect the request URI directly (for edge cases where
-        // WP_REST_Request is not passed through by the caller).
-        if (isset($_SERVER['REQUEST_URI']) && is_string($_SERVER['REQUEST_URI'])) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only check; sanitized on next line
-            $uri = sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI']));
-            if (str_contains($uri, '/wpmgr/v1/')) {
-                return true;
-            }
+        $uri = sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI'])); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized on this line
+        if (str_contains($uri, '/wpmgr/v1/')) {
+            return true;
         }
 
-        return false;
+        return str_contains(rawurldecode($uri), '/wpmgr/v1/');
     }
 
     /**

--- a/apps/agent/phpstan-baseline.neon
+++ b/apps/agent/phpstan-baseline.neon
@@ -1399,18 +1399,6 @@ parameters:
 			path: includes/security/class-security-policy.php
 
 		-
-			message: '#^Call to function method_exists\(\) with WP_REST_Request and ''get_route'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: includes/security/class-site-2fa-module.php
-
-		-
-			message: '#^Parameter \#1 \$object_or_class of function is_a expects object, WP_Error\|WP_User\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/security/class-site-2fa-module.php
-
-		-
 			message: '#^Property WP_Roles\:\:\$role_names \(array\<string\>\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 1

--- a/apps/agent/tests/Security/Site2faHookRegistrationTest.php
+++ b/apps/agent/tests/Security/Site2faHookRegistrationTest.php
@@ -1,0 +1,477 @@
+<?php
+/**
+ * Site2faModule hook-REGISTRATION tests (issue #523).
+ *
+ * WHY THIS FILE EXISTS, SEPARATELY FROM Site2faModuleTest:
+ * Site2faModuleTest covers what the app-password callback DOES when you call
+ * it directly. That is exactly the coverage shape that let the "H1 fix" sit
+ * dead in the tree: the callback was added to
+ * `wp_authenticate_application_password`, which is a core FUNCTION
+ * (wp-includes/user.php, registered by core on `authenticate` at priority 20
+ * in wp-includes/default-filters.php) and NOT a hook anybody ever fires.
+ * add_filter() against a name that is never fired stores the callback and
+ * warns about nothing, so every body-level test stayed green while the control
+ * had never executed on a single site.
+ *
+ * The tests here therefore assert the REGISTRATION and then DISPATCH the hook
+ * the way WordPress core dispatches it -- same hook name, same argument list,
+ * sliced to the arity the module actually declared -- and assert the observable
+ * result. A wrong hook name, a wrong arity or a wrong argument order all fail
+ * here, and none of them fail in a body-level test.
+ *
+ * PROCESS ISOLATION IS LOAD BEARING:
+ * install() guards itself with a `static $installed` local, and
+ * Site2faModuleTest defines WPMGR_DISABLE_SITE_2FA process-globally. Both are
+ * per-process state that would make install() a silent no-op here and turn
+ * every assertion below vacuous. @runInSeparateProcess +
+ * @preserveGlobalState disabled is what keeps them honest.
+ *
+ * @package WPMgr\Agent\Tests\Security
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests\Security;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Security\BackupCodesProvider;
+use WPMgr\Agent\Security\EmailCodeProvider;
+use WPMgr\Agent\Security\SecurityPolicy;
+use WPMgr\Agent\Security\Site2faModule;
+use WPMgr\Agent\Security\TotpProvider;
+use WPMgr\Agent\Support\AgeIdentity;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Security\Site2faModule
+ */
+final class Site2faHookRegistrationTest extends TestCase
+{
+    /**
+     * The core action the app-password block must be registered on.
+     *
+     * Fired by wp_authenticate_application_password() in wp-includes/user.php
+     * as do_action( 'wp_authenticate_application_password_errors', $error,
+     * $user, $item, $password ) -- after the supplied password has matched a
+     * stored application-password hash and before core records its use. Core
+     * documents it as the place "for plugins to add additional constraints to
+     * prevent an application password from being used": populate the passed
+     * WP_Error and core abandons the authentication.
+     */
+    private const APP_PASSWORD_HOOK = 'wp_authenticate_application_password_errors';
+
+    /**
+     * Every add_action()/add_filter() call made during install(), in order.
+     *
+     * @var list<array{hook:string,callback:mixed,priority:int,accepted_args:int}>
+     */
+    private array $registered = [];
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->registered = [];
+
+        // Record registrations instead of discarding them. Brain Monkey's own
+        // add_action/add_filter interception is not used here because we need
+        // the priority and arity, and we need to replay the callback later.
+        $recorder = function ($hook, $callback = null, $priority = 10, $acceptedArgs = 1): bool {
+            $this->registered[] = [
+                'hook'          => (string) $hook,
+                'callback'      => $callback,
+                'priority'      => (int) $priority,
+                'accepted_args' => (int) $acceptedArgs,
+            ];
+            return true;
+        };
+        Functions\when('add_action')->alias($recorder);
+        Functions\when('add_filter')->alias($recorder);
+
+        Functions\when('esc_html__')->alias(fn ($t, $d = '') => $t);
+        Functions\when('esc_html')->alias(fn ($t) => $t);
+        Functions\when('__')->alias(fn ($t, $d = '') => $t);
+        Functions\when('sanitize_text_field')->alias(fn ($t) => $t);
+        Functions\when('wp_unslash')->alias(fn ($t) => $t);
+        Functions\when('get_user_meta')->justReturn('');
+        Functions\when('update_user_meta')->justReturn(true);
+        Functions\when('delete_user_meta')->justReturn(true);
+        Functions\when('get_option')->justReturn('');
+    }
+
+    protected function tear_down(): void
+    {
+        unset($_SERVER['REQUEST_URI']);
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param list<string> $roles
+     */
+    private function makeUser(int $id = 1, array $roles = ['administrator']): \WP_User
+    {
+        $u             = new \WP_User();
+        $u->ID         = $id;
+        $u->roles      = $roles;
+        $u->user_login = 'user' . $id;
+        $u->user_email = 'user' . $id . '@example.com';
+        return $u;
+    }
+
+    /**
+     * @return list<\WPMgr\Agent\Security\SiteTwoFactorProvider>
+     */
+    private function makeProviders(): array
+    {
+        $ageIdentity = new class extends AgeIdentity {
+            public function __construct()
+            {
+                // Skip parent -- no keystore needed in tests.
+            }
+
+            public function encryptChunk(string $plaintext): string
+            {
+                return $plaintext;
+            }
+
+            public function decryptChunk(string $ciphertext): string
+            {
+                return $ciphertext;
+            }
+        };
+
+        return [
+            new TotpProvider($ageIdentity),
+            new EmailCodeProvider(),
+            new BackupCodesProvider(),
+        ];
+    }
+
+    /**
+     * Prove the recorder is wired up before any "nothing was registered"
+     * assertion leans on it. A recorder that silently captured nothing would
+     * make every negative assertion in this file pass for the wrong reason.
+     *
+     * @return void
+     */
+    private function assertRecorderIsLive(): void
+    {
+        $before = count($this->registered);
+        add_action('wpmgr_recorder_self_check', 'wpmgr_recorder_self_check_cb', 7, 2);
+        $this->assertCount(
+            $before + 1,
+            $this->registered,
+            'instrument self-check: the add_action recorder must capture registrations'
+        );
+        array_pop($this->registered);
+    }
+
+    /**
+     * Find the single recorded registration for a hook name.
+     *
+     * @param string $hook
+     * @return array{hook:string,callback:mixed,priority:int,accepted_args:int}|null
+     */
+    private function findRegistration(string $hook): ?array
+    {
+        foreach ($this->registered as $entry) {
+            if ($entry['hook'] === $hook) {
+                return $entry;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Replay a recorded registration exactly as WordPress core would: core
+     * slices the fired argument list down to the callback's declared
+     * accepted_args before invoking it (WP_Hook::apply_filters). Declaring the
+     * wrong arity therefore changes what the callback actually receives, which
+     * is why the slice is reproduced here rather than splatting all four.
+     *
+     * @param array{hook:string,callback:mixed,priority:int,accepted_args:int} $registration
+     * @param list<mixed>                                                      $args
+     * @return mixed
+     */
+    private function fireAsCore(array $registration, array $args): mixed
+    {
+        $sliced = array_slice($args, 0, $registration['accepted_args']);
+        return call_user_func_array($registration['callback'], $sliced);
+    }
+
+    private function policyRequiringAdmins(): SecurityPolicy
+    {
+        return SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'        => true,
+                'two_factor_required_roles' => ['administrator'],
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // #523: the app-password block must be registered on a hook core FIRES
+    // -------------------------------------------------------------------------
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_app_password_block_is_registered_on_a_hook_core_actually_fires(): void
+    {
+        $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
+        $module->install();
+
+        $names = array_column($this->registered, 'hook');
+
+        $this->assertContains(
+            self::APP_PASSWORD_HOOK,
+            $names,
+            '#523: the app-password block must be registered on ' . self::APP_PASSWORD_HOOK
+            . ', the action core fires. Registered instead: ' . implode(', ', $names)
+        );
+
+        $registration = $this->findRegistration(self::APP_PASSWORD_HOOK);
+        $this->assertNotNull($registration);
+        $this->assertSame(
+            4,
+            $registration['accepted_args'],
+            '#523: core fires ' . self::APP_PASSWORD_HOOK . ' with ($error, $user, $item, $password)'
+            . ' -- a callback declaring any other arity is handed the wrong arguments'
+        );
+    }
+
+    /**
+     * The registration must not have been "fixed" by moving the block onto the
+     * `authenticate` filter, which every wp-login.php form post also runs
+     * through. That would put the app-password refusal in the path of ordinary
+     * interactive logins, which are supposed to reach the 2FA interstitial
+     * rather than be refused outright.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_app_password_block_is_not_registered_on_the_shared_authenticate_filter(): void
+    {
+        $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
+        $module->install();
+
+        foreach ($this->registered as $entry) {
+            if ($entry['hook'] !== 'authenticate') {
+                continue;
+            }
+            $callbackName = is_array($entry['callback']) ? (string) ($entry['callback'][1] ?? '') : '';
+            $this->assertNotSame(
+                'blockAppPasswordFor2faUser',
+                $callbackName,
+                'the app-password block must not sit on `authenticate`: that filter also runs for'
+                . ' ordinary wp-login.php form logins'
+            );
+        }
+    }
+
+    /**
+     * FIRES: dispatch the recorded callback with core's own argument list and
+     * assert the credential is refused for a user whose role requires 2FA.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_dispatching_the_core_hook_blocks_a_2fa_required_user(): void
+    {
+        $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
+        $module->install();
+
+        $registration = $this->findRegistration(self::APP_PASSWORD_HOOK);
+        $this->assertNotNull(
+            $registration,
+            '#523: nothing is registered on ' . self::APP_PASSWORD_HOOK . ', so the control never runs'
+        );
+
+        // Exactly what wp_authenticate_application_password() passes.
+        $error = new \WP_Error();
+        $user  = $this->makeUser(1, ['administrator']);
+        $item  = ['uuid' => '11111111-2222-3333-4444-555555555555', 'name' => 'ci'];
+
+        $this->fireAsCore($registration, [$error, $user, $item, 'abcd efgh ijkl mnop']);
+
+        $this->assertSame(
+            'wpmgr_2fa_app_password_blocked',
+            $error->get_error_code(),
+            '#523: firing the core hook must populate the WP_Error core inspects,'
+            . ' which is how core abandons the application-password authentication'
+        );
+        $this->assertNotSame('', $error->get_error_message(), 'the refusal must carry a message for the caller');
+    }
+
+    /**
+     * FIRES: a user with TOTP deliberately enrolled is refused even though the
+     * policy does not require 2FA for their role.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_dispatching_the_core_hook_blocks_a_user_with_totp_enrolled(): void
+    {
+        $userId = 3;
+        Functions\when('get_user_meta')->alias(function ($uid, $key, $single = false) use ($userId) {
+            if ($uid === $userId && $key === TotpProvider::META_SECRET) {
+                return base64_encode('FAKEBASE32SECRET');
+            }
+            return '';
+        });
+
+        $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
+        $module->install();
+
+        $registration = $this->findRegistration(self::APP_PASSWORD_HOOK);
+        $this->assertNotNull($registration);
+
+        $error = new \WP_Error();
+        $this->fireAsCore($registration, [$error, $this->makeUser($userId, ['subscriber']), [], 'app-pw']);
+
+        $this->assertSame(
+            'wpmgr_2fa_app_password_blocked',
+            $error->get_error_code(),
+            'a subscriber with TOTP enrolled must be refused an application password'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // OVER-FIRE: application passwords must keep working for everyone else
+    // -------------------------------------------------------------------------
+
+    /**
+     * DOES NOT OVER-FIRE: a user who is neither role-required nor enrolled must
+     * keep authenticating with an application password. A block that refused
+     * everybody would break every integration on the site silently -- core
+     * returns the WP_Error we populate, and nothing else reports it.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_dispatching_the_core_hook_leaves_a_non_2fa_user_authenticated(): void
+    {
+        $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
+        $module->install();
+
+        $registration = $this->findRegistration(self::APP_PASSWORD_HOOK);
+        $this->assertNotNull(
+            $registration,
+            'the callback must be registered, or this test passes for the wrong reason'
+        );
+
+        $error = new \WP_Error();
+        // Subscriber: not role-required, nothing enrolled. EmailCodeProvider is
+        // "configured" for anyone with an email address and must not count.
+        $this->fireAsCore($registration, [$error, $this->makeUser(2, ['subscriber']), [], 'app-pw']);
+
+        $this->assertSame(
+            [],
+            $error->errors,
+            'over-fire: application-password auth must still succeed for a user without 2FA'
+        );
+    }
+
+    /**
+     * DOES NOT OVER-FIRE: the agent's own /wpmgr/v1 REST channel is exempt even
+     * for a 2FA-required administrator. Those routes authenticate with an
+     * Ed25519 signature at the permission callback.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_dispatching_the_core_hook_exempts_the_agent_rest_channel(): void
+    {
+        $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
+        $module->install();
+
+        $registration = $this->findRegistration(self::APP_PASSWORD_HOOK);
+        $this->assertNotNull($registration);
+
+        $_SERVER['REQUEST_URI'] = '/wp-json/wpmgr/v1/command/sync_security_policy';
+
+        $error = new \WP_Error();
+        $this->fireAsCore($registration, [$error, $this->makeUser(1, ['administrator']), [], 'app-pw']);
+
+        $this->assertSame(
+            [],
+            $error->errors,
+            'over-fire: the agent /wpmgr/v1 channel must never be refused by the app-password block'
+        );
+    }
+
+    /**
+     * DOES NOT OVER-FIRE: with 2FA switched off the callback is not registered
+     * at all, so application passwords are untouched on the overwhelming
+     * majority of sites.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_app_password_block_is_not_registered_when_two_factor_is_off(): void
+    {
+        $this->assertRecorderIsLive();
+
+        $module = new Site2faModule(SecurityPolicy::defaults(), $this->makeProviders());
+        $module->install();
+
+        $this->assertNull(
+            $this->findRegistration(self::APP_PASSWORD_HOOK),
+            'with two_factor_enabled=false the app-password block must not be registered'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Recovery constant: install() must register NOTHING
+    // -------------------------------------------------------------------------
+
+    /**
+     * The WPMGR_DISABLE_SITE_2FA escape hatch is the fleet's way out of a
+     * lockout, so its contract is not "install() does not crash" -- it is
+     * "install() leaves no hook behind". Asserted against a live recorder so
+     * that an empty result means the module registered nothing, not that the
+     * instrument was broken.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_disable_constant_makes_install_register_no_hooks(): void
+    {
+        $this->assertRecorderIsLive();
+
+        if (!defined('WPMGR_DISABLE_SITE_2FA')) {
+            define('WPMGR_DISABLE_SITE_2FA', true);
+        }
+        $this->assertTrue(
+            defined('WPMGR_DISABLE_SITE_2FA') && (bool) WPMGR_DISABLE_SITE_2FA,
+            'the escape hatch must be defined and true in this process'
+        );
+
+        // A policy that would otherwise register every hook the module owns.
+        $policy = SecurityPolicy::fromArray([
+            'policy' => [
+                'two_factor_enabled'          => true,
+                'two_factor_required_roles'   => ['administrator'],
+                'block_xmlrpc_for_2fa_users'  => true,
+                'password_max_age_days'       => 30,
+            ],
+        ]);
+
+        $module = new Site2faModule($policy, $this->makeProviders());
+        $module->install();
+
+        $this->assertSame(
+            [],
+            array_column($this->registered, 'hook'),
+            'WPMGR_DISABLE_SITE_2FA must leave install() with zero hook registrations'
+        );
+    }
+}

--- a/apps/agent/tests/Security/Site2faHookRegistrationTest.php
+++ b/apps/agent/tests/Security/Site2faHookRegistrationTest.php
@@ -93,7 +93,12 @@ final class Site2faHookRegistrationTest extends TestCase
         Functions\when('esc_html__')->alias(fn ($t, $d = '') => $t);
         Functions\when('esc_html')->alias(fn ($t) => $t);
         Functions\when('__')->alias(fn ($t, $d = '') => $t);
-        Functions\when('sanitize_text_field')->alias(fn ($t) => $t);
+        // sanitize_text_field() is deliberately NOT stubbed to identity here.
+        // Core's _sanitize_text_fields() DELETES percent-encoded octets rather
+        // than decoding them, and an identity stub discards exactly that
+        // behaviour -- which is how a REQUEST_URI claim about `%2F` went
+        // unnoticed in review. tests/wp-stubs.php carries a faithful
+        // implementation, including the octet strip; let it stand.
         Functions\when('wp_unslash')->alias(fn ($t) => $t);
         Functions\when('get_user_meta')->justReturn('');
         Functions\when('update_user_meta')->justReturn(true);
@@ -344,6 +349,85 @@ final class Site2faHookRegistrationTest extends TestCase
         );
     }
 
+    /**
+     * THE BYPASS (#536 review). Until this commit the callback consulted
+     * REQUEST_URI and returned early on `str_contains($uri, '/wpmgr/v1/')` --
+     * an unanchored substring test over the WHOLE client-supplied request
+     * target, query string included. An attacker holding a stolen application
+     * password for a 2FA-required administrator appended one unused parameter
+     * and the control never fired:
+     *
+     *     control: /wp-json/wp/v2/users/1                  -> refused
+     *     attack:  /wp-json/wp/v2/users/1?wpmgr=/wpmgr/v1/ -> ALLOWED
+     *
+     * The exemption was REMOVED rather than repaired. The agent authenticates
+     * its own /wpmgr/v1 routes with an Ed25519 signature at the REST
+     * permission callback, and the autologin route treats the signed JWT
+     * itself as the authorization; neither presents an application password on
+     * any route, and no application-password API is referenced anywhere in
+     * includes/ outside this module. The exemption therefore protected nothing
+     * while creating the entire bypass. Deleting it also takes a
+     * client-controlled input out of an auth decision, which no matcher could
+     * have done: even the anchored path/query matcher in AuthHeaderShield is
+     * reachable with `?x=rest_route=/wpmgr/v1/`.
+     *
+     * Every shape below must be REFUSED, the agent's own route included.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_no_request_uri_can_exempt_a_2fa_required_user(): void
+    {
+        $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
+        $module->install();
+
+        $registration = $this->findRegistration(self::APP_PASSWORD_HOOK);
+        $this->assertNotNull(
+            $registration,
+            'the callback must be registered, or this test passes for the wrong reason'
+        );
+
+        $uris = [
+            // Control from the review: no exemption token anywhere.
+            '/wp-json/wp/v2/users/1',
+            // The working bypass: one unused query parameter.
+            '/wp-json/wp/v2/users/1?wpmgr=/wpmgr/v1/',
+            // The same trick on a redirect-shaped parameter.
+            '/wp-json/wp/v2/users/1?redirect_to=/wpmgr/v1/settings',
+            // Plain-permalink REST form, namespace smuggled into a second param.
+            '/?rest_route=/wp/v2/users/1&next=/wpmgr/v1/',
+            // Defeats even an anchored path+query matcher copied verbatim from
+            // AuthHeaderShield, because the query half really does contain the
+            // literal 'rest_route=/wpmgr/v1/'.
+            '/wp-json/wp/v2/users/1?x=rest_route=/wpmgr/v1/',
+            // Percent-encoded. sanitize_text_field() DELETES %XX octets rather
+            // than decoding them, so this shape never matched anything anyway.
+            '/?rest_route=%2Fwpmgr%2Fv1%2Fstatus',
+            // The agent's own channel, now equally refused.
+            '/wp-json/wpmgr/v1/command/sync_security_policy',
+        ];
+
+        $allowed = [];
+        foreach ($uris as $uri) {
+            $_SERVER['REQUEST_URI'] = $uri;
+
+            $error = new \WP_Error();
+            $this->fireAsCore($registration, [$error, $this->makeUser(1, ['administrator']), [], 'app-pw']);
+
+            if ($error->get_error_code() !== 'wpmgr_2fa_app_password_blocked') {
+                $allowed[] = $uri;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $allowed,
+            '#536: REQUEST_URI is client-supplied and must not be able to exempt a'
+            . ' 2FA-required administrator from the application-password block.'
+            . ' Credential ALLOWED for: ' . implode(' | ', $allowed)
+        );
+    }
+
     // -------------------------------------------------------------------------
     // OVER-FIRE: application passwords must keep working for everyone else
     // -------------------------------------------------------------------------
@@ -381,14 +465,17 @@ final class Site2faHookRegistrationTest extends TestCase
     }
 
     /**
-     * DOES NOT OVER-FIRE: the agent's own /wpmgr/v1 REST channel is exempt even
-     * for a 2FA-required administrator. Those routes authenticate with an
-     * Ed25519 signature at the permission callback.
+     * The over-fire question the removed exemption was trying to answer is
+     * settled by the USER, not by the request: the agent's own /wpmgr/v1
+     * channel never presents an application password, so refusing one there
+     * costs the agent nothing. Asserted both ways round on the agent's own
+     * route, so a future reintroduction of a URI exemption fails here:
+     * a 2FA-required administrator is refused, and a user with no 2FA is not.
      *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_dispatching_the_core_hook_exempts_the_agent_rest_channel(): void
+    public function test_the_decision_is_made_from_the_user_not_the_request_uri(): void
     {
         $module = new Site2faModule($this->policyRequiringAdmins(), $this->makeProviders());
         $module->install();
@@ -398,13 +485,22 @@ final class Site2faHookRegistrationTest extends TestCase
 
         $_SERVER['REQUEST_URI'] = '/wp-json/wpmgr/v1/command/sync_security_policy';
 
-        $error = new \WP_Error();
-        $this->fireAsCore($registration, [$error, $this->makeUser(1, ['administrator']), [], 'app-pw']);
+        $blocked = new \WP_Error();
+        $this->fireAsCore($registration, [$blocked, $this->makeUser(1, ['administrator']), [], 'app-pw']);
+        $this->assertSame(
+            'wpmgr_2fa_app_password_blocked',
+            $blocked->get_error_code(),
+            '#536: the agent REST namespace must not exempt a 2FA-required administrator;'
+            . ' the agent authenticates that channel with Ed25519, never an application password'
+        );
 
+        $allowed = new \WP_Error();
+        $this->fireAsCore($registration, [$allowed, $this->makeUser(2, ['subscriber']), [], 'app-pw']);
         $this->assertSame(
             [],
-            $error->errors,
-            'over-fire: the agent /wpmgr/v1 channel must never be refused by the app-password block'
+            $allowed->errors,
+            'over-fire: the same URI must still allow a user who neither requires 2FA nor is enrolled,'
+            . ' proving the refusal above came from the user and not from the request'
         );
     }
 

--- a/apps/agent/tests/Security/Site2faModuleTest.php
+++ b/apps/agent/tests/Security/Site2faModuleTest.php
@@ -16,8 +16,10 @@
  *   C1. Session destruction is proven: wp_destroy_all_sessions + wp_clear_auth_cookie
  *       are both invoked BEFORE the interstitial renders (no half-auth window).
  *   H1. Application-password bypass is blocked: a 2FA-required user's app-password
- *       auth is rejected; a non-required user's app password still works; the agent's
- *       own /wpmgr/v1 channel is unaffected.
+ *       auth is rejected and a non-required user's app password still works. The
+ *       decision is made from the WP_User alone -- REQUEST_URI cannot exempt it
+ *       (#536), because it is client-supplied and the old substring exemption was
+ *       satisfiable with one spare query parameter.
  *   H2. Forced-change enforcement: a user with META_FORCE_CHANGE is intercepted on
  *       login; the flag is cleared on successful password change; autologin and the
  *       escape hatch bypass it; the new password is validated against the policy.
@@ -643,10 +645,13 @@ final class Site2faModuleTest extends TestCase
         );
     }
 
-    public function test_h1_app_password_allowed_for_agent_rest_request(): void
+    public function test_h1_request_uri_cannot_exempt_an_app_password(): void
     {
-        // Requests to /wpmgr/v1/* must always be exempted from app-password blocking,
-        // regardless of user role -- the agent's own REST channel uses Ed25519 auth.
+        // #536: there is no REQUEST_URI exemption any more. It used to be
+        // str_contains($uri, '/wpmgr/v1/') over the whole client-supplied
+        // request target, which any caller could satisfy with one spare query
+        // parameter. The agent's own channel is Ed25519-signed and never
+        // presents an application password, so the exemption bought nothing.
         $policy = SecurityPolicy::fromArray([
             'policy' => [
                 'two_factor_enabled'        => true,
@@ -657,22 +662,26 @@ final class Site2faModuleTest extends TestCase
 
         $user = $this->makeUser(1, ['administrator']);
 
-        // Core fires the action with no WP_REST_Request, and on the
-        // determine_current_user path REST routing has not run yet, so
-        // REQUEST_URI is the only signal the exemption can read.
-        $_SERVER['REQUEST_URI'] = '/wp-json/wpmgr/v1/command/sync_security_policy';
+        $uris = [
+            '/wp-json/wpmgr/v1/command/sync_security_policy',
+            '/wp-json/wp/v2/users/1?wpmgr=/wpmgr/v1/',
+            '/?rest_route=/wpmgr/v1/status',
+        ];
 
-        $error = new \WP_Error();
-        $module->blockAppPasswordFor2faUser($error, $user, null, 'app-pw');
+        foreach ($uris as $uri) {
+            $_SERVER['REQUEST_URI'] = $uri;
+
+            $error = new \WP_Error();
+            $module->blockAppPasswordFor2faUser($error, $user, null, 'app-pw');
+
+            $this->assertSame(
+                'wpmgr_2fa_app_password_blocked',
+                $error->get_error_code(),
+                'H1/#536: REQUEST_URI must not exempt a 2FA-required user; failed for ' . $uri
+            );
+        }
 
         unset($_SERVER['REQUEST_URI']);
-
-        // The agent channel is exempted: the WP_Error must come back untouched.
-        $this->assertSame(
-            [],
-            $error->errors,
-            'H1: agent /wpmgr/v1 requests must be exempted from app-password blocking'
-        );
     }
 
     // -------------------------------------------------------------------------

--- a/apps/agent/tests/Security/Site2faModuleTest.php
+++ b/apps/agent/tests/Security/Site2faModuleTest.php
@@ -172,26 +172,35 @@ final class Site2faModuleTest extends TestCase
     /**
      * The WPMGR_DISABLE_SITE_2FA escape hatch is the fleet's way out of a 2FA
      * lockout, so its contract is not "install() does not crash" -- it is
-     * "install() leaves no hook behind". Asserting that requires recording the
-     * registrations rather than discarding them, and two things could make an
-     * empty result meaningless:
+     * "install() leaves no hook behind". Asserting that means recording the
+     * registrations rather than discarding them, and asserting the recording is
+     * empty; a recorder that captured nothing at all would make that pass for
+     * the wrong reason, so it is proven live first.
      *
-     *   1. a dead recorder, so nothing was ever captured -- ruled out by the
-     *      self-check below, which registers a probe and asserts it lands;
-     *   2. install()'s `static $installed` guard having already fired earlier
-     *      in this process, which would make install() return before it looks
-     *      at the constant at all -- ruled out by reading the static through
-     *      reflection and asserting it is still false.
+     * WHAT THIS TEST DELIBERATELY DOES NOT CLAIM:
+     * install() guards itself with a process-wide `static $installed`. If
+     * anything called install() earlier in this PHPUnit process it returns
+     * before it ever looks at the constant, and "registered nothing" would then
+     * be true for that reason instead. This test cannot rule that out from
+     * inside the shared process, and it must stay in the shared process because
+     * the constant it defines is process-global and several later tests in this
+     * file assert it is set. The non-vacuous version -- fresh process, fresh
+     * static, same assertion -- is
+     * Site2faHookRegistrationTest::test_disable_constant_makes_install_register_no_hooks.
      *
-     * The constant is process-global once defined and several later tests in
-     * this file assert it is set, so it is deliberately defined here in the
-     * shared process rather than under @runInSeparateProcess.
-     *
-     * The mirror of this test that proves the recorder DOES capture the
-     * module's real registrations lives in Site2faHookRegistrationTest.
+     * The constant is defined before anything here can fail, so a failure below
+     * can never cascade into those later tests by leaving it undefined.
      */
     public function test_safety_disable_constant_makes_install_register_no_hooks(): void
     {
+        if (!defined('WPMGR_DISABLE_SITE_2FA')) {
+            define('WPMGR_DISABLE_SITE_2FA', true);
+        }
+        $this->assertTrue(
+            defined('WPMGR_DISABLE_SITE_2FA') && (bool) WPMGR_DISABLE_SITE_2FA,
+            'the escape hatch must be defined and true in this process'
+        );
+
         $registered = [];
         $recorder   = function ($hook, $callback = null, $priority = 10, $acceptedArgs = 1) use (&$registered): bool {
             $registered[] = (string) $hook;
@@ -200,8 +209,8 @@ final class Site2faModuleTest extends TestCase
         Functions\when('add_action')->alias($recorder);
         Functions\when('add_filter')->alias($recorder);
 
-        // (1) Instrument self-check: a recorder that captures nothing would make
-        // the assertion at the end of this test pass for the wrong reason.
+        // Instrument self-check: a recorder that captures nothing would make the
+        // assertion at the end of this test pass for the wrong reason.
         add_action('wpmgr_recorder_self_check', 'wpmgr_recorder_self_check_cb', 7, 2);
         $this->assertSame(
             ['wpmgr_recorder_self_check'],
@@ -209,22 +218,6 @@ final class Site2faModuleTest extends TestCase
             'instrument self-check: the add_action recorder must capture registrations'
         );
         $registered = [];
-
-        // (2) The idempotence guard must not have fired yet, or install() would
-        // return early and register nothing regardless of the constant.
-        $installGuard = (new \ReflectionMethod(Site2faModule::class, 'install'))->getStaticVariables();
-        $this->assertFalse(
-            $installGuard['installed'] ?? true,
-            'install()\'s static guard must still be unset in this process, or the assertion below is vacuous'
-        );
-
-        if (!defined('WPMGR_DISABLE_SITE_2FA')) {
-            define('WPMGR_DISABLE_SITE_2FA', true);
-        }
-        $this->assertTrue(
-            defined('WPMGR_DISABLE_SITE_2FA') && (bool) WPMGR_DISABLE_SITE_2FA,
-            'the escape hatch must be defined and true in this process'
-        );
 
         // A policy that would otherwise register every hook the module owns.
         $policy = SecurityPolicy::fromArray([

--- a/apps/agent/tests/Security/Site2faModuleTest.php
+++ b/apps/agent/tests/Security/Site2faModuleTest.php
@@ -169,21 +169,82 @@ final class Site2faModuleTest extends TestCase
     // SAFETY: constant disables enforcement
     // -------------------------------------------------------------------------
 
-    public function test_safety_disable_constant_makes_install_noop(): void
+    /**
+     * The WPMGR_DISABLE_SITE_2FA escape hatch is the fleet's way out of a 2FA
+     * lockout, so its contract is not "install() does not crash" -- it is
+     * "install() leaves no hook behind". Asserting that requires recording the
+     * registrations rather than discarding them, and two things could make an
+     * empty result meaningless:
+     *
+     *   1. a dead recorder, so nothing was ever captured -- ruled out by the
+     *      self-check below, which registers a probe and asserts it lands;
+     *   2. install()'s `static $installed` guard having already fired earlier
+     *      in this process, which would make install() return before it looks
+     *      at the constant at all -- ruled out by reading the static through
+     *      reflection and asserting it is still false.
+     *
+     * The constant is process-global once defined and several later tests in
+     * this file assert it is set, so it is deliberately defined here in the
+     * shared process rather than under @runInSeparateProcess.
+     *
+     * The mirror of this test that proves the recorder DOES capture the
+     * module's real registrations lives in Site2faHookRegistrationTest.
+     */
+    public function test_safety_disable_constant_makes_install_register_no_hooks(): void
     {
+        $registered = [];
+        $recorder   = function ($hook, $callback = null, $priority = 10, $acceptedArgs = 1) use (&$registered): bool {
+            $registered[] = (string) $hook;
+            return true;
+        };
+        Functions\when('add_action')->alias($recorder);
+        Functions\when('add_filter')->alias($recorder);
+
+        // (1) Instrument self-check: a recorder that captures nothing would make
+        // the assertion at the end of this test pass for the wrong reason.
+        add_action('wpmgr_recorder_self_check', 'wpmgr_recorder_self_check_cb', 7, 2);
+        $this->assertSame(
+            ['wpmgr_recorder_self_check'],
+            $registered,
+            'instrument self-check: the add_action recorder must capture registrations'
+        );
+        $registered = [];
+
+        // (2) The idempotence guard must not have fired yet, or install() would
+        // return early and register nothing regardless of the constant.
+        $installGuard = (new \ReflectionMethod(Site2faModule::class, 'install'))->getStaticVariables();
+        $this->assertFalse(
+            $installGuard['installed'] ?? true,
+            'install()\'s static guard must still be unset in this process, or the assertion below is vacuous'
+        );
+
         if (!defined('WPMGR_DISABLE_SITE_2FA')) {
             define('WPMGR_DISABLE_SITE_2FA', true);
         }
+        $this->assertTrue(
+            defined('WPMGR_DISABLE_SITE_2FA') && (bool) WPMGR_DISABLE_SITE_2FA,
+            'the escape hatch must be defined and true in this process'
+        );
 
+        // A policy that would otherwise register every hook the module owns.
         $policy = SecurityPolicy::fromArray([
-            'policy' => ['two_factor_enabled' => true, 'two_factor_required_roles' => ['administrator']],
+            'policy' => [
+                'two_factor_enabled'         => true,
+                'two_factor_required_roles'  => ['administrator'],
+                'block_xmlrpc_for_2fa_users' => true,
+                'password_max_age_days'      => 30,
+            ],
         ]);
         Functions\when('esc_url_raw')->justReturn('');
 
         $module = $this->makeModule($policy);
         $module->install();
 
-        $this->assertTrue(true, 'install() with WPMGR_DISABLE_SITE_2FA must not crash');
+        $this->assertSame(
+            [],
+            $registered,
+            'WPMGR_DISABLE_SITE_2FA must leave install() with zero hook registrations'
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -460,6 +521,16 @@ final class Site2faModuleTest extends TestCase
 
     // -------------------------------------------------------------------------
     // H1: Application-password bypass block
+    //
+    // These exercise the callback's BODY. They deliberately do NOT prove it is
+    // reachable: that it was registered on a hook nothing fires went unnoticed
+    // for exactly as long as this was the only coverage (#523). The
+    // registration, the declared arity and a dispatch with core's own argument
+    // list are asserted in Site2faHookRegistrationTest.
+    //
+    // Core fires wp_authenticate_application_password_errors with ($error,
+    // $user, $item, $password) and inspects $error afterwards: a populated
+    // WP_Error means "refuse this credential", an untouched one means "allow".
     // -------------------------------------------------------------------------
 
     public function test_h1_app_password_blocked_for_2fa_required_user(): void
@@ -472,19 +543,19 @@ final class Site2faModuleTest extends TestCase
         ]);
         $module = $this->makeModule($policy);
 
-        $user              = $this->makeUser(1, ['administrator']);
-        $resolvedUser      = $this->makeUser(1, ['administrator']);
-
-        $result = $module->blockAppPasswordFor2faUser(
-            $user,           // $user (prior filter result, WP_User)
-            $resolvedUser,   // $inputUser
-            'app-pw',        // $appPassword
-            null,            // $item
-            null             // $request
+        $error = new \WP_Error();
+        $module->blockAppPasswordFor2faUser(
+            $error,                                 // $error (mutated in place)
+            $this->makeUser(1, ['administrator']),  // $user
+            ['uuid' => 'abc', 'name' => 'ci'],      // $item
+            'app-pw'                                // $password
         );
 
-        $this->assertInstanceOf(\WP_Error::class, $result, 'H1: app password must be blocked for 2FA-required user');
-        $this->assertSame('wpmgr_2fa_app_password_blocked', $result->get_error_code());
+        $this->assertSame(
+            'wpmgr_2fa_app_password_blocked',
+            $error->get_error_code(),
+            'H1: app password must be blocked for 2FA-required user'
+        );
     }
 
     public function test_h1_app_password_allowed_for_non_required_user(): void
@@ -499,14 +570,12 @@ final class Site2faModuleTest extends TestCase
 
         // Subscriber: not role-required, and no TOTP/backup enrolled (EmailCodeProvider
         // is always "configured", but does not count as deliberate enrollment).
-        $user         = $this->makeUser(2, ['subscriber']);
-        $resolvedUser = $this->makeUser(2, ['subscriber']);
-
-        $result = $module->blockAppPasswordFor2faUser($user, $resolvedUser, 'app-pw', null, null);
+        $error = new \WP_Error();
+        $module->blockAppPasswordFor2faUser($error, $this->makeUser(2, ['subscriber']), null, 'app-pw');
 
         $this->assertSame(
-            $user,
-            $result,
+            [],
+            $error->errors,
             'H1: app password must be allowed for a non-required, non-enrolled user'
         );
     }
@@ -546,29 +615,39 @@ final class Site2faModuleTest extends TestCase
 
         $module = new Site2faModule($policy, [$totpProvider, new EmailCodeProvider(), new BackupCodesProvider()]);
 
-        $result = $module->blockAppPasswordFor2faUser($user, $user, 'app-pw', null, null);
+        $error = new \WP_Error();
+        $module->blockAppPasswordFor2faUser($error, $user, null, 'app-pw');
 
-        $this->assertInstanceOf(
-            \WP_Error::class,
-            $result,
+        $this->assertSame(
+            'wpmgr_2fa_app_password_blocked',
+            $error->get_error_code(),
             'H1: app password must be blocked for a user with TOTP enrolled (even if not role-required)'
         );
     }
 
-    public function test_h1_app_password_passes_through_prior_wp_error(): void
+    public function test_h1_app_password_ignores_a_caller_that_is_not_core(): void
     {
-        // If a prior filter already returned a WP_Error, it must pass through unchanged.
+        // Core's contract is ($error, $user, ...). Another plugin re-firing the
+        // action with something else must not make this callback guess: there is
+        // no WP_Error to refuse through, so the only safe move is to do nothing.
         $policy = SecurityPolicy::fromArray([
-            'policy' => ['two_factor_enabled' => true],
+            'policy' => ['two_factor_enabled' => true, 'two_factor_required_roles' => ['administrator']],
         ]);
         $module = $this->makeModule($policy);
+        $user   = $this->makeUser(1, ['administrator']);
 
-        $priorError = new \WP_Error('prior_error', 'Some earlier auth failure');
-        $user       = $this->makeUser(1, ['administrator']);
+        $module->blockAppPasswordFor2faUser(null, $user, null, 'app-pw');
+        $module->blockAppPasswordFor2faUser(new \WP_Error(), 'not-a-user', null, 'app-pw');
 
-        $result = $module->blockAppPasswordFor2faUser($priorError, $user, 'app-pw', null, null);
-
-        $this->assertSame($priorError, $result, 'H1: prior WP_Error must pass through unchanged');
+        // Reaching here without a TypeError is the assertion; add an explicit one
+        // so the test is not a bare smoke test.
+        $error = new \WP_Error('prior_error', 'Some earlier auth failure');
+        $module->blockAppPasswordFor2faUser($error, false, null, 'app-pw');
+        $this->assertSame(
+            ['prior_error' => 'Some earlier auth failure'],
+            $error->errors,
+            'H1: a non-core argument shape must leave the passed WP_Error untouched'
+        );
     }
 
     public function test_h1_app_password_allowed_for_agent_rest_request(): void
@@ -583,20 +662,22 @@ final class Site2faModuleTest extends TestCase
         ]);
         $module = $this->makeModule($policy);
 
-        $user    = $this->makeUser(1, ['administrator']);
-        $request = new \WP_REST_Request();
+        $user = $this->makeUser(1, ['administrator']);
 
-        // Simulate the agent REST request by setting REQUEST_URI.
+        // Core fires the action with no WP_REST_Request, and on the
+        // determine_current_user path REST routing has not run yet, so
+        // REQUEST_URI is the only signal the exemption can read.
         $_SERVER['REQUEST_URI'] = '/wp-json/wpmgr/v1/command/sync_security_policy';
 
-        $result = $module->blockAppPasswordFor2faUser($user, $user, 'app-pw', null, $request);
+        $error = new \WP_Error();
+        $module->blockAppPasswordFor2faUser($error, $user, null, 'app-pw');
 
         unset($_SERVER['REQUEST_URI']);
 
-        // The agent channel is exempted: should return the original user, not a WP_Error.
+        // The agent channel is exempted: the WP_Error must come back untouched.
         $this->assertSame(
-            $user,
-            $result,
+            [],
+            $error->errors,
             'H1: agent /wpmgr/v1 requests must be exempted from app-password blocking'
         );
     }


### PR DESCRIPTION
Fixes #523.

## The defect

`Site2faModule::install()` added the application-password block to
`wp_authenticate_application_password`:

```php
add_filter('wp_authenticate_application_password', [$this, 'blockAppPasswordFor2faUser'], 10, 5);
```

That name is a core **function** (`wp-includes/user.php`), which core registers
on `authenticate` at priority 20 in `wp-includes/default-filters.php`. Nothing
anywhere fires it as a hook. `add_filter()` against a name nothing fires stores
the callback, warns about nothing, and never invokes it — so the control the
comment called the "H1 fix" has never executed on any site. The declared arity
was wrong too (5 against the 3 the real hook carries), so a rename alone would
not have been sufficient.

Verified against the vendored WordPress tree in `tools/plugincheck/wp`: no
`apply_filters( 'wp_authenticate_application_password', ... )` anywhere in core;
the same grep finds `apply_filters( 'authenticate'` at `pluggable.php:706`, so
the search works.

## The fix — option (1), register on the hook core fires

The protection is genuinely wanted: a 2FA requirement that application passwords
bypass is a real gap, and application passwords carry only password-equivalent
credentials while never firing `wp_login`, so the interstitial cannot see them.

The interception point is core's **`wp_authenticate_application_password_errors`
action**, fired with `($error, $user, $item, $password)` once a supplied
password has matched a stored application-password hash and before core records
its use. Core documents it as the place "for plugins to add additional
constraints to prevent an application password from being used": populate the
passed `WP_Error` and core abandons the authentication.

It was chosen over `authenticate` at priority 30 because:

- it fires on **both** application-password entry points — the `authenticate`
  chain and `wp_validate_application_password()` on `determine_current_user` —
  whereas an `authenticate` callback misses the second;
- it fires for **no other credential type**, so an ordinary `wp-login.php` form
  post never reaches it. A block on `authenticate` would sit in the path of
  interactive logins, which are supposed to reach the 2FA interstitial rather
  than be refused outright. There is a test asserting the block is *not* on
  `authenticate`.

The callback now mutates the passed `WP_Error` rather than returning one, which
is what core inspects.

`$item` and `$password` keep defaults purely so a third-party plugin re-firing
the action with a short argument list cannot fatal the callback; core always
passes all four, and the declared arity is asserted.

## Security fix on review: the exemption was a working bypass

The first revision of this branch kept an exemption for the agent's own REST
channel, reached from the top of the callback:

```php
$uri = sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI']));
if (str_contains($uri, '/wpmgr/v1/')) {
    return true;
}
```

`REQUEST_URI` is the raw, client-supplied request target, and that is an
unanchored substring match over the **whole** URI, query string included. An
attacker holding a stolen application password for a 2FA-required administrator
appended one unused parameter and the control never fired. Executed against the
real module through the real registration:

```
control: /wp-json/wp/v2/users/1                                -> wpmgr_2fa_app_password_blocked
attack:  /wp-json/wp/v2/users/1?wpmgr=/wpmgr/v1/               -> errors === [], credential ALLOWED
attack:  /wp-json/wp/v2/users/1?redirect_to=/wpmgr/v1/settings -> ALLOWED
attack:  /?rest_route=/wp/v2/users/1&next=/wpmgr/v1/           -> ALLOWED
```

**The exemption is deleted, not repaired.** The agent never authenticates with
an application password on any route: `/wpmgr/v1` is Ed25519-signed and verified
in the REST `permission_callback`, autologin treats the signed JWT itself as the
authorization, and

```
grep -rni "application_password\|app_password" apps/agent/includes/
```

returns nothing outside `class-site-2fa-module.php` — no `WP_Application_Passwords`
reference anywhere in the plugin, and none in the control plane either. The
exemption protected nothing while creating the entire attack surface, so removing
it is strictly safer than any matcher, and it takes a client-controlled input out
of an auth decision.

A repaired matcher would not have been enough. Copying `AuthHeaderShield`'s
anchored split-on-`?` path/query form verbatim is still bypassable via
`?x=rest_route=/wpmgr/v1/`, because the query half then genuinely contains
`rest_route=/wpmgr/v1/`. That shape is in the regression set.

### The percent-decoded branch was dead code

The earlier revision of this body claimed the `rest_route=` form was "now also
matched percent-decoded". That was **false**, and the opposite of what shipped.
Core's `sanitize_text_field()` **deletes** `%XX` octets rather than decoding
them, and it ran *before* the `rawurldecode()` fallback, so

```
'/?rest_route=%2Fwpmgr%2Fv1%2Fstatus'  ->  '/?rest_route=wpmgrv1status'
```

which matched nothing and was **blocked**, not exempted. It was invisible in
test because `Site2faHookRegistrationTest` stubbed `sanitize_text_field` to
identity, discarding the one behaviour that mattered. That stub is removed and
the faithful implementation in `tests/wp-stubs.php` — octet strip included —
now applies. The whole branch is gone with the exemption.

## ⚠️ Breaking change for integrations

On update, **every site with 2FA enabled will have application passwords stop
working** for users who are role-required or enrolled in TOTP / backup codes,
returning HTTP 401 with `wpmgr_2fa_app_password_blocked`. That is the intended
fix — it is the gap #523 is about — but it changes behaviour for anyone whose
integration authenticates as such a user. Sites with `two_factor_enabled` false
are untouched, because the callback is not registered at all.

**This needs a changelog entry and an announcement.** Routed separately; noting
it here so it is not lost.

## Proof

The existing tests covered the callback's **body**, which is exactly why an
unregistered callback stayed invisible. `Site2faHookRegistrationTest` asserts
the registration and its arity, then dispatches the recorded callback with
core's own argument list **sliced to the declared arity**, the way `WP_Hook`
does — so a wrong hook name, a wrong arity or a wrong argument order all fail
there, and none of them fail in a body-level test.

Red, against the pre-fix module restored from `origin/main`:

```
✘ App password block is registered on a hook core actually fires
  │ #523: the app-password block must be registered on wp_authenticate_application_password_errors,
  │ the action core fires. Registered instead: wp_login, login_init,
  │ wp_authenticate_application_password, authenticate, show_user_profile, edit_user_profile,
  │ personal_options_update, edit_user_profile_update
✘ Dispatching the core hook blocks a 2fa required user
  │ #523: nothing is registered on wp_authenticate_application_password_errors, so the control never runs
✘ Dispatching the core hook blocks a user with totp enrolled
✘ Dispatching the core hook leaves a non 2fa user authenticated
Tests: 8, Assertions: 11, Failures: 5.
```

Red for the bypass, against the parent commit `fedbb56d`:

```
php -d memory_limit=1024M vendor/bin/phpunit --no-progress \
  --filter test_no_request_uri_can_exempt_a_2fa_required_user \
  tests/Security/Site2faHookRegistrationTest.php

Credential ALLOWED for: /wp-json/wp/v2/users/1?wpmgr=/wpmgr/v1/
 | /wp-json/wp/v2/users/1?redirect_to=/wpmgr/v1/settings
 | /?rest_route=/wp/v2/users/1&next=/wpmgr/v1/
 | /wp-json/wp/v2/users/1?x=rest_route=/wpmgr/v1/
 | /wp-json/wpmgr/v1/command/sync_security_policy
Tests: 1, Assertions: 2, Failures: 1.
```

The control URI `/wp-json/wp/v2/users/1` is absent from that list — it was
correctly blocked, so the test is discriminating and not simply failing
everything. Green after the fix: `OK (1 test, 2 assertions)`.

**Over-fire.** A block that refused every application password would break every
integration on the site silently — core returns the `WP_Error` we populate and
nothing else reports it. The over-fire tests dispatch the real hook and assert
the `WP_Error` comes back **untouched** for:

- a user who is neither role-required nor enrolled in a non-email method;
- that same user on the agent's own `/wpmgr/v1` URI — which is what now proves
  the refusal comes from the **user** and not from the request, the property the
  deleted exemption used to obscure;
- and a fourth asserts nothing is registered at all when `two_factor_enabled`
  is false.

Each of them first asserts the callback *is* registered, so they cannot pass
because nothing ran.

## Also

`tests/Security/Site2faModuleTest.php` had
`assertTrue(true, 'install() with WPMGR_DISABLE_SITE_2FA must not crash')`. It
now records registrations and asserts `install()` under the recovery constant
leaves zero hooks behind, with the recorder proven live first so an empty result
cannot pass for the wrong reason. `install()`'s process-wide
`static $installed` means that assertion can still hold for the wrong reason in
the shared PHPUnit process, and the static cannot be reset from inside it — so
the shared-process test says so and names the isolated twin
(`Site2faHookRegistrationTest::test_disable_constant_makes_install_register_no_hooks`,
`@runInSeparateProcess`, fresh static) that proves it non-vacuously. The
constant is now defined as the first statement of the test, so a failure there
can no longer cascade into the later tests that read it.

The five body-level H1 tests were updated to the action's argument shape and
kept; one that only asserted a pass-through return value was replaced with one
covering a caller whose argument shape is not core's.

Two `phpstan-baseline.neon` entries for this file — the `method_exists` /
`WP_REST_Request` narrowing and the `is_a` `WP_Error|WP_User|null` argument —
were made stale by this branch's own diff and failed
`scripts/check-agent-phpstan.sh` (CI passed only because it runs with
`--allow-findings`). Both entries are removed. The baseline is **not**
regenerated.

## Gates

`composer install` in `apps/agent` first — the release targets strip the dev
toolchain, and a 127 is not a pass.

- `php -d memory_limit=1024M vendor/bin/phpunit --no-progress` — **3317 tests,
  0 failures, 0 errors, exit 0.**
- `WPMGR_PHPSTAN_MEMORY_LIMIT=2G scripts/check-agent-phpstan.sh` — **0 findings,
  exit 0.** This is the authoritative static-analysis gate; `make agent-check`
  is phpcs only and says so itself.
- `cd apps/agent && vendor/bin/phpcs -d memory_limit=1G` — 0 errors, exit 0,
  over 252 files.
- `make agent-plugincheck` — not run locally; the `plugincheck.yml` workflow
  runs it on this PR.

The previous revision of this body quoted an assertion total of 17,323. It is
**dropped rather than restated**, because the assertion count is not a stable
quantity: two back-to-back runs of the identical command on this commit, on one
machine, reported **17,304** and then **17,214** — 3317 tests and exit 0 both
times. Review had independently measured a third value. A number that moves
between consecutive runs is not a fact about the change, so only the test count
and the exit status are quoted above.
