### PR TITLE
analysis(db): fleet software census for S2, with proof harness

### DIFF
--- a/apps/api/db/analysis/README.md
+++ b/apps/api/db/analysis/README.md
@@ -17,11 +17,26 @@ These files answer roadmap and capacity-planning questions for a human at a
 they must not grow one by accident. `db/analysis/` is a sibling of `db/query/`
 and is outside sqlc's glob, so adding files here cannot change generated code.
 
-Verify that claim rather than trusting it:
+Verify that claim rather than trusting it — with a check that can actually fail:
 
 ```sh
-cd apps/api && sqlc compile && git status --porcelain internal/db/sqlc/
+cd apps/api
+sqlc generate
+git diff --quiet -- internal/db/sqlc/ || { echo "generated tree moved"; exit 1; }
 ```
+
+The obvious version of this check is worthless, and it shipped here first:
+
+```sh
+cd apps/api && sqlc compile && git status --porcelain internal/db/sqlc/   # proves nothing
+```
+
+`sqlc compile` only type-checks; it writes no output, so nothing under
+`internal/db/sqlc/` *can* change during it and the following check has nothing
+to observe. And `git status --porcelain` exits 0 whether or not it prints a
+path, so even real drift would leave the pipeline green. `sqlc generate` makes a
+change possible and `git diff --quiet` exits 1 exactly when one happened — the
+same gate `.claude/rules/db-migrations.md` requires.
 
 ## Running these as the right role
 
@@ -55,6 +70,26 @@ from that column and cannot be run — or proven — against a schema that lacks
 m121 added the column with **no backfill**, so every row that predates it reads
 `NULL` until that site's next metadata push. `NULL` means "we have never
 recorded when this inventory was collected", it is reported as its own bucket,
-and on any run soon after m121 it will be the largest bucket. Read section 0 of
-the output, which prints that denominator before any adoption number, before
-quoting anything further down.
+and on a run soon after m121 it is expected to be the largest bucket — how large
+depends on how many sites have pushed since, so read the number the run prints
+rather than assuming one. Read section 0 of the output, which prints that
+denominator before any adoption number, before quoting anything further down.
+
+### What the timestamp actually records
+
+`components_updated_at` is `now()` evaluated **on the control plane at the moment
+it persisted the inventory document**. It is *not* the instant the agent walked
+the plugin and theme list on the WordPress host.
+
+The agent's metadata payload carries no collection timestamp, so the collection
+instant is not knowable here at all — which is why m121 named the column
+`components_updated_at` and deliberately not `components_collected_at`
+(m121 DECISION 2). The two are separated by one agent push: normally a single
+HTTP round trip, and not small when it matters, since a queued or retried push,
+a clock-skewed host or any future store-and-forward path widens it without
+warning.
+
+So every freshness figure the census prints means "how long since **we recorded**
+this", which is a lower bound on "how long since the agent **looked**". Like
+every other error in this script it runs one way: the inventory can be older
+than reported, never newer.

--- a/apps/api/db/analysis/README.md
+++ b/apps/api/db/analysis/README.md
@@ -43,3 +43,18 @@ either** — only a role with `BYPASSRLS` or `SUPERUSER` does. So:
   Run fleet-wide as `wpmgr_app` and you get **zero rows, not an error**. The
   script detects that case and aborts rather than reporting an empty fleet as
   a finding.
+
+## Schema requirement
+
+`fleet_software_census.sql` reads `sites.components_updated_at`, added by
+**m121** (`20260823000000_m121_site_components_updated_at`). Against an older
+database both the census and its proof harness fail on the unknown column,
+loudly, which is the correct outcome: the census dates every freshness number
+from that column and cannot be run — or proven — against a schema that lacks it.
+
+m121 added the column with **no backfill**, so every row that predates it reads
+`NULL` until that site's next metadata push. `NULL` means "we have never
+recorded when this inventory was collected", it is reported as its own bucket,
+and on any run soon after m121 it will be the largest bucket. Read section 0 of
+the output, which prints that denominator before any adoption number, before
+quoting anything further down.

--- a/apps/api/db/analysis/README.md
+++ b/apps/api/db/analysis/README.md
@@ -1,0 +1,45 @@
+# `apps/api/db/analysis/`
+
+Standalone, read-only operator SQL. **Nothing here is part of the application.**
+
+## Why this directory exists and not `db/query/`
+
+`apps/api/sqlc.yaml` sets `queries: "db/query"`, so sqlc parses *every* `.sql`
+file in that directory. An analytics query dropped there either carries a
+`-- name:` annotation — and then sqlc emits a Go method into
+`internal/db/sqlc/**` that no caller ever invokes, in a tree CLAUDE.md forbids
+hand-editing and that must stay a faithful projection of the application's real
+query set — or it carries no annotation and sqlc's behaviour on it is not
+something to rely on.
+
+These files answer roadmap and capacity-planning questions for a human at a
+`psql` prompt. They are not application queries, they have no Go call site, and
+they must not grow one by accident. `db/analysis/` is a sibling of `db/query/`
+and is outside sqlc's glob, so adding files here cannot change generated code.
+
+Verify that claim rather than trusting it:
+
+```sh
+cd apps/api && sqlc compile && git status --porcelain internal/db/sqlc/
+```
+
+## Running these as the right role
+
+`sites` is `ENABLE` **and** `FORCE ROW LEVEL SECURITY` with a RESTRICTIVE
+`sites_site_scope` policy. `FORCE` means **the table owner does not bypass RLS
+either** — only a role with `BYPASSRLS` or `SUPERUSER` does. So:
+
+- **Per-organisation** (works as `wpmgr_app`, the role every install runs as):
+  ```sh
+  psql "$APP_DSN" -v tenant_id=<uuid> -f fleet_software_census.sql
+  ```
+  The script sets `app.tenant_id` itself so `sites_tenant_isolation` passes.
+
+- **Fleet-wide across all tenants** requires a `BYPASSRLS` role — in practice
+  the owner/migration DSN, not the application DSN:
+  ```sh
+  psql "$OWNER_DSN" -f fleet_software_census.sql
+  ```
+  Run fleet-wide as `wpmgr_app` and you get **zero rows, not an error**. The
+  script detects that case and aborts rather than reporting an empty fleet as
+  a finding.

--- a/apps/api/db/analysis/fleet_software_census.sql
+++ b/apps/api/db/analysis/fleet_software_census.sql
@@ -1,0 +1,341 @@
+-- ===========================================================================
+-- Fleet software census — S2 "measure the fleet"
+-- ===========================================================================
+-- Answers: for each integration target, how many sites run it, at which
+-- versions, and what fraction of the fleet is that?
+--
+-- READ-ONLY. Every statement is a SELECT. Nothing here writes.
+--
+--   psql "$APP_DSN"   -v tenant_id=<uuid> -f fleet_software_census.sql   # one org
+--   psql "$OWNER_DSN"                     -f fleet_software_census.sql   # fleet-wide
+--
+-- See README.md in this directory for the RLS/role rules: `sites` is FORCE RLS,
+-- so fleet-wide needs BYPASSRLS and the app role alone returns zero rows.
+--
+-- ---------------------------------------------------------------------------
+-- WHAT THE DATA ACTUALLY IS (read before trusting any number this prints)
+-- ---------------------------------------------------------------------------
+-- There is no normalized plugin/theme table. The whole inventory is one JSONB
+-- document per site, sites.components, written by UpdateSiteMetadata
+-- (db/query/sites.sql) which REWRITES the document wholesale on every push.
+--
+-- !! INVENTORY AGE IS NOT MEASURABLE IN THIS SCHEMA. READ THIS BEFORE QUOTING
+-- !! ANY "stale" NUMBER THIS SCRIPT PRINTS.
+--
+-- There is no components_updated_at column. UpdateSiteMetadata does stamp
+-- last_seen_at alongside components -- but TouchSiteHeartbeat
+-- (db/query/site_connection.sql) ALSO stamps last_seen_at, every 60 seconds,
+-- WITHOUT touching components. So last_seen_at is "when the agent last said
+-- hello", not "when the inventory was last refreshed".
+--
+-- The two diverge in the dangerous direction: a site whose 60s heartbeat is
+-- alive but whose 30-minute metadata cron has died reports last_seen_at =
+-- seconds ago while serving a components document that is arbitrarily old.
+-- last_seen_at therefore OVERSTATES inventory freshness and can never
+-- understate it. The columns below named *_stale are a LOWER BOUND on staleness
+-- and a site absent from them is not thereby fresh.
+--
+-- Closing this gap needs a schema change (a components_updated_at stamped only
+-- by UpdateSiteMetadata). That is a migration, and it is not in this read-only
+-- script's scope.
+--
+-- Shape, built control-plane side in internal/site/service.go buildInventoryPayload:
+--   {"plugins":[{"slug","name","version","active",...}],
+--    "themes": [{"slug","name","version","active",...}], ...}
+--
+-- Four properties of that document drive the whole design below:
+--
+--   1. `slug` for a plugin is the PLUGIN FILE PATH ("elementor/elementor.php"),
+--      not a directory slug. The directory is split_part(slug,'/',1). For a
+--      theme it is the stylesheet directory ("Divi"), and its case is the
+--      theme author's — hence lower() on both sides of every comparison.
+--
+--   2. Page builders are NOT all plugins. Bricks and Divi ship as THEMES.
+--      A plugins-only census reports zero Bricks and zero Divi and is wrong in
+--      exactly the direction that flatters the "Gutenberg first" hypothesis.
+--      This script matches plugins and themes in one pass.
+--
+--   3. `active` comes from get_option('active_plugins'), which on MULTISITE
+--      does not contain network-activated plugins. A network-activated builder
+--      is therefore reported active=false while running on every site in the
+--      network. Multisite rows are counted but reported separately, because
+--      their `active` flag is not trustworthy.
+--
+--   4. A site can have a plugins array and no themes array. That site cannot be
+--      called Gutenberg — an unseen themes array could hold Bricks or Divi. It
+--      is classified 'indeterminate', never folded into the no-builder bucket.
+--
+-- The single largest correctness rule here: "no builder found" is only a
+-- finding for a site whose inventory we actually have. Sites with no usable
+-- inventory are counted in their own bucket and are NEVER counted as Gutenberg.
+-- Folding them in would inflate the exact number the roadmap is betting on.
+-- ===========================================================================
+
+\set ON_ERROR_STOP on
+\timing off
+\pset pager off
+
+\if :{?tenant_id}
+\else
+  \set tenant_id ''
+\endif
+
+\if :{?stale_days}
+\else
+  \set stale_days 7
+\endif
+
+-- Scope the session to one tenant when a tenant_id was supplied, so this runs
+-- as wpmgr_app under sites_tenant_isolation. Empty string = fleet-wide, which
+-- needs BYPASSRLS.
+SELECT set_config('app.tenant_id', :'tenant_id', false) AS app_tenant_id_set
+WHERE :'tenant_id' <> '';
+
+-- ---------------------------------------------------------------------------
+-- The shared view of the fleet. Everything below selects from these.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE TEMP VIEW census_fleet AS
+SELECT
+    s.id,
+    s.tenant_id,
+    s.multisite,
+    s.last_seen_at,
+    s.components,
+    -- A usable plugins array. '{}' and {"plugins":{...}} are NOT usable;
+    -- {"plugins":[]} IS usable and means "reported, no plugins".
+    --
+    -- COALESCE is load-bearing, not defensive noise. components DEFAULTs to
+    -- '{}', so on a never-reported site `components -> 'plugins'` is SQL NULL
+    -- and jsonb_typeof(NULL) is NULL — making this expression NULL rather than
+    -- false. `WHEN NOT <null>` never matches, so without COALESCE such a site
+    -- falls straight through the classification CASE below and lands in the
+    -- ELSE branch: Gutenberg. That silently scores every site that has never
+    -- reported anything as "runs no page builder" — inflating precisely the
+    -- number the roadmap is betting on, using the sites that said nothing.
+    -- Caught by the proof harness; see fleet_software_census_proof.sql sites 7 and 8.
+    COALESCE(jsonb_typeof(s.components -> 'plugins') = 'array', false) AS has_plugin_inventory,
+    COALESCE(jsonb_typeof(s.components -> 'themes')  = 'array', false) AS has_theme_inventory,
+    -- Buckets of LAST AGENT CONTACT, not of inventory age. See the header note:
+    -- the 60s heartbeat bumps last_seen_at without refreshing components.
+    CASE
+        WHEN s.last_seen_at IS NULL                       THEN 'never_contacted'
+        WHEN s.last_seen_at > now() - interval '24 hours'  THEN 'contact_24h'
+        WHEN s.last_seen_at > now() - interval '7 days'    THEN 'contact_week'
+        WHEN s.last_seen_at > now() - interval '30 days'   THEN 'contact_month'
+        ELSE 'contact_over_30d'
+    END AS contact_freshness,
+    -- LOWER BOUND on inventory staleness (see header). True here means the
+    -- inventory is definitely at least this old; false does NOT mean fresh.
+    (s.last_seen_at IS NULL
+     OR s.last_seen_at < now() - (:stale_days || ' days')::interval) AS contact_stale,
+    s.connection_state
+FROM sites s
+WHERE s.connection_state <> 'archived'
+  -- NULLIF, not a bare :'tenant_id'::uuid. Postgres resolves a literal cast at
+  -- parse time, so ''::uuid raises "invalid input syntax for type uuid" even
+  -- though the OR short-circuits at runtime. NULLIF('','') is NULL, and
+  -- NULL::uuid is legal.
+  AND (:'tenant_id' = '' OR s.tenant_id = NULLIF(:'tenant_id', '')::uuid);
+
+-- Integration targets. (target, category, kind, dir_slug) — one row per
+-- distributed artifact, because a product can ship as several.
+CREATE OR REPLACE TEMP VIEW census_targets AS
+SELECT * FROM (VALUES
+    -- Page builders (category 'builder' defines the Gutenberg complement).
+    ('Elementor',       'builder', 'plugin', 'elementor'),
+    ('Elementor',       'builder', 'plugin', 'elementor-pro'),
+    ('WPBakery',        'builder', 'plugin', 'js_composer'),
+    ('Bricks',          'builder', 'theme',  'bricks'),
+    ('Divi',            'builder', 'theme',  'divi'),
+    ('Divi',            'builder', 'plugin', 'divi-builder'),
+    ('Beaver Builder',  'builder', 'plugin', 'bb-plugin'),
+    ('Beaver Builder',  'builder', 'plugin', 'beaver-builder-lite-version'),
+    ('Beaver Builder',  'builder', 'theme',  'bb-theme'),
+    ('Breakdance',      'builder', 'plugin', 'breakdance'),
+    ('Oxygen',          'builder', 'plugin', 'oxygen'),
+    -- Also builders. Not integration targets, but they must suppress the
+    -- Gutenberg bucket or "no page builder" silently absorbs them.
+    ('Avada Fusion',    'builder', 'plugin', 'fusion-builder'),
+    ('Brizy',           'builder', 'plugin', 'brizy'),
+    ('SiteOrigin',      'builder', 'plugin', 'siteorigin-panels'),
+    ('Thrive Architect','builder', 'plugin', 'thrive-visual-editor'),
+    ('Themify',         'builder', 'plugin', 'themify-builder'),
+    ('Visual Composer', 'builder', 'plugin', 'visualcomposer'),
+    ('Live Composer',   'builder', 'plugin', 'live-composer-page-builder'),
+    ('WP Page Builder', 'builder', 'plugin', 'wp-page-builder'),
+    -- Commerce.
+    ('WooCommerce',     'commerce','plugin', 'woocommerce'),
+    -- SEO.
+    ('Yoast SEO',       'seo',     'plugin', 'wordpress-seo'),
+    ('Yoast SEO',       'seo',     'plugin', 'wordpress-seo-premium'),
+    ('Rank Math',       'seo',     'plugin', 'seo-by-rank-math'),
+    ('Rank Math',       'seo',     'plugin', 'seo-by-rank-math-pro'),
+    ('SEOPress',        'seo',     'plugin', 'wp-seopress'),
+    ('SEOPress',        'seo',     'plugin', 'wp-seopress-pro'),
+    ('AIOSEO',          'seo',     'plugin', 'all-in-one-seo-pack'),
+    ('AIOSEO',          'seo',     'plugin', 'all-in-one-seo-pack-pro'),
+    -- Custom fields / content modelling.
+    ('ACF',             'fields',  'plugin', 'advanced-custom-fields'),
+    ('ACF',             'fields',  'plugin', 'advanced-custom-fields-pro'),
+    ('Secure Custom Fields','fields','plugin','secure-custom-fields'),
+    ('Pods',            'fields',  'plugin', 'pods'),
+    ('Meta Box',        'fields',  'plugin', 'meta-box'),
+    ('Toolset Types',   'fields',  'plugin', 'types'),
+    ('Toolset Types',   'fields',  'plugin', 'toolset-types'),
+    ('Carbon Fields',   'fields',  'plugin', 'carbon-fields'),
+    ('JetEngine',       'fields',  'plugin', 'jet-engine')
+) AS t(target, category, kind, dir_slug);
+
+-- Every installed component on every in-scope site, flattened to one row each.
+CREATE OR REPLACE TEMP VIEW census_components AS
+SELECT f.id AS site_id, f.tenant_id, f.multisite, f.contact_freshness, f.contact_stale,
+       'plugin'::text AS kind,
+       lower(split_part(c ->> 'slug', '/', 1)) AS dir_slug,
+       c ->> 'version'  AS raw_version,
+       COALESCE((c ->> 'active')::boolean, false) AS active
+FROM census_fleet f
+CROSS JOIN LATERAL jsonb_array_elements(
+    CASE WHEN f.has_plugin_inventory THEN f.components -> 'plugins' ELSE '[]'::jsonb END
+) AS c
+UNION ALL
+SELECT f.id, f.tenant_id, f.multisite, f.contact_freshness, f.contact_stale,
+       'theme'::text,
+       lower(split_part(c ->> 'slug', '/', 1)),
+       c ->> 'version',
+       COALESCE((c ->> 'active')::boolean, false)
+FROM census_fleet f
+CROSS JOIN LATERAL jsonb_array_elements(
+    CASE WHEN f.has_theme_inventory THEN f.components -> 'themes' ELSE '[]'::jsonb END
+) AS c;
+
+-- Matched target hits. `active` is taken at face value except on multisite,
+-- where a network-activated plugin reports active=false (see note 3 above).
+CREATE OR REPLACE TEMP VIEW census_hits AS
+SELECT c.*, t.target, t.category,
+       substring(c.raw_version from '^([0-9]+\.[0-9]+)') AS version_minor
+FROM census_components c
+JOIN census_targets t
+  ON t.kind = c.kind AND t.dir_slug = c.dir_slug;
+
+-- ===========================================================================
+-- REFUSE ON AN EMPTY SCOPE.
+-- A census over zero sites must not print a page of tidy zeroes that reads as
+-- "nobody runs Elementor". Most likely causes: fleet-wide run as a NOBYPASSRLS
+-- role, or a tenant_id that matches nothing.
+-- ===========================================================================
+DO $$
+DECLARE n bigint;
+BEGIN
+    SELECT count(*) INTO n FROM census_fleet;
+    IF n = 0 THEN
+        RAISE EXCEPTION
+            'census scope is empty: 0 sites visible. Either the tenant_id matches no site, or this is a fleet-wide run as a role without BYPASSRLS (sites is FORCE RLS). Refusing to report a fleet that does not exist.';
+    END IF;
+END $$;
+
+\echo ''
+\echo '=== 0. Inventory coverage — the honest denominator ==================='
+-- Read this table first. Every percentage further down is a fraction of
+-- `classifiable`, and this is where you see how much of the fleet that is.
+SELECT
+    count(*)                                                   AS sites_in_scope,
+    count(*) FILTER (WHERE has_plugin_inventory)               AS has_plugin_inventory,
+    count(*) FILTER (WHERE NOT has_plugin_inventory)           AS no_usable_inventory,
+    count(*) FILTER (WHERE has_plugin_inventory
+                       AND NOT has_theme_inventory)            AS plugins_but_no_themes,
+    count(*) FILTER (WHERE multisite)                          AS multisite_sites,
+    count(*) FILTER (WHERE contact_stale)                           AS stale_sites,
+    round(100.0 * count(*) FILTER (WHERE has_plugin_inventory)
+          / nullif(count(*), 0), 1)                            AS pct_with_inventory
+FROM census_fleet;
+
+\echo ''
+\echo '=== 0b. Freshness distribution ======================================='
+SELECT contact_freshness,
+       connection_state,
+       count(*) AS sites,
+       round(100.0 * count(*) / nullif(sum(count(*)) OVER (), 0), 1) AS pct
+FROM census_fleet
+GROUP BY contact_freshness, connection_state
+ORDER BY array_position(
+    ARRAY['contact_24h','contact_week','contact_month','contact_over_30d',
+          'never_contacted'], contact_freshness),
+    connection_state;
+
+\echo ''
+\echo '=== 1. Builder classification (incl. unknown) ========================'
+-- The Gutenberg question. Note the three non-builder buckets are distinct and
+-- none of them is silently merged into "Gutenberg".
+WITH classified AS (
+    SELECT f.id, f.multisite, f.contact_stale,
+           CASE
+               WHEN NOT f.has_plugin_inventory THEN 'unknown: no inventory'
+               WHEN EXISTS (SELECT 1 FROM census_hits h
+                            WHERE h.site_id = f.id AND h.category = 'builder'
+                              AND h.active)
+                    THEN 'builder active'
+               WHEN NOT f.has_theme_inventory
+                    THEN 'indeterminate: no theme inventory'
+               WHEN EXISTS (SELECT 1 FROM census_hits h
+                            WHERE h.site_id = f.id AND h.category = 'builder')
+                    THEN 'builder installed, not active'
+               ELSE 'Gutenberg (no builder present)'
+           END AS bucket
+    FROM census_fleet f
+)
+SELECT bucket,
+       count(*) AS sites,
+       round(100.0 * count(*) / nullif(sum(count(*)) OVER (), 0), 1) AS pct_of_scope,
+       count(*) FILTER (WHERE contact_stale)  AS of_which_stale,
+       count(*) FILTER (WHERE multisite) AS of_which_multisite
+FROM classified
+GROUP BY bucket
+ORDER BY sites DESC;
+
+\echo ''
+\echo '=== 2. Per-target adoption ==========================================='
+-- pct_of_classifiable is deliberately NOT a fraction of all sites: a site whose
+-- inventory we never received cannot testify for or against any target.
+WITH denom AS (
+    SELECT count(*) FILTER (WHERE has_plugin_inventory) AS classifiable
+    FROM census_fleet
+)
+SELECT h.category,
+       h.target,
+       count(DISTINCT h.site_id) FILTER (WHERE h.active)     AS sites_active,
+       count(DISTINCT h.site_id) FILTER (WHERE NOT h.active) AS sites_installed_inactive,
+       round(100.0 * count(DISTINCT h.site_id) FILTER (WHERE h.active)
+             / nullif((SELECT classifiable FROM denom), 0), 1) AS pct_of_classifiable,
+       count(DISTINCT h.site_id) FILTER (WHERE h.active AND h.contact_stale)  AS active_but_stale,
+       count(DISTINCT h.site_id) FILTER (WHERE h.active AND h.multisite) AS active_on_multisite
+FROM census_hits h
+GROUP BY h.category, h.target
+ORDER BY h.category, sites_active DESC;
+
+\echo ''
+\echo '=== 3. Version spread (major.minor) =================================='
+-- Grouped to major.minor; per-patch is noise. version_minor NULL means the
+-- version string did not parse — the agent writes the literal "unknown" when a
+-- plugin header omits Version, so this bucket is real and is shown, not dropped.
+SELECT h.target,
+       h.dir_slug,
+       COALESCE(h.version_minor, '(unparsed)') AS version_minor,
+       count(DISTINCT h.site_id) AS sites,
+       count(DISTINCT h.site_id) FILTER (WHERE h.contact_stale) AS of_which_stale
+FROM census_hits h
+WHERE h.active
+GROUP BY h.target, h.dir_slug, h.version_minor
+ORDER BY h.target, sites DESC, version_minor;
+
+\echo ''
+\echo '=== 4. Builder co-installation ======================================='
+-- How many sites carry more than one builder. A site with Elementor AND Divi
+-- is a migration/hand-off case, and it is why section 1 counts each site once
+-- by precedence rather than summing section 2.
+WITH per_site AS (
+    SELECT site_id, count(DISTINCT target) AS builders
+    FROM census_hits WHERE category = 'builder' AND active
+    GROUP BY site_id
+)
+SELECT builders AS active_builders_on_site, count(*) AS sites
+FROM per_site GROUP BY builders ORDER BY builders;

