### PR TITLE
docs(adr-064): add open question 4 on unbounded context row size

### DIFF
--- a/docs/adr/ADR-064-governed-site-org-context.md
+++ b/docs/adr/ADR-064-governed-site-org-context.md
@@ -963,8 +963,9 @@ explicitly rather than drift into it unannounced.
 ## Open questions
 
 Named and owned, rather than answered with an invented mechanism this
-document has not earned the right to assert. Neither blocks merging this
-ADR as Proposed; both block it moving to **Accepted**.
+document has not earned the right to assert. None of the questions below
+blocks merging this ADR as Proposed; all of them block it moving to
+**Accepted**.
 
 1. **What "surface" means for ADR-060's freeze clause.** Relationship,
    above, argues Decision 13's routes are not gated by ADR-060's freeze
@@ -1009,3 +1010,17 @@ ADR as Proposed; both block it moving to **Accepted**.
    whoever eventually builds site-to-organisation transfer, unassigned
    today; that build is itself a prerequisite this ADR depends on and
    does not provide (see "What has to exist before this ships").
+4. **Nothing bounds the size of a stored context row.** Decision 9 caps
+   each layer's contribution and the resolved whole in bytes, but
+   specifies *truncation at resolution* — at a field or record boundary,
+   marked, starting from the lowest surviving layer. That is a property
+   of the resolution function, not of storage, so m122 deliberately added
+   no write-time size `CHECK`: a write-time refusal is different
+   behaviour with a different error contract, and Decision 13 enumerates
+   exactly two write refusals (`409` widening, `422` credential-shaped).
+   Inventing a third, and a byte threshold this ADR never states, would
+   be designing past the specification. **Owner:** `backend-architect`,
+   alongside the resolution function — to decide whether an unbounded
+   stored row is acceptable given truncation always runs downstream of
+   it, or whether a storage cap and its reason code belong in Decision 9
+   and Decision 13.


### PR DESCRIPTION
## Summary
- Adds a fourth Open Question to ADR-064, recording that m122 deliberately omits a write-time size CHECK on stored context rows: Decision 9's byte caps are enforced by truncation at resolution (not at write), and a write-time refusal would need a reason code Decision 13 does not enumerate. Owner: backend-architect, alongside the resolution function.
- Fixes the "Neither ... both ..." framing sentence that introduced the Open Questions section: it only held for exactly two entries and breaks with a fourth. Restated by category (none / all) instead of by count, so it holds for any number of entries.
- Does not touch ADR-064's Status (stays Proposed) and does not touch apps/api; the schema/migration work is on a separate branch.

## Test plan
- [x] `make check-versions-test`
- [x] `make check-versions`
- [x] `node apps/marketing/scripts/check-copy.mjs`
- [x] Re-ran the Docs vocabulary check from `.github/workflows/ci.yml` verbatim against `docs/ ./*.md` — no hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the governed site and organization context decision record to reflect the expanded set of open questions.
  * Added an open question addressing stored context size limits versus resolution-time truncation.
  * Clarified that remaining questions are blocking and documented the decision needed on acceptable storage limits and associated handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->