### PR TITLE
fix(web): honest inventory-age-unknown state for null as_of (GH #553)

### DIFF
--- a/apps/web/src/features/updates/available-updates-card.test.tsx
+++ b/apps/web/src/features/updates/available-updates-card.test.tsx
@@ -201,3 +201,35 @@ describe("AvailableUpdatesCard agent honesty (GH #314)", () => {
     expect(within(list).queryByText("WPMgr agent")).not.toBeInTheDocument();
   });
 });
+
+// GH #553: `as_of` used to be stamped from the 60s site heartbeat, so it was
+// practically never null. It now reads `components_updated_at`, which is only
+// set when the inventory is genuinely (re)written, and it shipped with no
+// backfill, so every site that existed before the fix reports `as_of: null`
+// until its next sync. `null` is a real, common, temporary state here, not an
+// absence to paper over with a generic "Never".
+describe("AvailableUpdatesCard as_of honesty (GH #553)", () => {
+  it("tells the operator the collection time is unknown, and how it resolves, instead of claiming it was never collected", () => {
+    setup(payload({ as_of: null }), null);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    // Distinct from FreshnessBadge's generic "Never", which would wrongly
+    // assert this site's inventory was never collected -- it was, we just
+    // don't have a genuine collection time for it yet.
+    const unknownCopy = screen.getAllByText(/inventory age unknown/i);
+    expect(unknownCopy.length).toBeGreaterThan(0);
+    expect(screen.queryByText(/^Never$/)).not.toBeInTheDocument();
+
+    // States what resolves it, in operator terms, with no raw field names.
+    expect(screen.getAllByText(/next sync/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/as_of/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/components_updated_at/i)).not.toBeInTheDocument();
+  });
+
+  it("does not show the unknown-age copy when a real collection time is present", () => {
+    setup(payload({ as_of: "2026-08-04T10:00:00Z" }), null);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    expect(screen.queryAllByText(/inventory age unknown/i).length).toBe(0);
+  });
+});

--- a/apps/web/src/features/updates/available-updates-card.test.tsx
+++ b/apps/web/src/features/updates/available-updates-card.test.tsx
@@ -215,13 +215,14 @@ describe("AvailableUpdatesCard as_of honesty (GH #553)", () => {
 
     // Distinct from FreshnessBadge's generic "Never", which would wrongly
     // assert this site's inventory was never collected -- it was, we just
-    // don't have a genuine collection time for it yet.
-    const unknownCopy = screen.getAllByText(/inventory age unknown/i);
-    expect(unknownCopy.length).toBeGreaterThan(0);
+    // don't have a genuine collection time for it yet. Exactly once: the
+    // header owns this state, the empty-state block below must not repeat it
+    // (a site with no updates renders both regions at once).
+    expect(screen.getAllByText(/inventory age unknown/i)).toHaveLength(1);
     expect(screen.queryByText(/^Never$/)).not.toBeInTheDocument();
 
     // States what resolves it, in operator terms, with no raw field names.
-    expect(screen.getAllByText(/next sync/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/next sync/i)).toHaveLength(1);
     expect(screen.queryByText(/as_of/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/components_updated_at/i)).not.toBeInTheDocument();
   });