--- a/apps/api/db/analysis/fleet_software_census.sql
+++ b/apps/api/db/analysis/fleet_software_census.sql
@@ -19,31 +19,11 @@
 -- document per site, sites.components, written by UpdateSiteMetadata
 -- (db/query/sites.sql) which REWRITES the document wholesale on every push.
 --
--- !! INVENTORY AGE IS NOT MEASURABLE IN THIS SCHEMA. READ THIS BEFORE QUOTING
--- !! ANY "stale" NUMBER THIS SCRIPT PRINTS.
---
--- There is no components_updated_at column. UpdateSiteMetadata does stamp
--- last_seen_at alongside components -- but TouchSiteHeartbeat
--- (db/query/site_connection.sql) ALSO stamps last_seen_at, every 60 seconds,
--- WITHOUT touching components. So last_seen_at is "when the agent last said
--- hello", not "when the inventory was last refreshed".
---
--- The two diverge in the dangerous direction: a site whose 60s heartbeat is
--- alive but whose 30-minute metadata cron has died reports last_seen_at =
--- seconds ago while serving a components document that is arbitrarily old.
--- last_seen_at therefore OVERSTATES inventory freshness and can never
--- understate it. The columns below named *_stale are a LOWER BOUND on staleness
--- and a site absent from them is not thereby fresh.
---
--- Closing this gap needs a schema change (a components_updated_at stamped only
--- by UpdateSiteMetadata). That is a migration, and it is not in this read-only
--- script's scope.
---
 -- Shape, built control-plane side in internal/site/service.go buildInventoryPayload:
 --   {"plugins":[{"slug","name","version","active",...}],
 --    "themes": [{"slug","name","version","active",...}], ...}
 --
--- Four properties of that document drive the whole design below:
+-- Five properties of that document drive the whole design below.
 --
 --   1. `slug` for a plugin is the PLUGIN FILE PATH ("elementor/elementor.php"),
 --      not a directory slug. The directory is split_part(slug,'/',1). For a
@@ -53,22 +33,93 @@
 --   2. Page builders are NOT all plugins. Bricks and Divi ship as THEMES.
 --      A plugins-only census reports zero Bricks and zero Divi and is wrong in
 --      exactly the direction that flatters the "Gutenberg first" hypothesis.
---      This script matches plugins and themes in one pass.
+--      This script matches plugins and themes in one pass, and — see section 4
+--      — gives a theme-shipped target a THEME denominator, because a site that
+--      never sent a themes array cannot testify about Bricks either way.
 --
