### PR TITLE
fix(email): confirm the row before a resend, so a restored site cannot send the wrong mail (#528)

### DIFF
--- a/apps/api/internal/agentcmd/resend_email_contract.go
+++ b/apps/api/internal/agentcmd/resend_email_contract.go
@@ -8,6 +8,8 @@ package agentcmd
 //	POST {siteURL}/wp-json/wpmgr/v1/command/resend_email
 //	Authorization: Bearer <Ed25519 JWT, cmd="resend_email", aud=<siteId>>
 //	Body: {"agent_seq": <int>, "message_id": <string, optional>}
+//	Response: {"ok": <bool>, "detail": <string>, "message_id": <string>,
+//	           "verified": <bool, absent on agents older than #541>}
 //
 // The agent looks the row up in its own wpmgr_email_log by that local row id,
 // refuses when the row is gone or its body was not captured, and otherwise
@@ -98,4 +100,43 @@ type ResendEmailResult struct {
 	Detail string `json:"detail,omitempty"`
 	// MessageID is the provider-returned Message-ID header value for the new send.
 	MessageID string `json:"message_id,omitempty"`
+
+	// Verified is the AGENT'S ATTESTATION that it compared the message_id the
+	// CP supplied against the message_id on its own row, and they matched —
+	// GH #528. The agent sets it true only on that path (see #541); every
+	// other path leaves it false.
+	//
+	// A POINTER, deliberately. Three wire states have to stay distinguishable
+	// at the point where the decision is written down:
+	//
+	//	{"verified": true}   → a comparison happened and matched
+	//	{"verified": false}  → the agent ran but did not (or could not) compare
+	//	  (key absent)       → an agent too old to know the field exists
+	//
+	// The last one is the one that matters and it is why this is not a plain
+	// bool. A compatible older agent reads only agent_seq, ignores message_id,
+	// resends whatever now sits at that row and answers ok=true. Decoded into
+	// a plain bool its silence would become `false` by Go's zero value — the
+	// right answer, but reached by accident, invisible to a reader, and one
+	// refactor away from becoming true. IsVerified() below is where the
+	// decision is stated instead.
+	//
+	// Never derive this from the request. Sending message_id only ASKS for the
+	// comparison; this field is the only thing that reports one happened.
+	Verified *bool `json:"verified"`
+}
+
+// IsVerified reports whether the site confirmed it resent the message the
+// operator selected.
+//
+// ABSENT MEANS FALSE, explicitly and on purpose (GH #528, PR #542 review).
+// A legacy agent says nothing about `verified`, and silence from a site that
+// never performed the check must never read as confirmation that it did. This
+// is the whole safety property of the field: the CP may only claim a check
+// happened when a site says it happened.
+func (r ResendEmailResult) IsVerified() bool {
+	if r.Verified == nil {
+		return false
+	}
+	return *r.Verified
 }

--- a/apps/api/internal/agentcmd/resend_email_contract.go
+++ b/apps/api/internal/agentcmd/resend_email_contract.go
@@ -7,11 +7,25 @@ package agentcmd
 //
 //	POST {siteURL}/wp-json/wpmgr/v1/command/resend_email
 //	Authorization: Bearer <Ed25519 JWT, cmd="resend_email", aud=<siteId>>
-//	Body: {"agent_seq": <int>}
+//	Body: {"agent_seq": <int>, "message_id": <string, optional>}
 //
 // The agent looks the row up in its own wpmgr_email_log by that local row id,
 // refuses when the row is gone or its body was not captured, and otherwise
 // re-sends through its configured provider and returns the new Message-ID.
+//
+// GH #528: agent_seq alone is not a safe selector across a site database
+// restore. It is a MySQL AUTO_INCREMENT on the site's own table
+// (apps/agent/includes/class-schema.php), so a restore rolls the counter back
+// and later sends re-use ids the CP has already bound to different messages.
+// wpmgr performs restores itself, so this is reachable in normal operation:
+// CP row X holds agent_seq 42 = "Invoice for Alice"; after a restore the site's
+// own row 42 is "Password reset for Bob"; the operator sees Alice and clicks
+// Resend; the agent sends Bob's message to Bob. An email cannot be recalled.
+//
+// message_id is the confirmation field. It is a ROW SELECTOR, not message
+// content: the provider's Message-ID header for the send the CP has on record.
+// It carries no recipients, no subject and no body, so it does not reopen what
+// #520 settled — stored message bodies stay off the command channel.
 //
 // GH #520: the CP used to send a log_id UUID plus an (unpopulated) copy of the
 // message itself. The agent has required agent_seq since the same commit that
@@ -26,14 +40,29 @@ package agentcmd
 
 // ResendEmailRequest is the POST body for the `resend_email` agent command.
 //
-// One field, deliberately. Everything the agent needs to rebuild the message
+// Two fields, both selectors. Everything the agent needs to rebuild the message
 // (recipients, from, subject, body, provider) it reads from its own log row —
-// the CP names the row and nothing more.
+// the CP names the row, confirms which row it meant, and nothing more.
 type ResendEmailRequest struct {
 	// AgentSeq is the agent-local wpmgr_email_log row id, mirrored into the CP
-	// as site_email_log.agent_seq at ingest. It is the only field the agent
-	// reads, and it must be a positive integer or the agent refuses.
+	// as site_email_log.agent_seq at ingest. It is the field the agent
+	// addresses by, and it must be a positive integer or the agent refuses.
 	AgentSeq int64 `json:"agent_seq"`
+
+	// MessageID is the provider Message-ID the CP has recorded for that row.
+	// When present the agent compares it against its own row's message_id and
+	// refuses on a mismatch (ResendDetailMessageIDMismatch) rather than sending
+	// a message the operator did not choose — see GH #528.
+	//
+	// omitempty is load-bearing. The CP's message_id is NULL for every send
+	// that FAILED at the time (all five agent provider handlers return an empty
+	// message id on their failure branch) and for a success whose provider did
+	// not surface a Message-ID header. Failed sends are precisely the rows an
+	// operator most wants to resend, so the CP does not refuse them; it omits
+	// the key, and the omission is what tells the agent no comparison is
+	// possible. An empty string would instead read as "compare against empty"
+	// and would refuse every one of those rows.
+	MessageID string `json:"message_id,omitempty"`
 }
 
 // Known `detail` values the agent returns with ok=false. These are contract
@@ -55,6 +84,12 @@ const (
 	ResendDetailMissingSeq = "missing required field: agent_seq"
 	// ResendDetailBadSeq — agent_seq was present but not a positive integer.
 	ResendDetailBadSeq = "agent_seq must be a positive integer"
+	// ResendDetailMessageIDMismatch — GH #528. The CP sent a message_id and the
+	// agent's row at that agent_seq carries a different one, so the local id no
+	// longer names the message the operator chose. The usual cause is a site
+	// database restore rolling the AUTO_INCREMENT counter back. Refusing is
+	// correct: the alternative is sending someone else's mail.
+	ResendDetailMessageIDMismatch = "message_id_mismatch"
 )
 
 // ResendEmailResult is the response body for the `resend_email` agent command.

--- a/apps/api/internal/agentcmd/resend_email_contract_test.go
+++ b/apps/api/internal/agentcmd/resend_email_contract_test.go
@@ -2,8 +2,11 @@ package agentcmd
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
+
+func boolPtr(b bool) *bool { return &b }
 
 // TestResendEmailRequest_WireShape pins the bytes that go on the command
 // channel for a resend.
@@ -29,6 +32,162 @@ func TestResendEmailRequest_WireShape(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// The RESPONSE half of the contract
+// ---------------------------------------------------------------------------
+//
+// The request half above is pinned to exact bytes because a mismatch there
+// broke every resend on every site (GH #520). The response half now carries a
+// SECURITY-RELEVANT field and gets the same treatment.
+//
+// `verified` is the agent's attestation that it compared the message_id the CP
+// supplied against its own row and they matched (GH #528 / PR #541). Everything
+// the CP tells the operator about whether the right message went out rests on
+// it, so a rename, a drop or a type change on either side has to be a test
+// failure — not a field that quietly decodes to false and makes every resend
+// read "unconfirmed", and not one that quietly decodes to true.
+
+// wantResendResponseKeys is the exact set of JSON keys the agent's resend_email
+// handler returns on the confirmed-success path. Keep it in lockstep with
+// class-resend-email-command.php::execute().
+var wantResendResponseKeys = []string{"ok", "detail", "message_id", "verified"}
+
+// assertResendResponseShape asserts a literal agent response against the pinned
+// key set, then decodes it with UNKNOWN FIELDS REFUSED, which is what proves
+// the CP actually reads every key the agent sends under exactly these names.
+//
+// Exact in all four directions, mirroring assertResendPayload on the request
+// side:
+//   - a MISSING key fails the per-key loop,
+//   - an EXTRA key fails the length check and the strict decode,
+//   - a RENAMED key fails both at once — and a rename of `verified` is the one
+//     that matters, because a key the CP does not read leaves the field at its
+//     legacy default forever,
+//   - a WRONG VALUE fails the field comparison below.
+//
+// The strictness lives HERE, in the contract test, not in the client: the real
+// decode path must stay tolerant of keys a future agent adds. That tolerance is
+// proven separately by TestResendEmailResult_UnknownKeyIsTolerated.
+func assertResendResponseShape(t *testing.T, body string, want ResendEmailResult) {
+	t.Helper()
+
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &keys); err != nil {
+		t.Fatalf("agent response is not a JSON object: %v\n  got: %s", err, body)
+	}
+	if len(keys) != len(wantResendResponseKeys) {
+		t.Errorf("agent response has %d field(s), want %d\n  got: %s\n  want keys: %v",
+			len(keys), len(wantResendResponseKeys), body, wantResendResponseKeys)
+	}
+	for _, k := range wantResendResponseKeys {
+		if _, ok := keys[k]; !ok {
+			t.Errorf("agent response is missing %q — the CP cannot read what it is not sent\n  got: %s", k, body)
+		}
+	}
+
+	dec := json.NewDecoder(strings.NewReader(body))
+	dec.DisallowUnknownFields()
+	var got ResendEmailResult
+	if err := dec.Decode(&got); err != nil {
+		t.Fatalf("the CP does not read every key the agent sends: %v\n  got: %s", err, body)
+	}
+
+	if got.OK != want.OK {
+		t.Errorf("ok = %v, want %v\n  got: %s", got.OK, want.OK, body)
+	}
+	if got.Detail != want.Detail {
+		t.Errorf("detail = %q, want %q\n  got: %s", got.Detail, want.Detail, body)
+	}
+	if got.MessageID != want.MessageID {
+		t.Errorf("message_id = %q, want %q\n  got: %s", got.MessageID, want.MessageID, body)
+	}
+	// Presence AND value. Collapsing the two is how "the agent said nothing"
+	// and "the agent said no" became the same thing.
+	if (got.Verified == nil) != (want.Verified == nil) {
+		t.Errorf("verified present = %v, want %v\n  got: %s", got.Verified != nil, want.Verified != nil, body)
+	}
+	if got.IsVerified() != want.IsVerified() {
+		t.Errorf("IsVerified() = %v, want %v\n  got: %s", got.IsVerified(), want.IsVerified(), body)
+	}
+}
+
+// TestResendEmailResult_WireShape pins the exact response of a current agent
+// that compared the id it was given and matched it.
+func TestResendEmailResult_WireShape(t *testing.T) {
+	assertResendResponseShape(t,
+		`{"ok":true,"detail":"resent","message_id":"<abc@site>","verified":true}`,
+		ResendEmailResult{OK: true, Detail: "resent", MessageID: "<abc@site>", Verified: boolPtr(true)},
+	)
+}
+
+// TestResendEmailResult_LegacyAgentOmitsVerified is the safety property of the
+// whole change: an agent too old to know the field exists says nothing, and
+// silence must decode to "not verified", distinguishably so.
+func TestResendEmailResult_LegacyAgentOmitsVerified(t *testing.T) {
+	var got ResendEmailResult
+	if err := json.Unmarshal([]byte(`{"ok":true,"detail":"resent","message_id":"<abc@site>"}`), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Verified != nil {
+		t.Errorf("an absent key must stay absent, not become a value: %v", *got.Verified)
+	}
+	if got.IsVerified() {
+		t.Error("an agent that said nothing about verification must never read as verified")
+	}
+}
+
+// TestResendEmailResult_RenamedVerifiedKeyIsCaught proves the rename direction.
+// The strict contract decode rejects it outright, and the CP's real (lenient)
+// decode falls back to unverified rather than to verified — so even the failure
+// mode of this guard is the safe one.
+func TestResendEmailResult_RenamedVerifiedKeyIsCaught(t *testing.T) {
+	const renamed = `{"ok":true,"detail":"resent","message_id":"<abc@site>","is_verified":true}`
+
+	dec := json.NewDecoder(strings.NewReader(renamed))
+	dec.DisallowUnknownFields()
+	var strict ResendEmailResult
+	if err := dec.Decode(&strict); err == nil {
+		t.Error("a renamed verification key must be caught by the contract decode, not absorbed")
+	}
+
+	var lenient ResendEmailResult
+	if err := json.Unmarshal([]byte(renamed), &lenient); err != nil {
+		t.Fatalf("the real decode path must not hard-fail on an unread key: %v", err)
+	}
+	if lenient.IsVerified() {
+		t.Error("a key the CP does not read must not produce a verified resend")
+	}
+}
+
+// TestResendEmailResult_WrongTypeFailsClosed covers the wrong-value direction.
+// A non-boolean `verified` is a decode error, which client.post() returns as an
+// error and Client.ResendEmail turns into ok=false — the resend is reported as
+// failed rather than as verified.
+func TestResendEmailResult_WrongTypeFailsClosed(t *testing.T) {
+	var got ResendEmailResult
+	err := json.Unmarshal([]byte(`{"ok":true,"detail":"resent","message_id":"<a@site>","verified":"true"}`), &got)
+	if err == nil {
+		t.Fatal("a non-boolean verified must not decode; a string \"true\" is not an attestation")
+	}
+	if got.IsVerified() {
+		t.Error("a failed decode must leave the result unverified")
+	}
+}
+
+// TestResendEmailResult_UnknownKeyIsTolerated is the over-fire guard. The real
+// decode path must keep accepting a response from an agent NEWER than this
+// control plane, and an unread key must not move `verified` in either direction.
+func TestResendEmailResult_UnknownKeyIsTolerated(t *testing.T) {
+	var got ResendEmailResult
+	body := `{"ok":true,"detail":"resent","message_id":"<a@site>","verified":true,"queued_at":"2026-08-26T00:00:00Z"}`
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("a future agent key must not break the CP: %v", err)
+	}
+	if !got.IsVerified() {
+		t.Error("an unknown extra key must not suppress a real attestation")
+	}
+}
+
 // TestResendEmailResult_DecodesAgentResponses decodes the exact bodies the
 // agent's execute() returns, so a rename on either side is a test failure
 // rather than a silently empty result.
@@ -39,7 +198,17 @@ func TestResendEmailResult_DecodesAgentResponses(t *testing.T) {
 		want ResendEmailResult
 	}{
 		{
-			name: "resent",
+			name: "resent and confirmed",
+			body: `{"ok":true,"detail":"resent","message_id":"<abc@site>","verified":true}`,
+			want: ResendEmailResult{OK: true, Detail: "resent", MessageID: "<abc@site>", Verified: boolPtr(true)},
+		},
+		{
+			name: "resent without a confirmation to give",
+			body: `{"ok":true,"detail":"resent","message_id":"<abc@site>","verified":false}`,
+			want: ResendEmailResult{OK: true, Detail: "resent", MessageID: "<abc@site>", Verified: boolPtr(false)},
+		},
+		{
+			name: "resent by an agent too old to confirm",
 			body: `{"ok":true,"detail":"resent","message_id":"<abc@site>"}`,
 			want: ResendEmailResult{OK: true, Detail: "resent", MessageID: "<abc@site>"},
 		},
@@ -58,6 +227,11 @@ func TestResendEmailResult_DecodesAgentResponses(t *testing.T) {
 			body: `{"ok":false,"detail":"missing required field: agent_seq","message_id":""}`,
 			want: ResendEmailResult{OK: false, Detail: ResendDetailMissingSeq},
 		},
+		{
+			name: "the #528 refusal",
+			body: `{"ok":false,"detail":"message_id_mismatch","message_id":"","verified":false}`,
+			want: ResendEmailResult{OK: false, Detail: ResendDetailMessageIDMismatch, Verified: boolPtr(false)},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -65,8 +239,15 @@ func TestResendEmailResult_DecodesAgentResponses(t *testing.T) {
 			if err := json.Unmarshal([]byte(tc.body), &got); err != nil {
 				t.Fatalf("unmarshal: %v", err)
 			}
-			if got != tc.want {
-				t.Errorf("decoded %+v, want %+v", got, tc.want)
+			if got.OK != tc.want.OK || got.Detail != tc.want.Detail || got.MessageID != tc.want.MessageID {
+				t.Errorf("decoded ok=%v detail=%q message_id=%q, want ok=%v detail=%q message_id=%q",
+					got.OK, got.Detail, got.MessageID, tc.want.OK, tc.want.Detail, tc.want.MessageID)
+			}
+			if (got.Verified == nil) != (tc.want.Verified == nil) {
+				t.Errorf("verified present = %v, want %v", got.Verified != nil, tc.want.Verified != nil)
+			}
+			if got.IsVerified() != tc.want.IsVerified() {
+				t.Errorf("IsVerified() = %v, want %v", got.IsVerified(), tc.want.IsVerified())
 			}
 		})
 	}

--- a/apps/api/internal/api/gen/oas_json_gen.go
+++ b/apps/api/internal/api/gen/oas_json_gen.go
@@ -30663,12 +30663,19 @@ func (s *BulkResendItemResult) encodeFields(e *jx.Encoder) {
 			s.Detail.Encode(e)
 		}
 	}
+	{
+		if s.Verified.Set {
+			e.FieldStart("verified")
+			s.Verified.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfBulkResendItemResult = [3]string{
+var jsonFieldsNameOfBulkResendItemResult = [4]string{
 	0: "log_id",
 	1: "ok",
 	2: "detail",
+	3: "verified",
 }
 
 // Decode decodes BulkResendItemResult from json.
@@ -30713,6 +30720,16 @@ func (s *BulkResendItemResult) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"detail\"")
+			}
+		case "verified":
+			if err := func() error {
+				s.Verified.Reset()
+				if err := s.Verified.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"verified\"")
 			}
 		default:
 			return d.Skip()
@@ -96126,12 +96143,19 @@ func (s *ResendEmailResult) encodeFields(e *jx.Encoder) {
 			s.MessageID.Encode(e)
 		}
 	}
