### PR TITLE
fix(agent): report network-activated plugins as active in metadata

### DIFF
--- a/apps/agent/includes/commands/class-metadata-command.php
+++ b/apps/agent/includes/commands/class-metadata-command.php
@@ -361,6 +361,28 @@ final class MetadataCommand implements CommandInterface
      * force-refreshes that transient before the metadata push so dashboards
      * see fresh data within the 30-minute cadence.
      *
+     * `active` is the union of per-site activation (`active_plugins`, a LIST
+     * of plugin files, from `get_option()`) and network-wide activation on
+     * multisite (`active_sitewide_plugins`, a MAP keyed by plugin file with
+     * activation timestamps as values, from `get_site_option()` — a
+     * different option AND a different shape). A network-activated plugin
+     * never appears in `active_plugins`, so without this union it is
+     * reported inactive on every site in the network even when it is
+     * running on all of them. Mirrors
+     * DbCleanup::buildInstalledPluginsSnapshot() Pass 4, the existing
+     * reference implementation of this same union.
+     *
+     * The wire contract has no field to distinguish "active on this subsite
+     * only" from "active network-wide" — `active` is a single bool. A
+     * distinguishing field was deliberately not added: the control plane's
+     * persistence (sanitizeComponents() in apps/api/internal/site/service.go)
+     * already reconstructs each Component from only
+     * slug/name/version/active/available_update and drops every other field
+     * the agent sends (plugin_uri/update_uri/author_uri/network included), so
+     * a new field here would be silently discarded server-side rather than
+     * stored. The union is reported as `active`; the subsite-vs-network
+     * distinction is not carried to the control plane.
+     *
      * @return array<int,array{slug:string,name:string,version:string,active:bool,available_update:?array{new_version:string,package:?string,tested:?string,requires_php:?string}}>
      */
     private function plugins(): array
@@ -375,6 +397,18 @@ final class MetadataCommand implements CommandInterface
         foreach ($active as $a) {
             if (is_string($a)) {
                 $activeSet[$a] = true;
+            }
+        }
+
+        // Network-activated plugins (multisite). See docblock above.
+        if (function_exists('is_multisite') && is_multisite() && function_exists('get_site_option')) {
+            $networkActive = get_site_option('active_sitewide_plugins');
+            if (is_array($networkActive)) {
+                foreach (array_keys($networkActive) as $file) {
+                    if (is_string($file) && $file !== '') {
+                        $activeSet[$file] = true;
+                    }
+                }
             }
         }
 

--- a/apps/agent/tests/MetadataCommandTest.php
+++ b/apps/agent/tests/MetadataCommandTest.php
@@ -193,6 +193,106 @@ final class MetadataCommandTest extends TestCase
         $this->assertArrayHasKey('core_update', $data);
     }
 
