### PR TITLE
fix(db): tighten tenant scoping on email webhook dedup

### DIFF
--- a/apps/api/db/rls-cross-tenant-policies.txt
+++ b/apps/api/db/rls-cross-tenant-policies.txt
@@ -60,6 +60,23 @@
 # asserting a grant that does not exist costs the file the only thing it has,
 # which is being true.
 #
+# A ROW CAN ALSO BE TRUE AND STILL BE WRONG ABOUT ITS OWN REASON.
+# email_webhook_events_tenant_isolation was in this file until m125. Its
+# predicate really was `tenant_id IS NULL OR tenant_id = app.tenant_id`, so the
+# classification was correct, but the RATIONALE that kept it here was not: it
+# argued the unbound branch had to stay or webhook dedup would break, while its
+# own last sentence recorded that both writers run under InAgentTx and are
+# admitted by email_webhook_events_agent. Those two statements cannot both hold.
+# The branch was serving no path, m125 dropped it, and the policy is tenant-bound
+# now and no longer belongs here.
+#
+# The lesson is about the shape of a ledger entry, not about that one table. An
+# entry has to justify THE BRANCH, not the table's need for unattributed rows.
+# The table did need them; this policy was never what let it have them. When a
+# rationale ends by naming the sibling policy that actually carries the path,
+# that is the entry arguing against itself, and it is worth re-reading rather
+# than filing.
+#
 # RESTRICTIVE policies are excluded deliberately: a restrictive policy can only
 # narrow the row set, never grant one. The site_scope policies are restrictive
 # and do not mention app.tenant_id, so a classifier that ignored `permissive`
@@ -177,7 +194,6 @@ email_notify_settings|email_notify_settings_agent|app.agent|ALL|-|FOR ALL admits
 email_suppression|email_suppression_agent|app.agent|ALL|-|FOR ALL admits every verb, so the FOR SELECT silence cannot arise here; the path was not individually audited
 email_verification_tokens|email_verification_tokens_agent|app.agent|ALL|-|FOR ALL admits every verb, so the FOR SELECT silence cannot arise here; the path was not individually audited
 email_webhook_events|email_webhook_events_agent|app.agent|ALL|-|FOR ALL admits every verb, so the FOR SELECT silence cannot arise here; the path was not individually audited
-email_webhook_events|email_webhook_events_tenant_isolation|app.tenant_id|ALL|-|NAMED tenant_isolation, BUT IT IS A CROSS-TENANT GRANT. Its predicate is (tenant_id IS NULL OR tenant_id = app.tenant_id), and the first branch binds nothing, so every tenant sees -- and under FOR ALL may modify -- every row whose tenant was never resolved. That is deliberate, not a bug: m60 stores one row per (provider, provider_event_id) for webhook dedup and replay defence, and the row is written BEFORE the tenant is known (fan-out happens after dedup), so tenant_id stays NULL whenever provider metadata was absent or unparseable. A NULL-tenant row that only its own tenant could see would be a row nobody could see, and the dedup key would stop working. Exposure is bounded three ways: the rows hold provider ids, an event type and an email HASH (m61), never plaintext; EmailWebhookDedupGCWorker prunes them after 7 days; and no production caller reads this table under tenant scope at all -- both writers, InsertWebhookEventDedup (email/repo.go:1633) and PruneWebhookDedup (email/repo.go:1699), run under InAgentTx and are therefore admitted by the _agent policy above, not by this one. So the grant is latent rather than exercised. ops is '-' because no code path runs under THIS policy; FOR ALL admits every verb regardless, so the FOR SELECT silence cannot arise. Recorded because an unattributed row visible to everyone is exactly the kind of deliberate cross-tenant visibility this file exists to make explicit, and the policy's NAME actively hides it
 file_transfers|file_transfers_agent|app.agent|ALL|-|FOR ALL admits every verb, so the FOR SELECT silence cannot arise here; the path was not individually audited
 font_results|font_results_agent_access|app.agent|ALL|-|FOR ALL admits every verb, so the FOR SELECT silence cannot arise here; the path was not individually audited
 font_transcode_results|agent_access|app.agent|ALL|-|FOR ALL admits every verb, so the FOR SELECT silence cannot arise here; the path was not individually audited

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -4087,15 +4087,16 @@ CREATE POLICY email_webhook_events_agent ON email_webhook_events
     USING      (current_setting('app.agent', true) = 'on')
     WITH CHECK (current_setting('app.agent', true) = 'on');
 
