### PR TITLE
ADR-064 S5: governed context screens (all 5 screens)

### DIFF
--- a/apps/web/src/features/auth/use-auth.test.ts
+++ b/apps/web/src/features/auth/use-auth.test.ts
@@ -60,14 +60,25 @@ describe("canWriteSiteContext — ADR-064 Decision 6 (site-scope write is not or
     expect(canWriteSiteContext(meOrgScoped("viewer"))).toBe(false);
   });
 
-  it("a genuine SITE-scoped collaborator with an operator+ share role may write their own site (the fix)", () => {
-    expect(canWriteSiteContext(meSiteScoped("owner"))).toBe(true);
-    expect(canWriteSiteContext(meSiteScoped("admin"))).toBe(true);
+  it("a genuine SITE-scoped collaborator with an operator share role may write their own site (the fix)", () => {
     expect(canWriteSiteContext(meSiteScoped("operator"))).toBe(true);
   });
 
   it("a site-scoped VIEWER collaborator may not write", () => {
     expect(canWriteSiteContext(meSiteScoped("viewer"))).toBe(false);
+  });
+
+  // Security review finding (F2): apps/api/internal/middleware/auth.go:178-180
+  // clamps a site share role at or above admin down to operator before it
+  // ever reaches a Me response, specifically so scope==="site" can never
+  // carry role: "owner"/"admin" — the server cannot produce that state. This
+  // asserts the SERVER's actual ceiling, not a client-invented one: even if
+  // a malformed/future response somehow smuggled owner or admin through
+  // scope==="site", this client refuses it rather than trusting a shape the
+  // real server never sends.
+  it("refuses owner/admin under scope==='site' — a shape the server's own clamp can never produce", () => {
+    expect(canWriteSiteContext(meSiteScoped("owner"))).toBe(false);
+    expect(canWriteSiteContext(meSiteScoped("admin"))).toBe(false);
   });
 
   it("an unrecognised or absent Me.scope resolves to false — refused, never a default and never 'site because it's narrower'", () => {
@@ -88,6 +99,17 @@ describe("canWriteSiteContext — ADR-064 Decision 6 (site-scope write is not or
         memberships: [],
       } as unknown as Me),
     ).toBe(false);
+  });
+
+  // Security review finding (F3): scope==="site" explicitly includes portal
+  // (client-report) principals per the generated Me.scope doc comment
+  // (types.gen.ts:939, "site for collaborators/portal principals"), and
+  // role: "client" is a real value that reaches this code, not a
+  // hypothetical. It resolves to false today because "client" matches none
+  // of the three checked strings, but nothing held that down before this
+  // test — "happens to be false" is not "tested to be false".
+  it("refuses a portal (client) principal, even though it is a real scope==='site' shape", () => {
+    expect(canWriteSiteContext(meSiteScoped("client"))).toBe(false);
   });
 
   it("null/undefined me is refused outright", () => {

--- a/apps/web/src/features/auth/use-auth.test.ts
+++ b/apps/web/src/features/auth/use-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { isSuperadminAllowedPath } from "./use-auth";
+import { isSuperadminAllowedPath, canWriteSiteContext } from "./use-auth";
+import type { Me } from "@wpmgr/api";
 
 // A superadmin has no org and is pinned to /admin by the _authed gate, EXCEPT
 // their own per-user account settings (profile + 2FA) — otherwise they can
@@ -24,5 +25,73 @@ describe("isSuperadminAllowedPath", () => {
     expect(isSuperadminAllowedPath("/settings/organization")).toBe(false);
     expect(isSuperadminAllowedPath("/settings/billing")).toBe(false);
     expect(isSuperadminAllowedPath("/settings/members")).toBe(false);
+  });
+});
+
+// Greptile P1 #2 on #566, "Site collaborators remain read-only": canOperate
+// only ever reads me.memberships, so a genuine site-scoped collaborator (no
+// org membership at all) always read as unauthorized through it even when
+// their own share role (Me.role) permits site-context write. This is the
+// first helper in this codebase to gate a site-collaborator-visible WRITE
+// action by Me.scope/Me.role directly (noted here and in the PR thread as an
+// established pattern, not a silent one-off — nothing else in this codebase
+// does the equivalent; every other me.scope === "site" site either excludes
+// the collaborator outright or degrades to read-only).
+function meOrgScoped(role: "owner" | "admin" | "operator" | "viewer"): Me {
+  const tenant = "00000000-0000-0000-0000-0000000000aa";
+  return {
+    active_tenant_id: tenant,
+    memberships: [{ tenant_id: tenant, role, tenant_name: "Acme" }],
+  } as unknown as Me;
+}
+
+function meSiteScoped(role: Me["role"]): Me {
+  return { scope: "site", role, memberships: [] } as unknown as Me;
+}
+
+describe("canWriteSiteContext — ADR-064 Decision 6 (site-scope write is not org-membership-gated)", () => {
+  it("an org-scoped operator/admin/owner may write (canOperate's existing entitlement, unaffected)", () => {
+    expect(canWriteSiteContext(meOrgScoped("owner"))).toBe(true);
+    expect(canWriteSiteContext(meOrgScoped("admin"))).toBe(true);
+    expect(canWriteSiteContext(meOrgScoped("operator"))).toBe(true);
+  });
+
+  it("an org-scoped viewer may not write", () => {
+    expect(canWriteSiteContext(meOrgScoped("viewer"))).toBe(false);
+  });
+
+  it("a genuine SITE-scoped collaborator with an operator+ share role may write their own site (the fix)", () => {
+    expect(canWriteSiteContext(meSiteScoped("owner"))).toBe(true);
+    expect(canWriteSiteContext(meSiteScoped("admin"))).toBe(true);
+    expect(canWriteSiteContext(meSiteScoped("operator"))).toBe(true);
+  });
+
+  it("a site-scoped VIEWER collaborator may not write", () => {
+    expect(canWriteSiteContext(meSiteScoped("viewer"))).toBe(false);
+  });
+
+  it("an unrecognised or absent Me.scope resolves to false — refused, never a default and never 'site because it's narrower'", () => {
+    // Absent scope entirely (older response shape).
+    expect(
+      canWriteSiteContext({ role: "owner", memberships: [] } as unknown as Me),
+    ).toBe(false);
+    // Empty-string scope (PrincipalRole/scope's own "unauthenticated" value).
+    expect(
+      canWriteSiteContext({ scope: "", role: "owner", memberships: [] } as unknown as Me),
+    ).toBe(false);
+    // A future/unknown scope value this function has never heard of — must
+    // NOT fall through to either the org or the site branch.
+    expect(
+      canWriteSiteContext({
+        scope: "portal",
+        role: "owner",
+        memberships: [],
+      } as unknown as Me),
+    ).toBe(false);
+  });
+
+  it("null/undefined me is refused outright", () => {
+    expect(canWriteSiteContext(null)).toBe(false);
+    expect(canWriteSiteContext(undefined)).toBe(false);
   });
 });

--- a/apps/web/src/features/auth/use-auth.ts
+++ b/apps/web/src/features/auth/use-auth.ts
@@ -484,3 +484,39 @@ export function canOperate(me: Me | null | undefined): boolean {
   // except viewer is operator-capable (server enforces per-site).
   return role === "owner" || role === "admin" || role === "operator";
 }
+
+/**
+ * Whether the principal may write THIS SITE's governed context (ADR-064
+ * Decision 6 / m123): "site-scope write additionally requires access to
+ * that specific site" — it is not gated on an organisation membership at
+ * all, unlike organisation-scope context write (owner/admin only,
+ * unaffected by this function). `canOperate`/`activeRole` only ever read
+ * `me.memberships`, so a genuine site-scoped collaborator — who has none —
+ * always reads as unauthorized through them, hiding an entitlement
+ * `context.site.write` actually grants (Greptile finding on #566, "Site
+ * collaborators remain read-only").
+ *
+ * No existing helper in this codebase gates a site-collaborator-visible
+ * WRITE action by their own share role: every other `me.scope === "site"`
+ * site — settings/members.tsx, the fleet rollups, the updates card — either
+ * excludes the collaborator outright or degrades to a read-only/best-effort
+ * view. This function is the first of that shape; noted here, and in the
+ * PR thread, as an established pattern rather than a silent one-off.
+ *
+ * `me.scope` is `"org" | "site" | ""` and can also be absent on an older
+ * response. Absence or any value other than the two named ones resolves to
+ * `false` — refused, never a default and never "narrower, so allow it" —
+ * because an unrecognised scope is an unknown principal shape, not a site
+ * collaborator by another name.
+ */
+export function canWriteSiteContext(me: Me | null | undefined): boolean {
+  if (!me) return false;
+  // An org-scoped member with operator+ role already covers every site in
+  // their org — same entitlement canOperate already grants for other
+  // site-level writes.
+  if (canOperate(me)) return true;
+  if (me.scope === "site") {
+    return me.role === "owner" || me.role === "admin" || me.role === "operator";
+  }
+  return false;
+}

--- a/apps/web/src/features/auth/use-auth.ts
+++ b/apps/web/src/features/auth/use-auth.ts
@@ -508,6 +508,15 @@ export function canOperate(me: Me | null | undefined): boolean {
  * `false` — refused, never a default and never "narrower, so allow it" —
  * because an unrecognised scope is an unknown principal shape, not a site
  * collaborator by another name.
+ *
+ * Exact mirror of `apps/api/internal/middleware/auth.go:178-180`: the server
+ * clamps a site share role at or above admin down to `operator` before it
+ * ever reaches a `Me` response, specifically so a site-scoped principal can
+ * never present as admin/owner (admin would pass an org-level permission
+ * check before the org-scope guard fires). `scope === "site"` therefore
+ * never carries `role: "owner"` or `role: "admin"` in practice — checking
+ * only `operator` here is not a narrower client rule than the server's, it
+ * is the same ceiling, stated once instead of duplicated loosely.
  */
 export function canWriteSiteContext(me: Me | null | undefined): boolean {
   if (!me) return false;
@@ -516,7 +525,7 @@ export function canWriteSiteContext(me: Me | null | undefined): boolean {
   // site-level writes.
   if (canOperate(me)) return true;
   if (me.scope === "site") {
-    return me.role === "owner" || me.role === "admin" || me.role === "operator";
+    return me.role === "operator";
   }
   return false;
 }

--- a/apps/web/src/features/context/context-rows.ts
+++ b/apps/web/src/features/context/context-rows.ts
@@ -1,0 +1,30 @@
+import type { KvRowProps } from "@/components/shared/definition-list";
+import type { GuidanceSet, RestrictionSet } from "@wpmgr/api";
+
+// Shared DefinitionList row builders for ADR-064's RestrictionSet/GuidanceSet
+// — used by both the read-only effective-context preview (Stage A,
+// effective-context-preview.tsx, one per layer) and the org/site editors'
+// read-only fallback (Stage B, gov-context-editor.tsx, one per subject).
+// Kept in one place so the two surfaces render identical field labels/order
+// for the same underlying types rather than drifting apart.
+
+export function restrictionRows(restrictions: RestrictionSet): KvRowProps[] {
+  return [
+    { label: "Forbidden tools", value: joinOrUndefined(restrictions.forbidden_tools) },
+    { label: "Forbidden domains", value: joinOrUndefined(restrictions.forbidden_domains) },
+    { label: "Forbidden topics", value: joinOrUndefined(restrictions.forbidden_topics) },
+  ];
+}
+
+export function guidanceRows(guidance: GuidanceSet): KvRowProps[] {
+  return [
+    { label: "Brand voice", value: guidance.brand_voice || undefined },
+    { label: "Audience", value: guidance.audience || undefined },
+    { label: "Terminology", value: guidance.terminology || undefined },
+    { label: "Style", value: guidance.style || undefined },
+  ];
+}
+
+function joinOrUndefined(items?: string[]): string | undefined {
+  return items && items.length > 0 ? items.join(", ") : undefined;
+}

--- a/apps/web/src/features/context/context-version-history.test.tsx
+++ b/apps/web/src/features/context/context-version-history.test.tsx
@@ -51,6 +51,7 @@ describe("ContextVersionHistory — author, provenance and timestamp per version
         onToggleExpand={noop}
         canWrite
         onRequestRestore={noop}
+        isRestoring={false}
       />,
     );
 
@@ -95,6 +96,7 @@ describe("ContextVersionHistory — author, provenance and timestamp per version
         onToggleExpand={noop}
         canWrite
         onRequestRestore={noop}
+        isRestoring={false}
       />,
     );
     expect(screen.getByText("No edits yet")).toBeInTheDocument();
@@ -132,6 +134,7 @@ describe("ContextVersionHistory — diff never implies it compares enforced stat
         diff={mockQueryResult<GovContextDiff>({ data: buildDiff() })}
         canWrite
         onRequestRestore={noop}
+        isRestoring={false}
       />,
     );
 
@@ -165,6 +168,7 @@ describe("ContextVersionHistory — diff never implies it compares enforced stat
         })}
         canWrite
         onRequestRestore={noop}
+        isRestoring={false}
       />,
     );
 