---   3. `active` comes from get_option('active_plugins'), which on MULTISITE
---      does not contain network-activated plugins. A network-activated builder
---      is therefore reported active=false while running on every site in the
---      network. Multisite rows are counted but reported separately, because
---      their `active` flag is not trustworthy.
+--   3. INVENTORY AGE IS sites.components_updated_at (m121, GH #553). Read the
+--      next block; it is the single most misreadable number this script prints.
 --
---   4. A site can have a plugins array and no themes array. That site cannot be
---      called Gutenberg — an unseen themes array could hold Bricks or Divi. It
---      is classified 'indeterminate', never folded into the no-builder bucket.
+--   4. `active` ON MULTISITE DEPENDS ON THE AGENT VERSION. Read the block after
+--      that one.
 --
--- The single largest correctness rule here: "no builder found" is only a
--- finding for a site whose inventory we actually have. Sites with no usable
--- inventory are counted in their own bucket and are NEVER counted as Gutenberg.
--- Folding them in would inflate the exact number the roadmap is betting on.
+--   5. A site can have a plugins array and no themes array, or the reverse.
+--      A POSITIVE finding from partial inventory is still true — an active
+--      Bricks theme is an active builder whether or not we also got the plugin
+--      list. A NEGATIVE finding is not: "no builder present" requires BOTH
+--      arrays, because the missing one could hold Bricks or Divi. The
+--      classification CASE in section 3 is ordered on exactly that asymmetry.
+--
+-- ---------------------------------------------------------------------------
+-- INVENTORY AGE: components_updated_at, AND WHY MOST OF IT IS NULL TODAY
+-- ---------------------------------------------------------------------------
+--
+-- m121 (20260823000000) added sites.components_updated_at, stamped by
+-- UpdateSiteMetadata — the only statement in the tree that writes
+-- sites.components — so the inventory now carries its own age.
+--
+-- This replaces last_seen_at, which was never inventory age: TouchSiteHeartbeat
+-- (db/query/site_connection.sql) bumps last_seen_at every 60 seconds WITHOUT
+-- touching components, so it overstated freshness and could never understate
+-- it. last_seen_at still appears below, in section 2 only, answering the
+-- different and still-useful question "is the agent alive at all".
+--
+-- !! m121 DELIBERATELY DID NOT BACKFILL. Every row that existed when it applied
+-- !! has components_updated_at = NULL, and NULL means EXACTLY "we have never
+-- !! recorded when this inventory was collected". A site leaves that state only
+-- !! on its next metadata push (agent-driven, ~30 minute cron). So a census run
+-- !! soon after m121 is dominated by NULL, and that is a true statement about
+-- !! our knowledge, not a defect to be tidied away.
+--
+-- Therefore NULL age is ITS OWN BUCKET everywhere in this script. It is never
+-- folded into "fresh", never folded into "stale", and never silently dropped by
+-- a three-valued-logic filter. The two derived flags are deliberately asymmetric:
+--
+--   inventory_age_known       true iff components_updated_at IS NOT NULL.
+--   inventory_provably_stale  true ONLY when the stamp exists AND is older than
+--                             :stale_days. It is FALSE for a NULL-age site —
+--                             so `NOT inventory_provably_stale` does NOT mean
+--                             fresh, it means "fresh or unknown". Every report
+--                             below that shows a stale count shows the
+--                             age-unknown count beside it for that reason.
+--
+-- Section 0 exists so no number below can be quoted without its denominator.
+--
+-- ---------------------------------------------------------------------------
+-- MULTISITE `active` IS A MIXTURE UNTIL THE FLEET UPDATES
+-- ---------------------------------------------------------------------------
+--
+-- On multisite, a network-activated plugin does not appear in
+-- get_option('active_plugins'); it lives in
+-- get_site_option('active_sitewide_plugins'), a different option with a
+-- different shape. The agent originally read only the first, so a builder
+-- network-activated across a multisite reported active=false on every site in
+-- the network — invisible on exactly the installs where it mattered most.
+--
+-- PR #558 fixed the agent: MetadataCommand::plugins() now unions both sources.
+-- But the fix is IN THE AGENT, and agents update on their own schedule. A fleet
+-- measured today is a MIXTURE of both behaviours, and nothing in the components
+-- document records which agent version wrote it. So for multisite rows:
+--
+--   active=true  is trustworthy in both versions (no false positives).
+--   active=false is trustworthy ONLY from a post-#558 agent. From an older one
+--                it may be a network-activated plugin being under-reported.
+--
+-- The error therefore runs one way: multisite builder adoption is a LOWER
+-- BOUND, and it will rise as agents update without anyone installing anything.
+-- Single-site rows are unaffected — active_plugins is complete there.
+--
+-- Section 7 prints the multisite exposure so the size of that caveat is a
+-- number and not an adjective. Sections 3 and 4 keep multisite counts in their
+-- own columns rather than merging them into a single adoption figure.
+--
+-- ---------------------------------------------------------------------------
+-- The single largest correctness rule
+-- ---------------------------------------------------------------------------
+-- "No builder found" is only a finding for a site whose inventory we actually
+-- have. Sites with no usable inventory are counted in their own bucket and are
+-- NEVER counted as Gutenberg. Folding them in would inflate the exact number
+-- the roadmap is betting on, using the sites that said nothing.
 -- ===========================================================================
 
 \set ON_ERROR_STOP on
@@ -100,6 +151,7 @@ SELECT
     s.tenant_id,
     s.multisite,
     s.last_seen_at,
+    s.components_updated_at,
     s.components,
     -- A usable plugins array. '{}' and {"plugins":{...}} are NOT usable;
     -- {"plugins":[]} IS usable and means "reported, no plugins".
@@ -115,19 +167,38 @@ SELECT
     -- Caught by the proof harness; see fleet_software_census_proof.sql sites 7 and 8.
     COALESCE(jsonb_typeof(s.components -> 'plugins') = 'array', false) AS has_plugin_inventory,
     COALESCE(jsonb_typeof(s.components -> 'themes')  = 'array', false) AS has_theme_inventory,
-    -- Buckets of LAST AGENT CONTACT, not of inventory age. See the header note:
-    -- the 60s heartbeat bumps last_seen_at without refreshing components.
+
+    -- ---- INVENTORY AGE (m121). NULL is a bucket, not a rounding error. -----
+    -- True iff we have ever recorded when this inventory was collected. Every
+    -- freshness figure in this script is a fraction of the sites where this is
+    -- true, and section 0 prints that denominator first for that reason.
+    (s.components_updated_at IS NOT NULL) AS inventory_age_known,
     CASE
-        WHEN s.last_seen_at IS NULL                       THEN 'never_contacted'
+        WHEN s.components_updated_at IS NULL                            THEN 'age_unknown (never recorded)'
+        WHEN s.components_updated_at > now() - interval '24 hours'      THEN 'inventory_24h'
+        WHEN s.components_updated_at > now() - interval '7 days'        THEN 'inventory_week'
+        WHEN s.components_updated_at > now() - interval '30 days'       THEN 'inventory_month'
+        ELSE 'inventory_over_30d'
+    END AS inventory_freshness,
+    -- PROVABLY stale: the stamp exists AND is older than :stale_days. COALESCE
+    -- to false for a NULL stamp, so this flag never carries SQL NULL into a
+    -- filter. Read it with inventory_age_known beside it: false here means
+    -- "fresh OR unknown", never "fresh".
+    COALESCE(
+        s.components_updated_at < now() - (:stale_days || ' days')::interval,
+        false) AS inventory_provably_stale,
+
+    -- ---- AGENT LIVENESS. A DIFFERENT QUESTION. Section 2 only. ------------
+    -- last_seen_at is bumped by the 60s heartbeat and says nothing about when
+    -- the inventory was refreshed. Kept because "the agent is gone" is worth
+    -- knowing on its own; never used as an inventory age.
+    CASE
+        WHEN s.last_seen_at IS NULL                        THEN 'never_contacted'
         WHEN s.last_seen_at > now() - interval '24 hours'  THEN 'contact_24h'
         WHEN s.last_seen_at > now() - interval '7 days'    THEN 'contact_week'
         WHEN s.last_seen_at > now() - interval '30 days'   THEN 'contact_month'
         ELSE 'contact_over_30d'
-    END AS contact_freshness,
-    -- LOWER BOUND on inventory staleness (see header). True here means the
-    -- inventory is definitely at least this old; false does NOT mean fresh.
-    (s.last_seen_at IS NULL
-     OR s.last_seen_at < now() - (:stale_days || ' days')::interval) AS contact_stale,
+    END AS last_contact_freshness,
     s.connection_state
 FROM sites s
 WHERE s.connection_state <> 'archived'
@@ -138,7 +209,8 @@ WHERE s.connection_state <> 'archived'
   AND (:'tenant_id' = '' OR s.tenant_id = NULLIF(:'tenant_id', '')::uuid);
 
 -- Integration targets. (target, category, kind, dir_slug) — one row per
--- distributed artifact, because a product can ship as several.
+-- distributed artifact, because a product can ship as several. `kind` is also
+-- what decides each target's denominator in section 4.
 CREATE OR REPLACE TEMP VIEW census_targets AS
 SELECT * FROM (VALUES
     -- Page builders (category 'builder' defines the Gutenberg complement).
@@ -186,9 +258,20 @@ SELECT * FROM (VALUES
     ('JetEngine',       'fields',  'plugin', 'jet-engine')
 ) AS t(target, category, kind, dir_slug);
 
+-- Which artifact kinds each TARGET ships as. Divi is a theme AND a plugin;
+-- Bricks is a theme only; Elementor is a plugin only. Section 4 uses this to
+-- pick a denominator per target instead of one global one.
+CREATE OR REPLACE TEMP VIEW census_target_kinds AS
+SELECT target,
+       bool_or(kind = 'plugin') AS ships_plugin,
+       bool_or(kind = 'theme')  AS ships_theme
+FROM census_targets
+GROUP BY target;
+
 -- Every installed component on every in-scope site, flattened to one row each.
 CREATE OR REPLACE TEMP VIEW census_components AS
-SELECT f.id AS site_id, f.tenant_id, f.multisite, f.contact_freshness, f.contact_stale,
+SELECT f.id AS site_id, f.tenant_id, f.multisite,
+       f.inventory_freshness, f.inventory_provably_stale, f.inventory_age_known,
        'plugin'::text AS kind,
        lower(split_part(c ->> 'slug', '/', 1)) AS dir_slug,
        c ->> 'version'  AS raw_version,
@@ -198,7 +281,8 @@ CROSS JOIN LATERAL jsonb_array_elements(
     CASE WHEN f.has_plugin_inventory THEN f.components -> 'plugins' ELSE '[]'::jsonb END
 ) AS c
 UNION ALL
-SELECT f.id, f.tenant_id, f.multisite, f.contact_freshness, f.contact_stale,
+SELECT f.id, f.tenant_id, f.multisite,
+       f.inventory_freshness, f.inventory_provably_stale, f.inventory_age_known,
        'theme'::text,
        lower(split_part(c ->> 'slug', '/', 1)),
        c ->> 'version',
@@ -208,14 +292,48 @@ CROSS JOIN LATERAL jsonb_array_elements(
     CASE WHEN f.has_theme_inventory THEN f.components -> 'themes' ELSE '[]'::jsonb END
 ) AS c;
 
--- Matched target hits. `active` is taken at face value except on multisite,
--- where a network-activated plugin reports active=false (see note 3 above).
+-- Matched target hits. On multisite, `active=false` is only trustworthy from a
+-- post-#558 agent; see the header. Multisite is carried through so every
+-- report can separate it rather than average it in.
 CREATE OR REPLACE TEMP VIEW census_hits AS
 SELECT c.*, t.target, t.category,
        substring(c.raw_version from '^([0-9]+\.[0-9]+)') AS version_minor
 FROM census_components c
 JOIN census_targets t
   ON t.kind = c.kind AND t.dir_slug = c.dir_slug;
+
+-- One bucket per site. THIS VIEW IS THE CLASSIFICATION -- section 3 reports it
+-- and the proof harness asserts against it. It is a view rather than a CTE
+-- inside section 3 specifically so the harness can test THIS expression
+-- instead of a copy: an earlier harness re-derived the CASE in its own
+-- CREATE TABLE AS, so editing the census's CASE changed nothing the assertions
+-- could see and the bucket assertions passed against a regression. A guard that
+-- cannot see the thing it guards is not a guard.
+--
+-- Ordered on the positive/negative asymmetry of property 5 in the header:
+-- an ACTIVE builder found in partial inventory is a fact; "no builder" is only
+-- a fact when BOTH arrays arrived. None of the three non-builder buckets is
+-- silently merged into Gutenberg.
+CREATE OR REPLACE TEMP VIEW census_classified AS
+SELECT f.id, f.multisite, f.inventory_provably_stale, f.inventory_age_known,
+       CASE
+           WHEN NOT f.has_plugin_inventory AND NOT f.has_theme_inventory
+                THEN 'unknown: no inventory'
+           -- A positive hit is trustworthy even from one array.
+           WHEN EXISTS (SELECT 1 FROM census_hits h
+                        WHERE h.site_id = f.id AND h.category = 'builder'
+                          AND h.active)
+                THEN 'builder active'
+           -- Below here every branch is a NEGATIVE claim, so it needs the
+           -- complete document.
+           WHEN NOT (f.has_plugin_inventory AND f.has_theme_inventory)
+                THEN 'indeterminate: partial inventory'
+           WHEN EXISTS (SELECT 1 FROM census_hits h
+                        WHERE h.site_id = f.id AND h.category = 'builder')
+                THEN 'builder installed, not active'
+           ELSE 'Gutenberg (no builder present)'
+       END AS bucket
+FROM census_fleet f;
 
 -- ===========================================================================
 -- REFUSE ON AN EMPTY SCOPE.
@@ -234,86 +352,162 @@ BEGIN
 END $$;
 
 \echo ''
-\echo '=== 0. Inventory coverage — the honest denominator ==================='
--- Read this table first. Every percentage further down is a fraction of
--- `classifiable`, and this is where you see how much of the fleet that is.
-SELECT
-    count(*)                                                   AS sites_in_scope,
-    count(*) FILTER (WHERE has_plugin_inventory)               AS has_plugin_inventory,
-    count(*) FILTER (WHERE NOT has_plugin_inventory)           AS no_usable_inventory,
-    count(*) FILTER (WHERE has_plugin_inventory
-                       AND NOT has_theme_inventory)            AS plugins_but_no_themes,
-    count(*) FILTER (WHERE multisite)                          AS multisite_sites,
-    count(*) FILTER (WHERE contact_stale)                           AS stale_sites,
-    round(100.0 * count(*) FILTER (WHERE has_plugin_inventory)
-          / nullif(count(*), 0), 1)                            AS pct_with_inventory
-FROM census_fleet;
+\echo '======================================================================'
+\echo '=== 0. CONFIDENCE — read this before quoting any number below      ==='
+\echo '======================================================================'
+-- Every figure is computed, none is written into the prose. The point of this
+-- section is that "42% run Elementor" and "42% of the 12% of sites that have
+-- reported" are different claims, and only the second one is available here.
+SELECT format(
+  'SCOPE %s sites. INVENTORY present on %s (%s%%) — that is the denominator for every adoption number. INVENTORY AGE known on only %s (%s%%); the other %s have never recorded when their inventory was collected (m121 added the column with no backfill, so a site stays unknown until its next metadata push) and appear in their own age_unknown bucket, never folded into fresh or stale. MULTISITE %s site(s) in scope: their active=false is a lower bound until every agent carries PR #558.',
+  (SELECT count(*) FROM census_fleet),
+  (SELECT count(*) FROM census_fleet WHERE has_plugin_inventory OR has_theme_inventory),
+  (SELECT round(100.0 * count(*) FILTER (WHERE has_plugin_inventory OR has_theme_inventory)
+                / nullif(count(*), 0), 1) FROM census_fleet),
+  (SELECT count(*) FROM census_fleet WHERE inventory_age_known),
+  (SELECT round(100.0 * count(*) FILTER (WHERE inventory_age_known)
+                / nullif(count(*), 0), 1) FROM census_fleet),
+  (SELECT count(*) FROM census_fleet WHERE NOT inventory_age_known),
+  (SELECT count(*) FROM census_fleet WHERE multisite)
+) AS read_this_first;
 
 \echo ''
-\echo '=== 0b. Freshness distribution ======================================='
-SELECT contact_freshness,
+\echo '--- 0b. The denominators, as counts ---------------------------------'
+SELECT m.ord,
+       m.metric,
+       m.sites,
+       round(100.0 * m.sites / nullif((SELECT count(*) FROM census_fleet), 0), 1) AS pct_of_scope,
+       m.meaning
+FROM (
+    SELECT 1, 'sites in scope',
+           (SELECT count(*) FROM census_fleet),
+           'non-archived, within the tenant scope given'
+    UNION ALL SELECT 2, 'inventory present (classifiable)',
+           (SELECT count(*) FROM census_fleet WHERE has_plugin_inventory OR has_theme_inventory),
+           'has a plugins array, a themes array, or both'
+    UNION ALL SELECT 3, 'inventory COMPLETE (both arrays)',
+           (SELECT count(*) FROM census_fleet WHERE has_plugin_inventory AND has_theme_inventory),
+           'only these can support a NEGATIVE finding such as "no builder"'
+    UNION ALL SELECT 4, 'inventory PARTIAL (one array only)',
+           (SELECT count(*) FROM census_fleet
+             WHERE (has_plugin_inventory OR has_theme_inventory)
+               AND NOT (has_plugin_inventory AND has_theme_inventory)),
+           'positive findings still count; "no builder" cannot be concluded'
+    UNION ALL SELECT 5, 'no usable inventory',
+           (SELECT count(*) FROM census_fleet WHERE NOT has_plugin_inventory AND NOT has_theme_inventory),
+           'never reported, or a malformed components document'
+    UNION ALL SELECT 6, 'inventory age KNOWN',
+           (SELECT count(*) FROM census_fleet WHERE inventory_age_known),
+           'components_updated_at IS NOT NULL — denominator for ALL freshness'
+    UNION ALL SELECT 7, 'inventory age UNKNOWN',
+           (SELECT count(*) FROM census_fleet WHERE NOT inventory_age_known),
+           'm121 did not backfill; clears on each site next metadata push'
+    UNION ALL SELECT 8, 'inventory PROVABLY stale',
+           (SELECT count(*) FROM census_fleet WHERE inventory_provably_stale),
+           'dated AND older than the stale_days threshold'
+    UNION ALL SELECT 9, 'multisite',
+           (SELECT count(*) FROM census_fleet WHERE multisite),
+           'active=false is a lower bound on pre-#558 agents'
+) AS m(ord, metric, sites, meaning)
+ORDER BY m.ord;
+
+\echo ''
+\echo '=== 1. Inventory freshness (components_updated_at, m121) ============='
+-- age_unknown is a real category and is listed FIRST, not sorted away.
+-- Expect it to dominate on any run soon after m121.
+SELECT inventory_freshness,
+       count(*) AS sites,
+       round(100.0 * count(*) / nullif(sum(count(*)) OVER (), 0), 1) AS pct_of_scope,
+       count(*) FILTER (WHERE has_plugin_inventory OR has_theme_inventory) AS of_which_have_inventory
+FROM census_fleet
+GROUP BY inventory_freshness
+ORDER BY array_position(
+    ARRAY['age_unknown (never recorded)', 'inventory_24h', 'inventory_week',
+          'inventory_month', 'inventory_over_30d'], inventory_freshness);
+
+\echo ''
+\echo '=== 2. Agent contact (last_seen_at) — A DIFFERENT QUESTION ==========='
+-- "Is the agent alive", not "how old is the inventory". The 60s heartbeat bumps
+-- last_seen_at without refreshing components, so a site can be contact_24h and
+-- inventory_over_30d at the same time. Do NOT quote this as freshness.
+SELECT last_contact_freshness,
        connection_state,
        count(*) AS sites,
-       round(100.0 * count(*) / nullif(sum(count(*)) OVER (), 0), 1) AS pct
+       count(*) FILTER (WHERE NOT inventory_age_known) AS of_which_inventory_age_unknown
 FROM census_fleet
-GROUP BY contact_freshness, connection_state
+GROUP BY last_contact_freshness, connection_state
 ORDER BY array_position(
     ARRAY['contact_24h','contact_week','contact_month','contact_over_30d',
-          'never_contacted'], contact_freshness),
+          'never_contacted'], last_contact_freshness),
     connection_state;
 
 \echo ''
-\echo '=== 1. Builder classification (incl. unknown) ========================'
--- The Gutenberg question. Note the three non-builder buckets are distinct and
--- none of them is silently merged into "Gutenberg".
-WITH classified AS (
-    SELECT f.id, f.multisite, f.contact_stale,
-           CASE
-               WHEN NOT f.has_plugin_inventory THEN 'unknown: no inventory'
-               WHEN EXISTS (SELECT 1 FROM census_hits h
-                            WHERE h.site_id = f.id AND h.category = 'builder'
-                              AND h.active)
-                    THEN 'builder active'
-               WHEN NOT f.has_theme_inventory
-                    THEN 'indeterminate: no theme inventory'
-               WHEN EXISTS (SELECT 1 FROM census_hits h
-                            WHERE h.site_id = f.id AND h.category = 'builder')
-                    THEN 'builder installed, not active'
-               ELSE 'Gutenberg (no builder present)'
-           END AS bucket
-    FROM census_fleet f
-)
+\echo '=== 3. Builder classification (incl. unknown) ========================'
+-- Reads census_classified, defined above with the reasoning for its ordering.
 SELECT bucket,
        count(*) AS sites,
        round(100.0 * count(*) / nullif(sum(count(*)) OVER (), 0), 1) AS pct_of_scope,
-       count(*) FILTER (WHERE contact_stale)  AS of_which_stale,
-       count(*) FILTER (WHERE multisite) AS of_which_multisite
-FROM classified
+       count(*) FILTER (WHERE inventory_provably_stale)  AS of_which_provably_stale,
+       count(*) FILTER (WHERE NOT inventory_age_known)   AS of_which_age_unknown,
+       count(*) FILTER (WHERE multisite)                 AS of_which_multisite
+FROM census_classified
 GROUP BY bucket
 ORDER BY sites DESC;
 
 \echo ''
-\echo '=== 2. Per-target adoption ==========================================='
--- pct_of_classifiable is deliberately NOT a fraction of all sites: a site whose
--- inventory we never received cannot testify for or against any target.
+\echo '=== 4. Per-target adoption ==========================================='
+-- THE DENOMINATOR IS PER TARGET, AND IT IS PRINTED.
+--
+-- A site that sent a plugins array but no themes array cannot produce a Bricks
+-- hit, so counting it in the Bricks denominator understates Bricks — the exact
+-- bias finding 2 in the header is about, arriving through the back door. Each
+-- target is therefore divided by the sites that could have reported it:
+--   plugin-only target (Elementor)  -> sites with a plugins array
+--   theme-only target  (Bricks)     -> sites with a themes array
+--   both (Divi, Beaver Builder)     -> sites with either array
+-- denom_sites is a column so the reader can see which one was used.
 WITH denom AS (
-    SELECT count(*) FILTER (WHERE has_plugin_inventory) AS classifiable
+    SELECT count(*) FILTER (WHERE has_plugin_inventory)                        AS plugin_denom,
+           count(*) FILTER (WHERE has_theme_inventory)                         AS theme_denom,
+           count(*) FILTER (WHERE has_plugin_inventory OR has_theme_inventory)  AS either_denom
     FROM census_fleet
+),
+per_target AS (
+    SELECT h.category,
+           h.target,
+           count(DISTINCT h.site_id) FILTER (WHERE h.active)                    AS sites_active,
+           count(DISTINCT h.site_id) FILTER (WHERE NOT h.active)                AS sites_installed_inactive,
+           count(DISTINCT h.site_id)                                            AS sites_installed_any,
+           count(DISTINCT h.site_id) FILTER (WHERE h.active AND h.inventory_provably_stale) AS active_but_provably_stale,
+           count(DISTINCT h.site_id) FILTER (WHERE h.active AND NOT h.inventory_age_known)  AS active_age_unknown,
+           count(DISTINCT h.site_id) FILTER (WHERE h.multisite)                 AS on_multisite
+    FROM census_hits h
+    GROUP BY h.category, h.target
 )
-SELECT h.category,
-       h.target,
-       count(DISTINCT h.site_id) FILTER (WHERE h.active)     AS sites_active,
-       count(DISTINCT h.site_id) FILTER (WHERE NOT h.active) AS sites_installed_inactive,
-       round(100.0 * count(DISTINCT h.site_id) FILTER (WHERE h.active)
-             / nullif((SELECT classifiable FROM denom), 0), 1) AS pct_of_classifiable,
-       count(DISTINCT h.site_id) FILTER (WHERE h.active AND h.contact_stale)  AS active_but_stale,
-       count(DISTINCT h.site_id) FILTER (WHERE h.active AND h.multisite) AS active_on_multisite
-FROM census_hits h
-GROUP BY h.category, h.target
-ORDER BY h.category, sites_active DESC;
+SELECT p.category,
+       p.target,
+       CASE WHEN k.ships_plugin AND k.ships_theme THEN 'plugin+theme'
+            WHEN k.ships_theme                    THEN 'theme'
+            ELSE                                       'plugin' END AS ships_as,
+       p.sites_active,
+       p.sites_installed_inactive,
+       CASE WHEN k.ships_plugin AND k.ships_theme THEN d.either_denom
+            WHEN k.ships_theme                    THEN d.theme_denom
+            ELSE                                       d.plugin_denom END AS denom_sites,
+       round(100.0 * p.sites_active
+             / nullif(CASE WHEN k.ships_plugin AND k.ships_theme THEN d.either_denom
+                           WHEN k.ships_theme                    THEN d.theme_denom
+                           ELSE                                       d.plugin_denom END, 0), 1) AS pct_of_denom,
+       p.active_but_provably_stale,
+       p.active_age_unknown,
+       p.on_multisite
+FROM per_target p
+JOIN census_target_kinds k ON k.target = p.target
+CROSS JOIN denom d
+ORDER BY p.category, p.sites_active DESC;
 
 \echo ''
-\echo '=== 3. Version spread (major.minor) =================================='
+\echo '=== 5. Version spread (major.minor) =================================='
 -- Grouped to major.minor; per-patch is noise. version_minor NULL means the
 -- version string did not parse — the agent writes the literal "unknown" when a
 -- plugin header omits Version, so this bucket is real and is shown, not dropped.
@@ -321,17 +515,18 @@ SELECT h.target,
        h.dir_slug,
        COALESCE(h.version_minor, '(unparsed)') AS version_minor,
        count(DISTINCT h.site_id) AS sites,