+	{
+		if s.Verified.Set {
+			e.FieldStart("verified")
+			s.Verified.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfResendEmailResult = [3]string{
+var jsonFieldsNameOfResendEmailResult = [4]string{
 	0: "ok",
 	1: "detail",
 	2: "message_id",
+	3: "verified",
 }
 
 // Decode decodes ResendEmailResult from json.
@@ -96174,6 +96198,16 @@ func (s *ResendEmailResult) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"message_id\"")
+			}
+		case "verified":
+			if err := func() error {
+				s.Verified.Reset()
+				if err := s.Verified.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"verified\"")
 			}
 		default:
 			return d.Skip()

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -40263,11 +40263,16 @@ type ResendEmailResult struct {
 	Detail OptNilString `json:"detail"`
 	// Provider message ID assigned to the resent email (if agent returned it).
 	MessageID OptNilString `json:"message_id"`
-	// Whether wpmgr was able to confirm the site resent the same message the operator selected (GH #528).
-	// The site's log ids are a local AUTO_INCREMENT that a database restore rolls back, so wpmgr sends the
-	// Message-ID it has on record and the site refuses on a mismatch. `false` means no Message-ID was
-	// recorded for that entry — normal when the original send failed — so the resend went out
-	// unconfirmed. `detail` carries the same warning in prose. Only meaningful when `ok` is true.
+	// Whether the SITE confirmed it resent the same message the operator selected (GH #528). The site's
+	// log ids are a local AUTO_INCREMENT that a database restore rolls back, so wpmgr sends the Message-ID
+	// it has on record, the site compares it against its own row, and it refuses on a mismatch. This flag
+	// is the site's answer, never wpmgr's assumption: a site that does not answer is never counted as
+	// having confirmed.
+	//
+	// `false` has two causes, and `detail` names the one that applies: no Message-ID was recorded for that
+	// entry (normal when the original send failed, and nothing to fix), or the site's wpmgr plugin is too
+	// old to perform the check (fixed by updating the plugin). Either way the message was sent and the
+	// confirmation is missing. Only meaningful when `ok` is true.
 	Verified OptBool `json:"verified"`
 }
 

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -11943,6 +11943,9 @@ type BulkResendItemResult struct {
 	LogID  uuid.UUID    `json:"log_id"`
 	Ok     bool         `json:"ok"`
 	Detail OptNilString `json:"detail"`
+	// Per-entry equivalent of ResendEmailResult.verified (GH #528). One batch routinely mixes entries that
+	// could be confirmed with entries that could not, so this is reported per entry, never per batch.
+	Verified OptBool `json:"verified"`
 }
 
 // GetLogID returns the value of LogID.
@@ -11960,6 +11963,11 @@ func (s *BulkResendItemResult) GetDetail() OptNilString {
 	return s.Detail
 }
 
