### PR TITLE
feat(mcp): refuse a client that requests no recognised scope (S6b-1 exit gate)

### DIFF
--- a/apps/api/internal/mcp/model.go
+++ b/apps/api/internal/mcp/model.go
@@ -1,0 +1,103 @@
+// Package mcp is the read-only MCP connection surface (ADR-064 S6b).
+//
+// Storage is m124 (20260826000000_m124_mcp_connection_surface.sql), which is
+// SCHEMA ONLY: four tables, their RLS and their grants, and no behaviour. That
+// file's header carries nine numbered DECISIONs explaining the shape of every
+// column, and a closing block titled "WHAT S6b MUST DO" listing seven
+// obligations this package owes. Read it before changing anything here; the
+// constraints below are deliberately redundant with CHECKs in that file and
+// the redundancy is the point.
+//
+// This file holds the domain vocabulary. The OAuth endpoints, the PKCE
+// exchange and the site-scope resolution chokepoint live alongside it.
+package mcp
+
+import "github.com/google/uuid"
+
+// Scope is an OAuth scope this surface recognises. The registry in scope.go is
+// CLOSED: an unrecognised scope is refused, never ignored.
+type Scope string
+
+// ScopeRead is the only scope this surface grants, and the surface is
+// read-only by construction rather than by configuration (m124 DECISION 1:
+// there is deliberately no capability column, because it would be the place a
+// write capability could later appear without a migration and without a
+// review). A write scope does not belong here; it belongs in its own migration
+// with its own review.
+const ScopeRead Scope = "mcp:read"
+
+// SiteScopeMode says which sites a grant may read. It mirrors
+// mcp_grants_site_scope_mode_check: NOT NULL, closed set, and deliberately NO
+// DEFAULT, because the whole failure this slice differentiates against is a
+// scope column whose unset value means everything.
+type SiteScopeMode string
+
+const (
+	// SiteScopeModeAll covers every site in the tenant, and carries no payload.
+	SiteScopeModeAll SiteScopeMode = "all"
+	// SiteScopeModeTags resolves through site_tags and must name >=1 tag.
+	SiteScopeModeTags SiteScopeMode = "tags"
+	// SiteScopeModeList is a literal site allowlist and must name >=1 site.
+	SiteScopeModeList SiteScopeMode = "list"
+)
+
+// GrantStatus mirrors mcp_grants_status_check. Liveness is a stored column and
+// not an inference from an expiry (m124 DECISION 2), so that revoking is a
+// write somebody made rather than a clock somebody trusted.
+type GrantStatus string
+
+const (
+	GrantStatusActive  GrantStatus = "active"
+	GrantStatusRevoked GrantStatus = "revoked"
+)
+
+// SiteScopeRequest is what a caller asked for, before validation. It is
+// deliberately NOT the stored shape: Mode has no zero-value meaning, and
+// ValidateSiteScopeRequest refuses an empty Mode rather than reading it as
+// SiteScopeModeAll.
+type SiteScopeRequest struct {
+	Mode    SiteScopeMode
+	TagIDs  []uuid.UUID
+	SiteIDs []uuid.UUID
+}
+
+// SiteSet is a RESOLVED set of site ids: the output of the single audited
+// chokepoint that turns a grant's stored scope into the sites it may actually
+// read, inside InTenantTx so that `sites` RLS drops every foreign UUID
+// (m124 obligation 2 -- scope_site_ids is a uuid[] and PostgreSQL has no
+// foreign key over array elements, so the column accepts any UUID including
+// another organisation's site).
+//
+// It is a struct and not a []uuid.UUID on purpose. A bare slice has a zero
+// value that reads as "no filter applied" at every call site that forgets to
+// check it; this type's zero value allows NOTHING, and there is deliberately
+// no method that answers "does this mean everything". Empty means no sites.
+type SiteSet struct {
+	ids map[uuid.UUID]struct{}
+}
+
+// NewSiteSet builds a SiteSet from ids that have ALREADY been resolved through
+// `sites` under tenant RLS. Passing an unresolved or cached list defeats the
+// only check that catches a foreign UUID.
+func NewSiteSet(ids []uuid.UUID) SiteSet {
+	set := SiteSet{ids: make(map[uuid.UUID]struct{}, len(ids))}
+	for _, id := range ids {
+		set.ids[id] = struct{}{}
+	}
+	return set
+}
+
+// Allows reports whether this grant may read the given site. On an empty or
+// zero-value set it returns false for every id, which is the entire point.
+func (s SiteSet) Allows(id uuid.UUID) bool {
+	_, ok := s.ids[id]
+	return ok
+}
+
+// Len is the number of sites resolved.
+func (s SiteSet) Len() int { return len(s.ids) }
+
+// IsEmpty reports that this grant resolved to no sites at all -- a tag that
+// matches nothing, or a list whose every id was dropped by RLS. The caller
+// must handle it as "reads nothing", and must never widen it.
+func (s SiteSet) IsEmpty() bool { return len(s.ids) == 0 }