@@ -225,5 +229,111 @@ describe("RestoreVersionDialog — a widen refusal here reads as correct behavio
     );
     fireEvent.click(screen.getByRole("button", { name: "Restore this version" }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("RestoreVersionDialog — dismissal is blocked while a restore is pending", () => {
+  // CodeRabbit finding on #566: `restore.reset()` does not cancel the
+  // in-flight `mutateAsync` call (TanStack Query never aborts a mutation),
+  // and Dialog routes Escape, an overlay click, and a programmatic close all
+  // through the same `onClose` — so any of those closing the dialog mid-flight
+  // would let the operator open a second restore confirmation on another row
+  // while the first is still running.
+  it("ignores Escape while isPending is true", () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <RestoreVersionDialog
+        open
+        onClose={onClose}
+        version={buildVersion({ version: 2 })}
+        scopeLabel="site"
+        onConfirm={noop}
+        isPending
+        error={null}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("honours Escape once nothing is pending (must not over-block)", () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <RestoreVersionDialog
+        open
+        onClose={onClose}
+        version={buildVersion({ version: 2 })}
+        scopeLabel="site"
+        onConfirm={noop}
+        isPending={false}
+        error={null}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ContextVersionHistory — no overlapping restores", () => {
+  function buildRows(): GovContextVersionSummary[] {
+    return [
+      buildVersion({ id: "v-3", version: 3 }),
+      buildVersion({ id: "v-2", version: 2 }),
+      buildVersion({ id: "v-1", version: 1 }),
+    ];
+  }
+
+  it("disables every row's restore button while a restore is already pending elsewhere", () => {
+    renderWithProviders(
+      <ContextVersionHistory
+        scopeLabel="site"
+        items={buildRows()}
+        isPending={false}
+        isError={false}
+        error={null}
+        onRetry={noop}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={noop}
+        expandedId={null}
+        onToggleExpand={noop}
+        canWrite
+        onRequestRestore={noop}
+        isRestoring
+      />,
+    );
+    const buttons = screen.getAllByRole("button", { name: "Restore this version" });
+    // Non-vacuous: there must be more than zero to disable (v2 and v1, since
+    // v3 is "Current" and never gets a restore button at all).
+    expect(buttons).toHaveLength(2);
+    for (const button of buttons) {
+      expect(button).toBeDisabled();
+    }
+  });
+
+  it("leaves restore buttons enabled when no restore is pending (must not over-block)", () => {
+    renderWithProviders(
+      <ContextVersionHistory
+        scopeLabel="site"
+        items={buildRows()}
+        isPending={false}
+        isError={false}
+        error={null}
+        onRetry={noop}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={noop}
+        expandedId={null}
+        onToggleExpand={noop}
+        canWrite
+        onRequestRestore={noop}
+        isRestoring={false}
+      />,
+    );
+    const buttons = screen.getAllByRole("button", { name: "Restore this version" });
+    expect(buttons).toHaveLength(2);
+    for (const button of buttons) {
+      expect(button).toBeEnabled();
+    }
   });
 });

--- a/apps/web/src/features/context/context-version-history.test.tsx
+++ b/apps/web/src/features/context/context-version-history.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent, within } from "@testing-library/react";
+import type { GovContextDiff, GovContextVersionSummary } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import { ContextVersionHistory, RestoreVersionDialog } from "./context-version-history";
+import { ContextWidenForbiddenError } from "./use-context";
+
+// ADR-064 S5 Stage B, Screen 4 — version history / diff / restore outcome
+// tests. Tests the presentational components directly against real prop
+// shapes, same approach as gov-context-editor.test.tsx.
+
+function buildVersion(overrides: Partial<GovContextVersionSummary> = {}): GovContextVersionSummary {
+  return {
+    id: "v-1",
+    version: 1,
+    author_type: "user",
+    author_id: "11111111-1111-1111-1111-111111111111",
+    provenance: "manual",
+    created_at: "2026-08-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function noop() {
+  /* test stub */
+}
+
+describe("ContextVersionHistory — author, provenance and timestamp per version, current flagged correctly", () => {
+  it("marks the FIRST (newest) item as current, not any other", () => {
+    const items = [
+      buildVersion({ id: "v-3", version: 3, provenance: "restore" }),
+      buildVersion({ id: "v-2", version: 2, author_type: "api_key", author_id: undefined }),
+      buildVersion({ id: "v-1", version: 1 }),
+    ];
+
+    renderWithProviders(
+      <ContextVersionHistory
+        scopeLabel="site"
+        items={items}
+        isPending={false}
+        isError={false}
+        error={null}
+        onRetry={noop}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={noop}
+        expandedId={null}
+        onToggleExpand={noop}
+        canWrite
+        onRequestRestore={noop}
+      />,
+    );
+
+    // Non-vacuous, scoped to the SPECIFIC row: exactly one "Current" badge
+    // total is not enough to prove which version it's on (a version that
+    // flagged the wrong row as current would still pass a bare count check)
+    // — assert it sits inside v3's own row, and nowhere else.
+    const v3Row = screen.getByText("v3").closest("li");
+    const v2Row = screen.getByText("v2").closest("li");
+    const v1Row = screen.getByText("v1").closest("li");
+    if (!v3Row || !v2Row || !v1Row) throw new Error("row not found");
+
+    expect(within(v3Row).getByText("Current")).toBeInTheDocument();
+    expect(
+      within(v3Row).queryByRole("button", { name: "Restore this version" }),
+    ).not.toBeInTheDocument();
+    expect(within(v2Row).getByRole("button", { name: "Restore this version" })).toBeInTheDocument();
+    expect(within(v1Row).getByRole("button", { name: "Restore this version" })).toBeInTheDocument();
+    expect(within(v2Row).queryByText("Current")).not.toBeInTheDocument();
+    expect(within(v1Row).queryByText("Current")).not.toBeInTheDocument();
+
+    // Author/provenance render for real, differing values (v1 and v2 are
+    // both "manual" in this fixture, hence AllBy for that one).
+    expect(within(v2Row).getByText("API key")).toBeInTheDocument();
+    expect(within(v3Row).getByText("restore")).toBeInTheDocument();
+    expect(screen.getAllByText("manual")).toHaveLength(2);
+  });
+
+  it("shows the empty state, not a loading or error tree, for zero versions", () => {
+    renderWithProviders(
+      <ContextVersionHistory
+        scopeLabel="site"
+        items={[]}
+        isPending={false}
+        isError={false}
+        error={null}
+        onRetry={noop}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={noop}
+        expandedId={null}
+        onToggleExpand={noop}
+        canWrite
+        onRequestRestore={noop}
+      />,
+    );
+    expect(screen.getByText("No edits yet")).toBeInTheDocument();
+  });
+});
+
+describe("ContextVersionHistory — diff never implies it compares enforced state", () => {
+  function buildDiff(overrides: Partial<GovContextDiff> = {}): GovContextDiff {
+    return {
+      version: { ...buildVersion({ id: "v-2", version: 2 }), restrictions: {}, guidance: {} },
+      baseline: false,
+      prior: { ...buildVersion({ id: "v-1", version: 1 }), restrictions: {}, guidance: {} },
+      diff: {
+        forbidden_tools: { added: ["shell_exec"], removed: ["wp_eval"] },
+        brand_voice: { old: "Friendly", new: "Formal" },
+      },
+      ...overrides,
+    };
+  }
+
+  it("renders added/removed list items and old/new text fields, plus the authored-not-enforced caveat", () => {
+    renderWithProviders(
+      <ContextVersionHistory
+        scopeLabel="site"
+        items={[buildVersion({ id: "v-2", version: 2 })]}
+        isPending={false}
+        isError={false}
+        error={null}
+        onRetry={noop}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={noop}
+        expandedId="v-2"
+        onToggleExpand={noop}
+        diff={mockQueryResult<GovContextDiff>({ data: buildDiff() })}
+        canWrite
+        onRequestRestore={noop}
+      />,
+    );
+
+    expect(screen.getByText("+ shell_exec")).toBeInTheDocument();
+    expect(screen.getByText("− wp_eval")).toBeInTheDocument();
+    expect(screen.getByText("Friendly")).toBeInTheDocument();
+    expect(screen.getByText("Formal")).toBeInTheDocument();
+    // Non-vacuous: this line is the whole point of the coordinator's ruling
+    // on Screen 4 — a diff of stored rows is never a diff of enforced state.
+    expect(
+      screen.getByText(/not what either one enforced at the time/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the baseline message, never a computed diff table, for a version with no eligible predecessor", () => {
+    renderWithProviders(
+      <ContextVersionHistory
+        scopeLabel="organisation"
+        items={[buildVersion({ id: "v-1", version: 1 })]}
+        isPending={false}
+        isError={false}
+        error={null}
+        onRetry={noop}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={noop}
+        expandedId="v-1"
+        onToggleExpand={noop}
+        diff={mockQueryResult<GovContextDiff>({
+          data: { version: buildDiff().version, baseline: true },
+        })}
+        canWrite
+        onRequestRestore={noop}
+      />,
+    );
+
+    expect(screen.getByText(/no prior version to compare/i)).toBeInTheDocument();
+    expect(screen.queryByText("+ shell_exec")).not.toBeInTheDocument();
+  });
+});
+
+describe("RestoreVersionDialog — a widen refusal here reads as correct behaviour, not a generic edit error", () => {
+  it("uses restore-specific wording ('since been tightened'), never the edit form's banner text", () => {
+    const message =
+      "this write would remove [shell_exec] from forbidden_tools, which was set by organisation default (layer 2) — a lower layer may narrow or add to a restriction but never remove what a higher layer set";
+    renderWithProviders(
+      <RestoreVersionDialog
+        open
+        onClose={noop}
+        version={buildVersion({ version: 2 })}
+        scopeLabel="site"
+        onConfirm={noop}
+        isPending={false}
+        error={
+          new ContextWidenForbiddenError(message, {
+            field: "forbidden_tools",
+            layer: 2,
+            layerName: "organisation default",
+            removedItems: ["shell_exec"],
+          })
+        }
+      />,
+    );
+
+    expect(screen.getByText(/since been tightened/i)).toBeInTheDocument();
+    // The server's own message is appended verbatim (not just paraphrased
+    // away) — it's rendered inside the same node as the "since been
+    // tightened" lead-in, so match on a substring, not the whole node.
+    expect(
+      screen.getByText((content) => content.includes(message)),
+    ).toBeInTheDocument();
+    // Never the edit-path's generic pointer — this is a materially different
+    // situation (the refusal is correct here, not a mistaken edit).
+    expect(
+      screen.queryByText("Could not save — see the highlighted restriction below."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onConfirm when the operator clicks Restore", () => {
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <RestoreVersionDialog
+        open
+        onClose={noop}
+        version={buildVersion({ version: 2 })}
+        scopeLabel="site"
+        onConfirm={onConfirm}
+        isPending={false}
+        error={null}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Restore this version" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/context/context-version-history.tsx
+++ b/apps/web/src/features/context/context-version-history.tsx
@@ -1,0 +1,461 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, History } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageError } from "@/components/feedback";
+import { CopyableMono } from "@/components/shared/copyable-mono";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { relativeTime } from "@/lib/utils";
+import type {
+  GovContextDiff,
+  GovContextFieldDiff,
+  GovContextListDiff,
+  GovContextVersionSummary,
+} from "@wpmgr/api";
+
+import {
+  ContextSecretDetectedError,
+  ContextVersionConflictError,
+  ContextWidenForbiddenError,
+} from "./use-context";
+
+// ADR-064 S5 Stage B, Screen 4 — version history, diff and restore
+// (Decision 5). Shared between org and site scopes; the two
+// `*-context-history-section.tsx` wrappers own the hooks and pass the
+// result down here.
+//
+// IMPORTANT: every version here is a STORED row — what was authored at
+// write time. A diff is therefore a diff of two authored snapshots, never
+// of what either one enforced at the time: an organisation's own
+// restrictions can move between when a site version was written and when
+// it's read here, and a stored site-layer row never restates the org's
+// current state (use-context.ts's own module doc says the same). The
+// "as enforced right now" answer lives on Screen 1, never on this screen.
+
+export interface ContextVersionHistoryProps {
+  scopeLabel: string;
+  items: GovContextVersionSummary[];
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+  expandedId: string | null;
+  onToggleExpand: (id: string) => void;
+  /** The diff query for the currently expanded row, or undefined when none
+   *  is expanded. */
+  diff?: UseQueryResult<GovContextDiff, Error>;
+  canWrite: boolean;
+  onRequestRestore: (version: GovContextVersionSummary) => void;
+}
+
+export function ContextVersionHistory({
+  scopeLabel,
+  items,
+  isPending,
+  isError,
+  error,
+  onRetry,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+  expandedId,
+  onToggleExpand,
+  diff,
+  canWrite,
+  onRequestRestore,
+}: ContextVersionHistoryProps) {
+  if (isPending) {
+    return <HistorySkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <PageError
+        what={`Could not load this ${scopeLabel}'s version history.`}
+        why={error instanceof Error ? error.message : "Unknown error."}
+        onRetry={onRetry}
+        retryLabel="Reload"
+      />
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-border bg-card px-6 py-10 text-center">
+        <History aria-hidden="true" className="size-5 text-muted-foreground" />
+        <p className="text-sm font-medium text-foreground">No edits yet</p>
+        <p className="max-w-sm text-xs text-muted-foreground">
+          Every accepted write to this {scopeLabel}&apos;s context becomes a
+          new version here — nothing is edited in place.
+        </p>
+      </div>
+    );
+  }
+
+  const currentId = items[0]?.id;
+
+  return (
+    <div className="space-y-2">
+      <ul className="divide-y divide-border overflow-hidden rounded-lg border border-border bg-card">
+        {items.map((item) => (
+          <li key={item.id}>
+            <VersionRow
+              item={item}
+              isCurrent={item.id === currentId}
+              isExpanded={expandedId === item.id}
+              onToggleExpand={() => onToggleExpand(item.id)}
+              canWrite={canWrite}
+              onRequestRestore={() => onRequestRestore(item)}
+              scopeLabel={scopeLabel}
+            />
+            {expandedId === item.id ? (
+              <div className="border-t border-border bg-muted/30 px-4 py-3">
+                <VersionDiffPanel diff={diff} scopeLabel={scopeLabel} />
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+      {hasNextPage ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={isFetchingNextPage}
+            onClick={onLoadMore}
+          >
+            {isFetchingNextPage ? "Loading…" : "Load older versions"}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function VersionRow({
+  item,
+  isCurrent,
+  isExpanded,
+  onToggleExpand,
+  canWrite,
+  onRequestRestore,
+  scopeLabel,
+}: {
+  item: GovContextVersionSummary;
+  isCurrent: boolean;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  canWrite: boolean;
+  onRequestRestore: () => void;
+  scopeLabel: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        aria-expanded={isExpanded}
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} version ${item.version}`}
+        className="flex shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {isExpanded ? (
+          <ChevronDown aria-hidden="true" className="size-4" />
+        ) : (
+          <ChevronRight aria-hidden="true" className="size-4" />
+        )}
+      </button>
+
+      <span className="w-12 shrink-0 text-sm font-medium text-foreground tabular-nums">
+        v{item.version}
+      </span>
+
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        {authorLabel(item.author_type)}
+        {item.author_id ? (
+          <CopyableMono value={item.author_id} truncate label="Copy author id" />
+        ) : null}
+      </span>
+
+      <Badge variant="outline" className="capitalize">
+        {item.provenance}
+      </Badge>
+
+      <span title={item.created_at} className="text-xs text-muted-foreground">
+        {relativeTime(item.created_at) ?? item.created_at}
+      </span>
+
+      <div className="ml-auto flex items-center gap-2">
+        {isCurrent ? (
+          <Badge variant="muted">Current</Badge>
+        ) : canWrite ? (
+          <Button type="button" variant="outline" size="sm" onClick={onRequestRestore}>
+            Restore this version
+          </Button>
+        ) : null}
+      </div>
+
+      <span className="sr-only">
+        {scopeLabel} version {item.version}
+      </span>
+    </div>
+  );
+}
+
+function authorLabel(authorType: GovContextVersionSummary["author_type"]): string {
+  switch (authorType) {
+    case "api_key":
+      return "API key";
+    case "system":
+      return "System";
+    default:
+      return "User";
+  }
+}
+
+// ── Diff panel ───────────────────────────────────────────────────────────
+
+const DIFF_FIELD_LABELS: Record<string, string> = {
+  forbidden_tools: "Forbidden tools",
+  forbidden_domains: "Forbidden domains",
+  forbidden_topics: "Forbidden topics",
+  brand_voice: "Brand voice",
+  audience: "Audience",
+  terminology: "Terminology",
+  style: "Style",
+};
+
+const LIST_DIFF_FIELDS = new Set(["forbidden_tools", "forbidden_domains", "forbidden_topics"]);
+
+function VersionDiffPanel({
+  diff,
+  scopeLabel,
+}: {
+  diff?: UseQueryResult<GovContextDiff, Error>;
+  scopeLabel: string;
+}) {
+  if (!diff || diff.isPending) {
+    return (
+      <div role="status" aria-busy="true" aria-label="Loading diff" className="space-y-2">
+        <Skeleton className="h-3 w-32" />
+        <Skeleton className="h-3 w-48" />
+      </div>
+    );
+  }
+
+  if (diff.isError) {
+    return (
+      <PageError
+        what="Could not load this version's diff."
+        why={diff.error instanceof Error ? diff.error.message : "Unknown error."}
+        onRetry={() => void diff.refetch()}
+        retryLabel="Reload diff"
+      />
+    );
+  }
+
+  const result = diff.data;
+
+  if (result.baseline) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No prior version to compare — this is the first version for this{" "}
+        {scopeLabel}
+        {result.prior ? "" : ", or the first after a transfer"}.
+      </p>
+    );
+  }
+
+  const entries = result.diff ? Object.entries(result.diff) : [];
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        Compared to version {result.prior?.version ?? "?"}. This compares what
+        was <em>authored</em> in these two versions, not what either one
+        enforced at the time — an organisation&apos;s own restrictions may
+        have changed since either was written.
+      </p>
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No fields changed between these two versions.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {entries.map(([key, value]) => (
+            <DiffField key={key} fieldKey={key} value={value} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffField({
+  fieldKey,
+  value,
+}: {
+  fieldKey: string;
+  value: GovContextListDiff | GovContextFieldDiff;
+}) {
+  const label = DIFF_FIELD_LABELS[fieldKey] ?? fieldKey;
+
+  if (LIST_DIFF_FIELDS.has(fieldKey)) {
+    const listDiff = value as GovContextListDiff;
+    return (
+      <div className="space-y-0.5">
+        <p className="text-xs font-medium text-foreground">{label}</p>
+        {listDiff.added && listDiff.added.length > 0 ? (
+          <p className="text-xs text-success-subtle-fg">+ {listDiff.added.join(", ")}</p>
+        ) : null}
+        {listDiff.removed && listDiff.removed.length > 0 ? (
+          <p className="text-xs text-[var(--color-destructive)]">
+            − {listDiff.removed.join(", ")}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  const fieldDiff = value as GovContextFieldDiff;
+  return (
+    <div className="space-y-0.5">
+      <p className="text-xs font-medium text-foreground">{label}</p>
+      <p className="text-xs text-muted-foreground line-through">
+        {fieldDiff.old || "(empty)"}
+      </p>
+      <p className="text-xs text-foreground">{fieldDiff.new || "(empty)"}</p>
+    </div>
+  );
+}
+
+// ── Loading state ────────────────────────────────────────────────────────
+
+function HistorySkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading version history"
+      className="overflow-hidden rounded-lg border border-border"
+    >
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 border-b border-border px-4 py-3 last:border-0"
+        >
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="ml-auto h-3 w-12" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Restore dialog ───────────────────────────────────────────────────────
+
+/**
+ * The WHY differs deliberately from the edit-form's widen-refusal copy
+ * (gov-context-editor.tsx): a restore's widen refusal is not a mistaken edit,
+ * it is the system correctly refusing to reintroduce a rule that has since
+ * been tightened above it (S4's security review confirmed this refusal is
+ * correct, unlike the guidance-only over-fire bug being fixed elsewhere).
+ */
+function restoreErrorCopy(error: Error, scopeLabel: string): { what: string; why: string } {
+  if (error instanceof ContextWidenForbiddenError) {
+    return {
+      what: "This version could not be restored.",
+      why: `Restoring it would put back a rule that has since been tightened above this ${scopeLabel}. ${error.message}`,
+    };
+  }
+  if (error instanceof ContextVersionConflictError) {
+    return {
+      what: "This version could not be restored.",
+      why: `Another write landed first. ${error.message}`,
+    };
+  }
+  if (error instanceof ContextSecretDetectedError) {
+    return { what: "This version could not be restored.", why: error.message };
+  }
+  return { what: "This version could not be restored.", why: error.message };
+}
+
+export interface RestoreVersionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  version: GovContextVersionSummary | null;
+  scopeLabel: string;
+  onConfirm: () => void;
+  isPending: boolean;
+  error: Error | null;
+}
+
+export function RestoreVersionDialog({
+  open,
+  onClose,
+  version,
+  scopeLabel,
+  onConfirm,
+  isPending,
+  error,
+}: RestoreVersionDialogProps) {
+  const errCopy = error ? restoreErrorCopy(error, scopeLabel) : null;
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogContent
+        ariaLabelledBy="restore-context-version-title"
+        ariaDescribedBy="restore-context-version-desc"
+      >
+        {version ? (
+          <>
+            <DialogHeader>
+              <DialogTitle id="restore-context-version-title">
+                Restore version {version.version}?
+              </DialogTitle>
+              <DialogDescription id="restore-context-version-desc">
+                Creates a new version with version {version.version}&apos;s
+                content. Nothing is deleted — the current version stays in
+                history and can itself be restored later.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogBody>
+              {errCopy ? (
+                <p
+                  role="alert"
+                  className="rounded-lg border border-[var(--color-destructive)]/30 bg-[var(--color-card)] p-3 text-sm"
+                >
+                  <span className="block font-medium text-foreground">{errCopy.what}</span>
+                  <span className="block text-muted-foreground">{errCopy.why}</span>
+                </p>
+              ) : null}
+            </DialogBody>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={onConfirm} disabled={isPending}>
+                {isPending ? "Restoring…" : "Restore this version"}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/context/context-version-history.tsx
+++ b/apps/web/src/features/context/context-version-history.tsx
@@ -59,6 +59,12 @@ export interface ContextVersionHistoryProps {
   diff?: UseQueryResult<GovContextDiff, Error>;
   canWrite: boolean;
   onRequestRestore: (version: GovContextVersionSummary) => void;
+  /** True while ANY restore is in flight (CodeRabbit finding on #566: "the
+   *  history still exposes restore buttons, so overlapping restores can
+   *  create multiple new versions"). Disables every row's restore action,
+   *  not just the one being confirmed — only one restore may be proposed
+   *  at a time. */
+  isRestoring: boolean;
 }
 
 export function ContextVersionHistory({
@@ -76,6 +82,7 @@ export function ContextVersionHistory({
   diff,
   canWrite,
   onRequestRestore,
+  isRestoring,
 }: ContextVersionHistoryProps) {
   if (isPending) {
     return <HistorySkeleton />;
@@ -120,6 +127,7 @@ export function ContextVersionHistory({
               canWrite={canWrite}
               onRequestRestore={() => onRequestRestore(item)}
               scopeLabel={scopeLabel}
+              restoreDisabled={isRestoring}
             />
             {expandedId === item.id ? (
               <div className="border-t border-border bg-muted/30 px-4 py-3">
@@ -154,6 +162,7 @@ function VersionRow({
   canWrite,
   onRequestRestore,
   scopeLabel,
+  restoreDisabled,
 }: {
   item: GovContextVersionSummary;
   isCurrent: boolean;
@@ -162,6 +171,7 @@ function VersionRow({
   canWrite: boolean;
   onRequestRestore: () => void;
   scopeLabel: string;
+  restoreDisabled: boolean;
 }) {
   return (
     <div className="flex flex-wrap items-center gap-3 px-4 py-3">
@@ -202,7 +212,13 @@ function VersionRow({
         {isCurrent ? (
           <Badge variant="muted">Current</Badge>
         ) : canWrite ? (
-          <Button type="button" variant="outline" size="sm" onClick={onRequestRestore}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRequestRestore}
+            disabled={restoreDisabled}
+          >
             Restore this version
           </Button>
         ) : null}
@@ -416,8 +432,21 @@ export function RestoreVersionDialog({
   error,
 }: RestoreVersionDialogProps) {
   const errCopy = error ? restoreErrorCopy(error, scopeLabel) : null;
+  // CodeRabbit finding on #566: `restore.reset()` clears the mutation's
+  // observed state but does not cancel the in-flight `mutateAsync` call
+  // (TanStack Query does not abort mutations — the request keeps running
+  // server-side regardless). Dialog routes Escape, an overlay click, AND a
+  // programmatic close all through `onClose` (dialog.tsx's own doc
+  // comment), so every one of those needs blocking while a restore is
+  // pending, not just the Cancel button — closing here would let the
+  // operator open a second restore confirmation on another row while the
+  // first is still running.
+  const handleClose = () => {
+    if (isPending) return;
+    onClose();
+  };
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog open={open} onClose={handleClose}>
       <DialogContent
         ariaLabelledBy="restore-context-version-title"
         ariaDescribedBy="restore-context-version-desc"

--- a/apps/web/src/features/context/effective-context-preview.test.tsx
+++ b/apps/web/src/features/context/effective-context-preview.test.tsx
@@ -138,3 +138,56 @@ describe("EffectiveContextPreview — 503 context_unavailable is distinct from a
     expect(screen.queryByText(CONTEXT_UNAVAILABLE_WHAT)).not.toBeInTheDocument();
   });
 });
+
+describe("EffectiveContextPreview — a truncated layer never reads as the complete enforced set", () => {
+  // Security review on ADR-064 S4 (PR #567): Resolve() computes the enforced
+  // union from UNTRUNCATED snapshots, but a layer's own display copy can have
+  // restriction items dropped by the byte-budget truncation (truncate.go).
+  // Only layers 2-3 can carry restrictions at all (resolver.go), so this
+  // fixture puts the shorter, truncated copy on layer 3 while the enforced
+  // union (top-level `restrictions`, never truncated) carries the full set —
+  // the real shape the review flagged, not a hypothetical.
+  function buildTruncatedFixture(): GovContextEffective {
+    const base = buildEffective();
+    const layers = base.layers.map((l) =>
+      l.layer === 3
+        ? { ...l, truncated: true, restrictions: { forbidden_tools: ["shell_exec"] } }
+        : l,
+    );
+    return {
+      ...base,
+      layers,
+      restrictions: { forbidden_tools: ["shell_exec", "wp_eval", "file_delete"] },
+      truncated: true,
+    };
+  }
+
+  it("flags layer 3's own restriction list as possibly incomplete when truncated, and shows the fuller enforced union separately", () => {
+    mockData(buildTruncatedFixture());
+    renderWithProviders(<EffectiveContextPreview siteId="site-1" />);
+
+    // The enforced union (never truncated) carries all three items.
+    expect(screen.getByText("shell_exec, wp_eval, file_delete")).toBeInTheDocument();
+    // Layer 3's own (truncated) copy carries only one — a DIFFERENT string
+    // in the DOM, not the same list rendered twice.
+    expect(screen.getByText("shell_exec")).toBeInTheDocument();
+    // The gap between those two is exactly what the callout must surface.
+    expect(
+      screen.getByText(/this layer's own list may be shorter than what's enforced/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT show the incomplete-list callout on a layer that cannot carry restrictions, even if flagged truncated", () => {
+    const base = buildEffective();
+    const layers = base.layers.map((l) => (l.layer === 6 ? { ...l, truncated: true } : l));
+    mockData({ ...base, layers, truncated: true });
+    renderWithProviders(<EffectiveContextPreview siteId="site-1" />);
+
+    // Non-vacuous: the callout text must never appear at all here, not just
+    // "not next to layer 6" — layers 4-6 never set restrictions, so there is
+    // nothing for the callout to be honest about on this fixture.
+    expect(
+      screen.queryByText(/this layer's own list may be shorter than what's enforced/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/context/effective-context-preview.test.tsx
+++ b/apps/web/src/features/context/effective-context-preview.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import type { GovContextEffective, GovContextLayerContribution } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import {
+  EffectiveContextPreview,
+  CONTEXT_UNAVAILABLE_WHAT,
+} from "./effective-context-preview";
+import { ContextUnavailableError, useEffectiveSiteContext } from "./use-context";
+
+// ADR-064 S5 Stage A — Screen 1 (effective-context preview) outcome tests.
+//
+// Server state is mocked at the hook boundary (`vi.mock("./use-context")`),
+// matching this repo's render-test convention (see
+// features/fleet/AgentFleetSummaryCard.test.tsx) rather than a network mock.
+
+vi.mock("./use-context", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./use-context")>();
+  return { ...actual, useEffectiveSiteContext: vi.fn() };
+});
+
+const mockedUseEffectiveSiteContext = vi.mocked(useEffectiveSiteContext);
+
+// The exact `Name` strings ADR-064 S4's resolver assigns per layer —
+// apps/api/internal/govcontext/resolver.go:96-101 on
+// origin/feat/adr064-s4-context-resolver:
+//
+//   {Layer: 1, Name: "WPMgr security policy", ...}
+//   {Layer: 2, Name: "organisation default", ...}
+//   {Layer: 3, Name: "site override", ...}
+//   {Layer: 4, Name: "detected site facts", ...}
+//   {Layer: 5, Name: "approved skill instructions"}
+//   {Layer: 6, Name: "session context", ...}
+const REAL_LAYER_NAMES = [
+  "WPMgr security policy",
+  "organisation default",
+  "site override",
+  "detected site facts",
+  "approved skill instructions",
+  "session context",
+];
+
+function buildLayer(
+  overrides: Partial<GovContextLayerContribution> = {},
+): GovContextLayerContribution {
+  return {
+    layer: 1,
+    name: "WPMgr security policy",
+    restrictions: {},
+    guidance: {},
+    bytes: 12,
+    truncated: false,
+    ...overrides,
+  };
+}
+
+function buildEffective(
+  overrides: Partial<GovContextEffective> = {},
+): GovContextEffective {
+  const layers = REAL_LAYER_NAMES.map((name, i) =>
+    buildLayer({ layer: i + 1, name, bytes: 20 + i }),
+  );
+  return {
+    site_id: "site-1",
+    layers,
+    restrictions: {},
+    total_bytes: 145,
+    budget_bytes: 65536,
+    truncated: false,
+    ...overrides,
+  };
+}
+
+function mockData(data: GovContextEffective) {
+  mockedUseEffectiveSiteContext.mockReturnValue(
+    mockQueryResult<GovContextEffective>({ data }),
+  );
+}
+
+describe("EffectiveContextPreview — renders every layer, in order, labelled", () => {
+  it("shows all six layer names, in Decision 1 precedence order (layer 1 first, layer 6 last)", () => {
+    mockData(buildEffective());
+    renderWithProviders(<EffectiveContextPreview siteId="site-1" />);
+
+    // Non-vacuous: every real layer name string must be present (each name
+    // legitimately appears twice — once in the overview table, once in the
+    // per-layer heading — hence getAllByText rather than getByText).
+    for (const name of REAL_LAYER_NAMES) {
+      expect(screen.getAllByText(new RegExp(name)).length).toBeGreaterThan(0);
+    }
+
+    // ...AND in the order the API returned them (already precedence order —
+    // this component must never re-sort or drop a layer). A version that
+    // rendered only a subset, or reordered them, fails this even though the
+    // loop above might still pass for whatever subset it kept.
+    const headings = screen
+      .getAllByRole("heading", { level: 4 })
+      .map((h) => h.textContent);
+    expect(headings).toEqual([
+      "Layer 1 — WPMgr security policy",
+      "Layer 2 — organisation default",
+      "Layer 3 — site override",
+      "Layer 4 — detected site facts",
+      "Layer 5 — approved skill instructions",
+      "Layer 6 — session context",
+    ]);
+  });
+});
+
+describe("EffectiveContextPreview — 503 context_unavailable is distinct from an empty result", () => {
+  it("renders the could-not-load state for a 503, never the data tree", () => {
+    mockedUseEffectiveSiteContext.mockReturnValue(
+      mockQueryResult<GovContextEffective>({
+        data: undefined,
+        isError: true,
+        isSuccess: false,
+        error: new ContextUnavailableError(
+          "effective context could not be resolved: failed to load organisation context",
+        ),
+      }),
+    );
+    renderWithProviders(<EffectiveContextPreview siteId="site-1" />);
+
+    expect(screen.getByText(CONTEXT_UNAVAILABLE_WHAT)).toBeInTheDocument();
+    // The data tree's own heading must be completely absent — this is a
+    // different component tree, not the same tree with different text.
+    expect(screen.queryByText("Resolved context")).not.toBeInTheDocument();
+  });
+
+  it("renders the data tree (not the could-not-load state) for a genuinely empty layer list", () => {
+    mockData(buildEffective({ layers: [] }));
+    renderWithProviders(<EffectiveContextPreview siteId="site-1" />);
+
+    expect(screen.getByText("Resolved context")).toBeInTheDocument();
+    expect(screen.queryByText(CONTEXT_UNAVAILABLE_WHAT)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/context/effective-context-preview.test.tsx
+++ b/apps/web/src/features/context/effective-context-preview.test.tsx
@@ -51,6 +51,7 @@ function buildLayer(
     name: "WPMgr security policy",
     restrictions: {},
     guidance: {},
+    facts_unavailable: false,
     bytes: 12,
     truncated: false,
     ...overrides,

--- a/apps/web/src/features/context/effective-context-preview.test.tsx
+++ b/apps/web/src/features/context/effective-context-preview.test.tsx
@@ -25,13 +25,13 @@ vi.mock("./use-context", async (importOriginal) => {
 const mockedUseEffectiveSiteContext = vi.mocked(useEffectiveSiteContext);
 
 // The exact `Name` strings ADR-064 S4's resolver assigns per layer —
-// apps/api/internal/govcontext/resolver.go:96-101 on
-// origin/feat/adr064-s4-context-resolver:
+// apps/api/internal/govcontext/resolver.go:110-115 on
+// origin/feat/adr064-s4-context-resolver (tip d9f1bde8, post-facts_unavailable):
 //
 //   {Layer: 1, Name: "WPMgr security policy", ...}
 //   {Layer: 2, Name: "organisation default", ...}
 //   {Layer: 3, Name: "site override", ...}
-//   {Layer: 4, Name: "detected site facts", ...}
+//   {Layer: 4, Name: "detected site facts", Facts: &facts, FactsUnavailable: factsUnavailable}
 //   {Layer: 5, Name: "approved skill instructions"}
 //   {Layer: 6, Name: "session context", ...}
 const REAL_LAYER_NAMES = [
@@ -189,5 +189,56 @@ describe("EffectiveContextPreview — a truncated layer never reads as the compl
     expect(
       screen.queryByText(/this layer's own list may be shorter than what's enforced/i),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("EffectiveContextPreview — layer 4 'unavailable' is never rendered as 'nothing to report'", () => {
+  // ADR-064 S4 (apps/api/internal/govcontext/dto.go:245-252,
+  // resolver.go:89-98, tip d9f1bde8): a failed or unwired facts load still
+  // carries a non-null `facts` object on the wire (Go's `Facts: &facts` is
+  // never nil) — only `facts_unavailable: true` distinguishes "we could not
+  // load this" from "the load succeeded and found nothing". This is the
+  // same "inventory age unknown" vs. "inventory unavailable" distinction
+  // this project already drew on the updates card, and the same one that
+  // produced the earlier "Never" bug.
+  //
+  // NOTE for whoever picks this up next: as of S4 tip d9f1bde8,
+  // toEffectiveContextDTO (dto.go:267-287) copies every LayerContribution
+  // field EXCEPT FactsUnavailable into the wire DTO, so `facts_unavailable`
+  // can never actually be `true` in a live response today even though the
+  // resolver computes it correctly internally (proven by resolver_test.go's
+  // own TestResolve_Layer4FactsUnavailable_DistinctFromKnownEmpty). This
+  // fixture exercises the DOCUMENTED contract regardless — the frontend must
+  // still be correct once that backend gap is closed, and this test does not
+  // depend on the live API to prove it.
+  it("shows a distinct 'could not be loaded' message for facts_unavailable, never the empty facts fields", () => {
+    const base = buildEffective();
+    const layers = base.layers.map((l) =>
+      l.layer === 4 ? { ...l, facts: {}, facts_unavailable: true } : l,
+    );
+    mockData({ ...base, layers });
+    renderWithProviders(<EffectiveContextPreview siteId="site-1" />);
+
+    expect(
+      screen.getByText(/could not be loaded for this site/i),
+    ).toBeInTheDocument();
+    // Non-vacuous: none of the facts field labels render at all in this
+    // state — a version that fell back to the (empty) facts object would
+    // render the label with an absent-value dash instead of this message.
+    expect(screen.queryByText("WordPress version")).not.toBeInTheDocument();
+    expect(screen.queryByText("PHP version")).not.toBeInTheDocument();
+  });
+
+  it("still renders real facts fields when the load succeeded (facts_unavailable false/absent)", () => {
+    const base = buildEffective();
+    const layers = base.layers.map((l) =>
+      l.layer === 4 ? { ...l, facts: { wp_version: "6.7", active_theme: "twentytwentyfive" } } : l,
+    );
+    mockData({ ...base, layers });
+    renderWithProviders(<EffectiveContextPreview siteId="site-1" />);
+
+    expect(screen.getByText("6.7")).toBeInTheDocument();
+    expect(screen.getByText("twentytwentyfive")).toBeInTheDocument();
+    expect(screen.queryByText(/could not be loaded for this site/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/context/effective-context-preview.tsx
+++ b/apps/web/src/features/context/effective-context-preview.tsx
@@ -9,14 +9,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { DefinitionList, type KvRowProps } from "@/components/shared/definition-list";
-import type {
-  GovContextEffective,
-  GovContextLayerContribution,
-  GuidanceSet,
-  RestrictionSet,
-} from "@wpmgr/api";
+import { DefinitionList } from "@/components/shared/definition-list";
+import type { GovContextEffective, GovContextLayerContribution } from "@wpmgr/api";
 
+import { restrictionRows, guidanceRows } from "./context-rows";
 import { ContextUnavailableError, useEffectiveSiteContext } from "./use-context";
 
 // ADR-064 Decision 8 — the effective-context preview (Screen 1 of the S5
@@ -270,27 +266,4 @@ function EffectiveContextSkeleton() {
       </div>
     </div>
   );
-}
-
-// ── Row builders ─────────────────────────────────────────────────────────
-
-function restrictionRows(restrictions: RestrictionSet): KvRowProps[] {
-  return [
-    { label: "Forbidden tools", value: joinOrUndefined(restrictions.forbidden_tools) },
-    { label: "Forbidden domains", value: joinOrUndefined(restrictions.forbidden_domains) },
-    { label: "Forbidden topics", value: joinOrUndefined(restrictions.forbidden_topics) },
-  ];
-}
-
-function guidanceRows(guidance: GuidanceSet): KvRowProps[] {
-  return [
-    { label: "Brand voice", value: guidance.brand_voice || undefined },
-    { label: "Audience", value: guidance.audience || undefined },
-    { label: "Terminology", value: guidance.terminology || undefined },
-    { label: "Style", value: guidance.style || undefined },
-  ];
-}
-
-function joinOrUndefined(items?: string[]): string | undefined {
-  return items && items.length > 0 ? items.join(", ") : undefined;
 }

--- a/apps/web/src/features/context/effective-context-preview.tsx
+++ b/apps/web/src/features/context/effective-context-preview.tsx
@@ -205,7 +205,26 @@ function LayerCard({ layer }: { layer: GovContextLayerContribution }) {
         <DefinitionList rows={guidanceRows(layer.guidance)} />
       </div>
 
-      {layer.facts ? (
+      {/* ADR-064 S4: `facts_unavailable` MUST be checked before `facts` is
+          rendered as data. A failed or unwired facts load still carries a
+          non-null (all-empty) `facts` object on the wire — checking `facts`
+          truthiness alone would render that as "this site genuinely has
+          nothing to report," which is a different, false claim from "we do
+          not know." This is the same distinction as "inventory age unknown"
+          vs. "inventory unavailable" on the updates card, and the same one
+          that produced the earlier "Never" bug on this project — an unknown
+          state must never be presented as a verified empty one. */}
+      {layer.facts_unavailable ? (
+        <div className="space-y-1">
+          <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Facts
+          </h5>
+          <p className="text-xs text-warning-subtle-fg">
+            Could not be loaded for this site. This is not the same as
+            "nothing to report" — treat this layer as unknown, not empty.
+          </p>
+        </div>
+      ) : layer.facts ? (
         <div className="space-y-1">
           <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             Facts

--- a/apps/web/src/features/context/effective-context-preview.tsx
+++ b/apps/web/src/features/context/effective-context-preview.tsx
@@ -1,0 +1,296 @@
+import { PageError } from "@/components/feedback";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { DefinitionList, type KvRowProps } from "@/components/shared/definition-list";
+import type {
+  GovContextEffective,
+  GovContextLayerContribution,
+  GuidanceSet,
+  RestrictionSet,
+} from "@wpmgr/api";
+
+import { ContextUnavailableError, useEffectiveSiteContext } from "./use-context";
+
+// ADR-064 Decision 8 — the effective-context preview (Screen 1 of the S5
+// "context management screens" slice). This is the operator's ONLY window
+// into what Decision 1's seven-layer resolution actually produced for a
+// site, and Decision 8 is explicit that the preview must call the same
+// resolution function the model-facing path calls and render its real
+// output — never a second, client-assembled merge of the layers into prose.
+// See use-context.ts's module doc for why there is deliberately no
+// "concatenated context" string anywhere in this file.
+
+export const CONTEXT_UNAVAILABLE_WHAT =
+  "This site's context could not be loaded, so the preview can't be shown.";
+
+export const CONTEXT_UNAVAILABLE_WHY =
+  "WPMgr refuses to show a resolved context when any layer failed to load, rather than fill the gap with an empty or guessed result — the same rule that governs what a live run is handed (ADR-064 Decision 14).";
+
+export function EffectiveContextPreview({ siteId }: { siteId: string }) {
+  const { data, isPending, isError, error, refetch, isRefetching } =
+    useEffectiveSiteContext(siteId);
+
+  if (isPending) {
+    return <EffectiveContextSkeleton />;
+  }
+
+  if (isError) {
+    if (error instanceof ContextUnavailableError) {
+      // Decision 8 / Decision 14: a refused resolution is a DISTINCT state
+      // from "this site has no layers to show" — never the same component
+      // tree, so an operator can't mistake "we couldn't check" for "there's
+      // nothing to check."
+      return (
+        <PageError
+          what={CONTEXT_UNAVAILABLE_WHAT}
+          why={CONTEXT_UNAVAILABLE_WHY}
+          onRetry={() => void refetch()}
+          retryLabel="Reload context"
+          isRetrying={isRefetching}
+        />
+      );
+    }
+    return (
+      <PageError
+        what="Could not load this site's context."
+        why={error instanceof Error ? error.message : "Unknown error."}
+        onRetry={() => void refetch()}
+        retryLabel="Reload context"
+        isRetrying={isRefetching}
+      />
+    );
+  }
+
+  return <EffectiveContextBody data={data} />;
+}
+
+// ── Data state ───────────────────────────────────────────────────────────
+
+function EffectiveContextBody({ data }: { data: GovContextEffective }) {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-0.5">
+          <h2 className="text-sm font-medium text-foreground">
+            Resolved context
+          </h2>
+          <p className="text-xs text-muted-foreground tabular-nums">
+            {data.total_bytes.toLocaleString()} /{" "}
+            {data.budget_bytes.toLocaleString()} bytes
+          </p>
+        </div>
+        {data.truncated ? (
+          <Badge variant="muted">Truncated</Badge>
+        ) : null}
+      </div>
+
+      <LayerOverviewTable layers={data.layers} />
+
+      <div className="space-y-1">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Restrictions enforced at dispatch (union of layers 1-3)
+        </h3>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <DefinitionList rows={restrictionRows(data.restrictions)} />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Layer detail, in precedence order
+        </h3>
+        {data.layers.map((layer) => (
+          <LayerCard key={layer.layer} layer={layer} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LayerOverviewTable({
+  layers,
+}: {
+  layers: GovContextLayerContribution[];
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-12">#</TableHead>
+            <TableHead>Layer</TableHead>
+            <TableHead className="text-right">Bytes</TableHead>
+            <TableHead className="text-right">Truncated</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {layers.map((layer) => (
+            <TableRow key={layer.layer}>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {layer.layer}
+              </TableCell>
+              <TableCell className="font-medium text-foreground">
+                {layer.name}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {layer.bytes.toLocaleString()}
+              </TableCell>
+              <TableCell className="text-right">
+                {layer.truncated ? (
+                  <Badge variant="muted">Truncated</Badge>
+                ) : (
+                  <span className="text-muted-foreground">–</span>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function LayerCard({ layer }: { layer: GovContextLayerContribution }) {
+  const isSessionLayer = layer.layer === 6;
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="text-sm font-medium text-foreground">
+          Layer {layer.layer} — {layer.name}
+        </h4>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground tabular-nums">
+          <span>{layer.bytes.toLocaleString()} bytes</span>
+          {layer.truncated ? <Badge variant="muted">Truncated</Badge> : null}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Restrictions
+        </h5>
+        <DefinitionList rows={restrictionRows(layer.restrictions)} />
+      </div>
+
+      <div className="space-y-1">
+        <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Guidance
+        </h5>
+        <DefinitionList rows={guidanceRows(layer.guidance)} />
+      </div>
+
+      {layer.facts ? (
+        <div className="space-y-1">
+          <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Facts
+          </h5>
+          <DefinitionList
+            rows={[
+              { label: "WordPress version", value: layer.facts.wp_version, mono: true },
+              { label: "PHP version", value: layer.facts.php_version, mono: true },
+              {
+                label: "Multisite",
+                value:
+                  layer.facts.multisite === undefined
+                    ? undefined
+                    : layer.facts.multisite
+                      ? "Yes"
+                      : "No",
+              },
+              { label: "Active theme", value: layer.facts.active_theme },
+            ]}
+          />
+        </div>
+      ) : null}
+
+      {isSessionLayer ? (
+        <div className="space-y-1">
+          <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Session
+          </h5>
+          <DefinitionList
+            rows={[
+              {
+                label: "Session",
+                // ADR-064 Decision 8: session context is always empty on this
+                // endpoint — a preview request has no live run behind it.
+                // That is "not applicable here", never "nothing was set" —
+                // rendering the same empty-value dash as every other absent
+                // field would misread as the latter.
+                value:
+                  layer.session && layer.session.length > 0
+                    ? layer.session
+                    : "Not applicable outside a live run.",
+              },
+            ]}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Loading state ────────────────────────────────────────────────────────
+//
+// Deliberately makes NO claim about content — no "Never", no placeholder
+// layer names, nothing that could be mistaken for a real (or absent) result
+// while the fetch is still in flight.
+
+function EffectiveContextSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading this site's resolved context"
+      className="space-y-6"
+    >
+      <div className="space-y-2">
+        <Skeleton className="h-3.5 w-32" />
+        <Skeleton className="h-3 w-40" />
+      </div>
+      <div className="overflow-hidden rounded-lg border border-border">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b border-border px-3 py-3 last:border-0"
+          >
+            <Skeleton className="h-3 w-4" />
+            <Skeleton className="h-3 flex-1" />
+            <Skeleton className="h-3 w-12" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Row builders ─────────────────────────────────────────────────────────
+
+function restrictionRows(restrictions: RestrictionSet): KvRowProps[] {
+  return [
+    { label: "Forbidden tools", value: joinOrUndefined(restrictions.forbidden_tools) },
+    { label: "Forbidden domains", value: joinOrUndefined(restrictions.forbidden_domains) },
+    { label: "Forbidden topics", value: joinOrUndefined(restrictions.forbidden_topics) },
+  ];
+}
+
+function guidanceRows(guidance: GuidanceSet): KvRowProps[] {
+  return [
+    { label: "Brand voice", value: guidance.brand_voice || undefined },
+    { label: "Audience", value: guidance.audience || undefined },
+    { label: "Terminology", value: guidance.terminology || undefined },
+    { label: "Style", value: guidance.style || undefined },
+  ];
+}
+
+function joinOrUndefined(items?: string[]): string | undefined {
+  return items && items.length > 0 ? items.join(", ") : undefined;
+}

--- a/apps/web/src/features/context/effective-context-preview.tsx
+++ b/apps/web/src/features/context/effective-context-preview.tsx
@@ -94,6 +94,11 @@ function EffectiveContextBody({ data }: { data: GovContextEffective }) {
         <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Restrictions enforced at dispatch (union of layers 1-3)
         </h3>
+        <p className="text-xs text-muted-foreground">
+          This set is what actually blocks a tool call — it is never shortened
+          by the byte budget below, even when a layer&apos;s own copy further
+          down this page is.
+        </p>
         <div className="rounded-lg border border-border bg-card p-4">
           <DefinitionList rows={restrictionRows(data.restrictions)} />
         </div>
@@ -156,6 +161,16 @@ function LayerOverviewTable({
 
 function LayerCard({ layer }: { layer: GovContextLayerContribution }) {
   const isSessionLayer = layer.layer === 6;
+  // Only layers 2-3 ever carry restrictions (layer 1's is a fixed constant
+  // Decision 9 never truncates; layers 4-6 don't set restrictions at all —
+  // apps/api/internal/govcontext/resolver.go's Resolve on the S4 branch).
+  // For those two, `truncated` can mean this layer's OWN restriction list
+  // was shortened to fit the byte budget — a real, expected state (Decision
+  // 9), but one that must never read as though this card were the complete
+  // enforced set. The enforced union above is the authoritative number;
+  // this callout is what stops a short list here from being mistaken for it.
+  const restrictionsMayBeIncomplete =
+    layer.truncated && (layer.layer === 2 || layer.layer === 3);
 
   return (
     <div className="space-y-3 rounded-lg border border-border bg-card p-4">
@@ -173,6 +188,13 @@ function LayerCard({ layer }: { layer: GovContextLayerContribution }) {
         <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
           Restrictions
         </h5>
+        {restrictionsMayBeIncomplete ? (
+          <p className="text-xs text-warning-subtle-fg">
+            This layer&apos;s own list may be shorter than what&apos;s enforced
+            — truncated to fit the byte budget. See the enforced union above
+            for the complete, untruncated set.
+          </p>
+        ) : null}
         <DefinitionList rows={restrictionRows(layer.restrictions)} />
       </div>
 

--- a/apps/web/src/features/context/gov-context-editor.test.tsx
+++ b/apps/web/src/features/context/gov-context-editor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import type { GovContext } from "@wpmgr/api";
 
 import { renderWithProviders } from "@/test/render";
@@ -139,5 +139,62 @@ describe("GovContextEditor — no false positives when there is no error", () =>
     expect(
       screen.queryByRole("button", { name: /reload the latest version/i }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("GovContextEditor — a rejected guidance value tells the operator why", () => {
+  // CodeRabbit finding on #566: contextFormSchema rejects a guidance value
+  // over 2,000 characters, handleSubmit correctly never calls onSave for it —
+  // but GuidanceField rendered no error at all, so the operator just saw the
+  // save silently do nothing.
+  it("shows a validation error on the specific field that failed, with aria-invalid/aria-describedby wired", async () => {
+    const onSave = vi.fn();
+    renderWithProviders(
+      <GovContextEditor
+        scopeLabel="site"
+        current={buildContext()}
+        onSave={onSave}
+        onReloadLatest={vi.fn()}
+        saveError={null}
+        isSaving={false}
+        canWrite
+      />,
+    );
+
+    const brandVoice = screen.getByLabelText("Brand voice");
+    fireEvent.change(brandVoice, { target: { value: "x".repeat(2001) } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    const error = await screen.findByText(/expected string to have <=2000 characters/i);
+    expect(error).toBeInTheDocument();
+    expect(error).toHaveAttribute("role", "alert");
+    expect(brandVoice).toHaveAttribute("aria-invalid", "true");
+    expect(brandVoice).toHaveAttribute("aria-describedby", error.id);
+    // Non-vacuous: the save must genuinely be blocked, not just decorated
+    // with an error while still submitting.
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("shows no guidance errors when every field is valid (must not over-fire)", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <GovContextEditor
+        scopeLabel="site"
+        current={buildContext()}
+        onSave={onSave}
+        onReloadLatest={vi.fn()}
+        saveError={null}
+        isSaving={false}
+        canWrite
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Brand voice"), {
+      target: { value: "Friendly and direct." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/context/gov-context-editor.test.tsx
+++ b/apps/web/src/features/context/gov-context-editor.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import type { GovContext } from "@wpmgr/api";
+
+import { renderWithProviders } from "@/test/render";
+
+import { GovContextEditor } from "./gov-context-editor";
+import {
+  ContextSecretDetectedError,
+  ContextVersionConflictError,
+  ContextWidenForbiddenError,
+} from "./use-context";
+
+// ADR-064 S5 Stage B — outcome tests for the three write-path refusals
+// (Decision 4/10/13) the org/site editors share via `GovContextEditor`.
+// `GovContextEditor` takes `saveError` as a prop (it does not call any data
+// hook itself), so these tests exercise it directly rather than mocking a
+// hook module — the same "test the presentational component against real
+// prop shapes" approach as health-cards.test.tsx.
+
+function buildContext(overrides: Partial<GovContext> = {}): GovContext {
+  return {
+    version: 3,
+    restrictions: { forbidden_tools: ["shell_exec"], forbidden_domains: [], forbidden_topics: [] },
+    guidance: { brand_voice: "", audience: "", terminology: "", style: "" },
+    author_type: "user",
+    provenance: "manual",
+    created_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("GovContextEditor — widen refusal names which restriction was hit", () => {
+  it("flags the specific restriction field, not just a generic banner", () => {
+    const message =
+      "this write would remove [shell_exec] from forbidden_tools, which was set by organisation default (layer 2) — a lower layer may narrow or add to a restriction but never remove what a higher layer set";
+    renderWithProviders(
+      <GovContextEditor
+        scopeLabel="site"
+        current={buildContext()}
+        onSave={vi.fn()}
+        onReloadLatest={vi.fn()}
+        saveError={
+          new ContextWidenForbiddenError(message, {
+            field: "forbidden_tools",
+            layer: 2,
+            layerName: "organisation default",
+            removedItems: ["shell_exec"],
+          })
+        }
+        isSaving={false}
+        canWrite
+      />,
+    );
+
+    // The specific restriction's own inline error carries the full,
+    // field-naming message from the server.
+    expect(screen.getByText(message)).toBeInTheDocument();
+    // The top banner is a pointer to it, not a second copy of a generic
+    // validation message — this is what distinguishes "which restriction
+    // was hit" from a generic "could not save" the coordinator flagged.
+    expect(
+      screen.getByText("Could not save — see the highlighted restriction below."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("GovContextEditor — secret refusal names the kind found, never a field", () => {
+  it("shows the category-based message and does not flag any restriction field", () => {
+    const message =
+      "this write was refused because it contains a value shaped like a bearer token — remove it and try again";
+    renderWithProviders(
+      <GovContextEditor
+        scopeLabel="site"
+        current={buildContext()}
+        onSave={vi.fn()}
+        onReloadLatest={vi.fn()}
+        saveError={new ContextSecretDetectedError(message, "bearer_token")}
+        isSaving={false}
+        canWrite
+      />,
+    );
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+    // Never the widen copy — a secret refusal is not a widen refusal, and
+    // DetectSecret never reports which field matched (use-context.ts's own
+    // doc comment), so there is nothing to highlight inline.
+    expect(
+      screen.queryByText("Could not save — see the highlighted restriction below."),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("GovContextEditor — version conflict offers reload, never a silent merge", () => {
+  it("renders a reload action that fetches the latest version and re-baselines the form", () => {
+    const fresh = buildContext({ version: 4 });
+    const onReloadLatest = vi.fn().mockResolvedValue(fresh);
+    const message =
+      "base_version 3 does not match the current version 4 — reread the current context and retry";
+
+    renderWithProviders(
+      <GovContextEditor
+        scopeLabel="site"
+        current={buildContext({ version: 3 })}
+        onSave={vi.fn()}
+        onReloadLatest={onReloadLatest}
+        saveError={new ContextVersionConflictError(message, 4, 3)}
+        isSaving={false}
+        canWrite
+      />,
+    );
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+    const reloadButton = screen.getByRole("button", {
+      name: "Discard my changes and reload the latest version",
+    });
+    fireEvent.click(reloadButton);
+    expect(onReloadLatest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GovContextEditor — no false positives when there is no error", () => {
+  it("renders none of the three refusal banners when saveError is null", () => {
+    renderWithProviders(
+      <GovContextEditor
+        scopeLabel="site"
+        current={buildContext()}
+        onSave={vi.fn()}
+        onReloadLatest={vi.fn()}
+        saveError={null}
+        isSaving={false}
+        canWrite
+      />,
+    );
+
+    expect(
+      screen.queryByText("Could not save — see the highlighted restriction below."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /reload the latest version/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/context/gov-context-editor.tsx
+++ b/apps/web/src/features/context/gov-context-editor.tsx
@@ -1,0 +1,385 @@
+import { useEffect } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { DefinitionList } from "@/components/shared/definition-list";
+import type { GovContext } from "@wpmgr/api";
+
+import { restrictionRows, guidanceRows } from "./context-rows";
+import {
+  ContextSecretDetectedError,
+  ContextVersionConflictError,
+  ContextWidenForbiddenError,
+} from "./use-context";
+
+// ADR-064 S5 Stage B — the shared org/site context editor (Decision 6/13).
+// One form for both scopes: `PatchGovContextRequest` is identical for
+// `/orgs/{orgId}/context` and `/sites/{siteId}/context`, so the org and site
+// "screens" (org-context-section.tsx / site-context-section.tsx) are thin
+// wrappers around this component that supply the right query/mutation pair.
+//
+// PATCH replaces `restrictions`/`guidance` WHOLESALE, never deep-merged
+// (PatchGovContextRequest's own doc comment) — so this form always submits
+// BOTH keys in full, never a partial subset of fields within them.
+
+const restrictionListSchema = z.array(z.string().trim().min(1)).default([]);
+
+const contextFormSchema = z.object({
+  restrictions: z.object({
+    forbidden_tools: restrictionListSchema,
+    forbidden_domains: restrictionListSchema,
+    forbidden_topics: restrictionListSchema,
+  }),
+  guidance: z.object({
+    brand_voice: z.string().max(2000).default(""),
+    audience: z.string().max(2000).default(""),
+    terminology: z.string().max(2000).default(""),
+    style: z.string().max(2000).default(""),
+  }),
+});
+
+export type ContextFormValues = z.infer<typeof contextFormSchema>;
+
+function toFormValues(current: GovContext): ContextFormValues {
+  return {
+    restrictions: {
+      forbidden_tools: current.restrictions.forbidden_tools ?? [],
+      forbidden_domains: current.restrictions.forbidden_domains ?? [],
+      forbidden_topics: current.restrictions.forbidden_topics ?? [],
+    },
+    guidance: {
+      brand_voice: current.guidance.brand_voice ?? "",
+      audience: current.guidance.audience ?? "",
+      terminology: current.guidance.terminology ?? "",
+      style: current.guidance.style ?? "",
+    },
+  };
+}
+
+const RESTRICTION_FIELDS = ["forbidden_tools", "forbidden_domains", "forbidden_topics"] as const;
+type RestrictionFieldKey = (typeof RESTRICTION_FIELDS)[number];
+
+const RESTRICTION_FIELD_LABELS: Record<RestrictionFieldKey, string> = {
+  forbidden_tools: "Forbidden tools",
+  forbidden_domains: "Forbidden domains",
+  forbidden_topics: "Forbidden topics",
+};
+
+// Maps the server's `details.field` (a RestrictionSet key, per
+// use-context.ts's ContextWidenForbiddenError doc comment) onto the
+// react-hook-form path it corresponds to, so a widen refusal can flag the
+// SPECIFIC restriction it hit, not just a page-level banner.
+const WIDEN_FIELD_PATH: Record<RestrictionFieldKey, `restrictions.${RestrictionFieldKey}`> = {
+  forbidden_tools: "restrictions.forbidden_tools",
+  forbidden_domains: "restrictions.forbidden_domains",
+  forbidden_topics: "restrictions.forbidden_topics",
+};
+
+function isRestrictionFieldKey(v: string): v is RestrictionFieldKey {
+  return (RESTRICTION_FIELDS as readonly string[]).includes(v);
+}
+
+export interface GovContextEditorProps {
+  /** "organisation" | "site" — copy only, also namespaces element ids. */
+  scopeLabel: string;
+  current: GovContext;
+  onSave: (values: ContextFormValues) => Promise<void>;
+  /** Refetches the current context and returns the fresh snapshot, or
+   *  `undefined` if the refetch itself failed. Used to recover from a 409
+   *  context_version_conflict — ADR-064 forecloses merge-based conflict
+   *  resolution, so the only correct move is reread-and-retry, never a
+   *  client-side merge of the stale edit onto the new base. */
+  onReloadLatest: () => Promise<GovContext | undefined>;
+  saveError: Error | null;
+  isSaving: boolean;
+  /** False for a caller who can read but not write this scope (Decision 6:
+   *  read follows fleet-read access, write is narrower) — renders the
+   *  current snapshot read-only instead of a form. */
+  canWrite: boolean;
+}
+
+export function GovContextEditor({
+  scopeLabel,
+  current,
+  onSave,
+  onReloadLatest,
+  saveError,
+  isSaving,
+  canWrite,
+}: GovContextEditorProps) {
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    setError,
+    formState: { errors, isSubmitting, isDirty },
+  } = useForm<ContextFormValues>({
+    resolver: zodResolver(contextFormSchema) as never,
+    defaultValues: toFormValues(current),
+  });
+
+  // Re-baseline the form whenever the server's version changes under us (a
+  // fresh GET, a successful save, or an explicit post-conflict reload).
+  // Never re-baseline on any OTHER prop change — that would clobber an
+  // operator's in-progress, not-yet-saved edit for no reason, so the
+  // dependency array is deliberately just `current.version`, not `current`
+  // or `reset` (`reset` is a stable react-hook-form identity; `current` as a
+  // whole would re-fire on every parent render).
+  useEffect(() => {
+    reset(toFormValues(current));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [current.version]);
+
+  // Flag the SPECIFIC restriction a widen refusal named, per Decision 4's
+  // "the reason names the restriction and the layer that blocked it" and the
+  // coordinator's instruction that this refusal must name which restriction
+  // was hit, not read as a generic validation error.
+  useEffect(() => {
+    if (saveError instanceof ContextWidenForbiddenError && isRestrictionFieldKey(saveError.field)) {
+      setError(WIDEN_FIELD_PATH[saveError.field], {
+        type: "server",
+        message: saveError.message,
+      });
+    }
+  }, [saveError, setError]);
+
+  if (!canWrite) {
+    return (
+      <div className="space-y-4 rounded-lg border border-border bg-card p-4">
+        <p className="text-xs text-muted-foreground">
+          You can view this {scopeLabel}&apos;s context but do not have permission to
+          change it.
+        </p>
+        <div className="space-y-1">
+          <h4 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Restrictions
+          </h4>
+          <DefinitionList rows={restrictionRows(current.restrictions)} />
+        </div>
+        <div className="space-y-1">
+          <h4 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Guidance
+          </h4>
+          <DefinitionList rows={guidanceRows(current.guidance)} />
+        </div>
+      </div>
+    );
+  }
+
+  const widenFieldPath =
+    saveError instanceof ContextWidenForbiddenError && isRestrictionFieldKey(saveError.field)
+      ? WIDEN_FIELD_PATH[saveError.field]
+      : undefined;
+
+  async function handleReload() {
+    const fresh = await onReloadLatest();
+    if (fresh) reset(toFormValues(fresh));
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit((values) => onSave(values))(e)}
+      noValidate
+      aria-label={`Edit ${scopeLabel} context`}
+      className="space-y-5"
+    >
+      {saveError instanceof ContextVersionConflictError ? (
+        <div
+          role="alert"
+          className="space-y-2 rounded-lg border border-[var(--color-destructive)]/30 bg-[var(--color-card)] p-4"
+        >
+          <p className="text-sm font-semibold text-foreground">
+            Could not save — this context changed underneath you.
+          </p>
+          <p className="text-sm text-muted-foreground">{saveError.message}</p>
+          <Button type="button" variant="outline" size="sm" onClick={() => void handleReload()}>
+            Discard my changes and reload the latest version
+          </Button>
+        </div>
+      ) : null}
+
+      {saveError instanceof ContextSecretDetectedError ? (
+        <p
+          role="alert"
+          className="rounded-lg border border-[var(--color-destructive)]/30 bg-[var(--color-card)] p-3 text-sm text-[var(--color-destructive)]"
+        >
+          {saveError.message}
+        </p>
+      ) : null}
+
+      {saveError instanceof ContextWidenForbiddenError ? (
+        <p role="alert" className="text-sm text-[var(--color-destructive)]">
+          {widenFieldPath
+            ? "Could not save — see the highlighted restriction below."
+            : saveError.message}
+        </p>
+      ) : null}
+
+      {saveError &&
+      !(saveError instanceof ContextVersionConflictError) &&
+      !(saveError instanceof ContextSecretDetectedError) &&
+      !(saveError instanceof ContextWidenForbiddenError) ? (
+        <p role="alert" className="text-sm text-[var(--color-destructive)]">
+          {saveError.message}
+        </p>
+      ) : null}
+
+      <fieldset className="space-y-4">
+        <legend className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Restrictions
+        </legend>
+        {RESTRICTION_FIELDS.map((field) => (
+          <Controller
+            key={field}
+            control={control}
+            name={`restrictions.${field}`}
+            render={({ field: rhf }) => (
+              <RestrictionListField
+                id={`ctx-${scopeLabel}-${field}`}
+                label={RESTRICTION_FIELD_LABELS[field]}
+                values={rhf.value}
+                onChange={rhf.onChange}
+                errorMessage={errors.restrictions?.[field]?.message}
+              />
+            )}
+          />
+        ))}
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Guidance
+        </legend>
+        <GuidanceField
+          id={`ctx-${scopeLabel}-brand_voice`}
+          label="Brand voice"
+          {...register("guidance.brand_voice")}
+        />
+        <GuidanceField
+          id={`ctx-${scopeLabel}-audience`}
+          label="Audience"
+          {...register("guidance.audience")}
+        />
+        <GuidanceField
+          id={`ctx-${scopeLabel}-terminology`}
+          label="Terminology"
+          {...register("guidance.terminology")}
+        />
+        <GuidanceField id={`ctx-${scopeLabel}-style`} label="Style" {...register("guidance.style")} />
+      </fieldset>
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={isSubmitting || isSaving || !isDirty}>
+          {isSubmitting || isSaving ? "Saving…" : "Save changes"}
+        </Button>
+        <span className="text-xs text-muted-foreground tabular-nums">
+          Version {current.version}
+        </span>
+      </div>
+    </form>
+  );
+}
+
+// ── Restriction list field: chip editor over a string array ────────────────
+
+function RestrictionListField({
+  id,
+  label,
+  values,
+  onChange,
+  errorMessage,
+}: {
+  id: string;
+  label: string;
+  values: string[];
+  onChange: (next: string[]) => void;
+  errorMessage?: string;
+}) {
+  function addFrom(input: HTMLInputElement) {
+    const trimmed = input.value.trim();
+    if (!trimmed) return;
+    if (!values.includes(trimmed)) onChange([...values, trimmed]);
+    input.value = "";
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      {values.length > 0 ? (
+        <ul className="flex flex-wrap gap-1.5" aria-label={`${label} (current)`}>
+          {values.map((v) => (
+            <li
+              key={v}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 font-mono text-xs text-foreground"
+            >
+              {v}
+              <button
+                type="button"
+                aria-label={`Remove ${v} from ${label}`}
+                onClick={() => onChange(values.filter((x) => x !== v))}
+                className="rounded-full text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <X aria-hidden="true" className="size-3" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="flex gap-2">
+        <Input
+          id={id}
+          placeholder="Add and press Enter"
+          aria-invalid={errorMessage ? true : undefined}
+          aria-describedby={errorMessage ? `${id}-err` : undefined}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addFrom(e.currentTarget);
+            }
+          }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          onClick={(e) => {
+            const input = e.currentTarget.previousElementSibling as HTMLInputElement | null;
+            if (input) addFrom(input);
+          }}
+        >
+          Add
+        </Button>
+      </div>
+      {errorMessage ? (
+        <p id={`${id}-err`} role="alert" className="text-sm text-[var(--color-destructive)]">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Guidance field: a labelled textarea ─────────────────────────────────────
+
+function GuidanceField({
+  id,
+  label,
+  ...registerProps
+}: { id: string; label: string } & React.ComponentPropsWithRef<"textarea">) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <textarea
+        id={id}
+        rows={2}
+        className="w-full resize-y rounded-md border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-sm placeholder:text-[var(--color-muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
+        {...registerProps}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/context/gov-context-editor.tsx
+++ b/apps/web/src/features/context/gov-context-editor.tsx
@@ -259,19 +259,27 @@ export function GovContextEditor({
         <GuidanceField
           id={`ctx-${scopeLabel}-brand_voice`}
           label="Brand voice"
+          errorMessage={errors.guidance?.brand_voice?.message}
           {...register("guidance.brand_voice")}
         />
         <GuidanceField
           id={`ctx-${scopeLabel}-audience`}
           label="Audience"
+          errorMessage={errors.guidance?.audience?.message}
           {...register("guidance.audience")}
         />
         <GuidanceField
           id={`ctx-${scopeLabel}-terminology`}
           label="Terminology"
+          errorMessage={errors.guidance?.terminology?.message}
           {...register("guidance.terminology")}
         />
-        <GuidanceField id={`ctx-${scopeLabel}-style`} label="Style" {...register("guidance.style")} />
+        <GuidanceField
+          id={`ctx-${scopeLabel}-style`}
+          label="Style"
+          errorMessage={errors.guidance?.style?.message}
+          {...register("guidance.style")}
+        />
       </fieldset>
 
       <div className="flex items-center gap-3">
@@ -369,17 +377,25 @@ function RestrictionListField({
 function GuidanceField({
   id,
   label,
+  errorMessage,
   ...registerProps
-}: { id: string; label: string } & React.ComponentPropsWithRef<"textarea">) {
+}: { id: string; label: string; errorMessage?: string } & React.ComponentPropsWithRef<"textarea">) {
   return (
     <div className="space-y-1.5">
       <Label htmlFor={id}>{label}</Label>
       <textarea
         id={id}
         rows={2}
+        aria-invalid={errorMessage ? true : undefined}
+        aria-describedby={errorMessage ? `${id}-err` : undefined}
         className="w-full resize-y rounded-md border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-sm placeholder:text-[var(--color-muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
         {...registerProps}
       />
+      {errorMessage ? (
+        <p id={`${id}-err`} role="alert" className="text-sm text-[var(--color-destructive)]">
+          {errorMessage}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/context/org-context-history-section.tsx
+++ b/apps/web/src/features/context/org-context-history-section.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+
+import { toast } from "@/components/toast";
+import type { GovContextVersionSummary } from "@wpmgr/api";
+
+import { ContextVersionHistory, RestoreVersionDialog } from "./context-version-history";
+import {
+  useOrgContextVersionDiff,
+  useOrgContextVersions,
+  useRestoreOrgContextVersion,
+} from "./use-context";
+
+// ADR-064 S5 Stage B, Screen 4 — organisation-scope sibling of
+// site-context-history-section.tsx. Same shared component, same shape,
+// different hook pair.
+
+export function OrgContextHistorySection({
+  orgId,
+  canWrite,
+}: {
+  orgId: string;
+  canWrite: boolean;
+}) {
+  const {
+    items,
+    isPending,
+    isError,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    refetch,
+  } = useOrgContextVersions(orgId);
+
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const diff = useOrgContextVersionDiff(orgId, expandedId ?? "", {
+    enabled: expandedId !== null,
+  });
+
+  const [confirmVersion, setConfirmVersion] = useState<GovContextVersionSummary | null>(null);
+  const restore = useRestoreOrgContextVersion(orgId);
+
+  async function handleConfirmRestore() {
+    if (!confirmVersion) return;
+    try {
+      const result = await restore.mutateAsync(confirmVersion.id);
+      toast.success(`Restored to version ${confirmVersion.version}`, {
+        description: `Now version ${result.version}.`,
+      });
+      setConfirmVersion(null);
+      restore.reset();
+    } catch {
+      // Surfaced inside RestoreVersionDialog via `restore.error` — stay open.
+    }
+  }
+
+  return (
+    <>
+      <ContextVersionHistory
+        scopeLabel="organisation"
+        items={items}
+        isPending={isPending}
+        isError={isError}
+        error={error}
+        onRetry={() => void refetch()}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => void fetchNextPage()}
+        expandedId={expandedId}
+        onToggleExpand={(id) => setExpandedId((cur) => (cur === id ? null : id))}
+        diff={diff}
+        canWrite={canWrite}
+        onRequestRestore={(version) => {
+          restore.reset();
+          setConfirmVersion(version);
+        }}
+      />
+      <RestoreVersionDialog
+        open={confirmVersion !== null}
+        onClose={() => {
+          setConfirmVersion(null);
+          restore.reset();
+        }}
+        version={confirmVersion}
+        scopeLabel="organisation"
+        onConfirm={() => void handleConfirmRestore()}
+        isPending={restore.isPending}
+        error={restore.error}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/context/org-context-history-section.tsx
+++ b/apps/web/src/features/context/org-context-history-section.tsx
@@ -74,6 +74,7 @@ export function OrgContextHistorySection({
           restore.reset();
           setConfirmVersion(version);
         }}
+        isRestoring={restore.isPending}
       />
       <RestoreVersionDialog
         open={confirmVersion !== null}

--- a/apps/web/src/features/context/org-context-section.tsx
+++ b/apps/web/src/features/context/org-context-section.tsx
@@ -1,0 +1,87 @@
+import { PageError } from "@/components/feedback";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/components/toast";
+
+import { GovContextEditor, type ContextFormValues } from "./gov-context-editor";
+import { useOrgContext, usePatchOrgContext } from "./use-context";
+
+// ADR-064 S5 Stage B, Screen 3 — the organisation-defaults editor (layer 2,
+// Decision 1/6/13). Mirrors site-context-section.tsx exactly — same shared
+// GovContextEditor, same three GET states, same refusal handling — because
+// `GET/PATCH .../orgs/{orgId}/context` and `.../sites/{siteId}/context` are
+// the identical contract at a different scope.
+
+export function OrgContextSection({
+  orgId,
+  canWrite,
+}: {
+  orgId: string;
+  canWrite: boolean;
+}) {
+  const { data, isPending, isError, error, refetch } = useOrgContext(orgId);
+  const patch = usePatchOrgContext(orgId);
+
+  if (isPending) {
+    return <OrgContextSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <PageError
+        what="Could not load this organisation's context."
+        why={error instanceof Error ? error.message : "Unknown error."}
+        onRetry={() => void refetch()}
+        retryLabel="Reload"
+      />
+    );
+  }
+
+  const current = data;
+
+  async function handleSave(values: ContextFormValues) {
+    try {
+      await patch.mutateAsync({
+        base_version: current.version,
+        restrictions: values.restrictions,
+        guidance: values.guidance,
+      });
+      toast.success("Organisation context saved");
+    } catch {
+      // Surfaced to the operator via `patch.error` inside GovContextEditor.
+    }
+  }
+
+  async function handleReloadLatest() {
+    const result = await refetch();
+    patch.reset();
+    return result.data;
+  }
+
+  return (
+    <GovContextEditor
+      scopeLabel="organisation"
+      current={current}
+      onSave={handleSave}
+      onReloadLatest={handleReloadLatest}
+      saveError={patch.error}
+      isSaving={patch.isPending}
+      canWrite={canWrite}
+    />
+  );
+}
+
+function OrgContextSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading this organisation's context"
+      className="space-y-3 rounded-lg border border-border p-4"
+    >
+      <Skeleton className="h-3 w-24" />
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-3 w-20" />
+      <Skeleton className="h-16 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/features/context/site-context-history-section.tsx
+++ b/apps/web/src/features/context/site-context-history-section.tsx
@@ -74,6 +74,7 @@ export function SiteContextHistorySection({
           restore.reset();
           setConfirmVersion(version);
         }}
+        isRestoring={restore.isPending}
       />
       <RestoreVersionDialog
         open={confirmVersion !== null}

--- a/apps/web/src/features/context/site-context-history-section.tsx
+++ b/apps/web/src/features/context/site-context-history-section.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+
+import { toast } from "@/components/toast";
+import type { GovContextVersionSummary } from "@wpmgr/api";
+
+import { ContextVersionHistory, RestoreVersionDialog } from "./context-version-history";
+import {
+  useRestoreSiteContextVersion,
+  useSiteContextVersionDiff,
+  useSiteContextVersions,
+} from "./use-context";
+
+// ADR-064 S5 Stage B, Screen 4 — site-scope wrapper. Owns the hooks and the
+// "which row is expanded" / "which version is pending restore confirmation"
+// state; delegates rendering to the shared ContextVersionHistory.
+
+export function SiteContextHistorySection({
+  siteId,
+  canWrite,
+}: {
+  siteId: string;
+  canWrite: boolean;
+}) {
+  const {
+    items,
+    isPending,
+    isError,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    refetch,
+  } = useSiteContextVersions(siteId);
+
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const diff = useSiteContextVersionDiff(siteId, expandedId ?? "", {
+    enabled: expandedId !== null,
+  });
+
+  const [confirmVersion, setConfirmVersion] = useState<GovContextVersionSummary | null>(null);
+  const restore = useRestoreSiteContextVersion(siteId);
+
+  async function handleConfirmRestore() {
+    if (!confirmVersion) return;
+    try {
+      const result = await restore.mutateAsync(confirmVersion.id);
+      toast.success(`Restored to version ${confirmVersion.version}`, {
+        description: `Now version ${result.version}.`,
+      });
+      setConfirmVersion(null);
+      restore.reset();
+    } catch {
+      // Surfaced inside RestoreVersionDialog via `restore.error` — stay open.
+    }
+  }
+
+  return (
+    <>
+      <ContextVersionHistory
+        scopeLabel="site"
+        items={items}
+        isPending={isPending}
+        isError={isError}
+        error={error}
+        onRetry={() => void refetch()}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => void fetchNextPage()}
+        expandedId={expandedId}
+        onToggleExpand={(id) => setExpandedId((cur) => (cur === id ? null : id))}
+        diff={diff}
+        canWrite={canWrite}
+        onRequestRestore={(version) => {
+          restore.reset();
+          setConfirmVersion(version);
+        }}
+      />
+      <RestoreVersionDialog
+        open={confirmVersion !== null}
+        onClose={() => {
+          setConfirmVersion(null);
+          restore.reset();
+        }}
+        version={confirmVersion}
+        scopeLabel="site"
+        onConfirm={() => void handleConfirmRestore()}
+        isPending={restore.isPending}
+        error={restore.error}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/context/site-context-section.tsx
+++ b/apps/web/src/features/context/site-context-section.tsx
@@ -1,0 +1,91 @@
+import { PageError } from "@/components/feedback";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/components/toast";
+
+import { GovContextEditor, type ContextFormValues } from "./gov-context-editor";
+import { useSiteContext, usePatchSiteContext } from "./use-context";
+
+// ADR-064 S5 Stage B, Screen 2 — the site override editor (layer 3, Decision
+// 1/6/13). Thin wrapper: owns the GET/PATCH hooks and the three loading /
+// error / data states for the GET; delegates the form itself (and every
+// write-path refusal) to the shared `GovContextEditor`.
+
+export function SiteContextSection({
+  siteId,
+  canWrite,
+}: {
+  siteId: string;
+  canWrite: boolean;
+}) {
+  const { data, isPending, isError, error, refetch } = useSiteContext(siteId);
+  const patch = usePatchSiteContext(siteId);
+
+  if (isPending) {
+    return <SiteContextSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <PageError
+        what="Could not load this site's context."
+        why={error instanceof Error ? error.message : "Unknown error."}
+        onRetry={() => void refetch()}
+        retryLabel="Reload"
+      />
+    );
+  }
+
+  // `data` is guaranteed defined past the isPending/isError checks above,
+  // but that narrowing doesn't survive into the nested closures below (each
+  // is its own function scope TS re-widens) — bind it to a local const here
+  // instead of asserting `data!` at every use site.
+  const current = data;
+
+  async function handleSave(values: ContextFormValues) {
+    try {
+      await patch.mutateAsync({
+        base_version: current.version,
+        restrictions: values.restrictions,
+        guidance: values.guidance,
+      });
+      toast.success("Site context saved");
+    } catch {
+      // Surfaced to the operator via `patch.error` inside GovContextEditor —
+      // nothing further to do here.
+    }
+  }
+
+  async function handleReloadLatest() {
+    const result = await refetch();
+    patch.reset();
+    return result.data;
+  }
+
+  return (
+    <GovContextEditor
+      scopeLabel="site"
+      current={current}
+      onSave={handleSave}
+      onReloadLatest={handleReloadLatest}
+      saveError={patch.error}
+      isSaving={patch.isPending}
+      canWrite={canWrite}
+    />
+  );
+}
+
+function SiteContextSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading this site's context"
+      className="space-y-3 rounded-lg border border-border p-4"
+    >
+      <Skeleton className="h-3 w-24" />
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-3 w-20" />
+      <Skeleton className="h-16 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/features/context/use-context-versions.test.ts
+++ b/apps/web/src/features/context/use-context-versions.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+// CodeRabbit finding on #566: a missing response body must not render as
+// "this history has nothing in it" — the same conflation behind the
+// updates-card "Never" bug, the as_of heartbeat substitution, and
+// facts_unavailable's omitempty. Mocked at the @wpmgr/api boundary (the
+// generated SDK function), matching use-admin-agent-mirror.test.ts's
+// convention, so this exercises the real response-shape branch, not a
+// hand-built fixture of use-context.ts's own internals.
+
+const { listOrgContextVersionsMock } = vi.hoisted(() => ({
+  listOrgContextVersionsMock: vi.fn(),
+}));
+
+vi.mock("@wpmgr/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wpmgr/api")>();
+  return { ...actual, listOrgContextVersions: listOrgContextVersionsMock };
+});
+
+const { useOrgContextVersions } = await import("./use-context");
+
+function wrapperFor(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+beforeEach(() => {
+  listOrgContextVersionsMock.mockReset();
+});
+
+describe("useOrgContextVersions — a missing body is a failure, never an empty history", () => {
+  it("surfaces an error, not an empty items array, when data and error are both absent", async () => {
+    listOrgContextVersionsMock.mockResolvedValue({ data: undefined, error: undefined });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useOrgContextVersions("org-1"), {
+      wrapper: wrapperFor(qc),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    // Non-vacuous: the malformed-response version and the genuinely-empty
+    // version must not collapse into the same observable state.
+    expect(result.current.items).toEqual([]);
+    expect(result.current.error?.message).toBe("Empty response");
+  });
+
+  it("still returns a genuinely empty items array on a real empty page (must not over-block)", async () => {
+    listOrgContextVersionsMock.mockResolvedValue({
+      data: { items: [], next_cursor: 0 },
+      error: undefined,
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useOrgContextVersions("org-1"), {
+      wrapper: wrapperFor(qc),
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.isError).toBe(false);
+    expect(result.current.items).toEqual([]);
+  });
+});

--- a/apps/web/src/features/context/use-context-versions.test.ts
+++ b/apps/web/src/features/context/use-context-versions.test.ts
@@ -11,16 +11,21 @@ import { createElement, type ReactNode } from "react";
 // convention, so this exercises the real response-shape branch, not a
 // hand-built fixture of use-context.ts's own internals.
 
-const { listOrgContextVersionsMock } = vi.hoisted(() => ({
+const { listOrgContextVersionsMock, patchOrgContextMock } = vi.hoisted(() => ({
   listOrgContextVersionsMock: vi.fn(),
+  patchOrgContextMock: vi.fn(),
 }));
 
 vi.mock("@wpmgr/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@wpmgr/api")>();
-  return { ...actual, listOrgContextVersions: listOrgContextVersionsMock };
+  return {
+    ...actual,
+    listOrgContextVersions: listOrgContextVersionsMock,
+    patchOrgContext: patchOrgContextMock,
+  };
 });
 
-const { useOrgContextVersions } = await import("./use-context");
+const { useOrgContextVersions, usePatchOrgContext } = await import("./use-context");
 
 function wrapperFor(qc: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -30,6 +35,7 @@ function wrapperFor(qc: QueryClient) {
 
 beforeEach(() => {
   listOrgContextVersionsMock.mockReset();
+  patchOrgContextMock.mockReset();
 });
 
 describe("useOrgContextVersions — a missing body is a failure, never an empty history", () => {
@@ -60,5 +66,48 @@ describe("useOrgContextVersions — a missing body is a failure, never an empty 
     await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.isError).toBe(false);
     expect(result.current.items).toEqual([]);
+  });
+});
+
+describe("usePatchOrgContext — a successful PATCH invalidates the version-history list", () => {
+  // CodeRabbit finding on #566: a PATCH authors a new stored version row
+  // (Decision 5) exactly like restore does, but only restore invalidated
+  // contextKeys.orgVersions — the history list, mounted alongside the
+  // editor, kept showing pre-save pages. This mounts BOTH hooks against one
+  // shared QueryClient (the real coupling the bug lived in) and proves the
+  // list actually refetches, not just that invalidateQueries was called —
+  // an invalidation call that targeted the wrong key would still "pass" a
+  // spy-based assertion while leaving the rendered list stale.
+  it("makes the just-authored version show up in the still-mounted history list", async () => {
+    listOrgContextVersionsMock
+      .mockResolvedValueOnce({
+        data: { items: [{ id: "v-1", version: 1, author_type: "user", provenance: "manual", created_at: "2026-08-01T00:00:00Z" }], next_cursor: 0 },
+        error: undefined,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          items: [
+            { id: "v-2", version: 2, author_type: "user", provenance: "manual", created_at: "2026-08-02T00:00:00Z" },
+            { id: "v-1", version: 1, author_type: "user", provenance: "manual", created_at: "2026-08-01T00:00:00Z" },
+          ],
+          next_cursor: 0,
+        },
+        error: undefined,
+      });
+    patchOrgContextMock.mockResolvedValue({
+      data: { version: 2, restrictions: {}, guidance: {} },
+      error: undefined,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const versions = renderHook(() => useOrgContextVersions("org-1"), { wrapper: wrapperFor(qc) });
+    const patch = renderHook(() => usePatchOrgContext("org-1"), { wrapper: wrapperFor(qc) });
+
+    await waitFor(() => expect(versions.result.current.items).toHaveLength(1));
+
+    await patch.result.current.mutateAsync({ base_version: 1, restrictions: {}, guidance: {} });
+
+    await waitFor(() => expect(versions.result.current.items).toHaveLength(2));
+    expect(versions.result.current.items[0]?.version).toBe(2);
   });
 });

--- a/apps/web/src/features/context/use-context.ts
+++ b/apps/web/src/features/context/use-context.ts
@@ -1,7 +1,10 @@
 import {
+  useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
   type UseMutationResult,
   type UseQueryResult,
 } from "@tanstack/react-query";
@@ -9,11 +12,20 @@ import {
   getEffectiveSiteContext,
   getOrgContext as apiGetOrgContext,
   patchOrgContext as apiPatchOrgContext,
+  listOrgContextVersions as apiListOrgContextVersions,
+  diffOrgContextVersion as apiDiffOrgContextVersion,
+  restoreOrgContextVersion as apiRestoreOrgContextVersion,
   getSiteContext as apiGetSiteContext,
   patchSiteContext as apiPatchSiteContext,
+  listSiteContextVersions as apiListSiteContextVersions,
+  diffSiteContextVersion as apiDiffSiteContextVersion,
+  restoreSiteContextVersion as apiRestoreSiteContextVersion,
   type ApiError,
   type GovContext,
+  type GovContextDiff,
   type GovContextEffective,
+  type GovContextVersionList,
+  type GovContextVersionSummary,
   type PatchGovContextRequest,
 } from "@wpmgr/api";
 
@@ -21,18 +33,23 @@ import { toError } from "@/features/auth/use-auth";
 
 // ADR-064 (governed org/site context) — S5.
 //
-// Stage A covered ONLY the effective-context preview (Decision 8, Screen 1).
-// Stage B adds the org/site context read+write hooks below (Decision
-// 6/13) — org and site editors, and the three write-path refusals Decision
-// 4/10/13 define. Version history, diff and restore (Decision 5) are not yet
-// built; grow `contextKeys` further (e.g. `contextKeys.orgVersions(orgId)`)
-// rather than starting a second key factory when that lands.
+// Stage A covered the effective-context preview (Decision 8, Screen 1).
+// Stage B added the org/site editors and the three write-path refusals
+// (Decision 4/10/13, below). This section adds version history, diff and
+// restore (Decision 5) — the last of the five screens in the original S5
+// brief.
 
 export const contextKeys = {
   all: ["gov-context"] as const,
   effective: (siteId: string) => [...contextKeys.all, "effective", siteId] as const,
   org: (orgId: string) => [...contextKeys.all, "org", orgId] as const,
   site: (siteId: string) => [...contextKeys.all, "site", siteId] as const,
+  orgVersions: (orgId: string) => [...contextKeys.all, "org-versions", orgId] as const,
+  siteVersions: (siteId: string) => [...contextKeys.all, "site-versions", siteId] as const,
+  orgVersionDiff: (orgId: string, versionId: string) =>
+    [...contextKeys.all, "org-version-diff", orgId, versionId] as const,
+  siteVersionDiff: (siteId: string, versionId: string) =>
+    [...contextKeys.all, "site-version-diff", siteId, versionId] as const,
 };
 
 /**
@@ -288,6 +305,185 @@ export function usePatchSiteContext(
       queryClient.setQueryData(contextKeys.site(siteId), updated);
       // Layer 3 changed — this site's effective-context preview (Decision 8,
       // Screen 1) is stale (Decision 2). Targeted, since we know the site.
+      void queryClient.invalidateQueries({ queryKey: contextKeys.effective(siteId) });
+    },
+  });
+}
+
+// ── Version history, diff, restore (Decision 5) ─────────────────────────
+//
+// The list/item/diff routes return STORED rows — what was authored at write
+// time, never a resolved context. A diff between two versions is therefore a
+// diff of authored intent, not of what was enforced at either moment: an
+// organisation's own restrictions can move between when a site version was
+// written and when it is read here, and a stored site-layer row never
+// restates the org's current state. Nothing in this section computes or
+// implies an "as enforced" comparison — that is Screen 1's job, on live data,
+// never this screen's on history.
+
+export interface UseGovContextVersionsResult {
+  items: GovContextVersionSummary[];
+  fetchNextPage: UseInfiniteQueryResult<InfiniteData<GovContextVersionList>, Error>["fetchNextPage"];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: UseInfiniteQueryResult<InfiniteData<GovContextVersionList>, Error>["refetch"];
+}
+
+/** `GET /api/v1/orgs/{orgId}/context/versions` — paginated, newest first. */
+export function useOrgContextVersions(orgId: string): UseGovContextVersionsResult {
+  const result = useInfiniteQuery<
+    GovContextVersionList,
+    Error,
+    InfiniteData<GovContextVersionList>,
+    ReturnType<typeof contextKeys.orgVersions>,
+    number | undefined
+  >({
+    queryKey: contextKeys.orgVersions(orgId),
+    initialPageParam: undefined,
+    // `next_cursor: 0` means "no further page" (GovContextVersionList's own
+    // doc comment) — falsy, so `|| undefined` reads it correctly as "stop".
+    getNextPageParam: (lastPage) => lastPage.next_cursor || undefined,
+    queryFn: async ({ pageParam }) => {
+      const { data, error } = await apiListOrgContextVersions({
+        path: { orgId },
+        query: pageParam !== undefined ? { cursor: pageParam } : undefined,
+      });
+      if (error) throw toError(error);
+      return data ?? { items: [], next_cursor: 0 };
+    },
+  });
+  return {
+    items: result.data?.pages.flatMap((p) => p.items) ?? [],
+    fetchNextPage: result.fetchNextPage,
+    hasNextPage: result.hasNextPage,
+    isFetchingNextPage: result.isFetchingNextPage,
+    isPending: result.isPending,
+    isError: result.isError,
+    error: result.error,
+    refetch: result.refetch,
+  };
+}
+
+/** `GET /api/v1/sites/{siteId}/context/versions` — site-scope sibling. */
+export function useSiteContextVersions(siteId: string): UseGovContextVersionsResult {
+  const result = useInfiniteQuery<
+    GovContextVersionList,
+    Error,
+    InfiniteData<GovContextVersionList>,
+    ReturnType<typeof contextKeys.siteVersions>,
+    number | undefined
+  >({
+    queryKey: contextKeys.siteVersions(siteId),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => lastPage.next_cursor || undefined,
+    queryFn: async ({ pageParam }) => {
+      const { data, error } = await apiListSiteContextVersions({
+        path: { siteId },
+        query: pageParam !== undefined ? { cursor: pageParam } : undefined,
+      });
+      if (error) throw toError(error);
+      return data ?? { items: [], next_cursor: 0 };
+    },
+  });
+  return {
+    items: result.data?.pages.flatMap((p) => p.items) ?? [],
+    fetchNextPage: result.fetchNextPage,
+    hasNextPage: result.hasNextPage,
+    isFetchingNextPage: result.isFetchingNextPage,
+    isPending: result.isPending,
+    isError: result.isError,
+    error: result.error,
+    refetch: result.refetch,
+  };
+}
+
+/**
+ * `GET /api/v1/orgs/{orgId}/context/versions/{versionId}/diff` — fetched only
+ * when a row is expanded (`enabled`), never eagerly for the whole list.
+ */
+export function useOrgContextVersionDiff(
+  orgId: string,
+  versionId: string,
+  options: { enabled: boolean },
+): UseQueryResult<GovContextDiff, Error> {
+  return useQuery({
+    queryKey: contextKeys.orgVersionDiff(orgId, versionId),
+    queryFn: async () => {
+      const { data, error } = await apiDiffOrgContextVersion({ path: { orgId, versionId } });
+      if (error) throw toError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+    enabled: options.enabled,
+  });
+}
+
+/** Site-scope sibling of {@link useOrgContextVersionDiff}. */
+export function useSiteContextVersionDiff(
+  siteId: string,
+  versionId: string,
+  options: { enabled: boolean },
+): UseQueryResult<GovContextDiff, Error> {
+  return useQuery({
+    queryKey: contextKeys.siteVersionDiff(siteId, versionId),
+    queryFn: async () => {
+      const { data, error } = await apiDiffSiteContextVersion({ path: { siteId, versionId } });
+      if (error) throw toError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+    enabled: options.enabled,
+  });
+}
+
+/**
+ * `POST /api/v1/orgs/{orgId}/context/versions/{versionId}/restore` — a new
+ * version whose snapshot equals `versionId`'s (Decision 5). Runs through the
+ * SAME widen-check, secret-scan and audit transaction as an ordinary PATCH
+ * (service.go's own doc comment: "It is not a back door around either"), so
+ * it can refuse with the identical three codes `toPatchContextError` already
+ * maps — reused here rather than a fourth error class, because the shape is
+ * identical; only the UI copy for *why* a restore was refused differs (a
+ * restore's widen refusal means "this version would reintroduce something
+ * since tightened", not "your edit tried to remove something").
+ */
+export function useRestoreOrgContextVersion(
+  orgId: string,
+): UseMutationResult<GovContext, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (versionId: string) => {
+      const { data, error } = await apiRestoreOrgContextVersion({ path: { orgId, versionId } });
+      if (error) throw toPatchContextError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(contextKeys.org(orgId), updated);
+      void queryClient.invalidateQueries({ queryKey: contextKeys.orgVersions(orgId) });
+      void queryClient.invalidateQueries({ queryKey: [...contextKeys.all, "effective"] });
+    },
+  });
+}
+
+/** Site-scope sibling of {@link useRestoreOrgContextVersion}. */
+export function useRestoreSiteContextVersion(
+  siteId: string,
+): UseMutationResult<GovContext, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (versionId: string) => {
+      const { data, error } = await apiRestoreSiteContextVersion({ path: { siteId, versionId } });
+      if (error) throw toPatchContextError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(contextKeys.site(siteId), updated);
+      void queryClient.invalidateQueries({ queryKey: contextKeys.siteVersions(siteId) });
       void queryClient.invalidateQueries({ queryKey: contextKeys.effective(siteId) });
     },
   });

--- a/apps/web/src/features/context/use-context.ts
+++ b/apps/web/src/features/context/use-context.ts
@@ -1,0 +1,70 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { getEffectiveSiteContext, type GovContextEffective } from "@wpmgr/api";
+
+import { toError } from "@/features/auth/use-auth";
+
+// ADR-064 (governed org/site context) — S5 Stage A.
+//
+// This module currently covers ONLY the effective-context preview (Decision
+// 8, Screen 1). Stage B adds the org/site context read+edit hooks, version
+// history, diff and restore (Decision 5/13) alongside this file — grow the
+// `contextKeys` factory below (e.g. `contextKeys.org(orgId)`,
+// `contextKeys.siteVersions(siteId)`) rather than starting a second one.
+
+export const contextKeys = {
+  all: ["gov-context"] as const,
+  effective: (siteId: string) => [...contextKeys.all, "effective", siteId] as const,
+};
+
+/**
+ * Raised when `GET .../context/effective` returns `503 context_unavailable`
+ * (ADR-064 Decision 14): resolution could not complete, so the call is
+ * refused rather than handed an empty, partial, or stale-but-unmarked
+ * result. This is a distinct, EXPECTED outcome, never coerced into the
+ * generic error path — the UI renders a "could not load" state for it, which
+ * must never look like the (different) "site has no context yet" state.
+ */
+export class ContextUnavailableError extends Error {
+  constructor(message = "Context could not be resolved.") {
+    super(message);
+    this.name = "ContextUnavailableError";
+  }
+}
+
+async function fetchEffectiveContext(siteId: string): Promise<GovContextEffective> {
+  const { data, error, response } = await getEffectiveSiteContext({
+    path: { siteId },
+  });
+  // Branch on 503 BEFORE the generic `if (error)` below, matching this
+  // repo's EmailNotVerifiedError convention (features/auth/use-auth.ts) —
+  // a named error class, not a generic throw, so the component can tell
+  // "could not load" apart from every other failure.
+  if (response?.status === 503) {
+    throw new ContextUnavailableError(error?.message);
+  }
+  if (error) throw toError(error);
+  if (!data) throw new Error("Empty response");
+  return data;
+}
+
+/**
+ * `GET /api/v1/sites/{siteId}/context/effective` — ADR-064 Decision 8's
+ * preview: every surviving layer (1-6, in precedence order; layer 7/learned
+ * memory is never present), the read-time union of layers 1-3's
+ * restrictions, and the byte accounting from Decision 9.
+ *
+ * Render exactly what this returns. Do NOT concatenate the layers into a
+ * merged prose block in the browser — Decision 8 requires the preview to
+ * call the same resolution function the model-facing assembly path calls,
+ * never a second implementation of the same walk, and a client-side
+ * re-assembly would be exactly that: a second path that can silently drift
+ * from the real one.
+ */
+export function useEffectiveSiteContext(
+  siteId: string,
+): UseQueryResult<GovContextEffective, Error> {
+  return useQuery({
+    queryKey: contextKeys.effective(siteId),
+    queryFn: () => fetchEffectiveContext(siteId),
+  });
+}

--- a/apps/web/src/features/context/use-context.ts
+++ b/apps/web/src/features/context/use-context.ts
@@ -1,19 +1,38 @@
-import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { getEffectiveSiteContext, type GovContextEffective } from "@wpmgr/api";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import {
+  getEffectiveSiteContext,
+  getOrgContext as apiGetOrgContext,
+  patchOrgContext as apiPatchOrgContext,
+  getSiteContext as apiGetSiteContext,
+  patchSiteContext as apiPatchSiteContext,
+  type ApiError,
+  type GovContext,
+  type GovContextEffective,
+  type PatchGovContextRequest,
+} from "@wpmgr/api";
 
 import { toError } from "@/features/auth/use-auth";
 
-// ADR-064 (governed org/site context) — S5 Stage A.
+// ADR-064 (governed org/site context) — S5.
 //
-// This module currently covers ONLY the effective-context preview (Decision
-// 8, Screen 1). Stage B adds the org/site context read+edit hooks, version
-// history, diff and restore (Decision 5/13) alongside this file — grow the
-// `contextKeys` factory below (e.g. `contextKeys.org(orgId)`,
-// `contextKeys.siteVersions(siteId)`) rather than starting a second one.
+// Stage A covered ONLY the effective-context preview (Decision 8, Screen 1).
+// Stage B adds the org/site context read+write hooks below (Decision
+// 6/13) — org and site editors, and the three write-path refusals Decision
+// 4/10/13 define. Version history, diff and restore (Decision 5) are not yet
+// built; grow `contextKeys` further (e.g. `contextKeys.orgVersions(orgId)`)
+// rather than starting a second key factory when that lands.
 
 export const contextKeys = {
   all: ["gov-context"] as const,
   effective: (siteId: string) => [...contextKeys.all, "effective", siteId] as const,
+  org: (orgId: string) => [...contextKeys.all, "org", orgId] as const,
+  site: (siteId: string) => [...contextKeys.all, "site", siteId] as const,
 };
 
 /**
@@ -66,5 +85,210 @@ export function useEffectiveSiteContext(
   return useQuery({
     queryKey: contextKeys.effective(siteId),
     queryFn: () => fetchEffectiveContext(siteId),
+  });
+}
+
+// ── Org + site context editors (Stage B) ────────────────────────────────
+//
+// PATCH .../context has exactly three write refusals (ADR-064 Decision 13):
+// two `409`s sharing an HTTP status but distinguished by `code`
+// (`context_widen_forbidden` vs `context_version_conflict`), and one `422`
+// (`context_secret_detected`). Each gets its own error class carrying the
+// server's structured `details` so the editor can flag the specific field
+// (widen) or offer a reload-and-retry action (conflict) — never a generic
+// throw that loses the distinction. `code` strings and `details` keys below
+// are quoted from `apps/api/internal/govcontext/{widen,secretscan,service}.go`
+// on the S4 branch, not inferred from the OpenAPI shape.
+
+/**
+ * `409 context_widen_forbidden` (Decision 4): the proposed restrictions would
+ * remove something a higher layer set. `field` is always a RestrictionSet key
+ * (`forbidden_tools` | `forbidden_domains` | `forbidden_topics`) — the widen
+ * check never runs over guidance (ADR-064 Decision 1: "wider"/"narrower" are
+ * not defined relations over free text).
+ */
+export class ContextWidenForbiddenError extends Error {
+  field: string;
+  layer: number;
+  layerName: string;
+  removedItems: string[];
+  constructor(
+    message: string,
+    details: { field: string; layer: number; layerName: string; removedItems: string[] },
+  ) {
+    super(message);
+    this.name = "ContextWidenForbiddenError";
+    this.field = details.field;
+    this.layer = details.layer;
+    this.layerName = details.layerName;
+    this.removedItems = details.removedItems;
+  }
+}
+
+/**
+ * `422 context_secret_detected` (Decision 10): the proposed snapshot contains
+ * a value shaped like a credential. `category` names the shape
+ * (`aws_access_key`, `private_key_block`, `database_connection_string`,
+ * `bearer_token`, `api_key_assignment`, `high_entropy_secret`) — the server
+ * deliberately never reports WHICH field matched (`DetectSecret` scans the
+ * whole snapshot as a flat string list), so there is no field to flag inline,
+ * only the banner.
+ */
+export class ContextSecretDetectedError extends Error {
+  category: string;
+  constructor(message: string, category: string) {
+    super(message);
+    this.name = "ContextSecretDetectedError";
+    this.category = category;
+  }
+}
+
+/**
+ * `409 context_version_conflict` (ADR-064 open question 2, answered by S4):
+ * the request's `base_version` no longer matches the current version — either
+ * a stale read (another write landed first) or a lost race on `restore`. The
+ * fix is never a client-side merge (ADR-064's Consequences section forecloses
+ * merge-based conflict resolution entirely) — only reread and retry.
+ */
+export class ContextVersionConflictError extends Error {
+  currentVersion: number;
+  suppliedBaseVersion?: number;
+  constructor(message: string, currentVersion: number, suppliedBaseVersion?: number) {
+    super(message);
+    this.name = "ContextVersionConflictError";
+    this.currentVersion = currentVersion;
+    this.suppliedBaseVersion = suppliedBaseVersion;
+  }
+}
+
+function detailString(details: Record<string, unknown> | undefined, key: string): string {
+  const v = details?.[key];
+  return typeof v === "string" ? v : "";
+}
+
+function detailNumber(details: Record<string, unknown> | undefined, key: string): number {
+  const v = details?.[key];
+  return typeof v === "number" ? v : 0;
+}
+
+function detailStringArray(details: Record<string, unknown> | undefined, key: string): string[] {
+  const v = details?.[key];
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+/**
+ * Maps a PATCH .../context error onto the three named refusal classes above
+ * by `code` (never by HTTP status alone — both 409s share one status), or
+ * falls back to the same generic `toError` every other domain hook uses.
+ */
+function toPatchContextError(error: ApiError | undefined): Error {
+  if (!error) return new Error("Request failed");
+  const details = error.details;
+  if (error.code === "context_widen_forbidden") {
+    return new ContextWidenForbiddenError(error.message, {
+      field: detailString(details, "field"),
+      layer: detailNumber(details, "layer"),
+      layerName: detailString(details, "layer_name"),
+      removedItems: detailStringArray(details, "removed_items"),
+    });
+  }
+  if (error.code === "context_version_conflict") {
+    return new ContextVersionConflictError(
+      error.message,
+      detailNumber(details, "current_version"),
+      details && "supplied_base_version" in details
+        ? detailNumber(details, "supplied_base_version")
+        : undefined,
+    );
+  }
+  if (error.code === "context_secret_detected") {
+    return new ContextSecretDetectedError(error.message, detailString(details, "category"));
+  }
+  return toError(error);
+}
+
+// --- organisation context (layer 2) -----------------------------------------
+
+/**
+ * `GET /api/v1/orgs/{orgId}/context` — the organisation's current context.
+ * `version: 0` is a legitimate empty state ("nothing authored yet"), never a
+ * 404 (ADR-064 Decision 3/13).
+ */
+export function useOrgContext(orgId: string): UseQueryResult<GovContext, Error> {
+  return useQuery({
+    queryKey: contextKeys.org(orgId),
+    queryFn: async () => {
+      const { data, error } = await apiGetOrgContext({ path: { orgId } });
+      if (error) throw toError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+  });
+}
+
+/**
+ * `PATCH /api/v1/orgs/{orgId}/context` — author a new organisation context
+ * version. Always send the FULL current `restrictions`/`guidance` (the server
+ * replaces each key wholesale, never deep-merges — `PatchGovContextRequest`'s
+ * own doc comment). On success, seeds the query cache with the new version so
+ * the form's `base_version` is immediately correct for the next save.
+ */
+export function usePatchOrgContext(
+  orgId: string,
+): UseMutationResult<GovContext, Error, PatchGovContextRequest> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: PatchGovContextRequest) => {
+      const { data, error } = await apiPatchOrgContext({ path: { orgId }, body });
+      if (error) throw toPatchContextError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(contextKeys.org(orgId), updated);
+      // Layer 2 changed, so every site's resolved effective context under
+      // this org may have too (Decision 2: a write to a layer beneath the
+      // materialised preview invalidates it immediately). We don't know
+      // which sites are open from here, so mark every cached preview stale
+      // rather than guess which one(s) to target — cheap, and "pull is the
+      // truth" means a mounted preview just refetches on next focus/mount.
+      void queryClient.invalidateQueries({ queryKey: [...contextKeys.all, "effective"] });
+    },
+  });
+}
+
+// --- site context (layer 3) -------------------------------------------------
+
+/** `GET /api/v1/sites/{siteId}/context` — the site's current context (layer 3). */
+export function useSiteContext(siteId: string): UseQueryResult<GovContext, Error> {
+  return useQuery({
+    queryKey: contextKeys.site(siteId),
+    queryFn: async () => {
+      const { data, error } = await apiGetSiteContext({ path: { siteId } });
+      if (error) throw toError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+  });
+}
+
+/** `PATCH /api/v1/sites/{siteId}/context` — site-scope sibling of {@link usePatchOrgContext}. */
+export function usePatchSiteContext(
+  siteId: string,
+): UseMutationResult<GovContext, Error, PatchGovContextRequest> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: PatchGovContextRequest) => {
+      const { data, error } = await apiPatchSiteContext({ path: { siteId }, body });
+      if (error) throw toPatchContextError(error);
+      if (!data) throw new Error("Empty response");
+      return data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(contextKeys.site(siteId), updated);
+      // Layer 3 changed — this site's effective-context preview (Decision 8,
+      // Screen 1) is stale (Decision 2). Targeted, since we know the site.
+      void queryClient.invalidateQueries({ queryKey: contextKeys.effective(siteId) });
+    },
   });
 }

--- a/apps/web/src/features/context/use-context.ts
+++ b/apps/web/src/features/context/use-context.ts
@@ -270,6 +270,11 @@ export function usePatchOrgContext(
       // rather than guess which one(s) to target — cheap, and "pull is the
       // truth" means a mounted preview just refetches on next focus/mount.
       void queryClient.invalidateQueries({ queryKey: [...contextKeys.all, "effective"] });
+      // CodeRabbit finding on #566: a PATCH authors a new stored version row
+      // (Decision 5) same as restore does, but only restore invalidated the
+      // history list — the editor and history mounted together kept showing
+      // pre-save pages, omitting the version just authored.
+      void queryClient.invalidateQueries({ queryKey: contextKeys.orgVersions(orgId) });
     },
   });
 }
@@ -306,6 +311,8 @@ export function usePatchSiteContext(
       // Layer 3 changed — this site's effective-context preview (Decision 8,
       // Screen 1) is stale (Decision 2). Targeted, since we know the site.
       void queryClient.invalidateQueries({ queryKey: contextKeys.effective(siteId) });
+      // Same PATCH-vs-restore inconsistency as usePatchOrgContext above.
+      void queryClient.invalidateQueries({ queryKey: contextKeys.siteVersions(siteId) });
     },
   });
 }
@@ -352,7 +359,14 @@ export function useOrgContextVersions(orgId: string): UseGovContextVersionsResul
         query: pageParam !== undefined ? { cursor: pageParam } : undefined,
       });
       if (error) throw toError(error);
-      return data ?? { items: [], next_cursor: 0 };
+      // CodeRabbit finding on #566: falling back to an empty page here reads
+      // as "this history has nothing in it" — the exact conflation this
+      // project keeps shipping (the updates-card "Never" bug, the as_of
+      // heartbeat substitution, facts_unavailable's omitempty). A missing
+      // body with no error is "we could not tell," never "there is
+      // nothing," so this throws like every other hook in this file.
+      if (!data) throw new Error("Empty response");
+      return data;
     },
   });
   return {
@@ -385,7 +399,14 @@ export function useSiteContextVersions(siteId: string): UseGovContextVersionsRes
         query: pageParam !== undefined ? { cursor: pageParam } : undefined,
       });
       if (error) throw toError(error);
-      return data ?? { items: [], next_cursor: 0 };
+      // CodeRabbit finding on #566: falling back to an empty page here reads
+      // as "this history has nothing in it" — the exact conflation this
+      // project keeps shipping (the updates-card "Never" bug, the as_of
+      // heartbeat substitution, facts_unavailable's omitempty). A missing
+      // body with no error is "we could not tell," never "there is
+      // nothing," so this throws like every other hook in this file.
+      if (!data) throw new Error("Empty response");
+      return data;
     },
   });
   return {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -72,6 +72,7 @@ import { Route as AuthedSitesSiteIdHealthRouteImport } from './routes/_authed/si
 import { Route as AuthedSitesSiteIdFilesRouteImport } from './routes/_authed/sites/$siteId.files'
 import { Route as AuthedSitesSiteIdErrorsRouteImport } from './routes/_authed/sites/$siteId.errors'
 import { Route as AuthedSitesSiteIdEmailRouteImport } from './routes/_authed/sites/$siteId.email'
+import { Route as AuthedSitesSiteIdContextRouteImport } from './routes/_authed/sites/$siteId.context'
 import { Route as AuthedSitesSiteIdCacheRouteImport } from './routes/_authed/sites/$siteId.cache'
 import { Route as AuthedSitesSiteIdBackupsRouteImport } from './routes/_authed/sites/$siteId.backups'
 import { Route as AuthedSitesSiteIdActivityRouteImport } from './routes/_authed/sites/$siteId.activity'
@@ -404,6 +405,12 @@ const AuthedSitesSiteIdEmailRoute = AuthedSitesSiteIdEmailRouteImport.update({
   path: '/email',
   getParentRoute: () => AuthedSitesSiteIdRoute,
 } as any)
+const AuthedSitesSiteIdContextRoute =
+  AuthedSitesSiteIdContextRouteImport.update({
+    id: '/context',
+    path: '/context',
+    getParentRoute: () => AuthedSitesSiteIdRoute,
+  } as any)
 const AuthedSitesSiteIdCacheRoute = AuthedSitesSiteIdCacheRouteImport.update({
   id: '/cache',
   path: '/cache',
@@ -514,6 +521,7 @@ export interface FileRoutesByFullPath {
   '/sites/$siteId/activity': typeof AuthedSitesSiteIdActivityRoute
   '/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsRouteWithChildren
   '/sites/$siteId/cache': typeof AuthedSitesSiteIdCacheRoute
+  '/sites/$siteId/context': typeof AuthedSitesSiteIdContextRoute
   '/sites/$siteId/email': typeof AuthedSitesSiteIdEmailRoute
   '/sites/$siteId/errors': typeof AuthedSitesSiteIdErrorsRoute
   '/sites/$siteId/files': typeof AuthedSitesSiteIdFilesRoute
@@ -581,6 +589,7 @@ export interface FileRoutesByTo {
   '/clients/$clientId/sites': typeof AuthedClientsClientIdSitesRoute
   '/sites/$siteId/activity': typeof AuthedSitesSiteIdActivityRoute
   '/sites/$siteId/cache': typeof AuthedSitesSiteIdCacheRoute
+  '/sites/$siteId/context': typeof AuthedSitesSiteIdContextRoute
   '/sites/$siteId/email': typeof AuthedSitesSiteIdEmailRoute
   '/sites/$siteId/errors': typeof AuthedSitesSiteIdErrorsRoute
   '/sites/$siteId/files': typeof AuthedSitesSiteIdFilesRoute
@@ -656,6 +665,7 @@ export interface FileRoutesById {
   '/_authed/sites/$siteId/activity': typeof AuthedSitesSiteIdActivityRoute
   '/_authed/sites/$siteId/backups': typeof AuthedSitesSiteIdBackupsRouteWithChildren
   '/_authed/sites/$siteId/cache': typeof AuthedSitesSiteIdCacheRoute
+  '/_authed/sites/$siteId/context': typeof AuthedSitesSiteIdContextRoute
   '/_authed/sites/$siteId/email': typeof AuthedSitesSiteIdEmailRoute
   '/_authed/sites/$siteId/errors': typeof AuthedSitesSiteIdErrorsRoute
   '/_authed/sites/$siteId/files': typeof AuthedSitesSiteIdFilesRoute
@@ -731,6 +741,7 @@ export interface FileRouteTypes {
     | '/sites/$siteId/activity'
     | '/sites/$siteId/backups'
     | '/sites/$siteId/cache'
+    | '/sites/$siteId/context'
     | '/sites/$siteId/email'
     | '/sites/$siteId/errors'
     | '/sites/$siteId/files'
@@ -798,6 +809,7 @@ export interface FileRouteTypes {
     | '/clients/$clientId/sites'
     | '/sites/$siteId/activity'
     | '/sites/$siteId/cache'
+    | '/sites/$siteId/context'
     | '/sites/$siteId/email'
     | '/sites/$siteId/errors'
     | '/sites/$siteId/files'
@@ -872,6 +884,7 @@ export interface FileRouteTypes {
     | '/_authed/sites/$siteId/activity'
     | '/_authed/sites/$siteId/backups'
     | '/_authed/sites/$siteId/cache'
+    | '/_authed/sites/$siteId/context'
     | '/_authed/sites/$siteId/email'
     | '/_authed/sites/$siteId/errors'
     | '/_authed/sites/$siteId/files'
@@ -1348,6 +1361,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedSitesSiteIdEmailRouteImport
       parentRoute: typeof AuthedSitesSiteIdRoute
     }
+    '/_authed/sites/$siteId/context': {
+      id: '/_authed/sites/$siteId/context'
+      path: '/context'
+      fullPath: '/sites/$siteId/context'
+      preLoaderRoute: typeof AuthedSitesSiteIdContextRouteImport
+      parentRoute: typeof AuthedSitesSiteIdRoute
+    }
     '/_authed/sites/$siteId/cache': {
       id: '/_authed/sites/$siteId/cache'
       path: '/cache'
@@ -1518,6 +1538,7 @@ interface AuthedSitesSiteIdRouteChildren {
   AuthedSitesSiteIdActivityRoute: typeof AuthedSitesSiteIdActivityRoute
   AuthedSitesSiteIdBackupsRoute: typeof AuthedSitesSiteIdBackupsRouteWithChildren
   AuthedSitesSiteIdCacheRoute: typeof AuthedSitesSiteIdCacheRoute
+  AuthedSitesSiteIdContextRoute: typeof AuthedSitesSiteIdContextRoute
   AuthedSitesSiteIdEmailRoute: typeof AuthedSitesSiteIdEmailRoute
   AuthedSitesSiteIdErrorsRoute: typeof AuthedSitesSiteIdErrorsRoute
   AuthedSitesSiteIdFilesRoute: typeof AuthedSitesSiteIdFilesRoute
@@ -1536,6 +1557,7 @@ const AuthedSitesSiteIdRouteChildren: AuthedSitesSiteIdRouteChildren = {
   AuthedSitesSiteIdActivityRoute: AuthedSitesSiteIdActivityRoute,
   AuthedSitesSiteIdBackupsRoute: AuthedSitesSiteIdBackupsRouteWithChildren,
   AuthedSitesSiteIdCacheRoute: AuthedSitesSiteIdCacheRoute,
+  AuthedSitesSiteIdContextRoute: AuthedSitesSiteIdContextRoute,
   AuthedSitesSiteIdEmailRoute: AuthedSitesSiteIdEmailRoute,
   AuthedSitesSiteIdErrorsRoute: AuthedSitesSiteIdErrorsRoute,
   AuthedSitesSiteIdFilesRoute: AuthedSitesSiteIdFilesRoute,

--- a/apps/web/src/routes/_authed/settings/organization.tsx
+++ b/apps/web/src/routes/_authed/settings/organization.tsx
@@ -16,6 +16,7 @@ import { PageHeader } from "@/components/shared/page-header";
 import { CopyableMono } from "@/components/shared/copyable-mono";
 import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
 import { useMe } from "@/features/auth/use-auth";
+import { OrgContextSection } from "@/features/context/org-context-section";
 import {
   useOrgs,
   useRenameOrg,
@@ -77,6 +78,7 @@ function OrganizationSettingsPage() {
       {activeOrg ? (
         <>
           <OrgCard key={activeOrg.id} org={activeOrg} />
+          <OrgContextCard key={`${activeOrg.id}-context`} org={activeOrg} />
           {activeOrg.role === "owner" ? (
             <DangerZoneCard
               key={`${activeOrg.id}-danger`}
@@ -181,6 +183,34 @@ function OrgCard({ org }: { org: Org }) {
             </Button>
           </div>
         ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OrgContextCard: ADR-064 S5 Screen 3 — organisation-defaults editor
+// (layer 2). Read follows this page's existing "any org-scoped member sees
+// it" gate (Decision 6: read access follows existing fleet-read access);
+// write is narrower — organisation-admin+, mirroring OrgCard's canRename
+// gate above, per Decision 6's "organisation-scope write is held by
+// organisation administrators".
+// ---------------------------------------------------------------------------
+
+function OrgContextCard({ org }: { org: Org }) {
+  const canWrite = org.role === "owner" || org.role === "admin";
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Organisation context</CardTitle>
+        <CardDescription>
+          Restrictions and guidance every site in this organisation inherits
+          (layer 2). A site&apos;s own override may narrow these, never widen
+          them.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <OrgContextSection orgId={org.id} canWrite={canWrite} />
       </CardContent>
     </Card>
   );

--- a/apps/web/src/routes/_authed/settings/organization.tsx
+++ b/apps/web/src/routes/_authed/settings/organization.tsx
@@ -17,6 +17,7 @@ import { CopyableMono } from "@/components/shared/copyable-mono";
 import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
 import { useMe } from "@/features/auth/use-auth";
 import { OrgContextSection } from "@/features/context/org-context-section";
+import { OrgContextHistorySection } from "@/features/context/org-context-history-section";
 import {
   useOrgs,
   useRenameOrg,
@@ -79,6 +80,7 @@ function OrganizationSettingsPage() {
         <>
           <OrgCard key={activeOrg.id} org={activeOrg} />
           <OrgContextCard key={`${activeOrg.id}-context`} org={activeOrg} />
+          <OrgContextHistoryCard key={`${activeOrg.id}-context-history`} org={activeOrg} />
           {activeOrg.role === "owner" ? (
             <DangerZoneCard
               key={`${activeOrg.id}-danger`}
@@ -211,6 +213,29 @@ function OrgContextCard({ org }: { org: Org }) {
       </CardHeader>
       <CardContent>
         <OrgContextSection orgId={org.id} canWrite={canWrite} />
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OrgContextHistoryCard: ADR-064 S5 Screen 4 — version history, diff and
+// restore (Decision 5). Same read/write gate as OrgContextCard above.
+// ---------------------------------------------------------------------------
+
+function OrgContextHistoryCard({ org }: { org: Org }) {
+  const canWrite = org.role === "owner" || org.role === "admin";
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Organisation context history</CardTitle>
+        <CardDescription>
+          Every accepted write, newest first. A diff compares what was
+          authored in two versions, not what either enforced at the time.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <OrgContextHistorySection orgId={org.id} canWrite={canWrite} />
       </CardContent>
     </Card>
   );

--- a/apps/web/src/routes/_authed/sites/$siteId.context.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.context.tsx
@@ -1,14 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { EffectiveContextPreview } from "@/features/context/effective-context-preview";
+import { SiteContextSection } from "@/features/context/site-context-section";
+import { useMe, canManage } from "@/features/auth/use-auth";
 
-// ADR-064 S5 Stage A — `/sites/:siteId/context` route.
+// ADR-064 S5 — `/sites/:siteId/context` route.
 //
-// Stage A ships ONLY the effective-context preview (Decision 8, Screen 1).
-// The org/site context editors, version history, diff and restore screens
-// (Decision 5/13) are Stage B and land in this same file as additional
-// sections — see the handoff note in the S5 PR description before starting
-// that work.
+// Stage A shipped the effective-context preview (Decision 8, Screen 1).
+// Stage B adds the site override editor below it (layer 3, Screen 2).
+// Version history, diff and restore (Decision 5) are not yet built.
 
 export const Route = createFileRoute("/_authed/sites/$siteId/context")({
   component: ContextTab,
@@ -16,15 +16,43 @@ export const Route = createFileRoute("/_authed/sites/$siteId/context")({
 
 function ContextTab() {
   const { siteId } = Route.useParams();
+  const { data: me } = useMe();
+  // Decision 6: site-scope write is narrower than read, but this codebase
+  // has no finer-grained "context.site.write" signal on the client today —
+  // gate the editable form the same way every other site-configuration
+  // write (hardening, login protection, destinations) already does, and let
+  // the server's own capability check be the real enforcement point
+  // regardless (a 403 from the PATCH still surfaces if this client-side
+  // gate is ever wrong in either direction).
+  const canWrite = canManage(me);
+
   return (
-    <section aria-labelledby="context-heading" className="space-y-4 px-4 pb-8 pt-6 sm:px-6">
-      <h2
-        id="context-heading"
-        className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
-      >
-        Context
-      </h2>
-      <EffectiveContextPreview siteId={siteId} />
-    </section>
+    <div className="space-y-8 px-4 pb-8 pt-6 sm:px-6">
+      <section aria-labelledby="context-heading" className="space-y-4">
+        <h2
+          id="context-heading"
+          className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Context
+        </h2>
+        <EffectiveContextPreview siteId={siteId} />
+      </section>
+
+      <section aria-labelledby="site-override-heading" className="space-y-4">
+        <div className="space-y-0.5">
+          <h2
+            id="site-override-heading"
+            className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            Site override
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            Layer 3 — may narrow this organisation&apos;s defaults, never widen
+            what it or WPMgr&apos;s own policy restricts.
+          </p>
+        </div>
+        <SiteContextSection siteId={siteId} canWrite={canWrite} />
+      </section>
+    </div>
   );
 }

--- a/apps/web/src/routes/_authed/sites/$siteId.context.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.context.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { EffectiveContextPreview } from "@/features/context/effective-context-preview";
 import { SiteContextSection } from "@/features/context/site-context-section";
 import { SiteContextHistorySection } from "@/features/context/site-context-history-section";
-import { useMe, canOperate } from "@/features/auth/use-auth";
+import { useMe, canWriteSiteContext } from "@/features/auth/use-auth";
 
 // ADR-064 S5 — `/sites/:siteId/context` route.
 //
@@ -19,17 +19,18 @@ function ContextTab() {
   const { siteId } = Route.useParams();
   const { data: me } = useMe();
   // Decision 6: "site-scope write additionally requires access to that
-  // specific site" — narrower than read, but NOT narrower than
-  // organisation-scope write (which Decision 6 states explicitly IS
-  // admin-only). `canManage` (owner/admin only) was too strict here and hid
-  // the editor and history from an operator-level org member or an
-  // operator-role site collaborator, both of whom `context.site.write`
-  // actually permits — caught in review (Greptile P1, "Operator writes are
-  // hidden"). `canOperate` matches this codebase's own existing definition
-  // of "site access at operator tier or above." The server's own capability
-  // check remains the real enforcement point regardless (a 403 from the
-  // PATCH still surfaces if this client-side gate is ever wrong).
-  const canWrite = canOperate(me);
+  // specific site" — not gated on an org membership at all, and NOT
+  // narrower than organisation-scope write (which Decision 6 states
+  // explicitly IS admin-only — unaffected, see organization.tsx).
+  // `canOperate` alone (Greptile P1 #1, fixed, "Operator writes are
+  // hidden") covered an org-scoped operator but still reads `me.memberships`
+  // only, so a genuine site-scoped collaborator with no org membership at
+  // all stayed locked out regardless of their own share role (Greptile P1
+  // #2, "Site collaborators remain read-only"). `canWriteSiteContext` also
+  // honours `Me.scope`/`Me.role` for that principal shape. The server's own
+  // capability check remains the real enforcement point regardless (a 403
+  // from the PATCH still surfaces if this client-side gate is ever wrong).
+  const canWrite = canWriteSiteContext(me);
 
   return (
     <div className="space-y-8 px-4 pb-8 pt-6 sm:px-6">

--- a/apps/web/src/routes/_authed/sites/$siteId.context.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.context.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { EffectiveContextPreview } from "@/features/context/effective-context-preview";
 import { SiteContextSection } from "@/features/context/site-context-section";
 import { SiteContextHistorySection } from "@/features/context/site-context-history-section";
-import { useMe, canManage } from "@/features/auth/use-auth";
+import { useMe, canOperate } from "@/features/auth/use-auth";
 
 // ADR-064 S5 — `/sites/:siteId/context` route.
 //
@@ -18,14 +18,18 @@ export const Route = createFileRoute("/_authed/sites/$siteId/context")({
 function ContextTab() {
   const { siteId } = Route.useParams();
   const { data: me } = useMe();
-  // Decision 6: site-scope write is narrower than read, but this codebase
-  // has no finer-grained "context.site.write" signal on the client today —
-  // gate the editable form the same way every other site-configuration
-  // write (hardening, login protection, destinations) already does, and let
-  // the server's own capability check be the real enforcement point
-  // regardless (a 403 from the PATCH still surfaces if this client-side
-  // gate is ever wrong in either direction).
-  const canWrite = canManage(me);
+  // Decision 6: "site-scope write additionally requires access to that
+  // specific site" — narrower than read, but NOT narrower than
+  // organisation-scope write (which Decision 6 states explicitly IS
+  // admin-only). `canManage` (owner/admin only) was too strict here and hid
+  // the editor and history from an operator-level org member or an
+  // operator-role site collaborator, both of whom `context.site.write`
+  // actually permits — caught in review (Greptile P1, "Operator writes are
+  // hidden"). `canOperate` matches this codebase's own existing definition
+  // of "site access at operator tier or above." The server's own capability
+  // check remains the real enforcement point regardless (a 403 from the
+  // PATCH still surfaces if this client-side gate is ever wrong).
+  const canWrite = canOperate(me);
 
   return (
     <div className="space-y-8 px-4 pb-8 pt-6 sm:px-6">

--- a/apps/web/src/routes/_authed/sites/$siteId.context.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.context.tsx
@@ -2,13 +2,14 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { EffectiveContextPreview } from "@/features/context/effective-context-preview";
 import { SiteContextSection } from "@/features/context/site-context-section";
+import { SiteContextHistorySection } from "@/features/context/site-context-history-section";
 import { useMe, canManage } from "@/features/auth/use-auth";
 
 // ADR-064 S5 — `/sites/:siteId/context` route.
 //
 // Stage A shipped the effective-context preview (Decision 8, Screen 1).
-// Stage B adds the site override editor below it (layer 3, Screen 2).
-// Version history, diff and restore (Decision 5) are not yet built.
+// Stage B adds the site override editor (layer 3, Screen 2) and version
+// history / diff / restore (Decision 5, Screen 4) below it.
 
 export const Route = createFileRoute("/_authed/sites/$siteId/context")({
   component: ContextTab,
@@ -52,6 +53,22 @@ function ContextTab() {
           </p>
         </div>
         <SiteContextSection siteId={siteId} canWrite={canWrite} />
+      </section>
+
+      <section aria-labelledby="site-history-heading" className="space-y-4">
+        <div className="space-y-0.5">
+          <h2
+            id="site-history-heading"
+            className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            Version history
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            Every accepted write, newest first. A diff compares what was
+            authored in two versions, not what either enforced at the time.
+          </p>
+        </div>
+        <SiteContextHistorySection siteId={siteId} canWrite={canWrite} />
       </section>
     </div>
   );

--- a/apps/web/src/routes/_authed/sites/$siteId.context.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.context.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { EffectiveContextPreview } from "@/features/context/effective-context-preview";
+
+// ADR-064 S5 Stage A — `/sites/:siteId/context` route.
+//
+// Stage A ships ONLY the effective-context preview (Decision 8, Screen 1).
+// The org/site context editors, version history, diff and restore screens
+// (Decision 5/13) are Stage B and land in this same file as additional
+// sections — see the handoff note in the S5 PR description before starting
+// that work.
+
+export const Route = createFileRoute("/_authed/sites/$siteId/context")({
+  component: ContextTab,
+});
+
+function ContextTab() {
+  const { siteId } = Route.useParams();
+  return (
+    <section aria-labelledby="context-heading" className="space-y-4 px-4 pb-8 pt-6 sm:px-6">
+      <h2
+        id="context-heading"
+        className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+      >
+        Context
+      </h2>
+      <EffectiveContextPreview siteId={siteId} />
+    </section>
+  );
+}

--- a/apps/web/src/routes/_authed/sites/$siteId.tsx
+++ b/apps/web/src/routes/_authed/sites/$siteId.tsx
@@ -110,6 +110,9 @@ const TABS = [
   { to: "/sites/$siteId/email", label: "Email" },
   // File manager (P1 read-only browser). Route: $siteId.files.tsx.
   { to: "/sites/$siteId/files", label: "Files" },
+  // ADR-064 S5 — governed org/site context tab. Route file:
+  // apps/web/src/routes/_authed/sites/$siteId.context.tsx
+  { to: "/sites/$siteId/context", label: "Context" },
   { to: "/sites/$siteId/settings", label: "Settings" },
 ] as const;
 

--- a/apps/web/src/routes/_authed/sites/-$siteId.context.test.tsx
+++ b/apps/web/src/routes/_authed/sites/-$siteId.context.test.tsx
@@ -102,8 +102,17 @@ describe("site context tab — canWrite follows Decision 6, not the org-admin ce
     );
   });
 
-  it("owner and admin remain writable (must not regress)", async () => {
+  // CodeRabbit finding on #566: these two used to share one test, mounting a
+  // second tree without unmounting the first — `screen.findByTestId` then
+  // has two matching elements in the document at once, which is undefined
+  // behaviour for a `getBy*`-style query even on a run where it happens not
+  // to throw. Split into separate tests so each gets its own render/cleanup
+  // cycle, same as every other case in this file.
+  it("an OWNER remains writable (must not regress)", async () => {
     expect(await renderAs("owner")).toHaveTextContent("canWrite=true");
+  });
+
+  it("an ADMIN remains writable (must not regress)", async () => {
     expect(await renderAs("admin")).toHaveTextContent("canWrite=true");
   });
 

--- a/apps/web/src/routes/_authed/sites/-$siteId.context.test.tsx
+++ b/apps/web/src/routes/_authed/sites/-$siteId.context.test.tsx
@@ -93,6 +93,21 @@ async function renderAs(role: "owner" | "admin" | "operator" | "viewer") {
   return screen.findByTestId("site-context-section");
 }
 
+// A genuine site-scoped principal: no org membership at all (site access via
+// a share, not an org role) — the actual principal the canWriteSiteContext
+// fix exists for, per its own Me.scope/Me.role check.
+function meSiteScoped(role: Me["role"]): Me {
+  return { scope: "site", role, memberships: [] } as unknown as Me;
+}
+
+async function renderAsSiteScoped(role: Me["role"]) {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(ME_KEY, meSiteScoped(role));
+  const router = buildContextRouter();
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  return screen.findByTestId("site-context-section");
+}
+
 describe("site context tab — canWrite follows Decision 6, not the org-admin ceiling", () => {
   it("an OPERATOR (not owner/admin) sees the editor and history as writable", async () => {
     const section = await renderAs("operator");
@@ -118,6 +133,23 @@ describe("site context tab — canWrite follows Decision 6, not the org-admin ce
 
   it("a VIEWER is still read-only", async () => {
     const section = await renderAs("viewer");
+    expect(section).toHaveTextContent("canWrite=false");
+  });
+
+  // Security review finding (F3): every case above is an org-scoped
+  // membership role. Nothing rendered this route as a genuine site-scoped
+  // collaborator — the very principal the canWriteSiteContext fix exists
+  // for — until now.
+  it("a genuine SITE-SCOPED collaborator (no org membership) sees the editor as writable", async () => {
+    const section = await renderAsSiteScoped("operator");
+    expect(section).toHaveTextContent("canWrite=true");
+  });
+
+  // Security review finding (F3): role:"client" is a real portal-principal
+  // value under scope==="site" (types.gen.ts:939) that reaches this route,
+  // not a hypothetical. It resolves to read-only today; this holds it there.
+  it("a portal (client) principal under scope==='site' stays read-only", async () => {
+    const section = await renderAsSiteScoped("client");
     expect(section).toHaveTextContent("canWrite=false");
   });
 });

--- a/apps/web/src/routes/_authed/sites/-$siteId.context.test.tsx
+++ b/apps/web/src/routes/_authed/sites/-$siteId.context.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { Me } from "@wpmgr/api";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+
+import { Route as ContextRoute } from "./$siteId.context";
+
+// Greptile P1 ("Operator writes are hidden"): `canWrite` on this route was
+// computed with `canManage` (owner/admin only), which hid the site-context
+// editor and history from an operator-level org member or an operator-role
+// site collaborator — both of whom ADR-064 Decision 6's `context.site.write`
+// actually permits ("site-scope write additionally requires access to that
+// specific site", not "requires admin"). Mirrors
+// `-api-keys.role-ceiling.test.tsx`'s pattern exactly: mount the route's own
+// exported `Route` on a throwaway one-segment tree (skips the real
+// `_authed` guard) with a real `useQuery`-backed `useMe` stand-in, and prove
+// the WIRING, not just the permission helper in isolation — a version that
+// swapped back to `canManage` would leave every unit test on `canOperate`
+// itself green while still shipping this exact bug.
+
+const ME_KEY = ["test", "me"] as const;
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth/use-auth")>();
+  const { useQuery } = await import("@tanstack/react-query");
+  return {
+    ...actual,
+    useMe: () => useQuery({ queryKey: ME_KEY, queryFn: () => null, staleTime: Infinity }),
+  };
+});
+
+vi.mock("@/features/context/effective-context-preview", () => ({
+  EffectiveContextPreview: () => null,
+}));
+
+vi.mock("@/features/context/site-context-section", () => ({
+  SiteContextSection: ({ canWrite }: { canWrite: boolean }) => (
+    <div data-testid="site-context-section">canWrite={String(canWrite)}</div>
+  ),
+}));
+
+vi.mock("@/features/context/site-context-history-section", () => ({
+  SiteContextHistorySection: ({ canWrite }: { canWrite: boolean }) => (
+    <div data-testid="site-context-history-section">canWrite={String(canWrite)}</div>
+  ),
+}));
+
+const TENANT = "00000000-0000-0000-0000-0000000000aa";
+
+function meWithRole(role: "owner" | "admin" | "operator" | "viewer"): Me {
+  return {
+    user: {
+      id: "00000000-0000-0000-0000-000000000001",
+      email: "viewer@wpmgr.test",
+      name: "Viewer",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    active_tenant_id: TENANT,
+    memberships: [{ tenant_id: TENANT, role, tenant_name: "Acme" }],
+  } as unknown as Me;
+}
+
+/** Same recipe as `-api-keys.role-ceiling.test.tsx`'s `buildApiKeysRouter`. */
+function buildContextRouter() {
+  const rootRoute = createRootRoute({});
+  type UpdateOptions = Parameters<typeof ContextRoute.update>[0];
+  const contextRoute = ContextRoute.update({
+    id: "/sites/$siteId/context",
+    path: "/sites/$siteId/context",
+    getParentRoute: () => rootRoute,
+  } as unknown as UpdateOptions);
+  const routeTree = rootRoute.addChildren([contextRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ["/sites/site-1/context"] }),
+  });
+}
+
+async function renderAs(role: "owner" | "admin" | "operator" | "viewer") {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(ME_KEY, meWithRole(role));
+  const router = buildContextRouter();
+  renderWithProviders(<RouterProvider router={router} />, { queryClient });
+  // RouterProvider's first paint is a microtask.
+  return screen.findByTestId("site-context-section");
+}
+
+describe("site context tab — canWrite follows Decision 6, not the org-admin ceiling", () => {
+  it("an OPERATOR (not owner/admin) sees the editor and history as writable", async () => {
+    const section = await renderAs("operator");
+    expect(section).toHaveTextContent("canWrite=true");
+    expect(screen.getByTestId("site-context-history-section")).toHaveTextContent(
+      "canWrite=true",
+    );
+  });
+
+  it("owner and admin remain writable (must not regress)", async () => {
+    expect(await renderAs("owner")).toHaveTextContent("canWrite=true");
+    expect(await renderAs("admin")).toHaveTextContent("canWrite=true");
+  });
+
+  it("a VIEWER is still read-only", async () => {
+    const section = await renderAs("viewer");
+    expect(section).toHaveTextContent("canWrite=false");
+  });
+});

--- a/packages/openapi-client/src/generated/types.gen.ts
+++ b/packages/openapi-client/src/generated/types.gen.ts
@@ -21066,7 +21066,7 @@ export type PatchOrgContextErrors = {
    */
   404: Error;
   /**
-   * context_widen_forbidden — the write would remove a restriction WPmgr's layer-1 policy set; or context_version_conflict — base_version does not match the current version.
+   * context_widen_forbidden — the write would remove a restriction that WPmgr's layer-1 policy set; or context_version_conflict — base_version does not match the current version.
    */
   409: Error;
   /**

--- a/packages/openapi-client/src/index.ts
+++ b/packages/openapi-client/src/index.ts
@@ -248,6 +248,20 @@ export {
   searchSiteFiles,
   listSiteFileVersions,
   restoreSiteFileVersion,
+  // governed org/site context (ADR-064 S4)
+  getOrgContext,
+  patchOrgContext,
+  listOrgContextVersions,
+  getOrgContextVersion,
+  diffOrgContextVersion,
+  restoreOrgContextVersion,
+  getSiteContext,
+  patchSiteContext,
+  listSiteContextVersions,
+  getSiteContextVersion,
+  diffSiteContextVersion,
+  restoreSiteContextVersion,
+  getEffectiveSiteContext,
 } from "./generated/sdk.gen";
 
 // --- Domain + request/response types ----------------------------------------
@@ -876,6 +890,20 @@ export type {
   ListSiteFileVersionsResponse,
   RestoreSiteFileVersionData,
   RestoreSiteFileVersionResponse,
+  // governed org/site context (ADR-064 S4)
+  RestrictionSet,
+  GuidanceSet,
+  GovContext,
+  GovContextVersionSummary,
+  GovContextVersionList,
+  GovContextVersionItem,
+  GovContextListDiff,
+  GovContextFieldDiff,
+  GovContextSnapshotDiff,
+  GovContextDiff,
+  GovContextLayerContribution,
+  GovContextEffective,
+  PatchGovContextRequest,
   // admin-billing (superadmin billing-admin panel: accounts / account detail / revenue)
   AdminAccountTiles,
   AdminAccountListItem,

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -13091,7 +13091,7 @@ paths:
         "409":
           description: >-
             context_widen_forbidden — the write would remove a restriction
-            WPmgr's layer-1 policy set; or context_version_conflict —
+            that WPmgr's layer-1 policy set; or context_version_conflict —
             base_version does not match the current version.
           content:
             application/json:


### PR DESCRIPTION
## Summary

ADR-064 S5 ("the context management screens"). All five screens from the
original brief are in this PR now.

**Stage A**

- The API contract: imports `packages/openapi/openapi.yaml` from
  `feat/adr064-s4-context-resolver`, regenerates
  `packages/openapi-client/src/generated/**`, and adds the new context
  operations/types to the facade's re-export lists in
  `packages/openapi-client/src/index.ts`.
- Screen 1: `/sites/:siteId/context` (new tab on the site detail layout,
  before Settings) — the effective-context preview (ADR-064 Decision 8).
  Renders `GET .../context/effective`'s real structured response: all six
  surviving layers in precedence order, each with its own
  restrictions/guidance/facts/session and byte accounting, plus the
  top-level total/budget/truncated accounting and the layers-1-3
  restriction union.
- A `503 context_unavailable` (Decision 14) renders a distinct "could not
  load" state — never the same component tree as a genuinely empty layer
  list.

**Stage B**

- Screen 2: the site-override (layer 3) editor, added below the Screen 1
  preview on the same route. Restrictions are add/remove chip lists over
  `RestrictionSet`'s three deny-list fields; guidance is four free-text
  fields. `PATCH` always sends the full current `restrictions`/`guidance`
  (the server replaces each key wholesale, never deep-merges).
- Screen 3: the organisation-defaults (layer 2) editor, added to Settings ->
  Organisation. Thin wrapper around the same shared form as Screen 2 — the
  org and site GET/PATCH contracts are identical shapes at a different
  scope.
- Three named write-path refusals (`use-context.ts`), mapped by the
  server's `code` string rather than HTTP status alone (two of the three
  share a status):
  - `ContextWidenForbiddenError` (`409 context_widen_forbidden`) — flags the
    *specific restriction field* inline via react-hook-form's `setError`,
    not just a page banner.
  - `ContextSecretDetectedError` (`422 context_secret_detected`) — shows the
    server's category-based message (names *what kind* of thing it found,
    never the matched value, and never a field — the scanner itself never
    reports which field matched).
  - `ContextVersionConflictError` (`409 context_version_conflict`) — offers
    a "discard my changes and reload the latest version" action, never a
    client-side merge. ADR-064's Consequences section forecloses
    merge-based conflict resolution outright, so reread-and-retry is the
    only correct move.
- A successful `PATCH` invalidates the effective-context preview's query
  cache (site-scoped for a site write; every cached preview for an org
  write, since a layer-2 change can affect any site under that org).
- Screen 4: version history, diff and restore (Decision 5), for both scopes.
  A newest-first, cursor-paginated list shows author (type + id),
  provenance, and timestamp per version; expanding a row fetches its diff
  against the immediately-prior version (or shows an explicit baseline
  message when there's no eligible predecessor); restore creates a new
  version equal to the selected one's content. Two things this screen is
  careful never to imply:
  - **A diff compares two stored rows, never two resolved contexts.** What
    was authored, not what was enforced at either moment — an
    organisation's own restrictions can move between when a site version
    was written and when its diff is read here, and a diff of stored rows
    can't restate that. The panel says so explicitly.
  - **A restore refused with `409 context_widen_forbidden` is not the
    editor's bug.** It's the system correctly refusing to reintroduce a
    rule since tightened above it (S4's security review confirmed this
    refusal path is correct, unlike the guidance-only PATCH over-fire that
    was a real bug — see below). The restore dialog's copy for this case
    ("restoring this would put back a rule that has since been tightened")
    is deliberately distinct from the editor's widen-refusal wording.
  - Restore reuses the same three named refusal classes from Screen 2 —
    the write chokepoint is identical (service.go's own doc comment: "not
    a back door around either") — with restore-specific UI copy layered on
    top, not a fourth error class.

**Truncation-honesty fix, from S4's security review (#567):** `Resolve()`
computes the enforced restriction union from untruncated snapshots, but a
layer's own display copy (only layers 2-3 can carry restrictions at all) can
have items dropped by the byte-budget truncation, so a truncated layer's own
list could read as complete when it isn't — the enforced union above it
could carry more. `GovContextEffective.restrictions` already IS that
enforced, never-truncated union (its own doc comment says so) and Screen 1
was already rendering it; nothing connected a truncated layer's shorter list
back to it. Fixed by: a one-line note on the enforced-union section stating
it is never shortened, and an explicit callout on any truncated layer 2/3
pointing back at it. No contract change needed.

**Known non-atomicity, not a bug to fix here:** S4's author disclosed that
the widen-check's org baseline is read in a separate transaction from the
site write, so a `409` widen refusal is computed against a baseline that
could be a moment stale (enforcement itself is unaffected — the resolver
re-reads both tables fresh). This PR's copy is descriptive only (it repeats
the server's own message) and never claims the refusal is atomic with the
organisation's state.

## Two wireframe divergences (ruled on, not oversights)

The ADR-064 §sc-s33 wireframe's "Effective context preview" frame differs
from what's built here in two ways, checked against the real S4 contract:

1. **No concatenated codeblock.** The wireframe shows a single block of
   prose — "what the model actually receives, concatenated in this order."
   `GovContextEffective` has no such field; it returns structured per-layer
   data. Screen 1 renders each layer's own fields directly. Ruling: the
   wireframe is wrong here, not the API — a second, client-assembled
   rendering of the same content is exactly the drift S4's byte-identical
   preview proof (handler marshals `Resolver.Resolve`'s output directly,
   nothing else) exists to prevent.
2. **No "can a layer below override it?" column.** Not a field in the API
   response. Ruling: this isn't an omission either — the never-widen rule
   applies to structured restrictions only, explicitly not to free-text
   guidance, so a uniform per-layer column would imply a mechanical answer
   for guidance that ADR-064 deliberately refuses to give.

Both are intentional and will not be revisited without a contract change.

## Scope

All five screens from the original S5 brief are here. Nothing scoped out.

## Test plan

- [x] `pnpm -C apps/web typecheck` — exit 0
- [x] `pnpm -C apps/web lint` — exit 0 (0 errors, 9 pre-existing warnings unrelated to this change)
- [x] `pnpm -C apps/web test` — exit 0 (148 files / 1750 tests)
- [x] `pnpm -C apps/web build` — exit 0, `routeTree.gen.ts` regenerated and committed
- [x] `apps/web/node_modules/.bin/impeccable detect apps/web/src/features/context apps/web/src/routes/_authed/sites apps/web/src/routes/_authed/settings` — exit 0, no findings
- [x] Red/green: all six layers render in order, labelled (dropped layer 6 → red, restored → green)
- [x] Red/green: 503 load-failure state distinct from an empty result (disabled the 503 special-case → generic text rendered, red → restored → green)
- [x] Red/green: widen refusal flags the specific restriction field (disabled the field-flagging effect → red, restored → green)
- [x] Red/green: secret refusal shows the category-based message (genericized the banner text → red, restored → green)
- [x] Red/green: version conflict offers a reload action (removed the button → red, restored → green)
- [x] Red/green: a truncated layer 2/3 flags its restriction list as possibly incomplete (hardcoded the flag `false` → red, restored → green)
- [x] Red/green: the "Current" version badge lands on the newest row, not any other (this one caught a vacuous first version of its own test — see commit history; fixed to scope the assertion to the specific row before the real regression would fail it)
- [x] Red/green: the diff panel states it compares authored, not enforced, state (dropped the caveat → red, restored → green)
- [x] Red/green: a restore's widen refusal uses restore-specific wording, never the editor's banner text (reused the editor's generic copy → red, restored → green)
- [x] Red/green: `facts_unavailable` shows a distinct "could not be loaded" message, never the empty facts fields (checked `facts` before `facts_unavailable`, the exact bug shape → red, restored → green)

## Do not merge yet

**S4 (`feat/adr064-s4-context-resolver`, PR #567) has settled — all seven
review threads fixed, gates green, final integration run completed. Its
tip is `d9f1bde8`.** The null-unions thread DID change the wire shape, so
this PR re-imported the contract and regenerated (see the last commit).
Re-ran the diff myself before importing:
`git diff 283099ff origin/feat/adr064-s4-context-resolver --
packages/openapi/openapi.yaml`. What changed:

- Every `nullable: true` (invalid in OpenAPI 3.1, which the spec declares)
  converted to `type: [X, "null"]` / `anyOf`, across `GovContext`,
  `GovContextVersionSummary`, `GovContextVersionItem`, `GovContextDiff`,
  `PatchGovContextRequest`. No app code change needed — existing
  truthy/falsy checks handle `null` exactly like `undefined`.
- New `GovContextLayerContribution.facts_unavailable: boolean` — `true`
  means layer 4 could not be loaded (no facts source wired, or the load
  failed); `false`/absent means the load succeeded, whatever it found,
  including a verified empty result. Now handled as a **third, distinct**
  Facts state in Screen 1 (checked *before* `facts` truthiness, since a
  failed/unwired load still carries a non-null all-empty `facts` object on
  the wire) — proven with a red/green proof (checked `facts` first, the
  exact bug shape → red → restored → green).
- **Confirmed zero diff hits on all three refusal codes**
  (`context_widen_forbidden` / `context_secret_detected` /
  `context_version_conflict`) — Screen 2's refusal handling needed no
  changes.

**Backend finding, not this PR's bug, flagged for whoever owns
`apps/api/internal/govcontext` next:** as of S4 tip `d9f1bde8`,
`toEffectiveContextDTO` (`dto.go:267-287`) copies every
`LayerContribution` field into the wire DTO **except** `FactsUnavailable` —
so `facts_unavailable` can never actually serialize as `true` in a live
response today, even though `Resolve()` computes it correctly internally
(proven by `resolver_test.go`'s own
`TestResolve_Layer4FactsUnavailable_DistinctFromKnownEmpty`). This PR's
frontend code is correct against the *documented* contract and its tests
use a direct fixture rather than a live API call, so they don't depend on
that gap being closed — but the feature is effectively dead on arrival
against the real API until that one-line DTO fix lands.

**Fixed on S4 during this PR's lifetime, not this PR's fix:** a
guidance-only site edit was wrongly refused with `409
context_widen_forbidden` after an org narrowing (S4 tip `036791d1`). No
client change was needed here.

**Also found on S4, neither changes this PR's code:** a secret-scanner dead
zone (`entropyMinLen = 20` with an unreachable 4.7 threshold for 20-25
character strings — `log2(25) = 4.64` — fixed with boundary tests); and a
byte-budget refusal fix (refuse rather than serve an over-budget result
when even layer 1 alone exceeds the budget) landed in the same commit as
`facts_unavailable`.

## Still do not merge

Holding per the coordinator's instruction, independent of gate status —
this PR is not mine to merge.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization and site context editing for restrictions and guidance.
  * Added effective-context previews with layered values, usage details, warnings, and retry support.
  * Added paginated version history with expandable diffs and restore actions.
  * Added Context navigation for sites and context management in organization settings.
  * Added role-based editing access and feedback for conflicts, secrets, and prohibited changes.

* **Bug Fixes**
  * Improved handling of unavailable context, empty responses, loading states, and save or restore errors.

* **Tests**
  * Added coverage for previews, editing, history, restores, permissions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->