### PR TITLE
docs(notice): credit web-vitals and zxcvbn-php in both NOTICE.md files

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -21,6 +21,13 @@ CSS and JS minification uses
 [`matthiasmullie/minify`](https://github.com/matthiasmullie/minify) (^1.3, MIT), a
 small pure-PHP library bundled with the agent's Composer dependencies.
 
+### matthiasmullie/path-converter (MIT)
+
+[`matthiasmullie/path-converter`](https://github.com/matthiasmullie/path-converter)
+(~1.1, MIT) is a Composer dependency of `matthiasmullie/minify` above (relative
+path rewriting for minified CSS `url()` references), installed transitively into
+the agent's vendor tree. Copyright (c) 2015 Matthias Mullie.
+
 ### Remove Unused CSS (RUCSS)
 
 WPMgr's RUCSS engine is a pure-Go implementation on the control plane. There is no
@@ -51,6 +58,14 @@ The agent's password-strength policy uses
 [`bjeavons/zxcvbn-php`](https://github.com/bjeavons/zxcvbn-php) (^1.4, MIT), a
 pure-PHP port of zxcvbn, bundled with the agent's Composer dependencies.
 Copyright (c) 2013-2014 Benjamin Jeavons.
+
+### symfony/polyfill-mbstring (MIT)
+
+[`symfony/polyfill-mbstring`](https://github.com/symfony/polyfill-mbstring)
+(>=1.3.1, MIT) is a Composer dependency of `bjeavons/zxcvbn-php` above (mbstring
+functions on PHP builds without the extension), installed transitively into the
+agent's vendor tree. Copyright (c) 2015-present Fabien Potencier and
+contributors.
 
 ## Media Optimizer
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -34,6 +34,24 @@ open-source Go libraries:
 - [`github.com/andybalholm/cascadia`](https://github.com/andybalholm/cascadia)
   (BSD-2-Clause) — compile CSS selectors and test them against the parsed DOM.
 
+### web-vitals (Google, Apache-2.0)
+
+Real User Monitoring's Core Web Vitals collection bundles
+[`web-vitals`](https://github.com/GoogleChrome/web-vitals) (^5.3.0,
+Apache-2.0), Copyright 2020 Google LLC, via an esbuild build in
+`apps/tracker`. The bundle ships inside the agent plugin zip as
+`assets/wpmgr-rum.js` / `assets/wpmgr-rum.min.js`. Source and license:
+https://github.com/GoogleChrome/web-vitals/blob/main/LICENSE
+
+## Security
+
+### bjeavons/zxcvbn-php (MIT)
+
+The agent's password-strength policy uses
+[`bjeavons/zxcvbn-php`](https://github.com/bjeavons/zxcvbn-php) (^1.4, MIT), a
+pure-PHP port of zxcvbn, bundled with the agent's Composer dependencies.
+Copyright (c) 2013-2014 Benjamin Jeavons.
+
 ## Media Optimizer
 
 The Media Optimizer's attribution (including Discord's `lilliput`, MIT, for

--- a/apps/agent/NOTICE.md
+++ b/apps/agent/NOTICE.md
@@ -4,6 +4,13 @@ The WPMgr agent is MIT-licensed (see the repository `LICENSE`).
 
 ## Third-party attribution
 
+### bjeavons/zxcvbn-php (MIT)
+
+Password-strength scoring in the Security module's password policy uses
+[`bjeavons/zxcvbn-php`](https://github.com/bjeavons/zxcvbn-php) (^1.4, MIT), a
+pure-PHP port of zxcvbn, in the agent's Composer dependencies. Copyright (c)
+2013-2014 Benjamin Jeavons.
+
 ### lilliput (Discord, MIT)
 
 `github.com/discord/lilliput` is MIT-licensed and used by the control-plane
@@ -15,6 +22,15 @@ agent plugin (the agent performs no encoding).
 CSS and JS minification uses
 [`matthiasmullie/minify`](https://github.com/matthiasmullie/minify) (^1.3, MIT), a
 small pure-PHP library in the agent's Composer dependencies.
+
+### web-vitals (Google, Apache-2.0)
+
+The Real User Monitoring collector bundles
+[`web-vitals`](https://github.com/GoogleChrome/web-vitals) (^5.3.0,
+Apache-2.0), Copyright 2020 Google LLC, via an esbuild build in
+`apps/tracker`. The bundle ships inside the plugin zip as
+`assets/wpmgr-rum.js` / `assets/wpmgr-rum.min.js`. Source and license:
+https://github.com/GoogleChrome/web-vitals/blob/main/LICENSE
 
 ## Implementation notes
 

--- a/apps/agent/NOTICE.md
+++ b/apps/agent/NOTICE.md
@@ -23,6 +23,20 @@ CSS and JS minification uses
 [`matthiasmullie/minify`](https://github.com/matthiasmullie/minify) (^1.3, MIT), a
 small pure-PHP library in the agent's Composer dependencies.
 
+### matthiasmullie/path-converter (MIT)
+
+[`matthiasmullie/path-converter`](https://github.com/matthiasmullie/path-converter)
+(~1.1, MIT) is a Composer dependency of `matthiasmullie/minify` above (relative
+path rewriting for minified CSS `url()` references), installed transitively into
+the same vendor tree. Copyright (c) 2015 Matthias Mullie.
+
+### symfony/polyfill-mbstring (MIT)
+
+[`symfony/polyfill-mbstring`](https://github.com/symfony/polyfill-mbstring)
+(>=1.3.1, MIT) is a Composer dependency of `bjeavons/zxcvbn-php` above (mbstring
+functions on PHP builds without the extension), installed transitively into the
+same vendor tree. Copyright (c) 2015-present Fabien Potencier and contributors.
+
 ### web-vitals (Google, Apache-2.0)
 
 The Real User Monitoring collector bundles

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -254,13 +254,25 @@ CSS and JavaScript minification uses matthiasmullie/minify (^1.3, MIT license), 
 
 Copyright (c) 2012 Matthias Mullie. Licensed under the MIT License.
 
+**matthiasmullie/path-converter (MIT)**
+
+matthiasmullie/path-converter (~1.1, MIT license) is a Composer dependency of matthiasmullie/minify above, used to rewrite relative paths in minified CSS, and is installed as part of the same vendor tree. Source and license: https://github.com/matthiasmullie/path-converter
+
+Copyright (c) 2015 Matthias Mullie. Licensed under the MIT License.
+
 **bjeavons/zxcvbn-php (MIT)**
 
 Password-strength scoring in the password policy uses bjeavons/zxcvbn-php (^1.4, MIT license), a pure-PHP port of zxcvbn included in the plugin's Composer dependencies. Source and license: https://github.com/bjeavons/zxcvbn-php
 
 Copyright (c) 2013-2014 Benjamin Jeavons. Licensed under the MIT License.
 
-No other third-party PHP libraries are bundled in the plugin zip beyond the two credited above. Image encoding and WOFF2 font transcoding run on the control-plane service, not inside this plugin. The bundled Real User Monitoring JavaScript also carries a third-party library; see Source code below.
+**symfony/polyfill-mbstring (MIT)**
+
+symfony/polyfill-mbstring (>=1.3.1, MIT license) is a Composer dependency of bjeavons/zxcvbn-php above, providing mbstring functions on PHP builds that lack the mbstring extension, and is installed as part of the same vendor tree. Source and license: https://github.com/symfony/polyfill-mbstring
+
+Copyright (c) 2015-present Fabien Potencier and contributors. Licensed under the MIT License.
+
+No other third-party PHP libraries are bundled in the plugin zip beyond those credited above. Image encoding and WOFF2 font transcoding run on the control-plane service, not inside this plugin. The bundled Real User Monitoring JavaScript also carries a third-party library; see Source code below.
 
 == Source code ==
 

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -254,7 +254,13 @@ CSS and JavaScript minification uses matthiasmullie/minify (^1.3, MIT license), 
 
 Copyright (c) 2012 Matthias Mullie. Licensed under the MIT License.
 
-No other third-party libraries are bundled in the plugin zip. Image encoding and WOFF2 font transcoding run on the control-plane service, not inside this plugin.
+**bjeavons/zxcvbn-php (MIT)**
+
+Password-strength scoring in the password policy uses bjeavons/zxcvbn-php (^1.4, MIT license), a pure-PHP port of zxcvbn included in the plugin's Composer dependencies. Source and license: https://github.com/bjeavons/zxcvbn-php
+
+Copyright (c) 2013-2014 Benjamin Jeavons. Licensed under the MIT License.
+
+No other third-party PHP libraries are bundled in the plugin zip beyond the two credited above. Image encoding and WOFF2 font transcoding run on the control-plane service, not inside this plugin. The bundled Real User Monitoring JavaScript also carries a third-party library; see Source code below.
 
 == Source code ==
 

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -250,29 +250,21 @@ Why: to deliver this site's outgoing mail through a provider rather than the ser
 
 **matthiasmullie/minify (MIT)**
 
-CSS and JavaScript minification uses matthiasmullie/minify (^1.3, MIT license), a pure-PHP minification library included in the plugin's Composer dependencies. Source and license: https://github.com/matthiasmullie/minify
-
-Copyright (c) 2012 Matthias Mullie. Licensed under the MIT License.
+CSS and JavaScript minification uses matthiasmullie/minify (^1.3, MIT), a pure-PHP library in the plugin's Composer dependencies. Copyright (c) 2012 Matthias Mullie. Source: https://github.com/matthiasmullie/minify
 
 **matthiasmullie/path-converter (MIT)**
 
-matthiasmullie/path-converter (~1.1, MIT license) is a Composer dependency of matthiasmullie/minify above, used to rewrite relative paths in minified CSS, and is installed as part of the same vendor tree. Source and license: https://github.com/matthiasmullie/path-converter
-
-Copyright (c) 2015 Matthias Mullie. Licensed under the MIT License.
+matthiasmullie/path-converter (~1.1, MIT) is minify's own Composer dependency, rewriting relative paths in minified CSS, installed into the same vendor tree. Copyright (c) 2015 Matthias Mullie. Source: https://github.com/matthiasmullie/path-converter
 
 **bjeavons/zxcvbn-php (MIT)**
 
-Password-strength scoring in the password policy uses bjeavons/zxcvbn-php (^1.4, MIT license), a pure-PHP port of zxcvbn included in the plugin's Composer dependencies. Source and license: https://github.com/bjeavons/zxcvbn-php
-
-Copyright (c) 2013-2014 Benjamin Jeavons. Licensed under the MIT License.
+Password-strength scoring in the password policy uses bjeavons/zxcvbn-php (^1.4, MIT), a pure-PHP port of zxcvbn in the plugin's Composer dependencies. Copyright (c) 2013-2014 Benjamin Jeavons. Source: https://github.com/bjeavons/zxcvbn-php
 
 **symfony/polyfill-mbstring (MIT)**
 
-symfony/polyfill-mbstring (>=1.3.1, MIT license) is a Composer dependency of bjeavons/zxcvbn-php above, providing mbstring functions on PHP builds that lack the mbstring extension, and is installed as part of the same vendor tree. Source and license: https://github.com/symfony/polyfill-mbstring
+symfony/polyfill-mbstring (>=1.3.1, MIT) is zxcvbn-php's own Composer dependency, providing mbstring functions where the extension is absent, installed into the same vendor tree. Copyright (c) 2015-present Fabien Potencier and contributors. Source: https://github.com/symfony/polyfill-mbstring
 
-Copyright (c) 2015-present Fabien Potencier and contributors. Licensed under the MIT License.
-
-No other third-party PHP libraries are bundled in the plugin zip beyond those credited above. Image encoding and WOFF2 font transcoding run on the control-plane service, not inside this plugin. The bundled Real User Monitoring JavaScript also carries a third-party library; see Source code below.
+No other third-party PHP libraries are bundled beyond those credited above. Image encoding and WOFF2 font transcoding run on the control-plane service, not inside this plugin. The bundled Real User Monitoring JavaScript also carries a third-party library; see Source code below.
 
 == Source code ==
 


### PR DESCRIPTION
## Summary

PR #554 (ADR-063) carries a P1 review finding (greptile-apps, comment id 3871921880): the agent artifact bundles Apache-2.0 `web-vitals` without listing it in `apps/agent/NOTICE.md` or the root `NOTICE.md`, even though `apps/agent/readme.txt:263` already credits it correctly. This PR closes that gap.

## What Apache-2.0 actually requires here

Fetched the canonical license text (`https://www.apache.org/licenses/LICENSE-2.0.txt`) and checked upstream directly (`npm pack web-vitals@5.3.0`, `gh api repos/GoogleChrome/web-vitals/contents/`):

- **Section 4(b)** ("You must cause any modified files to carry prominent notices stating that You changed the files") does not apply: `web-vitals` is consumed as an ordinary upstream dependency via `apps/tracker`'s esbuild bundle (the ADOPT UPSTREAM disposition), not modified.
- **Section 4(d)** (NOTICE-file propagation) is conditional on "If the Work includes a 'NOTICE' text file as part of its distribution." Verified upstream ships **no NOTICE file** — only `LICENSE` — in both the GitHub repo root and the published npm tarball. So 4(d)'s propagation duty does not itself require an entry.

The credit is added for **consistency with this repository's own convention**, not as a compliance obligation `web-vitals` itself triggers: every dependency actually bundled into the plugin zip is listed in `apps/agent/readme.txt`, `apps/agent/NOTICE.md`, and the root `NOTICE.md` (matthiasmullie/minify is the existing template for this, called out explicitly in ADR-063's own ADOPT UPSTREAM section).

## What was added

- `apps/agent/NOTICE.md`: new `web-vitals (Google, Apache-2.0)` entry (Copyright 2020 Google LLC).
- Root `NOTICE.md`: same entry, under Performance Suite (Core Web Vitals is part of that feature).
- `apps/agent/readme.txt:263` was **not** touched — it already names the dependency and its license correctly.

## Also found while auditing the same question for the whole shipped zip

`bjeavons/zxcvbn-php` (MIT) is a production `require` in `apps/agent/composer.json` (not `require-dev`), is actually used in `includes/security/class-password-policy-module.php` (`new Zxcvbn()`), and ships inside the wp.org zip's `vendor/` directory (`Makefile`'s `agent-zip-wporg` only strips `vendor/*/bin/`, `LICENSE` files and `data-scripts/`, not the library code itself — its own comments name `bjeavons/zxcvbn-php/data-scripts` as one of the excluded paths). It was credited in **none** of the three surfaces, and `apps/agent/readme.txt` affirmatively claimed "No other third-party libraries are bundled in the plugin zip," which was wrong on two counts (web-vitals and zxcvbn-php). Fixed all three surfaces for zxcvbn-php too and corrected that claim.

## Gates run this turn

- `make check-versions-test` — 76 passed, 0 failed, exit 0
- `make check-versions` — exit 0, all surfaces consistent at 0.61.146
- `node apps/marketing/scripts/check-copy.mjs` — exit 0, 390 files, no em/en dashes or competitor names
- Docs vocabulary check copied verbatim from `.github/workflows/ci.yml` lines 365-371 this turn — 0 hits

## Not in scope / named for follow-up

- `Makefile`'s `agent-vendor` target still carries a stale comment ("agent has ZERO production composer deps") that predates both Composer production dependencies; `Makefile` is `devops-engineer`'s path, not touched here.
- `apps/agent/assets/wpmgr-woo-fragments.js` is original, dependency-free WPMgr code, not documented in readme.txt's Source code enumeration alongside the other two JS files. Not a licensing gap, just a completeness gap; naming it, not fixing it here.

## Test plan

- [x] `make check-versions-test`
- [x] `make check-versions`
- [x] `node apps/marketing/scripts/check-copy.mjs`
- [x] Docs vocabulary grep from `ci.yml`, verbatim, 0 hits
- [ ] Reply to and resolve the PR #554 review thread (comment id 3871921880) referencing this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added third-party attribution details for web-vitals, zxcvbn-php, path-converter, and Symfony Polyfill Mbstring.
  * Expanded plugin credits with licensing, copyright, source, and dependency information.
  * Clarified bundled PHP libraries and service-provided processing.
  * Documented the bundled Real User Monitoring JavaScript’s third-party source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->