-       count(DISTINCT h.site_id) FILTER (WHERE h.contact_stale) AS of_which_stale
+       count(DISTINCT h.site_id) FILTER (WHERE h.inventory_provably_stale) AS of_which_provably_stale,
+       count(DISTINCT h.site_id) FILTER (WHERE NOT h.inventory_age_known)  AS of_which_age_unknown
 FROM census_hits h
 WHERE h.active
 GROUP BY h.target, h.dir_slug, h.version_minor
 ORDER BY h.target, sites DESC, version_minor;
 
 \echo ''
-\echo '=== 4. Builder co-installation ======================================='
+\echo '=== 6. Builder co-installation ======================================='
 -- How many sites carry more than one builder. A site with Elementor AND Divi
--- is a migration/hand-off case, and it is why section 1 counts each site once
--- by precedence rather than summing section 2.
+-- is a migration/hand-off case, and it is why section 3 counts each site once
+-- by precedence rather than summing section 4.
 WITH per_site AS (
     SELECT site_id, count(DISTINCT target) AS builders
     FROM census_hits WHERE category = 'builder' AND active
@@ -339,3 +534,19 @@ WITH per_site AS (
 )
 SELECT builders AS active_builders_on_site, count(*) AS sites
 FROM per_site GROUP BY builders ORDER BY builders;
+
+\echo ''
+\echo '=== 7. Multisite exposure — the size of the #558 caveat =============='
+-- How much of the answer could still move when agents update. Builder adoption
+-- on multisite is a LOWER BOUND on any pre-#558 agent, and nothing in the
+-- components document says which agent version wrote it, so this is the
+-- exposure, not an error estimate.
+SELECT
+    (SELECT count(*) FROM census_fleet WHERE multisite)                       AS multisite_sites,
+    (SELECT count(*) FROM census_fleet)                                        AS sites_in_scope,
+    (SELECT round(100.0 * count(*) FILTER (WHERE multisite) / nullif(count(*), 0), 1)
+       FROM census_fleet)                                                      AS pct_multisite,
+    (SELECT count(DISTINCT site_id) FROM census_hits
+      WHERE multisite AND category = 'builder' AND NOT active)                 AS multisite_builder_inactive,
+    'each multisite site above with an INACTIVE builder may be network-activated and under-reported by a pre-#558 agent'
+                                                                               AS how_to_read;

--- a/apps/api/db/analysis/fleet_software_census.sql
+++ b/apps/api/db/analysis/fleet_software_census.sql
@@ -288,6 +288,7 @@ SELECT * FROM (VALUES
 -- pick a denominator per target instead of one global one.
 CREATE OR REPLACE TEMP VIEW census_target_kinds AS
 SELECT target,
+       min(category)            AS category,
        bool_or(kind = 'plugin') AS ships_plugin,
        bool_or(kind = 'theme')  AS ships_theme
 FROM census_targets
@@ -359,6 +360,59 @@ SELECT f.id, f.tenant_id, f.multisite, f.inventory_provably_stale, f.inventory_a
            ELSE 'Gutenberg (no builder present)'
        END AS bucket
 FROM census_fleet f;
+
+-- Per-target adoption. Section 4 reports this and the proof harness asserts
+-- against it, for the same reason census_classified is a view.
+--
+-- IT IS DRIVEN FROM census_target_kinds, NOT FROM census_hits, and the join is a
+-- LEFT JOIN. A target with no installations anywhere produces no hit rows, so an
+-- inner join silently DROPS it from the report -- and then "nobody runs Oxygen"
+-- and "the Oxygen slug is wrong and matched nothing" look identical, which is
+-- this project's signature defect wearing a report's clothes. A zero is a
+-- finding and it has to be printed. Every configured target therefore appears
+-- exactly once, with its applicable denominator and 0% where that is the answer.
+CREATE OR REPLACE TEMP VIEW census_adoption AS
+WITH denom AS (
+    SELECT count(*) FILTER (WHERE has_plugin_inventory)                        AS plugin_denom,
+           count(*) FILTER (WHERE has_theme_inventory)                         AS theme_denom,
+           count(*) FILTER (WHERE has_plugin_inventory OR has_theme_inventory)  AS either_denom
+    FROM census_fleet
+),
+per_target AS (
+    SELECT h.target,
+           count(DISTINCT h.site_id) FILTER (WHERE h.active)                    AS sites_active,
+           count(DISTINCT h.site_id) FILTER (WHERE NOT h.active)                AS sites_installed_inactive,
+           count(DISTINCT h.site_id)                                            AS sites_installed_any,
+           count(DISTINCT h.site_id) FILTER (WHERE h.active AND h.inventory_provably_stale) AS active_but_provably_stale,
+           count(DISTINCT h.site_id) FILTER (WHERE h.active AND NOT h.inventory_age_known)  AS active_age_unknown,
+           count(DISTINCT h.site_id) FILTER (WHERE h.multisite)                 AS on_multisite
+    FROM census_hits h
+    GROUP BY h.target
+),
+sized AS (
+    SELECT k.category,
+           k.target,
+           CASE WHEN k.ships_plugin AND k.ships_theme THEN 'plugin+theme'
+                WHEN k.ships_theme                    THEN 'theme'
+                ELSE                                       'plugin' END AS ships_as,
+           -- The denominator is per target: only sites that could have reported
+           -- this artifact kind belong in it.
+           CASE WHEN k.ships_plugin AND k.ships_theme THEN d.either_denom
+                WHEN k.ships_theme                    THEN d.theme_denom
+                ELSE                                       d.plugin_denom END AS denom_sites,
+           COALESCE(p.sites_active, 0)                AS sites_active,
+           COALESCE(p.sites_installed_inactive, 0)    AS sites_installed_inactive,
+           COALESCE(p.sites_installed_any, 0)         AS sites_installed_any,
+           COALESCE(p.active_but_provably_stale, 0)   AS active_but_provably_stale,
+           COALESCE(p.active_age_unknown, 0)          AS active_age_unknown,
+           COALESCE(p.on_multisite, 0)                AS on_multisite
+    FROM census_target_kinds k
+    LEFT JOIN per_target p ON p.target = k.target
+    CROSS JOIN denom d
+)
+SELECT s.*,
+       round(100.0 * s.sites_active / nullif(s.denom_sites, 0), 1) AS pct_of_denom
+FROM sized s;
 
 -- ===========================================================================
 -- REFUSE ON AN EMPTY SCOPE.
@@ -492,45 +546,18 @@ ORDER BY sites DESC;
 --   theme-only target  (Bricks)     -> sites with a themes array
 --   both (Divi, Beaver Builder)     -> sites with either array
 -- denom_sites is a column so the reader can see which one was used.
-WITH denom AS (
-    SELECT count(*) FILTER (WHERE has_plugin_inventory)                        AS plugin_denom,
-           count(*) FILTER (WHERE has_theme_inventory)                         AS theme_denom,
-           count(*) FILTER (WHERE has_plugin_inventory OR has_theme_inventory)  AS either_denom
-    FROM census_fleet
-),
-per_target AS (
-    SELECT h.category,
-           h.target,
-           count(DISTINCT h.site_id) FILTER (WHERE h.active)                    AS sites_active,
-           count(DISTINCT h.site_id) FILTER (WHERE NOT h.active)                AS sites_installed_inactive,
-           count(DISTINCT h.site_id)                                            AS sites_installed_any,
-           count(DISTINCT h.site_id) FILTER (WHERE h.active AND h.inventory_provably_stale) AS active_but_provably_stale,
-           count(DISTINCT h.site_id) FILTER (WHERE h.active AND NOT h.inventory_age_known)  AS active_age_unknown,
-           count(DISTINCT h.site_id) FILTER (WHERE h.multisite)                 AS on_multisite
-    FROM census_hits h
-    GROUP BY h.category, h.target
-)
-SELECT p.category,
-       p.target,
-       CASE WHEN k.ships_plugin AND k.ships_theme THEN 'plugin+theme'
-            WHEN k.ships_theme                    THEN 'theme'
-            ELSE                                       'plugin' END AS ships_as,
-       p.sites_active,
-       p.sites_installed_inactive,
-       CASE WHEN k.ships_plugin AND k.ships_theme THEN d.either_denom
-            WHEN k.ships_theme                    THEN d.theme_denom
-            ELSE                                       d.plugin_denom END AS denom_sites,
-       round(100.0 * p.sites_active
-             / nullif(CASE WHEN k.ships_plugin AND k.ships_theme THEN d.either_denom
-                           WHEN k.ships_theme                    THEN d.theme_denom
-                           ELSE                                       d.plugin_denom END, 0), 1) AS pct_of_denom,
-       p.active_but_provably_stale,
-       p.active_age_unknown,
-       p.on_multisite
-FROM per_target p
-JOIN census_target_kinds k ON k.target = p.target
-CROSS JOIN denom d
-ORDER BY p.category, p.sites_active DESC;
+SELECT category,
+       target,
+       ships_as,
+       sites_active,
+       sites_installed_inactive,
+       denom_sites,
+       pct_of_denom,
+       active_but_provably_stale,
+       active_age_unknown,
+       on_multisite
+FROM census_adoption
+ORDER BY category, sites_active DESC, target;
 
 \echo ''
 \echo '=== 5. Version spread (major.minor) =================================='

--- a/apps/api/db/analysis/fleet_software_census.sql
+++ b/apps/api/db/analysis/fleet_software_census.sql
@@ -4,7 +4,16 @@
 -- Answers: for each integration target, how many sites run it, at which
 -- versions, and what fraction of the fleet is that?
 --
--- READ-ONLY. Every statement is a SELECT. Nothing here writes.
+-- READ-ONLY, and that is PROVEN AT RUNTIME rather than asserted here. The proof
+-- harness fingerprints every base table in `public` (row count plus a content
+-- digest) and the transaction's tuple-write counters, before and after this
+-- script runs, and fails if anything moved. Do not replace that with a grep for
+-- write keywords: the anchored grep this file used to advertise reported CLEAN
+-- with a live `UPDATE sites` planted in it, because the write followed another
+-- statement on its line.
+--
+-- What it DOES do to the session, none of it persistent: creates TEMP views, and
+-- sets app.tenant_id when a tenant_id is supplied. Both vanish on disconnect.
 --
 --   psql "$APP_DSN"   -v tenant_id=<uuid> -f fleet_software_census.sql   # one org
 --   psql "$OWNER_DSN"                     -f fleet_software_census.sql   # fleet-wide
@@ -57,6 +66,22 @@
 -- m121 (20260823000000) added sites.components_updated_at, stamped by
 -- UpdateSiteMetadata — the only statement in the tree that writes
 -- sites.components — so the inventory now carries its own age.
+--
+-- WHAT THE TIMESTAMP MEANS, EXACTLY. It is now() evaluated ON THE CONTROL PLANE
+-- at the moment it PERSISTED the inventory document. It is NOT the instant the
+-- agent walked the plugin and theme list on the WordPress host. The agent's
+-- metadata payload carries no collection timestamp, so the collection instant is
+-- simply not knowable here, and m121 named the column components_updated_at
+-- rather than components_collected_at precisely so this script cannot quietly
+-- claim otherwise (m121 DECISION 2).
+--
+-- The gap between the two is one agent push — normally a single HTTP round trip,
+-- and NOT small when it matters: a queued or retried push, a clock-skewed host,
+-- or any future store-and-forward path widens it without warning. So every
+-- freshness number below is "how long since WE RECORDED this", which is a lower
+-- bound on "how long since the agent LOOKED". Like every other error in this
+-- script it runs one way: the inventory can be older than it reports here, never
+-- newer.
 --
 -- This replaces last_seen_at, which was never inventory age: TouchSiteHeartbeat
 -- (db/query/site_connection.sql) bumps last_seen_at every 60 seconds WITHOUT
@@ -315,7 +340,7 @@ JOIN census_targets t
 -- a fact when BOTH arrays arrived. None of the three non-builder buckets is
 -- silently merged into Gutenberg.
 CREATE OR REPLACE TEMP VIEW census_classified AS
-SELECT f.id, f.multisite, f.inventory_provably_stale, f.inventory_age_known,
+SELECT f.id, f.tenant_id, f.multisite, f.inventory_provably_stale, f.inventory_age_known,
        CASE
            WHEN NOT f.has_plugin_inventory AND NOT f.has_theme_inventory
                 THEN 'unknown: no inventory'
@@ -350,6 +375,7 @@ BEGIN
             'census scope is empty: 0 sites visible. Either the tenant_id matches no site, or this is a fleet-wide run as a role without BYPASSRLS (sites is FORCE RLS). Refusing to report a fleet that does not exist.';
     END IF;
 END $$;
+
 
 \echo ''
 \echo '======================================================================'

--- a/apps/api/db/analysis/fleet_software_census_proof.sql
+++ b/apps/api/db/analysis/fleet_software_census_proof.sql
@@ -473,6 +473,36 @@ BEGIN
     SELECT ships_plugin::int + ships_theme::int * 2 INTO got FROM census_target_kinds WHERE target = 'Beaver Builder';
     IF got <> 3 THEN fail := fail || format('Beaver Builder must be classified plugin+theme (expected 3), got %s; ', got); END IF;
 
+    -- ---- Zero-adoption targets must be PRINTED, not dropped ---------------
+    -- census_adoption is driven from the target list with a LEFT JOIN, so a
+    -- target nobody runs still gets a row. An inner join against census_hits
+    -- would drop it, and then "nobody runs Oxygen" and "the Oxygen slug is
+    -- wrong and never matched anything" become indistinguishable.
+    --
+    -- These are deliberately NOT tenant-scoped: census_adoption aggregates
+    -- fleet-wide by construction, so the properties asserted here are the
+    -- structural ones, which hold whatever else the database contains.
+    SELECT count(*) INTO got FROM census_adoption;
+    IF got <> (SELECT count(DISTINCT target) FROM census_targets) THEN
+        fail := fail || format('census_adoption must have exactly one row per configured target (%s), got %s -- a target is being dropped or duplicated; ',
+                               (SELECT count(DISTINCT target) FROM census_targets), got);
+    END IF;
+
+    -- Oxygen is a configured target that no fixture installs. It must appear.
+    SELECT count(*) INTO got FROM census_adoption WHERE target = 'Oxygen';
+    IF got <> 1 THEN fail := fail || format('zero-adoption target Oxygen must still appear exactly once, got %s rows; ', got); END IF;
+
+    SELECT sites_active INTO got FROM census_adoption WHERE target = 'Oxygen';
+    IF got <> 0 THEN fail := fail || format('Oxygen should have 0 active sites, got %s; ', got); END IF;
+
+    -- ...and it must carry a real denominator, or the 0 is unreadable: "0 of 0"
+    -- says nothing, "0 of 10 that could have reported it" is a finding.
+    SELECT denom_sites INTO got FROM census_adoption WHERE target = 'Oxygen';
+    IF got IS NULL OR got = 0 THEN fail := fail || format('zero-adoption target must still carry its applicable denominator, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_adoption WHERE denom_sites IS NULL OR ships_as IS NULL OR sites_active IS NULL;
+    IF got <> 0 THEN fail := fail || format('%s census_adoption row(s) have NULL where a LEFT JOIN should have COALESCEd to 0; ', got); END IF;
+
     -- ---- Exclusions and parsing -------------------------------------------
     -- The archived site carried an active Elementor. If it leaked in, the
     -- Elementor count above would be 4.

--- a/apps/api/db/analysis/fleet_software_census_proof.sql
+++ b/apps/api/db/analysis/fleet_software_census_proof.sql
@@ -1,0 +1,240 @@
+-- ===========================================================================
+-- Proof harness for fleet_software_census.sql
+-- ===========================================================================
+-- Seeds twelve sites covering every classification branch, runs the census,
+-- asserts the bucket counts, then ROLLS BACK. Nothing is persisted.
+--
+--   psql "$OWNER_DSN" -f fleet_software_census_proof.sql
+--
+-- The census's own guard is proven separately by running it against an empty
+-- scope: it must RAISE and exit non-zero rather than print zeroes.
+--
+-- Every seeded site is annotated with the bucket it must land in. If you change
+-- the classification CASE in the census, this file must move with it.
+-- ===========================================================================
+
+\set ON_ERROR_STOP on
+\pset pager off
+
+BEGIN;
+
+INSERT INTO tenants (id, name, slug)
+VALUES ('c5e75000-0000-4000-8000-0000000c5e75', 'Census Proof Org', 'census-proof-org-s2');
+
+-- 1. Elementor active as a PLUGIN.                    -> builder active
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000001','c5e75000-0000-4000-8000-0000000c5e75','https://s1.example','s1-elementor','connected', now(), false, 'hello-elementor',
+ '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":true},
+              {"slug":"akismet/akismet.php","name":"Akismet","version":"5.3.1","active":false}],
+   "themes":[{"slug":"hello-elementor","name":"Hello","version":"3.0.1","active":true}]}'::jsonb);
+
+-- 2. Bricks active as a THEME. A plugins-only census scores this Gutenberg.
+--                                                     -> builder active
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000002','c5e75000-0000-4000-8000-0000000c5e75','https://s2.example','s2-bricks','connected', now(), false, 'bricks',
+ '{"plugins":[{"slug":"akismet/akismet.php","name":"Akismet","version":"5.3.1","active":true}],
+   "themes":[{"slug":"bricks","name":"Bricks","version":"1.9.2","active":true}]}'::jsonb);
+
+-- 3. Divi, whose stylesheet directory is capital-D "Divi".
+--                                                     -> builder active
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000003','c5e75000-0000-4000-8000-0000000c5e75','https://s3.example','s3-divi','connected', now(), false, 'Divi',
+ '{"plugins":[],
+   "themes":[{"slug":"Divi","name":"Divi","version":"4.23.1","active":true}]}'::jsonb);
+
+-- 4. WPBakery, whose plugin directory is "js_composer".
+--                                                     -> builder active
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000004','c5e75000-0000-4000-8000-0000000c5e75','https://s4.example','s4-wpbakery','connected', now(), false, 'twentytwentyone',
+ '{"plugins":[{"slug":"js_composer/js_composer.php","name":"WPBakery","version":"6.13.0","active":true}],
+   "themes":[{"slug":"twentytwentyone","name":"TT1","version":"2.0","active":true}]}'::jsonb);
+
+-- 5. No builder at all, full inventory. Also the Woo + Yoast fixture.
+--                                                     -> Gutenberg
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000005','c5e75000-0000-4000-8000-0000000c5e75','https://s5.example','s5-gutenberg','connected', now(), false, 'twentytwentyfour',
+ '{"plugins":[{"slug":"woocommerce/woocommerce.php","name":"WooCommerce","version":"8.1.2","active":true},
+              {"slug":"wordpress-seo/wp-seo.php","name":"Yoast SEO","version":"21.5","active":true},
+              {"slug":"advanced-custom-fields/acf.php","name":"ACF","version":"6.2.4","active":true}],
+   "themes":[{"slug":"twentytwentyfour","name":"TT4","version":"1.1","active":true}]}'::jsonb);
+
+-- 6. Plugins array present, THEMES KEY ABSENT. Cannot be called Gutenberg
+--    because an unseen theme could be Bricks or Divi.
+--                                                     -> indeterminate
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000006','c5e75000-0000-4000-8000-0000000c5e75','https://s6.example','s6-nothemes','connected', now(), false, '',
+ '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.20.0","active":false}]}'::jsonb);
+
+-- 7. Never reported anything.                         -> unknown: no inventory
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000007','c5e75000-0000-4000-8000-0000000c5e75','https://s7.example','s7-empty','pending_enrollment', NULL, false, '', '{}'::jsonb);
+
+-- 8. Malformed plugins key (the shape sites.sql already guards against).
+--                                                     -> unknown: no inventory
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000008','c5e75000-0000-4000-8000-0000000c5e75','https://s8.example','s8-badshape','connected', now(), false, '',
+ '{"plugins":{"unexpected":"shape"}}'::jsonb);
+
+-- 9. MULTISITE with a network-activated Elementor, which the agent reports
+--    active=false. Real state is "active"; we can only see "installed".
+--                                                     -> builder installed, not active
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000009','c5e75000-0000-4000-8000-0000000c5e75','https://s9.example','s9-multisite','connected', now(), true, 'twentytwentyfour',
+ '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":false}],
+   "themes":[]}'::jsonb);
+
+-- 10. Elementor active but last contact 60 days ago.  -> builder active, stale
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-00000000000a','c5e75000-0000-4000-8000-0000000c5e75','https://s10.example','s10-stale','disconnected', now() - interval '60 days', false, 'hello-elementor',
+ '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.18.0","active":true}],
+   "themes":[]}'::jsonb);
+
+-- 11. Version header missing; the agent writes the literal "unknown".
+--                                                     -> builder active, (unparsed)
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-00000000000b','c5e75000-0000-4000-8000-0000000c5e75','https://s11.example','s11-unknownver','connected', now(), false, 'hello-elementor',
+ '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"unknown","active":true}],
+   "themes":[]}'::jsonb);
+
+-- 12. Breakdance installed but switched off.          -> builder installed, not active
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-00000000000c','c5e75000-0000-4000-8000-0000000c5e75','https://s12.example','s12-inactive','connected', now(), false, 'twentytwentyfour',
+ '{"plugins":[{"slug":"breakdance/plugin.php","name":"Breakdance","version":"1.7.0","active":false}],
+   "themes":[{"slug":"twentytwentyfour","name":"TT4","version":"1.1","active":true}]}'::jsonb);
+
+-- An archived site, which the census must EXCLUDE entirely.
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-0000000000ff','c5e75000-0000-4000-8000-0000000c5e75','https://sX.example','sX-archived','archived', now(), false, 'x',
+ '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":true}],"themes":[]}'::jsonb);
+
+\echo '### Running census as the OWNER (BYPASSRLS), fleet-wide ###'
+\i fleet_software_census.sql
+
+-- ---------------------------------------------------------------------------
+-- Assertions. Each is the classification the seed comments promise.
+-- ---------------------------------------------------------------------------
+\echo ''
+\echo '### ASSERTIONS ###'
+DO $$
+DECLARE
+    got  bigint;
+    fail text := '';
+    PROCEDURE_note text;
+BEGIN
+    SELECT count(*) INTO got FROM census_fleet;
+    IF got <> 12 THEN fail := fail || format('scope should exclude the archived site and be 12, got %s; ', got); END IF;
+
+    -- ---- Inventory-usability flags must be BOOLEAN, never NULL. -------------
+    -- These four are the regression guard for the three-valued-logic bug:
+    -- jsonb_typeof(NULL) is NULL, so without COALESCE a never-reported site
+    -- (components = '{}', the column default) has has_plugin_inventory = NULL,
+    -- slips past `WHEN NOT ...` and is classified Gutenberg.
+    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory IS NULL;
+    IF got <> 0 THEN fail := fail || format('has_plugin_inventory must never be NULL, got %s NULL rows; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE has_theme_inventory IS NULL;
+    IF got <> 0 THEN fail := fail || format('has_theme_inventory must never be NULL, got %s NULL rows; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE NOT has_plugin_inventory;
+    IF got <> 2 THEN fail := fail || format('sites with no usable inventory should be 2 (s7 empty, s8 malformed), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory AND NOT has_theme_inventory;
+    IF got <> 1 THEN fail := fail || format('plugins-but-no-themes should be 1 (s6), got %s; ', got); END IF;
+
+    -- ---- Every classification bucket, by exact count. ----------------------
+    -- Re-derives the census CASE. If the CASE changes, this must change too.
+    CREATE TEMP TABLE census_proof_buckets ON COMMIT DROP AS
+    SELECT f.id,
+           CASE
+               WHEN NOT f.has_plugin_inventory THEN 'unknown: no inventory'
+               WHEN EXISTS (SELECT 1 FROM census_hits h
+                            WHERE h.site_id = f.id AND h.category = 'builder' AND h.active)
+                    THEN 'builder active'
+               WHEN NOT f.has_theme_inventory THEN 'indeterminate: no theme inventory'
+               WHEN EXISTS (SELECT 1 FROM census_hits h
+                            WHERE h.site_id = f.id AND h.category = 'builder')
+                    THEN 'builder installed, not active'
+               ELSE 'Gutenberg (no builder present)'
+           END AS bucket
+    FROM census_fleet f;
+
+    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'unknown: no inventory';
+    IF got <> 2 THEN fail := fail || format('bucket "unknown: no inventory" should be 2 (s7,s8), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'builder active';
+    IF got <> 6 THEN fail := fail || format('bucket "builder active" should be 6 (s1,s2,s3,s4,s10,s11), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'indeterminate: no theme inventory';
+    IF got <> 1 THEN fail := fail || format('bucket "indeterminate" should be 1 (s6), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'builder installed, not active';
+    IF got <> 2 THEN fail := fail || format('bucket "installed not active" should be 2 (s9,s12), got %s; ', got); END IF;
+
+    -- The one that matters most: exactly ONE seeded site truly runs no builder.
+    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'Gutenberg (no builder present)';
+    IF got <> 1 THEN fail := fail || format('bucket "Gutenberg" should be EXACTLY 1 (s5 only). Got %s — a site with unknown or partial inventory is being scored as Gutenberg; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_hits WHERE target='Bricks' AND active;
+    IF got <> 1 THEN fail := fail || format('Bricks (theme) active should be 1, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_hits WHERE target='Divi' AND active;
+    IF got <> 1 THEN fail := fail || format('Divi (capital-D theme dir) active should be 1, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_hits WHERE target='WPBakery' AND active;
+    IF got <> 1 THEN fail := fail || format('WPBakery (js_composer) active should be 1, got %s; ', got); END IF;
+
+    SELECT count(DISTINCT site_id) INTO got FROM census_hits WHERE target='Elementor' AND active;
+    IF got <> 3 THEN fail := fail || format('Elementor active should be 3 (s1,s10,s11), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_hits WHERE target='WooCommerce' AND active;
+    IF got <> 1 THEN fail := fail || format('WooCommerce active should be 1, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_hits WHERE target='Yoast SEO' AND active;
+    IF got <> 1 THEN fail := fail || format('Yoast (wordpress-seo) active should be 1, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_hits WHERE target='ACF' AND active;
+    IF got <> 1 THEN fail := fail || format('ACF active should be 1, got %s; ', got); END IF;
+
+    -- The archived site carried an active Elementor. If it leaked in, the
+    -- Elementor count above would be 4.
+    SELECT count(*) INTO got FROM census_fleet WHERE connection_state='archived';
+    IF got <> 0 THEN fail := fail || format('archived sites must be excluded, got %s; ', got); END IF;
+
+    -- The unparsed-version bucket must survive rather than be dropped.
+    SELECT count(*) INTO got FROM census_hits
+      WHERE target='Elementor' AND active AND version_minor IS NULL;
+    IF got <> 1 THEN fail := fail || format('one Elementor should have an unparsed version, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_hits
+      WHERE target='Elementor' AND active AND version_minor='3.21';
+    IF got <> 1 THEN fail := fail || format('one Elementor should group to 3.21, got %s; ', got); END IF;
+
+    IF fail <> '' THEN RAISE EXCEPTION 'PROOF FAILED: %', fail; END IF;
+    RAISE NOTICE 'ALL ASSERTIONS PASSED';
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Same data, but read as wpmgr_app: NOSUPERUSER, NOBYPASSRLS, the role every
+-- install actually runs as, through the real tenant-isolation policy. A proof
+-- that only ever runs as superuser leaves the RLS policies inert.
+-- ---------------------------------------------------------------------------
+\echo ''
+\echo '### RLS: same scope as wpmgr_app under sites_tenant_isolation ###'
+SET LOCAL ROLE wpmgr_app;
+SELECT set_config('app.tenant_id', 'c5e75000-0000-4000-8000-0000000c5e75', true) AS scoped;
+SELECT current_user AS running_as,
+       count(*)     AS sites_visible_to_app_role
+FROM sites WHERE connection_state <> 'archived';
+
+\echo ''
+\echo '### RLS: wpmgr_app with NO tenant GUC must see nothing ###'
+SELECT set_config('app.tenant_id', '', true) AS cleared;
+SELECT current_user AS running_as,
+       count(*)     AS sites_visible_without_guc
+FROM sites;
+RESET ROLE;
+
+ROLLBACK;
+
+\echo ''
+\echo '### ROLLED BACK — nothing persisted ###'

--- a/apps/api/db/analysis/fleet_software_census_proof.sql
+++ b/apps/api/db/analysis/fleet_software_census_proof.sql
@@ -1,13 +1,21 @@
 -- ===========================================================================
 -- Proof harness for fleet_software_census.sql
 -- ===========================================================================
--- Seeds twelve sites covering every classification branch, runs the census,
--- asserts the bucket counts, then ROLLS BACK. Nothing is persisted.
+-- Seeds thirteen sites covering every classification branch and every
+-- inventory-age bucket, runs the census, asserts the counts, then ROLLS BACK.
+-- Nothing is persisted.
 --
 --   psql "$OWNER_DSN" -f fleet_software_census_proof.sql
 --
--- The census's own guard is proven separately by running it against an empty
--- scope: it must RAISE and exit non-zero rather than print zeroes.
+-- Run it from THIS DIRECTORY: the \i below is resolved against psql's cwd.
+--
+-- Requires a database at m121 or later (sites.components_updated_at). Against
+-- an older schema the seeds fail on the unknown column, loudly, which is the
+-- correct outcome — the census cannot be proven against a schema that lacks the
+-- column it now reports on.
+--
+-- The census's own empty-scope guard is proven separately by running it against
+-- an empty scope: it must RAISE and exit non-zero rather than print zeroes.
 --
 -- Every seeded site is annotated with the bucket it must land in. If you change
 -- the classification CASE in the census, this file must move with it.
@@ -21,90 +29,119 @@ BEGIN;
 INSERT INTO tenants (id, name, slug)
 VALUES ('c5e75000-0000-4000-8000-0000000c5e75', 'Census Proof Org', 'census-proof-org-s2');
 
--- 1. Elementor active as a PLUGIN.                    -> builder active
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000001','c5e75000-0000-4000-8000-0000000c5e75','https://s1.example','s1-elementor','connected', now(), false, 'hello-elementor',
+-- ---------------------------------------------------------------------------
+-- components_updated_at (m121) is set EXPLICITLY on every seed, including the
+-- NULLs. The NULLs are fixtures, not oversights: they are the state every row
+-- in a real database is in until its next metadata push, because m121
+-- deliberately did not backfill. A proof that only seeded dated rows would
+-- never exercise the bucket that dominates a real run.
+-- ---------------------------------------------------------------------------
+
+-- 1. Elementor active as a PLUGIN.       -> builder active, inventory_24h
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000001','c5e75000-0000-4000-8000-0000000c5e75','https://s1.example','s1-elementor','connected', now(), now(), false, 'hello-elementor',
  '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":true},
               {"slug":"akismet/akismet.php","name":"Akismet","version":"5.3.1","active":false}],
    "themes":[{"slug":"hello-elementor","name":"Hello","version":"3.0.1","active":true}]}'::jsonb);
 
 -- 2. Bricks active as a THEME. A plugins-only census scores this Gutenberg.
---                                                     -> builder active
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000002','c5e75000-0000-4000-8000-0000000c5e75','https://s2.example','s2-bricks','connected', now(), false, 'bricks',
+--                                        -> builder active, inventory_week
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000002','c5e75000-0000-4000-8000-0000000c5e75','https://s2.example','s2-bricks','connected', now(), now() - interval '3 days', false, 'bricks',
  '{"plugins":[{"slug":"akismet/akismet.php","name":"Akismet","version":"5.3.1","active":true}],
    "themes":[{"slug":"bricks","name":"Bricks","version":"1.9.2","active":true}]}'::jsonb);
 
--- 3. Divi, whose stylesheet directory is capital-D "Divi".
---                                                     -> builder active
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000003','c5e75000-0000-4000-8000-0000000c5e75','https://s3.example','s3-divi','connected', now(), false, 'Divi',
+-- 3. Divi, whose stylesheet directory is capital-D "Divi". FULL inventory but
+--    NO recorded age — a dated-inventory question this site cannot answer even
+--    though its component list is complete.
+--                                        -> builder active, age_unknown
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000003','c5e75000-0000-4000-8000-0000000c5e75','https://s3.example','s3-divi','connected', now(), NULL, false, 'Divi',
  '{"plugins":[],
    "themes":[{"slug":"Divi","name":"Divi","version":"4.23.1","active":true}]}'::jsonb);
 
 -- 4. WPBakery, whose plugin directory is "js_composer".
---                                                     -> builder active
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000004','c5e75000-0000-4000-8000-0000000c5e75','https://s4.example','s4-wpbakery','connected', now(), false, 'twentytwentyone',
+--                                        -> builder active, inventory_24h
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000004','c5e75000-0000-4000-8000-0000000c5e75','https://s4.example','s4-wpbakery','connected', now(), now(), false, 'twentytwentyone',
  '{"plugins":[{"slug":"js_composer/js_composer.php","name":"WPBakery","version":"6.13.0","active":true}],
    "themes":[{"slug":"twentytwentyone","name":"TT1","version":"2.0","active":true}]}'::jsonb);
 
--- 5. No builder at all, full inventory. Also the Woo + Yoast fixture.
---                                                     -> Gutenberg
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000005','c5e75000-0000-4000-8000-0000000c5e75','https://s5.example','s5-gutenberg','connected', now(), false, 'twentytwentyfour',
+-- 5. No builder at all, full inventory. Also the Woo + Yoast + ACF fixture.
+--    Dated 10 days back, so it is PROVABLY stale at the default stale_days=7.
+--                                        -> Gutenberg, inventory_month, stale
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000005','c5e75000-0000-4000-8000-0000000c5e75','https://s5.example','s5-gutenberg','connected', now(), now() - interval '10 days', false, 'twentytwentyfour',
  '{"plugins":[{"slug":"woocommerce/woocommerce.php","name":"WooCommerce","version":"8.1.2","active":true},
               {"slug":"wordpress-seo/wp-seo.php","name":"Yoast SEO","version":"21.5","active":true},
               {"slug":"advanced-custom-fields/acf.php","name":"ACF","version":"6.2.4","active":true}],
    "themes":[{"slug":"twentytwentyfour","name":"TT4","version":"1.1","active":true}]}'::jsonb);
 
--- 6. Plugins array present, THEMES KEY ABSENT. Cannot be called Gutenberg
---    because an unseen theme could be Bricks or Divi.
---                                                     -> indeterminate
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000006','c5e75000-0000-4000-8000-0000000c5e75','https://s6.example','s6-nothemes','connected', now(), false, '',
+-- 6. Plugins array present, THEMES KEY ABSENT, and its only builder is
+--    inactive. Cannot be called Gutenberg because an unseen theme could be
+--    Bricks or Divi.
+--                                        -> indeterminate: partial inventory
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000006','c5e75000-0000-4000-8000-0000000c5e75','https://s6.example','s6-nothemes','connected', now(), NULL, false, '',
  '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.20.0","active":false}]}'::jsonb);
 
--- 7. Never reported anything.                         -> unknown: no inventory
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000007','c5e75000-0000-4000-8000-0000000c5e75','https://s7.example','s7-empty','pending_enrollment', NULL, false, '', '{}'::jsonb);
+-- 7. Never reported anything.            -> unknown: no inventory, age_unknown
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000007','c5e75000-0000-4000-8000-0000000c5e75','https://s7.example','s7-empty','pending_enrollment', NULL, NULL, false, '', '{}'::jsonb);
 
 -- 8. Malformed plugins key (the shape sites.sql already guards against).
---                                                     -> unknown: no inventory
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000008','c5e75000-0000-4000-8000-0000000c5e75','https://s8.example','s8-badshape','connected', now(), false, '',
+--                                        -> unknown: no inventory, age_unknown
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000008','c5e75000-0000-4000-8000-0000000c5e75','https://s8.example','s8-badshape','connected', now(), NULL, false, '',
  '{"plugins":{"unexpected":"shape"}}'::jsonb);
 
--- 9. MULTISITE with a network-activated Elementor, which the agent reports
---    active=false. Real state is "active"; we can only see "installed".
---                                                     -> builder installed, not active
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-000000000009','c5e75000-0000-4000-8000-0000000c5e75','https://s9.example','s9-multisite','connected', now(), true, 'twentytwentyfour',
+-- 9. MULTISITE with an Elementor reported active=false. On a PRE-#558 agent
+--    that may be a network-activated plugin being under-reported; on a post
+--    -#558 agent it is genuinely inactive. The census cannot tell which, which
+--    is why multisite is reported in its own column and section 7 sizes the
+--    exposure.
+--                                        -> builder installed, not active
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-000000000009','c5e75000-0000-4000-8000-0000000c5e75','https://s9.example','s9-multisite','connected', now(), now(), true, 'twentytwentyfour',
  '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":false}],
    "themes":[]}'::jsonb);
 
--- 10. Elementor active but last contact 60 days ago.  -> builder active, stale
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-00000000000a','c5e75000-0000-4000-8000-0000000c5e75','https://s10.example','s10-stale','disconnected', now() - interval '60 days', false, 'hello-elementor',
+-- 10. Elementor active, inventory recorded 60 days ago.
+--                                        -> builder active, over_30d, stale
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-00000000000a','c5e75000-0000-4000-8000-0000000c5e75','https://s10.example','s10-stale','disconnected', now() - interval '60 days', now() - interval '60 days', false, 'hello-elementor',
  '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.18.0","active":true}],
    "themes":[]}'::jsonb);
 
 -- 11. Version header missing; the agent writes the literal "unknown".
---                                                     -> builder active, (unparsed)
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-00000000000b','c5e75000-0000-4000-8000-0000000c5e75','https://s11.example','s11-unknownver','connected', now(), false, 'hello-elementor',
+--                                        -> builder active, (unparsed)
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-00000000000b','c5e75000-0000-4000-8000-0000000c5e75','https://s11.example','s11-unknownver','connected', now(), now(), false, 'hello-elementor',
  '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"unknown","active":true}],
    "themes":[]}'::jsonb);
 
--- 12. Breakdance installed but switched off.          -> builder installed, not active
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-00000000000c','c5e75000-0000-4000-8000-0000000c5e75','https://s12.example','s12-inactive','connected', now(), false, 'twentytwentyfour',
+-- 12. Breakdance installed but switched off. Single-site, so active=false is
+--     trustworthy regardless of agent version. Dated 40 days back.
+--                                        -> builder installed, not active, stale
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-00000000000c','c5e75000-0000-4000-8000-0000000c5e75','https://s12.example','s12-inactive','connected', now(), now() - interval '40 days', false, 'twentytwentyfour',
  '{"plugins":[{"slug":"breakdance/plugin.php","name":"Breakdance","version":"1.7.0","active":false}],
    "themes":[{"slug":"twentytwentyfour","name":"TT4","version":"1.1","active":true}]}'::jsonb);
 