+// GetVerified returns the value of Verified.
+func (s *BulkResendItemResult) GetVerified() OptBool {
+	return s.Verified
+}
+
 // SetLogID sets the value of LogID.
 func (s *BulkResendItemResult) SetLogID(val uuid.UUID) {
 	s.LogID = val
@@ -11973,6 +11981,11 @@ func (s *BulkResendItemResult) SetOk(val bool) {
 // SetDetail sets the value of Detail.
 func (s *BulkResendItemResult) SetDetail(val OptNilString) {
 	s.Detail = val
+}
+
+// SetVerified sets the value of Verified.
+func (s *BulkResendItemResult) SetVerified(val OptBool) {
+	s.Verified = val
 }
 
 // Ref: #/components/schemas/BulkResendRequest
@@ -40250,6 +40263,12 @@ type ResendEmailResult struct {
 	Detail OptNilString `json:"detail"`
 	// Provider message ID assigned to the resent email (if agent returned it).
 	MessageID OptNilString `json:"message_id"`
+	// Whether wpmgr was able to confirm the site resent the same message the operator selected (GH #528).
+	// The site's log ids are a local AUTO_INCREMENT that a database restore rolls back, so wpmgr sends the
+	// Message-ID it has on record and the site refuses on a mismatch. `false` means no Message-ID was
+	// recorded for that entry — normal when the original send failed — so the resend went out
+	// unconfirmed. `detail` carries the same warning in prose. Only meaningful when `ok` is true.
+	Verified OptBool `json:"verified"`
 }
 
 // GetOk returns the value of Ok.
@@ -40267,6 +40286,11 @@ func (s *ResendEmailResult) GetMessageID() OptNilString {
 	return s.MessageID
 }
 
+// GetVerified returns the value of Verified.
+func (s *ResendEmailResult) GetVerified() OptBool {
+	return s.Verified
+}
+
 // SetOk sets the value of Ok.
 func (s *ResendEmailResult) SetOk(val bool) {
 	s.Ok = val
@@ -40280,6 +40304,11 @@ func (s *ResendEmailResult) SetDetail(val OptNilString) {
 // SetMessageID sets the value of MessageID.
 func (s *ResendEmailResult) SetMessageID(val OptNilString) {
 	s.MessageID = val
+}
+
+// SetVerified sets the value of Verified.
+func (s *ResendEmailResult) SetVerified(val OptBool) {
+	s.Verified = val
 }
 
 func (*ResendEmailResult) resendEmailLogRes() {}

--- a/apps/api/internal/email/handler.go
+++ b/apps/api/internal/email/handler.go
@@ -613,6 +613,12 @@ func resendAuditMeta(logID uuid.UUID, res ResendResult) (map[string]any, bool) {
 		// resend from an unconfirmed one is the same defect as one that records
 		// intentions: it is believed.
 		"verified": res.Verified,
+		// PR #542 review: an unverified resend has two causes with different
+		// remedies (see ResendResult.LegacyAgent). An audit row that collapses
+		// them is the same defect one layer down — it cannot tell a reader
+		// auditing this site's history whether the plugin needed updating or
+		// nothing was wrong at all. Meaningless (false) when verified is true.
+		"legacy_agent": res.LegacyAgent,
 	}, true
 }
 
@@ -623,7 +629,7 @@ func resendAuditMeta(logID uuid.UUID, res ResendResult) (map[string]any, bool) {
 // reading {"count": N}. `requested` is kept beside it so a partial batch stays
 // legible, and a batch that resent nothing writes no row at all.
 func bulkResendAuditMeta(requested int, results []BulkResendResult) (map[string]any, bool) {
-	resent, unverified := 0, 0
+	resent, unverified, legacyAgent := 0, 0, 0
 	for _, r := range results {
 		if !r.OK {
 			continue
@@ -631,6 +637,9 @@ func bulkResendAuditMeta(requested int, results []BulkResendResult) (map[string]
 		resent++
 		if !r.Verified {
 			unverified++
+			if r.LegacyAgent {
+				legacyAgent++
+			}
 		}
 	}
 	if resent == 0 {
@@ -642,6 +651,11 @@ func bulkResendAuditMeta(requested int, results []BulkResendResult) (map[string]
 		// GH #528: how many of those confirmed resends went out without the
 		// site confirming the row identity. Counted, not summarised away.
 		"unverified": unverified,
+		// PR #542 review: of those unverified, how many were unverifiable
+		// because the site's agent is too old to attest at all (fixable by
+		// updating the plugin), versus a current agent correctly reporting it
+		// had nothing to compare (nothing to fix). See ResendResult.LegacyAgent.
+		"legacy_agent_count": legacyAgent,
 	}, true
 }
 

--- a/apps/api/internal/email/handler.go
+++ b/apps/api/internal/email/handler.go
@@ -759,6 +759,11 @@ func (h *Handler) bulkResendLog(c *gin.Context) {
 			"log_id": r.LogID.String(),
 			"ok":     r.OK,
 			"detail": r.Detail,
+			// GH #528: BulkResendItemResult declares `verified` in the spec, so
+			// the body has to carry it. A batch routinely mixes confirmed and
+			// unconfirmed entries and only the per-entry flag can tell an
+			// operator which of the two a given row was.
+			"verified": r.Verified,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"results": dtos})

--- a/apps/api/internal/email/handler.go
+++ b/apps/api/internal/email/handler.go
@@ -613,11 +613,15 @@ func resendAuditMeta(logID uuid.UUID, res ResendResult) (map[string]any, bool) {
 		// resend from an unconfirmed one is the same defect as one that records
 		// intentions: it is believed.
 		"verified": res.Verified,
-		// PR #542 review: an unverified resend has two causes with different
-		// remedies (see ResendResult.LegacyAgent). An audit row that collapses
-		// them is the same defect one layer down — it cannot tell a reader
-		// auditing this site's history whether the plugin needed updating or
-		// nothing was wrong at all. Meaningless (false) when verified is true.
+		// PR #542 review: an unverified resend has two fixable-or-not causes
+		// with different remedies (see ResendResult.LegacyAgent). An audit row
+		// that collapses them is the same defect one layer down — it cannot
+		// tell a reader auditing this site's history whether the plugin
+		// needed updating or nothing was wrong at all. ResendResult.LegacyAgent
+		// is already gated on askedForCheck, so a request that never had a
+		// Message-ID to send records false here too: "legacy agent" is a
+		// verdict on this response, not an inference from silence when
+		// nothing was asked. Meaningless (false) when verified is true.
 		"legacy_agent": res.LegacyAgent,
 	}, true
 }

--- a/apps/api/internal/email/handler.go
+++ b/apps/api/internal/email/handler.go
@@ -608,6 +608,11 @@ func resendAuditMeta(logID uuid.UUID, res ResendResult) (map[string]any, bool) {
 	return map[string]any{
 		"log_id":     logID.String(),
 		"message_id": res.MessageID,
+		// GH #528: whether the site confirmed it resent the message the
+		// operator selected. An audit row that cannot distinguish a confirmed
+		// resend from an unconfirmed one is the same defect as one that records
+		// intentions: it is believed.
+		"verified": res.Verified,
 	}, true
 }
 
@@ -618,10 +623,14 @@ func resendAuditMeta(logID uuid.UUID, res ResendResult) (map[string]any, bool) {
 // reading {"count": N}. `requested` is kept beside it so a partial batch stays
 // legible, and a batch that resent nothing writes no row at all.
 func bulkResendAuditMeta(requested int, results []BulkResendResult) (map[string]any, bool) {
-	resent := 0
+	resent, unverified := 0, 0
 	for _, r := range results {
-		if r.OK {
-			resent++
+		if !r.OK {
+			continue
+		}
+		resent++
+		if !r.Verified {
+			unverified++
 		}
 	}
 	if resent == 0 {
@@ -630,6 +639,9 @@ func bulkResendAuditMeta(requested int, results []BulkResendResult) (map[string]
 	return map[string]any{
 		"count":     resent,
 		"requested": requested,
+		// GH #528: how many of those confirmed resends went out without the
+		// site confirming the row identity. Counted, not summarised away.
+		"unverified": unverified,
 	}, true
 }
 
@@ -659,6 +671,7 @@ func (h *Handler) resendLog(c *gin.Context) {
 		"ok":         result.OK,
 		"detail":     result.Detail,
 		"message_id": result.MessageID,
+		"verified":   result.Verified,
 	})
 }
 

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -609,6 +609,13 @@ type ResendResult struct {
 	// the question. It is never silently false — Detail names the cause and the
 	// audit row records the flag.
 	Verified bool
+	// LegacyAgent distinguishes those two causes (PR #542 review): true when
+	// the agent's response omitted `verified` altogether (too old to know the
+	// field exists — updating the plugin is the fix), false when a current
+	// agent answered `verified: false` out loud (it ran and had nothing to
+	// compare, normally because the original send failed — nothing to fix).
+	// Meaningless when Verified is true.
+	LegacyAgent bool
 }
 
 // BulkResendInput is the request for POST /sites/:siteId/email/log/resend (bulk).
@@ -627,6 +634,8 @@ type BulkResendResult struct {
 	// per-batch: one batch routinely mixes rows that could be confirmed with
 	// rows that could not.
 	Verified bool
+	// LegacyAgent mirrors ResendResult.LegacyAgent for this entry — see there.
+	LegacyAgent bool
 }
 
 // BulkDeleteLogsInput is the request for DELETE /sites/:siteId/email/log (bulk).

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -609,12 +609,15 @@ type ResendResult struct {
 	// the question. It is never silently false — Detail names the cause and the
 	// audit row records the flag.
 	Verified bool
-	// LegacyAgent distinguishes those two causes (PR #542 review): true when
-	// the agent's response omitted `verified` altogether (too old to know the
-	// field exists — updating the plugin is the fix), false when a current
-	// agent answered `verified: false` out loud (it ran and had nothing to
-	// compare, normally because the original send failed — nothing to fix).
-	// Meaningless when Verified is true.
+	// LegacyAgent distinguishes those two causes (PR #542 review, second
+	// pass): true only when the CP actually had a Message-ID to send AND the
+	// agent's response omitted `verified` altogether (too old to know the
+	// field exists — updating the plugin is the fix). False both when a
+	// current agent answered `verified: false` out loud (it ran and had
+	// nothing to compare) and when the CP never sent a Message-ID at all — in
+	// that case the agent's silence proves nothing about its version, so
+	// recording legacy_agent=true would state an intention rather than a
+	// fact. Meaningless when Verified is true.
 	LegacyAgent bool
 }
 

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -425,6 +425,11 @@ type LogDetail struct {
 type ResendTarget struct {
 	AgentSeq   *int64
 	BodyStored bool
+	// MessageID is the provider Message-ID recorded for this row, or nil when
+	// none was ever captured. Sent to the agent as the #528 confirmation
+	// selector when present. Nil is common and expected — see
+	// agentcmd.ResendEmailRequest.MessageID.
+	MessageID *string
 }
 
 // IngestEntry is one entry from the agent's ingest push.
@@ -595,6 +600,12 @@ type ResendResult struct {
 	OK        bool
 	Detail    string
 	MessageID string
+	// Verified reports whether the CP was able to ask the site to confirm it
+	// was resending the same message the operator selected (GH #528). False
+	// means the row carried no recorded Message-ID to compare against, so the
+	// send went out unconfirmed. It is never silently false: Detail carries
+	// resendUnverifiedNote() alongside it and the audit row records it.
+	Verified bool
 }
 
 // BulkResendInput is the request for POST /sites/:siteId/email/log/resend (bulk).
@@ -609,6 +620,10 @@ type BulkResendResult struct {
 	LogID  uuid.UUID
 	OK     bool
 	Detail string
+	// Verified mirrors ResendResult.Verified for this entry. Per-entry, not
+	// per-batch: one batch routinely mixes rows that could be confirmed with
+	// rows that could not.
+	Verified bool
 }
 
 // BulkDeleteLogsInput is the request for DELETE /sites/:siteId/email/log (bulk).

--- a/apps/api/internal/email/model.go
+++ b/apps/api/internal/email/model.go
@@ -600,11 +600,14 @@ type ResendResult struct {
 	OK        bool
 	Detail    string
 	MessageID string
-	// Verified reports whether the CP was able to ask the site to confirm it
-	// was resending the same message the operator selected (GH #528). False
-	// means the row carried no recorded Message-ID to compare against, so the
-	// send went out unconfirmed. It is never silently false: Detail carries
-	// resendUnverifiedNote() alongside it and the audit row records it.
+	// Verified is the SITE's confirmation that it resent the same message the
+	// operator selected (GH #528) — agentcmd.ResendEmailResult.IsVerified(),
+	// never anything the CP inferred from its own request.
+	//
+	// False has two causes, both unconfirmed sends: the row carried no recorded
+	// Message-ID to compare against, or the site's plugin is too old to answer
+	// the question. It is never silently false — Detail names the cause and the
+	// audit row records the flag.
 	Verified bool
 }
 

--- a/apps/api/internal/email/repo.go
+++ b/apps/api/internal/email/repo.go
@@ -1710,7 +1710,8 @@ func (r *Repo) PruneWebhookDedup(ctx context.Context, cutoffTs time.Time) (int64
 
 // GetResendTarget fetches everything a resend dispatch needs to decide whether
 // the command can succeed, and to name the row to the agent: the agent-local
-// row id (agent_seq) and the body_stored flag.
+// row id (agent_seq), the body_stored flag, and the recorded Message-ID that
+// confirms agent_seq still names the message the operator chose (GH #528).
 //
 // GH #520: the resend gate used to read body_stored alone, because the CP
 // believed it was sending the body itself. The agent addresses its own log by
@@ -1736,6 +1737,10 @@ func (r *Repo) GetResendTarget(ctx context.Context, tenantID, siteID, id uuid.UU
 		}
 		target.AgentSeq = row.AgentSeq
 		target.BodyStored = row.BodyStored
+		// GH #528: the recorded Message-ID is the confirmation selector the
+		// agent checks its own row against. Nullable, and legitimately null for
+		// failed sends — the service handles the absence, it does not refuse.
+		target.MessageID = row.MessageID
 		return nil
 	})
 	return target, err

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -479,6 +479,69 @@ func TestResendEmail_LegacyAgentSilence_IsNotVerified(t *testing.T) {
 	}
 }
 
+// TestResendEmail_NoMessageID_LegacyAgentSilence_IsNotAPluginProblem is the
+// regression test for a CodeRabbit thread on PR #542: the combination the
+// legacyAgent-only branching in this same PR's first pass got wrong.
+//
+// The row has no recorded Message-ID (askedForCheck=false, the ordinary shape
+// of a resend whose original send failed), AND the agent's response happens to
+// omit `verified` altogether — the same wire shape as a legacy agent's
+// silence. The first pass keyed the operator note on that silence alone
+// (legacyAgent := res.Verified == nil) and told this operator to update the
+// plugin. That advice cannot possibly help: the CP never had a Message-ID to
+// send, so no agent of any version — current or legacy — could have confirmed
+// anything. Whether nothing could be checked must be decided before whether
+// the agent stayed silent; it wins over legacyAgent, not the other way round.
+func TestResendEmail_NoMessageID_LegacyAgentSilence_IsNotAPluginProblem(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	const agentSeq int64 = 202
+
+	repo := newFakeResendRepo(logID, agentSeq) // no message_id — a failed send
+	// Same wire shape as TestResendEmail_LegacyAgentSilence_IsNotVerified: no
+	// `verified` key at all. The only difference is this row never had a
+	// Message-ID to send in the first place.
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>"}`)}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("a row without a Message-ID must still resend, got ok=false detail=%q", res.Detail)
+	}
+	if agent.lastReq.MessageID != "" {
+		t.Fatalf("precondition: this row has no Message-ID, so none may be sent; got %q", agent.lastReq.MessageID)
+	}
+	if res.Verified {
+		t.Error("the agent returned no `verified` field; this must not report a verified resend")
+	}
+	if !strings.Contains(res.Detail, "could not confirm") {
+		t.Errorf("an unconfirmed resend must say so to the operator, got %q", res.Detail)
+	}
+	// The crux of the bug: nothing could have been checked, so telling this
+	// operator to update the plugin is advice that cannot help.
+	if strings.Contains(res.Detail, "too old") || strings.Contains(res.Detail, "Update the plugin") {
+		t.Errorf("no Message-ID was ever sent, so this is not a plugin problem, got %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "no provider message ID was recorded") {
+		t.Errorf("expected the no-recorded-id cause, got %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "nothing to fix") {
+		t.Errorf("the operator must be told plainly there is nothing to fix, got %q", res.Detail)
+	}
+
+	meta, ok := resendAuditMeta(logID, res)
+	if !ok {
+		t.Fatal("a completed send must still be audited when unverified")
+	}
+	if meta["legacy_agent"] != false {
+		t.Errorf("audit metadata legacy_agent = %v, want false: a request that never asked for a "+
+			"check cannot use the agent's silence as evidence it is a legacy agent", meta["legacy_agent"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GH #528, PR #542 review — the CP never normalises a Message-ID it dispatches
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -244,6 +244,8 @@ func TestResendEmail_DispatchedPayloadMatchesAgentContract(t *testing.T) {
 		t.Error("a confirmed resend must be audited")
 	} else if meta["verified"] != true {
 		t.Errorf("audit metadata verified = %v, want true", meta["verified"])
+	} else if meta["legacy_agent"] != false {
+		t.Errorf("audit metadata legacy_agent = %v, want false", meta["legacy_agent"])
 	}
 }
 
@@ -273,6 +275,19 @@ func TestResendEmail_AgentSaysUnverified_IsNotVerified(t *testing.T) {
 	}
 	if !strings.Contains(res.Detail, "could not confirm") {
 		t.Errorf("an unconfirmed resend must say so to the operator, got %q", res.Detail)
+	}
+	// PR #542 review: an EXPLICIT `verified:false` is a current agent saying it
+	// ran and had nothing to compare. That is never a plugin problem, so the
+	// note must never send this operator to update anything — even though the
+	// CP DID have a Message-ID to send (askedForCheck=true), which is exactly
+	// the case the old askedForCheck-keyed wording got wrong.
+	if strings.Contains(res.Detail, "too old") || strings.Contains(res.Detail, "Update the plugin") {
+		t.Errorf("a current agent's explicit verified=false is not a plugin problem, got %q", res.Detail)
+	}
+	if meta, ok := resendAuditMeta(logID, res); !ok {
+		t.Error("a completed send must still be audited when unverified")
+	} else if meta["legacy_agent"] != false {
+		t.Errorf("audit metadata legacy_agent = %v, want false (the agent answered explicitly)", meta["legacy_agent"])
 	}
 }
 
@@ -348,6 +363,10 @@ func TestResendEmail_NoMessageID_OmitsKeyAndReportsUnverified(t *testing.T) {
 	if strings.Contains(res.Detail, "too old") {
 		t.Errorf("this site's plugin is not the problem; the note misdirects: %q", res.Detail)
 	}
+	// PR #542 review: this state must say plainly that there is nothing to fix.
+	if !strings.Contains(res.Detail, "nothing to fix") {
+		t.Errorf("an explicit verified=false with no prior Message-ID must tell the operator there is nothing to fix, got %q", res.Detail)
+	}
 
 	// The audit row must record it too, or the log cannot tell the two apart.
 	meta, ok := resendAuditMeta(logID, res)
@@ -356,6 +375,10 @@ func TestResendEmail_NoMessageID_OmitsKeyAndReportsUnverified(t *testing.T) {
 	}
 	if meta["verified"] != false {
 		t.Errorf("audit metadata verified = %v, want false", meta["verified"])
+	}
+	// This is a current agent answering honestly, not one too old to attest.
+	if meta["legacy_agent"] != false {
+		t.Errorf("audit metadata legacy_agent = %v, want false", meta["legacy_agent"])
 	}
 }
 
@@ -438,6 +461,11 @@ func TestResendEmail_LegacyAgentSilence_IsNotVerified(t *testing.T) {
 	if strings.Contains(res.Detail, "no provider message ID was recorded") {
 		t.Errorf("wrong cause reported: the CP had a Message-ID and sent it, got %q", res.Detail)
 	}
+	// PR #542 review: an agent old enough to omit `verified` entirely is
+	// exactly the state where updating the plugin is the fix — say so.
+	if !strings.Contains(res.Detail, "Update the plugin") {
+		t.Errorf("a legacy agent's silence must tell the operator to update the plugin, got %q", res.Detail)
+	}
 
 	meta, ok := resendAuditMeta(logID, res)
 	if !ok {
@@ -445,6 +473,9 @@ func TestResendEmail_LegacyAgentSilence_IsNotVerified(t *testing.T) {
 	}
 	if meta["verified"] != false {
 		t.Errorf("audit metadata verified = %v, want false", meta["verified"])
+	}
+	if meta["legacy_agent"] != true {
+		t.Errorf("audit metadata legacy_agent = %v, want true (the agent never answered `verified`)", meta["legacy_agent"])
 	}
 }
 

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -449,6 +449,99 @@ func TestResendEmail_LegacyAgentSilence_IsNotVerified(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// GH #528, PR #542 review — the CP never normalises a Message-ID it dispatches
+// ---------------------------------------------------------------------------
+//
+// The agent now compares raw bytes on both sides, untouched, and pins that
+// with its own tests (PR #541): test_whitespace_only_supplied_id_is_compared_
+// not_discarded, test_supplied_id_padded_with_whitespace_is_a_mismatch, and
+// test_identically_padded_ids_on_both_sides_still_resend. The CP used to call
+// strings.TrimSpace on the way out, which disagreed with that contract in two
+// directions: a row stored as "  <a@x>  " would dispatch as "<a@x>", so a
+// byte-comparing agent sees a mismatch and refuses a legitimate resend, and a
+// row stored as "   " would trim to "" and the CP would omit the key, so the
+// agent skips verification and sends the mail unverified — the exact outcome
+// #528 exists to prevent.
+//
+// The rule: nil, or exactly "", omits the key. Anything else — including a
+// whitespace-only or whitespace-padded id — goes out verbatim.
+
+func TestResendEmail_NilMessageID_OmitsKey(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := newFakeResendRepo(logID, 501) // addRow leaves MessageID nil
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":false}`)}
+	svc := newResendSvc(repo, agent)
+
+	_, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	assertResendPayload(t, agent.lastReq, wantResendKeysUnverified, map[string]any{
+		"agent_seq": int64(501),
+	})
+}
+
+func TestResendEmail_EmptyMessageID_OmitsKey(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRowWithMessageID(logID, 502, "") // exactly empty, distinct from nil
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":false}`)}
+	svc := newResendSvc(repo, agent)
+
+	_, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	assertResendPayload(t, agent.lastReq, wantResendKeysUnverified, map[string]any{
+		"agent_seq": int64(502),
+	})
+}
+
+// TestResendEmail_WhitespaceOnlyMessageID_SentVerbatim is the case #528's fix
+// mishandled: TrimSpace turns a whitespace-only id into "", which is the
+// OMITTED shape, not the verbatim shape a raw-byte-comparing agent expects.
+func TestResendEmail_WhitespaceOnlyMessageID_SentVerbatim(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRowWithMessageID(logID, 503, "   ") // whitespace-only, not empty
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":true}`)}
+	svc := newResendSvc(repo, agent)
+
+	_, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	assertResendPayload(t, agent.lastReq, wantResendKeysVerified, map[string]any{
+		"agent_seq":  int64(503),
+		"message_id": "   ",
+	})
+}
+
+// TestResendEmail_PaddedMessageID_SentWithPadIntact is the other half: a
+// stored id with real content and surrounding whitespace must reach the agent
+// with both pads intact, or a legitimate resend is refused as a mismatch.
+func TestResendEmail_PaddedMessageID_SentWithPadIntact(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRowWithMessageID(logID, 504, "  <a@x>  ")
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":true}`)}
+	svc := newResendSvc(repo, agent)
+
+	_, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	assertResendPayload(t, agent.lastReq, wantResendKeysVerified, map[string]any{
+		"agent_seq":  int64(504),
+		"message_id": "  <a@x>  ",
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Accounting: resent_count and the audit row move on SUCCESS only
 // ---------------------------------------------------------------------------
 
@@ -777,7 +870,7 @@ func TestResendFailureMessage(t *testing.T) {
 		{
 			name:   "#528 row identity mismatch",
 			detail: agentcmd.ResendDetailMessageIDMismatch,
-			want:   "no longer the message shown here",
+			want:   "this entry can't be resent from here",
 		},
 		{name: "old plugin", detail: "resend_email command rejected by agent: status 404 body=x", want: "too old"},
 		{name: "silent refusal", detail: "", want: "without giving a reason"},

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -35,9 +35,81 @@ import (
 // The agent's reader is apps/agent/includes/commands/class-resend-email-command.php:
 // execute() rejects a params array without agent_seq before anything else runs.
 
-// wantResendKeys is the exact set of JSON keys the agent's resend_email handler
-// reads. Keep this in lockstep with class-resend-email-command.php::execute().
-var wantResendKeys = []string{"agent_seq"}
+// GH #528 — agent_seq alone is not a safe selector.
+//
+// agent_seq is a MySQL AUTO_INCREMENT on the site's own table. A database
+// restore rolls it back, later sends re-use ids the CP has already bound to
+// other messages, and the operator's "Resend Alice's invoice" becomes "send
+// Bob's password reset to Bob". The CP now sends the recorded Message-ID
+// alongside it so the agent can confirm the row before it sends.
+//
+// The payload therefore has TWO shapes, and both are pinned below:
+//
+//	verified   {"agent_seq": N, "message_id": "<...>"}  — CP had a Message-ID
+//	unverified {"agent_seq": N}                          — CP had none
+//
+// The unverified shape is not a degenerate case to wave through. message_id is
+// NULL on the CP for every send that failed at the time, which is the most
+// common thing anyone resends, so this shape is the common one and it must stay
+// exactly one key: an empty "message_id" on the wire would read to the agent as
+// "compare against empty" and refuse every such row.
+
+// wantResendKeysVerified is the exact set of JSON keys the agent's resend_email
+// handler reads when the CP has a Message-ID to confirm against.
+// Keep this in lockstep with class-resend-email-command.php::execute().
+var wantResendKeysVerified = []string{"agent_seq", "message_id"}
+
+// wantResendKeysUnverified is the exact set when the CP has no Message-ID.
+// message_id must be ABSENT, not empty.
+var wantResendKeysUnverified = []string{"agent_seq"}
+
+// assertResendPayload marshals the request the service actually dispatched and
+// asserts it against an exact key set and exact values.
+//
+// Exact in all four directions, which is the whole point of this file:
+//   - a MISSING key fails the per-key loop (the #520 bug),
+//   - an EXTRA key fails the length check (data on the command channel the
+//     agent never reads — how message bodies would leak back onto the wire),
+//   - a RENAMED key fails both at once,
+//   - a WRONG VALUE fails the value comparison.
+func assertResendPayload(t *testing.T, req agentcmd.ResendEmailRequest, wantKeys []string, wantValues map[string]any) {
+	t.Helper()
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal dispatched request: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal dispatched request: %v", err)
+	}
+
+	if len(got) != len(wantKeys) {
+		t.Errorf("dispatched payload has %d field(s), want %d\n  got:  %s\n  want keys: %v",
+			len(got), len(wantKeys), raw, wantKeys)
+	}
+	for _, k := range wantKeys {
+		if _, ok := got[k]; !ok {
+			t.Errorf("dispatched payload is missing %q — the agent cannot act on this request\n  got: %s", k, raw)
+		}
+	}
+	for k, want := range wantValues {
+		switch w := want.(type) {
+		case int64:
+			n, ok := got[k].(float64)
+			if !ok || int64(n) != w {
+				t.Errorf("%s = %v, want %d\n  got: %s", k, got[k], w, raw)
+			}
+		case string:
+			s, ok := got[k].(string)
+			if !ok || s != w {
+				t.Errorf("%s = %v, want %q\n  got: %s", k, got[k], w, raw)
+			}
+		default:
+			t.Fatalf("assertResendPayload: unsupported want type for %q", k)
+		}
+	}
+}
 
 // fakeResendAgent captures the ResendEmailRequest the service dispatches.
 type fakeResendAgent struct {
@@ -78,12 +150,24 @@ func newFakeResendRepo(logID uuid.UUID, agentSeq int64) *fakeResendRepo {
 	return r
 }
 
+// addRow adds a row with NO recorded Message-ID — the #528 unverified shape,
+// and the shape every row of a failed send has.
 func (r *fakeResendRepo) addRow(id uuid.UUID, agentSeq int64, bodyStored bool) {
 	t := ResendTarget{BodyStored: bodyStored}
 	if agentSeq != 0 {
 		seq := agentSeq
 		t.AgentSeq = &seq
 	}
+	r.rows[id] = t
+}
+
+// addRowWithMessageID adds a row that DOES carry a recorded Message-ID, so the
+// dispatch can be confirmed by the agent.
+func (r *fakeResendRepo) addRowWithMessageID(id uuid.UUID, agentSeq int64, messageID string) {
+	r.addRow(id, agentSeq, true)
+	t := r.rows[id]
+	m := messageID
+	t.MessageID = &m
 	r.rows[id] = t
 }
 
@@ -113,13 +197,16 @@ func newResendSvc(repo repository, agent AgentEmailClient) *Service {
 }
 
 // TestResendEmail_DispatchedPayloadMatchesAgentContract is the regression test
-// for GH #520. It asserts the literal JSON the agent would receive.
+// for GH #520, extended for GH #528. It asserts the literal JSON the agent
+// would receive, in both the verified and the unverified shape.
 func TestResendEmail_DispatchedPayloadMatchesAgentContract(t *testing.T) {
 	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
 	const agentSeq int64 = 4242
+	const storedMsgID = "<stored-4242@site.example>"
 
-	repo := newFakeResendRepo(logID, agentSeq)
-	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true, Detail: "resent", MessageID: "<m@site>"}}
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRowWithMessageID(logID, agentSeq, storedMsgID)
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true, Detail: "resent", MessageID: "<new@site>"}}
 	svc := newResendSvc(repo, agent)
 
 	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
@@ -133,29 +220,63 @@ func TestResendEmail_DispatchedPayloadMatchesAgentContract(t *testing.T) {
 		t.Fatalf("expected exactly 1 agent dispatch, got %d", agent.calls)
 	}
 
-	raw, err := json.Marshal(agent.lastReq)
-	if err != nil {
-		t.Fatalf("marshal dispatched request: %v", err)
+	// message_id must be the CP's RECORDED id for the row (the selector the
+	// agent compares against), never the id the agent returns for the new send.
+	assertResendPayload(t, agent.lastReq, wantResendKeysVerified, map[string]any{
+		"agent_seq":  agentSeq,
+		"message_id": storedMsgID,
+	})
+
+	if !res.Verified {
+		t.Error("a dispatch that carried message_id must report Verified=true")
 	}
-	var got map[string]any
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("unmarshal dispatched request: %v", err)
+	if strings.Contains(res.Detail, "could not confirm") {
+		t.Errorf("a verified resend must not carry the unverified note: %q", res.Detail)
+	}
+}
+
+// TestResendEmail_NoMessageID_OmitsKeyAndReportsUnverified pins the other half
+// of the #528 decision: a row with no recorded Message-ID is still resent, the
+// key is ABSENT rather than empty, and the operator is told it was not
+// confirmed. The forbidden outcome is sending unconfirmed and saying nothing.
+func TestResendEmail_NoMessageID_OmitsKeyAndReportsUnverified(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	const agentSeq int64 = 99
+
+	repo := newFakeResendRepo(logID, agentSeq) // no message_id — a failed send
+	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true, Detail: "resent", MessageID: "<new@site>"}}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("a row without a Message-ID must still resend, got ok=false detail=%q", res.Detail)
+	}
+	if agent.calls != 1 {
+		t.Fatalf("expected exactly 1 agent dispatch, got %d", agent.calls)
 	}
 
-	// Exact key set — a missing key is the #520 bug, an extra key puts data on
-	// the command channel that the agent never reads.
-	if len(got) != len(wantResendKeys) {
-		t.Errorf("dispatched payload has %d field(s), want %d\n  got:  %s\n  want keys: %v",
-			len(got), len(wantResendKeys), raw, wantResendKeys)
+	// Exactly one key. An empty "message_id" would make the agent refuse.
+	assertResendPayload(t, agent.lastReq, wantResendKeysUnverified, map[string]any{
+		"agent_seq": agentSeq,
+	})
+
+	if res.Verified {
+		t.Error("a dispatch with no message_id must report Verified=false")
 	}
-	for _, k := range wantResendKeys {
-		if _, ok := got[k]; !ok {
-			t.Errorf("dispatched payload is missing %q — the agent rejects this request\n  got: %s", k, raw)
-		}
+	if !strings.Contains(res.Detail, "could not confirm") {
+		t.Errorf("an unverified resend must say so to the operator, got %q", res.Detail)
 	}
-	// agent_seq must be the row's own local id, as a JSON number.
-	if n, ok := got["agent_seq"].(float64); !ok || int64(n) != agentSeq {
-		t.Errorf("agent_seq = %v, want %d\n  got: %s", got["agent_seq"], agentSeq, raw)
+
+	// The audit row must record it too, or the log cannot tell the two apart.
+	meta, ok := resendAuditMeta(logID, res)
+	if !ok {
+		t.Fatal("a confirmed send must still be audited even when unverified")
+	}
+	if meta["verified"] != false {
+		t.Errorf("audit metadata verified = %v, want false", meta["verified"])
 	}
 }
 
@@ -291,7 +412,7 @@ func TestBulkResendEmail_MixedOutcomes(t *testing.T) {
 	okID, refusedID, noSeqID, missingID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 
 	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
-	repo.addRow(okID, 11, true)
+	repo.addRowWithMessageID(okID, 11, "<a-orig@site>")
 	repo.addRow(refusedID, 12, true)
 	repo.addRow(noSeqID, 0, true)
 
@@ -360,6 +481,58 @@ func TestBulkResendEmail_MixedOutcomes(t *testing.T) {
 	if meta["requested"] != len(ids) {
 		t.Errorf("audit requested = %v, want %d", meta["requested"], len(ids))
 	}
+	// GH #528: the only entry that resent carried a Message-ID, so none of the
+	// confirmed sends were unverified.
+	if meta["unverified"] != 0 {
+		t.Errorf("audit unverified = %v, want 0", meta["unverified"])
+	}
+
+	// Each addressable row must be addressed with its OWN selectors — the row
+	// with a recorded Message-ID sends it, the row without omits it. A batch
+	// that reused one row's message_id for the whole batch would be the #528
+	// bug wearing a fix.
+	if got := agent.msgIDs; len(got) != 2 || got[0] != "<a-orig@site>" || got[1] != "" {
+		t.Errorf("agent saw message_id sequence %q, want [\"<a-orig@site>\" \"\"]", got)
+	}
+}
+
+// TestBulkResendEmail_UnverifiedCounted proves the bulk audit row distinguishes
+// a confirmed resend from an unconfirmed one rather than collapsing both into
+// `count`.
+func TestBulkResendEmail_UnverifiedCounted(t *testing.T) {
+	tenantID, siteID := uuid.New(), uuid.New()
+	withID, withoutID := uuid.New(), uuid.New()
+
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRowWithMessageID(withID, 31, "<x@site>")
+	repo.addRow(withoutID, 32, true)
+
+	agent := &perSeqResendAgent{results: map[int64]agentcmd.ResendEmailResult{
+		31: {OK: true, Detail: "resent", MessageID: "<n1@site>"},
+		32: {OK: true, Detail: "resent", MessageID: "<n2@site>"},
+	}}
+	svc := newResendSvc(repo, agent)
+
+	results, err := svc.BulkResendEmail(context.Background(), tenantID, siteID, []uuid.UUID{withID, withoutID})
+	if err != nil {
+		t.Fatalf("BulkResendEmail: unexpected error: %v", err)
+	}
+	for _, r := range results {
+		wantVerified := r.LogID == withID
+		if r.Verified != wantVerified {
+			t.Errorf("log %s: Verified=%v, want %v", r.LogID, r.Verified, wantVerified)
+		}
+	}
+	meta, ok := bulkResendAuditMeta(2, results)
+	if !ok {
+		t.Fatal("a batch with confirmed resends must be audited")
+	}
+	if meta["count"] != 2 {
+		t.Errorf("audit count = %v, want 2", meta["count"])
+	}
+	if meta["unverified"] != 1 {
+		t.Errorf("audit unverified = %v, want 1", meta["unverified"])
+	}
 }
 
 // TestBulkResendEmail_AllFail_NoAuditRow is the N-commands-zero-emails case:
@@ -391,6 +564,7 @@ func TestBulkResendEmail_AllFail_NoAuditRow(t *testing.T) {
 type perSeqResendAgent struct {
 	calls   int
 	seqs    []int64
+	msgIDs  []string
 	results map[int64]agentcmd.ResendEmailResult
 }
 
@@ -405,6 +579,7 @@ func (f *perSeqResendAgent) SendTestEmail(_ context.Context, _ uuid.UUID, _ stri
 func (f *perSeqResendAgent) ResendEmail(_ context.Context, _ uuid.UUID, _ string, req agentcmd.ResendEmailRequest) (agentcmd.ResendEmailResult, error) {
 	f.calls++
 	f.seqs = append(f.seqs, req.AgentSeq)
+	f.msgIDs = append(f.msgIDs, req.MessageID)
 	res, ok := f.results[req.AgentSeq]
 	if !ok {
 		return agentcmd.ResendEmailResult{OK: false, Detail: agentcmd.ResendDetailRowNotFound}, nil
@@ -428,6 +603,11 @@ func TestResendFailureMessage(t *testing.T) {
 		{name: "unconfigured", detail: "no email config, run sync_email_config first", want: "no email configuration yet"},
 		{name: "the #520 string", detail: agentcmd.ResendDetailMissingSeq, want: "update the wpmgr plugin"},
 		{name: "bad seq", detail: agentcmd.ResendDetailBadSeq, want: "update the wpmgr plugin"},
+		{
+			name:   "#528 row identity mismatch",
+			detail: agentcmd.ResendDetailMessageIDMismatch,
+			want:   "no longer the message shown here",
+		},
 		{name: "old plugin", detail: "resend_email command rejected by agent: status 404 body=x", want: "too old"},
 		{name: "silent refusal", detail: "", want: "without giving a reason"},
 		{

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -991,3 +991,65 @@ func TestResendFailureMessage(t *testing.T) {
 		})
 	}
 }
+
+// TestResendUnverifiedNote_DefaultCase pins case 2 of resendUnverifiedNote's
+// doc comment directly: askedForCheck=true, legacyAgent=false. A provider
+// message ID WAS sent, and a current agent answered the comparison honestly
+// with verified:false. Before this fix, this branch returned the identical
+// sentence as the !askedForCheck case ("no provider message ID was recorded
+// for this entry"), which is the opposite of what happened here and
+// contradicted the doc comment immediately above the switch.
+//
+// As built, apps/agent's ResendEmailCommand::execute() cannot actually
+// produce this combination end to end (see the comment on the default case
+// in resendUnverifiedNote) — a supplied message_id either mismatches and
+// refuses outright, or matches and verified is fixed true through the return.
+// This test calls the function directly so the corrected wording is pinned
+// even though the branch is presently unreachable through a real agent.
+func TestResendUnverifiedNote_DefaultCase(t *testing.T) {
+	got := resendUnverifiedNote(true, false)
+
+	if strings.Contains(got, "no provider message ID was recorded") || strings.Contains(got, "usual when the original send failed") {
+		t.Errorf("a Message-ID WAS sent in this case; the note must not claim none was recorded, got %q", got)
+	}
+	if strings.Contains(got, "too old") || strings.Contains(got, "Update the plugin") {
+		t.Errorf("a current agent answered the check; the note must not send the operator to update it, got %q", got)
+	}
+	if !strings.Contains(got, "message ID was sent") {
+		t.Errorf("the note must say a Message-ID was sent, got %q", got)
+	}
+	if !strings.Contains(got, "current") {
+		t.Errorf("the note must say the plugin is current and did respond, got %q", got)
+	}
+	if !strings.Contains(got, "could not confirm the match") {
+		t.Errorf("the note must say the site reported it could not confirm the match, got %q", got)
+	}
+	if !strings.Contains(got, "message has been sent") {
+		t.Errorf("the note must say the message was sent, got %q", got)
+	}
+}
+
+// TestResendUnverifiedNote_AllCases is a light sanity check that the other two
+// branches keep their existing, distinct wording after the default case was
+// corrected — the switch was not restructured, only the default branch's
+// return value changed.
+func TestResendUnverifiedNote_AllCases(t *testing.T) {
+	cases := []struct {
+		name          string
+		askedForCheck bool
+		legacyAgent   bool
+		want          string
+	}{
+		{name: "no message id at all", askedForCheck: false, legacyAgent: false, want: "no provider message ID was recorded"},
+		{name: "legacy agent silence", askedForCheck: true, legacyAgent: true, want: "too old to support the check"},
+		{name: "current agent, verified:false", askedForCheck: true, legacyAgent: false, want: "could not confirm the match"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resendUnverifiedNote(tc.askedForCheck, tc.legacyAgent)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("resendUnverifiedNote(%v, %v) = %q, want it to contain %q", tc.askedForCheck, tc.legacyAgent, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/api/internal/email/resend_contract_test.go
+++ b/apps/api/internal/email/resend_contract_test.go
@@ -206,7 +206,10 @@ func TestResendEmail_DispatchedPayloadMatchesAgentContract(t *testing.T) {
 
 	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
 	repo.addRowWithMessageID(logID, agentSeq, storedMsgID)
-	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true, Detail: "resent", MessageID: "<new@site>"}}
+	// A CURRENT agent (PR #541): it compared the supplied message_id against
+	// its own row, they matched, and it says so.
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":true}`)}
 	svc := newResendSvc(repo, agent)
 
 	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
@@ -227,11 +230,77 @@ func TestResendEmail_DispatchedPayloadMatchesAgentContract(t *testing.T) {
 		"message_id": storedMsgID,
 	})
 
+	// OVER-FIRE GUARD: a site that DID do the comparison and says so must still
+	// come back verified, with no warning bolted onto its detail. A change that
+	// makes every resend read "unverified" would be as useless as one that makes
+	// every resend read "verified".
 	if !res.Verified {
-		t.Error("a dispatch that carried message_id must report Verified=true")
+		t.Error("an agent that attested verified=true must report Verified=true")
 	}
 	if strings.Contains(res.Detail, "could not confirm") {
 		t.Errorf("a verified resend must not carry the unverified note: %q", res.Detail)
+	}
+	if meta, ok := resendAuditMeta(logID, res); !ok {
+		t.Error("a confirmed resend must be audited")
+	} else if meta["verified"] != true {
+		t.Errorf("audit metadata verified = %v, want true", meta["verified"])
+	}
+}
+
+// TestResendEmail_AgentSaysUnverified_IsNotVerified covers the third wire
+// state: a current agent that answers the question with "no". It sent the mail
+// but did not confirm the row, so the CP must report exactly that — the
+// attestation is read, not assumed from the fact that the agent is new enough
+// to carry the field.
+func TestResendEmail_AgentSaysUnverified_IsNotVerified(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRowWithMessageID(logID, 77, "<stored-77@site.example>")
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":false}`)}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("the send succeeded, so ok must stay true; got detail=%q", res.Detail)
+	}
+	if res.Verified {
+		t.Error("the agent said verified=false; the CP must not report a verified resend")
+	}
+	if !strings.Contains(res.Detail, "could not confirm") {
+		t.Errorf("an unconfirmed resend must say so to the operator, got %q", res.Detail)
+	}
+}
+
+// TestResendEmail_UnaskedAttestation_FailsClosed is the other direction of the
+// same rule. The CP had no Message-ID, so it sent no message_id key and no
+// comparison against its record was possible; an agent that claims verified
+// anyway is violating the contract, and a claim we never asked for is not
+// evidence. Believing it would be the original defect wearing the fix.
+func TestResendEmail_UnaskedAttestation_FailsClosed(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+
+	repo := newFakeResendRepo(logID, 88) // no recorded Message-ID
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":true}`)}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if agent.lastReq.MessageID != "" {
+		t.Fatalf("precondition: this row has no Message-ID, so none may be sent; got %q", agent.lastReq.MessageID)
+	}
+	if res.Verified {
+		t.Error("the CP supplied nothing to compare against, so no attestation can be believed")
+	}
+	if !strings.Contains(res.Detail, "no provider message ID was recorded") {
+		t.Errorf("the operator must be told the real cause, got %q", res.Detail)
 	}
 }
 
@@ -244,7 +313,9 @@ func TestResendEmail_NoMessageID_OmitsKeyAndReportsUnverified(t *testing.T) {
 	const agentSeq int64 = 99
 
 	repo := newFakeResendRepo(logID, agentSeq) // no message_id — a failed send
-	agent := &fakeResendAgent{result: agentcmd.ResendEmailResult{OK: true, Detail: "resent", MessageID: "<new@site>"}}
+	// A current agent, asked for no comparison, answers the question honestly.
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>","verified":false}`)}
 	svc := newResendSvc(repo, agent)
 
 	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
@@ -269,11 +340,108 @@ func TestResendEmail_NoMessageID_OmitsKeyAndReportsUnverified(t *testing.T) {
 	if !strings.Contains(res.Detail, "could not confirm") {
 		t.Errorf("an unverified resend must say so to the operator, got %q", res.Detail)
 	}
+	// And with the RIGHT cause. Nothing here is fixable by updating the plugin,
+	// so the note must not send the operator after one.
+	if !strings.Contains(res.Detail, "no provider message ID was recorded") {
+		t.Errorf("expected the no-recorded-id cause, got %q", res.Detail)
+	}
+	if strings.Contains(res.Detail, "too old") {
+		t.Errorf("this site's plugin is not the problem; the note misdirects: %q", res.Detail)
+	}
 
 	// The audit row must record it too, or the log cannot tell the two apart.
 	meta, ok := resendAuditMeta(logID, res)
 	if !ok {
 		t.Fatal("a confirmed send must still be audited even when unverified")
+	}
+	if meta["verified"] != false {
+		t.Errorf("audit metadata verified = %v, want false", meta["verified"])
+	}
+}
+
+// mustDecodeResendResult builds an agent response by DECODING the literal bytes
+// a site would put on the wire, never by filling in the Go struct by hand.
+//
+// That distinction is the whole point of the tests below. "The agent did not
+// send a `verified` key" is a property of the bytes; a hand-built
+// agentcmd.ResendEmailResult{} would express it as a Go zero value chosen by
+// the test author, which is exactly the reasoning that produced the defect.
+func mustDecodeResendResult(t *testing.T, body string) agentcmd.ResendEmailResult {
+	t.Helper()
+	var out agentcmd.ResendEmailResult
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode agent response %s: %v", body, err)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// GH #528, PR #542 review — verification is the AGENT's attestation
+// ---------------------------------------------------------------------------
+//
+// The first cut of this fix set Verified from whether the CP had SENT
+// message_id, not from whether the site had CHECKED it. A site running a
+// compatible older agent reads only agent_seq, ignores the new key, resends
+// whatever now sits at that row, and answers ok=true. The CP then recorded a
+// verified resend, suppressed the unverified warning and wrote a verified audit
+// row, for a comparison that never happened — the same "claiming a check
+// happened when it did not" defect this whole issue is about, sitting inside
+// the fix for it.
+//
+// The contract, agreed with the agent half in PR #541: the response carries
+// `verified`, set true ONLY on a path where the agent compared a supplied
+// message_id against its own row and they matched. Absent means false.
+
+// TestResendEmail_LegacyAgentSilence_IsNotVerified is the regression test for
+// that defect. The CP has a Message-ID and sends it; the agent is old enough to
+// ignore the key and answers without a `verified` field. Silence is not
+// confirmation.
+func TestResendEmail_LegacyAgentSilence_IsNotVerified(t *testing.T) {
+	tenantID, siteID, logID := uuid.New(), uuid.New(), uuid.New()
+	const agentSeq int64 = 4242
+	const storedMsgID = "<stored-4242@site.example>"
+
+	repo := &fakeResendRepo{fakeRepo: newFakeRepo(), rows: map[uuid.UUID]ResendTarget{}}
+	repo.addRowWithMessageID(logID, agentSeq, storedMsgID)
+
+	// A COMPATIBLE OLDER AGENT: it routes resend_email, reads only agent_seq,
+	// never looks at message_id, and returns no `verified` key at all.
+	agent := &fakeResendAgent{result: mustDecodeResendResult(t,
+		`{"ok":true,"detail":"resent","message_id":"<new@site>"}`)}
+	svc := newResendSvc(repo, agent)
+
+	res, err := svc.ResendEmail(context.Background(), tenantID, siteID, logID)
+	if err != nil {
+		t.Fatalf("ResendEmail: unexpected error: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("the send itself succeeded, so ok must stay true; got detail=%q", res.Detail)
+	}
+	// The CP did ask for the comparison — that is what makes the silence
+	// meaningful rather than absent.
+	if agent.lastReq.MessageID != storedMsgID {
+		t.Fatalf("the CP must still send message_id; got %q", agent.lastReq.MessageID)
+	}
+
+	if res.Verified {
+		t.Error("an agent that returned no `verified` field never compared anything; " +
+			"reporting the resend as verified tells the operator a check happened when none did")
+	}
+	if !strings.Contains(res.Detail, "could not confirm") {
+		t.Errorf("an unconfirmed resend must say so to the operator, got %q", res.Detail)
+	}
+	// And the cause has to be the honest one: the plugin did not answer, which
+	// is NOT the same as "no Message-ID was recorded for this entry".
+	if !strings.Contains(res.Detail, "too old") {
+		t.Errorf("the operator must be told the site's plugin could not check, got %q", res.Detail)
+	}
+	if strings.Contains(res.Detail, "no provider message ID was recorded") {
+		t.Errorf("wrong cause reported: the CP had a Message-ID and sent it, got %q", res.Detail)
+	}
+
+	meta, ok := resendAuditMeta(logID, res)
+	if !ok {
+		t.Fatal("a completed send must still be audited when unverified")
 	}
 	if meta["verified"] != false {
 		t.Errorf("audit metadata verified = %v, want false", meta["verified"])
@@ -416,10 +584,11 @@ func TestBulkResendEmail_MixedOutcomes(t *testing.T) {
 	repo.addRow(refusedID, 12, true)
 	repo.addRow(noSeqID, 0, true)
 
-	// The agent resends the first row and refuses the second.
+	// The agent resends the first row (confirming the id it was given) and
+	// refuses the second.
 	agent := &perSeqResendAgent{results: map[int64]agentcmd.ResendEmailResult{
-		11: {OK: true, Detail: "resent", MessageID: "<a@site>"},
-		12: {OK: false, Detail: agentcmd.ResendDetailBodyNotStored},
+		11: mustDecodeResendResult(t, `{"ok":true,"detail":"resent","message_id":"<a@site>","verified":true}`),
+		12: mustDecodeResendResult(t, `{"ok":false,"detail":"body_not_stored"}`),
 	}}
 	svc := newResendSvc(repo, agent)
 
@@ -507,9 +676,11 @@ func TestBulkResendEmail_UnverifiedCounted(t *testing.T) {
 	repo.addRowWithMessageID(withID, 31, "<x@site>")
 	repo.addRow(withoutID, 32, true)
 
+	// Row 31 carried a Message-ID, so the agent compared it and confirms. Row 32
+	// carried none, so there was nothing to compare and the agent says so.
 	agent := &perSeqResendAgent{results: map[int64]agentcmd.ResendEmailResult{
-		31: {OK: true, Detail: "resent", MessageID: "<n1@site>"},
-		32: {OK: true, Detail: "resent", MessageID: "<n2@site>"},
+		31: mustDecodeResendResult(t, `{"ok":true,"detail":"resent","message_id":"<n1@site>","verified":true}`),
+		32: mustDecodeResendResult(t, `{"ok":true,"detail":"resent","message_id":"<n2@site>","verified":false}`),
 	}}
 	svc := newResendSvc(repo, agent)
 

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -987,9 +987,20 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 	// it when we have one, and the agent refuses rather than sending the wrong
 	// mail. When we have none the field is omitted, the send is unconfirmed,
 	// and that fact is reported rather than swallowed.
+	// PR #542 review: neither half normalises a Message-ID it compares.
+	// Normalisation is an ingestion-time policy (a provider handler parsing
+	// the id), never a comparison-time one. The agent now compares raw bytes,
+	// untouched, on both sides (PR #541); trimming here would silently break
+	// that agreement in two directions: a row stored as "  <a@x>  " would
+	// dispatch as "<a@x>", so a byte-comparing agent would see a mismatch and
+	// refuse a legitimate resend, and a row stored as "   " would trim to ""
+	// and the key would be omitted, so the agent would skip verification and
+	// send the mail unverified — the exact outcome #528 exists to prevent.
+	// So: nil, or exactly "", omits the key; anything else — including a
+	// whitespace-only or whitespace-padded id — goes out verbatim.
 	req := agentcmd.ResendEmailRequest{AgentSeq: *target.AgentSeq}
-	if target.MessageID != nil {
-		req.MessageID = strings.TrimSpace(*target.MessageID)
+	if target.MessageID != nil && *target.MessageID != "" {
+		req.MessageID = *target.MessageID
 	}
 	// askedForCheck is used for WORDING and for failing closed, never as the
 	// source of `verified` — see below.
@@ -1105,10 +1116,11 @@ func resendFailureMessage(detail string) string {
 		strings.Contains(detail, agentcmd.ResendDetailBadSeq):
 		return "the site rejected the resend request format; update the wpmgr plugin on this site"
 	case strings.Contains(detail, agentcmd.ResendDetailMessageIDMismatch):
-		return "the site refused this resend: the message stored at that position in the site's own " +
-			"email log is no longer the message shown here, which happens after a site database " +
-			"restore. Nothing was sent. Reload the email log so wpmgr can re-read the site's " +
-			"current entries, then try again"
+		return "wpmgr did not send this: it could not confirm that this is still the same email on " +
+			"the site, which can happen after the site's database has been restored. Nothing was " +
+			"sent, and this entry can't be resent from here. If you still need this email delivered, " +
+			"trigger it again on the site itself — for example, resubmit the form, resave the order, " +
+			"or whatever originally sent it"
 	case strings.Contains(detail, "status 404"):
 		return "this site's wpmgr plugin is too old to support resending; update the plugin and try again"
 	default:

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -982,7 +982,18 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 		return ResendResult{OK: false, Detail: "site not enrolled or unavailable"}, nil
 	}
 
-	res, err := s.agent.ResendEmail(ctx, siteID, siteURL, agentcmd.ResendEmailRequest{AgentSeq: *target.AgentSeq})
+	// GH #528: agent_seq is a site-local AUTO_INCREMENT, so a database restore
+	// can rebind it to a different message. Send the recorded Message-ID with
+	// it when we have one, and the agent refuses rather than sending the wrong
+	// mail. When we have none the field is omitted, the send is unconfirmed,
+	// and that fact is reported rather than swallowed.
+	req := agentcmd.ResendEmailRequest{AgentSeq: *target.AgentSeq}
+	if target.MessageID != nil {
+		req.MessageID = strings.TrimSpace(*target.MessageID)
+	}
+	verified := req.MessageID != ""
+
+	res, err := s.agent.ResendEmail(ctx, siteID, siteURL, req)
 	if err != nil {
 		return ResendResult{OK: false, Detail: resendFailureMessage(err.Error())}, nil
 	}
@@ -1003,7 +1014,30 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 			slog.String("err", err.Error()),
 		)
 	}
-	return ResendResult{OK: true, Detail: res.Detail, MessageID: res.MessageID}, nil
+	detail := res.Detail
+	if !verified {
+		detail = strings.TrimSpace(detail + " " + resendUnverifiedNote())
+	}
+	return ResendResult{OK: true, Detail: detail, MessageID: res.MessageID, Verified: verified}, nil
+}
+
+// resendUnverifiedNote is what an operator is told when the resend went out
+// without the GH #528 confirmation.
+//
+// DECISION (GH #528): a row with no recorded Message-ID is resent, not refused,
+// and the absence of confirmation is stated. Refusing would break resend for
+// every send that FAILED — all five agent provider handlers record an empty
+// message id on their failure branch, and a failed send is the single most
+// common thing an operator wants to resend. Refusing the main use case to close
+// a restore-only window trades a certain outage for an uncertain one.
+//
+// What is NOT acceptable is the third option: sending unconfirmed and saying
+// nothing. So the caller gets Verified=false, this sentence in Detail, and an
+// audit row that records the send as unverified.
+func resendUnverifiedNote() string {
+	return "Note: wpmgr could not confirm the site resent this exact message, because no " +
+		"provider message ID was recorded for this entry (usual when the original send failed). " +
+		"If this site's database was restored recently, check the delivery before relying on it."
 }
 
 // resendFailureMessage turns an agent-side refusal into a sentence an operator
@@ -1028,6 +1062,11 @@ func resendFailureMessage(detail string) string {
 	case strings.Contains(detail, agentcmd.ResendDetailMissingSeq),
 		strings.Contains(detail, agentcmd.ResendDetailBadSeq):
 		return "the site rejected the resend request format; update the wpmgr plugin on this site"
+	case strings.Contains(detail, agentcmd.ResendDetailMessageIDMismatch):
+		return "the site refused this resend: the message stored at that position in the site's own " +
+			"email log is no longer the message shown here, which happens after a site database " +
+			"restore. Nothing was sent. Reload the email log so wpmgr can re-read the site's " +
+			"current entries, then try again"
 	case strings.Contains(detail, "status 404"):
 		return "this site's wpmgr plugin is too old to support resending; update the plugin and try again"
 	default:
@@ -1073,7 +1112,7 @@ func (s *Service) BulkResendEmail(ctx context.Context, tenantID, siteID uuid.UUI
 			}
 			continue
 		}
-		results = append(results, BulkResendResult{LogID: id, OK: res.OK, Detail: res.Detail})
+		results = append(results, BulkResendResult{LogID: id, OK: res.OK, Detail: res.Detail, Verified: res.Verified})
 	}
 	return results, nil
 }

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -991,7 +991,9 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 	if target.MessageID != nil {
 		req.MessageID = strings.TrimSpace(*target.MessageID)
 	}
-	verified := req.MessageID != ""
+	// askedForCheck is used for WORDING and for failing closed, never as the
+	// source of `verified` — see below.
+	askedForCheck := req.MessageID != ""
 
 	res, err := s.agent.ResendEmail(ctx, siteID, siteURL, req)
 	if err != nil {
@@ -1014,9 +1016,33 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 			slog.String("err", err.Error()),
 		)
 	}
+	// GH #528, corrected in PR #542 review: verification is what the SITE
+	// attested, never what the CP asked for. This used to read
+	// `verified := req.MessageID != ""`, which recorded a verified resend
+	// whenever the CP had an id to send — including against a compatible older
+	// agent that reads only agent_seq, ignores message_id, resends whatever now
+	// sits at that row and answers ok=true. The operator was told the message
+	// they selected had been confirmed when nothing had been compared, which is
+	// the defect class of this whole issue sitting inside the fix for it.
+	//
+	// res.IsVerified() is the single source, and it states the legacy default
+	// rather than inheriting it: an absent `verified` key is false.
+	verified := res.IsVerified()
+	if verified && !askedForCheck {
+		// Fail closed. We supplied nothing to compare against, so no comparison
+		// against our recorded Message-ID was possible; an attestation here is a
+		// contract violation, not evidence. Believing it would be the same
+		// mistake in the other direction.
+		s.log.Warn("email resend: site claimed verification for a resend that carried no message_id",
+			slog.String("site_id", siteID.String()),
+			slog.String("log_id", logID.String()),
+		)
+		verified = false
+	}
+
 	detail := res.Detail
 	if !verified {
-		detail = strings.TrimSpace(detail + " " + resendUnverifiedNote())
+		detail = strings.TrimSpace(detail + " " + resendUnverifiedNote(askedForCheck))
 	}
 	return ResendResult{OK: true, Detail: detail, MessageID: res.MessageID, Verified: verified}, nil
 }
@@ -1034,7 +1060,23 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 // What is NOT acceptable is the third option: sending unconfirmed and saying
 // nothing. So the caller gets Verified=false, this sentence in Detail, and an
 // audit row that records the send as unverified.
-func resendUnverifiedNote() string {
+//
+// There are TWO reasons a send can be unconfirmed and they are not
+// interchangeable, so askedForCheck picks the true one. Telling an operator
+// "no message ID was recorded for this entry" when in fact one was recorded
+// and sent, and the SITE could not check it, is a false statement with a
+// misleading remedy attached — the same defect the rest of this change is
+// about, one layer down in the prose.
+//
+//	askedForCheck=false → the CP had no Message-ID to send. Nothing to fix.
+//	askedForCheck=true  → the CP sent one and the site did not answer the
+//	                      question. Updating the plugin fixes it.
+func resendUnverifiedNote(askedForCheck bool) string {
+	if askedForCheck {
+		return "Note: wpmgr could not confirm the site resent this exact message. wpmgr asked the " +
+			"site to check, and this site's wpmgr plugin is too old to answer. The message was " +
+			"sent. Update the plugin on this site so future resends are confirmed."
+	}
 	return "Note: wpmgr could not confirm the site resent this exact message, because no " +
 		"provider message ID was recorded for this entry (usual when the original send failed). " +
 		"If this site's database was restored recently, check the delivery before relying on it."

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -1053,13 +1053,21 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 		verified = false
 	}
 
-	// legacyAgent is the wire fact that distinguishes the two ways IsVerified()
-	// can come back false (PR #542 review) — see resendUnverifiedNote.
-	legacyAgent := res.Verified == nil
+	// legacyAgent is gated on askedForCheck (PR #542 review, second pass): the
+	// wire fact "the agent's response omitted `verified`" only means "this
+	// agent is too old" when the CP actually sent something for it to compare
+	// against. When askedForCheck is false there was nothing to check, so the
+	// field's absence proves nothing about the agent's version — recording
+	// legacy_agent=true here would state an intention (this agent must be old)
+	// rather than a fact, and it is exactly what sent an operator to update a
+	// plugin that update could never have helped, because the CP never had a
+	// Message-ID to send in the first place. See resendUnverifiedNote for the
+	// full priority order this same gating feeds.
+	legacyAgent := askedForCheck && res.Verified == nil
 
 	detail := res.Detail
 	if !verified {
-		detail = strings.TrimSpace(detail + " " + resendUnverifiedNote(legacyAgent))
+		detail = strings.TrimSpace(detail + " " + resendUnverifiedNote(askedForCheck, legacyAgent))
 	}
 	return ResendResult{OK: true, Detail: detail, MessageID: res.MessageID, Verified: verified, LegacyAgent: legacyAgent}, nil
 }
@@ -1078,38 +1086,47 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 // nothing. So the caller gets Verified=false, this sentence in Detail, and an
 // audit row that records the send as unverified.
 //
-// There are TWO reasons a send can be unconfirmed and they are not
-// interchangeable, so the wording is keyed on legacyAgent, not on what the CP
-// asked for.
+// There are three causes and they carry a PRIORITY ORDER, not an independent
+// pair of switches (PR #542 review, second pass — a CodeRabbit thread on #542
+// caught the first pass's remaining gap):
 //
-// PR #542 review: this used to branch on askedForCheck (did the CP have a
-// Message-ID to send). That is true whenever the original send succeeded, and
-// it is true regardless of which of the two causes below actually applies, so
-// it told a site running a fully current plugin to update it, on the strength
-// of a request-side fact that says nothing about the response. legacyAgent
-// reads the response instead: whether the agent's `verified` key was present
-// at all (agentcmd.ResendEmailResult.Verified == nil), which is exactly the
-// wire-level fact IsVerified() already treats as the legacy default.
+//  1. askedForCheck=false → the CP had no Message-ID to send, so nothing
+//     could possibly have been checked, whatever the site is running. Normal
+//     when the original send failed. Nothing for the operator to fix. This
+//     wins over everything below, including an agent that also happens to be
+//     legacy: an old agent's silence about a comparison it was never asked to
+//     run proves nothing about its version, and telling the operator to
+//     update the plugin cannot produce a comparison the CP never requested.
+//  2. askedForCheck=true, legacyAgent=false → a current agent ran the
+//     comparison and answered `verified: false` out loud. Nothing is wrong
+//     and there is nothing to fix.
+//  3. askedForCheck=true, legacyAgent=true → the agent never answered
+//     `verified` even though it was given something to compare against. Only
+//     here is updating the plugin the fix.
 //
-//	legacyAgent=true  → the agent never answered `verified`. It predates the
-//	                    GH #528 attestation and cannot confirm a resend no
-//	                    matter what the CP sends. Updating the plugin fixes
-//	                    it.
-//	legacyAgent=false → a current agent answered `verified: false` out loud:
-//	                    it ran and had nothing to compare, the normal shape
-//	                    of a resend whose original send failed and so never
-//	                    had a Message-ID recorded. Nothing is wrong and
-//	                    there is nothing to fix.
-func resendUnverifiedNote(legacyAgent bool) string {
-	if legacyAgent {
+// The first pass (this same PR) branched on legacyAgent alone, which reads
+// correctly for cases 2 and 3 but mis-selects case 3's wording whenever
+// legacyAgent happens to be true AND askedForCheck is false: an old agent
+// asked for nothing still says nothing, and the old branching sent that
+// operator to update a plugin that was never the cause and could not have
+// been the fix. askedForCheck is checked first so that case always wins.
+func resendUnverifiedNote(askedForCheck, legacyAgent bool) string {
+	switch {
+	case !askedForCheck:
+		return "Note: wpmgr could not confirm the site resent this exact message, because no " +
+			"provider message ID was recorded for this entry (usual when the original send failed) " +
+			"— there is nothing to fix here. The message has been sent; if this site's database was " +
+			"restored recently, check the delivery before relying on it."
+	case legacyAgent:
 		return "Note: wpmgr could not confirm the site resent this exact message, because this " +
 			"site's wpmgr plugin is too old to support the check. The message has been sent. " +
 			"Update the plugin on this site so future resends can be confirmed."
+	default:
+		return "Note: wpmgr could not confirm the site resent this exact message, because no " +
+			"provider message ID was recorded for this entry (usual when the original send failed) " +
+			"— there is nothing to fix here. The message has been sent; if this site's database was " +
+			"restored recently, check the delivery before relying on it."
 	}
-	return "Note: wpmgr could not confirm the site resent this exact message, because no " +
-		"provider message ID was recorded for this entry (usual when the original send failed) " +
-		"— there is nothing to fix here. The message has been sent; if this site's database was " +
-		"restored recently, check the delivery before relying on it."
 }
 
 // resendFailureMessage turns an agent-side refusal into a sentence an operator

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -1121,11 +1121,31 @@ func resendUnverifiedNote(askedForCheck, legacyAgent bool) string {
 		return "Note: wpmgr could not confirm the site resent this exact message, because this " +
 			"site's wpmgr plugin is too old to support the check. The message has been sent. " +
 			"Update the plugin on this site so future resends can be confirmed."
+	// default: askedForCheck=true, legacyAgent=false. A provider message ID
+	// WAS sent, and the site's plugin is current and did answer — it ran the
+	// comparison and reported back that it could not confirm the match. This
+	// is case 2 in the doc comment above, and is not a plugin problem, so the
+	// wording must not say a Message-ID was missing (case 1's sentence, wrongly
+	// reused here until this fix) and must not send the operator to update
+	// anything (case 3's remedy) — the plugin already answered.
+	//
+	// PR #542 follow-up: as built, apps/agent's ResendEmailCommand::execute()
+	// cannot actually reach this branch. When the CP supplies a message_id,
+	// the loaded row's id is compared once (class-resend-email-command.php
+	// ~L229-241): a mismatch returns ok=false via refuse() before verified is
+	// ever considered, and a match sets verified=true, which is never reset
+	// before the final `ok: $result['ok'], verified: $verified` return
+	// (~L256-268). So a CURRENT agent's ok=true reply always carries
+	// verified=true whenever askedForCheck is true; explicit ok=true,
+	// verified=false is not producible by this agent version. The branch is
+	// kept as a defensive fallback — for a future or nonstandard agent that
+	// runs the check and honestly reports a non-match without refusing — with
+	// wording that states the truth if it is ever hit.
 	default:
-		return "Note: wpmgr could not confirm the site resent this exact message, because no " +
-			"provider message ID was recorded for this entry (usual when the original send failed) " +
-			"— there is nothing to fix here. The message has been sent; if this site's database was " +
-			"restored recently, check the delivery before relying on it."
+		return "Note: wpmgr could not confirm the site resent this exact message. A provider " +
+			"message ID was sent for this entry, and this site's wpmgr plugin is current and " +
+			"checked it — it reported that it could not confirm the match. There is nothing to " +
+			"fix here. The message has been sent."
 	}
 }
 

--- a/apps/api/internal/email/service.go
+++ b/apps/api/internal/email/service.go
@@ -1002,8 +1002,10 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 	if target.MessageID != nil && *target.MessageID != "" {
 		req.MessageID = *target.MessageID
 	}
-	// askedForCheck is used for WORDING and for failing closed, never as the
-	// source of `verified` — see below.
+	// askedForCheck fails the resend closed below when the site attests a
+	// comparison it had nothing to compare against. It no longer selects the
+	// operator wording — see legacyAgent and the PR #542 review note on
+	// resendUnverifiedNote.
 	askedForCheck := req.MessageID != ""
 
 	res, err := s.agent.ResendEmail(ctx, siteID, siteURL, req)
@@ -1051,11 +1053,15 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 		verified = false
 	}
 
+	// legacyAgent is the wire fact that distinguishes the two ways IsVerified()
+	// can come back false (PR #542 review) — see resendUnverifiedNote.
+	legacyAgent := res.Verified == nil
+
 	detail := res.Detail
 	if !verified {
-		detail = strings.TrimSpace(detail + " " + resendUnverifiedNote(askedForCheck))
+		detail = strings.TrimSpace(detail + " " + resendUnverifiedNote(legacyAgent))
 	}
-	return ResendResult{OK: true, Detail: detail, MessageID: res.MessageID, Verified: verified}, nil
+	return ResendResult{OK: true, Detail: detail, MessageID: res.MessageID, Verified: verified, LegacyAgent: legacyAgent}, nil
 }
 
 // resendUnverifiedNote is what an operator is told when the resend went out
@@ -1073,24 +1079,37 @@ func (s *Service) ResendEmail(ctx context.Context, tenantID, siteID, logID uuid.
 // audit row that records the send as unverified.
 //
 // There are TWO reasons a send can be unconfirmed and they are not
-// interchangeable, so askedForCheck picks the true one. Telling an operator
-// "no message ID was recorded for this entry" when in fact one was recorded
-// and sent, and the SITE could not check it, is a false statement with a
-// misleading remedy attached — the same defect the rest of this change is
-// about, one layer down in the prose.
+// interchangeable, so the wording is keyed on legacyAgent, not on what the CP
+// asked for.
 //
-//	askedForCheck=false → the CP had no Message-ID to send. Nothing to fix.
-//	askedForCheck=true  → the CP sent one and the site did not answer the
-//	                      question. Updating the plugin fixes it.
-func resendUnverifiedNote(askedForCheck bool) string {
-	if askedForCheck {
-		return "Note: wpmgr could not confirm the site resent this exact message. wpmgr asked the " +
-			"site to check, and this site's wpmgr plugin is too old to answer. The message was " +
-			"sent. Update the plugin on this site so future resends are confirmed."
+// PR #542 review: this used to branch on askedForCheck (did the CP have a
+// Message-ID to send). That is true whenever the original send succeeded, and
+// it is true regardless of which of the two causes below actually applies, so
+// it told a site running a fully current plugin to update it, on the strength
+// of a request-side fact that says nothing about the response. legacyAgent
+// reads the response instead: whether the agent's `verified` key was present
+// at all (agentcmd.ResendEmailResult.Verified == nil), which is exactly the
+// wire-level fact IsVerified() already treats as the legacy default.
+//
+//	legacyAgent=true  → the agent never answered `verified`. It predates the
+//	                    GH #528 attestation and cannot confirm a resend no
+//	                    matter what the CP sends. Updating the plugin fixes
+//	                    it.
+//	legacyAgent=false → a current agent answered `verified: false` out loud:
+//	                    it ran and had nothing to compare, the normal shape
+//	                    of a resend whose original send failed and so never
+//	                    had a Message-ID recorded. Nothing is wrong and
+//	                    there is nothing to fix.
+func resendUnverifiedNote(legacyAgent bool) string {
+	if legacyAgent {
+		return "Note: wpmgr could not confirm the site resent this exact message, because this " +
+			"site's wpmgr plugin is too old to support the check. The message has been sent. " +
+			"Update the plugin on this site so future resends can be confirmed."
 	}
 	return "Note: wpmgr could not confirm the site resent this exact message, because no " +
-		"provider message ID was recorded for this entry (usual when the original send failed). " +
-		"If this site's database was restored recently, check the delivery before relying on it."
+		"provider message ID was recorded for this entry (usual when the original send failed) " +
+		"— there is nothing to fix here. The message has been sent; if this site's database was " +
+		"restored recently, check the delivery before relying on it."
 }
 
 // resendFailureMessage turns an agent-side refusal into a sentence an operator
@@ -1166,7 +1185,7 @@ func (s *Service) BulkResendEmail(ctx context.Context, tenantID, siteID uuid.UUI
 			}
 			continue
 		}
-		results = append(results, BulkResendResult{LogID: id, OK: res.OK, Detail: res.Detail, Verified: res.Verified})
+		results = append(results, BulkResendResult{LogID: id, OK: res.OK, Detail: res.Detail, Verified: res.Verified, LegacyAgent: res.LegacyAgent})
 	}
 	return results, nil
 }

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -8963,7 +8963,7 @@ export const ResendEmailResultSchema = {
     verified: {
       type: "boolean",
       description:
-        "Whether wpmgr was able to confirm the site resent the same message\nthe operator selected (GH #528). The site's log ids are a local\nAUTO_INCREMENT that a database restore rolls back, so wpmgr sends\nthe Message-ID it has on record and the site refuses on a mismatch.\n`false` means no Message-ID was recorded for that entry — normal\nwhen the original send failed — so the resend went out unconfirmed.\n`detail` carries the same warning in prose. Only meaningful when\n`ok` is true.\n",
+        "Whether the SITE confirmed it resent the same message the operator\nselected (GH #528). The site's log ids are a local AUTO_INCREMENT\nthat a database restore rolls back, so wpmgr sends the Message-ID it\nhas on record, the site compares it against its own row, and it\nrefuses on a mismatch. This flag is the site's answer, never\nwpmgr's assumption: a site that does not answer is never counted as\nhaving confirmed.\n\n`false` has two causes, and `detail` names the one that applies:\nno Message-ID was recorded for that entry (normal when the original\nsend failed, and nothing to fix), or the site's wpmgr plugin is too\nold to perform the check (fixed by updating the plugin). Either way\nthe message was sent and the confirmation is missing. Only\nmeaningful when `ok` is true.\n",
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -8960,6 +8960,11 @@ export const ResendEmailResultSchema = {
       description:
         "Provider message ID assigned to the resent email (if agent returned it).",
     },
+    verified: {
+      type: "boolean",
+      description:
+        "Whether wpmgr was able to confirm the site resent the same message\nthe operator selected (GH #528). The site's log ids are a local\nAUTO_INCREMENT that a database restore rolls back, so wpmgr sends\nthe Message-ID it has on record and the site refuses on a mismatch.\n`false` means no Message-ID was recorded for that entry — normal\nwhen the original send failed — so the resend went out unconfirmed.\n`detail` carries the same warning in prose. Only meaningful when\n`ok` is true.\n",
+    },
   },
 } as const;
 
@@ -8992,6 +8997,11 @@ export const BulkResendItemResultSchema = {
     },
     detail: {
       type: ["string", "null"],
+    },
+    verified: {
+      type: "boolean",
+      description:
+        "Per-entry equivalent of ResendEmailResult.verified (GH #528). One\nbatch routinely mixes entries that could be confirmed with entries\nthat could not, so this is reported per entry, never per batch.\n",
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5395,14 +5395,20 @@ export type ResendEmailResult = {
    */
   message_id?: string | null;
   /**
-   * Whether wpmgr was able to confirm the site resent the same message
-   * the operator selected (GH #528). The site's log ids are a local
-   * AUTO_INCREMENT that a database restore rolls back, so wpmgr sends
-   * the Message-ID it has on record and the site refuses on a mismatch.
-   * `false` means no Message-ID was recorded for that entry — normal
-   * when the original send failed — so the resend went out unconfirmed.
-   * `detail` carries the same warning in prose. Only meaningful when
-   * `ok` is true.
+   * Whether the SITE confirmed it resent the same message the operator
+   * selected (GH #528). The site's log ids are a local AUTO_INCREMENT
+   * that a database restore rolls back, so wpmgr sends the Message-ID it
+   * has on record, the site compares it against its own row, and it
+   * refuses on a mismatch. This flag is the site's answer, never
+   * wpmgr's assumption: a site that does not answer is never counted as
+   * having confirmed.
+   *
+   * `false` has two causes, and `detail` names the one that applies:
+   * no Message-ID was recorded for that entry (normal when the original
+   * send failed, and nothing to fix), or the site's wpmgr plugin is too
+   * old to perform the check (fixed by updating the plugin). Either way
+   * the message was sent and the confirmation is missing. Only
+   * meaningful when `ok` is true.
    *
    */
   verified?: boolean;

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -5394,6 +5394,18 @@ export type ResendEmailResult = {
    * Provider message ID assigned to the resent email (if agent returned it).
    */
   message_id?: string | null;
+  /**
+   * Whether wpmgr was able to confirm the site resent the same message
+   * the operator selected (GH #528). The site's log ids are a local
+   * AUTO_INCREMENT that a database restore rolls back, so wpmgr sends
+   * the Message-ID it has on record and the site refuses on a mismatch.
+   * `false` means no Message-ID was recorded for that entry — normal
+   * when the original send failed — so the resend went out unconfirmed.
+   * `detail` carries the same warning in prose. Only meaningful when
+   * `ok` is true.
+   *
+   */
+  verified?: boolean;
 };
 
 export type BulkResendRequest = {
@@ -5407,6 +5419,13 @@ export type BulkResendItemResult = {
   log_id: string;
   ok: boolean;
   detail?: string | null;
+  /**
+   * Per-entry equivalent of ResendEmailResult.verified (GH #528). One
+   * batch routinely mixes entries that could be confirmed with entries
+   * that could not, so this is reported per entry, never per batch.
+   *
+   */
+  verified?: boolean;
 };
 
 export type BulkResendResponse = {

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19599,14 +19599,20 @@ components:
         verified:
           type: boolean
           description: |
-            Whether wpmgr was able to confirm the site resent the same message
-            the operator selected (GH #528). The site's log ids are a local
-            AUTO_INCREMENT that a database restore rolls back, so wpmgr sends
-            the Message-ID it has on record and the site refuses on a mismatch.
-            `false` means no Message-ID was recorded for that entry — normal
-            when the original send failed — so the resend went out unconfirmed.
-            `detail` carries the same warning in prose. Only meaningful when
-            `ok` is true.
+            Whether the SITE confirmed it resent the same message the operator
+            selected (GH #528). The site's log ids are a local AUTO_INCREMENT
+            that a database restore rolls back, so wpmgr sends the Message-ID it
+            has on record, the site compares it against its own row, and it
+            refuses on a mismatch. This flag is the site's answer, never
+            wpmgr's assumption: a site that does not answer is never counted as
+            having confirmed.
+
+            `false` has two causes, and `detail` names the one that applies:
+            no Message-ID was recorded for that entry (normal when the original
+            send failed, and nothing to fix), or the site's wpmgr plugin is too
+            old to perform the check (fixed by updating the plugin). Either way
+            the message was sent and the confirmation is missing. Only
+            meaningful when `ok` is true.
 
     BulkResendRequest:
       type: object

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -19596,6 +19596,17 @@ components:
         message_id:
           type: [string, "null"]
           description: Provider message ID assigned to the resent email (if agent returned it).
+        verified:
+          type: boolean
+          description: |
+            Whether wpmgr was able to confirm the site resent the same message
+            the operator selected (GH #528). The site's log ids are a local
+            AUTO_INCREMENT that a database restore rolls back, so wpmgr sends
+            the Message-ID it has on record and the site refuses on a mismatch.
+            `false` means no Message-ID was recorded for that entry — normal
+            when the original send failed — so the resend went out unconfirmed.
+            `detail` carries the same warning in prose. Only meaningful when
+            `ok` is true.
 
     BulkResendRequest:
       type: object
@@ -19620,6 +19631,12 @@ components:
           type: boolean
         detail:
           type: [string, "null"]
+        verified:
+          type: boolean
+          description: |
+            Per-entry equivalent of ResendEmailResult.verified (GH #528). One
+            batch routinely mixes entries that could be confirmed with entries
+            that could not, so this is reported per entry, never per batch.
 
     BulkResendResponse:
       type: object


### PR DESCRIPTION
Control-plane half of #528. Does not merge on its own — `security-reviewer` reviews this, it is the agent command protocol, and the agent's verification half is being built in parallel.

## The defect

`agent_seq` is the only selector `resend_email` carries, and it is a MySQL `AUTO_INCREMENT` on the site's own table (`apps/agent/includes/class-schema.php`). A restore rolls the counter back; later sends re-use ids the CP has already bound to other messages. wpmgr performs restores itself, so this is reachable in normal operation. The operator sees "Invoice for Alice", clicks Resend, and the site sends whatever its own row 42 now holds.

## What changed

`resend_email` now carries the recorded provider Message-ID as an optional second field. It is a **row selector, not message content** — no recipients, no subject, no body — so it does not reopen what #520 settled about keeping stored bodies off the command channel. The agent compares it against its own row and refuses on a mismatch (`message_id_mismatch`, mapped to operator prose here).

## Decision on the nullable case

`message_id` is NULL on the CP for **every send that failed at the time** — all five agent provider handlers return an empty message id on their failure branch — and for a success whose provider surfaced no `Message-ID` header. A failed send is the single most common thing an operator resends, so refusing those rows would trade a restore-only window for a certain outage.

They are **resent, and the missing confirmation is stated**:

- the key is **omitted**, not sent empty (an empty string would read to the agent as "compare against empty" and refuse every one of those rows);
- `ResendResult.Verified` is false;
- the operator sees it in `detail`;
- the HTTP response carries `verified`, and so does each bulk item;
- the audit row records `verified`, and the bulk audit row counts `unverified` separately rather than folding it into `count`.

The outcome this rules out is the third one: sending unconfirmed and saying nothing.

## Backward compatibility — verified from the agent source

`ResendEmailCommand::execute()` reads only `$params['agent_seq']`; it never enumerates keys and has no whitelist. `Router::dispatch()` passes the decoded JSON body straight through, unsetting only its own `wpmgr_claims` attribute. An older plugin therefore ignores `message_id`. **Not a breaking change.**

## The #520 guard is extended, not relaxed

`wantResendKeys` now pins **both** wire shapes — `{agent_seq, message_id}` and `{agent_seq}` — through a shared exact-key-set-plus-values assertion. Each of the four directions was proven to redden the test and then restored to green.

## Findings for follow-up (not fixed here)

1. **`IngestEmailLogEntry`'s `ON CONFLICT` does not update `message_id`, `to_addresses`, `from_address` or `subject`** (`apps/api/db/query/site_email.sql`). The issue text assumed the window closes at the next ingest push; it does not. After a restore the CP row keeps showing Alice's recipient and subject indefinitely while the site's row 42 is Bob's. This is `database-engineer`'s path. It also means the CP's stored `message_id` is stable, which is what makes the check in this PR work.

2. **A second resend of the same row will mismatch.** The agent's `update_row_after_resend()` overwrites its own row's `message_id` with the new send's id, and `EmailLogReporter` only pushes rows with `id >` its cursor, so the CP never learns the new value. The agent's comparison should therefore be against the id the CP knows, not simply the current row value — worth settling with the agent half before both merge.

Closes #528 (control-plane half).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resend operations now confirm whether the selected message matches the recorded provider message.
  - Individual and bulk resend results show verification status for each message.
  - Resend records distinguish confirmed deliveries, unverified responses, and legacy agent responses.

- **Bug Fixes**
  - Added safeguards against resending the wrong message after data restoration.
  - Resends without recorded message identifiers remain supported with clear guidance.
  - Unverified responses now provide specific recovery instructions.
  - Bulk resend results now accurately report verification outcomes for each message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->