### PR TITLE
feat(db): governed org and site context tables (ADR-064 slice S3)

### DIFF
--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5379,6 +5379,16 @@ INSERT INTO agent_mirror_state (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
 --     is deleted; ON DELETE CASCADE would delete an organisation's context
 --     history because a member left. audit_log makes the same call for the
 --     same reason (actor_type + a bare actor_id, no FK).
+--
+--     CONSEQUENCE S4 MUST CLOSE, both halves. With no foreign key,
+--     restored_from_version_id accepts a uuid NAMING NO ROW THAT EVER EXISTED,
+--     as well as one on the far side of an organisation stamp. Those are two
+--     different checks: ADR-064 Decision 12 requires refusing a restore across
+--     a stamp boundary, and nothing anywhere requires refusing one that names
+--     nothing. A dangling pointer yields a version row claiming to be a restore
+--     of something unfindable -- provenance that cannot be substantiated, which
+--     is the opposite of what Decision 7 exists to guarantee. Validate that the
+--     referenced version EXISTS and that its stamp matches.
 --   * NEITHER TABLE HAS AN app.agent POLICY, deliberately. ADR-064 Decision 2
 --     forbids the agent holding any opinion about layers 2 and 3, no
 --     cross-tenant worker reads context, and the tenant purge does not need
@@ -5450,13 +5460,44 @@ CREATE POLICY org_context_versions_tenant_isolation ON org_context_versions
 -- row, which took three review rounds and seven handler fixes to close for the
 -- email domain.
 --
--- The table is append-only, so INSERT is the entire write surface and this one
--- policy closes all of it. There is deliberately NO restrictive SELECT policy
--- here: its absence is the mechanism by which the layer-2 read keeps working.
--- Do not "complete the set".
+-- THREE command-specific policies, and the shape matters (m122 + m123).
+--
+-- m122 shipped the INSERT gate alone, reasoning that the table is append-only
+-- so INSERT is the whole write surface. Security review on PR #562 showed why
+-- that is wrong: it is the REVOKE at the bottom of this block that makes INSERT
+-- the whole write surface, so the argument quietly promoted the REVOKE from
+-- second layer to ONLY layer. Granting UPDATE and DELETE back -- which a
+-- blanket "GRANT ... ON ALL TABLES", the statement m1 already contains and the
+-- test harness runs, does silently -- let a site-scoped collaborator rewrite
+-- and then destroy the ORGANISATION's context, layer 2 for every site in it.
+-- m123 added the two missing gates.
+--
+-- There is deliberately NO policy for SELECT, and that omission is
+-- load-bearing rather than an oversight: ADR-064 Decision 6 gives read access
+-- at the organisation AND site scope covering a site, and Decision 8's preview
+-- renders layer 2. A site-scoped collaborator must be able to READ the
+-- organisation context governing their own site. Do not "complete the set" --
+-- and do not collapse these three into one FOR ALL policy either, because
+-- FOR ALL would be AND-combined onto SELECT and break exactly that read.
 CREATE POLICY org_context_versions_site_scope_insert ON org_context_versions
     AS RESTRICTIVE FOR INSERT
     WITH CHECK (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+    );
+
+-- USING, not WITH CHECK: for UPDATE and DELETE the USING clause is what decides
+-- which existing rows the statement may touch, so a restrictive USING that is
+-- false for a site-scoped principal removes every row from its reach and the
+-- write matches nothing.
+CREATE POLICY org_context_versions_site_scope_update ON org_context_versions
+    AS RESTRICTIVE FOR UPDATE
+    USING (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+    );
+
+CREATE POLICY org_context_versions_site_scope_delete ON org_context_versions
+    AS RESTRICTIVE FOR DELETE
+    USING (
         coalesce(current_setting('app.site_scope', true), '') <> 'on'
     );
 

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5339,3 +5339,204 @@ CREATE TABLE agent_mirror_state (
 
 -- Seed the single row so every write is a plain UPDATE ... WHERE id = 1.
 INSERT INTO agent_mirror_state (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- org_context_versions / site_context_versions  (m122, ADR-064)
+-- ---------------------------------------------------------------------------
+-- Governed per-organisation (layer 2) and per-site (layer 3) context: human-
+-- authored instructions a future model-facing surface is handed alongside what
+-- it observes for itself. Both tables are APPEND-ONLY VERSION LOGS, not
+-- settings rows. ADR-064 Decision 3 defines "the current context" as "the
+-- latest version row", a read rather than a second mutable representation, so
+-- restore and diff never have two copies of the present to keep in sync.
+--
+-- The full argument for every column, constraint, policy and grant is in
+-- apps/api/migrations/20260824000000_m122_governed_context.sql. The headlines,
+-- because they are the ones a reader of THIS file would otherwise get wrong:
+--
+--   * restrictions and guidance are TWO COLUMNS ON PURPOSE. ADR-064 Decision 4
+--     runs a never-widen check over restrictions and explicitly does NOT over
+--     guidance, because "wider" is not a defined relation over free prose.
+--     Separate columns are what make that split mechanical rather than a
+--     naming convention; folding them into one document would let the check be
+--     handed prose, or let a restriction take the path that does not check.
+--   * APPEND-ONLY IS A PRIVILEGE, NOT A CONVENTION. wpmgr_app holds SELECT and
+--     INSERT only; UPDATE, DELETE and TRUNCATE are revoked, exactly as
+--     audit_log is. m1's ALTER DEFAULT PRIVILEGES grants UPDATE and DELETE on
+--     every new table in this schema, so the revoke is what withholds them --
+--     omitting the grant would not.
+--   * site_context_versions.tenant_id IS A STAMP, not a live view of the
+--     site's owner: the organisation that owned the site when the row was
+--     written, set once and never rewritten by a transfer (ADR-064 Decision 3,
+--     on which Decision 12's transfer sealing depends). DO NOT add the
+--     composite FOREIGN KEY (site_id, tenant_id) REFERENCES sites (id,
+--     tenant_id) that sites_id_tenant_key makes available -- it would force the
+--     stamp to equal the current owner, which is the property Decision 3
+--     forbids, and would refuse every pre-transfer row the day transfer ships.
+--   * author_id and restored_from_version_id carry NO foreign key, and that is
+--     load-bearing rather than an omission. ON DELETE SET NULL would mutate an
+--     append-only row and erase authorship of a governance record when a user
+--     is deleted; ON DELETE CASCADE would delete an organisation's context
+--     history because a member left. audit_log makes the same call for the
+--     same reason (actor_type + a bare actor_id, no FK).
+--   * NEITHER TABLE HAS AN app.agent POLICY, deliberately. ADR-064 Decision 2
+--     forbids the agent holding any opinion about layers 2 and 3, no
+--     cross-tenant worker reads context, and the tenant purge does not need
+--     one because PostgreSQL's referential actions bypass row security (probed
+--     on 16.4 as a NOSUPERUSER NOBYPASSRLS role; the migration header records
+--     the measurement). Consequence: neither table is reachable from
+--     InAgentTx. That is a constraint on callers, not an accident.
+
+CREATE TABLE org_context_versions (
+    id        uuid   PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- An organisation IS a tenant in this schema, so this is both the subject
+    -- key and the tenant-isolation key.
+    tenant_id uuid   NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    version   bigint NOT NULL
+        CONSTRAINT org_context_versions_version_positive_check CHECK (version >= 1),
+
+    -- Structured and mechanically comparable. The widen-check reads this.
+    restrictions jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT org_context_versions_restrictions_object_check
+        CHECK (jsonb_typeof(restrictions) = 'object'),
+    -- Free text. No mechanical check applies, and ADR-064 says so rather than
+    -- claiming one that would always pass.
+    guidance     jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT org_context_versions_guidance_object_check
+        CHECK (jsonb_typeof(guidance) = 'object'),
+
+    author_type text NOT NULL
+        CONSTRAINT org_context_versions_author_type_check
+        CHECK (author_type IN ('user', 'api_key', 'system')),
+    -- NULL exactly when the author has no principal id, which today means
+    -- ADR-064 Decision 12's transfer operation. No FK -- see the header.
+    author_id   uuid NULL,
+    CONSTRAINT org_context_versions_author_id_matches_type_check
+        CHECK ((author_type = 'system') = (author_id IS NULL)),
+
+    -- Closed set. 'import' is deliberately absent: ADR-064 calls it a
+    -- hypothetical ("if one is ever built"), and a value nothing can write is
+    -- manufactured vocabulary.
+    provenance text NOT NULL
+        CONSTRAINT org_context_versions_provenance_check
+        CHECK (provenance IN ('manual', 'restore', 'transfer')),
+    restored_from_version_id uuid NULL,
+    CONSTRAINT org_context_versions_restore_pointer_check
+        CHECK ((provenance = 'restore') = (restored_from_version_id IS NOT NULL)),
+
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Subject key, concurrency guard and latest-version read path in one index.
+-- ADR-064 open question 2 leaves PATCH concurrency undecided; this index is
+-- what makes two concurrent writers a 23505 instead of a lost update and two
+-- rows both claiming to be version N+1. tenant_id leads, so it also serves
+-- tenant lookups and the purge cascade -- hence no separate tenant_id index.
+CREATE UNIQUE INDEX org_context_versions_version_key
+    ON org_context_versions (tenant_id, version);
+
+ALTER TABLE org_context_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE org_context_versions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY org_context_versions_tenant_isolation ON org_context_versions
+    FOR ALL
+    USING      (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+
+-- A site-scoped collaborator may READ the organisation context governing their
+-- own site -- ADR-064 Decision 6 requires it and Decision 8's effective-context
+-- preview renders it -- but may never AUTHOR a version of it. That write is the
+-- m112 defect class exactly: a per-site principal reaching the organisation
+-- row, which took three review rounds and seven handler fixes to close for the
+-- email domain.
+--
+-- The table is append-only, so INSERT is the entire write surface and this one
+-- policy closes all of it. There is deliberately NO restrictive SELECT policy
+-- here: its absence is the mechanism by which the layer-2 read keeps working.
+-- Do not "complete the set".
+CREATE POLICY org_context_versions_site_scope_insert ON org_context_versions
+    AS RESTRICTIVE FOR INSERT
+    WITH CHECK (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+    );
+
+CREATE TABLE site_context_versions (
+    id        uuid   PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- THE ORGANISATION STAMP: who owned this site when this row was written.
+    -- Set once, never rewritten by a transfer. Not a live view of the current
+    -- owner. See the header before adding any composite key over it.
+    tenant_id uuid   NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    site_id   uuid   NOT NULL REFERENCES sites (id)   ON DELETE CASCADE,
+    -- Monotonic per SITE, not per (site, organisation): the sequence continues
+    -- across a transfer so "restore version 4" names one snapshot, not two.
+    version   bigint NOT NULL
+        CONSTRAINT site_context_versions_version_positive_check CHECK (version >= 1),
+
+    restrictions jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT site_context_versions_restrictions_object_check
+        CHECK (jsonb_typeof(restrictions) = 'object'),
+    guidance     jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT site_context_versions_guidance_object_check
+        CHECK (jsonb_typeof(guidance) = 'object'),
+
+    author_type text NOT NULL
+        CONSTRAINT site_context_versions_author_type_check
+        CHECK (author_type IN ('user', 'api_key', 'system')),
+    author_id   uuid NULL,
+    CONSTRAINT site_context_versions_author_id_matches_type_check
+        CHECK ((author_type = 'system') = (author_id IS NULL)),
+
+    provenance text NOT NULL
+        CONSTRAINT site_context_versions_provenance_check
+        CHECK (provenance IN ('manual', 'restore', 'transfer')),
+    restored_from_version_id uuid NULL,
+    CONSTRAINT site_context_versions_restore_pointer_check
+        CHECK ((provenance = 'restore') = (restored_from_version_id IS NOT NULL)),
+
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX site_context_versions_version_key
+    ON site_context_versions (site_id, version);
+-- tenant_id leads no other index here, and the tenant purge cascade would
+-- otherwise sequentially scan this table.
+CREATE INDEX site_context_versions_tenant_idx
+    ON site_context_versions (tenant_id);
+
+ALTER TABLE site_context_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE site_context_versions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY site_context_versions_tenant_isolation ON site_context_versions
+    FOR ALL
+    USING      (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+
+-- The m19/m113 exemplar shape. USING confines the collaborator's read to the
+-- sites they were granted; WITH CHECK stops them authoring a context version
+-- naming a site they were not. site_id is NOT NULL, so unlike m112's email
+-- tables there is no inheriting organisation row to keep readable and no reason
+-- to split read from write -- ADR-064 Decision 3 puts layer 2 in its own table
+-- above instead of as a null-keyed row in this one.
+CREATE POLICY site_context_versions_site_scope ON site_context_versions
+    AS RESTRICTIVE FOR ALL
+    USING (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+        OR site_id = ANY (
+            string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
+        )
+    )
+    WITH CHECK (
+        coalesce(current_setting('app.site_scope', true), '') <> 'on'
+        OR site_id = ANY (
+            string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
+        )
+    );
+
+-- Append-only at the privilege level, the audit_log posture ADR-064 requires
+-- by name. The REVOKE is the load-bearing half: m1's ALTER DEFAULT PRIVILEGES
+-- already granted UPDATE and DELETE on every future table in this schema.
+GRANT SELECT, INSERT ON org_context_versions  TO wpmgr_app;
+GRANT SELECT, INSERT ON site_context_versions TO wpmgr_app;
+
+REVOKE UPDATE, DELETE, TRUNCATE ON org_context_versions  FROM wpmgr_app;
+REVOKE UPDATE, DELETE, TRUNCATE ON site_context_versions FROM wpmgr_app;

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -460,6 +460,19 @@ type Membership struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+type OrgContextVersion struct {
+	ID                    uuid.UUID   `json:"id"`
+	TenantID              uuid.UUID   `json:"tenant_id"`
+	Version               int64       `json:"version"`
+	Restrictions          []byte      `json:"restrictions"`
+	Guidance              []byte      `json:"guidance"`
+	AuthorType            string      `json:"author_type"`
+	AuthorID              pgtype.UUID `json:"author_id"`
+	Provenance            string      `json:"provenance"`
+	RestoredFromVersionID pgtype.UUID `json:"restored_from_version_id"`
+	CreatedAt             time.Time   `json:"created_at"`
+}
+
 type PairingCode struct {
 	ID             uuid.UUID          `json:"id"`
 	TenantID       uuid.UUID          `json:"tenant_id"`
@@ -690,6 +703,20 @@ type SiteConnectionHistory struct {
 	Generation  int32       `json:"generation"`
 	OccurredAt  time.Time   `json:"occurred_at"`
 	Metadata    []byte      `json:"metadata"`
+}
+
+type SiteContextVersion struct {
+	ID                    uuid.UUID   `json:"id"`
+	TenantID              uuid.UUID   `json:"tenant_id"`
+	SiteID                uuid.UUID   `json:"site_id"`
+	Version               int64       `json:"version"`
+	Restrictions          []byte      `json:"restrictions"`
+	Guidance              []byte      `json:"guidance"`
+	AuthorType            string      `json:"author_type"`
+	AuthorID              pgtype.UUID `json:"author_id"`
+	Provenance            string      `json:"provenance"`
+	RestoredFromVersionID pgtype.UUID `json:"restored_from_version_id"`
+	CreatedAt             time.Time   `json:"created_at"`
 }
 
 type SiteDbCleanResult struct {

--- a/apps/api/migrations/20260824000000_m122_governed_context.sql
+++ b/apps/api/migrations/20260824000000_m122_governed_context.sql
@@ -1,0 +1,837 @@
+-- m122 - ADR-064 slice S3: storage for governed per-organisation and per-site
+-- context. SCHEMA ONLY.
+--
+-- THIS MIGRATION DELIBERATELY CHANGES NO BEHAVIOUR, in the m117 sense: it adds
+-- two tables, their indexes, their constraints, their RLS and their grants. No
+-- route reads them, no service writes them, no worker touches them. Every
+-- existing database lands with both tables empty, and empty is the correct and
+-- complete state for every organisation that has never authored context.
+--
+-- The Go half - the seven-layer resolution function, the write-time widen
+-- check, the secret scan, the fail-closed audit append, the effective-context
+-- preview and the `context.*` capabilities - is ADR-064's S4 and belongs to
+-- backend-architect. It lands on top of this. See "WHAT S4 MUST DO" at the end
+-- of this header.
+--
+-- Specification: docs/adr/ADR-064-governed-site-org-context.md (Status:
+-- Proposed). Every decision below cites the ADR decision it implements. Where
+-- the ADR is ambiguous this header says so in the AMBIGUITIES section rather
+-- than resolving it silently.
+--
+-- ===========================================================================
+-- WHAT THIS STORES, IN ONE PARAGRAPH
+-- ===========================================================================
+--
+-- Human-authored information about an organisation (ADR-064 layer 2) or a site
+-- (layer 3) that a future model-facing surface is handed alongside what it
+-- observes for itself. Each table is an APPEND-ONLY VERSION LOG, not a mutable
+-- settings row: "the current context" is defined by ADR-064 Decision 3 as "the
+-- latest version row", a read rather than a second representation to keep in
+-- sync. Every row carries the full resulting snapshot, its version number, its
+-- author, its provenance and its timestamp.
+--
+-- ===========================================================================
+-- DECISION 1: two columns, restrictions and guidance, never one
+-- ===========================================================================
+--
+-- ADR-064 Decision 3 splits every field into two kinds, and Decision 1 says
+-- the split is "load-bearing", not descriptive:
+--
+--   RESTRICTIONS  a closed structured set where "does this edit widen what a
+--                 higher layer set" is a well-defined comparison a machine can
+--                 make. Decision 4's write-time rejection runs over these.
+--   GUIDANCE      free text - brand voice, audience, terminology. "Wider" and
+--                 "narrower" are NOT defined relations over arbitrary prose,
+--                 and ADR-064 is explicit that it does not pretend otherwise.
+--
+-- They are two separate columns because that is what makes the split
+-- mechanical instead of a naming convention. If both lived in one document,
+-- the widen-check would have to decide which keys inside it are restrictions,
+-- and a write path that got that classification wrong would let a guidance key
+-- masquerade as a restriction - or, far worse in the direction that costs a
+-- boundary, let a restriction be edited through the code path that does not
+-- check. Two columns make that class unrepresentable: the widen-check reads
+-- `restrictions` and nothing else, and it cannot be handed guidance by
+-- accident.
+--
+-- The secret scan (ADR-064 Decision 10) reads BOTH. That asymmetry is the
+-- point of the split and is stated here so a later reader does not "simplify"
+-- the two columns back into one.
+--
+-- WHY jsonb AND NOT NAMED COLUMNS. ADR-064 fixes neither vocabulary. It gives
+-- an illustrative guidance list ("brand voice, audience, terminology notes,
+-- style preferences") and names no restriction key at all - Decision 4 puts
+-- the authoritative layer-1 restriction set in code, explicitly NOT in a table
+-- row ("WPMgr's layer-1 policy is not a row in either context table"). Minting
+-- named columns here would invent a closed vocabulary the ADR declined to fix,
+-- and would put every new guidance kind behind a migration, which is the wrong
+-- shape for a surface whose whole character is free text. The inner shape is
+-- fixed in Go, next to the layer-1 set it has to be compared against.
+--
+-- The jsonb_typeof CHECK below is the part that must not be dropped. Without
+-- it a bare string or an array lands in `restrictions`, and the widen-check
+-- Decision 4 builds on top has no object to compare. That is the m115 lesson
+-- applied on the way in rather than converged afterwards: m113 left a check
+-- constraint open, the value it should have refused got written, and m115 had
+-- to go round every database that had already applied m113.
+--
+-- ===========================================================================
+-- DECISION 2: append-only is enforced by PRIVILEGE, not by convention
+-- ===========================================================================
+--
+-- ADR-064's "What has to exist before this ships" requires "Version, author,
+-- and provenance columns on both context tables, with UPDATE/DELETE revoked
+-- from the application role at the privilege level, the same way the audit log
+-- already enforces append-only."
+--
+-- So the grants at the bottom of this file are SELECT + INSERT, followed by an
+-- explicit REVOKE of UPDATE, DELETE and TRUNCATE from wpmgr_app.
+--
+-- THE REVOKE IS NOT REDUNDANT AND MUST NOT BE DROPPED. The m1 auth migration
+-- (20260527130000_auth_multitenancy.sql:123-126) sets
+--
+--   ALTER DEFAULT PRIVILEGES IN SCHEMA public
+--     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO wpmgr_app;
+--
+-- so every table created by the migration owner - including these two -
+-- receives UPDATE and DELETE automatically, without anyone typing them. A
+-- table that merely omits an UPDATE grant is still updatable. audit_log is
+-- revoked for exactly this reason at m1:130 and these two tables follow it.
+--
+-- Append-only is why history is exact by construction (ADR-064 Decision 5)
+-- rather than by a second audit trail bolted alongside, and it is what makes
+-- Decision 7's claim - that an auditor can later prove what instruction set a
+-- model was given at a point in time - a property of the storage rather than a
+-- promise about the callers.
+--
+-- ===========================================================================
+-- DECISION 3: the organisation key IS tenant_id, and on the site table it is
+--             STAMPED rather than derived
+-- ===========================================================================
+--
+-- In this schema an organisation is a tenant: `/api/v1/orgs/{orgId}` addresses
+-- a `tenants` row, and `sites.tenant_id REFERENCES tenants (id)`. ADR-064
+-- says "organisation" throughout; this file says `tenant_id`, and they are the
+-- same key. The tables are named for the ADR's vocabulary (and for the route
+-- and capability names it fixes - `context.org.read`, `context.org.write`) and
+-- the column is named for the schema's.
+--
+-- On site_context_versions, ADR-064 Decision 3 is emphatic that this column is
+-- NOT the site's current owner:
+--
+--   "A context version row means 'as of when this was written,' so it stores
+--    the organisation id that owned the site AT THE TIME OF THAT WRITE, set
+--    once and never rewritten by a later transfer."
+--
+-- Decision 12 then depends on that stamp: a transfer resets the site's active
+-- context without retroactively reassigning authorship of everything written
+-- before it, and Decision 13's history routes authorize against the STAMPED
+-- organisation rather than the site's current one.
+--
+-- DO NOT ADD THE COMPOSITE FOREIGN KEY. `sites_id_tenant_key UNIQUE
+-- (id, tenant_id)` exists (schema.sql:444) and one table in this schema uses
+-- it as `FOREIGN KEY (site_id, tenant_id) REFERENCES sites (id, tenant_id)`.
+-- Adding that here would look like tidiness and would be a defect: it forces
+-- every row's stamp to equal the site's CURRENT owner, which is precisely the
+-- property Decision 3 forbids. It would work perfectly until the day site
+-- transfer ships and then refuse every pre-transfer row at once. The two
+-- single-column foreign keys below are deliberate.
+--
+-- ===========================================================================
+-- DECISION 4: both foreign keys are ON DELETE CASCADE - the opposite call to
+--             m113/m116, for a stated reason
+-- ===========================================================================
+--
+-- site_object_reclaim and tenant_object_reclaim carry NO foreign key at all,
+-- because a cascade onto a record of cleanup work destroys it in the very
+-- operation it exists to survive. The house rule that came out of GH #402 and
+-- GH #408 is: when you add a cascade, ask what audit or reclaim record dies
+-- with it.
+--
+-- Asked, and answered. What dies with this cascade is the context snapshots.
+-- What does NOT die with it is the accountability record, because ADR-064
+-- Decision 7 puts every context write in the hash-chained audit_log in the
+-- same transaction, and audit_log is a separate table with its own retention
+-- and its own append-only privilege revoke. The claim ADR-064 exists to
+-- support - that an organisation's auditor can prove what a model was given -
+-- rides on the ledger entry, not on the snapshot.
+--
+-- And these tables have no object-storage component at all. ADR-064 Decision
+-- 12 states that explicitly, so that the next person reading purge_worker.go's
+-- roster does not have to wonder whether context belongs on it:
+--
+--   "Context storage does not add an eighth root - it has no object-storage
+--    component at all."
+--
+-- Verified against the code rather than taken from the ADR: the seven roots
+-- are enumerated at internal/org/purge_worker.go:161-173 and asserted
+-- identical to the Lane-A drain set by TestGH408_TenantDrainRootsAreLaneBsRoots
+-- (internal/backup/gh408_tenant_drain_roots_test.go:28). Nothing here adds to
+-- that list, so nothing there changes.
+--
+-- So the cascade is correct, and it is what makes ADR-064 Decision 12's
+-- retention rule true: "retained for the life of the organisation or site ...
+-- and is removed only when the organisation or site is removed". Both purge
+-- paths are cascade-driven (admin_purge_tenant, m93:114-145;
+-- admin_delete_empty_tenant, m116:252-299) and neither enumerates tables, so
+-- these two tables are freed with no change to either function.
+--
+-- WHY THE CASCADE IS NOT BLOCKED BY THIS TABLE'S OWN RLS. Worth recording,
+-- because it is the obvious worry and the answer is not obvious.
+-- admin_delete_empty_tenant BLANKS app.tenant_id to '' before it deletes the
+-- tenants row (m116:270-271), and under FORCE ROW LEVEL SECURITY a
+-- tenant_isolation policy matches zero rows when that GUC is blank. The
+-- question is whether the cascaded child DELETE is therefore refused, leaving
+-- a foreign-key violation and an org nobody can delete.
+--
+-- It is not. PostgreSQL's referential actions bypass row security. Measured on
+-- postgres:16.4-alpine, as a NOSUPERUSER NOBYPASSRLS role owning the tables,
+-- with a child table carrying ENABLE + FORCE RLS and exactly the
+-- tenant_isolation policy below: with app.tenant_id set to '', the child row
+-- was invisible to a direct SELECT (0 rows), and DELETE on the parent still
+-- succeeded and still removed the child. Neither the delete nor the cascade
+-- errored. That is why these tables need no app.agent escape hatch for the
+-- purge path - see Decision 6.
+--
+-- ===========================================================================
+-- DECISION 5: version is monotonic per SUBJECT, and the unique index is what
+--             turns ADR-064's open question 2 from silence into an error
+-- ===========================================================================
+--
+-- ADR-064 Decision 2 gives every context row "a version number that increments
+-- on every accepted write". A writer computes max(version) + 1 for its subject
+-- and inserts.
+--
+-- UNIQUE (tenant_id, version) on the org table and UNIQUE (site_id, version)
+-- on the site table are therefore not decoration. ADR-064's open question 2
+-- records that PATCH concurrency is UNDECIDED and assigns it to
+-- backend-architect:
+--
+--   "Two concurrent PATCH calls touching disjoint fields can both read version
+--    N and both succeed, and the later write's snapshot will not carry
+--    whichever fields the earlier write changed."
+--
+-- Without the unique index that is a lost update: two rows both claiming to be
+-- version N+1, and "the latest version row" - which is ADR-064's definition of
+-- the current context - becomes ambiguous, resolved by whichever the planner
+-- returned. With it, one writer commits and the other gets SQLSTATE 23505 and
+-- can be told to retry. The database cannot decide the HTTP contract, but it
+-- can refuse to let the undecided case corrupt history quietly, which is the
+-- half that must not wait for the decision.
+--
+-- WHY THE SITE TABLE'S KEY IS (site_id, version) AND NOT
+-- (tenant_id, site_id, version). Version numbers must stay unique and
+-- monotonic across a transfer. Decision 12's cleared version is "itself a
+-- version" and continues the sequence; keying on the stamp as well would let
+-- version 4 exist twice for one site under two different organisations, and
+-- "restore version 4" would then name two different snapshots. Site history is
+-- one sequence with a stamp that changes partway down it, not two sequences.
+--
+-- These unique indexes are also the read path. "The latest version row for
+-- that organisation or site" is a backwards scan of the same btree, so no
+-- separate ordering index is needed and none is created.
+--
+-- WHY THE ORG TABLE GETS NO SEPARATE tenant_id INDEX. The house convention is
+-- an index on tenant_id, and it is satisfied here rather than skipped:
+-- tenant_id is the LEADING column of org_context_versions_version_key, so
+-- lookups and the purge cascade use that index already. A second index on the
+-- same leading column would be paid for on every insert and read by nothing.
+-- The site table DOES get one, because there tenant_id leads no index and the
+-- tenant cascade would otherwise sequentially scan the whole table.
+--
+-- ===========================================================================
+-- DECISION 6: NO app.agent POLICY ON EITHER TABLE
+-- ===========================================================================
+--
+-- This is a deliberate departure from the generic house pattern
+-- (.claude/rules/db-migrations.md lists a `<table>_agent` policy among what a
+-- new site-keyed table needs), argued in place, the way m116 argued its way
+-- out of the site-scope policy. Four reasons, in order of weight.
+--
+--   1. ADR-064 Decision 2 forbids the thing such a policy would enable. "The
+--      agent never holds an opinion about layers 1 through 3, never merges
+--      them locally, and is never asked to resolve a conflict between them."
+--      The agent's role is layer 4 - reporting what it observes - and layer 4
+--      is not stored here.
+--
+--   2. No cross-tenant control-plane worker reads context either. Resolution
+--      (Decision 8) runs on a request, under tenant scope. The materialised
+--      effective-context cache of Decision 2 is keyed per site and invalidated
+--      on write; it is not a fleet sweep.
+--
+--   3. The purge path does not need it. That was the one real candidate, and
+--      it is settled by measurement rather than by reading: referential
+--      actions bypass row security, so the cascade fires whatever GUC the
+--      purge function has set. See Decision 4 above for the probe and its
+--      result.
+--
+--   4. It would be a cross-tenant grant with no caller. app.agent policies are
+--      PERMISSIVE and do not bind tenant_id, so each one is a cross-tenant
+--      grant that scripts/check-rls-cross-tenant.sh requires a ledger row for.
+--      The only honest rationale available today would be "no code path runs
+--      under this policy", and db/rls-cross-tenant-policies.txt is explicit
+--      that a ledger row exists because "somebody had to look", not to
+--      pre-authorise a hole for a caller that may never arrive. Granting
+--      cross-tenant read of an organisation's governing instructions on the
+--      chance a worker might one day want it is exactly backwards for a
+--      boundary.
+--
+-- If a future cross-tenant worker genuinely needs to read context, the correct
+-- order is: a new migration adding the policy, WITH a ledger row naming the
+-- caller and stating what it does. Not this one, speculatively.
+--
+-- CONSEQUENCE, STATED SO NOBODY DISCOVERS IT AT RUNTIME: neither table is
+-- reachable from InAgentTx. A background job that needs context must run under
+-- a tenant transaction. That is a constraint on S4, not an accident.
+--
+-- ===========================================================================
+-- DECISION 7: the site-scope policies, and what each one actually refuses
+-- ===========================================================================
+--
+-- ADR-064's "What has to exist before this ships" requires:
+--
+--   "A restrictive site-scope policy on both context tables, not only tenant
+--    isolation ... Tenant isolation alone would let any principal scoped to
+--    the tenant read or resolve another site's context; the restrictive policy
+--    is what confines a read to the sites a principal can actually see."
+--
+-- and ADR-061 Decision 4 (ADR-061:370-371) pre-commits the deferred site-scope
+-- migration's scope, which ADR-064's Relationship section extends to name
+-- these two tables. This migration is where that lands for them.
+--
+-- site_context_versions - one RESTRICTIVE FOR ALL policy on site_id, the plain
+-- m19/m113 exemplar shape. site_id is NOT NULL, so unlike the m112 email
+-- tables there is no inheriting `site_id IS NULL` organisation row to keep
+-- readable and no reason to split read from write. ADR-064 Decision 3 puts the
+-- organisation layer in its OWN TABLE rather than as a null-keyed row in this
+-- one, which is what makes the simple shape correct here.
+--
+--   SELECT  a collaborator invited to site A cannot read site B's context.
+--   INSERT  a collaborator invited to site A cannot author a context version
+--           naming site B. That is the WITH CHECK half, and it is the half
+--           that stops the write.
+--
+-- org_context_versions - this one needs care, and the obvious reading of the
+-- ADR sentence above is wrong.
+--
+-- The org table has no site_id, so "confine a read to the sites a principal
+-- can see" cannot mean filtering its rows by site. Worse, a restrictive SELECT
+-- gate here would BREAK a read ADR-064 explicitly requires: Decision 6 says
+-- read access follows fleet-read access, "at the organisation AND the site
+-- scope that cover that site", and Decision 8's effective-context preview for
+-- a site renders layer 2's surviving contribution. A site-scoped collaborator
+-- is entitled to read the organisation context that governs their own site;
+-- they cannot understand the rules they are working under otherwise.
+--
+-- What they are NOT entitled to do is WRITE it. ADR-064 Decision 6:
+-- "organisation-scope write is held by organisation administrators; site-scope
+-- write additionally requires access to that specific site." A site-scoped
+-- collaborator authoring an organisation-wide context version is precisely the
+-- m112 defect class - a per-site principal reaching the organisation row - and
+-- m112 exists because three review rounds closed seven separate instances of
+-- it in handlers before anyone asked why they kept appearing.
+--
+-- So org_context_versions_site_scope_insert is RESTRICTIVE FOR INSERT with a
+-- WITH CHECK that is simply false whenever app.site_scope is 'on'. The table
+-- is append-only (Decision 2 above), so INSERT is the entire write surface and
+-- one policy closes all of it.
+--
+--   SELECT  unaffected. No restrictive SELECT policy exists, so tenant
+--           isolation alone governs the read, and the collaborator sees their
+--           organisation's context. This is deliberate, per Decision 6/8.
+--   INSERT  refused outright for any site-scoped principal, in the database,
+--           whatever a handler forgets.
+--
+-- For an ordinary organisation member, a service path or a worker,
+-- app.site_scope is unset and both policies' first branch is a tautology, so
+-- behaviour is unchanged. RESTRICTIVE policies are AND-combined with the
+-- permissive ones and can only ever subtract.
+--
+-- ===========================================================================
+-- DECISION 8: NULL means never set (GH #509)
+-- ===========================================================================
+--
+-- The columns that record a FACT get no manufactured default:
+--
+--   author_id                 NULL when the author is not a principal with an
+--                             id - ADR-064 Decision 12's transfer version,
+--                             whose author is "the transfer operation".
+--   restored_from_version_id  NULL means "this version is not a restore". Not
+--                             a sentinel, not the zero uuid.
+--
+-- The columns that record a SETTING do get one, and GH #509's rule is exactly
+-- that distinction: a default is right for a setting and wrong for an
+-- observation. `restrictions` and `guidance` default to '{}' because ADR-064
+-- Decision 3 requires every version row to carry "the full resulting
+-- snapshot"; a row exists only because somebody wrote it, so an empty document
+-- is a true statement that this version sets nothing of that kind, not an
+-- absence pretending to be a value.
+--
+-- created_at gets DEFAULT now() because now() at insert IS the measurement,
+-- not a stand-in for one.
+--
+-- author_type is NOT NULL with no default: every write has an author kind, and
+-- a default would let a caller that forgot to say who wrote something produce
+-- a row that claims a kind it never asserted.
+--
+-- ===========================================================================
+-- DECISION 9: the provenance set is CLOSED, and holds exactly what the ADR
+--             DECIDES - not what it speculates about
+-- ===========================================================================
+--
+--   'manual'    an operator edit (ADR-064 Decision 3).
+--   'restore'   ADR-064 Decision 5: restoring version N creates a new version
+--               attributed to whoever asked, "with provenance recorded as
+--               `restore` and a pointer to the version restored".
+--   'transfer'  ADR-064 Decision 12: the cleared version written when a site
+--               moves organisation, "author: the transfer operation,
+--               provenance: `transfer`".
+--
+-- 'import' is DELIBERATELY ABSENT. Decision 3 mentions "a later machine-
+-- assisted import IF ONE IS EVER BUILT" - a hypothetical, not a decision.
+-- Minting a value nothing can write would be manufacturing vocabulary; when an
+-- import path is actually designed it arrives with its own migration, the way
+-- site_object_reclaim.kind is a closed set extended by a later ordinal.
+--
+-- 'transfer' is in the set even though no site-to-organisation transfer
+-- mechanism exists anywhere in this codebase - ADR-064 verified that directly
+-- and records it as a prerequisite it depends on and does not build. The
+-- difference from 'import' is that ADR-064 DECIDES this value; the contract is
+-- written and only its caller is missing. The closed CHECK is the m115 lesson
+-- applied on the way in.
+--
+-- ===========================================================================
+-- AMBIGUITIES IN ADR-064, AND WHAT THIS MIGRATION CHOSE
+-- ===========================================================================
+--
+-- Recorded rather than resolved silently. Each is a place a later reader could
+-- reasonably have read the ADR differently.
+--
+-- A. "A restrictive site-scope policy on BOTH context tables." Taken literally
+--    against a table with no site_id, this is unimplementable as a row filter,
+--    and implemented as a SELECT filter it would break the layer-2 read
+--    Decision 6 and Decision 8 both require. Chosen reading: the org table's
+--    restrictive gate is on WRITE, not read - see Decision 7 above. This is
+--    the reading that satisfies both passages at once; the literal one
+--    satisfies neither.
+--
+-- B. Byte budgets (ADR-064 Decision 9). NO write-time size CHECK is added.
+--    Decision 9 specifies TRUNCATION at resolution ("truncation happens at a
+--    field or record boundary ... marked explicitly rather than silently
+--    dropped", and starting "at the lowest surviving layer"), which is a
+--    property of the resolution function, not of storage. A write-time
+--    refusal would be different behaviour with a different error contract, and
+--    Decision 13 enumerates exactly two write refusals - 409 for a widening
+--    restriction and 422 for a credential-shaped value. Inventing a third, and
+--    a byte threshold the ADR never states, would be designing past the
+--    specification. Consequence S4 must own: nothing in the database bounds
+--    the size of a context row today.
+--
+-- C. The restriction and guidance vocabularies are not fixed by the ADR. See
+--    Decision 1: they are jsonb here and their shape belongs in Go, beside the
+--    layer-1 restriction set Decision 4 already puts there.
+--
+-- D. "The author's principal id" (Decision 3) does not say which principal
+--    kinds can author. `author_type` is a closed discriminator over 'user',
+--    'api_key' and 'system': 'api_key' because ADR-064 Decision 6 gates these
+--    routes on the ADR-061 Decision 5 capability registry, which lives on API
+--    keys, and 'system' because Decision 12's transfer version has no human
+--    author. If a fourth kind is ever needed it arrives with a migration.
+--
+-- ===========================================================================
+-- WHY THERE IS NO FOREIGN KEY ON author_id
+-- ===========================================================================
+--
+-- Neither ON DELETE action is correct, which is the tell that the column is
+-- not a reference:
+--
+--   SET NULL  would MUTATE AN APPEND-ONLY ROW, erasing the authorship of a
+--             historical version when the author's user account is deleted.
+--             ADR-064 Decision 3 says author and provenance travel with each
+--             row; a deletion elsewhere in the schema must not quietly rewrite
+--             a governance record.
+--   CASCADE   would delete an organisation's context history because a member
+--             left. Absurd, and stated because it is the schema default people
+--             reach for.
+--
+-- audit_log makes the identical call for the identical reason - actor_type
+-- plus a bare actor_id, no foreign key (schema.sql:769-770) - and audit_log is
+-- the table ADR-064 Decision 7 explicitly models this one's accountability
+-- posture on. A dangling author id is the correct outcome here: the historical
+-- fact is that that principal wrote it.
+--
+-- restored_from_version_id has no foreign key either, and for a sharper
+-- reason. The constraint that actually matters on a restore is ADR-064
+-- Decision 12's - a restore may not cross an organisation stamp, and a
+-- pre-transfer version id is refused "outright and unconditionally, for every
+-- caller". That is a comparison of two rows' tenant_id values, which no
+-- single-column foreign key expresses. Adding one would imply a guarantee it
+-- does not provide, and this schema has already paid for that shape once.
+--
+-- ===========================================================================
+-- WHAT S4 (backend-architect) MUST DO, AND WHAT THIS FILE CANNOT
+-- ===========================================================================
+--
+-- Nothing below enforces any of the following. They are ADR-064 requirements
+-- that live in Go by the ADR's own design, listed here so the boundary between
+-- the two slices is explicit rather than assumed:
+--
+--   * The never-widen check on RESTRICTIONS ONLY, at the write chokepoint,
+--     against every layer above - not only the nearest (Decision 4). ADR-064
+--     Decision 1 and the Consequences are both emphatic that GUIDANCE gets no
+--     mechanical check and that claiming one "would be a check that always
+--     passes without ever having tested the thing it claims to test". Do not
+--     build it.
+--   * Restrictions must also reach the TOOL-DISPATCH chokepoint as a deny
+--     input (Decision 4), not merely be shown to the model as fenced prose.
+--   * The secret scan over BOTH columns, refusing with the category and never
+--     echoing the match (Decision 10).
+--   * The fail-closed audit append in the same transaction as the INSERT
+--     (Decision 7). This does not exist yet: audit.Record is best-effort today
+--     (internal/audit/audit.go:498-500) and ADR-064 names the fail-closed
+--     variant as required new work shared with ADR-061.
+--   * One resolution function shared by the model-facing path and the preview
+--     (Decision 8), refusing rather than returning an empty result when it
+--     cannot complete (Decision 14).
+--   * PATCH concurrency (open question 2). The unique indexes here turn the
+--     undecided case into SQLSTATE 23505 rather than a lost update; deciding
+--     the wire contract is still open and is assigned to backend-architect.
+--   * History routes authorized against the STAMPED tenant_id, not the site's
+--     current owner, and restore refused across a stamp boundary
+--     (Decisions 12 and 13).
+--
+-- ===========================================================================
+-- IDEMPOTENCE AND BOOT SAFETY
+-- ===========================================================================
+--
+-- internal/db/migrate.go applies this on boot, inside main(), in one
+-- transaction, in lexical order, so a failure here is a control-plane outage
+-- on every install at once. Every statement is guarded: CREATE TABLE and
+-- CREATE INDEX with IF NOT EXISTS, each policy wrapped in a pg_policies
+-- existence check because PostgreSQL 16 has no CREATE POLICY IF NOT EXISTS
+-- (the m94/m113 pattern), and GRANT/REVOKE are naturally idempotent. Nothing
+-- is dropped, no existing row is read or written, and there is no backfill:
+-- both tables start empty and empty is correct for every existing
+-- organisation.
+--
+-- ORDINAL: 20260824000000, the first free one after m121
+-- (20260823000000_m121_site_components_updated_at.sql), checked across every
+-- ref in the repository and not only main, because ordinal is APPLY order and
+-- not commit order - m113 carries 20260815000000 and was committed after m114
+-- and m115, and migrate.go does not verify atlas.sum.
+--
+-- CONVERGE PATH: none is required, and this is a statement about the world
+-- rather than an omission. No prior version of this migration has ever been
+-- applied to any database: the ordinal is new, the two tables are new, this
+-- file corrects nothing and it edits no applied migration. There is therefore
+-- no database in any state that needs converging onto this one, and no m114/
+-- m115-shaped follow-up is owed.
+
+-- ---------------------------------------------------------------------------
+-- org_context_versions - ADR-064 layer 2
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS "public"."org_context_versions" (
+    "id"        uuid   PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- The organisation. In this schema an organisation IS a tenant, so this
+    -- column is both the subject key and the tenant-isolation key.
+    "tenant_id" uuid   NOT NULL,
+    -- Monotonic from 1 per organisation. See DECISION 5: the unique index over
+    -- this is what makes a concurrent double-write an error instead of a lost
+    -- update, while ADR-064's open question 2 is still open.
+    "version"   bigint NOT NULL CONSTRAINT "org_context_versions_version_positive_check"
+        CHECK ("version" >= 1),
+
+    -- THE TWO KINDS OF FIELD (ADR-064 Decision 3). Two columns, never one:
+    -- the never-widen check reads restrictions and must not be reachable by
+    -- guidance. See DECISION 1.
+    --
+    -- Structured, mechanically comparable. Decision 4's widen-check runs here.
+    "restrictions" jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT "org_context_versions_restrictions_object_check"
+        CHECK (jsonb_typeof("restrictions") = 'object'),
+    -- Free text. ADR-064 is deliberate that "wider" and "narrower" are not
+    -- defined relations over prose, and that no mechanical check applies here.
+    "guidance"     jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT "org_context_versions_guidance_object_check"
+        CHECK (jsonb_typeof("guidance") = 'object'),
+
+    -- WHO. No foreign key, deliberately - see the header. author_id is NULL
+    -- exactly when the author has no principal id, which today means the
+    -- transfer operation of ADR-064 Decision 12.
+    "author_type" text NOT NULL CONSTRAINT "org_context_versions_author_type_check"
+        CHECK ("author_type" IN ('user', 'api_key', 'system')),
+    "author_id"   uuid NULL,
+    -- A 'system' author has no id and a credentialed one always does. This
+    -- deliberately does NOT constrain which of users or api_keys the id names:
+    -- that is what author_type is for, and no single column can reference two
+    -- tables.
+    CONSTRAINT "org_context_versions_author_id_matches_type_check"
+        CHECK (("author_type" = 'system') = ("author_id" IS NULL)),
+
+    -- HOW. Closed set; 'import' is deliberately absent. See DECISION 9.
+    "provenance" text NOT NULL CONSTRAINT "org_context_versions_provenance_check"
+        CHECK ("provenance" IN ('manual', 'restore', 'transfer')),
+    -- Which version this one reproduces. NULL means "not a restore" - never a
+    -- sentinel. No foreign key: the check that matters is a cross-row stamp
+    -- comparison no single-column reference can express.
+    "restored_from_version_id" uuid NULL,
+    -- A restore names the version it restored, and nothing else does. This is
+    -- the m115 lesson: close the constraint on the way in.
+    CONSTRAINT "org_context_versions_restore_pointer_check"
+        CHECK (("provenance" = 'restore') = ("restored_from_version_id" IS NOT NULL)),
+
+    "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- The subject key, the concurrency guard and the "latest version" read path,
+-- all in one index. tenant_id LEADS, so this also serves tenant lookups and
+-- the purge cascade; that is why no separate tenant_id index is created here.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public' AND tablename = 'org_context_versions'
+          AND indexname = 'org_context_versions_version_key'
+    ) THEN
+        CREATE UNIQUE INDEX "org_context_versions_version_key"
+            ON "public"."org_context_versions" ("tenant_id", "version");
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.org_context_versions'::regclass
+          AND conname  = 'org_context_versions_tenant_id_fkey'
+    ) THEN
+        ALTER TABLE "public"."org_context_versions"
+            ADD CONSTRAINT "org_context_versions_tenant_id_fkey"
+            FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants" ("id")
+            ON UPDATE NO ACTION ON DELETE CASCADE;
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    ALTER TABLE "public"."org_context_versions" ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE "public"."org_context_versions" FORCE ROW LEVEL SECURITY;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'org_context_versions'
+          AND policyname = 'org_context_versions_tenant_isolation'
+    ) THEN
+        CREATE POLICY "org_context_versions_tenant_isolation" ON "public"."org_context_versions"
+            FOR ALL
+            USING ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+-- A site-scoped collaborator may READ their organisation's context - ADR-064
+-- Decision 6 requires it and Decision 8's preview renders it - but may never
+-- AUTHOR a version of it. The table is append-only, so INSERT is the whole
+-- write surface and this one policy closes all of it. See DECISION 7.
+--
+-- Note there is deliberately NO restrictive SELECT policy on this table. Its
+-- absence is the mechanism by which the layer-2 read keeps working; do not
+-- "complete the set" by adding one.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'org_context_versions'
+          AND policyname = 'org_context_versions_site_scope_insert'
+    ) THEN
+        CREATE POLICY "org_context_versions_site_scope_insert" ON "public"."org_context_versions"
+            AS RESTRICTIVE FOR INSERT
+            WITH CHECK (
+                coalesce(current_setting('app.site_scope', true), '') <> 'on'
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- site_context_versions - ADR-064 layer 3
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS "public"."site_context_versions" (
+    "id"        uuid   PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- THE ORGANISATION STAMP, per ADR-064 Decision 3: the organisation that
+    -- owned this site AT THE TIME OF THIS WRITE. Set once, never rewritten by
+    -- a later transfer. It is NOT a live view of the site's current owner, and
+    -- the composite foreign key that would force it to be one is deliberately
+    -- absent - see the header.
+    "tenant_id" uuid   NOT NULL,
+    "site_id"   uuid   NOT NULL,
+    -- Monotonic from 1 per SITE, not per (site, organisation): the sequence
+    -- continues across a transfer so a restore reference stays unambiguous.
+    "version"   bigint NOT NULL CONSTRAINT "site_context_versions_version_positive_check"
+        CHECK ("version" >= 1),
+
+    "restrictions" jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT "site_context_versions_restrictions_object_check"
+        CHECK (jsonb_typeof("restrictions") = 'object'),
+    "guidance"     jsonb NOT NULL DEFAULT '{}'::jsonb
+        CONSTRAINT "site_context_versions_guidance_object_check"
+        CHECK (jsonb_typeof("guidance") = 'object'),
+
+    "author_type" text NOT NULL CONSTRAINT "site_context_versions_author_type_check"
+        CHECK ("author_type" IN ('user', 'api_key', 'system')),
+    "author_id"   uuid NULL,
+    CONSTRAINT "site_context_versions_author_id_matches_type_check"
+        CHECK (("author_type" = 'system') = ("author_id" IS NULL)),
+
+    "provenance" text NOT NULL CONSTRAINT "site_context_versions_provenance_check"
+        CHECK ("provenance" IN ('manual', 'restore', 'transfer')),
+    "restored_from_version_id" uuid NULL,
+    CONSTRAINT "site_context_versions_restore_pointer_check"
+        CHECK (("provenance" = 'restore') = ("restored_from_version_id" IS NOT NULL)),
+
+    "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- Subject key, concurrency guard and latest-version read path. Keyed on
+-- site_id ALONE alongside version - see DECISION 5 for why the stamp is not
+-- part of it.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public' AND tablename = 'site_context_versions'
+          AND indexname = 'site_context_versions_version_key'
+    ) THEN
+        CREATE UNIQUE INDEX "site_context_versions_version_key"
+            ON "public"."site_context_versions" ("site_id", "version");
+    END IF;
+END;
+$$;
+
+-- tenant_id leads no other index here, and the tenant purge cascade would
+-- otherwise sequentially scan this table.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public' AND tablename = 'site_context_versions'
+          AND indexname = 'site_context_versions_tenant_idx'
+    ) THEN
+        CREATE INDEX "site_context_versions_tenant_idx"
+            ON "public"."site_context_versions" ("tenant_id");
+    END IF;
+END;
+$$;
+
+-- Two SINGLE-COLUMN foreign keys, never the composite. Both ON DELETE CASCADE:
+-- ADR-064 Decision 12 retains context for the life of the organisation or the
+-- site and frees it with them, and the accountability record that must outlive
+-- the snapshot lives in audit_log, not here. See DECISION 4.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.site_context_versions'::regclass
+          AND conname  = 'site_context_versions_tenant_id_fkey'
+    ) THEN
+        ALTER TABLE "public"."site_context_versions"
+            ADD CONSTRAINT "site_context_versions_tenant_id_fkey"
+            FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants" ("id")
+            ON UPDATE NO ACTION ON DELETE CASCADE;
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.site_context_versions'::regclass
+          AND conname  = 'site_context_versions_site_id_fkey'
+    ) THEN
+        ALTER TABLE "public"."site_context_versions"
+            ADD CONSTRAINT "site_context_versions_site_id_fkey"
+            FOREIGN KEY ("site_id") REFERENCES "public"."sites" ("id")
+            ON UPDATE NO ACTION ON DELETE CASCADE;
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    ALTER TABLE "public"."site_context_versions" ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE "public"."site_context_versions" FORCE ROW LEVEL SECURITY;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'site_context_versions'
+          AND policyname = 'site_context_versions_tenant_isolation'
+    ) THEN
+        CREATE POLICY "site_context_versions_tenant_isolation" ON "public"."site_context_versions"
+            FOR ALL
+            USING ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid)
+            WITH CHECK ("tenant_id" = nullif(current_setting('app.tenant_id', true), '')::uuid);
+    END IF;
+END;
+$$;
+
+-- The m19/m113 exemplar shape, one RESTRICTIVE FOR ALL policy on site_id.
+-- USING confines the read; WITH CHECK stops a collaborator authoring a context
+-- version that names a site it was never granted. site_id is NOT NULL, so
+-- unlike m112's email tables there is no inheriting organisation row here to
+-- keep readable and no reason to split read from write - ADR-064 Decision 3
+-- puts layer 2 in its own table instead.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'site_context_versions'
+          AND policyname = 'site_context_versions_site_scope'
+    ) THEN
+        CREATE POLICY "site_context_versions_site_scope" ON "public"."site_context_versions"
+            AS RESTRICTIVE FOR ALL
+            USING (
+                coalesce(current_setting('app.site_scope', true), '') <> 'on'
+                OR "site_id" = ANY (
+                    string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
+                )
+            )
+            WITH CHECK (
+                coalesce(current_setting('app.site_scope', true), '') <> 'on'
+                OR "site_id" = ANY (
+                    string_to_array(nullif(current_setting('app.allowed_site_ids', true), ''), ',')::uuid[]
+                )
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Grants: append-only at the privilege level (ADR-064's own requirement)
+--
+-- The REVOKE is the load-bearing half. m1's ALTER DEFAULT PRIVILEGES
+-- (20260527130000_auth_multitenancy.sql:123-126) already granted wpmgr_app
+-- SELECT, INSERT, UPDATE and DELETE on every future table in this schema,
+-- these two included, without anyone typing it. Omitting an UPDATE grant does
+-- not withhold UPDATE; revoking it does. audit_log is revoked at m1:130 for
+-- the same reason and these follow it.
+-- ---------------------------------------------------------------------------
+
+GRANT SELECT, INSERT ON "public"."org_context_versions"  TO wpmgr_app;
+GRANT SELECT, INSERT ON "public"."site_context_versions" TO wpmgr_app;
+
+REVOKE UPDATE, DELETE, TRUNCATE ON "public"."org_context_versions"  FROM wpmgr_app;
+REVOKE UPDATE, DELETE, TRUNCATE ON "public"."site_context_versions" FROM wpmgr_app;

--- a/apps/api/migrations/20260825000000_m123_org_context_write_scope.sql
+++ b/apps/api/migrations/20260825000000_m123_org_context_write_scope.sql
@@ -1,0 +1,166 @@
+-- m123 - close the UPDATE/DELETE gap m122 left on org_context_versions.
+-- Found by security review on PR #562, before either table shipped anywhere.
+--
+-- WHY THIS IS A NEW ORDINAL AND NOT AN EDIT TO m122
+--
+-- m122 has already been applied to real databases: the security review rebuilt
+-- a full install from it (131 migrations, wpmgr_app provisioned the way
+-- infra/postgres/init/01-app-role.sh does), and every `make test-integration`
+-- run applies it to a fresh container. internal/db/migrate.go tracks applied
+-- versions in schema_migrations and skips anything already present, so editing
+-- m122 in place would be a silent no-op on exactly the databases that need
+-- changing, while looking like a fix. A correction is a new ordinal plus a
+-- converge path -- that is what m114 and m115 are, and this is the same shape
+-- caught earlier.
+--
+-- CONVERGE PATH: this file IS it, and it needs no separate branch. Every
+-- statement is guarded on pg_policies, so a database that applied m122 gains
+-- exactly the two missing policies, and a database that has never seen either
+-- migration applies m122 then m123 and lands in the same place. There is no
+-- third state, because m122 has never existed in more than one version.
+--
+-- ---------------------------------------------------------------------------
+-- WHAT WAS WRONG
+-- ---------------------------------------------------------------------------
+--
+-- m122 gave org_context_versions a RESTRICTIVE gate on INSERT alone, reasoning
+-- that the table is append-only so INSERT is the entire write surface.
+--
+-- That reasoning is wrong, and the way it is wrong is worth writing down
+-- because it is a shape that recurs. It is the REVOKE of UPDATE/DELETE that
+-- makes INSERT the whole write surface -- so the argument silently promoted the
+-- REVOKE from "second layer" to "only layer". Two independent protections were
+-- collapsed into one without anyone deciding to. site_context_versions never
+-- had this problem: its policy is FOR ALL, so the two layers there are actually
+-- two.
+--
+-- The review granted the privileges back -- simulating a future blanket
+-- GRANT ... ON ALL TABLES IN SCHEMA public TO wpmgr_app -- and found:
+--
+--   ORG  UPDATE by a site-scoped principal -> SUCCEEDED, 1 row
+--   ORG  DELETE by a site-scoped principal -> SUCCEEDED, 1 row
+--   SITE UPDATE of a sibling site          -> refused, 0 rows
+--
+-- That blanket GRANT is not an exotic hypothesis. m1 already contains the exact
+-- statement (20260527130000_auth_multitenancy.sql:120), and the integration
+-- harness runs it on every startPostgres
+-- (apps/api/tests/rls_integration_test.go). Any future migration, restore
+-- script or operator runbook repeating it re-arms the gap with no error and no
+-- log line.
+--
+-- The consequence is not a read leak. It is that a collaborator invited to ONE
+-- site could rewrite or destroy the ORGANISATION's governing context -- layer 2
+-- of ADR-064 Decision 1, which applies to every site in the organisation. A
+-- principal that can edit layer 2 does not need to widen anything; it becomes
+-- the higher layer. That is m112's defect class one more time.
+--
+-- ---------------------------------------------------------------------------
+-- WHAT THIS ADDS, AND WHAT IT DELIBERATELY DOES NOT
+-- ---------------------------------------------------------------------------
+--
+-- Two RESTRICTIVE policies on org_context_versions, FOR UPDATE and FOR DELETE,
+-- with the identical predicate m122's INSERT gate already uses:
+--
+--   coalesce(current_setting('app.site_scope', true), '') <> 'on'
+--
+-- USING rather than WITH CHECK, because for UPDATE and DELETE the USING clause
+-- is what decides which existing rows the statement may touch. A RESTRICTIVE
+-- USING that is false for a site-scoped principal removes every row from that
+-- statement's reach, so the write matches nothing.
+--
+-- NO POLICY IS ADDED FOR SELECT, and that is the load-bearing omission rather
+-- than an oversight. ADR-064 Decision 6 gives read access "at the organisation
+-- AND the site scope that cover that site", and Decision 8's effective-context
+-- preview renders layer 2's surviving contribution to a site. A site-scoped
+-- collaborator is entitled to READ the organisation context governing their own
+-- site; they cannot understand the rules they work under otherwise. A
+-- RESTRICTIVE SELECT gate here would break both decisions at once. m122's
+-- header says this and it remains true -- the fix is to cover the two write
+-- commands it missed, not to gate the read it correctly left open.
+--
+-- The result is that org_context_versions is now protected the way
+-- site_context_versions already was: a policy layer AND a privilege layer, with
+-- neither one load-bearing alone.
+--
+-- WHY NOT SIMPLY REPLACE THE THREE WITH ONE `FOR ALL` POLICY. Because FOR ALL
+-- is AND-combined onto SELECT as well, which is exactly the read this table
+-- must not gate -- the m112 trap in reverse. Three command-specific policies
+-- are the only shape that gates INSERT, UPDATE and DELETE while leaving SELECT
+-- alone. Dropping and recreating m122's INSERT policy to "tidy" the set would
+-- also be a needless irreversible statement over the tenant boundary taken at
+-- boot inside main(), which db/rls-cross-tenant-policies.txt already records a
+-- decision against.
+--
+-- ---------------------------------------------------------------------------
+-- A NOTE FOR S4 THAT m122 GOT HALF RIGHT
+-- ---------------------------------------------------------------------------
+--
+-- m122's header assigns the restore-pointer check to S4 as "refused across an
+-- organisation-stamp boundary" (ADR-064 Decision 12). That is one of TWO
+-- checks, and only that one was written down. The other:
+--
+--   restored_from_version_id CURRENTLY ACCEPTS A UUID NAMING NO ROW THAT EVER
+--   EXISTED. There is no foreign key -- deliberately, because the check that
+--   matters is a cross-row stamp comparison no single-column reference can
+--   express -- so nothing in the database refuses a dangling pointer.
+--
+-- "Refused across a stamp boundary" and "refused when it names nothing" are
+-- different checks with different failure modes. A dangling pointer produces a
+-- version row claiming to be a restore of something unfindable, which
+-- ADR-064 Decision 5's version list renders as an entry whose provenance
+-- cannot be substantiated -- the precise opposite of the attributability
+-- Decision 7 exists to guarantee. S4 must validate BOTH: that the referenced
+-- version exists, and that its stamp matches. Neither is enforced here.
+--
+-- ---------------------------------------------------------------------------
+-- IDEMPOTENCE AND BOOT SAFETY
+-- ---------------------------------------------------------------------------
+--
+-- Both statements are wrapped in pg_policies existence checks, because
+-- PostgreSQL 16 has no CREATE POLICY IF NOT EXISTS. Nothing is dropped, no
+-- existing policy is altered, no row is read or written. Adding a RESTRICTIVE
+-- policy can only ever subtract from what a principal may reach, and for any
+-- transaction that does not set app.site_scope -- every organisation-member
+-- path, every service path, every worker -- the predicate is a tautology and
+-- behaviour is unchanged. migrate.go applies this on boot inside main(), in one
+-- transaction; a second application is a no-op.
+
+-- ---------------------------------------------------------------------------
+-- org_context_versions: the UPDATE gate
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'org_context_versions'
+          AND policyname = 'org_context_versions_site_scope_update'
+    ) THEN
+        CREATE POLICY "org_context_versions_site_scope_update" ON "public"."org_context_versions"
+            AS RESTRICTIVE FOR UPDATE
+            USING (
+                coalesce(current_setting('app.site_scope', true), '') <> 'on'
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- org_context_versions: the DELETE gate
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'org_context_versions'
+          AND policyname = 'org_context_versions_site_scope_delete'
+    ) THEN
+        CREATE POLICY "org_context_versions_site_scope_delete" ON "public"."org_context_versions"
+            AS RESTRICTIVE FOR DELETE
+            USING (
+                coalesce(current_setting('app.site_scope', true), '') <> 'on'
+            );
+    END IF;
+END;
+$$;

--- a/apps/api/tests/adr064_governed_context_rls_integration_test.go
+++ b/apps/api/tests/adr064_governed_context_rls_integration_test.go
@@ -94,6 +94,15 @@ func adr064SeedFixture(t *testing.T, pool *db.Pool, admin *db.Pool) adr064Fixtur
 	f.siteB = adr064SeedSite(t, admin, f.tenant)
 
 	if err := pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		// The fixture must be built by the APPLICATION role, not the superuser
+		// pool. This is the sharper half of the CodeRabbit finding: rows
+		// inserted by an owner or a BYPASSRLS role never run the policies'
+		// WITH CHECK on the way in, so the fixture would prove nothing about
+		// insert-time enforcement and a broken WITH CHECK could ship unnoticed.
+		// Seeding through InTenantTx as wpmgr_app means these very INSERTs are
+		// themselves an assertion that the write path works for a legitimate
+		// principal.
+		adr064AssertUnprivilegedRole(t, tx)
 		if _, e := tx.Exec(ctx,
 			`INSERT INTO org_context_versions
 			   (tenant_id, version, restrictions, guidance, author_type, author_id, provenance)
@@ -129,8 +138,80 @@ func adr064SeedFixture(t *testing.T, pool *db.Pool, admin *db.Pool) adr064Fixtur
 // RESTRICTIVE policy's first branch into a tautology and hands the caller the
 // whole organisation. Every assertion below must go red when that is done; any
 // that still passes is not testing the policy.
-func adr064AsCollaborator(pool *db.Pool, tenant uuid.UUID, sites []uuid.UUID, fn func(tx pgx.Tx) error) error {
-	return pool.InScopedTenantTx(context.Background(), tenant, uuid.Nil, sites, fn)
+func adr064AsCollaborator(t *testing.T, pool *db.Pool, tenant uuid.UUID, sites []uuid.UUID, fn func(tx pgx.Tx) error) error {
+	t.Helper()
+	return pool.InScopedTenantTx(context.Background(), tenant, uuid.Nil, sites, func(tx pgx.Tx) error {
+		// PRECONDITIONS, CHECKED INSIDE THE TRANSACTION THAT MAKES THE CLAIM.
+		// Raised by CodeRabbit on PR #562, and the point is sound even though
+		// both conditions already held: without these, every assertion in this
+		// file is conditional on setup it inherits and never verifies. A harness
+		// change that connected as the owner, or a helper that stopped setting
+		// app.site_scope, would leave the policies inert and the whole file
+		// green -- which is the exact failure this codebase has shipped before.
+		adr064AssertUnprivilegedRole(t, tx)
+		adr064AssertSiteScopeActive(t, tx, sites)
+		return fn(tx)
+	})
+}
+
+// adr064AssertUnprivilegedRole fails the test unless the transaction is running
+// as the real application role.
+//
+// A superuser, or any role holding BYPASSRLS, ignores every policy in this
+// file. Under that role each proof passes without exercising anything, and
+// passes LOUDLY -- there is no symptom to notice. The role is therefore checked
+// from inside the transaction doing the work rather than assumed from how the
+// pool was built.
+func adr064AssertUnprivilegedRole(t *testing.T, tx pgx.Tx) {
+	t.Helper()
+	var role string
+	var super, bypass bool
+	if err := tx.QueryRow(context.Background(),
+		`SELECT current_user, rolsuper, rolbypassrls
+		   FROM pg_roles WHERE rolname = current_user`).Scan(&role, &super, &bypass); err != nil {
+		t.Fatalf("read the connection's own role: %v", err)
+	}
+	if super || bypass {
+		t.Fatalf("this proof is running as %q with rolsuper=%v rolbypassrls=%v. "+
+			"Either one bypasses every RLS policy on these tables, so every assertion "+
+			"in this file would pass without testing anything", role, super, bypass)
+	}
+	if role != "wpmgr_app" {
+		t.Fatalf("this proof is running as %q, not wpmgr_app. wpmgr_app is the role every "+
+			"real install connects as, and the only one these proofs describe", role)
+	}
+}
+
+// adr064AssertSiteScopeActive fails the test unless the site-scope GUCs are
+// actually in force, with the allowlist the caller asked for.
+//
+// InScopedTenantTx sets them with set_config(..., true) -- transaction-local,
+// so they cannot leak between tests on a pooled connection. That is the
+// property being pinned: if the GUC were ever set session-wide, or the helper
+// stopped setting it, the RESTRICTIVE policies' first branch becomes a
+// tautology and every site-scope assertion here silently stops testing a
+// boundary.
+func adr064AssertSiteScopeActive(t *testing.T, tx pgx.Tx, want []uuid.UUID) {
+	t.Helper()
+	var scope, allowed string
+	if err := tx.QueryRow(context.Background(),
+		`SELECT coalesce(current_setting('app.site_scope', true), ''),
+		        coalesce(current_setting('app.allowed_site_ids', true), '')`).
+		Scan(&scope, &allowed); err != nil {
+		t.Fatalf("read the site-scope GUCs: %v", err)
+	}
+	if scope != "on" {
+		t.Fatalf("app.site_scope is %q, want \"on\". The RESTRICTIVE policies short-circuit to a "+
+			"tautology when it is anything else, so this proof would assert nothing", scope)
+	}
+	ids := make([]string, len(want))
+	for i, id := range want {
+		ids[i] = id.String()
+	}
+	if got := strings.Join(ids, ","); allowed != got {
+		t.Fatalf("app.allowed_site_ids is %q, want %q; the collaborator is not scoped to the "+
+			"sites this test believes it granted", allowed, got)
+	}
 }
 
 // These two tables are protected by TWO INDEPENDENT LAYERS, and the whole
@@ -260,7 +341,7 @@ func TestADR064_SiteScope_ReadIsConfinedToTheGrantedSite(t *testing.T) {
 
 	f := adr064SeedFixture(t, pool, admin)
 
-	if err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+	if err := adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
 		if n := adr064CountVisible(t, tx, `SELECT count(*) FROM site_context_versions`); n != 1 {
 			t.Errorf("a collaborator invited to ONE site sees %d site context versions, want 1", n)
 		}
@@ -289,7 +370,7 @@ func TestADR064_SiteScope_CannotAuthorContextForAnotherSite(t *testing.T) {
 	f := adr064SeedFixture(t, pool, admin)
 
 	var insertErr error
-	_ = adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+	_ = adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
 		_, insertErr = tx.Exec(ctx,
 			`INSERT INTO site_context_versions
 			   (tenant_id, site_id, version, restrictions, author_type, author_id, provenance)
@@ -334,7 +415,7 @@ func TestADR064_OrgContext_SiteScopedCollaboratorMayRead(t *testing.T) {
 
 	f := adr064SeedFixture(t, pool, admin)
 
-	if err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+	if err := adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
 		n := adr064CountVisible(t, tx, `SELECT count(*) FROM org_context_versions`)
 		if n != 1 {
 			t.Errorf("a site-scoped collaborator sees %d organisation context versions, want 1. "+
@@ -357,7 +438,7 @@ func TestADR064_OrgContext_SiteScopedCollaboratorCannotAuthor(t *testing.T) {
 	f := adr064SeedFixture(t, pool, admin)
 
 	var insertErr error
-	_ = adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+	_ = adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
 		_, insertErr = tx.Exec(ctx,
 			`INSERT INTO org_context_versions
 			   (tenant_id, version, restrictions, author_type, author_id, provenance)
@@ -580,7 +661,7 @@ func TestADR064_OrgContext_WriteGatesSurviveARestoredGrant(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var affected int64
-			err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+			err := adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
 				tag, e := tx.Exec(ctx, tc.sql)
 				if e != nil {
 					return e
@@ -643,7 +724,7 @@ func TestADR064_SiteContext_WriteGatesSurviveARestoredGrant(t *testing.T) {
 	adr064GrantWriteBack(t, admin)
 
 	var affected int64
-	if err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+	if err := adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
 		tag, e := tx.Exec(ctx,
 			`UPDATE site_context_versions SET guidance = '{"brand_voice":"seized"}'::jsonb
 			  WHERE site_id = $1`, f.siteB)

--- a/apps/api/tests/adr064_governed_context_rls_integration_test.go
+++ b/apps/api/tests/adr064_governed_context_rls_integration_test.go
@@ -774,7 +774,14 @@ func TestADR064_ContextTablesCarryTheExpectedPolicies(t *testing.T) {
 	want := []struct {
 		table, policy, permissive, cmd string
 	}{
+		// Three command-specific gates on the org table, never one FOR ALL:
+		// FOR ALL would be AND-combined onto SELECT and break the layer-2 read
+		// ADR-064 Decision 6 and Decision 8 both require. m122 shipped only the
+		// INSERT one; m123 added UPDATE and DELETE after security review found
+		// the REVOKE was the sole layer behind them.
 		{"org_context_versions", "org_context_versions_site_scope_insert", "RESTRICTIVE", "INSERT"},
+		{"org_context_versions", "org_context_versions_site_scope_update", "RESTRICTIVE", "UPDATE"},
+		{"org_context_versions", "org_context_versions_site_scope_delete", "RESTRICTIVE", "DELETE"},
 		{"org_context_versions", "org_context_versions_tenant_isolation", "PERMISSIVE", "ALL"},
 		{"site_context_versions", "site_context_versions_site_scope", "RESTRICTIVE", "ALL"},
 		{"site_context_versions", "site_context_versions_tenant_isolation", "PERMISSIVE", "ALL"},
@@ -798,6 +805,29 @@ func TestADR064_ContextTablesCarryTheExpectedPolicies(t *testing.T) {
 			t.Errorf("policy %s on %s is %s/%s, want %s/%s",
 				w.policy, w.table, permissive, cmd, w.permissive, w.cmd)
 		}
+	}
+
+	// The ABSENCE of a restrictive SELECT gate on the org table is as
+	// load-bearing as any policy present, so it is asserted rather than left to
+	// a comment somebody will helpfully "complete" one day. A RESTRICTIVE
+	// SELECT policy here -- or a FOR ALL one, which is AND-combined onto SELECT
+	// and amounts to the same thing -- would break ADR-064 Decision 6's
+	// organisation-scope read and Decision 8's effective-context preview for
+	// every site-scoped collaborator, and it would do it silently, because a
+	// USING gate filters rows rather than raising.
+	var restrictiveReadGates int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM pg_policies
+		  WHERE schemaname = 'public' AND tablename = 'org_context_versions'
+		    AND permissive = 'RESTRICTIVE' AND cmd IN ('SELECT', 'ALL')`).
+		Scan(&restrictiveReadGates); err != nil {
+		t.Fatalf("count restrictive read gates: %v", err)
+	}
+	if restrictiveReadGates != 0 {
+		t.Errorf("org_context_versions carries %d RESTRICTIVE policy/policies covering SELECT, want 0. "+
+			"A site-scoped collaborator must be able to READ the organisation context governing "+
+			"their own site; gating that read breaks ADR-064 Decision 6 and Decision 8 at once",
+			restrictiveReadGates)
 	}
 
 	// FORCE matters as much as ENABLE: without it the table owner -- which is

--- a/apps/api/tests/adr064_governed_context_rls_integration_test.go
+++ b/apps/api/tests/adr064_governed_context_rls_integration_test.go
@@ -49,6 +49,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -132,19 +133,46 @@ func adr064AsCollaborator(pool *db.Pool, tenant uuid.UUID, sites []uuid.UUID, fn
 	return pool.InScopedTenantTx(context.Background(), tenant, uuid.Nil, sites, fn)
 }
 
-// adr064IsRefusal reports whether err is Postgres refusing the statement
-// itself, rather than the statement failing for some unrelated reason.
+// These two tables are protected by TWO INDEPENDENT LAYERS, and the whole
+// point of the pair is that neither is load-bearing alone. Postgres reports
+// both as SQLSTATE 42501 insufficient_privilege, so the code is NOT enough to
+// tell them apart and a helper that checks only the code proves whichever one
+// happens to fire.
 //
-//	42501 insufficient_privilege -- a RESTRICTIVE policy's WITH CHECK, and also
-//	      a missing table privilege (the append-only REVOKE).
+// That is not hypothetical. The org table shipped with an RLS gate on INSERT
+// alone; UPDATE and DELETE were held off only by the REVOKE, and a test that
+// accepted any 42501 passed on the privilege layer while there was no policy
+// layer behind it at all. The messages differ, and were read off
+// postgres:16-alpine rather than assumed:
 //
-// A USING clause refuses by filtering rows instead, so the ordinary refusal on
-// a read is zero rows and no error at all. Counting any other SQLSTATE as a
-// refusal would let an assertion pass because the statement never reached the
-// policy.
-func adr064IsRefusal(err error) bool {
+//	policy    ERROR: new row violates row-level security policy "x" for table "t"
+//	privilege ERROR: permission denied for table t
+//
+// A third shape has no error at all: a RESTRICTIVE policy's USING clause on
+// UPDATE or DELETE FILTERS rows rather than raising, so the refusal is
+// "0 rows affected" and a successful-looking command tag. Proofs of a USING
+// gate must therefore assert RowsAffected, never an error -- see
+// adr064AssertNoRowsTouched.
+
+// adr064IsRowSecurityRefusal reports whether err is a POLICY refusing the row.
+// This is the assertion to make when the privilege is genuinely held, so that
+// the only thing left to refuse is row security.
+func adr064IsRowSecurityRefusal(err error) bool {
 	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == "42501"
+	if !errors.As(err, &pgErr) || pgErr.Code != "42501" {
+		return false
+	}
+	return strings.Contains(pgErr.Message, "row-level security policy")
+}
+
+// adr064IsPermissionDenied reports whether err is the GRANT layer refusing --
+// the append-only REVOKE, not a policy.
+func adr064IsPermissionDenied(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "42501" {
+		return false
+	}
+	return strings.Contains(pgErr.Message, "permission denied")
 }
 
 // adr064CountVisible counts rows the given transaction can actually see.
@@ -273,10 +301,11 @@ func TestADR064_SiteScope_CannotAuthorContextForAnotherSite(t *testing.T) {
 		t.Error("a collaborator invited to siteA authored a context version for siteB. " +
 			"The RESTRICTIVE policy's WITH CHECK is missing or permissive, and a lower-privileged " +
 			"principal can now rewrite the rules another site's model-facing surface runs under")
-	} else if !adr064IsRefusal(insertErr) {
-		t.Fatalf("the INSERT was not refused by policy, it FAILED for another reason: %v.\n"+
-			"Only SQLSTATE 42501 is Postgres refusing the write; counting anything else as a "+
-			"refusal would let this assertion pass without testing the policy", insertErr)
+	} else if !adr064IsRowSecurityRefusal(insertErr) {
+		t.Fatalf("the INSERT was not refused by ROW SECURITY, it failed for another reason: %v.\n"+
+			"wpmgr_app holds INSERT on this table, so a permission-denied here would mean the "+
+			"grant refused it and the policy was never reached -- which would let this assertion "+
+			"pass without testing the policy at all", insertErr)
 	}
 
 	var n int
@@ -343,8 +372,9 @@ func TestADR064_OrgContext_SiteScopedCollaboratorCannotAuthor(t *testing.T) {
 			"principal that can write layer 2 does not need to widen anything -- it becomes the " +
 			"higher layer for every site in the organisation")
 	}
-	if !adr064IsRefusal(insertErr) {
-		t.Fatalf("the INSERT was not refused by policy, it FAILED for another reason: %v", insertErr)
+	if !adr064IsRowSecurityRefusal(insertErr) {
+		t.Fatalf("the INSERT was not refused by ROW SECURITY, it failed for another reason: %v.\n"+
+			"wpmgr_app holds INSERT on this table, so this must be the policy refusing", insertErr)
 	}
 
 	var n int
@@ -435,8 +465,12 @@ func TestADR064_HistoryIsAppendOnlyForTheApplicationRole(t *testing.T) {
 					"auditor can prove what instruction set a model was given at a point in time -- "+
 					"unprovable", tc.sql)
 			}
-			if !adr064IsRefusal(execErr) {
-				t.Fatalf("%q did not fail with insufficient_privilege but with: %v.\n"+
+			// This test is specifically about the PRIVILEGE layer, so it asserts
+			// permission-denied rather than any 42501. The policy layer behind it
+			// is proved separately, with the privileges granted back, by
+			// TestADR064_OrgContext_WriteGatesSurviveARestoredGrant.
+			if !adr064IsPermissionDenied(execErr) {
+				t.Fatalf("%q did not fail with permission denied but with: %v.\n"+
 					"Some other failure would let this assertion pass while the REVOKE was absent",
 					tc.sql, execErr)
 			}
@@ -451,6 +485,184 @@ func TestADR064_HistoryIsAppendOnlyForTheApplicationRole(t *testing.T) {
 	}
 	if n != 2 {
 		t.Errorf("%d site context versions survive the mutation attempts, want 2", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5b. The org table's write gates must survive the privileges coming back
+//
+// FOUND BY SECURITY REVIEW ON PR #562, and this test is the reason the finding
+// cannot return.
+//
+// org_context_versions originally carried a RESTRICTIVE gate on INSERT alone,
+// on the reasoning that the table is append-only so INSERT is the entire write
+// surface. That reasoning was wrong in a specific way: it is the REVOKE that
+// makes INSERT the whole write surface, so the argument quietly made the REVOKE
+// the ONLY layer. The site table never depended on that luck -- its policy is
+// FOR ALL.
+//
+// The review granted UPDATE and DELETE back and found:
+//
+//	ORG  UPDATE by site-scoped principal -> SUCCEEDED, 1 row(s)
+//	ORG  DELETE by site-scoped principal -> SUCCEEDED, 1 row(s)
+//	SITE UPDATE of a sibling site        -> refused, 0 row(s)
+//
+// A blanket "GRANT ... ON ALL TABLES IN SCHEMA public TO wpmgr_app" is not an
+// exotic hypothetical: m1:120 already contains that exact statement, and the
+// harness in rls_integration_test.go runs it on every startPostgres. Any future
+// migration or operator runbook repeating it silently re-arms the gap.
+//
+// So this test does what the reviewer did. It grants the privileges back and
+// then asserts the POLICY refuses, which is the only assertion that can tell a
+// real gate from an absent one.
+//
+// WHY THE ASSERTION IS ROWS-AFFECTED AND NOT AN ERROR. A RESTRICTIVE policy's
+// USING clause filters rows rather than raising: with the privilege held and
+// the policy in place, the UPDATE succeeds and reports 0 rows. That is the
+// #470 silence shape appearing as the CORRECT outcome, so the test reads the
+// command tag and then re-reads the row to prove it is genuinely untouched.
+// ---------------------------------------------------------------------------
+
+// adr064GrantWriteBack restores UPDATE and DELETE on the two context tables,
+// simulating a future blanket GRANT, and revokes them again on cleanup.
+//
+// startPostgres gives every test its own container (tcpostgres.Run, terminated
+// by t.Cleanup), so this cannot leak into another test even without the
+// restore. The restore is here anyway, because a grant that outlived its test
+// would make the append-only proofs above pass or fail for reasons belonging to
+// this one.
+func adr064GrantWriteBack(t *testing.T, admin *db.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	for _, tbl := range []string{"org_context_versions", "site_context_versions"} {
+		if _, err := admin.Exec(ctx,
+			"GRANT UPDATE, DELETE ON "+tbl+" TO wpmgr_app"); err != nil {
+			t.Fatalf("grant write back on %s: %v", tbl, err)
+		}
+		t.Cleanup(func() {
+			_, _ = admin.Exec(context.Background(),
+				"REVOKE UPDATE, DELETE ON "+tbl+" FROM wpmgr_app")
+		})
+	}
+
+	// The grant must actually have landed, or every assertion below passes on
+	// permission-denied and proves nothing -- which is the exact failure this
+	// whole test exists to rule out.
+	var canUpdate bool
+	if err := admin.QueryRow(ctx,
+		`SELECT has_table_privilege('wpmgr_app', 'org_context_versions', 'UPDATE')`).
+		Scan(&canUpdate); err != nil {
+		t.Fatalf("check restored privilege: %v", err)
+	}
+	if !canUpdate {
+		t.Fatal("wpmgr_app still lacks UPDATE after the GRANT; this test would pass on " +
+			"permission-denied without ever reaching a policy")
+	}
+}
+
+func TestADR064_OrgContext_WriteGatesSurviveARestoredGrant(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+	adr064GrantWriteBack(t, admin)
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"update", `UPDATE org_context_versions SET guidance = '{"brand_voice":"seized"}'::jsonb`},
+		{"delete", `DELETE FROM org_context_versions`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var affected int64
+			err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+				tag, e := tx.Exec(ctx, tc.sql)
+				if e != nil {
+					return e
+				}
+				affected = tag.RowsAffected()
+				return nil
+			})
+			if err != nil {
+				// An error is acceptable ONLY if it is row security. It must not
+				// be permission-denied: the grant is back, so that would mean the
+				// test never reached a policy.
+				if adr064IsPermissionDenied(err) {
+					t.Fatalf("%q was refused by the GRANT layer, not by a policy: %v.\n"+
+						"adr064GrantWriteBack was supposed to restore the privilege; with it "+
+						"absent this assertion proves nothing about row security", tc.sql, err)
+				}
+				if !adr064IsRowSecurityRefusal(err) {
+					t.Fatalf("%q failed for an unrelated reason: %v", tc.sql, err)
+				}
+				return
+			}
+			if affected != 0 {
+				t.Fatalf("%q by a SITE-SCOPED principal affected %d organisation context row(s), "+
+					"want 0.\nThe REVOKE is not a substitute for a policy: a blanket "+
+					"GRANT ... ON ALL TABLES (m1:120 contains that statement, and the test harness "+
+					"runs it) hands the privilege straight back, and with no RESTRICTIVE gate on "+
+					"this command a per-site collaborator can rewrite or destroy the organisation's "+
+					"governing context for every site in it", tc.sql, affected)
+			}
+		})
+	}
+
+	// The rows are genuinely untouched -- not merely unreported.
+	var n int
+	var guidance string
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*), coalesce(max(guidance ->> 'brand_voice'), '')
+		   FROM org_context_versions WHERE tenant_id = $1`, f.tenant).Scan(&n, &guidance); err != nil {
+		t.Fatalf("read back org context: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("the organisation has %d context versions after the attack, want the 1 it started with", n)
+	}
+	if guidance != "org-level house style" {
+		t.Errorf("organisation guidance is now %q, want it unchanged at %q",
+			guidance, "org-level house style")
+	}
+}
+
+// The site table's FOR ALL policy must hold under the same restored grant. This
+// is the control: it passed in the review while the org table failed, and if it
+// ever stops passing the two tables have diverged again.
+func TestADR064_SiteContext_WriteGatesSurviveARestoredGrant(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+	adr064GrantWriteBack(t, admin)
+
+	var affected int64
+	if err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx,
+			`UPDATE site_context_versions SET guidance = '{"brand_voice":"seized"}'::jsonb
+			  WHERE site_id = $1`, f.siteB)
+		if e != nil {
+			return e
+		}
+		affected = tag.RowsAffected()
+		return nil
+	}); err != nil {
+		if adr064IsPermissionDenied(err) {
+			t.Fatalf("refused by the GRANT layer, not a policy: %v", err)
+		}
+		if !adr064IsRowSecurityRefusal(err) {
+			t.Fatalf("failed for an unrelated reason: %v", err)
+		}
+		return
+	}
+	if affected != 0 {
+		t.Fatalf("a collaborator invited to siteA rewrote %d of siteB's context rows, want 0", affected)
 	}
 }
 

--- a/apps/api/tests/adr064_governed_context_rls_integration_test.go
+++ b/apps/api/tests/adr064_governed_context_rls_integration_test.go
@@ -1,0 +1,605 @@
+// adr064_governed_context_rls_integration_test.go: the tenancy, site-scope and
+// append-only properties of m122's two context tables, asserted against the
+// REAL schema (migrations + RLS) as a NON-SUPERUSER role.
+//
+// WHAT IS BEING PROTECTED. org_context_versions and site_context_versions hold
+// the human-authored instructions ADR-064 hands to a model-facing surface:
+// what it may do, what it may never do, and how it should speak for a client.
+// Two distinct escalations are possible if the database has no opinion, and
+// they are NOT the same escalation:
+//
+//   READ   a collaborator invited to exactly one site reading another site's
+//          context learns that site's brand rules, its terminology and, more
+//          to the point, the named boundaries its operator set.
+//   WRITE  a collaborator AUTHORING context for a site or an organisation they
+//          do not hold is the serious one. ADR-064 Decision 1's whole design
+//          rests on "a lower layer can never widen a higher one"; a
+//          site-scoped principal that can write the ORGANISATION's layer-2 row
+//          does not need to widen anything, because it simply becomes the
+//          higher layer. That is m112's defect class exactly -- a per-site
+//          principal reaching the organisation row -- which took three review
+//          rounds and seven handler fixes to close for the email domain before
+//          the fourth round worked out that the handlers were not the problem.
+//
+// So the write assertions matter at least as much as the read ones, and the
+// org-table assertions matter more than the site-table ones.
+//
+// HOW IT IS TESTED. Every read and every write goes through the real
+// transaction wrappers production uses -- db.Pool.InTenantTx for an ordinary
+// organisation member and db.Pool.InScopedTenantTx for a site-scoped
+// collaborator, which is what db.Pool.RunTenantTx dispatches to for
+// Scope == "site". GUCs are never hand-set. A test that opened its own
+// connection, or set app.site_scope itself, would leave every policy in this
+// file inert and pass while testing nothing; that has happened in this
+// codebase before.
+//
+// The rows under attack are seeded through InTenantTx as wpmgr_app rather than
+// inserted by the superuser pool, so the fixture itself exercises the policies'
+// WITH CHECK on the way in. There is no repository layer to seed through yet:
+// ADR-064's S4 (the resolution function, the widen-check, the secret scan and
+// the fail-closed audit append) is backend-architect's and lands on top of
+// this migration. When it exists, the seeds below should move onto it.
+//
+// The non-superuser role is load-bearing and not incidental: a superuser, or
+// any role with BYPASSRLS, ignores every policy in this file and all of it
+// would pass vacuously. startPostgres provisions the plain wpmgr_app role
+// (NOSUPERUSER NOBYPASSRLS, created in the m1 auth migration).
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+type adr064Fixture struct {
+	tenant       uuid.UUID
+	siteA, siteB uuid.UUID
+}
+
+func adr064SeedSite(t *testing.T, admin *db.Pool, tenant uuid.UUID) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := admin.QueryRow(context.Background(),
+		`INSERT INTO sites (tenant_id, url, name) VALUES ($1, $2, 'adr064') RETURNING id`,
+		tenant, "https://"+uuid.NewString()+".example.com").Scan(&id); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+	return id
+}
+
+// adr064SeedFixture builds one organisation with two sites, and gives the
+// organisation and both sites a version-1 context row.
+//
+// The seeds run through InTenantTx as wpmgr_app -- the wrapper an ordinary
+// organisation member gets -- so the rows arrive the way production would write
+// them, past the same tenant_isolation WITH CHECK.
+func adr064SeedFixture(t *testing.T, pool *db.Pool, admin *db.Pool) adr064Fixture {
+	t.Helper()
+	ctx := context.Background()
+
+	f := adr064Fixture{tenant: seedTenant(t, pool, "adr064-"+uuid.NewString()[:8])}
+	f.siteA = adr064SeedSite(t, admin, f.tenant)
+	f.siteB = adr064SeedSite(t, admin, f.tenant)
+
+	if err := pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		if _, e := tx.Exec(ctx,
+			`INSERT INTO org_context_versions
+			   (tenant_id, version, restrictions, guidance, author_type, author_id, provenance)
+			 VALUES ($1, 1, $2, $3, 'system', NULL, 'manual')`,
+			f.tenant,
+			`{"never_publish": true}`,
+			`{"brand_voice": "org-level house style"}`); e != nil {
+			return e
+		}
+		for _, s := range []uuid.UUID{f.siteA, f.siteB} {
+			if _, e := tx.Exec(ctx,
+				`INSERT INTO site_context_versions
+				   (tenant_id, site_id, version, restrictions, guidance, author_type, author_id, provenance)
+				 VALUES ($1, $2, 1, $3, $4, 'system', NULL, 'manual')`,
+				f.tenant, s,
+				`{"never_touch_theme": true}`,
+				`{"brand_voice": "site-level house style"}`); e != nil {
+				return e
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed context rows: %v", err)
+	}
+	return f
+}
+
+// adr064AsCollaborator runs fn under the exact GUCs a site-scoped collaborator
+// granted only `sites` gets in production.
+//
+// THIS IS THE MUTATION POINT for this file. Swapping InScopedTenantTx for the
+// unscoped pool.InTenantTx leaves app.site_scope unset, which turns every
+// RESTRICTIVE policy's first branch into a tautology and hands the caller the
+// whole organisation. Every assertion below must go red when that is done; any
+// that still passes is not testing the policy.
+func adr064AsCollaborator(pool *db.Pool, tenant uuid.UUID, sites []uuid.UUID, fn func(tx pgx.Tx) error) error {
+	return pool.InScopedTenantTx(context.Background(), tenant, uuid.Nil, sites, fn)
+}
+
+// adr064IsRefusal reports whether err is Postgres refusing the statement
+// itself, rather than the statement failing for some unrelated reason.
+//
+//	42501 insufficient_privilege -- a RESTRICTIVE policy's WITH CHECK, and also
+//	      a missing table privilege (the append-only REVOKE).
+//
+// A USING clause refuses by filtering rows instead, so the ordinary refusal on
+// a read is zero rows and no error at all. Counting any other SQLSTATE as a
+// refusal would let an assertion pass because the statement never reached the
+// policy.
+func adr064IsRefusal(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "42501"
+}
+
+// adr064CountVisible counts rows the given transaction can actually see.
+func adr064CountVisible(t *testing.T, tx pgx.Tx, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := tx.QueryRow(context.Background(), query, args...).Scan(&n); err != nil {
+		t.Fatalf("count query failed rather than returning a count: %v", err)
+	}
+	return n
+}
+
+// ---------------------------------------------------------------------------
+// 1. Tenant isolation, both tables
+// ---------------------------------------------------------------------------
+
+func TestADR064_TenantIsolation_AnotherOrgSeesNoContext(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+	other := seedTenant(t, pool, "adr064-other-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, other, func(tx pgx.Tx) error {
+		if n := adr064CountVisible(t, tx,
+			`SELECT count(*) FROM org_context_versions WHERE tenant_id = $1`, f.tenant); n != 0 {
+			t.Errorf("another organisation reads %d of this organisation's context versions, want 0", n)
+		}
+		if n := adr064CountVisible(t, tx,
+			`SELECT count(*) FROM site_context_versions WHERE tenant_id = $1`, f.tenant); n != 0 {
+			t.Errorf("another organisation reads %d of this organisation's site context versions, want 0", n)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("other-tenant tx: %v", err)
+	}
+}
+
+// A neighbouring organisation must not be able to AUTHOR context for someone
+// else's site either. tenant_isolation's WITH CHECK is what refuses this.
+func TestADR064_TenantIsolation_AnotherOrgCannotAuthorContext(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+	other := seedTenant(t, pool, "adr064-other-"+uuid.NewString()[:8])
+
+	var insertErr error
+	_ = pool.InTenantTx(ctx, other, func(tx pgx.Tx) error {
+		_, insertErr = tx.Exec(ctx,
+			`INSERT INTO site_context_versions
+			   (tenant_id, site_id, version, author_type, author_id, provenance)
+			 VALUES ($1, $2, 99, 'system', NULL, 'manual')`,
+			f.tenant, f.siteA)
+		return insertErr
+	})
+	if insertErr == nil {
+		t.Error("a neighbouring organisation authored a context version for another " +
+			"organisation's site; tenant_isolation's WITH CHECK is missing or permissive")
+	}
+
+	var n int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM site_context_versions WHERE site_id = $1 AND version = 99`,
+		f.siteA).Scan(&n); err != nil {
+		t.Fatalf("read back forged rows: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("%d forged context version(s) exist for another organisation's site", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Site scope on site_context_versions -- the m19/m113 shape
+// ---------------------------------------------------------------------------
+
+func TestADR064_SiteScope_ReadIsConfinedToTheGrantedSite(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	if err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+		if n := adr064CountVisible(t, tx, `SELECT count(*) FROM site_context_versions`); n != 1 {
+			t.Errorf("a collaborator invited to ONE site sees %d site context versions, want 1", n)
+		}
+		if n := adr064CountVisible(t, tx,
+			`SELECT count(*) FROM site_context_versions WHERE site_id = $1`, f.siteB); n != 0 {
+			t.Errorf("a collaborator invited to siteA read %d of siteB's context versions. "+
+				"site_context_versions is site-keyed, so tenant isolation alone is not the boundary", n)
+		}
+		// Their own site is still readable, so the policy filters rather than blocks.
+		if n := adr064CountVisible(t, tx,
+			`SELECT count(*) FROM site_context_versions WHERE site_id = $1`, f.siteA); n != 1 {
+			t.Errorf("a collaborator cannot read their OWN site's context (%d rows, want 1)", n)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("collaborator read: %v", err)
+	}
+}
+
+func TestADR064_SiteScope_CannotAuthorContextForAnotherSite(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	var insertErr error
+	_ = adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+		_, insertErr = tx.Exec(ctx,
+			`INSERT INTO site_context_versions
+			   (tenant_id, site_id, version, restrictions, author_type, author_id, provenance)
+			 VALUES ($1, $2, 2, $3, 'system', NULL, 'manual')`,
+			f.tenant, f.siteB, `{"never_touch_theme": false}`)
+		return insertErr
+	})
+	if insertErr == nil {
+		t.Error("a collaborator invited to siteA authored a context version for siteB. " +
+			"The RESTRICTIVE policy's WITH CHECK is missing or permissive, and a lower-privileged " +
+			"principal can now rewrite the rules another site's model-facing surface runs under")
+	} else if !adr064IsRefusal(insertErr) {
+		t.Fatalf("the INSERT was not refused by policy, it FAILED for another reason: %v.\n"+
+			"Only SQLSTATE 42501 is Postgres refusing the write; counting anything else as a "+
+			"refusal would let this assertion pass without testing the policy", insertErr)
+	}
+
+	var n int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM site_context_versions WHERE site_id = $1`, f.siteB).Scan(&n); err != nil {
+		t.Fatalf("read back siteB: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("siteB has %d context versions after the attack, want the 1 it started with", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. The org table: READ permitted, WRITE refused
+//
+// This pair is the reason org_context_versions_site_scope_insert exists, and
+// the two halves must be asserted together. A policy that refused the write by
+// also refusing the read would pass the second test and silently break the
+// layer-2 read ADR-064 Decision 6 and Decision 8 both require.
+// ---------------------------------------------------------------------------
+
+func TestADR064_OrgContext_SiteScopedCollaboratorMayRead(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	if err := adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+		n := adr064CountVisible(t, tx, `SELECT count(*) FROM org_context_versions`)
+		if n != 1 {
+			t.Errorf("a site-scoped collaborator sees %d organisation context versions, want 1. "+
+				"ADR-064 Decision 6 gives read access at the organisation AND site scope covering "+
+				"their site, and Decision 8's effective-context preview renders layer 2; a "+
+				"restrictive SELECT gate on this table would break both", n)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("collaborator org read: %v", err)
+	}
+}
+
+func TestADR064_OrgContext_SiteScopedCollaboratorCannotAuthor(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	var insertErr error
+	_ = adr064AsCollaborator(pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+		_, insertErr = tx.Exec(ctx,
+			`INSERT INTO org_context_versions
+			   (tenant_id, version, restrictions, author_type, author_id, provenance)
+			 VALUES ($1, 2, $2, 'system', NULL, 'manual')`,
+			f.tenant, `{"never_publish": false}`)
+		return insertErr
+	})
+	if insertErr == nil {
+		t.Fatal("a site-scoped collaborator authored an ORGANISATION context version. " +
+			"This is m112's defect class: a per-site principal reaching the organisation row. " +
+			"ADR-064 Decision 1 rests on a lower layer never widening a higher one, and a " +
+			"principal that can write layer 2 does not need to widen anything -- it becomes the " +
+			"higher layer for every site in the organisation")
+	}
+	if !adr064IsRefusal(insertErr) {
+		t.Fatalf("the INSERT was not refused by policy, it FAILED for another reason: %v", insertErr)
+	}
+
+	var n int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM org_context_versions WHERE tenant_id = $1`, f.tenant).Scan(&n); err != nil {
+		t.Fatalf("read back org versions: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("the organisation has %d context versions after the attack, want the 1 it started with", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. The restrictive policies must only ever SUBTRACT
+//
+// A policy that reddens correct work gets switched off, and then it guards
+// nothing. This is the over-fire half.
+// ---------------------------------------------------------------------------
+
+func TestADR064_OrdinaryOrgMemberIsUnaffected(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	if err := pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+		if n := adr064CountVisible(t, tx, `SELECT count(*) FROM site_context_versions`); n != 2 {
+			t.Errorf("an ordinary organisation member sees %d site context versions, want 2; "+
+				"the restrictive policy is subtracting from a principal it must not touch", n)
+		}
+		if n := adr064CountVisible(t, tx, `SELECT count(*) FROM org_context_versions`); n != 1 {
+			t.Errorf("an ordinary organisation member sees %d organisation context versions, want 1", n)
+		}
+		// And they can still author both layers -- the seeds already proved the
+		// site table, so prove the org table's INSERT is not blocked for them.
+		_, e := tx.Exec(ctx,
+			`INSERT INTO org_context_versions
+			   (tenant_id, version, author_type, author_id, provenance)
+			 VALUES ($1, 2, 'system', NULL, 'manual')`, f.tenant)
+		return e
+	}); err != nil {
+		t.Fatalf("an ordinary organisation member could not author organisation context: %v.\n"+
+			"org_context_versions_site_scope_insert is RESTRICTIVE and must be a tautology when "+
+			"app.site_scope is unset; if it is refusing here it is refusing every real write", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Append-only, enforced by PRIVILEGE
+//
+// ADR-064 requires UPDATE/DELETE revoked from the application role "the same
+// way the audit log already enforces append-only". A policy would not be
+// enough: policies filter rows, and a caller holding UPDATE could still
+// rewrite the rows it CAN see -- which for an ordinary organisation member is
+// its own entire history.
+// ---------------------------------------------------------------------------
+
+func TestADR064_HistoryIsAppendOnlyForTheApplicationRole(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"update org context", `UPDATE org_context_versions SET guidance = '{}'::jsonb`},
+		{"delete org context", `DELETE FROM org_context_versions`},
+		{"update site context", `UPDATE site_context_versions SET guidance = '{}'::jsonb`},
+		{"delete site context", `DELETE FROM site_context_versions`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var execErr error
+			_ = pool.InTenantTx(ctx, f.tenant, func(tx pgx.Tx) error {
+				_, execErr = tx.Exec(ctx, tc.sql)
+				return execErr
+			})
+			if execErr == nil {
+				t.Fatalf("%q succeeded as wpmgr_app. Context history is append-only by ADR-064's "+
+					"own requirement, and an editable history makes Decision 7's claim -- that an "+
+					"auditor can prove what instruction set a model was given at a point in time -- "+
+					"unprovable", tc.sql)
+			}
+			if !adr064IsRefusal(execErr) {
+				t.Fatalf("%q did not fail with insufficient_privilege but with: %v.\n"+
+					"Some other failure would let this assertion pass while the REVOKE was absent",
+					tc.sql, execErr)
+			}
+		})
+	}
+
+	// The rows are genuinely still there.
+	var n int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM site_context_versions WHERE tenant_id = $1`, f.tenant).Scan(&n); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("%d site context versions survive the mutation attempts, want 2", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. The tenant cascade frees both tables -- including on the Lane A path,
+//    which blanks app.tenant_id first
+//
+// ADR-064 Decision 12 says context rides "the same tenant-purge path every
+// other tenant-scoped table rides". Both purge functions are cascade-driven and
+// name no tables, so this is the only thing standing behind that sentence.
+//
+// The blank-GUC half is the one worth having. admin_delete_empty_tenant blanks
+// app.tenant_id to '' BEFORE deleting the tenants row (m116), and under FORCE
+// ROW LEVEL SECURITY these tables' tenant_isolation policy matches nothing when
+// that GUC is blank. If referential actions did NOT bypass row security, the
+// cascade would be refused and an organisation with context would become
+// undeletable. They do bypass it -- and this test is what keeps that true
+// rather than assumed, on whatever PostgreSQL the fleet actually runs.
+// ---------------------------------------------------------------------------
+
+func TestADR064_TenantDeleteCascadesBothContextTables(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	var before int
+	if err := admin.QueryRow(ctx,
+		`SELECT (SELECT count(*) FROM org_context_versions  WHERE tenant_id = $1)
+		      + (SELECT count(*) FROM site_context_versions WHERE tenant_id = $1)`,
+		f.tenant).Scan(&before); err != nil {
+		t.Fatalf("count before: %v", err)
+	}
+	if before != 3 {
+		t.Fatalf("fixture has %d context rows, want 3; this test would prove nothing", before)
+	}
+
+	// Delete the tenant with app.tenant_id BLANK, which is what Lane A does.
+	if _, err := admin.Exec(ctx, `SELECT set_config('app.tenant_id', '', false)`); err != nil {
+		t.Fatalf("blank the guc: %v", err)
+	}
+	if _, err := admin.Exec(ctx, `DELETE FROM tenants WHERE id = $1`, f.tenant); err != nil {
+		t.Fatalf("deleting a tenant that owns context rows failed: %v.\n"+
+			"If this is a foreign-key violation, the cascade onto the context tables was refused "+
+			"by their own RLS and an organisation with context cannot be deleted at all", err)
+	}
+
+	var after int
+	if err := admin.QueryRow(ctx,
+		`SELECT (SELECT count(*) FROM org_context_versions  WHERE tenant_id = $1)
+		      + (SELECT count(*) FROM site_context_versions WHERE tenant_id = $1)`,
+		f.tenant).Scan(&after); err != nil {
+		t.Fatalf("count after: %v", err)
+	}
+	if after != 0 {
+		t.Errorf("%d context rows survive the tenant delete, want 0. ADR-064 Decision 12 frees "+
+			"context with the organisation; surviving rows are an organisation's governing "+
+			"instructions outliving the organisation itself", after)
+	}
+}
+
+// The site-level cascade, separately: deleting one site must free that site's
+// context and leave its sibling's alone.
+func TestADR064_SiteDeleteCascadesOnlyThatSitesContext(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	if _, err := admin.Exec(ctx, `DELETE FROM sites WHERE id = $1`, f.siteA); err != nil {
+		t.Fatalf("delete siteA: %v", err)
+	}
+
+	var a, b int
+	if err := admin.QueryRow(ctx,
+		`SELECT (SELECT count(*) FROM site_context_versions WHERE site_id = $1),
+		        (SELECT count(*) FROM site_context_versions WHERE site_id = $2)`,
+		f.siteA, f.siteB).Scan(&a, &b); err != nil {
+		t.Fatalf("count after site delete: %v", err)
+	}
+	if a != 0 {
+		t.Errorf("%d context rows survive their site's deletion, want 0", a)
+	}
+	if b != 1 {
+		t.Errorf("deleting siteA took %d of siteB's context rows with it; want siteB left at 1", 1-b)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. The policies are actually the shape m122 says they are
+//
+// An anti-drift assertion read off pg_policies rather than off the migration
+// text, so a later migration that DROPs or widens one of these is caught here
+// and not in a review. The org table's gate being FOR INSERT rather than FOR
+// ALL is the load-bearing detail: FOR ALL would AND itself onto SELECT and
+// break the layer-2 read.
+// ---------------------------------------------------------------------------
+
+func TestADR064_ContextTablesCarryTheExpectedPolicies(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	want := []struct {
+		table, policy, permissive, cmd string
+	}{
+		{"org_context_versions", "org_context_versions_site_scope_insert", "RESTRICTIVE", "INSERT"},
+		{"org_context_versions", "org_context_versions_tenant_isolation", "PERMISSIVE", "ALL"},
+		{"site_context_versions", "site_context_versions_site_scope", "RESTRICTIVE", "ALL"},
+		{"site_context_versions", "site_context_versions_tenant_isolation", "PERMISSIVE", "ALL"},
+	}
+
+	for _, w := range want {
+		var permissive, cmd string
+		err := admin.QueryRow(ctx,
+			`SELECT permissive, cmd FROM pg_policies
+			  WHERE schemaname = 'public' AND tablename = $1 AND policyname = $2`,
+			w.table, w.policy).Scan(&permissive, &cmd)
+		if errors.Is(err, pgx.ErrNoRows) {
+			t.Errorf("policy %s on %s does not exist. A missing policy is not the same fact as "+
+				"a renamed one, and neither reads as 'this table needs no policy'", w.policy, w.table)
+			continue
+		}
+		if err != nil {
+			t.Fatalf("read pg_policies for %s: %v", w.policy, err)
+		}
+		if permissive != w.permissive || cmd != w.cmd {
+			t.Errorf("policy %s on %s is %s/%s, want %s/%s",
+				w.policy, w.table, permissive, cmd, w.permissive, w.cmd)
+		}
+	}
+
+	// FORCE matters as much as ENABLE: without it the table owner -- which is
+	// the role the application connects as in some deployments -- skips every
+	// policy above.
+	for _, tbl := range []string{"org_context_versions", "site_context_versions"} {
+		var enabled, forced bool
+		if err := admin.QueryRow(ctx,
+			`SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE relname = $1`,
+			tbl).Scan(&enabled, &forced); err != nil {
+			t.Fatalf("read pg_class for %s: %v", tbl, err)
+		}
+		if !enabled || !forced {
+			t.Errorf("%s has RLS enabled=%v forced=%v, want both true", tbl, enabled, forced)
+		}
+	}
+}

--- a/apps/api/tests/rls_integration_test.go
+++ b/apps/api/tests/rls_integration_test.go
@@ -170,6 +170,14 @@ func startPostgres(t *testing.T) *db.Pool {
 		// audit_log is append-only: re-revoke mutation in case the blanket grant
 		// above re-added it.
 		"REVOKE UPDATE, DELETE, TRUNCATE ON audit_log FROM wpmgr_app",
+		// The m122/ADR-064 context tables are append-only for the same reason
+		// and by the same mechanism, so they need the same re-revoke. Without
+		// these two lines the blanket GRANT above hands wpmgr_app an UPDATE it
+		// does not hold in production, and every test in this package would run
+		// against privileges no real install has -- including the append-only
+		// proofs, which would then pass by testing nothing.
+		"REVOKE UPDATE, DELETE, TRUNCATE ON org_context_versions FROM wpmgr_app",
+		"REVOKE UPDATE, DELETE, TRUNCATE ON site_context_versions FROM wpmgr_app",
 	} {
 		if _, err := adminPool.Exec(ctx, stmt); err != nil {
 			setupFatalf(t, err, "postgres: provision app role ("+stmt+")")


### PR DESCRIPTION
ADR-064 slice **S3**: give governed per-organisation and per-site context a home.

Specification: `docs/adr/ADR-064-governed-site-org-context.md` (Status: Proposed).

## Scope

**Storage only**, in the m117 sense — two tables, their constraints, indexes, RLS and grants. No route reads them, no service writes them, no worker touches them. Every existing database lands with both tables empty, and empty is the correct and complete state for every organisation that has never authored context.

**The API side is not forgotten — it is deliberately out of scope.** ADR-064's S4 belongs to `backend-architect` and lands on top of this: the seven-layer resolution function, the write-time widen check, the secret scan (Decision 10), the fail-closed audit append (Decision 7), the effective-context preview (Decision 8), the `context.*` capabilities (Decision 6) and the Decision 13 routes. There are also **no `db/query/*.sql` files in this PR** — every query shape embeds an API contract decision, and ADR-064's open question 2 (PATCH concurrency) is explicitly unmade and assigned to `backend-architect`. Writing the queries now would pre-commit a choice the ADR says is not settled. The migration header carries a `WHAT S4 MUST DO` section listing each requirement.

## The tables

Both are **append-only version logs**, not settings rows. ADR-064 Decision 3 defines "the current context" as "the latest version row", a read rather than a second mutable representation, so restore and diff never have two copies of the present to keep in sync.

| | `org_context_versions` (layer 2) | `site_context_versions` (layer 3) |
|---|---|---|
| subject key | `tenant_id` | `site_id` + stamped `tenant_id` |
| version | `bigint`, unique per `tenant_id` | `bigint`, unique per `site_id` |
| content | `restrictions jsonb`, `guidance jsonb` | same |
| author | `author_type` + nullable `author_id` | same |
| provenance | `manual` / `restore` / `transfer` | same |
| restore pointer | nullable `restored_from_version_id` | same |

### restrictions and guidance are two columns on purpose

ADR-064 Decision 1 calls the split load-bearing. Decision 4 runs a never-widen check over **restrictions** and explicitly does **not** over **guidance**, because "wider" and "narrower" are not defined relations over arbitrary prose — and the ADR says claiming otherwise "would be a check that always passes without ever having tested the thing it claims to test."

Separate columns make that split mechanical rather than a naming convention: the widen-check reads `restrictions` and cannot be handed guidance by accident. The secret scan reads both. That asymmetry is why they must not be folded back into one document.

## Tenancy

`ENABLE` + `FORCE ROW LEVEL SECURITY` and a permissive `_tenant_isolation` policy on both tables.

**`site_context_versions_site_scope`** — the m19/m113 exemplar shape, `AS RESTRICTIVE FOR ALL` on `site_id`. `site_id` is `NOT NULL`, so unlike m112's email tables there is no inheriting organisation row to keep readable and no reason to split read from write. ADR-064 Decision 3 puts layer 2 in its **own table** rather than as a null-keyed row in this one, which is what makes the simple shape correct here.

**`org_context_versions_site_scope_insert`** — `AS RESTRICTIVE FOR INSERT`, and the asymmetry is the point. The literal reading of ADR-064's "a restrictive site-scope policy on **both** context tables" is unimplementable on a table with no `site_id`, and implemented as a SELECT filter it would break a read the ADR requires elsewhere: Decision 6 gives read access "at the organisation **and** the site scope that cover that site", and Decision 8's effective-context preview renders layer 2's contribution. A site-scoped collaborator is entitled to read the organisation context governing their own site.

What they are not entitled to do is **write** it — and that write is m112's defect class exactly: a per-site principal reaching the organisation row, which took three review rounds and seven handler fixes to close for the email domain. A principal that can write layer 2 does not need to widen anything; it *becomes* the higher layer for every site in the organisation. The table is append-only, so `INSERT` is the entire write surface and one policy closes all of it.

### No `app.agent` policy on either table

A deliberate departure from the generic house pattern, argued in the migration header the way m116 argued its way out of the site-scope policy:

1. ADR-064 Decision 2 forbids the thing it would enable — "the agent never holds an opinion about layers 1 through 3".
2. No cross-tenant control-plane worker reads context; resolution runs on a request under tenant scope.
3. The tenant purge does not need it. **Measured, not assumed**: PostgreSQL's referential actions bypass row security, so the cascade fires whatever GUC the purge function has set. This mattered because `admin_delete_empty_tenant` blanks `app.tenant_id` to `''` *before* deleting the tenants row (m116), and under `FORCE ROW LEVEL SECURITY` these tables' isolation policy matches nothing when it is blank.
4. It would be a cross-tenant grant with no caller, and the only honest ledger rationale available would be "no code path runs under this policy".

**Consequence, stated so nobody discovers it at runtime:** neither table is reachable from `InAgentTx`. A background job needing context must run under a tenant transaction. That is a constraint on S4, not an accident.

### Cross-tenant ledger

**No entry required.** Neither table adds a permissive cross-tenant grant, so `scripts/check-rls-cross-tenant.sh` has nothing to record. The guard was run and confirmed it applied this migration (131 files) before classifying.

## Append-only is a privilege, not a convention

ADR-064 requires `UPDATE`/`DELETE` revoked from the application role "the same way the audit log already enforces append-only". `wpmgr_app` holds `SELECT` and `INSERT` only.

The `REVOKE` is the load-bearing half and must not be dropped: m1's `ALTER DEFAULT PRIVILEGES` already grants `SELECT, INSERT, UPDATE, DELETE` on every future table in this schema, these two included, without anyone typing it. Omitting an `UPDATE` grant does not withhold `UPDATE`; revoking it does.

## Cascades — the opposite call to m113/m116, for a stated reason

Both foreign keys are `ON DELETE CASCADE`, single-column. The house question is *what audit or reclaim record dies with this cascade*. Asked and answered: what dies is the snapshots; what does not is the accountability record, because Decision 7 puts every context write in the hash-chained `audit_log` in the same transaction, and that table has its own retention and its own append-only revoke. Context adds no object-storage root (Decision 12 says so, and it was verified against `purge_worker.go`'s seven roots), so nothing there changes and both purge functions free these tables with no code change.

**Do not add the composite FK.** `sites_id_tenant_key UNIQUE (id, tenant_id)` makes `FOREIGN KEY (site_id, tenant_id) REFERENCES sites (id, tenant_id)` available. It would look like tidiness and would be a defect: it forces every row's stamp to equal the site's *current* owner, which is exactly the property Decision 3 forbids, and would refuse every pre-transfer row the day site transfer ships.

## Where ADR-064 was ambiguous

Recorded in the migration header rather than resolved silently, and repeated in the PR so a reviewer can disagree:

- **"A restrictive site-scope policy on both context tables."** Unimplementable literally on a table with no `site_id`, and as a SELECT filter it contradicts Decisions 6 and 8. Chosen reading: the org table's restrictive gate is on **write**. This reading satisfies both passages; the literal one satisfies neither.
- **Byte budgets (Decision 9).** No write-time size `CHECK` was added. Decision 9 specifies *truncation at resolution*, marked and at a field boundary, which is a property of the resolution function, not of storage. A write-time refusal would be different behaviour with a different error contract, and Decision 13 enumerates exactly two write refusals (409 widening, 422 credential-shaped). Inventing a third, and a threshold the ADR never states, would be designing past the specification. **Consequence S4 must own: nothing in the database bounds the size of a context row today.**
- **Neither vocabulary is fixed by the ADR.** `restrictions` and `guidance` are `jsonb`; their shape belongs in Go beside the layer-1 restriction set Decision 4 already puts there. Named columns would invent a closed vocabulary the ADR declined to fix and put every new guidance kind behind a migration.
- **"The author's principal id"** does not say which principal kinds may author. `author_type` is a closed discriminator over `user`, `api_key` and `system` — `api_key` because Decision 6 gates these routes on the ADR-061 capability registry, which lives on API keys; `system` because Decision 12's transfer version has no human author.
- **`provenance` excludes `import`.** Decision 3 calls it a hypothetical ("if one is ever built"); `transfer` is included because Decision 12 *decides* it, even though no transfer mechanism exists.

## NULL means never set (GH #509)

`author_id` and `restored_from_version_id` record facts and get no manufactured default — `NULL` means "no principal id" and "not a restore" respectively. `restrictions`/`guidance` default to `'{}'` because Decision 3 requires every version row to carry the full snapshot and a row exists only because somebody wrote it, so an empty document is a true statement rather than an absence pretending to be a value. The generated sqlc types confirm the distinction: `AuthorID`/`RestoredFromVersionID` are `pgtype.UUID`, `TenantID` is `uuid.UUID`.

**No FK on `author_id`**, and that is load-bearing: `ON DELETE SET NULL` would mutate an append-only row and erase the authorship of a governance record when a user account is deleted; `ON DELETE CASCADE` would delete an organisation's context history because a member left. `audit_log` makes the identical call for the identical reason.

## Proofs

`apps/api/tests/adr064_governed_context_rls_integration_test.go` reaches both tables through the real `db.Pool` wrappers — `InTenantTx` for an organisation member, `InScopedTenantTx` for a site-scoped collaborator — as `wpmgr_app`, the `NOSUPERUSER NOBYPASSRLS` role every install runs as. GUCs are never hand-set. Fixture rows are seeded through `InTenantTx` as `wpmgr_app`, so the fixture itself exercises the policies' `WITH CHECK` on the way in.

Covered: tenant isolation on both tables (read and write); site-scope read confinement and forged-write refusal; the org table's read-permitted/write-refused pair asserted **together**, because a policy that refused the write by also refusing the read would pass one test and silently break the layer-2 read; the over-fire case (an ordinary org member is unaffected, and can still author both layers); append-only refusal of `UPDATE`/`DELETE`; the tenant cascade under a **blanked** `app.tenant_id`, which is the Lane A path; the site cascade freeing only that site's rows; and an anti-drift assertion read off `pg_policies` so a later migration that drops or widens one of these is caught here rather than in review.

`rls_integration_test.go` gains two lines re-revoking `UPDATE`/`DELETE` on the new tables after its blanket grant, mirroring the line already there for `audit_log`. Without them the package would run against privileges no real install has, and the append-only proofs would pass by testing nothing. That is the only non-migration Go file touched.

## Gates

Each run unpiped with its own exit status; results in the thread.

`go build ./...` · `go vet ./...` · `go test ./internal/...` · `sqlc generate` + `git diff --quiet` · `make gen` + `git status --porcelain` · `make check-rls-cross-tenant` · `make test-integration`

Equivalence between the migration and `db/schema.sql` was proved by applying each to its own database and diffing the resulting catalog (columns, constraints, indexes, policies, RLS flags, grants) for both tables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned governance context for organizations and sites.
  * Supports structured restrictions, guidance, authorship, provenance, restoration links, and timestamps.
  * Preserves context history as append-only records.

* **Security**
  * Enforced tenant and site-level access isolation.
  * Prevented site-scoped collaborators from creating or modifying organization-level context.
  * Restricted context changes to controlled additions and added cascading cleanup when tenants or sites are removed.

* **Tests**
  * Added coverage for access boundaries, history protection, policy enforcement, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->