### PR TITLE
feat(db): m121 - a dedicated age for the site inventory (GH #553)

### DIFF
--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -197,6 +197,23 @@ RETURNING *;
 -- name: UpdateSiteMetadata :one
 -- Tenant-scoped metadata update (used by the agent path inside the resolved
 -- site's own tenant scope).
+--
+-- m121 (GH #553): this is the ONLY statement in the tree that writes
+-- sites.components, so it is the only one that may write
+-- components_updated_at. Verified by grepping every db/query/*.sql and every
+-- raw UPDATE/INSERT on sites in non-test Go; the other two raw writers
+-- (diagnostics.UpdateSiteTimezone, diagnostics.SetSiteHostProvider) touch
+-- neither column. The two must move together: a write of components without
+-- its stamp re-creates the undated-inventory bug, and a write of the stamp
+-- without components would date an inventory that was not refreshed.
+--
+-- It is now() on the CONTROL PLANE, not the agent's collection instant, and it
+-- is written on every push even when the document is unchanged -- "as of T this
+-- was the inventory" is a truer statement than the previous stamp regardless.
+--
+-- NOTE FOR THE HEARTBEAT: TouchSiteHeartbeat (db/query/site_connection.sql)
+-- must NEVER add this column. Bumping updated_at on a 60s heartbeat that does
+-- not touch components is the whole of GH #553.
 UPDATE sites
 SET wp_version   = $3,
     php_version  = $4,
@@ -205,6 +222,7 @@ SET wp_version   = $3,
     active_theme = $7,
     agent_version = $8,
     components   = $9,
+    components_updated_at = now(),
     last_seen_at = now(),
     health_status = 'healthy',
     updated_at   = now()

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -307,6 +307,35 @@ CREATE TABLE sites (
     -- components holds the installed plugins/themes inventory as JSONB (M2): a
     -- normalized child table can come later; JSONB is sufficient for M2.
     components  jsonb       NOT NULL DEFAULT '{}'::jsonb,
+    -- m121 (GH #553): when the control plane last WROTE components, whether or
+    -- not the document changed. The inventory's own age, which updated_at is
+    -- not: TouchSiteHeartbeat bumps updated_at every 60s and never touches
+    -- components, so as_of stamped from updated_at can only ever OVERSTATE
+    -- freshness -- a site whose WP-Cron died keeps heartbeating while its
+    -- inventory freezes for months.
+    --
+    -- NULLABLE WITH NO DEFAULT, ON PURPOSE. NULL means "we have never recorded
+    -- this", which is the truth for every row predating m121, and there is no
+    -- backfill. Backfilling from updated_at or last_seen_at would write the
+    -- heartbeat instant this column exists to stop reporting; backfilling from
+    -- now() would claim the whole fleet was collected at boot. All three
+    -- manufacture an observation that was never taken -- GH #509's defect, where
+    -- NOT NULL DEFAULT 0 on a measurement column made "never measured"
+    -- indistinguishable from a real zero. A default is right for a setting, a
+    -- counter or a flag; this is an observation.
+    --
+    -- It is the CONTROL-PLANE WRITE instant, not the agent's collection instant:
+    -- the metadata payload carries no collection timestamp, so that fact is not
+    -- knowable here. Hence "updated_at" and not "collected_at".
+    --
+    -- Written ONLY by UpdateSiteMetadata (db/query/sites.sql), the only
+    -- statement in the tree that writes components, and written on every push
+    -- even when the document is byte-identical (freshness is when the claim was
+    -- last confirmed, not when it last changed). A disconnecting site is left
+    -- alone: the stamp goes stale and the staleness IS the signal. Nulling it
+    -- would erase a fact that happened while leaving components itself
+    -- populated, i.e. undated inventory data.
+    components_updated_at timestamptz,
     tags        text[]      NOT NULL DEFAULT '{}',
     -- M4 backups: the age PUBLIC recipient (X25519, "age1...") backups for this
     -- site are encrypted to. Client-side encryption is on the AGENT; the control

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -608,6 +608,7 @@ type Site struct {
 	Multisite              bool               `json:"multisite"`
 	ActiveTheme            string             `json:"active_theme"`
 	Components             []byte             `json:"components"`
+	ComponentsUpdatedAt    pgtype.Timestamptz `json:"components_updated_at"`
 	Tags                   []string           `json:"tags"`
 	AgeRecipient           string             `json:"age_recipient"`
 	WpTimezone             string             `json:"wp_timezone"`

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -3267,6 +3267,23 @@ type Querier interface {
 	UpdateSiteAppHealthSettings(ctx context.Context, arg UpdateSiteAppHealthSettingsParams) (UpdateSiteAppHealthSettingsRow, error)
 	// Tenant-scoped metadata update (used by the agent path inside the resolved
 	// site's own tenant scope).
+	//
+	// m121 (GH #553): this is the ONLY statement in the tree that writes
+	// sites.components, so it is the only one that may write
+	// components_updated_at. Verified by grepping every db/query/*.sql and every
+	// raw UPDATE/INSERT on sites in non-test Go; the other two raw writers
+	// (diagnostics.UpdateSiteTimezone, diagnostics.SetSiteHostProvider) touch
+	// neither column. The two must move together: a write of components without
+	// its stamp re-creates the undated-inventory bug, and a write of the stamp
+	// without components would date an inventory that was not refreshed.
+	//
+	// It is now() on the CONTROL PLANE, not the agent's collection instant, and it
+	// is written on every push even when the document is unchanged -- "as of T this
+	// was the inventory" is a truer statement than the previous stamp regardless.
+	//
+	// NOTE FOR THE HEARTBEAT: TouchSiteHeartbeat (db/query/site_connection.sql)
+	// must NEVER add this column. Bumping updated_at on a 60s heartbeat that does
+	// not touch components is the whole of GH #553.
 	UpdateSiteMetadata(ctx context.Context, arg UpdateSiteMetadataParams) (Site, error)
 	// UpdateTenantName renames a tenant. tenants has no RLS, so the handler verifies
 	// the caller's membership + admin/owner role before calling this.

--- a/apps/api/internal/db/sqlc/site_connection.sql.go
+++ b/apps/api/internal/db/sqlc/site_connection.sql.go
@@ -20,7 +20,7 @@ SET connection_state = 'archived',
     archived_at      = now(),
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type ArchiveSiteParams struct {
@@ -50,6 +50,7 @@ func (q *Queries) ArchiveSite(ctx context.Context, arg ArchiveSiteParams) (Site,
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -91,7 +92,7 @@ SET agent_public_key = $3,
     php_version      = $5,
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2 AND connection_state = 'pending_enrollment'
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type AttachAgentAndConnectParams struct {
@@ -138,6 +139,7 @@ func (q *Queries) AttachAgentAndConnect(ctx context.Context, arg AttachAgentAndC
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -173,7 +175,7 @@ SET connection_state = 'pending_enrollment',
     connection_generation = connection_generation + 1,
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type BeginSiteReEnrollmentParams struct {
@@ -204,6 +206,7 @@ func (q *Queries) BeginSiteReEnrollment(ctx context.Context, arg BeginSiteReEnro
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -234,7 +237,7 @@ func (q *Queries) BeginSiteReEnrollment(ctx context.Context, arg BeginSiteReEnro
 const createPendingSite = `-- name: CreatePendingSite :one
 INSERT INTO sites (tenant_id, url, name, status, connection_state, tags)
 VALUES ($1, $2, $3, 'pending', 'pending_enrollment', $4)
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type CreatePendingSiteParams struct {
@@ -272,6 +275,7 @@ func (q *Queries) CreatePendingSite(ctx context.Context, arg CreatePendingSitePa
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -383,7 +387,7 @@ func (q *Queries) GetSiteEvent(ctx context.Context, arg GetSiteEventParams) (Sit
 const getSiteForTransition = `-- name: GetSiteForTransition :one
 
 
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at FROM sites
+SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at FROM sites
 WHERE id = $1 AND tenant_id = $2
 FOR UPDATE
 `
@@ -424,6 +428,7 @@ func (q *Queries) GetSiteForTransition(ctx context.Context, arg GetSiteForTransi
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -714,7 +719,7 @@ SET connection_state   = 'connected',
     disconnected_reason = NULL,
     updated_at         = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type MarkSiteConnectedParams struct {
@@ -750,6 +755,7 @@ func (q *Queries) MarkSiteConnected(ctx context.Context, arg MarkSiteConnectedPa
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -783,7 +789,7 @@ SET connection_state = 'degraded',
     health_status    = 'unreachable',
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type MarkSiteDegradedParams struct {
@@ -812,6 +818,7 @@ func (q *Queries) MarkSiteDegraded(ctx context.Context, arg MarkSiteDegradedPara
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -848,7 +855,7 @@ SET connection_state    = 'disconnected',
     disconnected_reason = $3,
     updated_at          = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type MarkSiteDisconnectedParams struct {
@@ -879,6 +886,7 @@ func (q *Queries) MarkSiteDisconnected(ctx context.Context, arg MarkSiteDisconne
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -915,7 +923,7 @@ SET connection_state    = 'revoked',
     disconnected_reason = $3,
     updated_at          = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type MarkSiteRevokedParams struct {
@@ -950,6 +958,7 @@ func (q *Queries) MarkSiteRevoked(ctx context.Context, arg MarkSiteRevokedParams
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -1063,7 +1072,7 @@ SET connection_state = 'disconnected',
     archived_at      = NULL,
     updated_at       = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type RestoreSiteParams struct {
@@ -1092,6 +1101,7 @@ func (q *Queries) RestoreSite(ctx context.Context, arg RestoreSiteParams) (Site,
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -1126,7 +1136,7 @@ SET last_seen_at      = now(),
     missed_heartbeats = 0,
     updated_at        = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type TouchSiteHeartbeatParams struct {
@@ -1163,6 +1173,7 @@ func (q *Queries) TouchSiteHeartbeat(ctx context.Context, arg TouchSiteHeartbeat
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -24,7 +24,7 @@ SET agent_public_key = $3,
     php_version = $5,
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type AttachAgentToSiteParams struct {
@@ -62,6 +62,7 @@ func (q *Queries) AttachAgentToSite(ctx context.Context, arg AttachAgentToSitePa
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -92,7 +93,7 @@ func (q *Queries) AttachAgentToSite(ctx context.Context, arg AttachAgentToSitePa
 const createSite = `-- name: CreateSite :one
 INSERT INTO sites (tenant_id, url, name, status, wp_version, php_version)
 VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type CreateSiteParams struct {
@@ -133,6 +134,7 @@ func (q *Queries) CreateSite(ctx context.Context, arg CreateSiteParams) (Site, e
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -164,7 +166,7 @@ const createSiteForEnroll = `-- name: CreateSiteForEnroll :one
 INSERT INTO sites (tenant_id, url, name, status, wp_version, php_version,
                    agent_public_key, enrolled_at, last_seen_at, health_status, tags)
 VALUES ($1, $2, $3, 'active', $4, $5, $6, now(), now(), 'healthy', $7)
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type CreateSiteForEnrollParams struct {
@@ -205,6 +207,7 @@ func (q *Queries) CreateSiteForEnroll(ctx context.Context, arg CreateSiteForEnro
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -251,7 +254,7 @@ func (q *Queries) DeleteSite(ctx context.Context, arg DeleteSiteParams) (int64, 
 }
 
 const getSite = `-- name: GetSite :one
-SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.app_probe_path, s.app_alerts_disabled, s.monitoring_paused_at, s.monitoring_paused_by, s.monitoring_paused_reason, s.monitoring_resume_at, s.created_at, s.updated_at,
+SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.components_updated_at, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.app_probe_path, s.app_alerts_disabled, s.monitoring_paused_at, s.monitoring_paused_by, s.monitoring_paused_reason, s.monitoring_resume_at, s.created_at, s.updated_at,
        COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
        COALESCE(oc.enabled, false) AS object_cache_enabled
 FROM sites s
@@ -284,6 +287,7 @@ type GetSiteRow struct {
 	Multisite              bool               `json:"multisite"`
 	ActiveTheme            string             `json:"active_theme"`
 	Components             []byte             `json:"components"`
+	ComponentsUpdatedAt    pgtype.Timestamptz `json:"components_updated_at"`
 	Tags                   []string           `json:"tags"`
 	AgeRecipient           string             `json:"age_recipient"`
 	WpTimezone             string             `json:"wp_timezone"`
@@ -339,6 +343,7 @@ func (q *Queries) GetSite(ctx context.Context, arg GetSiteParams) (GetSiteRow, e
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -394,7 +399,7 @@ func (q *Queries) GetSiteAppHealthSettings(ctx context.Context, arg GetSiteAppHe
 
 const getSiteByAgentKey = `-- name: GetSiteByAgentKey :one
 
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at FROM sites
+SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at FROM sites
 WHERE agent_public_key = $1 AND agent_public_key <> ''
 `
 
@@ -421,6 +426,7 @@ func (q *Queries) GetSiteByAgentKey(ctx context.Context, agentPublicKey string) 
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -450,7 +456,7 @@ func (q *Queries) GetSiteByAgentKey(ctx context.Context, agentPublicKey string) 
 
 const getSiteByURLForEnroll = `-- name: GetSiteByURLForEnroll :one
 
-SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at FROM sites
+SELECT id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at FROM sites
 WHERE tenant_id = $1 AND url = $2
 `
 
@@ -482,6 +488,7 @@ func (q *Queries) GetSiteByURLForEnroll(ctx context.Context, arg GetSiteByURLFor
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -807,7 +814,7 @@ func (q *Queries) ListLatestBackupsForSites(ctx context.Context, arg ListLatestB
 }
 
 const listSites = `-- name: ListSites :many
-SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.app_probe_path, s.app_alerts_disabled, s.monitoring_paused_at, s.monitoring_paused_by, s.monitoring_paused_reason, s.monitoring_resume_at, s.created_at, s.updated_at,
+SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.components_updated_at, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.app_probe_path, s.app_alerts_disabled, s.monitoring_paused_at, s.monitoring_paused_by, s.monitoring_paused_reason, s.monitoring_resume_at, s.created_at, s.updated_at,
        COALESCE(pc.cache_enabled, false) AS page_cache_enabled,
        COALESCE(oc.enabled, false) AS object_cache_enabled
 FROM sites s
@@ -872,6 +879,7 @@ type ListSitesRow struct {
 	Multisite              bool               `json:"multisite"`
 	ActiveTheme            string             `json:"active_theme"`
 	Components             []byte             `json:"components"`
+	ComponentsUpdatedAt    pgtype.Timestamptz `json:"components_updated_at"`
 	Tags                   []string           `json:"tags"`
 	AgeRecipient           string             `json:"age_recipient"`
 	WpTimezone             string             `json:"wp_timezone"`
@@ -978,6 +986,7 @@ func (q *Queries) ListSites(ctx context.Context, arg ListSitesParams) ([]ListSit
 			&i.Multisite,
 			&i.ActiveTheme,
 			&i.Components,
+			&i.ComponentsUpdatedAt,
 			&i.Tags,
 			&i.AgeRecipient,
 			&i.WpTimezone,
@@ -1102,7 +1111,7 @@ const setSiteAgeRecipient = `-- name: SetSiteAgeRecipient :one
 UPDATE sites
 SET age_recipient = $3, updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type SetSiteAgeRecipientParams struct {
@@ -1133,6 +1142,7 @@ func (q *Queries) SetSiteAgeRecipient(ctx context.Context, arg SetSiteAgeRecipie
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -1185,7 +1195,7 @@ const setSiteTags = `-- name: SetSiteTags :one
 UPDATE sites
 SET tags = $3, updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type SetSiteTagsParams struct {
@@ -1214,6 +1224,7 @@ func (q *Queries) SetSiteTags(ctx context.Context, arg SetSiteTagsParams) (Site,
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -1247,7 +1258,7 @@ SET last_seen_at = now(),
     health_status = 'healthy',
     updated_at = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type TouchSiteSeenParams struct {
@@ -1275,6 +1286,7 @@ func (q *Queries) TouchSiteSeen(ctx context.Context, arg TouchSiteSeenParams) (S
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,
@@ -1348,11 +1360,12 @@ SET wp_version   = $3,
     active_theme = $7,
     agent_version = $8,
     components   = $9,
+    components_updated_at = now(),
     last_seen_at = now(),
     health_status = 'healthy',
     updated_at   = now()
 WHERE id = $1 AND tenant_id = $2
-RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
+RETURNING id, tenant_id, url, name, status, wp_version, php_version, agent_version, agent_public_key, enrolled_at, last_seen_at, health_status, server_info, multisite, active_theme, components, components_updated_at, tags, age_recipient, wp_timezone, wp_gmt_offset, host_provider, host_provider_org, host_provider_ip, host_provider_checked_at, connection_state, connection_generation, disconnected_at, disconnected_reason, archived_at, missed_heartbeats, client_id, app_probe_path, app_alerts_disabled, monitoring_paused_at, monitoring_paused_by, monitoring_paused_reason, monitoring_resume_at, created_at, updated_at
 `
 
 type UpdateSiteMetadataParams struct {
@@ -1369,6 +1382,23 @@ type UpdateSiteMetadataParams struct {
 
 // Tenant-scoped metadata update (used by the agent path inside the resolved
 // site's own tenant scope).
+//
+// m121 (GH #553): this is the ONLY statement in the tree that writes
+// sites.components, so it is the only one that may write
+// components_updated_at. Verified by grepping every db/query/*.sql and every
+// raw UPDATE/INSERT on sites in non-test Go; the other two raw writers
+// (diagnostics.UpdateSiteTimezone, diagnostics.SetSiteHostProvider) touch
+// neither column. The two must move together: a write of components without
+// its stamp re-creates the undated-inventory bug, and a write of the stamp
+// without components would date an inventory that was not refreshed.
+//
+// It is now() on the CONTROL PLANE, not the agent's collection instant, and it
+// is written on every push even when the document is unchanged -- "as of T this
+// was the inventory" is a truer statement than the previous stamp regardless.
+//
+// NOTE FOR THE HEARTBEAT: TouchSiteHeartbeat (db/query/site_connection.sql)
+// must NEVER add this column. Bumping updated_at on a 60s heartbeat that does
+// not touch components is the whole of GH #553.
 func (q *Queries) UpdateSiteMetadata(ctx context.Context, arg UpdateSiteMetadataParams) (Site, error) {
 	row := q.db.QueryRow(ctx, updateSiteMetadata,
 		arg.ID,
@@ -1399,6 +1429,7 @@ func (q *Queries) UpdateSiteMetadata(ctx context.Context, arg UpdateSiteMetadata
 		&i.Multisite,
 		&i.ActiveTheme,
 		&i.Components,
+		&i.ComponentsUpdatedAt,
 		&i.Tags,
 		&i.AgeRecipient,
 		&i.WpTimezone,

--- a/apps/api/migrations/20260823000000_m121_site_components_updated_at.sql
+++ b/apps/api/migrations/20260823000000_m121_site_components_updated_at.sql
@@ -1,0 +1,257 @@
+-- m121 - GH #553: the site inventory gets an age of its own.
+--
+-- Adds ONE nullable column to sites: components_updated_at. Nothing is
+-- backfilled, nothing is dropped, no existing row is written, and no reader
+-- changes today. The API half (stamping as_of from this column instead of from
+-- sites.updated_at) is backend-architect's slice and lands after this one; a
+-- change spanning a migration and Go code is two agents in sequence.
+--
+-- ---------------------------------------------------------------------------
+-- THE DEFECT
+-- ---------------------------------------------------------------------------
+--
+-- GET /sites/{id}/updates answers "how fresh is this inventory?" with
+-- sites.updated_at (internal/site/handler.go, out.AsOf). sites.updated_at is
+-- bumped every 60 seconds by the heartbeat - TouchSiteHeartbeat,
+-- db/query/site_connection.sql:
+--
+--     UPDATE sites
+--     SET last_seen_at      = now(),
+--         missed_heartbeats = 0,
+--         updated_at        = now()
+--
+-- That statement never touches components. So as_of reports "when did this site
+-- last say hello", not "when was this inventory recorded", and the two are
+-- unrelated facts.
+--
+-- THE ERROR RUNS ONE WAY ONLY. It can overstate freshness and can never
+-- understate it, because updated_at is always >= any instant components was
+-- written. The failure that makes it concrete: a site's WP-Cron dies, so the
+-- agent's 30-minute metadata refresh stops and components freezes, while the
+-- heartbeat keeps working and updated_at keeps advancing. The dashboard then
+-- shows an inventory timestamp seconds old over plugin data that may be months
+-- stale. The connection sweeper does not catch it either - it degrades at 300s
+-- and disconnects at 900s on AGENT REACHABILITY, which is the one thing still
+-- healthy in that scenario. There is no control-plane-side inventory refresh at
+-- all; the refresh is entirely agent-driven.
+--
+-- A stale inventory is not cosmetic. It drives the update list an operator acts
+-- on, and it is the only source for any fleet-wide "how many of my sites run X
+-- at version Y" question. Such a number carries no defensible as-of today
+-- because the column that would date it does not exist.
+--
+-- ---------------------------------------------------------------------------
+-- DECISION 1: nullable, NO DEFAULT, NO BACKFILL. This is the whole migration.
+-- ---------------------------------------------------------------------------
+--
+-- Every existing row lands with components_updated_at = NULL, and NULL means
+-- exactly "we have never recorded when this inventory was collected". That is
+-- the truth for every row that exists when this applies, because the fact was
+-- never captured. It is not an inconvenience to be tidied away.
+--
+-- The three tempting backfills, and why each manufactures a measurement that
+-- was never taken:
+--
+--   updated_at    is the defect itself. Backfilling from it would write the
+--                 exact wrong number this migration exists to stop reporting,
+--                 and it would write it as though it were a real observation -
+--                 permanently, with no way for any later reader to tell a
+--                 backfilled guess from a genuine stamp.
+--   last_seen_at  is heartbeat liveness. Same substitution, same one-way error:
+--                 it says when the agent last spoke, not when it last sent an
+--                 inventory.
+--   now()         claims every site's inventory was collected at the instant
+--                 this migration ran. That is false for all of them and it is
+--                 maximally flattering: it would report the entire fleet as
+--                 perfectly fresh at boot, which is the single most misleading
+--                 value available.
+--
+-- All three are the GH #509 defect one table over. #509 is
+-- site_object_cache_stats.oc_latency_ms / oc_used_memory_bytes declared
+-- NOT NULL DEFAULT 0, which makes "no heartbeat has arrived yet" indistinguish-
+-- able from a genuine zero reading, so the panel renders 0.0 ms for a site that
+-- has never reported. The nullable sibling three lines down,
+-- oc_hit_ratio_pct numeric(5,2), renders as an absence, correctly, because it
+-- can actually be absent. #509 names the class: a default is right for a
+-- SETTING, a COUNTER or a FLAG, and wrong for an OBSERVATION. A default on an
+-- observation destroys the information before any layer above can see it, and
+-- no amount of care in the API or the dashboard recovers the distinction.
+--
+-- This column is an observation. It gets no default.
+--
+-- A reader that wants "unknown" rendered as something has to decide that in the
+-- API or the UI, where the decision is visible and reversible, not here where it
+-- would be baked into the stored bytes.
+--
+-- ---------------------------------------------------------------------------
+-- DECISION 2: what the value MEANS - control-plane write instant, not agent
+--             collection instant
+-- ---------------------------------------------------------------------------
+--
+-- The value is now() evaluated on the CONTROL PLANE at the moment it persisted
+-- the inventory document. It is NOT the instant the agent walked the plugin and
+-- theme list on the WordPress host.
+--
+-- The distinction is small in the normal case (the two are separated by one
+-- HTTP round trip) and it is not small when it matters: a queued or retried
+-- push, a clock-skewed host, or a future store-and-forward path would widen it
+-- without warning. The agent's metadata payload carries no collection timestamp
+-- today, so the collection instant is simply not knowable here. Writing now()
+-- and CALLING it the collection time would be the same class of manufacture
+-- DECISION 1 refuses, just with a smaller error bar.
+--
+-- Hence the name. components_updated_at says "when we last wrote this column",
+-- which is precisely what is true, and it matches the house convention for a
+-- when-did-we-last-look field (sites.host_provider_checked_at, m28). It
+-- deliberately is not components_collected_at, which would assert a fact about
+-- the remote host that the control plane does not have.
+--
+-- It is written on EVERY metadata push, whether or not the inventory document
+-- changed. That is intended and it is the point: "as of T this was the
+-- inventory" is a newer and truer statement than the previous stamp even when
+-- the plugin list is byte-identical. Freshness is about when the claim was last
+-- confirmed, not about when it last changed. A write-only-if-different rule
+-- would freeze the timestamp on a stable site and reinvent the staleness bug
+-- for exactly the fleet that is behaving correctly.
+--
+-- ---------------------------------------------------------------------------
+-- DECISION 3: a disconnecting site is LEFT ALONE - the stamp is not cleared,
+--             not flagged, and not advanced
+-- ---------------------------------------------------------------------------
+--
+-- GH #553 asks what happens when a site goes disconnected. The answer is
+-- nothing, and it is recorded here because the column outlives the issue and a
+-- later phase will be tempted to "clean up".
+--
+-- No connection transition touches this column. It goes stale, and its
+-- staleness is the signal: any reader computes now() - components_updated_at
+-- and gets the truth about this inventory regardless of connection_state.
+--
+-- The two alternatives, and why both are worse:
+--
+--   NULL IT ON DISCONNECT would erase a fact that really happened. "We recorded
+--   this inventory at T" does not stop being true when the agent goes away.
+--   Worse, it collapses "recorded three months ago" into "never recorded",
+--   which is DECISION 1's conflation running backwards - and it would do so
+--   while LEAVING components ITSELF POPULATED, since nothing clears that column
+--   on disconnect either. The result is undated inventory data: strictly worse
+--   than dated stale data, because stale-and-dated can be reasoned about and
+--   stale-and-undated cannot.
+--
+--   ADD A SEPARATE STALE FLAG would be a second column that can disagree with
+--   the first, for a question the first column already answers exactly. It is
+--   m117's monitoring_paused_at argument: one nullable timestamp carries both
+--   the fact and the when, and a flag plus a timestamp can drift apart. A
+--   threshold ("how old is too old?") is a policy that belongs in the layer that
+--   renders or alerts, where it can be tuned per caller, not frozen into a
+--   boolean at write time.
+--
+-- Re-enrollment (AttachAgentToSite) does not touch it either, for the same
+-- reason: that statement does not rewrite components, so the surviving
+-- inventory keeps its true, older stamp until the next metadata push replaces
+-- both together. The column and the data it dates always move as a pair.
+--
+-- GH #553 item 4 - a control-plane-side staleness signal, since a dead agent
+-- cron is currently invisible - is a real gap and is deliberately NOT closed
+-- here. It needs a sweep, a threshold and an alert route. This migration is the
+-- column that would make such a sweep possible; it is not the sweep.
+--
+-- ---------------------------------------------------------------------------
+-- DECISION 4: no index
+-- ---------------------------------------------------------------------------
+--
+-- Following m117's DECISION 2 rather than reflex. The only reader that exists
+-- after this lands is the per-site detail path, which finds its row by primary
+-- key and reads the column off it; an index on a column you have already
+-- fetched the row for is pure write cost. And sites is the hottest-written
+-- table in this schema - the heartbeat writes it per site per interval, and the
+-- sweeper, the prober and the metadata push all UPDATE it - so a needless index
+-- here is paid on every one of those.
+--
+-- The query that WOULD justify one is the fleet-wide staleness sweep DECISION 3
+-- defers. It does not exist, and when it does it will look like this schema's
+-- other fleet enumerations (ListEnrolledSitesAllTenants,
+-- ListEnrolledSitesForProbe, ListConnectedSiteIDsForScreenshot in
+-- db/query/sites.sql), which are uncapped whole-fleet sequential scans with no
+-- index on enrolled_at at all. A "stale inventory" predicate would match a
+-- LARGE fraction of rows by construction - that is what makes it worth
+-- alerting on - and a partial index matching most of the table is a full-size
+-- index wearing a WHERE clause.
+--
+-- Whoever adds that sweep should measure with EXPLAIN ANALYZE as wpmgr_app
+-- before adding an index, not assume one. Also note migrate.go runs each
+-- migration in a single transaction and therefore cannot use CREATE INDEX
+-- CONCURRENTLY, so any later index takes a real lock on a live sites table.
+--
+-- ---------------------------------------------------------------------------
+-- RLS: nothing to add, and this was read rather than assumed
+-- ---------------------------------------------------------------------------
+--
+-- Row-level security is ROW level: a policy admits or refuses a row, so every
+-- column on an admitted row is covered by the policies the table already
+-- carries. A new column on an existing table inherits them with no new policy
+-- and no new grant. sites already carries, verified against the migrations
+-- (which are authoritative for RLS - db/schema.sql is sqlc's input and lags
+-- badly; the two counts are in this change's report):
+--
+--   ENABLE + FORCE ROW LEVEL SECURITY        20260527115454_initial.sql:32-33
+--   sites_tenant_isolation   PERMISSIVE      20260527115454_initial.sql:34
+--   sites_enroll             PERMISSIVE      m2  (20260527172114:48)
+--   sites_agent              PERMISSIVE      m2  (20260527172114:51)
+--   sites_site_scope         RESTRICTIVE     m19 (20260531050000:330)
+--   sites_shared_read        PERMISSIVE      m22 (20260531100000:16)
+--   sites_client_read        PERMISSIVE      m66 (20260629000000:188)
+--
+-- FORCE is on, so the policies apply to the table owner too - the role the
+-- application connects as. The RESTRICTIVE sites_site_scope policy is the one
+-- m112's lesson is about, and sites has carried it since m19: a collaborator
+-- scoped to one site cannot read another site's row, so it cannot read another
+-- site's inventory age either. That policy is FOR ALL, so it constrains the
+-- metadata-push UPDATE that writes this column as well as reads of it.
+--
+-- No table is created here, so the site-keyed-table checklist (tenant_id + its
+-- index, ENABLE and FORCE, _tenant_isolation, _agent, RESTRICTIVE _site_scope)
+-- does not apply: sites IS the site table and already satisfies all of it.
+--
+-- There is nothing to GRANT. The grants on sites are table-level, and a
+-- table-level GRANT covers columns added later; there are no column-level
+-- grants anywhere on this table.
+--
+-- ---------------------------------------------------------------------------
+-- IDEMPOTENCE AND CONVERGE PATH
+-- ---------------------------------------------------------------------------
+--
+-- Fully idempotent - ADD COLUMN IF NOT EXISTS, the convention here for a column
+-- addition (m101, m103, m107, m108, m117). Nothing is dropped, no existing row
+-- is written, and there is no backfill to get wrong, so there is no m110/m111
+-- shape available to repeat. internal/db/migrate.go applies this inside main()
+-- at boot in one transaction, so a failure here is a control-plane outage on
+-- every install at once; the single statement below is a no-op on second
+-- application.
+--
+-- CONVERGE PATH: none is required, and this is a positive statement rather than
+-- an omission. No earlier version of this migration has ever been applied to any
+-- database. The ordinal 20260823000000 is new and unique - the highest ordinal
+-- on any ref at the time of writing was m120's 20260822000000 - it corrects no
+-- earlier migration, and it edits no applied file. An applied migration is
+-- immutable (migrate.go skips any version already in schema_migrations, so
+-- editing one is a silent no-op that looks like a fix); a correction would need
+-- a new ordinal plus a converge path, which is what m114 and m115 are. This is
+-- neither.
+
+-- ---------------------------------------------------------------------------
+-- The column
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."sites"
+    -- When the control plane last WROTE sites.components, whether or not the
+    -- document changed. NULL means "we have never recorded this" and is the
+    -- correct value for every row existing when m121 applies - no default and
+    -- no backfill, because a manufactured observation is worse than an admitted
+    -- absence (GH #509). NOT the instant the agent collected the inventory: the
+    -- payload carries no such timestamp, so that fact is not knowable here.
+    -- Written only by UpdateSiteMetadata (db/query/sites.sql), which is the only
+    -- statement in the tree that writes components. Deliberately NOT written by
+    -- the heartbeat, by any connection-state transition, or by re-enrollment -
+    -- see DECISION 3.
+    ADD COLUMN IF NOT EXISTS "components_updated_at" timestamptz NULL;


### PR DESCRIPTION
Closes the database half of #553. **Schema only — no reader changes.**

## The defect

`GET /sites/{id}/updates` stamps `as_of` from `sites.updated_at`. That column is bumped every 60 seconds by `TouchSiteHeartbeat` (`apps/api/db/query/site_connection.sql`), which never touches `components`:

```sql
UPDATE sites
SET last_seen_at      = now(),
    missed_heartbeats = 0,
    updated_at        = now()
```

So `as_of` answers "when did this site last say hello", not "when was this inventory recorded". The error runs **one way only**: `updated_at` is always `>=` any instant `components` was written, so freshness can be overstated and never understated. A site whose WP-Cron dies stops refreshing its inventory while its heartbeat keeps advancing `updated_at` — the dashboard then shows a seconds-old timestamp over plugin data that may be months stale.

## The change

One nullable column on `sites`:

```sql
ALTER TABLE "public"."sites"
    ADD COLUMN IF NOT EXISTS "components_updated_at" timestamptz NULL;
```

Written on exactly one statement, `UpdateSiteMetadata` in `apps/api/db/query/sites.sql` — the only statement in the tree that writes `components`.

## Existing rows get NULL. No default, no backfill.

`NULL` means "we have never recorded when this was collected", which is the truth for every row that exists when this applies. The three tempting backfills all manufacture an observation that was never taken:

- **`updated_at`** is the defect itself — it would permanently store the heartbeat instant this column exists to stop reporting, indistinguishable from a genuine stamp.
- **`last_seen_at`** is the same substitution with the same one-way error.
- **`now()`** would claim the entire fleet was collected at boot — the most flattering and most misleading value available.

This is #509's defect one table over: `NOT NULL DEFAULT 0` on a measurement column made "never measured" indistinguishable from a real zero, and no care in the API or the UI can recover a distinction the schema already destroyed. A default is right for a setting, a counter or a flag, and wrong for an observation.

## Naming: `components_updated_at`, not `components_collected_at`

The value is `now()` on the **control plane** at the moment it persisted the document, not the instant the agent walked the plugin list on the WordPress host. The agent's metadata payload carries no collection timestamp, so the collection instant is not knowable here. Calling it `collected_at` would assert a fact about the remote host we do not have — the same manufacture as a backfill, just with a smaller error bar. `host_provider_checked_at` (m28) is the house precedent for a when-did-we-last-look field.

It is written on **every** metadata push, even when the document is byte-identical. Freshness is about when the claim was last confirmed, not when it last changed; a write-only-if-different rule would freeze the stamp on a stable site and reinvent the bug for exactly the fleet that is behaving correctly.

## Disconnected sites: left alone, deliberately

No connection transition touches this column. The stamp goes stale and **the staleness is the signal** — any reader computes `now() - components_updated_at` and gets the truth regardless of `connection_state`. The decision and its alternatives are recorded in the migration comment, because the column outlives the issue:

- **Nulling it on disconnect** would erase a fact that really happened, and collapse "recorded three months ago" into "never recorded" — the same conflation running backwards. Worse, nothing clears `components` itself on disconnect, so the result would be *undated inventory data*: strictly worse than dated stale data, because stale-and-dated can be reasoned about.
- **A separate stale flag** would be a second column that can disagree with the first, for a question the first already answers exactly. The threshold ("how old is too old?") is policy that belongs where it can be tuned per caller, not frozen into a boolean at write time.

Re-enrollment (`AttachAgentToSite`) does not touch it either, for the same reason: that statement does not rewrite `components`, so the surviving inventory keeps its true, older stamp. The column and the data it dates always move as a pair.

## What is NOT in this PR

- **`apps/api/internal/site/handler.go` is unchanged.** Stamping `as_of` from the new column is `backend-architect`'s slice and lands after this one — a change spanning a migration and Go code is two agents in sequence. The API side has not been forgotten; it is deliberately sequenced second, and until it lands `as_of` still reports the heartbeat.
- **No control-plane staleness sweep.** #553 item 4 is a real gap and is deliberately left open — it needs a sweep, a threshold and an alert route. This migration is the column that makes such a sweep possible; it is not the sweep.
- **No index.** The only reader that exists after this lands finds its row by primary key. `sites` is the hottest-written table in this schema, so a speculative index is paid on every heartbeat, sweep, probe and metadata push. The migration records what would justify one later and says to measure with `EXPLAIN ANALYZE` as `wpmgr_app` first.

## Write paths

`UpdateSiteMetadata` is the only one, established by grep rather than assumption:

- every `db/query/*.sql` mentioning `components` → only `sites.sql`
- every raw `UPDATE sites` / `INSERT INTO sites` in non-test Go → two writers, `diagnostics.UpdateSiteTimezone` and `diagnostics.SetSiteHostProvider`, neither of which touches `components`
- caller chain: agent metadata push → `Service.ApplyAgentMetadata` → `Service.ApplyMetadata` → `pgRepo.UpdateMetadata` → `sqlc.UpdateSiteMetadata`

The heartbeat path (`Heartbeat` / `RecordHeartbeat`) never reaches it. Both the query file and the migration carry a note that `TouchSiteHeartbeat` must never add this column.

## RLS

Nothing added, and this was read rather than assumed. Row-level security is row level, so a new column on an existing table inherits the table's policies with no new policy and no new grant. `sites` already carries `ENABLE` + `FORCE ROW LEVEL SECURITY`, `sites_tenant_isolation`, `sites_enroll`, `sites_agent`, the **RESTRICTIVE** `sites_site_scope` (m19), `sites_shared_read` (m22) and `sites_client_read` (m66). `sites_site_scope` is `FOR ALL`, so it constrains the metadata-push UPDATE as well as reads. No table is created, so the site-keyed-table checklist does not apply — `sites` *is* the site table.

Grants on `sites` are table-level, which covers columns added later; there are no column-level grants on this table.

## Converge path

**None required**, and this is a positive statement rather than an omission. The ordinal `20260823000000` is new and unique — the highest on any ref at the time of writing was m120's `20260822000000`. It corrects no earlier migration and edits no applied file, so there is no database on an earlier version of it to converge. Fully idempotent (`ADD COLUMN IF NOT EXISTS`), nothing dropped, no existing row written, no backfill to get wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site records now track when component metadata was last updated.
  * This timestamp is included in site details and listing responses.

* **Bug Fixes**
  * Component metadata updates now consistently refresh the associated update time, even when the content itself does not change.
  * Heartbeat updates remain separate and no longer affect this timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->