@@ -231,5 +232,74 @@ describe("AvailableUpdatesCard as_of honesty (GH #553)", () => {
     renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
 
     expect(screen.queryAllByText(/inventory age unknown/i).length).toBe(0);
+  });
+
+  // The header is the single owner of the freshness/age claim: it is the
+  // only place that renders in every query state (loading, error, loaded),
+  // so a second copy in the "all managed components are up to date" block
+  // would either duplicate it or, worse, drift from it.
+  it("shows the unknown-age copy exactly once even when the empty state also renders", () => {
+    setup(payload({ as_of: null, items: [], core_update: null }), null);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    // Sanity: this is genuinely the empty-state branch.
+    expect(
+      screen.getByText("All managed components are up to date"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/inventory age unknown/i)).toHaveLength(1);
+  });
+
+  // A query that is still loading has not established anything about the
+  // inventory yet -- not its age, and not whether it is unknown. Claiming
+  // "unknown, clears after next sync" here would be a guess dressed up as a
+  // fact, the same failure mode this whole fix is about, just earlier.
+  it("makes no age claim while the query is still loading", () => {
+    mockedUseAvailableUpdates.mockReturnValue(
+      mockQueryResult<SiteAvailableUpdates>({
+        data: undefined,
+        isPending: true,
+        isSuccess: false,
+        status: "pending",
+      }),
+    );
+    mockedUseRefresh.mockReturnValue(mockMutationResult<void, void>({}));
+    mockedUseSiteAgentUpdate.mockReturnValue(null);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    expect(screen.queryByText(/inventory age unknown/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/inventory age unavailable/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Never$/)).not.toBeInTheDocument();
+  });
+
+  // A failed request never loaded the inventory at all -- not the list, not
+  // an age for it. That is a different fact from "we have the inventory but
+  // not its collection time" (the unknown-age case above), and "clears after
+  // the next sync" is actively wrong advice here: a sync is not what fixes a
+  // request that did not load.
+  it("shows a distinct unavailable state, never the unknown-age copy, when the request itself fails", () => {
+    mockedUseAvailableUpdates.mockReturnValue(
+      mockQueryResult<SiteAvailableUpdates>({
+        data: undefined,
+        isPending: false,
+        isError: true,
+        isSuccess: false,
+        status: "error",
+        error: new Error("network down"),
+      }),
+    );
+    mockedUseRefresh.mockReturnValue(mockMutationResult<void, void>({}));
+    mockedUseSiteAgentUpdate.mockReturnValue(null);
+    renderWithProviders(<AvailableUpdatesCard siteId="site-1" />);
+
+    expect(screen.getByText(/inventory age unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByText(/inventory age unknown/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/next sync/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Never$/)).not.toBeInTheDocument();
+
+    // The body's own load-failure message still owns the "why" -- the header
+    // state above says only that no age is available, not says why twice.
+    expect(
+      screen.getByText("Could not load available updates"),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/updates/available-updates-card.tsx
+++ b/apps/web/src/features/updates/available-updates-card.tsx
@@ -96,12 +96,45 @@ function changelogHref(item: AvailableUpdateItem): string {
 // `as_of: null` here until its next sync, and that is common and temporary,
 // not an outage.
 //
-// `null` gets its own honest state rather than falling into FreshnessBadge's
-// generic "Never": "Never" asserts this site's inventory was never collected,
-// which is false for these sites (the list below is real data) and would
-// read as an alarm across an entire fleet on the day this ships. "Unknown, and
-// here is what clears it" is the true claim.
-function UpdatesAsOf({ asOf }: { asOf: string | null }) {
+// This is the SINGLE render site for the freshness/age claim. It used to
+// also be rendered a second time inside the "all managed components are up
+// to date" empty state, which put the same sentence on screen twice
+// whenever a site had no outstanding updates. The header is the only spot
+// that renders in every query state (loading, error, loaded), so it is the
+// one that owns the claim; the empty state no longer repeats it.
+//
+// Three states, not two, and they must not collapse into each other:
+//   - loading: nothing has loaded yet, not even whether the inventory
+//     exists. No claim is made.
+//   - unavailable (isError): the request itself failed. The inventory list
+//     below is also missing, not just its timestamp, and nothing about a
+//     sync fixes a broken request -- that is different advice for a
+//     different problem, and the PageError body already says why.
+//   - unknown (asOf === null but the request succeeded): the inventory itself
+//     did load, and is real, but this control plane has no genuine
+//     collection time for it yet. Falling into FreshnessBadge's generic
+//     "Never" here would assert the inventory was never collected, which is
+//     false, and would read as an alarm across an entire fleet on the day
+//     this ships. "Unknown, and here is what clears it" is the true claim.
+function UpdatesAsOf({
+  isPending,
+  isError,
+  asOf,
+}: {
+  isPending: boolean;
+  isError: boolean;
+  asOf: string | null;
+}) {
+  if (isPending) return null;
+
+  if (isError) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        Inventory age unavailable. The update check did not load.
+      </span>
+    );
+  }
+
   if (asOf === null) {
     return (
       <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -199,7 +232,11 @@ export function AvailableUpdatesCard({ siteId }: { siteId: string }) {
             ) : null}
           </div>
           <div className="text-xs">
-            <UpdatesAsOf asOf={data?.as_of ?? null} />
+            <UpdatesAsOf
+              isPending={isPending}
+              isError={isError}
+              asOf={data?.as_of ?? null}
+            />
           </div>
         </div>
         <Button
@@ -299,7 +336,10 @@ function UpdatesBody({
           <p className="text-sm font-medium text-[var(--color-foreground)]">
             All managed components are up to date
           </p>
-          <UpdatesAsOf asOf={data.as_of ?? null} />
+          {/* The freshness/age claim is rendered once, in the header above
+              (UpdatesAsOf), which is the only spot that renders in every
+              query state. Repeating it here would show the same sentence
+              twice on screen whenever a site has no outstanding updates. */}
         </div>
       ) : (
         <div className="space-y-3">

--- a/apps/web/src/features/updates/available-updates-card.tsx
+++ b/apps/web/src/features/updates/available-updates-card.tsx
@@ -86,6 +86,33 @@ function changelogHref(item: AvailableUpdateItem): string {
   return `https://wordpress.org/plugins/${encodeURIComponent(slug)}/#developers`;
 }
 
+// GH #553. `as_of` used to be stamped from the 60s site heartbeat
+// (`sites.updated_at`), so it was practically never null and always looked
+// seconds old regardless of how stale the reported inventory actually was.
+// It now reads `sites.components_updated_at`, set only when the inventory is
+// genuinely (re)written, and it shipped with no backfill — inventing a
+// collection time that never happened would recreate the exact bug this
+// fixed, one layer up. So every site that existed before the fix reports
+// `as_of: null` here until its next sync, and that is common and temporary,
+// not an outage.
+//
+// `null` gets its own honest state rather than falling into FreshnessBadge's
+// generic "Never": "Never" asserts this site's inventory was never collected,
+// which is false for these sites (the list below is real data) and would
+// read as an alarm across an entire fleet on the day this ships. "Unknown, and
+// here is what clears it" is the true claim.
+function UpdatesAsOf({ asOf }: { asOf: string | null }) {
+  if (asOf === null) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        Inventory age unknown. Clears after this site&rsquo;s next sync,
+        usually within 30 minutes.
+      </span>
+    );
+  }
+  return <FreshnessBadge collectedAt={asOf} />;
+}
+
 export function AvailableUpdatesCard({ siteId }: { siteId: string }) {
   const { data, isPending, isError, error, refetch, isFetching } =
     useAvailableUpdates(siteId);
@@ -172,7 +199,7 @@ export function AvailableUpdatesCard({ siteId }: { siteId: string }) {
             ) : null}
           </div>
           <div className="text-xs">
-            <FreshnessBadge collectedAt={data?.as_of ?? null} />
+            <UpdatesAsOf asOf={data?.as_of ?? null} />
           </div>
         </div>
         <Button
@@ -272,7 +299,7 @@ function UpdatesBody({
           <p className="text-sm font-medium text-[var(--color-foreground)]">
             All managed components are up to date
           </p>
-          <FreshnessBadge collectedAt={data.as_of ?? null} />
+          <UpdatesAsOf asOf={data.as_of ?? null} />
         </div>
       ) : (
         <div className="space-y-3">


### PR DESCRIPTION
## Summary

- `GET /sites/{id}/updates/available` now reports `as_of: null` (from `sites.components_updated_at`) for every site that existed before the GH #553 fix, until its next inventory sync. `updates/refresh` schema in `packages/openapi/openapi.yaml` documents this explicitly: "Explicit null when the inventory has never been collected; never falls back to the site's general updated_at."
- The available-updates card rendered that `null` through the shared `FreshnessBadge`, which shows the literal text "Never" for a null `collectedAt`. That recreates the exact bug GH #553 fixed, one layer up: the returned `items`/`core_update` are real, already-collected data, and "Never" wrongly asserts the inventory was never collected.
- Both places `as_of` is rendered (the card header's freshness line, and the "All managed components are up to date" empty state) now show a dedicated "Inventory age unknown" state instead, with plain-language copy on what resolves it: the site's next inventory sync, usually within 30 minutes. A real `as_of` timestamp still renders through the unmodified `FreshnessBadge` ("Updated Xm ago" / "Stale").
- `FreshnessBadge` itself is untouched: its two other call sites (`health-tab.tsx`, `diagnostic-card.tsx`) key off `collected_at` on individual diagnostic cards, where `null` genuinely does mean "never collected," so its "Never" copy stays correct there.

## Before vs after

- Before: `as_of: null` -> `FreshnessBadge` -> renders "Never" (confirmed by adding a test against the pre-fix code and watching it fail; see test plan).
- After: `as_of: null` -> "Inventory age unknown. Clears after this site's next sync, usually within 30 minutes." Copy contains no raw field names (`as_of`, `components_updated_at`) and no error codes.

## Test plan

- [x] Added a test asserting the pre-fix behavior is gone (the literal "Never" no longer appears) and the new copy is present and says what resolves it, using `as_of: null`.
- [x] Added a test asserting the unknown-age copy is absent when a real `as_of` timestamp is supplied.
- [x] Ran the first test against the pre-fix code and watched it fail (red), confirming it was actually exercising the bug, then watched it pass after the fix (green).
- [x] `pnpm -C apps/web typecheck` — exit 0
- [x] `pnpm -C apps/web lint` — exit 0 (0 errors, 9 pre-existing warnings unrelated to this change)
- [x] `pnpm -C apps/web test` — exit 0 (145 files, 1730 tests)
- [x] `impeccable detect` on the touched file — clean (`[]`)

Not merging; opening for review per standing repo policy that the only route to `main` is a PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update freshness messaging when inventory age is unavailable.
  * Replaced unclear “Never” or raw field displays with guidance that the status clears after the next site sync, typically within 30 minutes.
  * Preserved freshness details when a valid collection timestamp is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->