### PR TITLE
docs(adr): amend ADR-060 to define "externally-reachable surface"

### DIFF
--- a/docs/adr/ADR-060-phase-order-safety-before-capability.md
+++ b/docs/adr/ADR-060-phase-order-safety-before-capability.md
@@ -1,10 +1,18 @@
 # ADR-060 — Phase order: safety and truth before capability
 
-**Status:** Accepted · **Date:** 2026-08-18
+**Status:** Accepted (amended 2026-08-27) · **Date:** 2026-08-18
 **Supersedes/relates:** ADR-037 (superseded — see below), ADR-057 (phases 4-7 inherited into the differentiation phase below).
 
 This ADR fixes the order in which the next stretch of work is taken, and
 records why that order is a decision rather than a scheduling preference.
+
+**Amended 2026-08-27 — read [Amendments](#amendments-2026-08-27) before
+deciding whether a change trips the freeze clause.** The status stays
+Accepted and no decision text below is rewritten. One amendment, A1, defines
+"externally-reachable surface" for the freeze clause at :44 — a term this
+document used but never defined, which two separate ADRs had each been left
+to interpret for themselves, reaching opposite conclusions by different
+routes.
 
 ---
 
@@ -40,6 +48,10 @@ and nothing below is a second one. The freeze clause is this ADR's one
 absolute prohibition:
 
 ### Freeze clause
+
+*Amended 2026-08-27 — "externally-reachable surface" is defined in
+[Amendment A1](#amendments-2026-08-27) below. The clause's own text is
+unchanged.*
 
 > No new externally-reachable surface ships while an auth-boundary item is open.
 
@@ -87,6 +99,154 @@ they become eligible to start does.
   starting later work.
 - The freeze clause is the one hard prohibition, and it is a standing check
   on any change that adds a new externally-reachable surface: confirm no
-  auth-boundary item is open before it ships.
+  auth-boundary item is open before it ships. What counts as a new surface
+  is fixed by Amendment A1 below, not decided per feature.
 - Reordering this sequence again requires a superseding ADR — the same
   mechanism that reorders it here.
+
+---
+
+## Amendments (2026-08-27)
+
+Two ADRs each had to decide, for their own purposes, whether the work they
+proposed added a "new externally-reachable surface" under the freeze clause
+above — and each decided it independently, because this document never
+defined the term.
+
+ADR-064 (per-site and organisation context, Proposed, PR #548) needs about a
+dozen new routes on the existing, already-authenticated dashboard API. It
+argued these are not a new surface, said plainly that this was its own
+reading of an undefined term and not binding on any other document, and
+named the gap as an open question for whoever holds this ADR next to close.
+Separately, and earlier, an amendment to ADR-061 — its A9 — had already
+reached the opposite-shaped conclusion, that the assistant route *is* a new
+surface, and settled it inside an amendment section belonging to a different
+ADR rather than this one.
+
+Both documents reasoned carefully, and, on their own facts, both reached the
+right answer (see the edges below). That does not make the pattern safe.
+If every ADR is free to interpret "surface" for itself, the freeze clause
+stops being the one absolute prohibition the Decision section calls it in
+the sentence introducing it — a rule that gets interpreted around, document
+by document, is indistinguishable in practice from a rule that gets
+suspended informally, which the Freeze clause section already names as the
+failure a narrow freeze exists to avoid.
+
+**This is an amendment, not a rewrite. The Decision and Freeze clause text
+above is unchanged**, in wording and in force. What follows defines a term
+that text already uses; it does not loosen, tighten or relocate the rule the
+term sits inside.
+
+### A1 — Defining "externally-reachable surface" for the freeze clause
+
+**A surface is fixed by three things: the transport or listener it answers
+on, the authentication a caller must satisfy to reach it, and the class of
+caller that authentication admits. A change is a *new* surface when it
+changes at least one of those three — a new transport or listener; an
+authentication requirement that admits a class of caller that could not
+reach that perimeter before; or a route that becomes reachable to a class of
+caller that could not reach it before. A change that adds a route, resource
+or method inside an unchanged transport, an unchanged authentication
+requirement, and an unchanged, already-admitted class of caller is not a new
+surface — it is new capability on an existing one, and the freeze clause was
+never the rule that governs that.**
+
+Put as the test to run against a diff: before this change, did anything
+answer at this transport, to this class of caller, under this
+authentication? If no — the transport is new, or the authentication is
+weaker than it was, or the caller class is new — this is a new surface and
+the freeze clause governs it. If yes — the same transport and the same
+authentication already admitted this same class of caller, and the change
+only adds a resource inside that perimeter — it is not.
+
+**This is reading (a), a genuinely new reachable entry point, not reading
+(b), any new route on an already-authenticated perimeter.** The choice is
+forced by this document's own text, not asserted fresh here. The Freeze
+clause section already says, two lines below the clause itself, that it
+"does not freeze feature work in general — internal work, and work that
+adds no new externally-reachable surface, is unaffected" (:46-48). Reading
+(b) makes that sentence false: essentially all feature work adds a route
+somewhere, so essentially all feature work would freeze the moment any
+auth-boundary item is open — the broad freeze the same passage calls itself
+"deliberately narrow" (:46) to avoid being, and returns to at :48-50 ("a
+broad freeze gets suspended informally and the lift is never recorded ...
+a narrow freeze is cheap enough to actually hold"). A definition that makes
+this document's own scope statement false is the wrong definition, whatever
+else might recommend it.
+
+**The edges, worked through rather than asserted:**
+
+- **A new route on an existing, already-authenticated perimeter, answering
+  to a class of caller that could not reach that perimeter at all before.**
+  This is a new surface without qualification, on both grounds at once.
+  ADR-061's assistant route is exactly this case: it sits on the existing
+  API host, but nothing answering to an assistant-kind credential was
+  reachable there before it shipped — a new caller class — and (per its own
+  A6) it answers on a new protocol besides. Nothing answering to a wholly
+  new class of caller is "capability added to an existing surface" under
+  either reading. Contrast ADR-064: a dozen routes added for a caller class
+  already admitted on that perimeter (an existing dashboard session), under
+  an authentication requirement the ADR adds no new mechanism for. Same
+  transport, same authentication, same already-admitted caller class — only
+  the count of routes that class can reach changes. That fails the test the
+  other way, and is not a new surface.
+- **A route that changes an existing endpoint's authentication
+  requirement.** Direction decides it. Weakening — dropping a check,
+  accepting a second and weaker credential form, admitting a caller who
+  could not authenticate that way before — is a new surface: it is exactly
+  "authentication that admits a class of caller that could not reach that
+  perimeter before," above. Tightening is never a new surface under this
+  clause; it is Gate-phase work, the first item in this document's own
+  precedence order, and the freeze clause was never a reason to withhold it.
+- **A new transport on an existing host** — a new protocol, a new listener,
+  a new port — is a new surface if it is externally reachable at all,
+  regardless of whether the authentication behind it matches something else
+  on that host. Nothing answered on that transport before, which is the
+  test above by itself. A transport that is not externally reachable to
+  begin with — loopback-only, a private network — is outside the clause for
+  the reason anything non-externally-reachable already is; "externally-
+  reachable" is doing that work, and A1 does not reopen it.
+- **Reachable only after authentication, versus reachable before it.** A
+  route reachable without authentication, where every prior route on that
+  host required it, is a new surface on the same test: unauthenticated
+  reachability is a class of caller nothing before could satisfy merely by
+  existing on the network. A route reachable only to an already-admitted,
+  already-authenticated class, added behind an unchanged authentication
+  requirement, is not — the ADR-064 shape again, from the other side.
+
+**One edge this definition does not mechanically close, named rather than
+forced.** Whether a change "admits a class of caller that could not reach a
+perimeter before" is decidable by inspection when the class is a credential
+kind (an assistant-kind key versus a dashboard session) or a network
+position (unauthenticated versus authenticated). It is not always decidable
+by inspection when a change narrows what an *already-admitted* credential
+must additionally prove — a scope broadened, a check dropped that the same
+credential kind used to have to pass, a weaker proof of the same kind of
+secret accepted — because "class of caller" can be sliced at whatever
+granularity makes the answer come out either way, and this amendment has no
+test finer than the three-part one above. **That case is not settled here.
+The security-reviewer decides it**, on the diff in front of them, case by
+case — the same reviewer this project's routing rules already require for
+any change touching auth, tenancy or the agent protocol, regardless of
+whether the freeze clause happens to be live at the time. That is not a gap
+papered over with a name; it is the reviewer this kind of change already
+goes to, for reasons that have nothing to do with this amendment.
+
+**What this amendment does not change.** The freeze clause's force is
+unchanged: it remains this document's one absolute prohibition, not a
+second gate standing next to the precedence order. The precedence order —
+Gate, Recovery assurance, Operator workflow, Constrained automation,
+Differentiation — is unchanged, in content and in strength. Reordering it
+still takes a superseding ADR, not a re-reading of a word. This amendment
+defines a term the clause already used; nothing above loosens, tightens, or
+relocates the rule the term sits inside.
+
+**Consequence.** Once this lands, ADR-064's freeze-clause discussion should
+cite Amendment A1 rather than carry its own interpretation of "surface" —
+its own text already names this gap as the open question and this
+amendment as the resolution, rather than treating its own reading as
+binding on any later ADR. ADR-061's A9 reaches the same conclusion this
+amendment does for the assistant route, by the same reasoning (new
+transport, new caller class, either independently sufficient), so nothing
+there needs to change; a future document facing this question should still
+point here rather than re-argue the term in its own amendment section.

--- a/docs/adr/ADR-060-phase-order-safety-before-capability.md
+++ b/docs/adr/ADR-060-phase-order-safety-before-capability.md
@@ -9,10 +9,10 @@ records why that order is a decision rather than a scheduling preference.
 **Amended 2026-08-27 — read [Amendments](#amendments-2026-08-27) before
 deciding whether a change trips the freeze clause.** The status stays
 Accepted and no decision text below is rewritten. One amendment, A1, defines
-"externally-reachable surface" for the freeze clause at :44 — a term this
-document used but never defined, which two separate ADRs had each been left
-to interpret for themselves, reaching opposite conclusions by different
-routes.
+"externally-reachable surface" for the [Freeze clause](#freeze-clause)
+below — a term this document used but never defined, which two separate
+ADRs had each been left to interpret for themselves, reaching opposite
+conclusions by different routes.
 
 ---
 
@@ -118,10 +118,12 @@ dozen new routes on the existing, already-authenticated dashboard API. It
 argued these are not a new surface, said plainly that this was its own
 reading of an undefined term and not binding on any other document, and
 named the gap as an open question for whoever holds this ADR next to close.
-Separately, and earlier, an amendment to ADR-061 — its A9 — had already
+Separately, and earlier, a draft amendment to ADR-061 — its A9, in unmerged
+PR #519 and not on `main`, so it does not carry as an accepted decision —
 reached the opposite-shaped conclusion, that the assistant route *is* a new
-surface, and settled it inside an amendment section belonging to a different
-ADR rather than this one.
+surface, and did so inside an amendment section belonging to a different
+ADR rather than this one. The independent derivation below (see the edges,
+first bullet) does not depend on that draft landing.
 
 Both documents reasoned carefully, and, on their own facts, both reached the
 right answer (see the edges below). That does not make the pattern safe.
@@ -142,7 +144,8 @@ term sits inside.
 **A surface is fixed by three things: the transport or listener it answers
 on, the authentication a caller must satisfy to reach it, and the class of
 caller that authentication admits. A change is a *new* surface when it
-changes at least one of those three — a new transport or listener; an
+changes at least one of those three in a way that expands reachability — a
+new transport or listener; an
 authentication requirement that admits a class of caller that could not
 reach that perimeter before; or a route that becomes reachable to a class of
 caller that could not reach it before. A change that adds a route, resource
@@ -161,28 +164,30 @@ only adds a resource inside that perimeter — it is not.
 
 **This is reading (a), a genuinely new reachable entry point, not reading
 (b), any new route on an already-authenticated perimeter.** The choice is
-forced by this document's own text, not asserted fresh here. The Freeze
-clause section already says, two lines below the clause itself, that it
-"does not freeze feature work in general — internal work, and work that
-adds no new externally-reachable surface, is unaffected" (:46-48). Reading
-(b) makes that sentence false: essentially all feature work adds a route
-somewhere, so essentially all feature work would freeze the moment any
-auth-boundary item is open — the broad freeze the same passage calls itself
-"deliberately narrow" (:46) to avoid being, and returns to at :48-50 ("a
-broad freeze gets suspended informally and the lift is never recorded ...
-a narrow freeze is cheap enough to actually hold"). A definition that makes
-this document's own scope statement false is the wrong definition, whatever
-else might recommend it.
+forced by this document's own text, not asserted fresh here. The [Freeze
+clause](#freeze-clause) section already says, in the paragraph immediately
+below the clause itself, that it "does not freeze feature work in general —
+internal work, and work that adds no new externally-reachable surface, is
+unaffected." Reading (b) makes that sentence false: essentially all feature
+work adds a route somewhere, so essentially all feature work would freeze
+the moment any auth-boundary item is open — the broad freeze that same
+sentence calls itself "deliberately narrow" to avoid being, and the same
+paragraph goes on to say why: "a broad freeze gets suspended informally and
+the lift is never recorded ... a narrow freeze is cheap enough to actually
+hold." A definition that makes this document's own scope statement false is
+the wrong definition, whatever else might recommend it.
 
 **The edges, worked through rather than asserted:**
 
 - **A new route on an existing, already-authenticated perimeter, answering
   to a class of caller that could not reach that perimeter at all before.**
-  This is a new surface without qualification, on both grounds at once.
-  ADR-061's assistant route is exactly this case: it sits on the existing
-  API host, but nothing answering to an assistant-kind credential was
-  reachable there before it shipped — a new caller class — and (per its own
-  A6) it answers on a new protocol besides. Nothing answering to a wholly
+  This is a new surface without qualification. ADR-061's assistant route is
+  this case: it sits on the existing API host, but nothing answering to the
+  agent-kind key ADR-061 Decision 2 defines for the assistant proposer was
+  reachable there before it shipped — a new caller class, sufficient on its
+  own under the test above. (An unmerged draft amendment to ADR-061, its A6,
+  would add a new-transport ground as well; that draft is not on `main`,
+  and this amendment does not rely on it.) Nothing answering to a wholly
   new class of caller is "capability added to an existing surface" under
   either reading. Contrast ADR-064: a dozen routes added for a caller class
   already admitted on that perimeter (an existing dashboard session), under
@@ -245,8 +250,11 @@ relocates the rule the term sits inside.
 cite Amendment A1 rather than carry its own interpretation of "surface" —
 its own text already names this gap as the open question and this
 amendment as the resolution, rather than treating its own reading as
-binding on any later ADR. ADR-061's A9 reaches the same conclusion this
-amendment does for the assistant route, by the same reasoning (new
-transport, new caller class, either independently sufficient), so nothing
-there needs to change; a future document facing this question should still
-point here rather than re-argue the term in its own amendment section.
+binding on any later ADR. ADR-061 carries no amendment section on `main`
+today; its unmerged draft A9 (PR #519) reaches the same conclusion this
+amendment does for the assistant route, by the same reasoning, but that
+reference does not carry until #519 merges. This amendment does not depend
+on it: the caller-class ground alone, from ADR-061 Decision 2 as Accepted,
+already puts the assistant route on the new-surface side of the test above.
+A future document facing this question should still point here rather than
+re-argue the term in its own amendment section.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,7 +41,7 @@ each file (see "Status line formats" below — the tree is not normalized).
 | 056 | Dashboard Two-Factor Authentication | Accepted | 2026-06-16 | [ADR-056-dashboard-2fa.md](./ADR-056-dashboard-2fa.md) |
 | 057 | Security Suite Foundation: Per-Site Policy Model | Accepted | 2026-06-20 | [ADR-057-security-suite-foundation.md](./ADR-057-security-suite-foundation.md) |
 | 059 | Site-User Authentication Policy (2FA + Password Policy) | Accepted — 2026-06-20 | 2026-06-20 | [ADR-059-site-user-auth-policy.md](./ADR-059-site-user-auth-policy.md) |
-| 060 | Phase order: safety and truth before capability | Accepted | 2026-08-18 | [ADR-060-phase-order-safety-before-capability.md](./ADR-060-phase-order-safety-before-capability.md) |
+| 060 | Phase order: safety and truth before capability | Accepted (amended 2026-08-27) | 2026-08-18 | [ADR-060-phase-order-safety-before-capability.md](./ADR-060-phase-order-safety-before-capability.md) |
 | 061 | Assistant surface, Phase 1: control-plane server and out-of-band approval | Accepted | 2026-08-22 | [ADR-061-assistant-surface-phase-1.md](./ADR-061-assistant-surface-phase-1.md) |
 | 062 | Assistant surface, Phase 2: governed fleet content operations | Proposed | 2026-08-27 | [ADR-062-assistant-surface-phase-2-content-operations.md](./ADR-062-assistant-surface-phase-2-content-operations.md) |
 


### PR DESCRIPTION
## Summary

- ADR-060's freeze clause — "No new externally-reachable surface ships while an auth-boundary item is open" — names "surface" but never defines it. Two ADRs have each had to interpret it for their own purposes: ADR-064 (PR #548) argues its dozen new dashboard routes are not a new surface and names the gap as an open question owned by whoever holds ADR-060 next; ADR-061's amendment A9 (PR #519) separately concluded the assistant route is a new surface, settled inside ADR-061's own amendment section rather than in ADR-060. A security reviewer independently flagged both instances as the same problem: this cannot be settled document-by-document without the freeze clause stopping being absolute.
- Adds **Amendment A1** to ADR-060: a surface is fixed by (transport/listener, authentication requirement, admitted caller class); a change is a *new* surface only when it changes one of those three. Recommends reading (a) — genuinely new reachable entry point — over reading (b) — any new route — because ADR-060's own "does not freeze feature work in general" sentence (:46-48) is false under (b).
- Works the definition against the edges: a new credential class on an existing perimeter (ADR-061's assistant route — stays a new surface), a changed authentication requirement (direction decides it), a new transport on an existing host (new surface if externally reachable), and pre- vs. post-auth reachability. Names one edge the definition cannot mechanically close — narrowing what an already-admitted credential must additionally prove — and assigns it to the security-reviewer, per this repo's existing routing rule for auth-touching changes.
- States explicitly what does not change: the freeze clause's force, the five-phase precedence order, and the requirement that reordering takes a superseding ADR.
- Updates the `docs/adr/README.md` index row for ADR-060 to `Accepted (amended 2026-08-27)`.
- Does not edit ADR-064 (on another branch) — its consequences note says it should cite Amendment A1 instead of carrying its own interpretation.

## Test plan

- [x] `make check-versions-test` — 76 passed, 0 failed (docs-only change, no version surface should move)
- [x] `make check-versions` — all surfaces consistent at 0.61.146
- [x] `node apps/marketing/scripts/check-copy.mjs` — passed, no em/en dashes or competitor names across 390 files
- [x] `ci.yml`'s Docs vocabulary check, copied verbatim from `.github/workflows/ci.yml` this turn and run against `docs/` and `./*.md` — prints nothing (no competitor names)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ADR-060 to define “externally reachable surface” and clarify how changes are evaluated under the freeze clause.
  * Added amendment details and guidance for edge cases.
  * Updated the ADR index to reflect its amended acceptance status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->