### PR TITLE
fix(agent): verify an optional message_id before a resend (#528)

### DIFF
--- a/apps/agent/includes/commands/class-resend-email-command.php
+++ b/apps/agent/includes/commands/class-resend-email-command.php
@@ -14,7 +14,7 @@
  *   Body not stored: { "ok": false, "detail": "body_not_stored" }
  *   Row not found:   { "ok": false, "detail": "log_row_not_found" }
  *   Config missing:  { "ok": false, "detail": "no email config" }
- *   Identity check:  { "ok": false, "detail": "message_id_mismatch: …" }
+ *   Identity check:  { "ok": false, "detail": "message_id_mismatch" }
  *
  * The command:
  *   1. Looks up the buffered row by agent_seq in wpmgr_email_log.
@@ -41,12 +41,29 @@
  * exactly today's behaviour, because a resend is still better than no resend
  * and the pre-#528 CP has no id to offer.
  *
- * Empty compares as a value, not as "skip": an original send that failed is
- * logged with message_id='' and is mirrored to the CP as '', so ''-vs-'' is a
- * genuine match. ''-vs-non-empty in either direction is a genuine mismatch —
- * the CP's copy is a mirror of this row's own message_id, so presence on one
- * side and absence on the other means the two are not the same row. Only an
- * absent (or null) key skips verification.
+ * "Supplied" means a NON-EMPTY string. Absent, null and empty all mean the same
+ * thing — the control plane has no id to offer — and all three proceed without
+ * verifying. This matters more than it looks: message_id is NULL on the control
+ * plane for every send that failed at the time (all five provider handlers
+ * return '' on failure and the ingest only stores a non-empty pointer), and a
+ * failed send is the single most common thing an operator resends. Reading ''
+ * as "compare against empty" would refuse exactly the rows this fix exists to
+ * protect. The control plane omits the key outright for those rows; treating ''
+ * the same way means neither side can break the other by changing its mind
+ * about how it encodes "nothing".
+ *
+ * The reverse is NOT symmetric and must not be: when the control plane DOES
+ * supply an id and the local row has none, that is a refusal. The CP's copy is
+ * a mirror of this row's own message_id, so presence on one side with absence
+ * on the other means they are not the same row — which is precisely what a
+ * rolled-back counter re-issuing an id to a later failed send looks like.
+ *
+ * The refusal `detail` is the bare literal "message_id_mismatch" and nothing
+ * else. It is a contract string the control plane pins and maps to
+ * operator-facing wording ("this site's log row no longer matches the message
+ * you selected; the site's database may have been restored since — refresh the
+ * email log and try again"). Appending that sentence here instead would put raw
+ * agent text in front of a user, which is how GH #520 was reported.
  *
  * Note that this is why a successful resend no longer overwrites the row's
  * message_id: EmailLogReporter pages rows with `WHERE id > cursor`
@@ -74,15 +91,22 @@ use WPMgr\Agent\Schema;
 final class ResendEmailCommand implements CommandInterface {
 
 	/**
-	 * Stable `detail` prefix returned when the control plane named a message_id
-	 * that does not match the loaded log row. The control plane matches on the
-	 * prefix; the operator reads the sentence after it.
+	 * Exact `detail` returned when the control plane named a message_id that does
+	 * not match the loaded log row.
+	 *
+	 * This is the whole detail string, not a prefix. The control plane pins the
+	 * same literal (agentcmd.ResendDetailMessageIDMismatch) and owns the wording
+	 * the operator actually reads; the two sides must agree byte for byte.
 	 */
 	public const DETAIL_MISMATCH = 'message_id_mismatch';
 
 	/**
-	 * Stable `detail` prefix returned when message_id was present but was not a
-	 * string, i.e. a request we cannot verify against.
+	 * Exact `detail` returned when message_id was present and non-null but was
+	 * not a string — a request that cannot be verified and so is not sent.
+	 *
+	 * Unreachable from the control plane as built (it sends a string or omits
+	 * the key); it exists so a malformed caller fails closed and nameably rather
+	 * than falling through to an unverified send.
 	 */
 	public const DETAIL_INVALID = 'message_id_invalid';
 
@@ -119,21 +143,26 @@ final class ResendEmailCommand implements CommandInterface {
 			return array( 'ok' => false, 'detail' => 'agent_seq must be a positive integer', 'message_id' => '' );
 		}
 
-		// Validate the optional message_id (GH #528) before any work is done.
-		// null === array_key_exists()===false === "the control plane is not asking
-		// for verification" — that is the additive path an older CP takes. A
-		// present-but-not-a-string value is a request we cannot verify against,
-		// and an unverifiable resend is refused rather than sent.
+		// Resolve the optional message_id (GH #528) before any work is done.
+		// Absent, null and empty all mean "the control plane has no id to offer"
+		// and leave $expected_message_id null, which skips verification — that is
+		// the path an older control plane takes, and the path every failed send
+		// takes (its CP-side message_id is NULL). A present, non-null,
+		// non-string value is a request that cannot be verified at all, and an
+		// unverifiable resend is refused rather than sent.
 		$expected_message_id = null;
 		if ( array_key_exists( 'message_id', $params ) && $params['message_id'] !== null ) {
 			if ( ! is_string( $params['message_id'] ) ) {
 				return array(
 					'ok'         => false,
-					'detail'     => self::DETAIL_INVALID . ': message_id must be a string. Refusing to resend rather than send a message this site cannot verify.',
+					'detail'     => self::DETAIL_INVALID,
 					'message_id' => '',
 				);
 			}
-			$expected_message_id = trim( $params['message_id'] );
+			$supplied = trim( $params['message_id'] );
+			if ( $supplied !== '' ) {
+				$expected_message_id = $supplied;
+			}
 		}
 
 		// Load the email config, required before attempting a resend.
@@ -157,7 +186,7 @@ final class ResendEmailCommand implements CommandInterface {
 			if ( $stored_message_id !== $expected_message_id ) {
 				return array(
 					'ok'         => false,
-					'detail'     => self::DETAIL_MISMATCH . ': this site\'s log row no longer matches the message you selected. The site\'s database may have been restored since. Refresh the email log and try again.',
+					'detail'     => self::DETAIL_MISMATCH,
 					'message_id' => '',
 				);
 			}

--- a/apps/agent/includes/commands/class-resend-email-command.php
+++ b/apps/agent/includes/commands/class-resend-email-command.php
@@ -9,12 +9,12 @@
  *   Content-Type: application/json
  *   Body: { "agent_seq": <int>, "message_id": "<string>" (optional) }
  *
- * Response:
- *   On success: { "ok": true, "detail": "resent", "message_id": "<string>" }
- *   Body not stored: { "ok": false, "detail": "body_not_stored" }
- *   Row not found:   { "ok": false, "detail": "log_row_not_found" }
- *   Config missing:  { "ok": false, "detail": "no email config" }
- *   Identity check:  { "ok": false, "detail": "message_id_mismatch" }
+ * Response (every branch carries all four keys):
+ *   On success: { "ok": true, "detail": "resent", "message_id": "<string>", "verified": <bool> }
+ *   Body not stored: { "ok": false, "detail": "body_not_stored", "verified": <bool> }
+ *   Row not found:   { "ok": false, "detail": "log_row_not_found", "verified": false }
+ *   Config missing:  { "ok": false, "detail": "no email config", "verified": false }
+ *   Identity check:  { "ok": false, "detail": "message_id_mismatch", "verified": false }
  *
  * The command:
  *   1. Looks up the buffered row by agent_seq in wpmgr_email_log.
@@ -57,6 +57,31 @@
  * a mirror of this row's own message_id, so presence on one side with absence
  * on the other means they are not the same row — which is precisely what a
  * rolled-back counter re-issuing an id to a later failed send looks like.
+ *
+ * The ids are compared as RAW BYTES, both sides untouched. A provider message
+ * id is opaque: this plugin stores it and reports it without normalisation
+ * anywhere else, so normalising it at the comparison alone would invent an
+ * equality the rest of the system does not hold. Two ids that differ only in
+ * surrounding whitespace are two different ids, and folding them together
+ * weakens the guard in the single direction that matters — it lets a re-used
+ * agent_seq match a different stored email and send it. Nothing here trims,
+ * lowercases, unwraps angle brackets or otherwise "helps"; if some provider
+ * ever genuinely needs it, it gets a narrow rule naming that provider, never a
+ * blanket normalisation of both sides.
+ *
+ * The response carries "verified": THIS AGENT'S attestation that it performed
+ * the comparison, and not an inference anyone else may draw.
+ *
+ * It is true on exactly one code path — a supplied message_id was compared
+ * against the loaded row and matched — and false on every path that skipped the
+ * comparison or was refused by it. The control plane must not conclude "the
+ * agent checked" from "I sent the field", because an agent from before this
+ * change ignores the field, resends happily and answers ok=true: inferring
+ * verification from the request would record a confirmed resend and show an
+ * operator, and the audit trail, a check that never ran. That is the same
+ * defect this file exists to fix, one layer up. An older agent omits the key
+ * altogether and the control plane reads an absent field as false, so silence
+ * and "unverified" agree and the field is safe across versions.
  *
  * The refusal `detail` is the bare literal "message_id_mismatch" and nothing
  * else. It is a contract string the control plane pins and maps to
@@ -130,17 +155,17 @@ final class ResendEmailCommand implements CommandInterface {
 	 * @param array<string,mixed> $claims Validated JWT claims.
 	 * @param array<string,mixed> $params ResendEmailRequest fields
 	 *                                    (agent_seq: int, message_id: ?string optional).
-	 * @return array{ok:bool,detail:string,message_id:string}
+	 * @return array{ok:bool,detail:string,message_id:string,verified:bool}
 	 */
 	public function execute( array $claims, array $params ): array {
 		// Validate agent_seq.
 		if ( ! array_key_exists( 'agent_seq', $params ) ) {
-			return array( 'ok' => false, 'detail' => 'missing required field: agent_seq', 'message_id' => '' );
+			return $this->refuse( 'missing required field: agent_seq' );
 		}
 
 		$agent_seq = filter_var( $params['agent_seq'], FILTER_VALIDATE_INT );
 		if ( $agent_seq === false || $agent_seq < 1 ) {
-			return array( 'ok' => false, 'detail' => 'agent_seq must be a positive integer', 'message_id' => '' );
+			return $this->refuse( 'agent_seq must be a positive integer' );
 		}
 
 		// Resolve the optional message_id (GH #528) before any work is done.
@@ -153,48 +178,62 @@ final class ResendEmailCommand implements CommandInterface {
 		$expected_message_id = null;
 		if ( array_key_exists( 'message_id', $params ) && $params['message_id'] !== null ) {
 			if ( ! is_string( $params['message_id'] ) ) {
-				return array(
-					'ok'         => false,
-					'detail'     => self::DETAIL_INVALID,
-					'message_id' => '',
-				);
+				return $this->refuse( self::DETAIL_INVALID );
 			}
-			$supplied = trim( $params['message_id'] );
-			if ( $supplied !== '' ) {
-				$expected_message_id = $supplied;
+			// The empty test is on the RAW string, deliberately. Trimming first
+			// would reclassify a whitespace-only id as "nothing supplied" and
+			// send the mail unverified; a value that is not the empty string is
+			// an identifier, and identifiers get compared.
+			if ( $params['message_id'] !== '' ) {
+				$expected_message_id = $params['message_id'];
 			}
 		}
 
 		// Load the email config, required before attempting a resend.
 		$cfg = EmailConfig::load();
 		if ( ! $cfg->is_configured() ) {
-			return array( 'ok' => false, 'detail' => 'no email config, run sync_email_config first', 'message_id' => '' );
+			return $this->refuse( 'no email config, run sync_email_config first' );
 		}
 
 		// Fetch the log row.
 		$row = $this->fetch_row( $agent_seq );
 		if ( $row === null ) {
-			return array( 'ok' => false, 'detail' => 'log_row_not_found', 'message_id' => '' );
+			return $this->refuse( 'log_row_not_found' );
 		}
 
 		// GH #528: verify the loaded row IS the message the control plane named,
 		// before anything is built and long before anything is sent. This runs
 		// ahead of the body_stored check on purpose: "body_not_stored" about the
 		// wrong row is a misleading answer to give an operator.
+		//
+		// $verified is this agent's own attestation and nothing else. It starts
+		// false and is raised on exactly one line, below, after a supplied id has
+		// been compared against this row and found identical. It must never be
+		// derived from the presence of the request field: the control plane
+		// already knows what it sent, and what it cannot know is whether THIS
+		// agent looked. An agent from before this change omits the key entirely
+		// and the control plane reads that absence as false, so an old agent's
+		// silence and "unverified" say the same thing.
+		$verified = false;
 		if ( $expected_message_id !== null ) {
-			$stored_message_id = trim( (string) ( $row['message_id'] ?? '' ) );
+			// Compared as raw bytes, both sides untouched. A provider message id
+			// is opaque and is stored and reported without normalisation
+			// everywhere else in this plugin, so normalising it here would invent
+			// an equality the rest of the system does not hold — and it would do
+			// so in the one direction that matters, letting a re-used agent_seq
+			// match a different stored email and send it.
+			$stored_message_id = (string) ( $row['message_id'] ?? '' );
 			if ( $stored_message_id !== $expected_message_id ) {
-				return array(
-					'ok'         => false,
-					'detail'     => self::DETAIL_MISMATCH,
-					'message_id' => '',
-				);
+				return $this->refuse( self::DETAIL_MISMATCH );
 			}
+			$verified = true;
 		}
 
-		// Refuse resend when the body was not stored.
+		// Refuse resend when the body was not stored. The attestation is carried
+		// through: if the comparison ran and matched, it matched, and `ok` is
+		// what says the resend did not happen.
 		if ( (int) ( $row['body_stored'] ?? 0 ) !== 1 ) {
-			return array( 'ok' => false, 'detail' => 'body_not_stored', 'message_id' => '' );
+			return $this->refuse( 'body_not_stored', $verified );
 		}
 
 		// Rebuild the mail payload from the stored row.
@@ -214,12 +253,36 @@ final class ResendEmailCommand implements CommandInterface {
 			'ok'         => $result['ok'],
 			'detail'     => $result['ok'] ? 'resent' : $result['detail'],
 			'message_id' => $result['message_id'],
+			'verified'   => $verified,
 		);
 	}
 
 	// -------------------------------------------------------------------------
 	// Private helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a refusal, with the GH #528 attestation defaulted to false.
+	 *
+	 * Every refusal in execute() returns through here so that `verified` cannot
+	 * be dropped from one of them by accident and cannot become true by default
+	 * on any of them. The parameter exists for the single refusal that happens
+	 * AFTER a successful comparison (body_not_stored), and the only other place
+	 * `verified` is ever true is the compared-and-matched path in execute().
+	 *
+	 * @param string $detail   Contract `detail` string for the refusal.
+	 * @param bool   $verified Whether a supplied message_id was compared against
+	 *                         the loaded row and matched before this refusal.
+	 * @return array{ok:bool,detail:string,message_id:string,verified:bool}
+	 */
+	private function refuse( string $detail, bool $verified = false ): array {
+		return array(
+			'ok'         => false,
+			'detail'     => $detail,
+			'message_id' => '',
+			'verified'   => $verified,
+		);
+	}
 
 	/**
 	 * Fetch a single email log row by its local id.

--- a/apps/agent/includes/commands/class-resend-email-command.php
+++ b/apps/agent/includes/commands/class-resend-email-command.php
@@ -84,11 +84,13 @@
  * and "unverified" agree and the field is safe across versions.
  *
  * The refusal `detail` is the bare literal "message_id_mismatch" and nothing
- * else. It is a contract string the control plane pins and maps to
- * operator-facing wording ("this site's log row no longer matches the message
- * you selected; the site's database may have been restored since — refresh the
- * email log and try again"). Appending that sentence here instead would put raw
- * agent text in front of a user, which is how GH #520 was reported.
+ * else. It is a contract string the control plane pins and maps to whatever
+ * operator-facing wording it chooses; appending a sentence to it here instead
+ * would put raw agent text in front of a user, which is how GH #520 was
+ * reported. From this agent's side the condition is exactly this: the row now
+ * living at this agent_seq is not the row the control plane captured that
+ * message_id from, most often because the site's database was restored and
+ * the counter was reused for different mail.
  *
  * Note that this is why a successful resend no longer overwrites the row's
  * message_id: EmailLogReporter pages rows with `WHERE id > cursor`
@@ -97,6 +99,15 @@
  * would desynchronise the two and make the SECOND resend of any row refuse
  * itself. The new send's id still reaches the CP — it is the command's return
  * value.
+ *
+ * Known bounded false positive: a pre-#541 agent still rewrote the row's
+ * message_id on every successful resend, overwriting the value the control
+ * plane had mirrored at ingest. Any row resent by such an agent between the
+ * control-plane #520 fix deploying and this agent version landing on that
+ * site now carries a message_id the control plane does not have, so every
+ * later resend of that row is refused with "message_id_mismatch" forever.
+ * That is the safe direction to fail in: it refuses to send rather than
+ * risking the wrong mail.
  *
  * @package WPMgr\Agent\Commands
  */

--- a/apps/agent/includes/commands/class-resend-email-command.php
+++ b/apps/agent/includes/commands/class-resend-email-command.php
@@ -7,21 +7,54 @@
  *   POST /wp-json/wpmgr/v1/command/resend_email
  *   Authorization: Bearer <Ed25519 JWT with cmd="resend_email", aud=<siteId>>
  *   Content-Type: application/json
- *   Body: { "agent_seq": <int> }
+ *   Body: { "agent_seq": <int>, "message_id": "<string>" (optional) }
  *
  * Response:
  *   On success: { "ok": true, "detail": "resent", "message_id": "<string>" }
  *   Body not stored: { "ok": false, "detail": "body_not_stored" }
  *   Row not found:   { "ok": false, "detail": "log_row_not_found" }
  *   Config missing:  { "ok": false, "detail": "no email config" }
+ *   Identity check:  { "ok": false, "detail": "message_id_mismatch: …" }
  *
  * The command:
  *   1. Looks up the buffered row by agent_seq in wpmgr_email_log.
- *   2. If body_stored=0 returns ok=false with detail="body_not_stored".
- *   3. Rebuilds a minimal mail payload from the stored row + body.
- *   4. Sends via ProviderRouter (with suppress-check and fallback active).
- *   5. On success: increments resent_count and updates the log row's status,
- *      message_id, and response to reflect the new send.
+ *   2. Verifies the row's identity against the optional message_id (see below).
+ *   3. If body_stored=0 returns ok=false with detail="body_not_stored".
+ *   4. Rebuilds a minimal mail payload from the stored row + body.
+ *   5. Sends via ProviderRouter (with suppress-check and fallback active).
+ *   6. On success: increments resent_count and sets status='resent'.
+ *
+ * GH #528 — agent_seq alone is not a safe identity.
+ *
+ * agent_seq is the AUTO_INCREMENT id of this site's own wpmgr_email_log table.
+ * Restoring the site's database (something wpmgr itself performs) rolls that
+ * counter back, so later traffic re-uses ids the control plane has already
+ * bound to different messages. The CP row that says "agent_seq 42 = invoice for
+ * Alice" then points at whatever local send landed at id 42 after the restore,
+ * and a resend of "Alice's invoice" delivers Bob's password reset to bob@.
+ * Email cannot be recalled, so this must fail closed.
+ *
+ * The CP therefore sends the message_id it mirrored for that agent_seq at
+ * ingest. When it is present we compare it to the loaded row's stored
+ * message_id and refuse the send outright on any difference. The field is
+ * OPTIONAL and additive: an older control plane that does not send it gets
+ * exactly today's behaviour, because a resend is still better than no resend
+ * and the pre-#528 CP has no id to offer.
+ *
+ * Empty compares as a value, not as "skip": an original send that failed is
+ * logged with message_id='' and is mirrored to the CP as '', so ''-vs-'' is a
+ * genuine match. ''-vs-non-empty in either direction is a genuine mismatch —
+ * the CP's copy is a mirror of this row's own message_id, so presence on one
+ * side and absence on the other means the two are not the same row. Only an
+ * absent (or null) key skips verification.
+ *
+ * Note that this is why a successful resend no longer overwrites the row's
+ * message_id: EmailLogReporter pages rows with `WHERE id > cursor`
+ * (class-email-log-reporter.php), so an already-pushed row is never re-pushed
+ * and the CP's copy stays at the original send's id forever. Rewriting it here
+ * would desynchronise the two and make the SECOND resend of any row refuse
+ * itself. The new send's id still reaches the CP — it is the command's return
+ * value.
  *
  * @package WPMgr\Agent\Commands
  */
@@ -39,6 +72,19 @@ use WPMgr\Agent\Schema;
  * Re-sends a buffered email by its local log row id (agent_seq).
  */
 final class ResendEmailCommand implements CommandInterface {
+
+	/**
+	 * Stable `detail` prefix returned when the control plane named a message_id
+	 * that does not match the loaded log row. The control plane matches on the
+	 * prefix; the operator reads the sentence after it.
+	 */
+	public const DETAIL_MISMATCH = 'message_id_mismatch';
+
+	/**
+	 * Stable `detail` prefix returned when message_id was present but was not a
+	 * string, i.e. a request we cannot verify against.
+	 */
+	public const DETAIL_INVALID = 'message_id_invalid';
 
 	private ProviderRouter $provider_router;
 
@@ -58,7 +104,8 @@ final class ResendEmailCommand implements CommandInterface {
 	 * {@inheritDoc}
 	 *
 	 * @param array<string,mixed> $claims Validated JWT claims.
-	 * @param array<string,mixed> $params ResendEmailRequest fields (agent_seq: int).
+	 * @param array<string,mixed> $params ResendEmailRequest fields
+	 *                                    (agent_seq: int, message_id: ?string optional).
 	 * @return array{ok:bool,detail:string,message_id:string}
 	 */
 	public function execute( array $claims, array $params ): array {
@@ -70,6 +117,23 @@ final class ResendEmailCommand implements CommandInterface {
 		$agent_seq = filter_var( $params['agent_seq'], FILTER_VALIDATE_INT );
 		if ( $agent_seq === false || $agent_seq < 1 ) {
 			return array( 'ok' => false, 'detail' => 'agent_seq must be a positive integer', 'message_id' => '' );
+		}
+
+		// Validate the optional message_id (GH #528) before any work is done.
+		// null === array_key_exists()===false === "the control plane is not asking
+		// for verification" — that is the additive path an older CP takes. A
+		// present-but-not-a-string value is a request we cannot verify against,
+		// and an unverifiable resend is refused rather than sent.
+		$expected_message_id = null;
+		if ( array_key_exists( 'message_id', $params ) && $params['message_id'] !== null ) {
+			if ( ! is_string( $params['message_id'] ) ) {
+				return array(
+					'ok'         => false,
+					'detail'     => self::DETAIL_INVALID . ': message_id must be a string. Refusing to resend rather than send a message this site cannot verify.',
+					'message_id' => '',
+				);
+			}
+			$expected_message_id = trim( $params['message_id'] );
 		}
 
 		// Load the email config, required before attempting a resend.
@@ -84,6 +148,21 @@ final class ResendEmailCommand implements CommandInterface {
 			return array( 'ok' => false, 'detail' => 'log_row_not_found', 'message_id' => '' );
 		}
 
+		// GH #528: verify the loaded row IS the message the control plane named,
+		// before anything is built and long before anything is sent. This runs
+		// ahead of the body_stored check on purpose: "body_not_stored" about the
+		// wrong row is a misleading answer to give an operator.
+		if ( $expected_message_id !== null ) {
+			$stored_message_id = trim( (string) ( $row['message_id'] ?? '' ) );
+			if ( $stored_message_id !== $expected_message_id ) {
+				return array(
+					'ok'         => false,
+					'detail'     => self::DETAIL_MISMATCH . ': this site\'s log row no longer matches the message you selected. The site\'s database may have been restored since. Refresh the email log and try again.',
+					'message_id' => '',
+				);
+			}
+		}
+
 		// Refuse resend when the body was not stored.
 		if ( (int) ( $row['body_stored'] ?? 0 ) !== 1 ) {
 			return array( 'ok' => false, 'detail' => 'body_not_stored', 'message_id' => '' );
@@ -96,8 +175,10 @@ final class ResendEmailCommand implements CommandInterface {
 		$result = $this->provider_router->send( $mail, $cfg );
 
 		if ( $result['ok'] ) {
-			// Update the log row: increment resent_count, refresh status/message_id/response.
-			$this->update_row_after_resend( $agent_seq, $result['message_id'] );
+			// Update the log row: increment resent_count and mark it resent. The
+			// row's message_id is deliberately left at the original send's value —
+			// see the GH #528 note in the file header.
+			$this->update_row_after_resend( $agent_seq );
 		}
 
 		return array(
@@ -130,7 +211,7 @@ final class ResendEmailCommand implements CommandInterface {
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is $wpdb->prefix + a hard-coded constant, not user input
-				"SELECT id, mail_to, mail_from, subject, provider, body_stored, body, resent_count FROM {$table} WHERE id = %d LIMIT 1",
+				"SELECT id, message_id, mail_to, mail_from, subject, provider, body_stored, body, resent_count FROM {$table} WHERE id = %d LIMIT 1",
 				$agent_seq
 			),
 			ARRAY_A
@@ -201,11 +282,17 @@ final class ResendEmailCommand implements CommandInterface {
 	/**
 	 * Increment resent_count and update the status to 'resent' on the log row.
 	 *
-	 * @param int    $agent_seq  Log row id.
-	 * @param string $message_id New provider message id.
+	 * The row's message_id is intentionally NOT rewritten here. It is this row's
+	 * stable identity, mirrored to the control plane at ingest and never
+	 * re-pushed afterwards (EmailLogReporter pages `WHERE id > cursor`), and it
+	 * is what the GH #528 verification in execute() compares against. Rewriting
+	 * it would make the second resend of any row refuse itself. The new send's
+	 * message id is returned to the caller instead.
+	 *
+	 * @param int $agent_seq Log row id.
 	 * @return void
 	 */
-	private function update_row_after_resend( int $agent_seq, string $message_id ): void {
+	private function update_row_after_resend( int $agent_seq ): void {
 		global $wpdb;
 		if ( ! is_object( $wpdb ) ) {
 			return;
@@ -218,8 +305,7 @@ final class ResendEmailCommand implements CommandInterface {
 		$wpdb->query(
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is $wpdb->prefix + a hard-coded constant, not user input
-				"UPDATE {$table} SET resent_count = resent_count + 1, status = 'resent', message_id = %s WHERE id = %d",
-				$message_id,
+				"UPDATE {$table} SET resent_count = resent_count + 1, status = 'resent' WHERE id = %d",
 				$agent_seq
 			)
 		);

--- a/apps/agent/tests/Email/ResendEmailCommandTest.php
+++ b/apps/agent/tests/Email/ResendEmailCommandTest.php
@@ -81,10 +81,11 @@ class ResendEmailCommandTest extends TestCase
         return $router;
     }
 
-    private function make_log_row(int $id, bool $body_stored, string $body = ''): array
+    private function make_log_row(int $id, bool $body_stored, string $body = '', string $message_id = ''): array
     {
         return [
             'id'           => (string) $id,
+            'message_id'   => $message_id,
             'mail_to'      => 'recipient@example.com',
             'mail_from'    => 'Sender Name <sender@example.com>',
             'subject'      => 'Original subject',
@@ -93,6 +94,20 @@ class ResendEmailCommandTest extends TestCase
             'body'         => $body,
             'resent_count' => '0',
         ];
+    }
+
+    /**
+     * Build a router around a handler that RECORDS every send it is asked to
+     * make, so a test can assert on what was transmitted — or that nothing was.
+     */
+    private function make_router_with_spy(RecordingProviderHandler $spy): ProviderRouter
+    {
+        $logger = $this->createMock(EmailLogger::class);
+        $logger->method('write')->willReturn(1);
+
+        $router = new ProviderRouter(new FakeKeystore('test-secret'), $logger);
+        $router->register($spy);
+        return $router;
     }
 
     private function install_wpdb(?array $row): FakeResendWpdb
@@ -240,6 +255,305 @@ class ResendEmailCommandTest extends TestCase
         $this->assertStringContainsString('quota', $result['detail']);
         $this->assertFalse($wpdb->update_called, 'UPDATE must NOT be called when the provider send failed');
     }
+
+    // -------------------------------------------------------------------------
+    // GH #528 — agent_seq is not a safe identity across a database restore.
+    //
+    // A restore rolls the wpmgr_email_log AUTO_INCREMENT counter back, so later
+    // traffic re-uses ids the control plane already bound to other messages. The
+    // CP names the message_id it mirrored at ingest; a mismatch means the local
+    // row is no longer the message the operator selected, and email cannot be
+    // recalled, so the send must not happen at all.
+    //
+    // These tests do not depend on any process-global constant (the
+    // WPMGR_DISABLE_SITE_2FA leak that has silently disabled assertions in other
+    // files today), so they need no process isolation: every one of them asserts
+    // on the spy's own recorded state.
+    // -------------------------------------------------------------------------
+
+    /**
+     * The restore scenario itself. Local row 42 is Bob's password reset; the
+     * control plane still believes 42 is Alice's invoice. Nothing may be sent.
+     */
+    public function test_message_id_mismatch_refuses_and_sends_nothing(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+
+        // Post-restore: id 42 now holds a completely different message.
+        $row             = $this->make_log_row(42, true, '<p>Reset your password, Bob</p>', 'sg-bob-password-reset');
+        $row['mail_to']  = 'bob@example.com';
+        $row['subject']  = 'Password reset';
+        $wpdb            = $this->install_wpdb($row);
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-001', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        // The CP asks for agent_seq 42, the invoice it logged for Alice.
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        // The load-bearing assertion: no email left the site.
+        $this->assertSame(0, $spy->send_count, 'no email may be sent when the named message_id does not match the local row');
+        $this->assertSame([], $spy->sent, 'the provider handler must have received nothing at all');
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
+        $this->assertStringContainsString('restored', $result['detail']);
+        $this->assertSame('', $result['message_id']);
+        $this->assertFalse($wpdb->update_called, 'a refused resend must not touch the log row');
+    }
+
+    /**
+     * Over-fire guard 1: a legitimate resend, ids matching, still sends.
+     */
+    public function test_matching_message_id_still_resends(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $wpdb = $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-002', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertSame(1, $spy->send_count, 'a verified resend must still send');
+        $this->assertTrue($result['ok']);
+        $this->assertSame('resent', $result['detail']);
+        $this->assertSame('sg-new-002', $result['message_id']);
+        $this->assertTrue($wpdb->update_called);
+    }
+
+    /**
+     * Over-fire guard 2 — the one that keeps an older control plane working: a
+     * command with NO message_id key resends exactly as it does today.
+     */
+    public function test_absent_message_id_resends_exactly_as_today(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $wpdb = $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-003', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        // Exactly the pre-#528 payload.
+        $result = $cmd->execute([], ['agent_seq' => 42]);
+
+        $this->assertSame(1, $spy->send_count, 'a control plane that sends no message_id must keep working unchanged');
+        $this->assertTrue($result['ok']);
+        $this->assertSame('resent', $result['detail']);
+        $this->assertSame('sg-new-003', $result['message_id']);
+        $this->assertTrue($wpdb->update_called);
+    }
+
+    /**
+     * An explicit JSON null is the encoding of "no value", so it means the same
+     * as an absent key: the control plane is not asking for verification.
+     * Refusing on it would turn an additive field into a breaking one.
+     */
+    public function test_null_message_id_is_treated_as_not_supplied(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-004', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => null]);
+
+        $this->assertSame(1, $spy->send_count);
+        $this->assertTrue($result['ok']);
+    }
+
+    /**
+     * The row-has-no-stored-id case, and the decision it forces.
+     *
+     * The CP's copy of message_id is a mirror of this row's own value at ingest.
+     * If the CP holds one and the local row does not, they are not the same row
+     * — which is exactly what a rolled-back counter re-issuing an id to a FAILED
+     * send (logged with message_id='') looks like. We cannot verify, so we do
+     * not send, and we say why.
+     */
+    public function test_row_without_stored_message_id_refuses_when_cp_names_one(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $wpdb = $this->install_wpdb($this->make_log_row(42, true, '<p>whatever landed here</p>', ''));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-005', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertSame(0, $spy->send_count, 'an unverifiable resend must not be sent');
+        $this->assertFalse($result['ok']);
+        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
+        $this->assertFalse($wpdb->update_called);
+    }
+
+    /**
+     * The mirror of the above: empty is compared as a value, not read as "skip".
+     * A send that failed is logged with message_id='' and mirrored to the CP as
+     * '', so ''-vs-'' is a genuine match and that resend must still work.
+     */
+    public function test_empty_message_id_matches_a_row_logged_without_one(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>failed original send</p>', ''));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-006', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => '']);
+
+        $this->assertSame(1, $spy->send_count, 'a failed send mirrored as message_id="" must still be resendable');
+        $this->assertTrue($result['ok']);
+    }
+
+    /**
+     * ...and the same rule in the other direction: the CP holds no id, the local
+     * row does. Still not the same row. Still refuse.
+     */
+    public function test_empty_message_id_refuses_when_the_row_has_one(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-007', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => '']);
+
+        $this->assertSame(0, $spy->send_count);
+        $this->assertFalse($result['ok']);
+        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
+    }
+
+    /**
+     * A present-but-unusable message_id is refused before any work is done. An
+     * unverifiable resend is never a silent send.
+     */
+    public function test_non_string_message_id_refuses_and_sends_nothing(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-008', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => ['not', 'a', 'string']]);
+
+        $this->assertSame(0, $spy->send_count);
+        $this->assertFalse($result['ok']);
+        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_INVALID, $result['detail']);
+    }
+
+    /**
+     * The verification runs BEFORE the body_stored branch, so an operator whose
+     * row was replaced by a restore is told the truth ("this is not your
+     * message") rather than a misleading fact about the wrong row.
+     */
+    public function test_mismatch_is_reported_ahead_of_body_not_stored(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, false, '', 'sg-bob-password-reset'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-009', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertSame(0, $spy->send_count);
+        $this->assertFalse($result['ok']);
+        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
+    }
+
+    /**
+     * The guard must not redden correct work on the SECOND resend.
+     *
+     * EmailLogReporter pages rows with `WHERE id > cursor`, so a row that has
+     * already been pushed is never pushed again and the control plane's copy of
+     * message_id stays at the original send's value forever. A successful resend
+     * therefore must NOT rewrite the row's message_id, or resending the same row
+     * twice would refuse itself.
+     */
+    public function test_successful_resend_preserves_the_rows_message_id(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $wpdb = $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-010', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $first = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+        $this->assertTrue($first['ok']);
+        $this->assertTrue($wpdb->update_called);
+
+        $updates = array_values(array_filter(
+            $wpdb->queries,
+            static fn (string $q): bool => stripos($q, 'UPDATE') !== false
+        ));
+        $this->assertNotEmpty($updates, 'the successful resend must have issued an UPDATE');
+        foreach ($updates as $q) {
+            $this->assertStringNotContainsString(
+                'message_id',
+                $q,
+                'the row message_id is the identity the CP verifies against and must survive a resend'
+            );
+        }
+
+        // ...and the row is therefore still resendable with the same id.
+        $second = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+        $this->assertTrue($second['ok'], 'a second resend of the same row must not refuse itself');
+        $this->assertSame(2, $spy->send_count);
+    }
+}
+
+/**
+ * A provider handler that records every send it is asked to perform, so a test
+ * can assert that nothing was sent rather than merely that an error came back.
+ */
+class RecordingProviderHandler implements ProviderHandlerInterface
+{
+    public int $send_count = 0;
+
+    /** @var array<int,array<string,mixed>> Every mail payload handed to send(). */
+    public array $sent = [];
+
+    /** @var array{ok:bool,message_id:string,error:string,provider_response:string} */
+    private array $result;
+
+    /**
+     * @param array{ok:bool,message_id:string,error:string,provider_response:string} $result
+     */
+    public function __construct(array $result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @param array<string,mixed> $mail
+     * @param array<string,mixed> $config
+     * @return array{ok:bool,message_id:string,error:string,provider_response:string}
+     */
+    public function send(array $mail, array $config, string $secret): array
+    {
+        ++$this->send_count;
+        $this->sent[] = $mail;
+        return $this->result;
+    }
+
+    public function provider(): string
+    {
+        return 'sendgrid';
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +569,9 @@ class FakeResendWpdb
     public string $prefix = 'wp_';
 
     public bool $update_called = false;
+
+    /** @var array<int,string> Every query text passed to query(). */
+    public array $queries = [];
 
     /** @var array<string,mixed>|null */
     private ?array $row;
@@ -284,6 +601,7 @@ class FakeResendWpdb
      */
     public function query(string $query)
     {
+        $this->queries[] = $query;
         if (stripos($query, 'UPDATE') !== false) {
             $this->update_called = true;
             return 1;

--- a/apps/agent/tests/Email/ResendEmailCommandTest.php
+++ b/apps/agent/tests/Email/ResendEmailCommandTest.php
@@ -344,6 +344,7 @@ class ResendEmailCommandTest extends TestCase
         $this->assertSame('resent', $result['detail']);
         $this->assertSame('sg-new-002', $result['message_id']);
         $this->assertTrue($wpdb->update_called);
+        $this->assertTrue($result['verified'], 'this is the compared-and-matched path, so it attests true');
     }
 
     /**
@@ -367,6 +368,7 @@ class ResendEmailCommandTest extends TestCase
         $this->assertSame('resent', $result['detail']);
         $this->assertSame('sg-new-003', $result['message_id']);
         $this->assertTrue($wpdb->update_called);
+        $this->assertFalse($result['verified'], 'unchanged behaviour, and honestly reported as unverified');
     }
 
     /**
@@ -533,6 +535,9 @@ class ResendEmailCommandTest extends TestCase
         $this->assertTrue($third['ok'], 'nor the third');
         $this->assertSame(3, $spy->send_count, 'all three resends must actually have been sent');
         $this->assertSame('sg-resend-new', $second['message_id'], 'each resend still returns its own new provider id to the CP');
+        $this->assertTrue($first['verified'], 'every one of the three compared and matched');
+        $this->assertTrue($second['verified']);
+        $this->assertTrue($third['verified']);
     }
 
     /**
@@ -574,6 +579,302 @@ class ResendEmailCommandTest extends TestCase
         $second = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
         $this->assertTrue($second['ok'], 'a second resend of the same row must not refuse itself');
         $this->assertSame(2, $spy->send_count);
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #528, correction 1 — `verified` is THIS AGENT'S attestation, and the
+    // control plane must never infer it.
+    //
+    // The CP cannot learn from its own request whether a check happened. An
+    // older agent ignores an unknown message_id, resends happily and answers
+    // ok=true; a CP that read "I sent the field" as "the agent compared it"
+    // would record a VERIFIED resend and tell the operator and the audit trail
+    // that the message was confirmed when no comparison ever ran. That is the
+    // exact defect this issue is about, sitting inside its own fix.
+    //
+    // So the agent states it. `verified` is true on ONE code path: a supplied
+    // message_id was compared against the loaded row and matched. The CP reads
+    // an ABSENT field as false, which is what makes an older agent's silence
+    // mean "unverified" rather than "verified".
+    // -------------------------------------------------------------------------
+
+    /**
+     * The attestation exists, and it is true exactly where the work was done.
+     */
+    public function test_verified_is_true_only_when_the_id_was_compared_and_matched(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-011', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertArrayHasKey(
+            'verified',
+            $result,
+            'the agent must state whether it verified; leaving the CP to infer it from its own request is the defect'
+        );
+        $this->assertTrue($result['verified'], 'supplied, compared, matched — the one case that may attest true');
+        $this->assertTrue($result['ok']);
+        $this->assertSame(1, $spy->send_count);
+    }
+
+    /**
+     * The older-control-plane path. No message_id was supplied, so no
+     * comparison happened, so nothing may be attested — even though the resend
+     * itself succeeds.
+     */
+    public function test_verified_is_false_when_no_message_id_is_supplied(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-012', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42]);
+
+        $this->assertArrayHasKey('verified', $result);
+        $this->assertTrue($result['ok'], 'an unverified resend still sends — that is the additive contract');
+        $this->assertFalse($result['verified'], 'a send that skipped the comparison must never be recorded as verified');
+    }
+
+    /**
+     * null and '' are both "the CP has no id to offer", so both skip the
+     * comparison, and a skipped comparison attests false.
+     */
+    public function test_verified_is_false_when_message_id_is_null_or_empty(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+        $nullSpy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-013', 'error' => '', 'provider_response' => '202']);
+        $nullCmd = new ResendEmailCommand($this->make_router_with_spy($nullSpy));
+        $nullResult = $nullCmd->execute([], ['agent_seq' => 42, 'message_id' => null]);
+
+        $this->assertTrue($nullResult['ok']);
+        $this->assertFalse($nullResult['verified'], 'an explicit null supplied nothing to compare');
+
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+        $emptySpy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-014', 'error' => '', 'provider_response' => '202']);
+        $emptyCmd = new ResendEmailCommand($this->make_router_with_spy($emptySpy));
+        $emptyResult = $emptyCmd->execute([], ['agent_seq' => 42, 'message_id' => '']);
+
+        $this->assertTrue($emptyResult['ok']);
+        $this->assertFalse($emptyResult['verified'], 'an empty string supplied nothing to compare');
+    }
+
+    /**
+     * The other skip named in the contract: the local row carries no stored id.
+     * With nothing supplied either, there is nothing to compare on either side,
+     * the resend proceeds, and it is reported unverified.
+     */
+    public function test_verified_is_false_when_the_local_row_has_no_stored_id(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>failed original send</p>', ''));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-015', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42]);
+
+        $this->assertSame(1, $spy->send_count, 'a failed send with no stored id must still be resendable');
+        $this->assertTrue($result['ok']);
+        $this->assertFalse($result['verified'], 'no stored id means no comparison, which means no attestation');
+    }
+
+    /**
+     * A refusal is not an attestation. The comparison ran and REFUTED the row,
+     * so `verified` is false, not true — stated explicitly rather than left to
+     * fall out of the code.
+     */
+    public function test_verified_is_false_on_the_mismatch_refusal(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Reset your password, Bob</p>', 'sg-bob-password-reset'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-016', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertSame(0, $spy->send_count);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('message_id_mismatch', $result['detail']);
+        $this->assertFalse($result['verified'], 'a refuted comparison attests false, never true');
+    }
+
+    /**
+     * Every refusal that returns BEFORE the comparison attests false, because
+     * on each of those paths the agent never even loaded a row to compare.
+     */
+    public function test_verified_is_false_on_every_refusal_before_the_comparison(): void
+    {
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-017', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $missingSeq = $cmd->execute([], []);
+        $this->assertFalse($missingSeq['ok']);
+        $this->assertFalse($missingSeq['verified'], 'missing agent_seq compared nothing');
+
+        $badSeq = $cmd->execute([], ['agent_seq' => 0]);
+        $this->assertFalse($badSeq['ok']);
+        $this->assertFalse($badSeq['verified'], 'an invalid agent_seq compared nothing');
+
+        $badType = $cmd->execute([], ['agent_seq' => 42, 'message_id' => ['not', 'a', 'string']]);
+        $this->assertFalse($badType['ok']);
+        $this->assertSame('message_id_invalid', $badType['detail']);
+        $this->assertFalse($badType['verified'], 'an unusable message_id compared nothing');
+
+        // No email config in the option store, and a row that would otherwise send.
+        $this->install_wpdb($this->make_log_row(42, true, '<p>body</p>', 'sg-alice-invoice'));
+        $noConfig = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+        $this->assertFalse($noConfig['ok']);
+        $this->assertStringContainsString('no email config', $noConfig['detail']);
+        $this->assertFalse($noConfig['verified'], 'the config check returns before any row is loaded');
+
+        $this->install_email_config();
+        $this->install_wpdb(null);
+        $noRow = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+        $this->assertFalse($noRow['ok']);
+        $this->assertSame('log_row_not_found', $noRow['detail']);
+        $this->assertFalse($noRow['verified'], 'there was no row to compare against');
+
+        $this->assertSame(0, $spy->send_count, 'none of these paths may send');
+    }
+
+    /**
+     * The one ok=false path that legitimately attests TRUE, pinned so it is a
+     * decision rather than an accident.
+     *
+     * `verified` describes the identity comparison, not the send: the id was
+     * supplied, it was compared against this row, and it matched. That the body
+     * was never captured is a separate fact, carried by `ok` and `detail`. The
+     * CP records a resend only when ok=true, so this cannot manufacture a
+     * verified resend that did not happen.
+     */
+    public function test_verified_is_true_when_the_match_succeeded_but_the_body_was_not_stored(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, false, '', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-018', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertSame(0, $spy->send_count);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('body_not_stored', $result['detail']);
+        $this->assertTrue($result['verified'], 'the comparison did run and did match; verified describes that, not the send');
+    }
+
+    // -------------------------------------------------------------------------
+    // GH #528, correction 2 — provider message ids are OPAQUE. Compare exactly.
+    //
+    // These identifiers are stored and reported without any general trimming,
+    // so trimming only at the comparison invents an equality the rest of the
+    // system does not believe in. Two raw ids differing by surrounding
+    // whitespace are two different ids, and treating them as one weakens the
+    // fail-closed guard in the single direction that matters: it lets a re-used
+    // agent_seq select the wrong stored email and send it.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Whitespace on the SUPPLIED side is a difference, and a difference refuses.
+     */
+    public function test_supplied_id_padded_with_whitespace_is_a_mismatch(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $wpdb = $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-019', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => "  sg-alice-invoice\t"]);
+
+        $this->assertSame(0, $spy->send_count, 'two raw identifiers that differ must not compare equal');
+        $this->assertFalse($result['ok']);
+        $this->assertSame('message_id_mismatch', $result['detail']);
+        $this->assertFalse($result['verified']);
+        $this->assertFalse($wpdb->update_called);
+    }
+
+    /**
+     * ...and whitespace on the STORED side is equally a difference. Normalising
+     * either side alone would still be normalising.
+     */
+    public function test_stored_id_padded_with_whitespace_is_a_mismatch(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', " sg-alice-invoice "));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-020', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertSame(0, $spy->send_count);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('message_id_mismatch', $result['detail']);
+        $this->assertFalse($result['verified']);
+    }
+
+    /**
+     * A whitespace-only supplied id is a VALUE, not an absence.
+     *
+     * Trimming before the empty test silently reclassified "   " as "the CP has
+     * no id to offer" and sent the mail unverified. Without the trim it is a
+     * supplied id like any other, it is compared, it does not match, and the
+     * send is refused. Fail closed.
+     */
+    public function test_whitespace_only_supplied_id_is_compared_not_discarded(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-021', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => '   ']);
+
+        $this->assertSame(0, $spy->send_count, 'a whitespace-only id must be compared, not silently treated as absent');
+        $this->assertFalse($result['ok']);
+        $this->assertSame('message_id_mismatch', $result['detail']);
+        $this->assertFalse($result['verified']);
+    }
+
+    /**
+     * The over-fire guard for exact comparison: an id that genuinely carries
+     * whitespace still resends when BOTH sides carry it identically. The rule
+     * is "compare exactly", not "refuse anything with whitespace in it".
+     */
+    public function test_identically_padded_ids_on_both_sides_still_resend(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', " sg-alice-invoice "));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-new-022', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => " sg-alice-invoice "]);
+
+        $this->assertSame(1, $spy->send_count, 'byte-identical ids match, whatever bytes they are');
+        $this->assertTrue($result['ok']);
+        $this->assertTrue($result['verified']);
     }
 }
 

--- a/apps/agent/tests/Email/ResendEmailCommandTest.php
+++ b/apps/agent/tests/Email/ResendEmailCommandTest.php
@@ -297,10 +297,32 @@ class ResendEmailCommandTest extends TestCase
         $this->assertSame([], $spy->sent, 'the provider handler must have received nothing at all');
 
         $this->assertFalse($result['ok']);
-        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
-        $this->assertStringContainsString('restored', $result['detail']);
+        $this->assertSame('message_id_mismatch', $result['detail']);
         $this->assertSame('', $result['message_id']);
         $this->assertFalse($wpdb->update_called, 'a refused resend must not touch the log row');
+    }
+
+    /**
+     * The refusal detail is a contract string the control plane pins as
+     * agentcmd.ResendDetailMessageIDMismatch. It is the WHOLE detail, not a
+     * prefix with agent prose appended: raw agent text in front of a user is how
+     * GH #520 was reported. Pin the literal on this side too, so a well-meant
+     * reword here fails here rather than in a toast.
+     */
+    public function test_mismatch_detail_is_exactly_the_pinned_contract_literal(): void
+    {
+        $this->assertSame('message_id_mismatch', ResendEmailCommand::DETAIL_MISMATCH);
+
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>body</p>', 'sg-bob-password-reset'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-x', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertSame('message_id_mismatch', $result['detail'], 'the detail must be the bare contract literal, with nothing appended');
     }
 
     /**
@@ -389,16 +411,21 @@ class ResendEmailCommandTest extends TestCase
 
         $this->assertSame(0, $spy->send_count, 'an unverifiable resend must not be sent');
         $this->assertFalse($result['ok']);
-        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
+        $this->assertSame('message_id_mismatch', $result['detail']);
         $this->assertFalse($wpdb->update_called);
     }
 
     /**
-     * The mirror of the above: empty is compared as a value, not read as "skip".
-     * A send that failed is logged with message_id='' and mirrored to the CP as
-     * '', so ''-vs-'' is a genuine match and that resend must still work.
+     * Empty is NOT compared as a value — it means the same as an absent key.
+     *
+     * The control plane's message_id is NULL for every send that failed at the
+     * time (all five provider handlers return '' on failure, and ingest only
+     * stores a non-empty pointer), and a failed send is the most common thing an
+     * operator resends. The CP omits the key for those rows; treating an empty
+     * string the same way means neither side can break the other by changing how
+     * it encodes "nothing".
      */
-    public function test_empty_message_id_matches_a_row_logged_without_one(): void
+    public function test_empty_message_id_is_treated_as_not_supplied(): void
     {
         Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
         $this->install_email_config();
@@ -409,15 +436,16 @@ class ResendEmailCommandTest extends TestCase
 
         $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => '']);
 
-        $this->assertSame(1, $spy->send_count, 'a failed send mirrored as message_id="" must still be resendable');
+        $this->assertSame(1, $spy->send_count, 'a failed send whose CP-side message_id is NULL must still be resendable');
         $this->assertTrue($result['ok']);
     }
 
     /**
-     * ...and the same rule in the other direction: the CP holds no id, the local
-     * row does. Still not the same row. Still refuse.
+     * ...and it stays "not supplied" even when the local row does hold an id.
+     * An empty value is the absence of a claim, never a claim of absence, so it
+     * must not manufacture a refusal.
      */
-    public function test_empty_message_id_refuses_when_the_row_has_one(): void
+    public function test_empty_message_id_does_not_refuse_a_row_that_has_one(): void
     {
         Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
         $this->install_email_config();
@@ -428,9 +456,8 @@ class ResendEmailCommandTest extends TestCase
 
         $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => '']);
 
-        $this->assertSame(0, $spy->send_count);
-        $this->assertFalse($result['ok']);
-        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
+        $this->assertSame(1, $spy->send_count);
+        $this->assertTrue($result['ok']);
     }
 
     /**
@@ -450,7 +477,7 @@ class ResendEmailCommandTest extends TestCase
 
         $this->assertSame(0, $spy->send_count);
         $this->assertFalse($result['ok']);
-        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_INVALID, $result['detail']);
+        $this->assertSame('message_id_invalid', $result['detail']);
     }
 
     /**
@@ -470,12 +497,46 @@ class ResendEmailCommandTest extends TestCase
         $result = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
 
         $this->assertSame(0, $spy->send_count);
-        $this->assertFalse($result['ok']);
-        $this->assertStringStartsWith(ResendEmailCommand::DETAIL_MISMATCH, $result['detail']);
+        $this->assertSame('message_id_mismatch', $result['detail']);
     }
 
     /**
-     * The guard must not redden correct work on the SECOND resend.
+     * REQUIRED over-fire proof: resend the same row twice in a row, and the
+     * second one must still send.
+     *
+     * This is the case the fix is most likely to break. The control plane's copy
+     * of message_id is frozen at the ORIGINAL send's value — EmailLogReporter
+     * pages rows with `WHERE id > cursor`, so an already-pushed row is never
+     * pushed again and the CP never learns a resend's new id. It therefore sends
+     * the same original id every time. If a successful resend rewrote the local
+     * row's message_id, the second resend would compare the CP's original
+     * against the agent's newer value and refuse a completely legitimate action
+     * — turning a restore-only defect into a permanent one.
+     */
+    public function test_repeat_resend_of_the_same_row_still_sends(): void
+    {
+        Functions\when('current_time')->justReturn('2026-08-26 00:00:00');
+        $this->install_email_config();
+        $this->install_wpdb($this->make_log_row(42, true, '<p>Invoice for Alice</p>', 'sg-alice-invoice'));
+
+        $spy = new RecordingProviderHandler(['ok' => true, 'message_id' => 'sg-resend-new', 'error' => '', 'provider_response' => '202']);
+        $cmd = new ResendEmailCommand($this->make_router_with_spy($spy));
+
+        // The CP sends the same original id both times, because that is the only
+        // value it will ever hold for this row.
+        $first  = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+        $second = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+        $third  = $cmd->execute([], ['agent_seq' => 42, 'message_id' => 'sg-alice-invoice']);
+
+        $this->assertTrue($first['ok']);
+        $this->assertTrue($second['ok'], 'the second resend of the same row must not refuse itself');
+        $this->assertTrue($third['ok'], 'nor the third');
+        $this->assertSame(3, $spy->send_count, 'all three resends must actually have been sent');
+        $this->assertSame('sg-resend-new', $second['message_id'], 'each resend still returns its own new provider id to the CP');
+    }
+
+    /**
+     * The mechanism the test above depends on: the row's message_id survives.
      *
      * EmailLogReporter pages rows with `WHERE id > cursor`, so a row that has
      * already been pushed is never pushed again and the control plane's copy of
@@ -581,8 +642,19 @@ class FakeResendWpdb
         $this->row = $row;
     }
 
+    /**
+     * Substitute placeholders the way wpdb::prepare() does, so query() below can
+     * see the VALUES a statement carries and not just its shape. Without this
+     * the double cannot model an UPDATE at all, and a test asserting that a
+     * resend leaves the row's message_id alone would pass no matter what the
+     * command wrote.
+     */
     public function prepare(string $query, ...$args): string
     {
+        foreach ($args as $arg) {
+            $replacement = is_int($arg) ? (string) $arg : "'" . (string) $arg . "'";
+            $query       = preg_replace('/%[ds]/', $replacement, $query, 1) ?? $query;
+        }
         return $query;
     }
 
@@ -604,6 +676,12 @@ class FakeResendWpdb
         $this->queries[] = $query;
         if (stripos($query, 'UPDATE') !== false) {
             $this->update_called = true;
+            // Model the write, so a subsequent get_row() sees what the command
+            // actually stored. This is what lets the repeat-resend test go red
+            // against an implementation that overwrites message_id on resend.
+            if ($this->row !== null && preg_match("/message_id\s*=\s*'([^']*)'/i", $query, $m) === 1) {
+                $this->row['message_id'] = $m[1];
+            }
             return 1;
         }
         return false;


### PR DESCRIPTION
Agent half of #528.

## The defect

`agent_seq` is the AUTO_INCREMENT `id` of the site's own `wpmgr_email_log` table
(`apps/agent/includes/class-schema.php:412`). Restoring the site's database —
something wpmgr performs itself — rolls that counter back, so later traffic
re-uses ids the control plane has already bound to different messages. The CP row
that says `agent_seq 42` is "Invoice for Alice" then points at whatever landed at
local id 42 after the restore, and Resend delivers Bob's password reset to bob@.
Email cannot be recalled, so this has to fail closed.

## Backward compatibility: confirmed, an older agent ignores an unknown key

Read independently from the source, and it agrees with the CP half's reading:

- `Router::handleCommand()` (`apps/agent/includes/class-router.php:172-197`) takes
  the whole decoded body from `$request->get_json_params()`, `unset()`s only its
  own `wpmgr_claims` stash, and passes the rest through. The route's `args`
  declares only the `command` URL segment — no body schema, no
  `additionalProperties: false`, no unknown-key rejection anywhere on the path.
- `ResendEmailCommand::execute()` reads `$params['agent_seq']` and nothing else;
  it never enumerates keys and has no whitelist.

A pre-#528 agent receiving `{"agent_seq": 42, "message_id": "…"}` resends exactly
as it does today. **Additive, not breaking.**

## The change

`ResendEmailCommand` accepts an optional `message_id`, compares it against the
loaded row's stored `message_id`, and refuses the send on any difference.

- **Supplied means a non-empty string.** Absent, `null` and `''` all mean "the
  control plane has no id to offer" and all three proceed without verifying.
  `message_id` is NULL on the CP for every send that failed at the time (all five
  provider handlers return `''` on failure, ingest only stores a non-empty
  pointer), and a failed send is the most common thing an operator resends —
  reading `''` as "compare against empty" would refuse exactly the rows this fix
  protects. The CP omits the key for those rows; treating `''` identically means
  neither side can break the other by changing how it encodes "nothing".
- **The reverse is deliberately not symmetric.** CP supplies an id, local row has
  none → refuse. The CP's copy is a mirror of this row's own value, so presence on
  one side with absence on the other means they are not the same row — the exact
  fingerprint of a rolled-back counter re-issuing an id to a later failed send.
- **Present but not a string** → refused before any DB or provider work.
- The check runs **ahead of** the `body_stored` branch: `body_not_stored` about
  the wrong row is a misleading answer to give an operator.

The refusal `detail` is the bare literal **`message_id_mismatch`**, matching
`agentcmd.ResendDetailMessageIDMismatch`. The CP owns the operator-facing wording;
appending agent prose would put raw agent text in a toast, which is how #520 was
reported. `test_mismatch_detail_is_exactly_the_pinned_contract_literal` pins the
literal on this side so a reword fails here instead.

## One behaviour change the guard requires

A successful resend no longer rewrites the row's `message_id`. `EmailLogReporter`
pages rows with `WHERE id > cursor`
(`apps/agent/includes/email/class-email-log-reporter.php:220`), so an
already-pushed row is never re-pushed and the CP's copy stays frozen at the
original send's id. Rewriting it locally would make the *second* resend of any row
compare the CP's original against the agent's newer value and refuse a legitimate
action — turning a restore-only defect into a permanent one. The new send's id
still reaches the CP: it is the command's return value.

## Proof

**Red.** Three distinct planted failures, each restored to green afterwards.

With the fix stashed out:

```
$ php -d memory_limit=1024M vendor/bin/phpunit tests/Email/ResendEmailCommandTest.php \
    --filter 'test_message_id_mismatch_refuses_and_sends_nothing' --no-coverage
no email may be sent when the named message_id does not match the local row
Failed asserting that 1 is identical to 0.
EXIT=1
```

The pre-fix code sent Bob's password reset when the CP named Alice's invoice. Same
stash, the no-stored-id case also sent (`1 is identical to 0`).

With the *naive* implementation planted instead (overwrite `message_id` on resend
plus a straight equality check — the obvious way to get this wrong):

```
$ php -d memory_limit=1024M vendor/bin/phpunit tests/Email/ResendEmailCommandTest.php \
    --filter 'test_repeat_resend_of_the_same_row_still_sends|test_successful_resend_preserves_the_rows_message_id' --no-coverage
1) …::test_repeat_resend_of_the_same_row_still_sends
the second resend of the same row must not refuse itself
Failed asserting that false is true.
2) …::test_successful_resend_preserves_the_rows_message_id
Failed asserting that 'UPDATE wp_wpmgr_email_log SET resent_count = resent_count + 1,
status = 'resent', message_id = 'sg-new-010' WHERE id = 42' does not contain "message_id".
EXIT=1
```

That red is only reachable because `FakeResendWpdb` now substitutes `prepare()`
placeholders and applies a `message_id` UPDATE to its own row. Returning a static
row would have let that test pass no matter what the command wrote.

**Green.** Same tests, fix restored: `OK (20 tests, 63 assertions)`, EXIT=0. The
refusal tests assert on a recording provider handler's `send_count` and `sent`
array — they prove nothing was transmitted, not merely that an error came back.

**Over-fire, all three:**
- `test_matching_message_id_still_resends` — ids match, still sends.
- `test_absent_message_id_resends_exactly_as_today` — no `message_id` key, resends
  unchanged. This is the older-CP path.
- `test_repeat_resend_of_the_same_row_still_sends` — the same row resent three
  times with the CP sending its frozen original id each time; all three send.

## Gates

| Gate | Result |
|---|---|
| `php -d memory_limit=1024M vendor/bin/phpunit --no-coverage` | EXIT=0, `Tests: 3461` |
| `WPMGR_PHPSTAN_MEMORY=2G bash scripts/check-agent-phpstan.sh` | EXIT=0, 0 findings |
| `make agent-check` | EXIT=0 |
| `make agent-plugincheck` | EXIT=0, **0 errors**, 0 rows against this file |

`composer test` exits 255 on this machine — a 128M OOM in `SqlInspectorTest`,
cumulative across the suite. Reproduced on the untouched baseline
(`git checkout origin/main -- <both files>` → same exit, same message), so it is
pre-existing and independent of this change. CI's PHP does not cap memory at 128M.

Do not merge — `security-reviewer` reviews this.