--- a/apps/api/internal/mcp/scope.go
+++ b/apps/api/internal/mcp/scope.go
@@ -1,0 +1,181 @@
+package mcp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ErrCodeInvalidScope is the domain error code the OAuth error response renders
+// as RFC 6749 section 5.2 `invalid_scope`. httpx maps KindValidation to 400,
+// which is the correct status for both the authorize and the token endpoint.
+const ErrCodeInvalidScope = "mcp_invalid_scope"
+
+// ErrCodeInvalidSiteScope is the domain error code for a site-scope request
+// that names a mode and no payload, or a payload its mode forbids.
+const ErrCodeInvalidSiteScope = "mcp_invalid_site_scope"
+
+// recognisedScopes is the CLOSED registry of scopes this surface grants.
+//
+// It is closed in the strong sense: an unrecognised scope is a REFUSAL of the
+// whole request, not a token quietly dropped from an otherwise-honoured one.
+// Dropping is the tempting behaviour because it "still works" for well-behaved
+// clients, and it is wrong for the same reason a nullable tenant_id is wrong --
+// it lets the operator consent to a scope set that is not the one the client
+// asked for, and neither party ever learns they disagreed.
+//
+// The registry holds exactly one entry and the read-only surface is the whole
+// security claim of the feature (m124 obligation 5). A write scope arrives with
+// its own migration and its own review, never by being appended here.
+var recognisedScopes = map[Scope]struct{}{
+	ScopeRead: {},
+}
+
+// ParseRequestedScopes parses the RFC 6749 section 3.3 space-delimited `scope`
+// request parameter into the scopes this surface will grant.
+//
+// THIS IS S6's EXIT GATE (m124 obligation 3). A client that requests no
+// recognised scope is REFUSED. There is no default, no fallback and no
+// widening, and in particular:
+//
+//   - a missing, empty or whitespace-only parameter is an ABSENCE, and absence
+//     is refusal, never "everything we have";
+//   - an unrecognised scope refuses the WHOLE request rather than being
+//     silently dropped from it;
+//   - matching is exact and case-sensitive, per RFC 6749 section 3.3, so
+//     "MCP:READ" is unrecognised and is refused rather than normalised into a
+//     grant the client did not spell.
+//
+// The refusal path returns a nil slice as well as an error. A caller that
+// ignores the error still gets no authority, which is the fail-closed
+// direction; the schema half of this gate (m124 DECISION 1) makes the same
+// value unstorable.
+func ParseRequestedScopes(raw string) ([]Scope, error) {
+	fields := strings.Fields(raw)
+	if len(fields) == 0 {
+		return nil, domain.Validation(ErrCodeInvalidScope,
+			"the scope parameter is required and must name at least one recognised scope").
+			WithDetails(map[string]any{"supported_scopes": SupportedScopes()})
+	}
+
+	seen := make(map[Scope]struct{}, len(fields))
+	out := make([]Scope, 0, len(fields))
+	for _, field := range fields {
+		s := Scope(field)
+		if _, ok := recognisedScopes[s]; !ok {
+			// Refuse the whole request. Naming the offending scope back to the
+			// client is safe (it is the client's own input) and is what makes
+			// the failure debuggable instead of mysterious.
+			return nil, domain.Validation(ErrCodeInvalidScope,
+				fmt.Sprintf("scope %q is not recognised by this server", field)).
+				WithDetails(map[string]any{
+					"unrecognised_scope": field,
+					"supported_scopes":   SupportedScopes(),
+				})
+		}
+		if _, dup := seen[s]; dup {
+			continue // RFC 6749 permits repetition; it adds no authority
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+
+	// Belt and braces. Reaching here with an empty slice would mean the loop
+	// above accepted every field and appended none, which cannot happen -- but
+	// "cannot happen" returning a silently empty grant is precisely this
+	// project's signature defect, so it is checked rather than assumed.
+	if len(out) == 0 {
+		return nil, domain.Validation(ErrCodeInvalidScope,
+			"no recognised scope was requested")
+	}
+	return out, nil
+}
+
+// SupportedScopes lists the registry for discovery documents and error
+// details, sorted so the output is stable across map iterations.
+func SupportedScopes() []string {
+	out := make([]string, 0, len(recognisedScopes))
+	for s := range recognisedScopes {
+		out = append(out, string(s))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ValidateSiteScopeRequest refuses an incoherent or empty site-scope request
+// BEFORE it reaches the database.
+//
+// This mirrors mcp_grants_site_scope_payload_check in Go. The redundancy is
+// deliberate and is not defensive clutter: the CHECK guarantees such a row
+// cannot be STORED, which turns the bug into a bare SQLSTATE 23514 at INSERT
+// time, and a 23514 surfacing as a 500 tells the operator nothing about which
+// field was wrong. More importantly the CHECK cannot see a request that never
+// reaches an INSERT -- the authorize endpoint validates the requested scope
+// long before any row exists.
+//
+// "Requested a scope and named nothing" is refused in both places. An empty
+// mode is NOT read as SiteScopeModeAll: there is deliberately no DEFAULT 'all'
+// in the schema and there is deliberately no zero-value default here.
+func ValidateSiteScopeRequest(req SiteScopeRequest) error {
+	switch req.Mode {
+	case SiteScopeModeAll:
+		if len(req.TagIDs) > 0 || len(req.SiteIDs) > 0 {
+			return domain.Validation(ErrCodeInvalidSiteScope,
+				"site scope mode 'all' must not name tags or sites")
+		}
+		return nil
+
+	case SiteScopeModeTags:
+		if len(req.TagIDs) == 0 {
+			return domain.Validation(ErrCodeInvalidSiteScope,
+				"site scope mode 'tags' must name at least one tag; "+
+					"an empty tag list grants nothing and is not a way to request every site")
+		}
+		if len(req.SiteIDs) > 0 {
+			return domain.Validation(ErrCodeInvalidSiteScope,
+				"site scope mode 'tags' must not also name sites")
+		}
+		return validateNoNilIDs(req.TagIDs, "tag")
+
+	case SiteScopeModeList:
+		if len(req.SiteIDs) == 0 {
+			return domain.Validation(ErrCodeInvalidSiteScope,
+				"site scope mode 'list' must name at least one site; "+
+					"an empty allowlist grants nothing and is not a way to request every site")
+		}
+		if len(req.TagIDs) > 0 {
+			return domain.Validation(ErrCodeInvalidSiteScope,
+				"site scope mode 'list' must not also name tags")
+		}
+		return validateNoNilIDs(req.SiteIDs, "site")
+
+	default:
+		// Covers the empty mode and every unrecognised string. An absent mode
+		// is a caller that did not say what the grant covers, and the answer
+		// to that is 400, not 'all'.
+		return domain.Validation(ErrCodeInvalidSiteScope,
+			fmt.Sprintf("site scope mode %q is not recognised; expected one of 'all', 'tags', 'list'",
+				req.Mode)).
+			WithDetails(map[string]any{"supported_modes": []string{
+				string(SiteScopeModeAll), string(SiteScopeModeTags), string(SiteScopeModeList),
+			}})
+	}
+}
+
+// validateNoNilIDs refuses uuid.Nil in a scope payload. uuid.Nil is what a
+// failed parse decays to in Go, so accepting it would let a malformed request
+// through as a well-formed id that simply matches no row -- an absence wearing
+// the shape of a value.
+func validateNoNilIDs(ids []uuid.UUID, kind string) error {
+	for _, id := range ids {
+		if id == uuid.Nil {
+			return domain.Validation(ErrCodeInvalidSiteScope,
+				fmt.Sprintf("site scope names an empty %s id", kind))
+		}
+	}
+	return nil
+}

--- a/apps/api/internal/mcp/scope.go
+++ b/apps/api/internal/mcp/scope.go
@@ -11,8 +11,17 @@ import (
 )
 
 // ErrCodeInvalidScope is the domain error code the OAuth error response renders
-// as RFC 6749 section 5.2 `invalid_scope`. httpx maps KindValidation to 400,
-// which is the correct status for both the authorize and the token endpoint.
+// as RFC 6749 section 5.2 `invalid_scope`.
+//
+// THE OAUTH ENDPOINTS MUST SET THE STATUS THEMSELVES. This is KindValidation,
+// and domain.HTTPStatus maps KindValidation to 422 (errors.go:170-171), which
+// is what the generic httpx.Error renderer returns. RFC 6749 section 5.2
+// requires 400 on the token endpoint, so an OAuth handler that falls through to
+// the generic renderer answers 422 and is non-conformant. The handlers
+// therefore map this code explicitly rather than delegating.
+//
+// An earlier version of this comment asserted that httpx maps KindValidation to
+// 400. It does not, and never did.
 const ErrCodeInvalidScope = "mcp_invalid_scope"
 
 // ErrCodeInvalidSiteScope is the domain error code for a site-scope request
@@ -48,14 +57,17 @@ var recognisedScopes = map[Scope]struct{}{
 //     silently dropped from it;
 //   - matching is exact and case-sensitive, per RFC 6749 section 3.3, so
 //     "MCP:READ" is unrecognised and is refused rather than normalised into a
-//     grant the client did not spell.
+//     grant the client did not spell;
+//   - only ASCII space (U+0020) separates. A tab, newline, NBSP or any other
+//     Unicode space is not a delimiter, so it stays inside its token and the
+//     token is refused. See splitASCIISpace.
 //
 // The refusal path returns a nil slice as well as an error. A caller that
 // ignores the error still gets no authority, which is the fail-closed
 // direction; the schema half of this gate (m124 DECISION 1) makes the same
 // value unstorable.
 func ParseRequestedScopes(raw string) ([]Scope, error) {
-	fields := strings.Fields(raw)
+	fields := splitASCIISpace(raw)
 	if len(fields) == 0 {
 		return nil, domain.Validation(ErrCodeInvalidScope,
 			"the scope parameter is required and must name at least one recognised scope").
@@ -93,6 +105,39 @@ func ParseRequestedScopes(raw string) ([]Scope, error) {
 			"no recognised scope was requested")
 	}
 	return out, nil
+}
+
+// splitASCIISpace splits on U+0020 AND NOTHING ELSE, per RFC 6749 section 3.3:
+//
+//	scope = scope-token *( SP scope-token )
+//
+// This deliberately replaces strings.Fields, which splits on unicode.IsSpace
+// and therefore treated TAB, LF, CR, VT, FF, NBSP (U+00A0), LINE SEPARATOR
+// (U+2028), IDEOGRAPHIC SPACE (U+3000) and the rest as delimiters. That made
+// the parser REPAIR malformed input into a well-formed request before the gate
+// below ever saw it: "mcp:read\tmcp:read" was silently read as two valid
+// scopes. The absence of a valid separator became a valid separator, which is
+// the same coercion this whole file exists to refuse, one layer earlier.
+//
+// Any other whitespace now stays INSIDE its token, so that token is not in the
+// closed registry and the existing rule refuses the whole request. No new
+// refusal branch was needed; the bug was that the input never reached the one
+// already there.
+//
+// EMPTY SEGMENTS ARE DROPPED, and that is not the same kind of leniency.
+// Repeated, leading or trailing spaces produce segments that name no scope, so
+// dropping them cannot manufacture authority. Treating a tab as a delimiter can:
+// it invents a token boundary the client never wrote, and can turn one
+// unrecognised token into two recognised ones.
+func splitASCIISpace(raw string) []string {
+	parts := strings.Split(raw, " ")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // SupportedScopes lists the registry for discovery documents and error

--- a/apps/api/internal/mcp/scope_test.go
+++ b/apps/api/internal/mcp/scope_test.go
@@ -1,0 +1,246 @@
+package mcp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// THE EXIT GATE (m124 obligation 3).
+//
+// "A client that requests no recognised scope is REFUSED, not granted a
+// default." The migration makes the unset value unstorable; this is the
+// REQUEST side of the same gate, and it is S6's stated exit criterion.
+//
+// The failure this differentiates against is the project's signature defect:
+// an absence coerced into a plausible value and reported as success. Here that
+// is a missing, blank or unrecognised `scope` parameter read as full access.
+// ---------------------------------------------------------------------------
+
+func TestParseRequestedScopes_NoRecognisedScopeIsRefusedNotDefaulted(t *testing.T) {
+	// Every one of these is an ABSENCE. None of them may produce a grant.
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"parameter omitted entirely", ""},
+		{"single space", " "},
+		{"tabs and newlines only", "\t\n  \r"},
+		{"unrecognised scope alone", "fleet:admin"},
+		{"unrecognised scope, plausible prefix", "mcp:"},
+		{"unrecognised scope, plausible suffix", "read"},
+		{"case-mismatched scope", "MCP:READ"},
+		{"write scope, which this surface never grants", "mcp:write"},
+		{"only separators", "   "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRequestedScopes(tc.raw)
+
+			if err == nil {
+				t.Fatalf("ParseRequestedScopes(%q) returned no error and scopes %v; "+
+					"a request naming no recognised scope MUST be refused, never "+
+					"granted a default", tc.raw, got)
+			}
+			if len(got) != 0 {
+				t.Fatalf("ParseRequestedScopes(%q) refused with err=%v but still "+
+					"returned %d scope(s) %v; a refused request must carry no "+
+					"authority at all", tc.raw, err, len(got), got)
+			}
+
+			// The refusal must be a typed domain error the OAuth error
+			// response can render as RFC 6749 `invalid_scope`, not an
+			// unclassified infra error that httpx would turn into a 500.
+			var domErr *domain.Error
+			if !errors.As(err, &domErr) {
+				t.Fatalf("ParseRequestedScopes(%q) refused with a non-domain error %T (%v); "+
+					"the OAuth error response cannot classify it", tc.raw, err, err)
+			}
+			if domErr.Code != ErrCodeInvalidScope {
+				t.Errorf("ParseRequestedScopes(%q) refused with code %q, want %q",
+					tc.raw, domErr.Code, ErrCodeInvalidScope)
+			}
+		})
+	}
+}
+
+// A partially-recognised request must be refused WHOLE. Silently dropping the
+// unrecognised half and granting the remainder is the same fail-open shape
+// wearing a different hat: the client asked for something we did not
+// understand, and proceeding means the operator consents to a scope set that
+// is not the one that was requested.
+func TestParseRequestedScopes_UnrecognisedScopeRefusesTheWholeRequest(t *testing.T) {
+	got, err := ParseRequestedScopes(string(ScopeRead) + " fleet:destroy")
+	if err == nil {
+		t.Fatalf("a request mixing a recognised and an unrecognised scope returned "+
+			"%v with no error; it must be refused whole, not silently narrowed", got)
+	}
+	if len(got) != 0 {
+		t.Fatalf("refused request still returned %v", got)
+	}
+}
+
+// The gate must not over-fire: a correct request still works. A guard that
+// reddens correct work gets switched off, and then it guards nothing.
+func TestParseRequestedScopes_RecognisedScopeIsGranted(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"exact", "mcp:read"},
+		{"leading and trailing whitespace", "  mcp:read  "},
+		{"repeated, per RFC 6749 space delimiting", "mcp:read mcp:read"},
+		{"multiple internal spaces", "mcp:read   mcp:read"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRequestedScopes(tc.raw)
+			if err != nil {
+				t.Fatalf("ParseRequestedScopes(%q) refused a valid request: %v", tc.raw, err)
+			}
+			if len(got) != 1 || got[0] != ScopeRead {
+				t.Fatalf("ParseRequestedScopes(%q) = %v, want exactly [%s]", tc.raw, got, ScopeRead)
+			}
+		})
+	}
+}
+
+// The registry is closed and read-only by construction (m124 DECISION 1: "no
+// capability column exists, and that is a decision"). If a write scope ever
+// appears in the registry it must arrive with its own review, not by drifting
+// in. This test is the tripwire.
+func TestRecognisedScopes_AreReadOnlyAndClosed(t *testing.T) {
+	if len(recognisedScopes) != 1 {
+		t.Fatalf("recognised scope registry has %d entries, want exactly 1; a new "+
+			"scope on the read-only MCP surface needs its own review",
+			len(recognisedScopes))
+	}
+	for s := range recognisedScopes {
+		if strings.Contains(string(s), "write") || strings.Contains(string(s), "admin") {
+			t.Errorf("scope %q implies mutation; the MCP surface is read-only by "+
+				"construction and exposes no write tool", s)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE EMPTY-SET TRAP (m124 obligation 2).
+//
+// "An empty resolved set must mean NO SITES, never every site." The CHECK
+// stops an empty payload being STORED; nothing stops Go computing an empty set
+// from a tag that matches no site and then reading it as absence of a filter.
+// ---------------------------------------------------------------------------
+
+func TestSiteSet_EmptyAllowsNothing(t *testing.T) {
+	var zero SiteSet // the zero value is the one a bug reaches by accident
+	if zero.Len() != 0 {
+		t.Fatalf("zero SiteSet has Len() = %d, want 0", zero.Len())
+	}
+	if zero.Allows(uuid.New()) {
+		t.Fatal("the ZERO SiteSet allowed a site; empty must mean NO sites, never all")
+	}
+
+	empty := NewSiteSet(nil)
+	if empty.Allows(uuid.New()) {
+		t.Fatal("an empty resolved SiteSet allowed a site; a tag matching no site " +
+			"must grant nothing, not everything")
+	}
+	if empty.Allows(uuid.Nil) {
+		t.Fatal("an empty resolved SiteSet allowed the nil UUID")
+	}
+}
+
+func TestSiteSet_AllowsOnlyResolvedMembers(t *testing.T) {
+	member, foreign := uuid.New(), uuid.New()
+	set := NewSiteSet([]uuid.UUID{member})
+
+	if !set.Allows(member) {
+		t.Error("a resolved member was refused; the set must not over-fire")
+	}
+	if set.Allows(foreign) {
+		t.Error("a site outside the resolved set was allowed")
+	}
+	if set.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", set.Len())
+	}
+}
+
+// A grant whose stored payload names sites can still resolve to nothing once
+// `sites` RLS has dropped every foreign or deleted UUID. That grant authorizes
+// no read at all, and the caller must be told so explicitly rather than
+// receiving an empty slice it might read as "unfiltered".
+func TestSiteSet_ResolvesToNothingIsDetectable(t *testing.T) {
+	set := NewSiteSet([]uuid.UUID{})
+	if !set.IsEmpty() {
+		t.Fatal("a set resolved from zero surviving ids does not report IsEmpty()")
+	}
+	if set.Len() != 0 {
+		t.Fatalf("Len() = %d on an empty set", set.Len())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The requested site scope, validated BEFORE it reaches the database. This
+// mirrors mcp_grants_site_scope_payload_check in Go so an incoherent request is
+// refused with a 400 naming the problem rather than a bare 23514 from Postgres
+// -- and, more importantly, so "requested a scope and named nothing" is caught
+// on the request side too.
+// ---------------------------------------------------------------------------
+
+func TestValidateSiteScopeRequest_ModeWithEmptyPayloadIsRefused(t *testing.T) {
+	cases := []struct {
+		name string
+		req  SiteScopeRequest
+	}{
+		{"mode omitted entirely", SiteScopeRequest{}},
+		{"unrecognised mode", SiteScopeRequest{Mode: "everything"}},
+		{"mode all is not spelled with an empty string", SiteScopeRequest{Mode: ""}},
+		{"tags with no tags", SiteScopeRequest{Mode: SiteScopeModeTags}},
+		{"list with no sites", SiteScopeRequest{Mode: SiteScopeModeList}},
+		{"tags mode carrying only sites", SiteScopeRequest{
+			Mode: SiteScopeModeTags, SiteIDs: []uuid.UUID{uuid.New()}}},
+		{"list mode carrying only tags", SiteScopeRequest{
+			Mode: SiteScopeModeList, TagIDs: []uuid.UUID{uuid.New()}}},
+		{"all mode carrying a payload it must not have", SiteScopeRequest{
+			Mode: SiteScopeModeAll, SiteIDs: []uuid.UUID{uuid.New()}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSiteScopeRequest(tc.req)
+			if err == nil {
+				t.Fatalf("ValidateSiteScopeRequest(%+v) accepted an incoherent or "+
+					"empty scope request", tc.req)
+			}
+			var domErr *domain.Error
+			if !errors.As(err, &domErr) {
+				t.Fatalf("refusal was not a domain error: %T %v", err, err)
+			}
+		})
+	}
+}
+
+func TestValidateSiteScopeRequest_CoherentRequestsAreAccepted(t *testing.T) {
+	cases := []struct {
+		name string
+		req  SiteScopeRequest
+	}{
+		{"all", SiteScopeRequest{Mode: SiteScopeModeAll}},
+		{"tags", SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{uuid.New()}}},
+		{"list", SiteScopeRequest{Mode: SiteScopeModeList, SiteIDs: []uuid.UUID{uuid.New()}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateSiteScopeRequest(tc.req); err != nil {
+				t.Fatalf("ValidateSiteScopeRequest(%+v) refused a coherent request: %v",
+					tc.req, err)
+			}
+		})
+	}
+}

--- a/apps/api/internal/mcp/separator_test.go
+++ b/apps/api/internal/mcp/separator_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// SEPARATORS. RFC 6749 section 3.3 defines the scope parameter as an
+// ASCII-SPACE-delimited list:
+//
+//	scope = scope-token *( SP scope-token )
+//
+// SP is U+0020 and nothing else. `strings.Fields` splits on unicode.IsSpace,
+// which ALSO treats TAB, LF, CR, VT, FF, NBSP (U+00A0), LINE SEPARATOR
+// (U+2028), PARAGRAPH SEPARATOR (U+2029), EN QUAD (U+2000) and IDEOGRAPHIC
+// SPACE (U+3000) as delimiters -- so malformed input was being NORMALISED INTO
+// WELL-FORMED input before the gate ever saw it.
+//
+// That is this package's own thesis violated one layer earlier: the absence of
+// a valid separator quietly becoming a valid separator. The gate refuses an
+// unrecognised scope; it never got the chance, because the parser had already
+// repaired the request into one it recognised.
+//
+// The fix needs no new refusal rule. A non-space whitespace character is not a
+// separator, so it stays INSIDE the token: "mcp:read\tmcp:read" is one token,
+// that token is not in the registry, and the existing closed-registry rule
+// refuses the whole request.
+// ---------------------------------------------------------------------------
+
+func TestParseRequestedScopes_OnlyASCIISpaceSeparates(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"horizontal tab", "mcp:read\tmcp:read"},
+		{"line feed", "mcp:read\nmcp:read"},
+		{"carriage return", "mcp:read\rmcp:read"},
+		{"vertical tab", "mcp:read\vmcp:read"},
+		{"form feed", "mcp:read\fmcp:read"},
+		{"no-break space U+00A0", "mcp:read mcp:read"},
+		{"line separator U+2028", "mcp:read mcp:read"},
+		{"paragraph separator U+2029", "mcp:read mcp:read"},
+		{"en quad U+2000", "mcp:read mcp:read"},
+		{"ideographic space U+3000", "mcp:read　mcp:read"},
+		{"trailing tab on one valid scope", "mcp:read\t"},
+		{"leading tab on one valid scope", "\tmcp:read"},
+		{"CRLF between scopes", "mcp:read\r\nmcp:read"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRequestedScopes(tc.raw)
+			if err == nil {
+				t.Fatalf("ParseRequestedScopes(%q) accepted a non-ASCII-space separator "+
+					"and returned %v; RFC 6749 section 3.3 delimits on U+0020 only, so this "+
+					"input is malformed and must be REFUSED, never normalised into "+
+					"something valid", tc.raw, got)
+			}
+			if len(got) != 0 {
+				t.Fatalf("ParseRequestedScopes(%q) refused but still returned %v", tc.raw, got)
+			}
+		})
+	}
+}
+
+// The separator rule must not over-fire. ASCII space in every reasonable
+// arrangement still parses, including repeated, leading and trailing spaces.
+//
+// Tolerating EMPTY SEGMENTS between spaces coerces nothing: an empty segment
+// names no scope, so skipping it cannot manufacture authority. That is the
+// difference from treating a tab as a delimiter, which invents a token
+// boundary the client never wrote and can turn one unrecognised token into two
+// recognised ones.
+func TestParseRequestedScopes_ASCIISpaceArrangementsStillParse(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"single token", "mcp:read"},
+		{"leading spaces", "   mcp:read"},
+		{"trailing spaces", "mcp:read   "},
+		{"both", "  mcp:read  "},
+		{"repeated internal spaces", "mcp:read   mcp:read"},
+		{"duplicate separated by one space", "mcp:read mcp:read"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRequestedScopes(tc.raw)
+			if err != nil {
+				t.Fatalf("ParseRequestedScopes(%q) refused a well-formed request: %v", tc.raw, err)
+			}
+			if len(got) != 1 || got[0] != ScopeRead {
+				t.Fatalf("ParseRequestedScopes(%q) = %v, want exactly [%s]", tc.raw, got, ScopeRead)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #569 (m124). **Base is `feat/adr064-s6a-mcp-connection-surface`, not `main`.** Draft.

## What this is

The request-side half of S6's exit criterion, and deliberately not the whole OAuth surface — see "What is blocked" below.

**`ParseRequestedScopes`** is m124 obligation 3: *refusing a client that requests no recognised scope, rather than granting a default*. A missing, blank or whitespace-only `scope` is an absence, and absence is refusal. An unrecognised scope refuses the **whole** request rather than being dropped from an otherwise-honoured one — silently narrowing lets the operator consent to a scope set the client never asked for, and neither side learns they disagreed. Matching is exact and case-sensitive per RFC 6749 §3.3, so `MCP:READ` is refused rather than normalised into a grant nobody spelled.

The registry is closed and holds one entry. The surface is read-only *by construction*, which is why m124 DECISION 1 declines to mint a capability column at all. A test asserts the registry stays size one and that no entry implies mutation, so a new scope has to argue for itself rather than drift in.

**`SiteSet`** is the empty-set trap, m124 obligation 2. An empty resolved set must mean **no sites, never every site**, so it is a struct whose zero value allows nothing and which exposes no method answering "does this mean everything". A bare `[]uuid.UUID` has a zero value that reads as "no filter applied" at every call site that forgets to check it — the exact shape the obligation warns about, since the CHECK stops an empty payload being *stored* but nothing stops Go computing an empty set from a tag that matches no site.

**`ValidateSiteScopeRequest`** mirrors `mcp_grants_site_scope_payload_check` in Go. The redundancy is deliberate: the CHECK turns the bug into a bare 23514 at INSERT time naming no field, and it cannot see a request that never reaches an INSERT — the authorize endpoint validates long before a row exists. An empty mode is not read as `all`.

## Proof: red, then green

The gate was written against a deliberately naive draft that defaulted an unrecognised request to the full registry — the exact failure this surface is being built to avoid.

RED, `go test ./internal/mcp/ -run TestParseRequestedScopes` → **exit 1**:

```
--- FAIL: TestParseRequestedScopes_NoRecognisedScopeIsRefusedNotDefaulted/parameter_omitted_entirely
    ParseRequestedScopes("") returned no error and scopes [mcp:read]; a request
    naming no recognised scope MUST be refused, never granted a default
--- FAIL: .../unrecognised_scope_alone
    ParseRequestedScopes("fleet:admin") returned no error and scopes [mcp:read]; ...
--- FAIL: .../write_scope,_which_this_surface_never_grants
    ParseRequestedScopes("mcp:write") returned no error and scopes [mcp:read]; ...
--- FAIL: TestParseRequestedScopes_UnrecognisedScopeRefusesTheWholeRequest
    a request mixing a recognised and an unrecognised scope returned [mcp:read]
    with no error; it must be refused whole, not silently narrowed
FAIL	github.com/mosamlife/wpmgr/apps/api/internal/mcp	0.661s
```

GREEN, `go test ./internal/mcp/ -v -count=1` → **exit 0**, 9 absence cases plus the mixed-request case now refuse with a typed `domain.Error` carrying `mcp_invalid_scope`.

The over-fire cases pass alongside — exact, padded, repeated and multi-space requests are still granted — so the guard does not redden correct work.

Gates, each run unpiped so the status is the tool's own: `go build ./...` exit 0 (one pre-existing `ld:` alignment warning from `cmd/media-encoder`, not from this change), `go vet ./...` exit 0.

## What is blocked, and on whom

Dynamic client registration, the authorize and token endpoints, the PKCE exchange and the consent screen's server side are **not** here. All four must read and write the m124 tables, and there is no query layer to call:

- `apps/api/db/query/` carries no file for `mcp_grants`, `mcp_oauth_clients`, `mcp_authorization_codes` or `mcp_connection_tokens`.
- `internal/db/sqlc` therefore has the four models from `schema.sql` and **not one query method** — `grep -rn 'mcp_' internal/db/sqlc/*.go | grep -v models.go` returns nothing.

Those paths are `database-engineer`'s, and the rule is that the migration and its query layer land before the Go code depending on them. **S6b-1 cannot be finished until that lands.**

Two obligations to carry into that hand-off:

1. **The tx helpers are missing, and that half is this package's.** m124 gates its policies on `app.mcp_client_register`, `app.mcp_client_lookup` and `app.mcp_code_lookup`; `internal/db/db.go` defines none of them. They arrive with the repo that uses them rather than as dead code now.
2. **The consume-code trap (obligation 1) is unimplemented and must not be lost.** The three `_lookup` policies are `FOR SELECT`, so stamping `consumed_at` inside the lookup transaction matches zero rows and raises no error under `FORCE ROW LEVEL SECURITY` — single-use silently becomes multi-use with no log line. The consume belongs in a following `InTenantTx`, as `api_keys_prefix_lookup` records for its own stamp. The replay and revocation tests land with it.

## Not run

`make test-integration` was not run: this commit adds no SQL and touches no RLS path, and there is no database-backed test in it to exercise. It becomes mandatory for the follow-up that adds the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only MCP access scope support.
  * Added site access controls for all sites, tag-based selection, and explicit site lists.
  * Added safeguards ensuring empty or unresolved site selections grant access to no sites.
* **Bug Fixes**
  * Improved validation for missing, unsupported, duplicate, mixed, or write scopes.
  * Restricted scope parsing to standard ASCII-space separators.
* **Tests**
  * Added comprehensive coverage for scope parsing, site-scope validation, and access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->