+    // ---- Network-activated plugins (multisite) -----------------------------
+
+    /**
+     * A plugin network-activated via
+     * `get_site_option('active_sitewide_plugins')` must be reported active
+     * even though it never appears in `get_option('active_plugins')` — that
+     * option only ever holds per-site activations, and network activation
+     * lives in a different option with a different shape (a map keyed by
+     * plugin file, not a list). Before the fix this asserted true and
+     * failed because plugins() consulted only active_plugins.
+     */
+    public function test_plugins_reports_active_for_network_activated_plugin(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(true);
+        Functions\when('get_option')->alias(static function ($name) {
+            // Network-activated plugin does NOT appear in active_plugins.
+            return $name === 'active_plugins' ? [] : false;
+        });
+        Functions\when('get_site_option')->alias(static function ($name, $default = false) {
+            return $name === 'active_sitewide_plugins'
+                ? ['network-builder/network-builder.php' => 1700000000]
+                : $default;
+        });
+        Functions\when('get_plugins')->justReturn([
+            'network-builder/network-builder.php' => ['Name' => 'Network Builder', 'Version' => '2.0'],
+        ]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_site_transient')->justReturn(false);
+        Functions\when('get_core_updates')->justReturn([]);
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertCount(1, $data['plugins']);
+        $this->assertTrue(
+            $data['plugins'][0]['active'],
+            'a network-activated plugin must report active=true even though active_plugins is empty'
+        );
+    }
+
+    /**
+     * Over-fire guard: a plugin active only on the current subsite (present
+     * in active_plugins, absent from active_sitewide_plugins) must still
+     * report active — adding the network-activation union must not disturb
+     * the existing per-site signal.
+     */
+    public function test_plugins_reports_active_for_subsite_only_plugin_on_multisite(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(true);
+        Functions\when('get_option')->alias(static function ($name) {
+            return $name === 'active_plugins' ? ['subsite-only/subsite-only.php'] : false;
+        });
+        Functions\when('get_site_option')->alias(static function ($name, $default = false) {
+            return $name === 'active_sitewide_plugins' ? [] : $default;
+        });
+        Functions\when('get_plugins')->justReturn([
+            'subsite-only/subsite-only.php' => ['Name' => 'Subsite Only', 'Version' => '1.0'],
+        ]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_site_transient')->justReturn(false);
+        Functions\when('get_core_updates')->justReturn([]);
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertCount(1, $data['plugins']);
+        $this->assertTrue($data['plugins'][0]['active']);
+    }
+
+    /**
+     * Over-fire guard: a plugin present in NEITHER active_plugins nor
+     * active_sitewide_plugins must still report inactive — the union must
+     * not flip every installed plugin to active on a multisite request.
+     */
+    public function test_plugins_reports_inactive_for_plugin_active_nowhere_on_multisite(): void
+    {
+        Functions\when('get_bloginfo')->justReturn('6.5.2');
+        Functions\when('is_multisite')->justReturn(true);
+        Functions\when('get_option')->alias(static function ($name) {
+            return $name === 'active_plugins' ? [] : false;
+        });
+        Functions\when('get_site_option')->alias(static function ($name, $default = false) {
+            return $name === 'active_sitewide_plugins' ? [] : $default;
+        });
+        Functions\when('get_plugins')->justReturn([
+            'dormant/dormant.php' => ['Name' => 'Dormant', 'Version' => '1.0'],
+        ]);
+        Functions\when('wp_get_themes')->justReturn([]);
+        Functions\when('get_stylesheet')->justReturn('twentytwentyfour');
+        Functions\when('get_site_transient')->justReturn(false);
+        Functions\when('get_core_updates')->justReturn([]);
+
+        $data = (new MetadataCommand())->collect();
+
+        $this->assertCount(1, $data['plugins']);
+        $this->assertFalse($data['plugins'][0]['active']);
+    }
+
     public function test_plugins_include_available_update_when_transient_has_entry(): void
     {
         Functions\when('get_bloginfo')->justReturn('6.5.2');


### PR DESCRIPTION
## Problem

On a WordPress multisite network, a plugin can be network-activated — switched on across every site at once. Network-activated plugins live in `get_site_option('active_sitewide_plugins')` (a map keyed by plugin file, activation timestamp as the value), not in `get_option('active_plugins')` (a per-site list). `MetadataCommand::plugins()` (the command backing `/agent/v1/metadata`) only read `active_plugins`, so a network-activated plugin was reported `active: false` on every site in the network, even when running fleet-wide.

## Fix

`apps/agent/includes/commands/class-metadata-command.php`, `MetadataCommand::plugins()`: the `active` flag is now the union of `active_plugins` and (on multisite) the keys of `active_sitewide_plugins`. This mirrors the existing reference implementation of the same union in `DbCleanup::buildInstalledPluginsSnapshot()` (`apps/agent/includes/optimizer/class-db-cleanup.php` Pass 4) rather than inventing a second implementation of the rule.

## Subsite-vs-network distinction

Checked what the control plane actually persists before deciding whether to add a distinguishing field to the wire payload (`apps/api/internal/site/service.go`, `sanitizeComponents()`, around line 586). That function reconstructs each `Component` from only `slug`/`name`/`version`/`active`/`available_update` and drops every other agent-sent field — including the `plugin_uri`, `update_uri`, `author_uri`, and `network` fields the agent *already* sends today. A new field distinguishing "active on this subsite only" from "active network-wide" would follow the same fate: decoded off the wire, then silently discarded before persistence.

Given that, this PR does **not** add a new wire field. It reports the union as `active` and the subsite-vs-network distinction is not carried to the control plane. This is called out explicitly (rather than silently flattened) in this description and in a docblock on `plugins()`, per the task's instruction. Wiring an actual distinguishing field through would require a control-plane change to `sanitizeComponents()`/`Component`, which is a Go change outside `apps/agent/**` and out of scope here.

## Tests

`apps/agent/tests/MetadataCommandTest.php` adds three cases:
- `test_plugins_reports_active_for_network_activated_plugin` — the regression proof: a plugin present only in `active_sitewide_plugins` (absent from `active_plugins`) must report `active: true`.
- `test_plugins_reports_active_for_subsite_only_plugin_on_multisite` — over-fire guard: a plugin active only on the current subsite (present in `active_plugins`, absent from `active_sitewide_plugins`) still reports active.
- `test_plugins_reports_inactive_for_plugin_active_nowhere_on_multisite` — over-fire guard: a plugin in neither list still reports inactive on a multisite request.

Red proof (fix reverted via `git stash`, same 3 tests):
```
$ php -d memory_limit=1024M vendor/bin/phpunit --no-coverage --filter '...' tests/MetadataCommandTest.php
F..                                                                 3 / 3 (100%)
1) WPMgr\Agent\Tests\MetadataCommandTest::test_plugins_reports_active_for_network_activated_plugin
a network-activated plugin must report active=true even though active_plugins is empty
Failed asserting that false is true.
Tests: 3, Assertions: 6, Failures: 1.
```

Green proof (fix restored, same 3 tests):
```
$ php -d memory_limit=1024M vendor/bin/phpunit --no-coverage --filter '...' tests/MetadataCommandTest.php
...                                                                 3 / 3 (100%)
OK (3 tests, 6 assertions)
```

## Gates

- `composer install` in `apps/agent` — restored dev toolchain (`vendor/bin/` was missing phpunit/phpcs/phpstan before this).
- `php -d memory_limit=1024M vendor/bin/phpunit --no-coverage` (full suite) — exit 0, `Tests: 3475, Assertions: 17900, Deprecations: 59, PHPUnit Deprecations: 1, Skipped: 10`, no failures.
- `WPMGR_PHPSTAN_MEMORY=2G bash scripts/check-agent-phpstan.sh` — exit 0, "0 findings".
- `php vendor/bin/phpcs includes/commands/class-metadata-command.php` — exit 0, no errors/warnings.
- `php vendor/bin/phpcs tests/MetadataCommandTest.php` — exit 0, no errors/warnings.

`make agent-plugincheck` (the wp.org Docker gate) was not run for this change — it wipes `vendor/` and is unrelated to this PHP-only, no-new-dependency, no-asset change; the gates above are the ones the task specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin status reporting on multisite so network-activated plugins are correctly shown as active.
  * Fixed cases where plugin activity could be reported incorrectly when checking only site-level activation.
  * Added regression coverage for network-only, site-only, and inactive plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->