### PR TITLE
fix(agent): declare MIT everywhere, close the GPLv2/MIT split (GH #547)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,32 @@ jobs:
       - name: Version surface guard (openapi, changelog page, badge, agent, install pins)
         run: scripts/check-version-surfaces.sh
 
+      # ---- License surfaces --------------------------------------------------
+      # GH #547: the agent declared MIT in its plugin header and GPLv2 or later
+      # in the wp.org readme.txt, live, at the same time. This reconciles every
+      # place in apps/agent (plus the repo-root LICENSE-AGENT carve-out) that
+      # names the agent's own license, by name: the plugin header, both
+      # mu-plugin headers, readme.txt's structured header AND its Description
+      # prose, composer.json, NOTICE.md, README.md and LICENSE-AGENT's own
+      # title line.
+      #
+      # THE LOGIC LIVES IN scripts/check-license-surfaces.sh, same reasoning as
+      # the version surface guard immediately above: it is a file you can run
+      # and test, not shell text buried in this YAML.
+      #
+      # A surface a guard's own pattern fails to find is an ERROR here, not a
+      # skip — a check that passes because it matched nothing is the same
+      # defect the version surface guard's header comment already spent three
+      # review rounds discovering, one level up.
+      #
+      # Self-test runs FIRST, same reasoning as the version surface guard:
+      # a broken guard must fail here, not pass by failing open.
+      - name: License surface guard self-test (GH #547)
+        run: scripts/check-license-surfaces_test.sh
+
+      - name: License surface guard (plugin header, mu-plugins, readme.txt, composer.json, NOTICE.md, README.md, LICENSE-AGENT)
+        run: scripts/check-license-surfaces.sh
+
       # ---- Agent release manifest guard ------------------------------------
       # scripts/release-agent.sh is the trust boundary release.yml calls to
       # build the agent's self-update manifest (GH #515: it used to publish a

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,20 @@ check-versions: ## Check every version-naming surface (docs, marketing, agent)
 check-versions-test: ## Run the version surface guard's regression suite
 	scripts/check-version-surfaces_test.sh
 
+# GH #547: the agent declared MIT in its plugin header and GPLv2 or later in
+# the wp.org readme.txt at the same time. This reconciles every place in
+# apps/agent (plus the repo-root LICENSE-AGENT carve-out) that names the
+# agent's own license, by name, and fails if any is missing or any two
+# disagree. check-licenses-test is the guard's own regression suite; run it
+# after editing the guard.
+.PHONY: check-licenses
+check-licenses: ## Check every license-naming surface in the agent plugin
+	scripts/check-license-surfaces.sh
+
+.PHONY: check-licenses-test
+check-licenses-test: ## Run the license surface guard's regression suite
+	scripts/check-license-surfaces_test.sh
+
 # scripts/check-rls-cross-tenant.sh (GH #470) reconciles every cross-tenant RLS
 # policy against apps/api/db/rls-cross-tenant-policies.txt, the ledger that
 # says which access mode each one is MEANT to have. Run this before merging

--- a/Makefile
+++ b/Makefile
@@ -415,16 +415,26 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	rm -f release/fleet-agent-site-manager/readme.txt.bak
 	# Rewrite plugin-identity header fields in the staged main file:
 	#   Plugin Name  -> Fleet Agent Site Manager  (reviewer-accepted display name; no "WP" prefix)
-	#   License      -> GPLv2 or later            (§3 recommended posture)
-	#   License URI  -> gnu.org GPL-2.0 URL       (§3)
 	#   Text Domain  -> fleet-agent-site-manager  (matches new slug)
 	#   WPMGR_AGENT_DISPLAY_NAME -> Fleet Agent Site Manager (admin menu/page
 	#   title constant; keeps the wp.org admin screen name consistent with the
 	#   listing identity above instead of showing the self-hosted "WPMgr Agent")
+	#
+	# License / License URI are DELIBERATELY NOT rewritten here (GH #547). This
+	# target used to force the header to "GPLv2 or later" on the theory that
+	# wp.org expects it, while the source plugin header, composer.json,
+	# NOTICE.md and LICENSE-AGENT all say MIT (the owner's actual ruling, and
+	# MIT is fully GPL-compatible for a wp.org listing). That rewrite is what
+	# shipped the live bug #547 was filed against: readme.txt said GPLv2 while
+	# the header said MIT. Fixing readme.txt alone would have flipped the
+	# mismatch, not closed it — this sed line would still overwrite the
+	# freshly-agreed MIT header back to GPLv2 on every build. The header now
+	# carries whatever the source declares, unchanged, so it and readme.txt
+	# (and every other surface scripts/check-license-surfaces.sh reads) stay
+	# in agreement without the build pipeline being a 10th, unwatched place a
+	# license value could live.
 	sed -i.bak \
 		-e "s|^ \* Plugin Name:.*| * Plugin Name:       Fleet Agent Site Manager|" \
-		-e "s|^ \* License:.*| * License:           GPLv2 or later|" \
-		-e "s|^ \* License URI:.*| * License URI:       https://www.gnu.org/licenses/gpl-2.0.html|" \
 		-e "s|^ \* Text Domain:.*| * Text Domain:       fleet-agent-site-manager|" \
 		-e "s|define('WPMGR_AGENT_DISPLAY_NAME', 'WPMgr Agent');|define('WPMGR_AGENT_DISPLAY_NAME', 'Fleet Agent Site Manager');|" \
 		release/fleet-agent-site-manager/fleet-agent-site-manager.php

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 6.2
 Tested up to: 7.1
 Requires PHP: 8.1
 Stable tag: 0.61.146
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+License: MIT
+License URI: https://opensource.org/licenses/MIT
 
 Securely connects this site to a WPMgr dashboard, self-hosted or hosted, so backups, updates, security and speed all run from one screen.
 
@@ -48,7 +48,7 @@ Cache purge reaches the layer in front of WordPress too, detected automatically:
 
 The expensive work runs on the dashboard rather than on your server: unused-CSS computation, image and font encoding, vulnerability matching against a managed feed, uptime probing and site screenshots.
 
-This plugin is GPLv2 or later and the dashboard is AGPL-3.0. Source for both: https://github.com/mosamlife/wpmgr
+This plugin is MIT-licensed and the dashboard is AGPL-3.0. Source for both: https://github.com/mosamlife/wpmgr
 
 == Installation ==
 

--- a/scripts/check-license-surfaces.sh
+++ b/scripts/check-license-surfaces.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# scripts/check-license-surfaces.sh
+#
+# GH #547: the agent plugin declared MIT in its main header and GPLv2 or later
+# in the wordpress.org readme.txt, live, at the same time. Nothing checked
+# that the plugin's several license self-declarations agreed with each other,
+# so the wp.org listing quietly contradicted the plugin header, the repo's
+# own LICENSE-AGENT carve-out, and the third-party NOTICE for over a release.
+#
+# The owner's ruling: the agent is MIT. This guard does not encode that ruling
+# as a hard-coded expectation — it encodes AGREEMENT, so it fails just as hard
+# if some future edit moves every surface to a different license but misses
+# one, which is the failure mode #547 actually was.
+#
+# WHAT IT CHECKS. Every place in apps/agent (plus the repo-root LICENSE-AGENT
+# carve-out file) that names the agent's own license, by name:
+#
+#   1. apps/agent/wpmgr-agent.php           - the WordPress plugin header
+#   2. apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php      - its own header
+#   3. apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php - its own header
+#   4. apps/agent/readme.txt                - the wp.org listing header
+#   5. apps/agent/readme.txt                - the Description section's prose
+#   6. apps/agent/composer.json             - the "license" field
+#   7. apps/agent/NOTICE.md                 - "The WPMgr agent is ...-licensed"
+#   8. apps/agent/README.md                 - "...-licensed WordPress plugin"
+#   9. LICENSE-AGENT                        - the license-text title line
+#
+# NOT checked, deliberately: the matthiasmullie/minify third-party attribution
+# in readme.txt (a dependency's license, not the plugin's), and the lilliput
+# and web-vitals third-party mentions in NOTICE.md. Each pattern below is
+# anchored to the sentence shape THIS repo uses for the plugin's own
+# declaration, specifically so it cannot match a neighbouring third-party
+# credit that happens to say "MIT" too. See check-license-surfaces_test.sh's
+# "over-fire" cases for the proof.
+#
+# THE RULE THAT MATTERS MOST: A SURFACE THAT NAMES NOTHING IS AN ERROR, NEVER
+# A SKIP. A check whose pattern matches zero times because a header was
+# deleted, reworded, or moved out from under the pattern must go red, not
+# print nothing and exit 0 — a guard that passes because its own pattern found
+# nothing is the exact defect #547 was one level up (readme.txt's own License
+# header was RIGHT THERE and simply never compared to anything).
+#
+# RUN IT:
+#   make check-licenses          or  scripts/check-license-surfaces.sh
+#   make check-licenses-test     or  scripts/check-license-surfaces_test.sh
+#   scripts/check-license-surfaces.sh /path/to/some/other/tree
+#
+# Exit code is 0 when every surface is present and they all agree, 1 when any
+# surface is missing or any two disagree.
+
+set -uo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-license-surfaces.sh [ROOT]
+
+ROOT defaults to the repository this script lives in, or
+$WPMGR_LICENSE_SURFACE_ROOT when that is set.
+
+Exit 0: every license surface is present and they all agree.
+Exit 1: a surface is missing its declaration, or two surfaces disagree.
+USAGE
+}
+
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${1:-${WPMGR_LICENSE_SURFACE_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}}"
+
+if [ ! -d "$ROOT" ]; then
+  echo "ERROR: $ROOT is not a directory." >&2
+  exit 2
+fi
+cd "$ROOT" || exit 2
+
+fail=0
+errors=0
+err() {
+  printf 'ERROR: %s\n' "$1"
+  fail=1
+  errors=$((errors + 1))
+}
+detail() { printf '  %s\n' "$1"; }
+ok() { printf 'OK: %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# normalize LICENSE-STRING -> canonical comparison token.
+#
+# Strips only the decorative suffixes this repo's surfaces are actually
+# written with ("-licensed", " License"), and nothing else. It must NOT strip
+# a substantive middle token: "GPLv2" and "GPLv2 or later" are different
+# licenses, so "or later" is never touched. The point of normalizing at all is
+# so "MIT", "MIT-licensed" and "MIT License" compare equal, not so any two
+# different licenses are made to look the same.
+# ---------------------------------------------------------------------------
+normalize() {
+  printf '%s' "$1" \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | sed -E 's/-[Ll]icensed$//' \
+    | sed -E 's/[[:space:]][Ll]icense$//'
+}
+
+# The declarations found so far, one per line: NAME|FILE|RAW|NORMALIZED.
+# Only a surface that yielded a value is added here; an absent one is an ERROR
+# on the spot and contributes nothing to the agreement check below, exactly
+# like check-version-surfaces.sh's "missing" branch does not join its compare.
+SURFACES=''
+
+# add_surface NAME FILE RAW -> records RAW, or errors if RAW is empty.
+add_surface() {
+  _name="$1"
+  _file="$2"
+  _raw="$3"
+  if [ -z "$_raw" ]; then
+    err "$_file declares no license ($_name)."
+    detail "A missing declaration is not a pass. Either restore it, or this script's pattern for $_name no longer matches the real text — fix whichever is wrong."
+    return
+  fi
+  _norm="$(normalize "$_raw")"
+  SURFACES="$SURFACES$_name|$_file|$_raw|$_norm
+"
+  ok "$_name ($_file): $_raw"
+}
+
+# ---------------------------------------------------------------------------
+# 1-3. Plugin-style headers. wpmgr-agent.php and the two mu-plugin loaders
+# each carry their own "* License:  X" docblock line. Anchored on "License:"
+# with the colon immediately after the word, so "License URI:" (present on
+# the same block) never matches — after "License" there is a space then "URI"
+# then the colon, not a colon directly, so the substring "License:" does not
+# occur in that line at all.
+#
+# The whitespace after the colon is [[:space:]]* (zero or more), not one or
+# more. WordPress core's own header parser (get_file_data) does not require a
+# space either — it matches the field name, the colon, and captures the rest
+# of the line verbatim before trimming — so requiring a space here would be a
+# stricter reformat-survival bar than WordPress itself enforces, and a
+# formatter that collapsed "License:           MIT" to "License:MIT" would
+# still be read correctly by WordPress while silently switching this guard
+# off. It must not.
+# ---------------------------------------------------------------------------
+check_php_header() {
+  _label="$1"
+  _f="$2"
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _v="$(grep -m1 -E '^[[:space:]]*\*?[[:space:]]*License:' "$_f" 2>/dev/null |
+    sed -E 's/^[[:space:]]*\*?[[:space:]]*License:[[:space:]]*//')"
+  add_surface "$_label" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+# 4. readme.txt's wp.org listing header. Same anchor, but readme.txt's header
+# lines start at column 0 with no leading "*", so the pattern is a plain
+# line-start match. grep -m1 takes the FIRST such line in the file, which is
+# the header — the only other "license" text in readme.txt (the
+# matthiasmullie/minify attribution) never starts a line with "License:".
+# ---------------------------------------------------------------------------
+check_readme_header() {
+  _f='apps/agent/readme.txt'
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _v="$(grep -m1 -E '^License:' "$_f" 2>/dev/null | sed -E 's/^License:[[:space:]]*//')"
+  add_surface "the readme.txt wp.org header" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+# 5. readme.txt's Description section carries its own prose sentence,
+# "This plugin is X and the dashboard is Y.", read by a human on the wp.org
+# listing page independently of the structured header above. Anchored on the
+# literal "This plugin is ... and the dashboard is" phrase, which appears
+# nowhere else in the file (the third-party section never uses this
+# sentence), so it cannot pick up the minify attribution's "Licensed under
+# the MIT License." sentence, which does not start with "This plugin is".
+# ---------------------------------------------------------------------------
+check_readme_prose() {
+  _f='apps/agent/readme.txt'
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _v="$(grep -m1 -oE 'This plugin is .+ and the dashboard is' "$_f" 2>/dev/null |
+    sed -E 's/^This plugin is //; s/ and the dashboard is$//')"
+  add_surface "the readme.txt Description prose" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+# 6. composer.json's own "license" field, read as JSON-ish text (no jq
+# dependency, matching the rest of this repo's guards).
+# ---------------------------------------------------------------------------
+check_composer() {
+  _f='apps/agent/composer.json'
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _v="$(grep -m1 -oE '"license"[[:space:]]*:[[:space:]]*"[^"]+"' "$_f" 2>/dev/null |
+    sed -E 's/^.*:[[:space:]]*"//; s/"$//')"
+  add_surface "composer.json" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+# 7. NOTICE.md's own prose declaration. Anchored on the literal subject "The
+# WPMgr agent is", which is what this repo's NOTICE.md uses for its own
+# license claim. NOTICE.md also carries third-party attributions (lilliput,
+# matthiasmullie/minify) that say "is MIT-licensed" about THEMSELVES, not
+# about the WPMgr agent, so a looser "is X-licensed" pattern would double-read
+# this file; the anchor on the subject is what keeps this to the one sentence
+# that is actually the plugin's own claim.
+# ---------------------------------------------------------------------------
+check_notice() {
+  _f='apps/agent/NOTICE.md'
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _v="$(grep -m1 -oE 'The WPMgr agent is [A-Za-z0-9.+-]+-licensed' "$_f" 2>/dev/null |
+    sed -E 's/^The WPMgr agent is //')"
+  add_surface "NOTICE.md" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+# 8. apps/agent/README.md's opening line. Anchored at the start of the file's
+# first real line ("X-licensed WordPress plugin ..."), which is this repo's
+# one-line description of what the plugin is and under what terms.
+# ---------------------------------------------------------------------------
+check_agent_readme_md() {
+  _f='apps/agent/README.md'
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _v="$(grep -m1 -oE '^[A-Za-z0-9.+-]+-licensed WordPress plugin' "$_f" 2>/dev/null |
+    sed -E 's/-licensed WordPress plugin$//')"
+  add_surface "README.md" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+# 9. LICENSE-AGENT, the repo-root file that carves apps/agent (and
+# apps/tracker) out of the repository's AGPL default. Standard license texts
+# open with a title line naming themselves ("MIT License", "Apache License,
+# Version 2.0", ...); this reads that title line and requires it look like
+# one, so a title-less or emptied file is caught as absent rather than
+# silently comparing "" to nothing.
+# ---------------------------------------------------------------------------
+check_license_agent() {
+  _f='LICENSE-AGENT'
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _v="$(sed -n '1p' "$_f" 2>/dev/null | grep -E '^[A-Za-z0-9.(), -]+ License[[:space:]]*$' | sed -E 's/[[:space:]]+$//' || true)"
+  add_surface "LICENSE-AGENT" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+main() {
+  check_php_header "the main plugin header" 'apps/agent/wpmgr-agent.php'
+  check_php_header "the a-wpmgr-error-trap.php mu-plugin header" 'apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php'
+  check_php_header "the a-wpmgr-update-watchdog.php mu-plugin header" 'apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php'
+  check_readme_header
+  check_readme_prose
+  check_composer
+  check_notice
+  check_agent_readme_md
+  check_license_agent
+
+  uniq_licenses="$(printf '%s' "$SURFACES" | awk -F'|' 'NF{print $4}' | sort -u)"
+  n_uniq="$(printf '%s' "$uniq_licenses" | grep -c . || true)"
+
+  if [ "${n_uniq:-0}" -gt 1 ]; then
+    err "the agent declares more than one license:"
+    printf '%s' "$SURFACES" | awk -F'|' 'NF{printf "  %s (%s): %s\n", $2, $1, $3}'
+    detail "Every surface above must name the SAME license. Pick one (see the owner's ruling in the tracking issue) and fix every surface that disagrees with it."
+  fi
+
+  if [ "$fail" -ne 0 ]; then
+    printf '\n%s\n' "License surface check FAILED."
+    return 1
+  fi
+  printf '\nLicense surfaces agree: %s\n' "$uniq_licenses"
+  return 0
+}
+
+main
+exit "$?"

--- a/scripts/check-license-surfaces.sh
+++ b/scripts/check-license-surfaces.sh
@@ -24,6 +24,20 @@
 #   7. apps/agent/NOTICE.md                 - "The WPMgr agent is ...-licensed"
 #   8. apps/agent/README.md                 - "...-licensed WordPress plugin"
 #   9. LICENSE-AGENT                        - the license-text title line
+#  10. Makefile                             - the wp.org build must not
+#                                              override the header at all
+#
+# #10 exists because of how this exact bug shipped. Fixing readme.txt to MIT
+# is not sufficient on its own: Makefile's agent-zip-wporg target used to
+# carry a `sed` line that rewrote the STAGED plugin header's License field to
+# "GPLv2 or later" on every wp.org build, regardless of what the source
+# declared. Every check above reads the committed source tree, which agreed
+# on MIT throughout and would have stayed green, while the actual zip
+# uploaded to wordpress.org kept shipping a header that disagreed with
+# readme.txt - the literal defect #547 was filed against, reintroduced by the
+# build instead of the source. `make agent-plugincheck` (the authoritative
+# gate, real WordPress via Docker) is what caught it; this check is what
+# keeps it caught without a Docker run.
 #
 # NOT checked, deliberately: the matthiasmullie/minify third-party attribution
 # in readme.txt (a dependency's license, not the plugin's), and the lilliput
@@ -263,6 +277,54 @@ check_license_agent() {
 }
 
 # ---------------------------------------------------------------------------
+# 10. Makefile's wp.org build must not carry its own hard-coded rewrite of the
+# plugin header's License field. This is not a "declares X" surface like the
+# nine above it -- there is nothing legitimate for a packaging step to say
+# here, so the only correct state is ABSENT, and its presence is itself the
+# finding, independent of what value it hard-codes. A rewrite line always
+# contains the literal field name "License:" twice on one line: once as the
+# sed match (the field it targets) and once inside the literal replacement
+# text (the value it forces), which is what the pattern below keys on. It
+# does not fire on the plain-English Makefile comment describing the target,
+# because a comment states "License" and a value only once, not twice, and
+# never inside a sed s/// replacement.
+# ---------------------------------------------------------------------------
+#
+# grep's exit code is read explicitly, not swallowed into "no match" the way
+# add_surface's callers do (there is nothing to normalize into a license value
+# here). grep exits 1 for a clean "no match", which is the PASS case for this
+# check, and 0 when it found a hit. Anything else (2+) means the pattern
+# itself failed to run at all -- on this exact check, in an earlier revision,
+# an invalid empty-alternation group made both BSD grep and the ugrep-based
+# wrapper this repo's own shell uses error out, and a trailing `2>/dev/null ||
+# true` on the capture made that failure read as "found nothing", which
+# reported OK forever regardless of what the Makefile said. That is the same
+# defect this whole guard exists to catch, one level deeper: never let a
+# broken check's own tool error look like a clean pass.
+# ---------------------------------------------------------------------------
+check_makefile_no_license_override() {
+  _f='Makefile'
+  if [ ! -f "$_f" ]; then
+    err "$_f does not exist."
+    return
+  fi
+  _hit="$(grep -nE '\*[[:space:]]*(License|License URI):.*\*[[:space:]]*(License|License URI):' "$_f")"
+  _rc=$?
+  if [ "$_rc" -eq 0 ]; then
+    err "$_f rewrites the plugin header's License field during a build:"
+    printf '%s\n' "$_hit" | sed 's/^/  /'
+    detail "This is how GH #547 actually shipped a mismatched wp.org zip even after every source surface agreed on MIT: the build pipeline silently re-declared the header to a different license at package time. The source's declared license is the single source of truth; nothing may override it during packaging."
+    return
+  fi
+  if [ "$_rc" -gt 1 ]; then
+    err "$_f: the pattern this check uses to find a License override failed to run (grep exit $_rc), instead of cleanly finding zero or one matches."
+    detail "A broken pattern must not read as a clean pass. Fix the ERE in check_makefile_no_license_override before trusting this check again."
+    return
+  fi
+  ok "$_f's wp.org build does not override the plugin header's License field."
+}
+
+# ---------------------------------------------------------------------------
 main() {
   check_php_header "the main plugin header" 'apps/agent/wpmgr-agent.php'
   check_php_header "the a-wpmgr-error-trap.php mu-plugin header" 'apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php'
@@ -273,6 +335,7 @@ main() {
   check_notice
   check_agent_readme_md
   check_license_agent
+  check_makefile_no_license_override
 
   uniq_licenses="$(printf '%s' "$SURFACES" | awk -F'|' 'NF{print $4}' | sort -u)"
   n_uniq="$(printf '%s' "$uniq_licenses" | grep -c . || true)"

--- a/scripts/check-license-surfaces.sh
+++ b/scripts/check-license-surfaces.sh
@@ -125,6 +125,12 @@ normalize() {
 # like check-version-surfaces.sh's "missing" branch does not join its compare.
 SURFACES=''
 
+# The License URI declarations found so far, one per line: LABEL|FILE|URI.
+# Same rule as SURFACES: only a surface that passed its own checks joins this,
+# so an absent or self-inconsistent URI contributes nothing to the
+# cross-surface agreement check below.
+URI_SURFACES=''
+
 # add_surface NAME FILE RAW -> records RAW, or errors if RAW is empty.
 add_surface() {
   _name="$1"
@@ -205,6 +211,94 @@ check_readme_prose() {
   _v="$(grep -m1 -oE 'This plugin is .+ and the dashboard is' "$_f" 2>/dev/null |
     sed -E 's/^This plugin is //; s/ and the dashboard is$//')"
   add_surface "the readme.txt Description prose" "$_f" "$_v"
+}
+
+# ---------------------------------------------------------------------------
+# License URI companions.
+#
+# GH #547's reviewer found the next way this same bug reopens: a "License:"
+# name can agree everywhere while the "License URI:" beside it still points
+# at the wrong license. "License: MIT" paired with a GPL URL is not an
+# improvement on an outright name mismatch -- it is the identical defect one
+# field over, and a checker that only reads the name would call it clean.
+#
+# Two surfaces carry an explicit "License URI:" line: the plugin header and
+# readme.txt's own header (the two mu-plugin loaders and readme.txt's
+# Description prose never declare a URI at all, and are not asked to).
+#
+# Each is checked on two axes, both required:
+#   SELF-CONSISTENCY  its URI must match what THAT surface's own "License:"
+#                      name implies, read via expected_uri_for(). This is the
+#                      half-right case above, caught even if nothing else on
+#                      earth ever reads a second URI.
+#   CROSS-SURFACE      its URI must equal the other URI-bearing surface's,
+#                      the same agreement rule every name-only surface above
+#                      is already held to.
+# ---------------------------------------------------------------------------
+
+# expected_uri_for NAME -> the canonical URI for a license this repo has
+# actually declared, or empty for anything else. Empty is not a failure: it
+# means self-consistency cannot be judged for an unrecognized name, so only
+# the cross-surface compare still applies to that surface's URI.
+expected_uri_for() {
+  case "$1" in
+    MIT) printf 'https://opensource.org/licenses/MIT' ;;
+    'GPLv2 or later') printf 'https://www.gnu.org/licenses/gpl-2.0.html' ;;
+    *) printf '' ;;
+  esac
+}
+
+# check_license_uri_pair LABEL FILE NAME URI
+check_license_uri_pair() {
+  _label="$1"
+  _file="$2"
+  _name="$3"
+  _uri="$4"
+
+  # An absent NAME was already reported by this file's own license-name
+  # check above (check_php_header / check_readme_header); a second "missing
+  # license" error here about the same absence would only be confusing.
+  [ -n "$_name" ] || return
+
+  if [ -z "$_uri" ]; then
+    err "$_file declares a License but no License URI ($_label)."
+    detail "WordPress core and wordpress.org both read this field. A header or readme with a License and no License URI is incomplete, and one that used to carry a URI and silently lost it is exactly the kind of drift this guard exists to catch."
+    return
+  fi
+
+  _expected="$(expected_uri_for "$_name")"
+  if [ -n "$_expected" ] && [ "$_uri" != "$_expected" ]; then
+    err "$_label's License URI does not match its own declared license."
+    detail "$_file says \"License: $_name\" but \"License URI: $_uri\"."
+    detail "Expected $_expected for $_name. A URI that disagrees with the name right beside it is the half-right state GH #547 started as -- right name, wrong link (or vice versa)."
+    return
+  fi
+
+  URI_SURFACES="$URI_SURFACES$_label|$_file|$_uri
+"
+  ok "$_label License URI ($_file): $_uri"
+}
+
+check_main_header_license_uri() {
+  _f='apps/agent/wpmgr-agent.php'
+  if [ ! -f "$_f" ]; then
+    return # already reported by check_php_header
+  fi
+  _name="$(grep -m1 -E '^[[:space:]]*\*?[[:space:]]*License:' "$_f" 2>/dev/null |
+    sed -E 's/^[[:space:]]*\*?[[:space:]]*License:[[:space:]]*//')"
+  _uri="$(grep -m1 -E '^[[:space:]]*\*?[[:space:]]*License URI:' "$_f" 2>/dev/null |
+    sed -E 's/^[[:space:]]*\*?[[:space:]]*License URI:[[:space:]]*//')"
+  check_license_uri_pair "the main plugin header" "$_f" "$_name" "$_uri"
+}
+
+check_readme_header_license_uri() {
+  _f='apps/agent/readme.txt'
+  if [ ! -f "$_f" ]; then
+    return # already reported by check_readme_header
+  fi
+  _name="$(grep -m1 -E '^License:' "$_f" 2>/dev/null | sed -E 's/^License:[[:space:]]*//')"
+  _uri="$(grep -m1 -E '^License URI:' "$_f" 2>/dev/null | sed -E 's/^License URI:[[:space:]]*//')"
+  check_license_uri_pair "the readme.txt wp.org header" "$_f" "$_name" "$_uri"
 }
 
 # ---------------------------------------------------------------------------
@@ -336,6 +430,8 @@ main() {
   check_agent_readme_md
   check_license_agent
   check_makefile_no_license_override
+  check_main_header_license_uri
+  check_readme_header_license_uri
 
   uniq_licenses="$(printf '%s' "$SURFACES" | awk -F'|' 'NF{print $4}' | sort -u)"
   n_uniq="$(printf '%s' "$uniq_licenses" | grep -c . || true)"
@@ -344,6 +440,15 @@ main() {
     err "the agent declares more than one license:"
     printf '%s' "$SURFACES" | awk -F'|' 'NF{printf "  %s (%s): %s\n", $2, $1, $3}'
     detail "Every surface above must name the SAME license. Pick one (see the owner's ruling in the tracking issue) and fix every surface that disagrees with it."
+  fi
+
+  uniq_uris="$(printf '%s' "$URI_SURFACES" | awk -F'|' 'NF{print $3}' | sort -u)"
+  n_uniq_uris="$(printf '%s' "$uniq_uris" | grep -c . || true)"
+
+  if [ "${n_uniq_uris:-0}" -gt 1 ]; then
+    err "the agent declares more than one License URI:"
+    printf '%s' "$URI_SURFACES" | awk -F'|' 'NF{printf "  %s (%s): %s\n", $2, $1, $3}'
+    detail "Every License URI above must point at the SAME license text as every other surface's License name."
   fi
 
   if [ "$fail" -ne 0 ]; then

--- a/scripts/check-license-surfaces_test.sh
+++ b/scripts/check-license-surfaces_test.sh
@@ -341,6 +341,81 @@ case_run "disagree: LICENSE-AGENT's title alone diverging fails" \
   fail "$t" "+LICENSE-AGENT): Apache License"
 
 # ===========================================================================
+# LICENSE URI: a reviewer's finding on top of the two above. A "License:"
+# name can agree everywhere while the "License URI:" beside it still points
+# at a different license -- "License: MIT" paired with a GPL URL is not an
+# improvement on a name mismatch, it is the identical defect one field over.
+# ===========================================================================
+
+# THE EXACT HALF-RIGHT STATE THE REVIEWER DESCRIBED: the name says MIT, the
+# URI right beside it still says GPL. A guard that only reads the name would
+# call this file clean.
+t="$(tree halfright-main-header-uri-still-gpl)"
+sub "$t/apps/agent/wpmgr-agent.php" 's|^ \* License URI:       https://opensource\.org/licenses/MIT$| * License URI:       https://www.gnu.org/licenses/gpl-2.0.html|'
+case_run "half-right: the main header says License: MIT but License URI still points at the GPL text - fails, self-consistency" \
+  fail "$t" "+main plugin header's License URI does not match its own declared license" "+Expected https://opensource.org/licenses/MIT for MIT"
+
+t="$(tree halfright-readme-header-uri-still-gpl)"
+sub "$t/apps/agent/readme.txt" 's|^License URI: https://opensource\.org/licenses/MIT$|License URI: https://www.gnu.org/licenses/gpl-2.0.html|'
+case_run "half-right: readme.txt says License: MIT but License URI still points at the GPL text - fails, self-consistency" \
+  fail "$t" "+readme.txt wp.org header's License URI does not match its own declared license"
+
+# The inverse half-right shape: URI correct, but a still-honest MIT everywhere
+# else with just the URI silently pointing somewhere unrelated (not even a
+# recognized license's URL) - still caught by self-consistency because MIT
+# has a known expected URI to compare against.
+t="$(tree halfright-main-header-uri-garbage)"
+sub "$t/apps/agent/wpmgr-agent.php" 's|^ \* License URI:       https://opensource\.org/licenses/MIT$| * License URI:       https://example.com/not-a-license|'
+case_run "half-right: the main header's License URI pointing at neither known URL fails against its own MIT name" \
+  fail "$t" "+main plugin header's License URI does not match its own declared license"
+
+# CROSS-SURFACE: the two URI-bearing surfaces disagreeing with each other,
+# even though each one individually still names MIT. Constructed by aiming
+# readme.txt's URI at a domain that is not a recognized license's canonical
+# URL either, so self-consistency alone (which cannot judge an unrecognized
+# value against MIT) does not already catch it -- only the cross-surface
+# compare does.
+t="$(tree disagree-license-uri-cross-surface)"
+sub "$t/apps/agent/wpmgr-agent.php" 's|^ \* License:           MIT$| * License:           Custom|'
+sub "$t/apps/agent/wpmgr-agent.php" 's|^ \* License URI:       https://opensource\.org/licenses/MIT$| * License URI:       https://example.com/license-a|'
+sub "$t/apps/agent/readme.txt" 's/^License: MIT$/License: Custom/'
+sub "$t/apps/agent/readme.txt" 's|^License URI: https://opensource\.org/licenses/MIT$|License URI: https://example.com/license-b|'
+sub "$t/apps/agent/readme.txt" 's/^This plugin is MIT-licensed and the dashboard is AGPL-3\.0\./This plugin is Custom-licensed and the dashboard is AGPL-3.0./'
+sub "$t/apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php" 's/^ \* License:     MIT$/ * License:     Custom/'
+sub "$t/apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php" 's/^ \* License:     MIT$/ * License:     Custom/'
+sub "$t/apps/agent/composer.json" 's/"license": "MIT"/"license": "Custom"/'
+sub "$t/apps/agent/NOTICE.md" 's/The WPMgr agent is MIT-licensed/The WPMgr agent is Custom-licensed/'
+sub "$t/apps/agent/README.md" 's/^MIT-licensed WordPress plugin/Custom-licensed WordPress plugin/'
+sub "$t/LICENSE-AGENT" 's/^MIT License$/Custom License/'
+case_run "cross-surface: two URI-bearing surfaces naming the same unrecognized license but different URIs still fails" \
+  fail "$t" "+more than one License URI" "+example.com/license-a" "+example.com/license-b"
+
+# ABSENCE: a License with no License URI beside it at all.
+t="$(tree absent-main-header-uri)"
+drop "$t/apps/agent/wpmgr-agent.php" '^ \* License URI:'
+case_run "absent: the main plugin header has a License but no License URI - fails, not a silent pass" \
+  fail "$t" "+apps/agent/wpmgr-agent.php declares a License but no License URI"
+
+t="$(tree absent-readme-header-uri)"
+drop "$t/apps/agent/readme.txt" '^License URI:'
+case_run "absent: readme.txt's header has a License but no License URI - fails, not a silent pass" \
+  fail "$t" "+apps/agent/readme.txt declares a License but no License URI"
+
+# OVER-FIRE: the mu-plugin loaders never carry a License URI line at all (only
+# License:), and that is fine - they are not asked to have one, so their
+# absence must never be reported.
+t="$(tree overfire-mu-plugins-have-no-uri-line)"
+case_run "over-fire: the mu-plugin loaders having no License URI line at all does not trip the guard" \
+  pass "$t" "-mu-plugin-loader/a-wpmgr-error-trap.php declares a License but no License URI" "-mu-plugin-loader/a-wpmgr-update-watchdog.php declares a License but no License URI"
+
+# HONEST REFORMAT: the URI still reads correctly through ordinary whitespace
+# variance, the same tolerance every name-only check above already has.
+t="$(tree reformat-main-header-uri-spacing)"
+sub "$t/apps/agent/wpmgr-agent.php" 's|^ \* License URI:       https://opensource\.org/licenses/MIT$| *   License URI:https://opensource.org/licenses/MIT|'
+case_run "reformat: squeezed spacing around the main header's License URI still reads correctly" \
+  pass "$t" "+main plugin header License URI"
+
+# ===========================================================================
 # THE REAL BUG THIS SUITE MISSED FIRST TIME: fixing readme.txt to MIT is not
 # enough on its own. The Makefile's wp.org build used to carry its own `sed`
 # rewrite forcing the STAGED plugin header back to "GPLv2 or later" on every

--- a/scripts/check-license-surfaces_test.sh
+++ b/scripts/check-license-surfaces_test.sh
@@ -173,6 +173,19 @@ The rest of this repository is licensed under AGPL-3.0 (see LICENSE).
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), ...
 MD
+
+  # A trimmed stand-in for the real agent-zip-wporg target: identity rewrites
+  # (Plugin Name, Text Domain) that are legitimate, and NO License rewrite —
+  # the post-#547 honest state. The regression case below re-adds exactly the
+  # kind of line that shipped the bug.
+  cat >"$_dir/Makefile" <<'MK'
+.PHONY: agent-zip-wporg
+agent-zip-wporg:
+	sed -i.bak \
+		-e "s|^ \* Plugin Name:.*| * Plugin Name:       Fleet Agent Site Manager|" \
+		-e "s|^ \* Text Domain:.*| * Text Domain:       fleet-agent-site-manager|" \
+		release/fleet-agent-site-manager/fleet-agent-site-manager.php
+MK
 }
 
 # tree NAME -> path to a fresh honest tree
@@ -326,6 +339,42 @@ t="$(tree disagree-license-agent)"
 sub "$t/LICENSE-AGENT" 's/^MIT License$/Apache License/'
 case_run "disagree: LICENSE-AGENT's title alone diverging fails" \
   fail "$t" "+LICENSE-AGENT): Apache License"
+
+# ===========================================================================
+# THE REAL BUG THIS SUITE MISSED FIRST TIME: fixing readme.txt to MIT is not
+# enough on its own. The Makefile's wp.org build used to carry its own `sed`
+# rewrite forcing the STAGED plugin header back to "GPLv2 or later" on every
+# build, regardless of what the source said -- every surface above reads only
+# the committed source tree, so all nine would have stayed green while the
+# actual wp.org zip kept shipping a header that disagreed with readme.txt.
+# `make agent-plugincheck` (real WordPress, via Docker) is what caught it.
+# This is what keeps it caught without a Docker run.
+# ===========================================================================
+t="$(tree regress-makefile-license-override-reintroduced)"
+cat >>"$t/Makefile" <<'MK'
+
+.PHONY: agent-zip-wporg-broken-again
+agent-zip-wporg-broken-again:
+	sed -i.bak \
+		-e "s|^ \* License:.*| * License:           GPLv2 or later|" \
+		release/fleet-agent-site-manager/fleet-agent-site-manager.php
+MK
+case_run "regress: reintroducing the Makefile License override fails, quoting the offending line (GH #547's actual shape)" \
+  fail "$t" "+Makefile rewrites the plugin header's License field" "+GPLv2 or later"
+
+t="$(tree absent-makefile)"
+rm -f "$t/Makefile"
+case_run "file absent: no Makefile at all is an error naming the file" \
+  fail "$t" "+Makefile does not exist"
+
+t="$(tree overfire-makefile-mentions-license-once)"
+cat >>"$t/Makefile" <<'MK'
+
+# Reminder: apps/agent is MIT-licensed (see LICENSE-AGENT). Nothing here
+# should rewrite that during packaging.
+MK
+case_run "over-fire: a Makefile comment mentioning 'License' once (not a sed rewrite) does not trip the guard" \
+  pass "$t"
 
 # ===========================================================================
 # ABSENCE: a surface whose declaration disappears is an ERROR, never a silent

--- a/scripts/check-license-surfaces_test.sh
+++ b/scripts/check-license-surfaces_test.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+# scripts/check-license-surfaces_test.sh
+#
+# The regression suite for scripts/check-license-surfaces.sh (GH #547).
+#
+# HOW IT WORKS. Each case builds a complete little apps/agent tree (plugin
+# header, two mu-plugin headers, readme.txt, composer.json, NOTICE.md,
+# README.md, LICENSE-AGENT), mutates exactly one thing, runs the guard against
+# that tree and asserts the exit code plus what the output does and does not
+# say. No mocking: the real script reads real files.
+#
+# RUN IT:
+#   scripts/check-license-surfaces_test.sh            # everything
+#   scripts/check-license-surfaces_test.sh notice      # only cases matching "notice"
+#
+# Point it at a different implementation to prove the suite is not vacuous
+# (reintroduce a hole in a copy, watch the suite go red):
+#   WPMGR_LICENSE_SURFACE_SCRIPT=/tmp/guard-with-hole.sh \
+#     scripts/check-license-surfaces_test.sh
+#
+# PORTABILITY. Written for bash 3.2 (what macOS ships) and POSIX tools, so it
+# runs the same on a darwin laptop with BSD grep/sed/awk and on the ubuntu CI
+# runner with the GNU ones. No mapfile, no associative arrays, no sed -i, no
+# grep -P, no sort -V.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${WPMGR_LICENSE_SURFACE_SCRIPT:-$HERE/check-license-surfaces.sh}"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+FILTER="${1:-}"
+
+if [ ! -f "$GUARD" ]; then
+  echo "no guard script at $GUARD" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/wpmgr-license-surfaces.XXXXXX")" || exit 2
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+FAILED_NAMES=''
+
+# ---------------------------------------------------------------------------
+# Tree construction. Every surface starts honestly declaring MIT, including
+# the third-party mentions (matthiasmullie/minify and lilliput both happen to
+# be MIT upstream too), which is deliberate: it is the only way to prove the
+# guard is reading the PLUGIN's declaration and not just "the word MIT
+# appears somewhere in this file". The over-fire cases below flip a
+# third-party mention to a DIFFERENT license and require the guard to stay
+# green, which "everything is honestly MIT" cannot distinguish on its own.
+# ---------------------------------------------------------------------------
+write_tree() {
+  _dir="$1"
+  mkdir -p "$_dir/apps/agent/mu-plugin-loader"
+
+  cat >"$_dir/apps/agent/wpmgr-agent.php" <<'PHP'
+<?php
+/**
+ * Plugin Name:       WPMgr Agent
+ * Plugin URI:        https://github.com/mosamlife/wpmgr
+ * Version:           0.61.146
+ * Author:            WPMgr contributors
+ * License:           MIT
+ * License URI:       https://opensource.org/licenses/MIT
+ * Text Domain:       wpmgr-agent
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('WPMGR_AGENT_VERSION', '0.61.146');
+PHP
+
+  cat >"$_dir/apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: WPMgr Error Trap (mu-plugin loader)
+ * Version:     1.0.0
+ * Author:      WPMgr contributors
+ * License:     MIT
+ */
+PHP
+
+  cat >"$_dir/apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: WPMgr Update Watchdog (mu-plugin loader)
+ * Version:     1.0.0
+ * Author:      WPMgr contributors
+ * License:     MIT
+ */
+PHP
+
+  cat >"$_dir/apps/agent/readme.txt" <<'TXT'
+=== Fleet Agent Site Manager ===
+Contributors: mosamlife
+Tags: backup, security, performance, updates, site management
+Requires at least: 6.2
+Tested up to: 7.1
+Requires PHP: 8.1
+Stable tag: 0.61.146
+License: MIT
+License URI: https://opensource.org/licenses/MIT
+
+Securely connects this site to a WPMgr dashboard.
+
+== Description ==
+
+Some description prose goes here, across a few lines, before the licensing
+sentence that a human reads on the wp.org listing page.
+
+This plugin is MIT-licensed and the dashboard is AGPL-3.0. Source for both: https://github.com/mosamlife/wpmgr
+
+== Third-party / Credits ==
+
+**matthiasmullie/minify (MIT)**
+
+CSS and JavaScript minification uses matthiasmullie/minify (^1.3, MIT license), a pure-PHP minification library included in the plugin's Composer dependencies. Source and license: https://github.com/matthiasmullie/minify
+
+Copyright (c) 2012 Matthias Mullie. Licensed under the MIT License.
+TXT
+
+  cat >"$_dir/apps/agent/composer.json" <<'JSON'
+{
+  "name": "wpmgr/agent",
+  "description": "WPMgr WordPress agent plugin",
+  "type": "wordpress-plugin",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.1"
+  }
+}
+JSON
+
+  cat >"$_dir/apps/agent/NOTICE.md" <<'MD'
+# NOTICE — WPMgr WordPress agent
+
+The WPMgr agent is MIT-licensed (see the repository `LICENSE`).
+
+## Third-party attribution
+
+### lilliput (Discord, MIT)
+
+`github.com/discord/lilliput` is MIT-licensed and used by the control-plane
+`media-encoder` service for image decoding/encoding. It is not bundled with
+this agent plugin.
+
+### matthiasmullie/minify (MIT)
+
+CSS and JS minification uses matthiasmullie/minify (^1.3, MIT), a small
+pure-PHP library in the agent's Composer dependencies.
+MD
+
+  cat >"$_dir/apps/agent/README.md" <<'MD'
+# apps/agent — WPMgr WordPress agent (PHP 8.0+)
+
+MIT-licensed WordPress plugin installed on managed sites. Communicates with
+the control plane over Ed25519-signed REST requests.
+MD
+
+  cat >"$_dir/LICENSE-AGENT" <<'MD'
+MIT License
+
+Copyright (c) 2026 WPMgr contributors
+
+Applies to: apps/agent (WordPress plugin) and apps/tracker (JS web-vitals).
+The rest of this repository is licensed under AGPL-3.0 (see LICENSE).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), ...
+MD
+}
+
+# tree NAME -> path to a fresh honest tree
+tree() {
+  _t="$WORK/$1"
+  rm -rf "$_t"
+  mkdir -p "$_t"
+  write_tree "$_t"
+  printf '%s' "$_t"
+}
+
+# ---------------------------------------------------------------------------
+# Mutation helpers (portable: no sed -i, which differs between BSD and GNU)
+# ---------------------------------------------------------------------------
+sub() { # sub FILE SED-EXPR
+  sed -E "$2" "$1" >"$1.tmp" && mv "$1.tmp" "$1"
+}
+
+drop() { # drop FILE ERE  (delete every matching line)
+  grep -vE "$2" "$1" >"$1.tmp"
+  mv "$1.tmp" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Assertions
+#
+#   case NAME pass|fail DIR [+MUST-CONTAIN ...] [-MUST-NOT-CONTAIN ...]
+# ---------------------------------------------------------------------------
+case_run() {
+  _name="$1"
+  _want="$2"
+  _dir="$3"
+  shift 3
+
+  if [ -n "$FILTER" ]; then
+    case "$_name" in
+      *"$FILTER"*) : ;;
+      *)
+        SKIPPED=$((SKIPPED + 1))
+        return 0
+        ;;
+    esac
+  fi
+
+  _out="$("$GUARD" "$_dir" 2>&1)"
+  _code=$?
+  _problems=''
+
+  if [ "$_want" = pass ] && [ "$_code" -ne 0 ]; then
+    _problems="$_problems
+    expected exit 0, got $_code"
+  fi
+  if [ "$_want" = fail ] && [ "$_code" -eq 0 ]; then
+    _problems="$_problems
+    expected a non-zero exit, got 0"
+  fi
+
+  for _a in "$@"; do
+    case "$_a" in
+      +*)
+        _needle="${_a#+}"
+        if ! printf '%s\n' "$_out" | grep -qF "$_needle"; then
+          _problems="$_problems
+    expected the output to contain: $_needle"
+        fi
+        ;;
+      -*)
+        _needle="${_a#-}"
+        if printf '%s\n' "$_out" | grep -qF "$_needle"; then
+          _problems="$_problems
+    expected the output NOT to contain: $_needle"
+        fi
+        ;;
+    esac
+  done
+
+  if [ -n "$_problems" ]; then
+    FAILED=$((FAILED + 1))
+    FAILED_NAMES="$FAILED_NAMES  $_name
+"
+    printf 'FAIL %s%s\n' "$_name" "$_problems"
+    printf '%s\n' "$_out" | sed 's/^/      | /'
+  else
+    PASSED=$((PASSED + 1))
+    printf 'ok   %s\n' "$_name"
+  fi
+}
+
+# ===========================================================================
+# Honest trees. A guard that reddens correct work gets switched off, and then
+# it guards nothing.
+# ===========================================================================
+case_run "honest: the pristine tree passes" pass "$(tree honest-pristine)"
+
+case_run "honest: this repository's own tree passes" pass "$REPO_ROOT"
+
+# ===========================================================================
+# DISAGREEMENT: each surface, mutated alone to a different license, must fail
+# and the failure must name that surface's file.
+# ===========================================================================
+t="$(tree disagree-main-header)"
+sub "$t/apps/agent/wpmgr-agent.php" 's/^ \* License:           MIT/ * License:           GPLv2 or later/'
+case_run "disagree: the main plugin header alone diverging fails and is named" \
+  fail "$t" "+more than one license" "+apps/agent/wpmgr-agent.php (the main plugin header): GPLv2 or later"
+
+t="$(tree disagree-error-trap-header)"
+sub "$t/apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php" 's/^ \* License:     MIT/ * License:     GPLv2 or later/'
+case_run "disagree: the error-trap mu-plugin header alone diverging fails and is named" \
+  fail "$t" "+apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php" "+GPLv2 or later"
+
+t="$(tree disagree-watchdog-header)"
+sub "$t/apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php" 's/^ \* License:     MIT/ * License:     GPLv2 or later/'
+case_run "disagree: the update-watchdog mu-plugin header alone diverging fails and is named" \
+  fail "$t" "+apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php" "+GPLv2 or later"
+
+# The real GH #547 shape: both readme.txt surfaces say GPLv2 while every other
+# surface says MIT. This is not a synthetic mutation — it is the literal bug.
+t="$(tree disagree-readme-both-real-bug-shape)"
+sub "$t/apps/agent/readme.txt" 's/^License: MIT$/License: GPLv2 or later/'
+sub "$t/apps/agent/readme.txt" 's/^License URI: https:\/\/opensource\.org\/licenses\/MIT$/License URI: https:\/\/www.gnu.org\/licenses\/gpl-2.0.html/'
+sub "$t/apps/agent/readme.txt" 's/^This plugin is MIT-licensed and the dashboard is AGPL-3\.0\./This plugin is GPLv2 or later and the dashboard is AGPL-3.0./'
+case_run "disagree: readme.txt's header AND prose both diverging (the real #547 shape) fails, naming both" \
+  fail "$t" "+the readme.txt wp.org header): GPLv2 or later" "+the readme.txt Description prose): GPLv2 or later"
+
+t="$(tree disagree-readme-header-only)"
+sub "$t/apps/agent/readme.txt" 's/^License: MIT$/License: GPLv2 or later/'
+case_run "disagree: the readme.txt header alone diverging fails" \
+  fail "$t" "+the readme.txt wp.org header): GPLv2 or later" "-the readme.txt Description prose): GPLv2 or later"
+
+t="$(tree disagree-readme-prose-only)"
+sub "$t/apps/agent/readme.txt" 's/^This plugin is MIT-licensed and the dashboard is AGPL-3\.0\./This plugin is GPLv2 or later and the dashboard is AGPL-3.0./'
+case_run "disagree: the readme.txt Description prose alone diverging fails" \
+  fail "$t" "+the readme.txt Description prose): GPLv2 or later"
+
+t="$(tree disagree-composer)"
+sub "$t/apps/agent/composer.json" 's/"license": "MIT"/"license": "GPL-2.0-or-later"/'
+case_run "disagree: composer.json alone diverging fails" \
+  fail "$t" "+composer.json): GPL-2.0-or-later"
+
+t="$(tree disagree-notice)"
+sub "$t/apps/agent/NOTICE.md" 's/The WPMgr agent is MIT-licensed/The WPMgr agent is GPLv2-licensed/'
+case_run "disagree: NOTICE.md's own claim alone diverging fails" \
+  fail "$t" "+NOTICE.md): GPLv2-licensed"
+
+t="$(tree disagree-agent-readme-md)"
+sub "$t/apps/agent/README.md" 's/^MIT-licensed WordPress plugin/GPLv2-licensed WordPress plugin/'
+case_run "disagree: apps/agent/README.md alone diverging fails" \
+  fail "$t" "+README.md): GPLv2"
+
+t="$(tree disagree-license-agent)"
+sub "$t/LICENSE-AGENT" 's/^MIT License$/Apache License/'
+case_run "disagree: LICENSE-AGENT's title alone diverging fails" \
+  fail "$t" "+LICENSE-AGENT): Apache License"
+
+# ===========================================================================
+# ABSENCE: a surface whose declaration disappears is an ERROR, never a silent
+# pass. This is the failure mode the tracking issue calls out by name: a
+# check that passes because its pattern matched nothing is the same defect
+# one level up.
+# ===========================================================================
+t="$(tree absent-main-header)"
+drop "$t/apps/agent/wpmgr-agent.php" '^ \* License:'
+case_run "absent: the main plugin header's License line removed is an error, not a pass" \
+  fail "$t" "+declares no license" "+the main plugin header" "-OK: the main plugin header"
+
+t="$(tree absent-error-trap-header)"
+drop "$t/apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php" '^ \* License:'
+case_run "absent: the error-trap header's License line removed is an error" \
+  fail "$t" "+apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php declares no license"
+
+t="$(tree absent-watchdog-header)"
+drop "$t/apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php" '^ \* License:'
+case_run "absent: the update-watchdog header's License line removed is an error" \
+  fail "$t" "+apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php declares no license"
+
+t="$(tree absent-readme-header)"
+drop "$t/apps/agent/readme.txt" '^License:'
+case_run "absent: the readme.txt header's License line removed is an error, not a pass" \
+  fail "$t" "+the readme.txt wp.org header" "+declares no license"
+
+t="$(tree absent-readme-prose)"
+drop "$t/apps/agent/readme.txt" '^This plugin is MIT-licensed and the dashboard is'
+case_run "absent: the readme.txt Description prose sentence removed is an error" \
+  fail "$t" "+the readme.txt Description prose" "+declares no license"
+
+t="$(tree absent-composer)"
+sub "$t/apps/agent/composer.json" 's/"license": "MIT",//'
+case_run "absent: composer.json with no license field is an error, not a pass" \
+  fail "$t" "+composer.json declares no license"
+
+# The important one: deleting the plugin's OWN claim in NOTICE.md must be
+# reported absent even though the file still says "is MIT-licensed" twice,
+# about lilliput and about matthiasmullie. If this passed, the anchor would
+# be reading any third-party credit as the plugin's own declaration.
+t="$(tree absent-notice-not-fooled-by-third-party)"
+drop "$t/apps/agent/NOTICE.md" 'The WPMgr agent is MIT-licensed'
+case_run "absent: NOTICE.md's own claim removed is an error, and is NOT satisfied by the surviving third-party 'is MIT-licensed' mentions" \
+  fail "$t" "+apps/agent/NOTICE.md declares no license"
+
+t="$(tree absent-agent-readme-md)"
+drop "$t/apps/agent/README.md" 'MIT-licensed WordPress plugin'
+case_run "absent: apps/agent/README.md's opening line removed is an error" \
+  fail "$t" "+apps/agent/README.md declares no license"
+
+t="$(tree absent-license-agent-no-title)"
+sub "$t/LICENSE-AGENT" 's/^MIT License$/Copyright first, no title line/'
+case_run "absent: LICENSE-AGENT with no recognizable title line is an error, not a pass" \
+  fail "$t" "+LICENSE-AGENT declares no license"
+
+# ===========================================================================
+# FILES THAT ARE SIMPLY ABSENT.
+# ===========================================================================
+t="$(tree file-absent-main-plugin)"
+rm -f "$t/apps/agent/wpmgr-agent.php"
+case_run "file absent: no wpmgr-agent.php at all is an error naming the file" \
+  fail "$t" "+apps/agent/wpmgr-agent.php does not exist"
+
+t="$(tree file-absent-license-agent)"
+rm -f "$t/LICENSE-AGENT"
+case_run "file absent: no LICENSE-AGENT at all is an error naming the file" \
+  fail "$t" "+LICENSE-AGENT does not exist"
+
+# ===========================================================================
+# OVER-FIRE: the matthiasmullie/minify third-party attribution (readme.txt)
+# and the lilliput third-party mention (NOTICE.md) are dependency licenses,
+# not the plugin's own, and must never be read as a surface. Each case below
+# flips ONLY the third-party mention to a DIFFERENT license, leaving every
+# real surface honestly MIT, and requires the guard to stay green — if the
+# guard's patterns were loose enough to read these, it would fail here.
+# ===========================================================================
+t="$(tree overfire-minify-attribution-changed)"
+sub "$t/apps/agent/readme.txt" 's/matthiasmullie\/minify \(\^1\.3, MIT license\)/matthiasmullie\/minify (^1.3, GPL-3.0 license)/'
+sub "$t/apps/agent/readme.txt" 's/Copyright \(c\) 2012 Matthias Mullie\. Licensed under the MIT License\./Copyright (c) 2012 Matthias Mullie. Licensed under the GPL-3.0 License./'
+case_run "over-fire: the matthiasmullie/minify third-party attribution changing license does not trip the guard" \
+  pass "$t"
+
+t="$(tree overfire-minify-section-removed)"
+sub "$t/apps/agent/readme.txt" '/== Third-party \/ Credits ==/,$d'
+case_run "over-fire: removing the whole third-party section entirely still passes (it is not a required surface)" \
+  pass "$t"
+
+t="$(tree overfire-lilliput-changed)"
+sub "$t/apps/agent/NOTICE.md" 's/is MIT-licensed and used by the control-plane/is GPL-3.0-licensed and used by the control-plane/'
+case_run "over-fire: the lilliput third-party mention in NOTICE.md changing license does not trip the guard" \
+  pass "$t"
+
+# ===========================================================================
+# HONEST REFORMATS. A formatter, or an editor tidying whitespace, must never
+# redden CI.
+# ===========================================================================
+t="$(tree reformat-extra-header-spacing)"
+sub "$t/apps/agent/wpmgr-agent.php" 's/^ \* License:           MIT$/ *   License:MIT/'
+case_run "reformat: squeezed header spacing (License:MIT, no space before, extra indent) still reads MIT" \
+  pass "$t"
+
+t="$(tree reformat-readme-trailing-space)"
+sub "$t/apps/agent/readme.txt" 's/^License: MIT$/License: MIT   /'
+case_run "reformat: a trailing-space readme.txt header line still reads MIT" \
+  pass "$t"
+
+t="$(tree reformat-composer-spacing)"
+sub "$t/apps/agent/composer.json" 's/"license": "MIT"/"license":      "MIT"/'
+case_run "reformat: extra spacing around composer.json's license colon still reads MIT" \
+  pass "$t"
+
+t="$(tree reformat-notice-trailing-clause)"
+sub "$t/apps/agent/NOTICE.md" 's/The WPMgr agent is MIT-licensed \(see the repository `LICENSE`\)\./The WPMgr agent is MIT-licensed, per the top-level LICENSE-AGENT file./'
+case_run "reformat: a reworded trailing clause after 'MIT-licensed' in NOTICE.md still reads MIT" \
+  pass "$t"
+
+# ---------------------------------------------------------------------------
+printf '\n'
+if [ -n "$FILTER" ]; then
+  printf 'filter: %s (%s skipped)\n' "$FILTER" "$SKIPPED"
+fi
+printf '%s passed, %s failed\n' "$PASSED" "$FAILED"
+if [ "$FAILED" -ne 0 ]; then
+  printf 'failing cases:\n%s' "$FAILED_NAMES"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #547. The agent declared two different licenses at the same time:

| Surface | Before | After |
|---|---|---|
| `apps/agent/wpmgr-agent.php` plugin header | MIT | MIT (unchanged) |
| `apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php` header | MIT | MIT (unchanged) |
| `apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php` header | MIT | MIT (unchanged) |
| `apps/agent/readme.txt:8` header `License:` | GPLv2 or later | **MIT** |
| `apps/agent/readme.txt:51` Description prose | "This plugin is GPLv2 or later..." | **"This plugin is MIT-licensed..."** |
| `apps/agent/composer.json` `license` field | MIT | MIT (unchanged) |
| `apps/agent/NOTICE.md` | "The WPMgr agent is MIT-licensed" | MIT (unchanged) |
| `apps/agent/README.md` | "MIT-licensed WordPress plugin" | MIT (unchanged) |
| `LICENSE-AGENT` (repo root) | MIT License | MIT (unchanged) |

The owner's ruling is MIT, and it ships with the **next** agent release, not before — merging this does not change the wordpress.org listing by itself. The plugin currently live on wordpress.org declares GPLv2 in both its header and its readme, consistently, because of a build-time rewrite (see below); previously-distributed versions went out under GPLv2 and those grants stand. This PR only changes what the next build declares.

The third-party `matthiasmullie/minify` MIT attribution around `readme.txt:253` is untouched — it's a dependency credit, not the plugin's own declaration.