+-- m125: the predicate below was `tenant_id IS NULL OR tenant_id = <app.tenant_id>`
+-- as m60 wrote it. The first branch bound nothing. It was dropped because it was
+-- not load-bearing: every path that touches this table (InsertWebhookEventDedup,
+-- PruneWebhookDedup) runs under Pool.InAgentTx and is admitted by the _agent
+-- policy above, which is FOR ALL over every row. Permissive policies are ORed, so
+-- narrowing this one does not narrow the ingest or the GC sweep. There is no
+-- SELECT query against this table in db/query/*.sql and no handler reads it.
 CREATE POLICY email_webhook_events_tenant_isolation ON email_webhook_events
-    USING (
-        tenant_id IS NULL
-        OR tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
-    )
-    WITH CHECK (
-        tenant_id IS NULL
-        OR tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid
-    );
+    USING      (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
 
 -- ---------------------------------------------------------------------------
 -- m62 — site_email_connection (multi-connection + failover)

--- a/apps/api/migrations/20260827000000_m125_email_webhook_dedup_tenant_scope.sql
+++ b/apps/api/migrations/20260827000000_m125_email_webhook_dedup_tenant_scope.sql
@@ -1,0 +1,50 @@
+-- M125 — Bind email_webhook_events_tenant_isolation to app.tenant_id.
+--
+-- m60 (20260623000000) created email_webhook_events_tenant_isolation with a
+-- two-branch predicate in both USING and WITH CHECK:
+--
+--     tenant_id IS NULL OR tenant_id = <app.tenant_id>
+--
+-- Only the second branch binds the row's tenant_id to the caller's tenant. This
+-- migration drops the first branch, leaving the single bound branch that every
+-- sibling *_tenant_isolation policy carries (rum_rollup_daily_tenant_isolation
+-- is the shape being matched).
+--
+-- WHY THE DROPPED BRANCH IS NOT LOAD-BEARING
+--
+-- m60's header argues the branch is required because a dedup row is written
+-- before the tenant is known, so a row nobody could see would break the dedup
+-- key. That reasoning does not depend on THIS policy. Every code path that
+-- touches the table runs under Pool.InAgentTx (internal/db/db.go:429), which
+-- sets app.agent='on' and sets no tenant GUC at all:
+--
+--   * InsertWebhookEventDedup  (internal/email/repo.go:1633) — the dedup write
+--   * PruneWebhookDedup        (internal/email/repo.go:1699) — the 7-day sweep
+--
+-- Both are admitted by the separate email_webhook_events_agent policy, which is
+-- FOR ALL over every row regardless of tenant_id and is left untouched here.
+-- PostgreSQL ORs permissive policies, so removing a branch from a policy that
+-- never admitted the agent path cannot narrow it. The table has no SELECT query
+-- in db/query/*.sql and no handler reads it, so no operator-facing read regresses
+-- either. The policy retains the audit-read affordance m60 intended for it, now
+-- scoped to the reading tenant's own attributed rows.
+--
+-- CONVERGE PATH
+--
+-- Unconditional DROP ... IF EXISTS + CREATE, so a database that applied m60 and
+-- a database created fresh from db/schema.sql reach the same end state. m60 is
+-- applied in production and is not edited; this is the forward correction.
+--
+-- Deliberately NOT added here: a RESTRICTIVE email_webhook_events_site_scope
+-- policy. The table carries site_id, but it has no tenant- or site-scoped read
+-- path to narrow, and a RESTRICTIVE policy under FORCE ROW LEVEL SECURITY would
+-- also apply to the InAgentTx writers — the shape that matches zero rows with no
+-- error. That belongs in its own reviewed change, not folded into this one.
+--
+-- All DDL is idempotent.
+
+DROP POLICY IF EXISTS "email_webhook_events_tenant_isolation" ON "public"."email_webhook_events";
+
+CREATE POLICY "email_webhook_events_tenant_isolation" ON "public"."email_webhook_events"
+    USING      (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);


### PR DESCRIPTION
## What

`m125` narrows `email_webhook_events_tenant_isolation` to the single bound predicate every sibling `*_tenant_isolation` policy carries:

```sql
USING      (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
```

`rum_rollup_daily_tenant_isolation` is the shape being matched. `m60` is applied in production and is not edited — this is a forward migration with an unconditional `DROP ... IF EXISTS` + `CREATE`, so a database that ran `m60` and a database created fresh from `db/schema.sql` converge on the same end state.

Ordinal `20260827000000`, clear of `20260826000000_m124` on `feat/adr064-s6a-mcp-connection-surface`. The two migrations touch disjoint tables, so merge order between them does not matter.

## Why the removed branch was not load-bearing

`db/rls-cross-tenant-policies.txt` justified the wider predicate on the grounds that dedup would break without it. That reasoning does not depend on this policy. Every statement that touches the table runs under `Pool.InAgentTx` (`internal/db/db.go:429`), which sets `app.agent='on'` and no tenant GUC at all:

- `InsertWebhookEventDedup` — `internal/email/repo.go:1633`
- `PruneWebhookDedup` — `internal/email/repo.go:1699`

Both are admitted by the separate `email_webhook_events_agent` policy, which is `FOR ALL` over every row and is untouched here. PostgreSQL ORs permissive policies, so narrowing this one cannot narrow ingest or the GC sweep. There is no `SELECT` against this table anywhere in `db/query/*.sql` and no handler reads it.

## Proofs

All executed as `wpmgr_app` (`rolsuper=f`, `rolbypassrls=f`) against a throwaway Postgres built by applying the real `m60` file, then the real `m125` file. Same command before and after.

**Policy predicate, from live `pg_policies`:**

before → `((tenant_id IS NULL) OR (tenant_id = (NULLIF(current_setting('app.tenant_id'::text, true), ''::text))::uuid))`
after → `(tenant_id = (NULLIF(current_setting('app.tenant_id'::text, true), ''::text))::uuid)`

**Read, `psql -f /tmp/wpmgr-proof-read.sql`** — before: 1 row; after: `(0 rows)`.

**Write, `psql -f /tmp/wpmgr-proof-write.sql`** — before: `INSERT 0 1`; after: `ERROR: new row violates row-level security policy for table "email_webhook_events"`.

**Ingest still works, `psql -f /tmp/wpmgr-proof-ingest.sql`, after the change**, under `app.agent='on'` with no tenant GUC — exactly what `InAgentTx` sets:

- unattributed insert → `INSERT 0 1`, returning `tenant_id NULL`
- same event replayed → `INSERT 0 0`, `(0 rows)` — the dedup key still suppresses
- agent read → `rows_visible_to_agent = 4`
- retention sweep `DELETE` → `DELETE 4`, not zero

That last line is the check that matters: it rules out the `FOR SELECT` silence (`m84/#96`, `m89/#131`, `m118/#463`) where a write matches zero rows with no error.

## Gates

- `bash scripts/check-rls-cross-tenant_test.sh` → `54 passed, 0 failed` (self-test first, so a broken guard cannot pass by failing open)
- `sqlc v1.31.1`; `sqlc generate` then `git diff --quiet -- internal/db/sqlc/` → empty diff
- `go build ./...`, `go vet ./...` → clean
- `go test ./internal/...` → exit 0, 70 packages `ok`, no `FAIL`

## Ledger

The row for this policy is removed: the policy classifies `TENANT` now, and per the file's own rule a row asserting a grant that does not exist costs the file the only thing it has. The header records why the row's stated rationale did not survive checking.

## Not included, deliberately

No RESTRICTIVE `email_webhook_events_site_scope` policy. The table carries `site_id`, but it has no tenant- or site-scoped read path to narrow, and a RESTRICTIVE policy under `FORCE ROW LEVEL SECURITY` would also apply to the `InAgentTx` writers. That is its own reviewed change, not something to fold in here.

No Go change is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant isolation for email webhook events.
  * Email webhook records now require an explicit tenant match, preventing access to records without an assigned tenant.
  * Preserved existing agent-based ingestion and pruning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->