### PR TITLE
fix(site): stamp updates as_of from components_updated_at, not the heartbeat (GH #553)

### DIFF
--- a/apps/api/internal/api/gen/oas_client_gen.go
+++ b/apps/api/internal/api/gen/oas_client_gen.go
@@ -1831,7 +1831,8 @@ type Invoker interface {
 	//
 	// Returns the cached list of plugins/themes (and core) that have an update available, derived from the
 	// agent's last metadata sync. Items are sorted core -> plugins -> themes, with active before inactive.
-	// `as_of` is the site's last update timestamp. Requires viewer+.
+	// `as_of` is when that inventory was collected (GH #553); null when it never has been. Requires
+	// viewer+.
 	//
 	// GET /api/v1/sites/{siteId}/updates/available
 	GetSiteAvailableUpdates(ctx context.Context, params GetSiteAvailableUpdatesParams) (GetSiteAvailableUpdatesRes, error)
@@ -22632,7 +22633,8 @@ func (c *Client) sendGetSiteAutologinPolicy(ctx context.Context, params GetSiteA
 //
 // Returns the cached list of plugins/themes (and core) that have an update available, derived from the
 // agent's last metadata sync. Items are sorted core -> plugins -> themes, with active before inactive.
-// `as_of` is the site's last update timestamp. Requires viewer+.
+// `as_of` is when that inventory was collected (GH #553); null when it never has been. Requires
+// viewer+.
 //
 // GET /api/v1/sites/{siteId}/updates/available
 func (c *Client) GetSiteAvailableUpdates(ctx context.Context, params GetSiteAvailableUpdatesParams) (GetSiteAvailableUpdatesRes, error) {

--- a/apps/api/internal/api/gen/oas_schemas_gen.go
+++ b/apps/api/internal/api/gen/oas_schemas_gen.go
@@ -44633,7 +44633,12 @@ type SiteAvailableUpdates struct {
 	SiteID     uuid.UUID                            `json:"site_id"`
 	CoreUpdate OptNilSiteAvailableUpdatesCoreUpdate `json:"core_update"`
 	Items      []SiteAvailableUpdatesItemsItem      `json:"items"`
-	AsOf       OptNilDateTime                       `json:"as_of"`
+	// GH #553 — sites.components_updated_at: the control-plane instant this inventory was last collected
+	// (stamped by the agent metadata push that wrote `components`, never by the connection heartbeat).
+	// Explicit null when the inventory has never been collected; never falls back to the site's general
+	// updated_at, which the heartbeat bumps independently of components and would silently overstate
+	// freshness.
+	AsOf OptNilDateTime `json:"as_of"`
 }
 
 // GetSiteID returns the value of SiteID.

--- a/apps/api/internal/site/handler.go
+++ b/apps/api/internal/site/handler.go
@@ -486,7 +486,8 @@ func (h *Handler) refreshUpdates(c *gin.Context) {
 
 // getAvailableUpdates returns the cached list of items with updates available
 // for the resolved site, sorted core -> plugins -> themes (active before
-// inactive). as_of is the site's last updated_at.
+// inactive). as_of is the site's components_updated_at (GH #553): null when
+// the inventory has never been collected.
 func (h *Handler) getAvailableUpdates(c *gin.Context) {
 	tenantID, ok := domain.TenantIDFromContext(c.Request.Context())
 	if !ok {
@@ -535,7 +536,8 @@ func actionableUpdate(c Component) bool {
 // buildAvailableUpdates projects a Site's JSONB inventory into the OpenAPI
 // SiteAvailableUpdates response: filters to components with an AvailableUpdate,
 // attaches the optional CoreUpdate, sorts core->plugins->themes (active before
-// inactive within each kind), and stamps as_of with the site's updated_at.
+// inactive within each kind), and stamps as_of with the site's
+// components_updated_at (GH #553).
 func buildAvailableUpdates(s Site) gen.SiteAvailableUpdates {
 	plugins, themes := s.ParsedComponents()
 	core := s.ParsedCoreUpdate()
@@ -574,8 +576,17 @@ func buildAvailableUpdates(s Site) gen.SiteAvailableUpdates {
 			CurrentVersion: core.CurrentVersion,
 		})
 	}
-	if !s.UpdatedAt.IsZero() {
-		out.AsOf = gen.NewOptNilDateTime(s.UpdatedAt)
+	// GH #553: as_of must answer "when was this inventory collected", not "when
+	// did this site last say hello". sites.updated_at is bumped by the 60s
+	// heartbeat, which never touches components, so it can only overstate
+	// freshness. components_updated_at (m121) is nil when the inventory has
+	// never been collected — surface that as an explicit wire null, never as a
+	// fallback to UpdatedAt: a fallback would silently recreate this exact bug,
+	// invisibly, because the response would still carry a plausible timestamp.
+	if s.ComponentsUpdatedAt != nil {
+		out.AsOf = gen.NewOptNilDateTime(*s.ComponentsUpdatedAt)
+	} else {
+		out.AsOf.SetToNull()
 	}
 	return out
 }

--- a/apps/api/internal/site/model.go
+++ b/apps/api/internal/site/model.go
@@ -133,6 +133,17 @@ type Site struct {
 	// health verdict was last confirmed. Populated by repo.Get/List from
 	// site_uptime_status (PK-keyed, inside the same RLS-scoped tx).
 	HealthCheckedAt *time.Time
+	// ComponentsUpdatedAt is sites.components_updated_at (m121, GH #553): the
+	// control-plane write instant of the last UpdateSiteMetadata call, i.e. the
+	// age of the Components inventory. Nil means the inventory has never been
+	// collected — every pre-m121 row, and any row that has never synced.
+	//
+	// NOT UpdatedAt. sites.updated_at is bumped by the 60s heartbeat
+	// (TouchSiteHeartbeat), which never touches Components, so it can only ever
+	// overstate inventory freshness. This is the field getAvailableUpdates' as_of
+	// must read; falling back to UpdatedAt when this is nil silently recreates
+	// GH #553.
+	ComponentsUpdatedAt *time.Time
 }
 
 // CreateInput is the validated input for creating a site under a tenant.

--- a/apps/api/internal/site/repo.go
+++ b/apps/api/internal/site/repo.go
@@ -1016,6 +1016,12 @@ func toModel(s sqlc.Site) Site {
 		t := s.MonitoringResumeAt.Time
 		m.MonitoringResumeAt = &t
 	}
+	// m121 / GH #553 — nil means the inventory has never been collected; do not
+	// default it to CreatedAt/UpdatedAt.
+	if s.ComponentsUpdatedAt.Valid {
+		t := s.ComponentsUpdatedAt.Time
+		m.ComponentsUpdatedAt = &t
+	}
 	return m
 }
 
@@ -1090,6 +1096,7 @@ func toModelFromGetSiteRow(row sqlc.GetSiteRow) Site {
 		Multisite:             row.Multisite,
 		ActiveTheme:           row.ActiveTheme,
 		Components:            row.Components,
+		ComponentsUpdatedAt:   row.ComponentsUpdatedAt,
 		Tags:                  row.Tags,
 		AgeRecipient:          row.AgeRecipient,
 		WpTimezone:            row.WpTimezone,
@@ -1139,6 +1146,7 @@ func toModelFromListSitesRow(row sqlc.ListSitesRow) Site {
 		Multisite:             row.Multisite,
 		ActiveTheme:           row.ActiveTheme,
 		Components:            row.Components,
+		ComponentsUpdatedAt:   row.ComponentsUpdatedAt,
 		Tags:                  row.Tags,
 		AgeRecipient:          row.AgeRecipient,
 		WpTimezone:            row.WpTimezone,

--- a/apps/api/internal/site/updates_test.go
+++ b/apps/api/internal/site/updates_test.go
@@ -17,7 +17,7 @@ import (
 //   - sorts plugins before themes; within each kind, active before inactive,
 //     ties broken by slug
 //   - attaches the optional CoreUpdate from the JSONB inventory
-//   - stamps as_of from sites.updated_at
+//   - stamps as_of from sites.components_updated_at (GH #553)
 //   - GH #211: drops a same-version phantom advisory (available_update.new_version
 //     == the component's own Version) from both Items and the item count, while
 //     a legitimate newer advisory still surfaces, and an advisory on a component
@@ -59,7 +59,11 @@ func TestBuildAvailableUpdatesFiltersAndSorts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal inventory: %v", err)
 	}
-	s := Site{ID: siteID, Components: raw, UpdatedAt: updatedAt}
+	// UpdatedAt is deliberately different from ComponentsUpdatedAt so this test
+	// would catch a regression to the GH #553 fallback: as_of must come from
+	// the latter, never the former.
+	heartbeatAt := updatedAt.Add(5 * time.Minute)
+	s := Site{ID: siteID, Components: raw, UpdatedAt: heartbeatAt, ComponentsUpdatedAt: &updatedAt}
 
 	out := buildAvailableUpdates(s)
 	if out.SiteID != siteID {
@@ -141,6 +145,76 @@ func TestBuildAvailableUpdatesEmptyInventory(t *testing.T) {
 	}
 	if out.CoreUpdate.Set && !out.CoreUpdate.IsNull() {
 		t.Fatalf("core_update should be unset on empty inventory: %+v", out.CoreUpdate)
+	}
+}
+
+// GH #553 — as_of must report when the inventory was collected
+// (components_updated_at), never when the site last said hello (updated_at,
+// bumped every 60s by TouchSiteHeartbeat regardless of whether components
+// ever changes). Three states, proved individually:
+
+// TestBuildAvailableUpdatesAsOfFreshInventory: components_updated_at is set,
+// so as_of must carry it.
+func TestBuildAvailableUpdatesAsOfFreshInventory(t *testing.T) {
+	siteID := uuid.New()
+	collectedAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	s := Site{ID: siteID, ComponentsUpdatedAt: &collectedAt}
+
+	out := buildAvailableUpdates(s)
+
+	if !out.AsOf.Set || out.AsOf.IsNull() {
+		t.Fatalf("as_of must be a set, non-null value when the inventory has been collected: %+v", out.AsOf)
+	}
+	if !out.AsOf.Value.Equal(collectedAt) {
+		t.Fatalf("as_of = %v, want components_updated_at %v", out.AsOf.Value, collectedAt)
+	}
+}
+
+// TestBuildAvailableUpdatesAsOfNeverCollected: components_updated_at is NULL
+// (every pre-m121 row, and any site whose agent has never pushed metadata)
+// while updated_at is fresh, because the connection heartbeat keeps bumping it
+// on its own 60s cycle. as_of must surface the absence explicitly — not a zero
+// time, not an omitted field, and above all not the heartbeat's timestamp. A
+// fallback to UpdatedAt here IS the GH #553 defect, silently recreated.
+func TestBuildAvailableUpdatesAsOfNeverCollected(t *testing.T) {
+	siteID := uuid.New()
+	heartbeatAt := time.Now().UTC() // a live site's fresh row mtime
+	s := Site{ID: siteID, UpdatedAt: heartbeatAt, ComponentsUpdatedAt: nil}
+
+	out := buildAvailableUpdates(s)
+
+	if !out.AsOf.Set || !out.AsOf.IsNull() {
+		t.Fatalf("as_of must be an explicit wire null when the inventory has never been collected: %+v", out.AsOf)
+	}
+	// The whole bug: the field must not carry the heartbeat time under any
+	// name. IsNull() already implies a zeroed Value, but assert it by name
+	// too, since this is the exact regression a UpdatedAt fallback reintroduces.
+	if out.AsOf.Value.Equal(heartbeatAt) {
+		t.Fatalf("as_of must not be sites.updated_at (the heartbeat time): got %v", out.AsOf.Value)
+	}
+}
+
+// TestBuildAvailableUpdatesAsOfStaleInventory is the failure scenario from GH
+// #553 itself: components_updated_at is old (the agent's WP-Cron died months
+// ago) while updated_at is seconds old (the connection heartbeat never
+// stopped). as_of must report the old collection time, not the fresh
+// heartbeat — the case a fallback to UpdatedAt would silently get wrong.
+func TestBuildAvailableUpdatesAsOfStaleInventory(t *testing.T) {
+	siteID := uuid.New()
+	staleCollectedAt := time.Now().UTC().AddDate(0, -3, 0) // 3 months stale
+	freshHeartbeatAt := time.Now().UTC()                   // seconds old
+	s := Site{ID: siteID, UpdatedAt: freshHeartbeatAt, ComponentsUpdatedAt: &staleCollectedAt}
+
+	out := buildAvailableUpdates(s)
+
+	if !out.AsOf.Set || out.AsOf.IsNull() {
+		t.Fatalf("as_of must be a set, non-null value for a stale-but-collected inventory: %+v", out.AsOf)
+	}
+	if !out.AsOf.Value.Equal(staleCollectedAt) {
+		t.Fatalf("as_of = %v, want the stale components_updated_at %v", out.AsOf.Value, staleCollectedAt)
+	}
+	if out.AsOf.Value.Equal(freshHeartbeatAt) {
+		t.Fatalf("as_of must not report the fresh heartbeat time (updated_at) for a stale inventory")
 	}
 }
 

--- a/packages/openapi-client/src/generated/schemas.gen.ts
+++ b/packages/openapi-client/src/generated/schemas.gen.ts
@@ -510,6 +510,8 @@ export const SiteAvailableUpdatesSchema = {
     as_of: {
       type: ["string", "null"],
       format: "date-time",
+      description:
+        "GH #553 — sites.components_updated_at: the control-plane instant this\ninventory was last collected (stamped by the agent metadata push that\nwrote `components`, never by the connection heartbeat). Explicit null\nwhen the inventory has never been collected; never falls back to the\nsite's general updated_at, which the heartbeat bumps independently of\ncomponents and would silently overstate freshness.\n",
     },
   },
 } as const;

--- a/packages/openapi-client/src/generated/sdk.gen.ts
+++ b/packages/openapi-client/src/generated/sdk.gen.ts
@@ -5355,8 +5355,9 @@ export const refreshSiteScreenshot = <ThrowOnError extends boolean = false>(
  *
  * Returns the cached list of plugins/themes (and core) that have an update
  * available, derived from the agent's last metadata sync. Items are sorted
- * core -> plugins -> themes, with active before inactive. `as_of` is the
- * site's last update timestamp. Requires viewer+.
+ * core -> plugins -> themes, with active before inactive. `as_of` is when
+ * that inventory was collected (GH #553); null when it never has been.
+ * Requires viewer+.
  *
  */
 export const getSiteAvailableUpdates = <ThrowOnError extends boolean = false>(

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -322,6 +322,15 @@ export type SiteAvailableUpdates = {
     tested?: string | null;
     requires_php?: string | null;
   }>;
+  /**
+   * GH #553 — sites.components_updated_at: the control-plane instant this
+   * inventory was last collected (stamped by the agent metadata push that
+   * wrote `components`, never by the connection heartbeat). Explicit null
+   * when the inventory has never been collected; never falls back to the
+   * site's general updated_at, which the heartbeat bumps independently of
+   * components and would silently overstate freshness.
+   *
+   */
   as_of?: string | null;
 };
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -7287,8 +7287,9 @@ paths:
       description: |
         Returns the cached list of plugins/themes (and core) that have an update
         available, derived from the agent's last metadata sync. Items are sorted
-        core -> plugins -> themes, with active before inactive. `as_of` is the
-        site's last update timestamp. Requires viewer+.
+        core -> plugins -> themes, with active before inactive. `as_of` is when
+        that inventory was collected (GH #553); null when it never has been.
+        Requires viewer+.
       tags: [updates]
       parameters:
         - $ref: "#/components/parameters/SiteId"
@@ -13553,6 +13554,13 @@ components:
         as_of:
           type: [string, "null"]
           format: date-time
+          description: |
+            GH #553 — sites.components_updated_at: the control-plane instant this
+            inventory was last collected (stamped by the agent metadata push that
+            wrote `components`, never by the connection heartbeat). Explicit null
+            when the inventory has never been collected; never falls back to the
+            site's general updated_at, which the heartbeat bumps independently of
+            components and would silently overstate freshness.
     SiteTags:
       type: object
       required: [tags]


### PR DESCRIPTION
## Stacked on #559

This branches from `fix/issue-553-components-updated-at` (commit `0c4feb7a`), which adds `sites.components_updated_at` (nullable, no default, no backfill) and stamps it in `UpdateSiteMetadata`. **Base this PR against that branch, not `main`, until #559 merges** — then it should be rebased onto `main`.

## Problem (GH #553)

`GET /sites/{id}/updates/available` stamped `as_of` from `sites.updated_at`, which `TouchSiteHeartbeat` bumps every 60s and which `UpdateSiteMetadata` also bumps on every metadata push (heartbeat included). It never reflected only inventory collection, so a site whose WP-Cron died months ago but keeps heartbeating reports `as_of` as "just now" — freshness can only be overstated, never understated.

## Fix

`buildAvailableUpdates` (`apps/api/internal/site/handler.go`) now reads `sites.components_updated_at` via the new `Site.ComponentsUpdatedAt *time.Time` field (`apps/api/internal/site/model.go`), threaded from the sqlc row through `repo.go`'s `toModel`/`toModelFromGetSiteRow`/`toModelFromListSitesRow`.

`nil` (never collected — every pre-m121 row) surfaces as an **explicit wire `null`** via `out.AsOf.SetToNull()`, never a fallback to `UpdatedAt`. A fallback would silently recreate GH #553 while still returning a plausible-looking timestamp, which is worse than the original bug because it's undiscoverable.

Wire shape for `SiteAvailableUpdates.as_of` is unchanged (`type: [string, "null"]`, optional) — only the OpenAPI/generated doc comments moved, to explain the new source and null semantics. `packages/openapi/openapi.yaml` updated and both consumers regenerated (`apps/api/internal/api/gen`, `packages/openapi-client/src/generated`); diffs are comment-only, confirmed via `git diff` before commit.

## Tests — three states, first two proven red before the fix

`apps/api/internal/site/updates_test.go`:
- `TestBuildAvailableUpdatesAsOfFreshInventory` — `components_updated_at` set → `as_of` carries it.
- `TestBuildAvailableUpdatesAsOfNeverCollected` — NULL, with a fresh `updated_at` (heartbeat) present → `as_of` is an explicit null, and is asserted to **not** equal the heartbeat time. This is the exact GH #553 shape.
- `TestBuildAvailableUpdatesAsOfStaleInventory` — `components_updated_at` old, `updated_at` seconds-fresh → `as_of` reports the old collection time, not the fresh heartbeat.
- Updated `TestBuildAvailableUpdatesFiltersAndSorts` to source `as_of` from `ComponentsUpdatedAt` (previously asserted the `UpdatedAt` fallback).

All three new tests, plus the updated existing test, fail against the pre-fix `handler.go` (confirmed locally by reverting the handler change and re-running — the "never collected" case failed by returning the heartbeat time), and pass after it.

## Gates

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./internal/... -count=1` — pass
- `go test ./cmd/... -count=1` — pass
- `make gen` + `git status --porcelain` — clean, diff limited to the 10 expected files
- `./scripts/gen-openapi.sh --check` — `OK: committed generated trees match a fresh generation`
- `make test-integration` — run separately, see PR comment / session report

## Open question for frontend

The dashboard now has a state it's never had: **inventory age unknown** (every pre-m121 site, until its next metadata sync). The API expresses this as `as_of: null`, distinct from a real timestamp. Flagging for `frontend-architect`: does the updates UI currently assume `as_of` is always present, and does it need a distinct "unknown" rendering vs. "just synced"?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the available-updates timestamp to reflect when component inventory was last collected, rather than a general site heartbeat.
  * Returns a null timestamp when inventory has never been collected, avoiding misleading freshness information.
* **Documentation**
  * Updated API documentation to clearly describe the timestamp’s meaning and null behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->