## A second bug the readme fix alone didn't close

`make agent-plugincheck` (the authoritative gate) failed `ERROR license_mismatch` on the first run, even after the readme.txt fix. Root cause: `Makefile`'s `agent-zip-wporg` target carried its own `sed` rewrite forcing the **staged** plugin header's `License:` back to "GPLv2 or later" on every wp.org build, independent of the source. Every source surface agreed on MIT and always would have, while the actual zip uploaded to wordpress.org kept shipping a header that disagreed with readme.txt — the literal bug #547 was filed against, reintroduced by the build instead of the source.

Fixed by removing that rewrite (`57fba9be`). Verified against the **packaged artifact**, not the source tree:

```
$ make agent-zip-wporg && unzip -q release/fleet-agent-site-manager.zip -d /tmp/wporg-zip-inspect

$ grep -n "^ \* License" /tmp/wporg-zip-inspect/fleet-agent-site-manager/fleet-agent-site-manager.php
10: * License:           MIT
11: * License URI:       https://opensource.org/licenses/MIT

$ grep -n "^License" /tmp/wporg-zip-inspect/fleet-agent-site-manager/readme.txt
8:License: MIT
9:License URI: https://opensource.org/licenses/MIT
```

`make agent-plugincheck` re-run clean after the fix: `Plugin Check: 0 errors.`