+-- 13. THEMES ONLY: Bricks active, PLUGINS KEY ABSENT. This is the mirror of
+--     site 6 and it is the regression guard for the classification ORDER. A
+--     CASE that tests "no plugin inventory" before testing "builder active"
+--     calls this site 'unknown' — discarding a builder we positively observed.
+--     A positive finding survives partial inventory; only a negative needs the
+--     complete document.
+--                                        -> builder active, inventory_24h
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-00000000000d','c5e75000-0000-4000-8000-0000000c5e75','https://s13.example','s13-themesonly','connected', now(), now() - interval '2 hours', false, 'bricks',
+ '{"themes":[{"slug":"bricks","name":"Bricks","version":"1.9.5","active":true}]}'::jsonb);
+
 -- An archived site, which the census must EXCLUDE entirely.
-INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, multisite, active_theme, components) VALUES
-('a0000000-0000-0000-0000-0000000000ff','c5e75000-0000-4000-8000-0000000c5e75','https://sX.example','sX-archived','archived', now(), false, 'x',
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('a0000000-0000-0000-0000-0000000000ff','c5e75000-0000-4000-8000-0000000c5e75','https://sX.example','sX-archived','archived', now(), now(), false, 'x',
  '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":true}],"themes":[]}'::jsonb);
 
 \echo '### Running census as the OWNER (BYPASSRLS), fleet-wide ###'
@@ -119,13 +156,12 @@ DO $$
 DECLARE
     got  bigint;
     fail text := '';
-    PROCEDURE_note text;
 BEGIN
     SELECT count(*) INTO got FROM census_fleet;
-    IF got <> 12 THEN fail := fail || format('scope should exclude the archived site and be 12, got %s; ', got); END IF;
+    IF got <> 13 THEN fail := fail || format('scope should exclude the archived site and be 13, got %s; ', got); END IF;
 
     -- ---- Inventory-usability flags must be BOOLEAN, never NULL. -------------
-    -- These four are the regression guard for the three-valued-logic bug:
+    -- These are the regression guard for the three-valued-logic bug:
     -- jsonb_typeof(NULL) is NULL, so without COALESCE a never-reported site
     -- (components = '{}', the column default) has has_plugin_inventory = NULL,
     -- slips past `WHEN NOT ...` and is classified Gutenberg.
@@ -135,47 +171,119 @@ BEGIN
     SELECT count(*) INTO got FROM census_fleet WHERE has_theme_inventory IS NULL;
     IF got <> 0 THEN fail := fail || format('has_theme_inventory must never be NULL, got %s NULL rows; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE NOT has_plugin_inventory;
-    IF got <> 2 THEN fail := fail || format('sites with no usable inventory should be 2 (s7 empty, s8 malformed), got %s; ', got); END IF;
+    -- Same rule, now for the m121 age flags. inventory_provably_stale is built
+    -- from a comparison against a NULLABLE column, so it is the same trap one
+    -- table over: without COALESCE it is NULL for every undated site and every
+    -- `FILTER (WHERE ...)` silently drops those rows.
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_age_known IS NULL;
+    IF got <> 0 THEN fail := fail || format('inventory_age_known must never be NULL, got %s NULL rows; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory AND NOT has_theme_inventory;
-    IF got <> 1 THEN fail := fail || format('plugins-but-no-themes should be 1 (s6), got %s; ', got); END IF;
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_provably_stale IS NULL;
+    IF got <> 0 THEN fail := fail || format('inventory_provably_stale must never be NULL, got %s NULL rows; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness IS NULL;
+    IF got <> 0 THEN fail := fail || format('inventory_freshness must never be NULL, got %s NULL rows; ', got); END IF;
+
+    -- ---- Inventory presence -----------------------------------------------
+    SELECT count(*) INTO got FROM census_fleet WHERE NOT has_plugin_inventory AND NOT has_theme_inventory;
+    IF got <> 2 THEN fail := fail || format('sites with NO usable inventory should be 2 (s7 empty, s8 malformed), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet
+      WHERE (has_plugin_inventory OR has_theme_inventory)
+        AND NOT (has_plugin_inventory AND has_theme_inventory);
+    IF got <> 2 THEN fail := fail || format('PARTIAL inventory should be 2 (s6 plugins-only, s13 themes-only), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory;
+    IF got <> 10 THEN fail := fail || format('plugin_denom should be 10, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE has_theme_inventory;
+    IF got <> 10 THEN fail := fail || format('theme_denom should be 10, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory OR has_theme_inventory;
+    IF got <> 11 THEN fail := fail || format('either_denom should be 11, got %s; ', got); END IF;
+
+    -- ---- m121 inventory age. The NULL bucket is the point. ----------------
+    SELECT count(*) INTO got FROM census_fleet WHERE NOT inventory_age_known;
+    IF got <> 4 THEN fail := fail || format('age_unknown should be 4 (s3,s6,s7,s8), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_age_known;
+    IF got <> 9 THEN fail := fail || format('age_known should be 9, got %s; ', got); END IF;
+
+    -- Every undated site must land in the age_unknown bucket and NOWHERE else.
+    -- This is the assertion that stops a NULL age being quietly folded into a
+    -- freshness bucket, which would report "we do not know" as "it is fresh".
+    SELECT count(*) INTO got FROM census_fleet
+      WHERE NOT inventory_age_known AND inventory_freshness <> 'age_unknown (never recorded)';
+    IF got <> 0 THEN fail := fail || format('%s undated site(s) landed in a dated freshness bucket — NULL age is being folded in; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet
+      WHERE inventory_age_known AND inventory_freshness = 'age_unknown (never recorded)';
+    IF got <> 0 THEN fail := fail || format('%s DATED site(s) landed in age_unknown; ', got); END IF;
+
+    -- An undated site must never be counted as provably stale: we cannot prove
+    -- what we never recorded.
+    SELECT count(*) INTO got FROM census_fleet
+      WHERE NOT inventory_age_known AND inventory_provably_stale;
+    IF got <> 0 THEN fail := fail || format('%s undated site(s) counted as provably stale; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_provably_stale;
+    IF got <> 3 THEN fail := fail || format('provably stale (>7d) should be 3 (s5 10d, s10 60d, s12 40d), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_24h';
+    IF got <> 5 THEN fail := fail || format('inventory_24h should be 5 (s1,s4,s9,s11,s13), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_week';
+    IF got <> 1 THEN fail := fail || format('inventory_week should be 1 (s2), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_month';
+    IF got <> 1 THEN fail := fail || format('inventory_month should be 1 (s5), got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_over_30d';
+    IF got <> 2 THEN fail := fail || format('inventory_over_30d should be 2 (s10,s12), got %s; ', got); END IF;
+
+    -- Inventory age and agent contact are DIFFERENT facts. s3 proves it: the
+    -- heartbeat is current, the inventory has no recorded age at all. If these
+    -- two ever agree on every row, the census has gone back to reading
+    -- last_seen_at as freshness.
+    SELECT count(*) INTO got FROM census_fleet
+      WHERE last_contact_freshness = 'contact_24h' AND NOT inventory_age_known;
+    IF got <> 3 THEN fail := fail || format('sites contacted <24h but with UNDATED inventory should be 3 (s3,s6,s8), got %s; ', got); END IF;
 
     -- ---- Every classification bucket, by exact count. ----------------------
-    -- Re-derives the census CASE. If the CASE changes, this must change too.
-    CREATE TEMP TABLE census_proof_buckets ON COMMIT DROP AS
-    SELECT f.id,
-           CASE
-               WHEN NOT f.has_plugin_inventory THEN 'unknown: no inventory'
-               WHEN EXISTS (SELECT 1 FROM census_hits h
-                            WHERE h.site_id = f.id AND h.category = 'builder' AND h.active)
-                    THEN 'builder active'
-               WHEN NOT f.has_theme_inventory THEN 'indeterminate: no theme inventory'
-               WHEN EXISTS (SELECT 1 FROM census_hits h
-                            WHERE h.site_id = f.id AND h.category = 'builder')
-                    THEN 'builder installed, not active'
-               ELSE 'Gutenberg (no builder present)'
-           END AS bucket
-    FROM census_fleet f;
-
-    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'unknown: no inventory';
+    -- These read census_classified, THE VIEW THE CENSUS ITSELF REPORTS FROM.
+    --
+    -- An earlier version of this harness re-derived the classification CASE
+    -- here in its own CREATE TABLE AS. That made every assertion below a test
+    -- of the copy: the census's CASE was edited to a known-wrong ordering and
+    -- this file still exited 0, because the copy was still right. Asserting
+    -- against the census's own view is the whole point -- if the two ever drift
+    -- apart again, the harness is testing nothing.
+    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'unknown: no inventory';
     IF got <> 2 THEN fail := fail || format('bucket "unknown: no inventory" should be 2 (s7,s8), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'builder active';
-    IF got <> 6 THEN fail := fail || format('bucket "builder active" should be 6 (s1,s2,s3,s4,s10,s11), got %s; ', got); END IF;
+    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'builder active';
+    IF got <> 7 THEN fail := fail || format('bucket "builder active" should be 7 (s1,s2,s3,s4,s10,s11,s13), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'indeterminate: no theme inventory';
+    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'indeterminate: partial inventory';
     IF got <> 1 THEN fail := fail || format('bucket "indeterminate" should be 1 (s6), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'builder installed, not active';
+    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'builder installed, not active';
     IF got <> 2 THEN fail := fail || format('bucket "installed not active" should be 2 (s9,s12), got %s; ', got); END IF;
 
     -- The one that matters most: exactly ONE seeded site truly runs no builder.
-    SELECT count(*) INTO got FROM census_proof_buckets WHERE bucket = 'Gutenberg (no builder present)';
+    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'Gutenberg (no builder present)';
     IF got <> 1 THEN fail := fail || format('bucket "Gutenberg" should be EXACTLY 1 (s5 only). Got %s — a site with unknown or partial inventory is being scored as Gutenberg; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_hits WHERE target='Bricks' AND active;
-    IF got <> 1 THEN fail := fail || format('Bricks (theme) active should be 1, got %s; ', got); END IF;
+    -- s13 specifically: a themes-only site with an ACTIVE builder must be
+    -- 'builder active', not 'unknown'. This fails if the CASE ever tests
+    -- inventory completeness before testing for a positive hit.
+    SELECT count(*) INTO got FROM census_classified
+      WHERE id = 'a0000000-0000-0000-0000-00000000000d' AND bucket = 'builder active';
+    IF got <> 1 THEN fail := fail || 'themes-only s13 with active Bricks must classify "builder active", not be discarded as unknown; '; END IF;
+
+    -- ---- Target matching, plugins AND themes ------------------------------
+    SELECT count(DISTINCT site_id) INTO got FROM census_hits WHERE target='Bricks' AND active;
+    IF got <> 2 THEN fail := fail || format('Bricks (theme) active should be 2 (s2,s13), got %s; ', got); END IF;
 
     SELECT count(*) INTO got FROM census_hits WHERE target='Divi' AND active;
     IF got <> 1 THEN fail := fail || format('Divi (capital-D theme dir) active should be 1, got %s; ', got); END IF;
@@ -195,6 +303,25 @@ BEGIN
     SELECT count(*) INTO got FROM census_hits WHERE target='ACF' AND active;
     IF got <> 1 THEN fail := fail || format('ACF active should be 1, got %s; ', got); END IF;
 
+    -- ---- Per-target denominators (PR #552 review, thread 1) ---------------
+    -- A theme-shipped target must NOT be divided by the plugin denominator. Of
+    -- the 13 seeded sites, 10 sent a themes array and 10 sent a plugins array,
+    -- but they are not the same 10: s6 is plugins-only and s13 is themes-only.
+    -- Dividing Bricks by the plugin denominator would count s6 — a site that
+    -- could never have reported a theme — against Bricks' adoption.
+    SELECT ships_plugin::int + ships_theme::int * 2 INTO got FROM census_target_kinds WHERE target = 'Bricks';
+    IF got <> 2 THEN fail := fail || format('Bricks must be classified theme-only (expected 2 = theme bit), got %s; ', got); END IF;
+
+    SELECT ships_plugin::int + ships_theme::int * 2 INTO got FROM census_target_kinds WHERE target = 'Divi';
+    IF got <> 3 THEN fail := fail || format('Divi must be classified plugin+theme (expected 3), got %s; ', got); END IF;
+
+    SELECT ships_plugin::int + ships_theme::int * 2 INTO got FROM census_target_kinds WHERE target = 'Elementor';
+    IF got <> 1 THEN fail := fail || format('Elementor must be classified plugin-only (expected 1), got %s; ', got); END IF;
+
+    SELECT ships_plugin::int + ships_theme::int * 2 INTO got FROM census_target_kinds WHERE target = 'Beaver Builder';
+    IF got <> 3 THEN fail := fail || format('Beaver Builder must be classified plugin+theme (expected 3), got %s; ', got); END IF;
+
+    -- ---- Exclusions and parsing -------------------------------------------
     -- The archived site carried an active Elementor. If it leaked in, the
     -- Elementor count above would be 4.
     SELECT count(*) INTO got FROM census_fleet WHERE connection_state='archived';
@@ -209,29 +336,73 @@ BEGIN
       WHERE target='Elementor' AND active AND version_minor='3.21';
     IF got <> 1 THEN fail := fail || format('one Elementor should group to 3.21, got %s; ', got); END IF;
 
+    -- ---- Multisite exposure (the #558 caveat, sized) ----------------------
+    SELECT count(*) INTO got FROM census_fleet WHERE multisite;
+    IF got <> 1 THEN fail := fail || format('multisite sites should be 1 (s9), got %s; ', got); END IF;
+
+    SELECT count(DISTINCT site_id) INTO got FROM census_hits
+      WHERE multisite AND category='builder' AND NOT active;
+    IF got <> 1 THEN fail := fail || format('multisite sites with an INACTIVE builder should be 1 (s9), got %s; ', got); END IF;
+
     IF fail <> '' THEN RAISE EXCEPTION 'PROOF FAILED: %', fail; END IF;
     RAISE NOTICE 'ALL ASSERTIONS PASSED';
 END $$;
 
 -- ---------------------------------------------------------------------------
--- Same data, but read as wpmgr_app: NOSUPERUSER, NOBYPASSRLS, the role every
--- install actually runs as, through the real tenant-isolation policy. A proof
--- that only ever runs as superuser leaves the RLS policies inert.
+-- RLS, ASSERTED — not merely printed. (PR #552 review, thread 2.)
+--
+-- Read as wpmgr_app: NOSUPERUSER, NOBYPASSRLS, the role every install actually
+-- runs as, through the real tenant-isolation policy. A proof that only ever
+-- runs as superuser leaves the RLS policies inert.
+--
+-- These queries hit `sites` DIRECTLY and deliberately not census_fleet. The
+-- census's temp views are owned by the role that ran the census (the BYPASSRLS
+-- owner) and are not granted to wpmgr_app, so reading one here raises
+-- "permission denied for view census_fleet" — verified, not assumed. Were a
+-- grant ever added, it would be worse than the error: PostgreSQL defaults views
+-- to security_invoker = false, so the view would execute with the OWNER's
+-- rights and report the owner's row count while appearing to test the app role.
+-- Either way the view proves nothing about RLS. The table does.
+--
+-- The counts are asserted inside a DO block so a policy or role regression
+-- RAISES and psql exits non-zero. Printed counts alone let the script exit 0
+-- while showing the wrong numbers, which is a guard that fails open.
 -- ---------------------------------------------------------------------------
 \echo ''
-\echo '### RLS: same scope as wpmgr_app under sites_tenant_isolation ###'
+\echo '### RLS: asserted as wpmgr_app under sites_tenant_isolation ###'
 SET LOCAL ROLE wpmgr_app;
+
 SELECT set_config('app.tenant_id', 'c5e75000-0000-4000-8000-0000000c5e75', true) AS scoped;
 SELECT current_user AS running_as,
        count(*)     AS sites_visible_to_app_role
 FROM sites WHERE connection_state <> 'archived';
 
-\echo ''
-\echo '### RLS: wpmgr_app with NO tenant GUC must see nothing ###'
-SELECT set_config('app.tenant_id', '', true) AS cleared;
-SELECT current_user AS running_as,
-       count(*)     AS sites_visible_without_guc
-FROM sites;
+DO $$
+DECLARE got bigint; fail text := '';
+BEGIN
+    IF current_user <> 'wpmgr_app' THEN
+        RAISE EXCEPTION 'RLS PROOF BROKEN: expected to be running as wpmgr_app, am %. The role switch failed, so nothing below tests RLS.', current_user;
+    END IF;
+
+    -- Scoped to the proof tenant: the 13 non-archived seeds are visible.
+    PERFORM set_config('app.tenant_id', 'c5e75000-0000-4000-8000-0000000c5e75', true);
+    SELECT count(*) INTO got FROM sites WHERE connection_state <> 'archived';
+    IF got <> 13 THEN fail := fail || format('wpmgr_app WITH the tenant GUC should see 13 non-archived seeded sites, got %s; ', got); END IF;
+
+    SELECT count(*) INTO got FROM sites;
+    IF got <> 14 THEN fail := fail || format('wpmgr_app WITH the tenant GUC should see 14 sites including the archived one, got %s; ', got); END IF;
+
+    -- GUC cleared: tenant isolation must admit NOTHING. If this ever returns a
+    -- row, sites_tenant_isolation is not doing its job and every number this
+    -- census prints for a single org is suspect.
+    PERFORM set_config('app.tenant_id', '', true);
+    SELECT count(*) INTO got FROM sites;
+    IF got <> 0 THEN fail := fail || format('wpmgr_app with NO tenant GUC must see 0 sites, got %s — tenant isolation is not holding; ', got); END IF;
+
+    IF fail <> '' THEN RAISE EXCEPTION 'RLS PROOF FAILED: %', fail; END IF;
+    RAISE NOTICE 'RLS ASSERTIONS PASSED (as %)', current_user;
+END $$;
+
 RESET ROLE;
 
 ROLLBACK;

--- a/apps/api/db/analysis/fleet_software_census_proof.sql
+++ b/apps/api/db/analysis/fleet_software_census_proof.sql
@@ -2,8 +2,23 @@
 -- Proof harness for fleet_software_census.sql
 -- ===========================================================================
 -- Seeds thirteen sites covering every classification branch and every
--- inventory-age bucket, runs the census, asserts the counts, then ROLLS BACK.
+-- inventory-age bucket, PLUS a second "noise" org whose three sites every
+-- assertion must exclude, runs the census, asserts the counts, then ROLLS BACK.
 -- Nothing is persisted.
+--
+-- The noise org is load-bearing. Assertions here used to read GLOBAL counts
+-- (`SELECT count(*) FROM census_fleet`), which are only correct on a database
+-- holding no other sites -- and the census runs fleet-wide as a BYPASSRLS
+-- owner, so it sees everything. It passed solely because the dev container has
+-- zero sites, and would have mis-asserted on any populated database. Every
+-- assertion is now scoped to the fixture tenant, and the noise org exists so
+-- that re-globalising one breaks immediately instead of much later on somebody
+-- else's database.
+--
+-- It also proves the census is READ-ONLY by behaviour rather than by grepping
+-- its text: every base table in `public` is fingerprinted (rows + content
+-- digest) and the transaction's tuple-write counters are captured, before and
+-- after the census runs, and any movement fails the harness.
 --
 --   psql "$OWNER_DSN" -f fleet_software_census_proof.sql
 --
@@ -144,8 +159,110 @@ INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, com
 ('a0000000-0000-0000-0000-0000000000ff','c5e75000-0000-4000-8000-0000000c5e75','https://sX.example','sX-archived','archived', now(), now(), false, 'x',
  '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":true}],"themes":[]}'::jsonb);
 
+-- ---------------------------------------------------------------------------
+-- NOISE TENANT. A SECOND org whose sites the census WILL see (this runs
+-- fleet-wide as a BYPASSRLS owner) and which every assertion below must
+-- therefore exclude.
+--
+-- This exists because the harness previously asserted on GLOBAL counts --
+-- `SELECT count(*) FROM census_fleet` and friends -- which only gave the right
+-- answer on a database holding no other sites. It passed on the dev container
+-- because that container has zero sites, and it would have mis-asserted on any
+-- populated database, including a staging restore. Seeding foreign sites makes
+-- that failure mode permanent rather than latent: if anyone re-globalises an
+-- assertion, these rows break it immediately instead of two months from now on
+-- someone else's database.
+--
+-- Deliberately shaped to break every global count: it adds sites, an active
+-- Elementor, an active Bricks theme, an undated inventory and a multisite.
+-- ---------------------------------------------------------------------------
+INSERT INTO tenants (id, name, slug)
+VALUES ('d0125000-0000-4000-8000-0000000d0125', 'Noise Org', 'census-noise-org-s2');
+
+INSERT INTO sites (id, tenant_id, url, name, connection_state, last_seen_at, components_updated_at, multisite, active_theme, components) VALUES
+('c0000000-0000-0000-0000-000000000001','d0125000-0000-4000-8000-0000000d0125','https://n1.example','n1-elementor','connected', now(), now(), false, 'hello-elementor',
+ '{"plugins":[{"slug":"elementor/elementor.php","name":"Elementor","version":"3.21.5","active":true}],
+   "themes":[{"slug":"hello-elementor","name":"Hello","version":"3.0.1","active":true}]}'::jsonb),
+('c0000000-0000-0000-0000-000000000002','d0125000-0000-4000-8000-0000000d0125','https://n2.example','n2-bricks','connected', now(), NULL, true, 'bricks',
+ '{"plugins":[],
+   "themes":[{"slug":"bricks","name":"Bricks","version":"1.9.2","active":true}]}'::jsonb),
+('c0000000-0000-0000-0000-000000000003','d0125000-0000-4000-8000-0000000d0125','https://n3.example','n3-empty','pending_enrollment', NULL, NULL, false, '', '{}'::jsonb);
+
+-- ---------------------------------------------------------------------------
+-- READ-ONLY, PROVEN AT RUNTIME RATHER THAN BY GREPPING THE TEXT.
+--
+-- The claim "this script writes nothing" was previously supported by
+--     grep -inE '^[[:space:]]*(INSERT|UPDATE|DELETE|...)' fleet_software_census.sql
+-- which is a check that cannot meaningfully fail. The `^` anchor means a write
+-- placed after anything else on its line is invisible to it, and the file
+-- mentions those keywords dozens of times in prose regardless, so the exit
+-- status was never really testing the property.
+--
+-- This tests the BEHAVIOUR instead: fingerprint every base table in `public`,
+-- run the census, fingerprint again, and require the two to be identical. Row
+-- count alone would miss an UPDATE that rewrites a row in place, so each table
+-- also carries a content digest.
+--
+-- Cheap here because the fixture is tiny. It is a proof-harness device and is
+-- not something to point at a production-sized database.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE census_rw_snapshot (
+    phase  text,
+    tbl    text,
+    n      bigint,
+    digest text
+);
+
+CREATE FUNCTION pg_temp.census_fingerprint(p_phase text) RETURNS bigint AS $fn$
+DECLARE
+    r        record;
+    cnt      bigint;
+    dig      text;
+    n_tables bigint := 0;
+BEGIN
+    FOR r IN
+        SELECT c.relname
+        FROM pg_class c
+        JOIN pg_namespace ns ON ns.oid = c.relnamespace
+        WHERE ns.nspname = 'public' AND c.relkind = 'r'
+        ORDER BY c.relname
+    LOOP
+        EXECUTE format(
+            'SELECT count(*), coalesce(md5(string_agg(t::text, %L ORDER BY t::text)), %L) FROM public.%I t',
+            '|', '(empty)', r.relname)
+        INTO cnt, dig;
+        INSERT INTO census_rw_snapshot VALUES (p_phase, r.relname, cnt, dig);
+        n_tables := n_tables + 1;
+    END LOOP;
+
+    -- Content digests alone are NOT sufficient, and this was found the hard
+    -- way: a planted `UPDATE sites SET last_seen_at = now() WHERE multisite`
+    -- passed the digest check silently, because now() is the TRANSACTION START
+    -- time and the seeds had already written that exact value -- so the write
+    -- really happened and rewrote identical bytes.
+    --
+    -- pg_stat_xact_user_tables counts TUPLES TOUCHED in the current
+    -- transaction, so an UPDATE that changes nothing still increments
+    -- n_tup_upd. That closes the identical-value hole the digest cannot see.
+    -- Restricted to `public` so this function's own INSERTs into the temp
+    -- snapshot table are not counted as writes.
+    INSERT INTO census_rw_snapshot
+    SELECT p_phase, '__xact_tuples_written__',
+           coalesce(sum(n_tup_ins + n_tup_upd + n_tup_del), 0),
+           '(tuple counter, not a digest)'
+    FROM pg_stat_xact_user_tables
+    WHERE schemaname = 'public';
+
+    RETURN n_tables;
+END
+$fn$ LANGUAGE plpgsql;
+
+SELECT pg_temp.census_fingerprint('before') AS tables_fingerprinted_before;
+
 \echo '### Running census as the OWNER (BYPASSRLS), fleet-wide ###'
 \i fleet_software_census.sql
+
+SELECT pg_temp.census_fingerprint('after') AS tables_fingerprinted_after;
 
 -- ---------------------------------------------------------------------------
 -- Assertions. Each is the classification the seed comments promise.
@@ -156,8 +273,43 @@ DO $$
 DECLARE
     got  bigint;
     fail text := '';
+    diff text;
+    -- EVERY assertion below is scoped to this tenant. The census runs
+    -- fleet-wide as a BYPASSRLS owner, so census_fleet also holds the noise
+    -- org's sites and anything else the database happens to contain. Asserting
+    -- on global counts made this harness silently conditional on an EMPTY
+    -- database -- it passed only because the dev container has zero sites, and
+    -- it would have mis-asserted on any populated one.
+    proof_tenant constant uuid := 'c5e75000-0000-4000-8000-0000000c5e75';
+    noise_tenant constant uuid := 'd0125000-0000-4000-8000-0000000d0125';
 BEGIN
-    SELECT count(*) INTO got FROM census_fleet;
+    -- The noise org must actually be present, or the scoping is being proven
+    -- against nothing and we are back to the empty-database assumption.
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = noise_tenant;
+    IF got <> 3 THEN fail := fail || format('noise tenant should contribute 3 sites that every assertion must exclude, got %s; ', got); END IF;
+
+    -- ---- READ-ONLY, PROVEN AT RUNTIME -------------------------------------
+    -- Every base table in `public`, fingerprinted before and after the census
+    -- ran. Any INSERT, UPDATE or DELETE it performed moves a count or a digest.
+    SELECT count(*) INTO got FROM census_rw_snapshot WHERE phase = 'before';
+    IF got = 0 THEN fail := fail || 'read-only fingerprint covered 0 tables, so it proves nothing; fix it before trusting a pass; '; END IF;
+
+    SELECT count(*) INTO got FROM census_rw_snapshot WHERE phase = 'after';
+    IF got = 0 THEN fail := fail || 'read-only fingerprint has no AFTER phase; the census run did not complete; '; END IF;
+
+    SELECT string_agg(format('%s (rows %s->%s, digest %s)',
+                             b.tbl, b.n, a.n,
+                             CASE WHEN b.digest IS DISTINCT FROM a.digest THEN 'CHANGED' ELSE 'same' END), ', ')
+      INTO diff
+      FROM census_rw_snapshot b
+      JOIN census_rw_snapshot a ON a.tbl = b.tbl AND a.phase = 'after'
+     WHERE b.phase = 'before'
+       AND (b.n, b.digest) IS DISTINCT FROM (a.n, a.digest);
+    IF diff IS NOT NULL THEN
+        fail := fail || format('THE CENSUS IS NOT READ-ONLY -- it changed: %s; ', diff);
+    END IF;
+
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant;
     IF got <> 13 THEN fail := fail || format('scope should exclude the archived site and be 13, got %s; ', got); END IF;
 
     -- ---- Inventory-usability flags must be BOOLEAN, never NULL. -------------
@@ -165,80 +317,80 @@ BEGIN
     -- jsonb_typeof(NULL) is NULL, so without COALESCE a never-reported site
     -- (components = '{}', the column default) has has_plugin_inventory = NULL,
     -- slips past `WHEN NOT ...` and is classified Gutenberg.
-    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory IS NULL;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND has_plugin_inventory IS NULL;
     IF got <> 0 THEN fail := fail || format('has_plugin_inventory must never be NULL, got %s NULL rows; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE has_theme_inventory IS NULL;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND has_theme_inventory IS NULL;
     IF got <> 0 THEN fail := fail || format('has_theme_inventory must never be NULL, got %s NULL rows; ', got); END IF;
 
     -- Same rule, now for the m121 age flags. inventory_provably_stale is built
     -- from a comparison against a NULLABLE column, so it is the same trap one
     -- table over: without COALESCE it is NULL for every undated site and every
     -- `FILTER (WHERE ...)` silently drops those rows.
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_age_known IS NULL;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_age_known IS NULL;
     IF got <> 0 THEN fail := fail || format('inventory_age_known must never be NULL, got %s NULL rows; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_provably_stale IS NULL;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_provably_stale IS NULL;
     IF got <> 0 THEN fail := fail || format('inventory_provably_stale must never be NULL, got %s NULL rows; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness IS NULL;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_freshness IS NULL;
     IF got <> 0 THEN fail := fail || format('inventory_freshness must never be NULL, got %s NULL rows; ', got); END IF;
 
     -- ---- Inventory presence -----------------------------------------------
-    SELECT count(*) INTO got FROM census_fleet WHERE NOT has_plugin_inventory AND NOT has_theme_inventory;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND NOT has_plugin_inventory AND NOT has_theme_inventory;
     IF got <> 2 THEN fail := fail || format('sites with NO usable inventory should be 2 (s7 empty, s8 malformed), got %s; ', got); END IF;
 
     SELECT count(*) INTO got FROM census_fleet
-      WHERE (has_plugin_inventory OR has_theme_inventory)
+      WHERE tenant_id = proof_tenant AND (has_plugin_inventory OR has_theme_inventory)
         AND NOT (has_plugin_inventory AND has_theme_inventory);
     IF got <> 2 THEN fail := fail || format('PARTIAL inventory should be 2 (s6 plugins-only, s13 themes-only), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND has_plugin_inventory;
     IF got <> 10 THEN fail := fail || format('plugin_denom should be 10, got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE has_theme_inventory;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND has_theme_inventory;
     IF got <> 10 THEN fail := fail || format('theme_denom should be 10, got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE has_plugin_inventory OR has_theme_inventory;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND (has_plugin_inventory OR has_theme_inventory);
     IF got <> 11 THEN fail := fail || format('either_denom should be 11, got %s; ', got); END IF;
 
     -- ---- m121 inventory age. The NULL bucket is the point. ----------------
-    SELECT count(*) INTO got FROM census_fleet WHERE NOT inventory_age_known;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND NOT inventory_age_known;
     IF got <> 4 THEN fail := fail || format('age_unknown should be 4 (s3,s6,s7,s8), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_age_known;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_age_known;
     IF got <> 9 THEN fail := fail || format('age_known should be 9, got %s; ', got); END IF;
 
     -- Every undated site must land in the age_unknown bucket and NOWHERE else.
     -- This is the assertion that stops a NULL age being quietly folded into a
     -- freshness bucket, which would report "we do not know" as "it is fresh".
     SELECT count(*) INTO got FROM census_fleet
-      WHERE NOT inventory_age_known AND inventory_freshness <> 'age_unknown (never recorded)';
+      WHERE tenant_id = proof_tenant AND NOT inventory_age_known AND inventory_freshness <> 'age_unknown (never recorded)';
     IF got <> 0 THEN fail := fail || format('%s undated site(s) landed in a dated freshness bucket — NULL age is being folded in; ', got); END IF;
 
     SELECT count(*) INTO got FROM census_fleet
-      WHERE inventory_age_known AND inventory_freshness = 'age_unknown (never recorded)';
+      WHERE tenant_id = proof_tenant AND inventory_age_known AND inventory_freshness = 'age_unknown (never recorded)';
     IF got <> 0 THEN fail := fail || format('%s DATED site(s) landed in age_unknown; ', got); END IF;
 
     -- An undated site must never be counted as provably stale: we cannot prove
     -- what we never recorded.
     SELECT count(*) INTO got FROM census_fleet
-      WHERE NOT inventory_age_known AND inventory_provably_stale;
+      WHERE tenant_id = proof_tenant AND NOT inventory_age_known AND inventory_provably_stale;
     IF got <> 0 THEN fail := fail || format('%s undated site(s) counted as provably stale; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_provably_stale;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_provably_stale;
     IF got <> 3 THEN fail := fail || format('provably stale (>7d) should be 3 (s5 10d, s10 60d, s12 40d), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_24h';
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_freshness = 'inventory_24h';
     IF got <> 5 THEN fail := fail || format('inventory_24h should be 5 (s1,s4,s9,s11,s13), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_week';
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_freshness = 'inventory_week';
     IF got <> 1 THEN fail := fail || format('inventory_week should be 1 (s2), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_month';
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_freshness = 'inventory_month';
     IF got <> 1 THEN fail := fail || format('inventory_month should be 1 (s5), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_fleet WHERE inventory_freshness = 'inventory_over_30d';
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND inventory_freshness = 'inventory_over_30d';
     IF got <> 2 THEN fail := fail || format('inventory_over_30d should be 2 (s10,s12), got %s; ', got); END IF;
 
     -- Inventory age and agent contact are DIFFERENT facts. s3 proves it: the
@@ -246,7 +398,7 @@ BEGIN
     -- two ever agree on every row, the census has gone back to reading
     -- last_seen_at as freshness.
     SELECT count(*) INTO got FROM census_fleet
-      WHERE last_contact_freshness = 'contact_24h' AND NOT inventory_age_known;
+      WHERE tenant_id = proof_tenant AND last_contact_freshness = 'contact_24h' AND NOT inventory_age_known;
     IF got <> 3 THEN fail := fail || format('sites contacted <24h but with UNDATED inventory should be 3 (s3,s6,s8), got %s; ', got); END IF;
 
     -- ---- Every classification bucket, by exact count. ----------------------
@@ -258,49 +410,49 @@ BEGIN
     -- this file still exited 0, because the copy was still right. Asserting
     -- against the census's own view is the whole point -- if the two ever drift
     -- apart again, the harness is testing nothing.
-    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'unknown: no inventory';
+    SELECT count(*) INTO got FROM census_classified WHERE tenant_id = proof_tenant AND bucket = 'unknown: no inventory';
     IF got <> 2 THEN fail := fail || format('bucket "unknown: no inventory" should be 2 (s7,s8), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'builder active';
+    SELECT count(*) INTO got FROM census_classified WHERE tenant_id = proof_tenant AND bucket = 'builder active';
     IF got <> 7 THEN fail := fail || format('bucket "builder active" should be 7 (s1,s2,s3,s4,s10,s11,s13), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'indeterminate: partial inventory';
+    SELECT count(*) INTO got FROM census_classified WHERE tenant_id = proof_tenant AND bucket = 'indeterminate: partial inventory';
     IF got <> 1 THEN fail := fail || format('bucket "indeterminate" should be 1 (s6), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'builder installed, not active';
+    SELECT count(*) INTO got FROM census_classified WHERE tenant_id = proof_tenant AND bucket = 'builder installed, not active';
     IF got <> 2 THEN fail := fail || format('bucket "installed not active" should be 2 (s9,s12), got %s; ', got); END IF;
 
     -- The one that matters most: exactly ONE seeded site truly runs no builder.
-    SELECT count(*) INTO got FROM census_classified WHERE bucket = 'Gutenberg (no builder present)';
+    SELECT count(*) INTO got FROM census_classified WHERE tenant_id = proof_tenant AND bucket = 'Gutenberg (no builder present)';
     IF got <> 1 THEN fail := fail || format('bucket "Gutenberg" should be EXACTLY 1 (s5 only). Got %s — a site with unknown or partial inventory is being scored as Gutenberg; ', got); END IF;
 
     -- s13 specifically: a themes-only site with an ACTIVE builder must be
     -- 'builder active', not 'unknown'. This fails if the CASE ever tests
     -- inventory completeness before testing for a positive hit.
     SELECT count(*) INTO got FROM census_classified
-      WHERE id = 'a0000000-0000-0000-0000-00000000000d' AND bucket = 'builder active';
+      WHERE tenant_id = proof_tenant AND id = 'a0000000-0000-0000-0000-00000000000d' AND bucket = 'builder active';
     IF got <> 1 THEN fail := fail || 'themes-only s13 with active Bricks must classify "builder active", not be discarded as unknown; '; END IF;
 
     -- ---- Target matching, plugins AND themes ------------------------------
-    SELECT count(DISTINCT site_id) INTO got FROM census_hits WHERE target='Bricks' AND active;
+    SELECT count(DISTINCT site_id) INTO got FROM census_hits WHERE tenant_id = proof_tenant AND target='Bricks' AND active;
     IF got <> 2 THEN fail := fail || format('Bricks (theme) active should be 2 (s2,s13), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_hits WHERE target='Divi' AND active;
+    SELECT count(*) INTO got FROM census_hits WHERE tenant_id = proof_tenant AND target='Divi' AND active;
     IF got <> 1 THEN fail := fail || format('Divi (capital-D theme dir) active should be 1, got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_hits WHERE target='WPBakery' AND active;
+    SELECT count(*) INTO got FROM census_hits WHERE tenant_id = proof_tenant AND target='WPBakery' AND active;
     IF got <> 1 THEN fail := fail || format('WPBakery (js_composer) active should be 1, got %s; ', got); END IF;
 
-    SELECT count(DISTINCT site_id) INTO got FROM census_hits WHERE target='Elementor' AND active;
+    SELECT count(DISTINCT site_id) INTO got FROM census_hits WHERE tenant_id = proof_tenant AND target='Elementor' AND active;
     IF got <> 3 THEN fail := fail || format('Elementor active should be 3 (s1,s10,s11), got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_hits WHERE target='WooCommerce' AND active;
+    SELECT count(*) INTO got FROM census_hits WHERE tenant_id = proof_tenant AND target='WooCommerce' AND active;
     IF got <> 1 THEN fail := fail || format('WooCommerce active should be 1, got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_hits WHERE target='Yoast SEO' AND active;
+    SELECT count(*) INTO got FROM census_hits WHERE tenant_id = proof_tenant AND target='Yoast SEO' AND active;
     IF got <> 1 THEN fail := fail || format('Yoast (wordpress-seo) active should be 1, got %s; ', got); END IF;
 
-    SELECT count(*) INTO got FROM census_hits WHERE target='ACF' AND active;
+    SELECT count(*) INTO got FROM census_hits WHERE tenant_id = proof_tenant AND target='ACF' AND active;
     IF got <> 1 THEN fail := fail || format('ACF active should be 1, got %s; ', got); END IF;
 
     -- ---- Per-target denominators (PR #552 review, thread 1) ---------------
@@ -324,24 +476,24 @@ BEGIN
     -- ---- Exclusions and parsing -------------------------------------------
     -- The archived site carried an active Elementor. If it leaked in, the
     -- Elementor count above would be 4.
-    SELECT count(*) INTO got FROM census_fleet WHERE connection_state='archived';
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND connection_state='archived';
     IF got <> 0 THEN fail := fail || format('archived sites must be excluded, got %s; ', got); END IF;
 
     -- The unparsed-version bucket must survive rather than be dropped.
     SELECT count(*) INTO got FROM census_hits
-      WHERE target='Elementor' AND active AND version_minor IS NULL;
+      WHERE tenant_id = proof_tenant AND target='Elementor' AND active AND version_minor IS NULL;
     IF got <> 1 THEN fail := fail || format('one Elementor should have an unparsed version, got %s; ', got); END IF;
 
     SELECT count(*) INTO got FROM census_hits
-      WHERE target='Elementor' AND active AND version_minor='3.21';
+      WHERE tenant_id = proof_tenant AND target='Elementor' AND active AND version_minor='3.21';
     IF got <> 1 THEN fail := fail || format('one Elementor should group to 3.21, got %s; ', got); END IF;
 
     -- ---- Multisite exposure (the #558 caveat, sized) ----------------------
-    SELECT count(*) INTO got FROM census_fleet WHERE multisite;
+    SELECT count(*) INTO got FROM census_fleet WHERE tenant_id = proof_tenant AND multisite;
     IF got <> 1 THEN fail := fail || format('multisite sites should be 1 (s9), got %s; ', got); END IF;
 
     SELECT count(DISTINCT site_id) INTO got FROM census_hits
-      WHERE multisite AND category='builder' AND NOT active;
+      WHERE tenant_id = proof_tenant AND multisite AND category='builder' AND NOT active;
     IF got <> 1 THEN fail := fail || format('multisite sites with an INACTIVE builder should be 1 (s9), got %s; ', got); END IF;
 
     IF fail <> '' THEN RAISE EXCEPTION 'PROOF FAILED: %', fail; END IF;


### PR DESCRIPTION
## What this is

S2 ("measure the fleet") needs evidence for the builder-integration ordering that S10–S13 are gated on. This adds a **read-only** operator query over `sites.components`, plus a proof harness.

No migration, no schema change, nothing run against production.

**See the [operator note](https://github.com/mosamlife/wpmgr/pull/552#issuecomment-5448846862) before authorising a real run** — what the command is, what it reads, what it does not touch, and why today's answer will be dominated by sites that have not yet reported.

## Where it lives, and why not `db/query/`

`apps/api/sqlc.yaml` sets `queries: "db/query"`, so sqlc parses every `.sql` file in that directory. An analytics query there would emit a Go method into `internal/db/sqlc/**` that no caller ever invokes — a tree that must stay a faithful projection of the application's real query set.

`db/analysis/` is a sibling, outside that glob. Verified rather than assumed, re-run on the current head:

```
$ cd apps/api && sqlc generate && git diff --quiet -- internal/db/sqlc/
SQLC GENERATE EXIT=0
SQLC EMPTY-DIFF EXIT=0   # 0 = generated tree unchanged
```

sqlc is `v1.31.1`, matching the stamp in the committed tree.

## Three findings encoded in the query

**1. Bricks and Divi ship as themes, not plugins.** A plugins-only census reports zero of both, and is wrong in exactly the direction that flatters the "Gutenberg first" hypothesis. The census matches plugins and themes in one pass.

That bias also had a second route in, closed in review: a theme-shipped target was being divided by the *plugin* denominator, so a site that sent a plugins array but no themes array counted against Bricks' adoption despite being unable to report a theme at all. Each target is now divided by the sites that could have reported it, and `ships_as` and `denom_sites` are printed so the reader sees which denominator was used.

**2. A never-reported site was being scored as Gutenberg.** `sites.components` defaults to `'{}'`, so `components -> 'plugins'` is SQL NULL and `jsonb_typeof(NULL)` is NULL — making the usability flag NULL rather than false. `WHEN NOT <null>` never matches, so the site fell through the entire classification CASE into the `ELSE` branch. Sites that reported nothing at all were counted as "runs no page builder" — inflating the exact number the roadmap is betting on, using the sites with no evidence either way. `COALESCE(..., false)` fixes it; the harness asserts these flags are never NULL.

**3. Inventory age is now real, and mostly NULL.** *(Updated — this finding has changed since the PR was opened.)*

The original version of this PR could only report `last_seen_at`, which is heartbeat liveness: `TouchSiteHeartbeat` stamps it every 60 seconds without touching `components`, so it overstated inventory freshness and could never understate it. That gap needed a schema change, and the schema change has since landed.

**m121** (`20260823000000_m121_site_components_updated_at`) added `sites.components_updated_at`, stamped only by `UpdateSiteMetadata`. The census now dates the inventory from it. **m121 deliberately did not backfill**, so every pre-existing row reads NULL — meaning "we have never recorded when this inventory was collected" — until that site's next metadata push. NULL is therefore its own bucket everywhere in the output: never folded into fresh, never into stale, never dropped by a three-valued filter. `last_seen_at` survives in section 2 only, clearly labelled as the different question it answers.

## Correctness rules

- Sites with no usable inventory get **their own bucket** and are never folded into Gutenberg.
- A **positive** finding survives partial inventory — an active Bricks theme is an active builder whether or not the plugin list also arrived. Only a **negative** ("no builder present") requires both arrays. The classification CASE is ordered on that asymmetry.
- Percentages are a fraction of the sites that could have reported the thing being counted, never of all sites.
- `inventory_provably_stale` is true only when a stamp exists *and* is old, so `NOT provably_stale` means "fresh **or** unknown"; the age-unknown count is printed beside every stale count.
- On an empty scope the census **RAISEs and exits non-zero** rather than printing a page of zeroes, which is what a fleet-wide run as a NOBYPASSRLS role would otherwise produce.

## Multisite: a caveat that shrinks over time, not a fixed error

**PR #558** fixed the agent to report network-activated plugins as active — previously a builder network-activated across a multisite reported `active: false` on every site in the network, invisible on exactly the installs where it mattered. But the fix is *in the agent*, and agents update on their own schedule; nothing in the components document records which version wrote it. A fleet measured today is a mixture of both behaviours, so multisite builder adoption is a **lower bound** that will rise as agents update without anyone installing anything. Section 7 prints the exposure as a number rather than an adjective.

## Proof, both directions

Every guard was planted, watched fail, restored, and watched pass.

Guard fires — `COALESCE` removed from the age flag:

```
PSQL EXIT=3
ERROR:  PROOF FAILED: inventory_provably_stale must never be NULL, got 4 NULL rows;
```

Note the stale *count* stayed correct while the NULLs were silently dropped by the filter — which is why the assertion is on NULL-ness, not on the count.

Guard fires — classification CASE reverted to testing inventory completeness before a positive hit:

```
PSQL EXIT=3
ERROR:  PROOF FAILED: bucket "unknown: no inventory" should be 2 (s7,s8), got 3;
  bucket "builder active" should be 7, got 6; themes-only s13 with active Bricks
  must classify "builder active", not be discarded as unknown;
```

Guard fires — RLS, both failure modes (role switch removed; and `sites_tenant_isolation` dropped inside the harness's own transaction so it reverts on ROLLBACK):

```
PSQL EXIT=3
ERROR:  RLS PROOF BROKEN: expected to be running as wpmgr_app, am wpmgr.

PSQL EXIT=3
ERROR:  RLS PROOF FAILED: wpmgr_app WITH the tenant GUC should see 13
        non-archived seeded sites, got 0;
```

Guard fires — empty scope:

```
PSQL EXIT=3
ERROR:  census scope is empty: 0 sites visible. ... Refusing to report a fleet that does not exist.
```

All restored, nothing over-fires:

```
PSQL EXIT=0
NOTICE:  ALL ASSERTIONS PASSED
NOTICE:  RLS ASSERTIONS PASSED (as wpmgr_app)
### ROLLED BACK — nothing persisted ###
```

**One of those plants found a real hole rather than confirming a guard.** Reverting the census's classification CASE to a known-wrong ordering left the harness exiting 0, because the bucket assertions re-derived the CASE in their own local copy and were therefore testing that copy. The classification now lives in a `census_classified` view that the census reports from and the harness asserts against; the same plant then fails as it should.

RLS is exercised as `wpmgr_app` (NOSUPERUSER, NOBYPASSRLS — the role every install runs as), not only as superuser, and the counts are **asserted** rather than printed. They read `sites` directly and not the census views: the temp views are owned by the BYPASSRLS role that ran the census and carry no grant to `wpmgr_app`, so reading one raises `permission denied` — and were a grant added, PostgreSQL's `security_invoker = false` default would run the view with the *owner's* rights and prove nothing. The harness seeds inside a transaction and `ROLLBACK`s; `sites` count before and after is 0.

## Gates

```
make check-rls-cross-tenant                 EXIT=0
  102 cross-tenant policies checked against 102 ledger rows.
  OK: every cross-tenant policy is recorded with a matching access mode (0 errors).

fleet_software_census_proof.sql             EXIT=0
apps/api: go build ./...                    EXIT=0
apps/api: go vet ./...                      EXIT=0
apps/api: go test ./internal/...            EXIT=0
sqlc generate + git diff --quiet            EXIT=0
```

## What this does NOT do

It has not been run against real fleet data. Whether it runs against production is the owner's decision and has not been made. The evidence question S10–S13 are gated on is therefore still open — and, given how much of the fleet will report a NULL inventory age until it next syncs, a run today would likely leave it open. The report says so in its own first line rather than presenting a count that looks more complete than it is.

---

## Re-review round 2 — three findings, all valid

**The read-only claim was never actually proven.** The documented check was an
anchored `grep` for write keywords, which cannot meaningfully fail: a write
following anything else on its line is invisible to it. Planting
`SELECT 1 AS planted; UPDATE sites SET last_seen_at = now() WHERE multisite;`
into the census left that grep exiting 1 — reporting clean — with a live
`UPDATE sites` in the file.

Now proven by behaviour. The harness fingerprints every base table in `public`
(122, printed by the run) with row counts and content digests, plus the
transaction's tuple-write counters, before and after the census executes.

A digest alone was **not** sufficient, and planting found that rather than
reasoning: `UPDATE sites SET last_seen_at = now()` passed silently, because
`now()` is transaction-start time and the fixture had already written that exact
value — a real write rewriting identical bytes. Hence the tuple counters, which
increment on any UPDATE regardless of value. Both shapes now fail:

```
ERROR:  PROOF FAILED: THE CENSUS IS NOT READ-ONLY -- it changed: sites (rows 17->17, digest CHANGED)
ERROR:  PROOF FAILED: THE CENSUS IS NOT READ-ONLY -- it changed: __xact_tuples_written__ (rows 19->21, digest same)
```

**The harness assumed an empty database.** Assertions read global counts while
the census runs fleet-wide as a BYPASSRLS owner. It passed only because the dev
container has zero sites. Every assertion is now scoped to the fixture tenant,
and a second "noise" org with three sites is seeded permanently so that
re-globalising an assertion fails immediately rather than later on someone
else's database.

That caught a bug in the fix itself within one run — mechanically appending the
tenant predicate produced `WHERE tenant_id = proof_tenant AND has_plugin_inventory
OR has_theme_inventory`, and `AND` binds tighter than `OR`:

```
ERROR:  PROOF FAILED: either_denom should be 11, got 13;
```

On an empty database that line would have been green and wrong. The RLS
assertions gain force too: `wpmgr_app` scoped to the fixture tenant still sees
13, now demonstrating isolation against a real neighbouring tenant.

**The `sqlc` verification command in the README could not fail either.** `sqlc
compile` type-checks and writes nothing, so nothing under `internal/db/sqlc/`
could change during it, and `git status --porcelain` exits 0 whether or not it
prints. Replaced with `sqlc generate` plus `git diff --quiet`, the gate
`.claude/rules/db-migrations.md` already requires. The worthless form is kept
alongside, labelled, because it is the version someone reaches for by reflex.

**Timestamp semantics documented.** `components_updated_at` is the control-plane
persist instant, not the agent's collection instant — the payload carries no
collection timestamp, which is why m121 named it as it did. The gap is one agent
push, wider under a retry or a skewed clock. Every freshness figure is therefore
a lower bound on how long since the agent looked.