## The guard: `scripts/check-license-surfaces.sh`

Follows the `scripts/check-version-surfaces.sh` + `_test.sh` pattern: a repo script with a committed regression suite, wired into `ci.yml`'s `Security audit` job as its own two steps (self-test first), so a broken guard can't pass by failing open.

10 named surfaces, each required to agree:

1. `apps/agent/wpmgr-agent.php` plugin header
2. `apps/agent/mu-plugin-loader/a-wpmgr-error-trap.php` header
3. `apps/agent/mu-plugin-loader/a-wpmgr-update-watchdog.php` header
4. `apps/agent/readme.txt`'s structured header
5. `apps/agent/readme.txt`'s Description prose
6. `apps/agent/composer.json`
7. `apps/agent/NOTICE.md`
8. `apps/agent/README.md`
9. `LICENSE-AGENT`'s title line
10. `Makefile` — asserted to carry **no** rewrite of the header's License field at all (the exact bug above; there's nothing legitimate for a packaging step to say here)

Plus **License URI** agreement (added after review, see below) on the two surfaces that declare one (the plugin header and readme.txt's header): each URI is checked against its own file's declared License name, and against the other URI-bearing surface.

Every check fails loudly if its surface yields no declaration at all — a missing header is not a pass.

**Red proof (the real bug, not a synthetic mutation):** ran the finished guard against the actual pre-fix tree:
```
ERROR: the agent declares more than one license:
  apps/agent/readme.txt (the readme.txt wp.org header): GPLv2 or later
  apps/agent/readme.txt (the readme.txt Description prose): GPLv2 or later
  ...(the other 7 surfaces, all MIT)...
```
Exit 1. **Green, same tree, after the fix:** `License surfaces agree: MIT`, exit 0.

**Self-test suite:** `scripts/check-license-surfaces_test.sh` (`make check-licenses-test`) — 41 cases, 41 passed. Covers: honest trees, one disagreement and one absence per surface, the Makefile-override regression (GH #547's actual build-time shape), the License URI half-right state (`License: MIT` next to a GPL URL) proven both as a fixture case and as a live mutation of the real `apps/agent/wpmgr-agent.php` (red, then reverted to green), URI cross-surface disagreement, URI absence, three third-party over-fire proofs (matthiasmullie/minify, lilliput, and a whole-section deletion), and reformat-tolerance cases.

## Review findings addressed

Two threads from review, both fixed and resolved on the PR:
- **"Packaging restores license split"** — real, was the Makefile bug above; fixed in `57fba9be`, verified against the built zip.
- **"License URIs remain unchecked"** — fixed in `a77f1980`, adds the License URI self-consistency + cross-surface checks described above.

## Routing note

`scripts/**`, `.github/workflows/**` and `Makefile` are `devops-engineer`'s paths per the routing table in `CLAUDE.md`. This PR crosses that boundary deliberately, on the task owner's explicit direction, because the guard's surface list (and the build-pipeline bug it caught) requires plugin-specific knowledge that the readme/header fix work already required.

## Gates run

- `cd apps/agent && composer install` — restored the dev toolchain (phpunit, phpcs were previously stripped by a prior `--no-dev` build).
- `composer test` (phpunit): this machine's default PHP CLI `memory_limit` (128M) is too low for the full 3472-test suite and crashes on an unrelated pre-existing test (`SqlInspectorTest`, a `gzgets` call unrelated to this change). Re-ran with `-d memory_limit=512M` (matching what CI's `shivammathur/setup-php` allows by default): `Tests: 3472, Assertions: 18032, Skipped: 10`, 0 failures, 0 errors.
- `make agent-check` (fast phpcs): 0 errors.
- `make agent-plugincheck` (authoritative, Docker): 0 errors, both before and after the Makefile fix confirmed the fix was necessary and sufficient.
- `scripts/check-license-surfaces_test.sh`: 41 passed, 0 failed.
- `scripts/check-license-surfaces.sh`: passes against this branch's tree and against the built wp.org zip's contents.

## Test plan

- [x] `scripts/check-license-surfaces_test.sh` — 41/41 pass
- [x] `scripts/check-license-surfaces.sh` red on the pre-fix tree, green post-fix
- [x] `make agent-zip-wporg` + grep the packaged zip — MIT in both header and readme, confirmed post-Makefile-fix
- [x] `make agent-plugincheck` — 0 errors
- [x] `composer test` — 3472/3472, 0 failures (at adequate memory_limit; see note above)
- [x] `make agent-check` — 0 phpcs errors
- [x] Both review threads replied to with evidence and resolved
- [ ] Not releasing the agent from this PR — ships on the next agent release, per owner's ruling
