### PR TITLE
feat(mcp): the OAuth surface - DCR, PKCE authorize, consent and token exchange

### DIFF
--- a/apps/api/internal/db/db.go
+++ b/apps/api/internal/db/db.go
@@ -468,6 +468,99 @@ func (p *Pool) InAPIKeyLookupTx(ctx context.Context, fn func(tx pgx.Tx) error) e
 	return nil
 }
 
+// ---------------------------------------------------------------------------
+// The four MCP GUC helpers (m124 / m126).
+//
+// Each opens EXACTLY ONE table, and each of the four policies they enable is
+// FOR SELECT or FOR INSERT only -- never FOR ALL. That is the whole reason
+// these are four helpers rather than one "InMCPTx": the narrow name at the call
+// site is what tells you which table you are allowed to touch.
+//
+// THE TRAP THESE EXIST TO MAKE VISIBLE (m124 "WHAT S6b MUST DO" item 1, the one
+// that fails silently). The lookup policies are FOR SELECT. An UPDATE issued
+// inside one of the ...LookupTx helpers below matches ZERO ROWS AND RAISES NO
+// ERROR under FORCE ROW LEVEL SECURITY. Stamp consumed_at there and single-use
+// silently becomes multi-use, with nothing in any log. A security reviewer
+// reproduced exactly that. The tenant is known the moment a lookup resolves --
+// every one of these rows carries tenant_id, except the client row which has
+// none by design -- so every follow-up write belongs in a separate InTenantTx.
+// The generated query names carry the same warning: ...ForLookup reads,
+// ...InTenantTx writes. Never issue the second inside the first.
+// ---------------------------------------------------------------------------
+
+// InMCPClientRegisterTx runs fn with app.mcp_client_register set, enabling the
+// mcp_oauth_clients_registration INSERT-only policy.
+//
+// This is RFC 7591 dynamic client registration, which is an UNAUTHENTICATED
+// POST: there is no organisation to attribute the row to at INSERT time, which
+// is why mcp_oauth_clients carries no tenant_id at all (see m124's header). fn
+// must do nothing but insert one client row. The policy is FOR INSERT, so a
+// SELECT in here returns nothing -- registration cannot read the table, which
+// is the tighter grant and is deliberate.
+func (p *Pool) InMCPClientRegisterTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	return p.inMCPGUCTx(ctx, "app.mcp_client_register", fn)
+}
+
+// InMCPClientLookupTx runs fn with app.mcp_client_lookup set, enabling the
+// mcp_oauth_clients_lookup SELECT-only policy. fn must do nothing but resolve a
+// client by its client_id.
+//
+// The redirect_uri check does NOT belong in here and cannot be pushed into SQL:
+// the query takes no redirect_uri parameter on purpose, so the caller
+// exact-matches the presented URI against the returned array in Go. A prefix,
+// suffix or host-only comparison is an open redirector.
+func (p *Pool) InMCPClientLookupTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	return p.inMCPGUCTx(ctx, "app.mcp_client_lookup", fn)
+}
+
+// InMCPCodeLookupTx runs fn with app.mcp_code_lookup set, enabling the
+// mcp_authorization_codes_lookup SELECT-only policy. fn resolves a PKCE
+// authorization code by its hash and MUST NOT write.
+//
+// Consuming the code is ConsumeMCPAuthorizationCodeInTenantTx in a FOLLOWING
+// InTenantTx. Issued here it is the silent UPDATE 0 described above.
+func (p *Pool) InMCPCodeLookupTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	return p.inMCPGUCTx(ctx, "app.mcp_code_lookup", fn)
+}
+
+// InMCPTokenLookupTx runs fn with app.mcp_token_lookup set, enabling the
+// mcp_connection_tokens_lookup SELECT-only policy. fn resolves a bearer token
+// by its hash and MUST NOT write.
+//
+// AUTHENTICATION IS TWO QUERIES, NOT A JOIN. mcp_grants has no lookup policy --
+// only tenant isolation -- so `token JOIN grant` in here matches zero rows and
+// would fail EVERY MCP request with nothing in any log. Resolve the token here
+// to learn its tenant, then re-check the grant in an InTenantTx.
+func (p *Pool) InMCPTokenLookupTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	return p.inMCPGUCTx(ctx, "app.mcp_token_lookup", fn)
+}
+
+// inMCPGUCTx is the shared body of the four helpers above. It is unexported so
+// that no call site can invent a fifth GUC in passing: adding one means adding
+// a named helper next to its policy, which is a reviewable change.
+func (p *Pool) inMCPGUCTx(ctx context.Context, guc string, fn func(tx pgx.Tx) error) error {
+	tx, err := p.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// set_config's third arg is is_local: the setting is confined to this
+	// transaction (equivalent to SET LOCAL) and is safe under pgBouncer
+	// transaction-mode pooling. The GUC name is from the closed set above, not
+	// from caller input, so the format verb cannot inject.
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SELECT set_config('%s', 'on', true)", guc)); err != nil {
+		return fmt.Errorf("set %s: %w", guc, err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
 // InScopedTenantTx runs fn inside a transaction with four GUCs set:
 //   - app.tenant_id  — the active org (same as InTenantTx)
 //   - app.user_id    — the acting user (same as InTenantTxAsUser)

--- a/apps/api/internal/mcp/approve_test.go
+++ b/apps/api/internal/mcp/approve_test.go
@@ -418,9 +418,13 @@ func TestExchange_ConfidentialClientMustPresentItsSecret(t *testing.T) {
 			clientOK: true, client: confidentialClient(secret),
 		}
 	}
+	// ClientAuthVia is set to the REGISTERED transport throughout, so each
+	// subtest isolates the property it names rather than being refused by the
+	// transport check before reaching it.
 	base := TokenRequest{
 		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
 		ClientID: registeredClientID, CodeVerifier: verifier,
+		ClientAuthVia: "client_secret_basic",
 	}
 
 	t.Run("no secret at all", func(t *testing.T) {

--- a/apps/api/internal/mcp/approve_test.go
+++ b/apps/api/internal/mcp/approve_test.go
@@ -1,0 +1,498 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+// ---------------------------------------------------------------------------
+// THE APPROVAL PATH -- the minting path, and the one that had no tests at all.
+//
+// Review finding B1: /consent built its ConsentContext entirely from the POST
+// body and never re-resolved the client or re-matched the redirect. Authorize's
+// exact match was therefore discarded one request later, and the invariant
+// actually enforced was "a consent screen was shown once" rather than "this
+// code may only travel where this client registered". The minted code carries
+// the APPROVING OPERATOR'S tenant, so anything able to influence that POST --
+// CSRF, XSS, a consent page echoing raw query params -- yielded cross-org read
+// access. A minted grant and an issued token are not undone by refusing later.
+//
+// Findings G and H are the same hole seen from inside: the scope gate and the
+// PKCE check in Approve were unproven, so deleting either went green.
+// ---------------------------------------------------------------------------
+
+const (
+	registeredRedirect = "https://claude.ai/api/mcp/auth_callback"
+	registeredClientID = "client-abc"
+)
+
+func approvalStore() *fakeStore {
+	return &fakeStore{clientOK: true, client: liveClient(registeredRedirect)}
+}
+
+func validConsent() ConsentContext {
+	return ConsentContext{
+		ClientID:            registeredClientID,
+		RedirectURI:         registeredRedirect,
+		Scopes:              []Scope{ScopeRead},
+		State:               "opaque-state",
+		CodeChallenge:       "a-real-challenge-value",
+		CodeChallengeMethod: "S256",
+	}
+}
+
+func validApproval() ApprovalRequest {
+	return ApprovalRequest{
+		TenantID:  uuid.New(),
+		UserID:    uuid.New(),
+		Consent:   validConsent(),
+		GrantName: "Claude Desktop on my laptop",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+	}
+}
+
+// B1. A redirect_uri the client never registered must not mint a code, however
+// well-formed the rest of the approval is.
+func TestApprove_RefusesARedirectTheClientNeverRegistered(t *testing.T) {
+	attacker := []string{
+		"https://attacker.example/exfiltrate",
+		"https://claude.ai/api/mcp/auth_callback.evil.com",
+		"https://claude.ai.evil.com/api/mcp/auth_callback",
+		"https://claude.ai/api/mcp/auth_callback?next=https://evil.com",
+		"https://claude.ai/api/mcp/auth_callback/../../evil",
+		"http://claude.ai/api/mcp/auth_callback",
+		"",
+	}
+
+	for _, bad := range attacker {
+		t.Run(bad, func(t *testing.T) {
+			store := approvalStore()
+			req := validApproval()
+			req.Consent.RedirectURI = bad
+
+			got, err := NewService(store).Approve(context.Background(), req)
+			if err == nil {
+				t.Fatalf("Approve minted code %q for unregistered redirect_uri %q; "+
+					"the code would then be honoured by Exchange, because Exchange "+
+					"compares against the value STORED ON THE CODE ROW", got.Code, bad)
+			}
+			if got.Code != "" {
+				t.Fatal("a refused approval still returned a code")
+			}
+			for _, c := range store.calls {
+				if c == "CreateGrantWithCode" {
+					t.Fatal("a refused approval still created a grant; a minted grant " +
+						"is not undone by refusing afterwards")
+				}
+			}
+		})
+	}
+}
+
+// B1, the other half: an unregistered client_id must not mint either. There is
+// no foreign key to catch this -- mcp_authorization_codes.client_id carries
+// none by design (m124 DECISION 12) -- so Go is the only place it can be
+// caught.
+func TestApprove_RefusesAClientThatWasNeverRegistered(t *testing.T) {
+	store := &fakeStore{clientOK: false} // LookupClient returns pgx.ErrNoRows
+	req := validApproval()
+	req.Consent.ClientID = "client-that-was-never-registered"
+
+	got, err := NewService(store).Approve(context.Background(), req)
+	if err == nil {
+		t.Fatalf("Approve minted code %q for an unregistered client_id", got.Code)
+	}
+	for _, c := range store.calls {
+		if c == "CreateGrantWithCode" {
+			t.Fatal("a refused approval still created a grant")
+		}
+	}
+}
+
+// B1 must be enforced by RESOLVING the client, not by trusting the body. This
+// pins the mechanism: LookupClient has to actually be called on the minting
+// path, so the fix cannot regress into comparing the body against itself.
+func TestApprove_ResolvesTheClientBeforeMinting(t *testing.T) {
+	store := approvalStore()
+	if _, err := NewService(store).Approve(context.Background(), validApproval()); err != nil {
+		t.Fatalf("a legitimate approval was refused: %v", err)
+	}
+
+	var sawLookup, sawCreate bool
+	for _, c := range store.calls {
+		switch c {
+		case "LookupClient":
+			sawLookup = true
+		case "CreateGrantWithCode":
+			if !sawLookup {
+				t.Fatal("the grant was created BEFORE the client was resolved")
+			}
+			sawCreate = true
+		}
+	}
+	if !sawLookup {
+		t.Fatal("Approve minted a code without ever calling LookupClient; the " +
+			"redirect_uri is being matched against the request's own copy")
+	}
+	if !sawCreate {
+		t.Fatal("a valid approval did not create a grant")
+	}
+}
+
+// G. The exit gate must be re-run on the approval. The scope list arrives back
+// over the wire and a tampered resubmission must not widen what Authorize
+// already refused.
+func TestApprove_ReRunsTheScopeExitGate(t *testing.T) {
+	cases := []struct {
+		name   string
+		scopes []Scope
+	}{
+		{"no scopes at all", nil},
+		{"empty slice", []Scope{}},
+		{"unrecognised scope", []Scope{"fleet:admin"}},
+		{"a write scope smuggled into the approval", []Scope{"mcp:write"}},
+		{"recognised plus unrecognised", []Scope{ScopeRead, "fleet:destroy"}},
+		{"blank string scope", []Scope{""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := approvalStore()
+			req := validApproval()
+			req.Consent.Scopes = tc.scopes
+
+			if _, err := NewService(store).Approve(context.Background(), req); err == nil {
+				t.Fatal("Approve accepted an approval naming no recognised scope; " +
+					"the exit gate must hold on the minting path too")
+			}
+			for _, c := range store.calls {
+				if c == "CreateGrantWithCode" {
+					t.Fatal("a scope-refused approval still created a grant")
+				}
+			}
+		})
+	}
+}
+
+// H. PKCE must be re-checked on the approval. A code minted with no challenge,
+// or with a downgraded method, is a code redeemable without a verifier.
+func TestApprove_ReChecksThePKCEChallenge(t *testing.T) {
+	cases := []struct{ name, challenge, method string }{
+		{"no challenge", "", "S256"},
+		{"blank challenge", "   ", "S256"},
+		{"no method", "abc", ""},
+		{"plain downgrade", "abc", "plain"},
+		{"unknown method", "abc", "S512"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := approvalStore()
+			req := validApproval()
+			req.Consent.CodeChallenge = tc.challenge
+			req.Consent.CodeChallengeMethod = tc.method
+
+			if _, err := NewService(store).Approve(context.Background(), req); err == nil {
+				t.Fatal("Approve minted a code with no valid S256 PKCE challenge")
+			}
+			for _, c := range store.calls {
+				if c == "CreateGrantWithCode" {
+					t.Fatal("a PKCE-refused approval still created a grant")
+				}
+			}
+		})
+	}
+}
+
+// The site-scope gate on the minting path, and the empty-payload trap with it.
+func TestApprove_RefusesAnIncoherentOrEmptySiteScope(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope SiteScopeRequest
+	}{
+		{"mode omitted", SiteScopeRequest{}},
+		{"unrecognised mode", SiteScopeRequest{Mode: "everything"}},
+		{"tags naming nothing", SiteScopeRequest{Mode: SiteScopeModeTags}},
+		{"list naming nothing", SiteScopeRequest{Mode: SiteScopeModeList}},
+		{"all carrying a payload", SiteScopeRequest{
+			Mode: SiteScopeModeAll, SiteIDs: []uuid.UUID{uuid.New()}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validApproval()
+			req.SiteScope = tc.scope
+			if _, err := NewService(approvalStore()).Approve(context.Background(), req); err == nil {
+				t.Fatal("Approve accepted an incoherent or empty site scope")
+			}
+		})
+	}
+}
+
+// Not over-firing: a legitimate approval still mints, and the grant records the
+// RESOLVED client id rather than the body's copy.
+func TestApprove_ValidApprovalMintsAndRecordsTheResolvedClient(t *testing.T) {
+	store := approvalStore()
+	got, err := NewService(store).Approve(context.Background(), validApproval())
+	if err != nil {
+		t.Fatalf("a legitimate approval was refused: %v", err)
+	}
+	if got.Code == "" {
+		t.Fatal("no code was minted")
+	}
+	if got.RedirectURI != registeredRedirect {
+		t.Errorf("redirect = %q, want the registered one", got.RedirectURI)
+	}
+	if got.State != "opaque-state" {
+		t.Errorf("state = %q; state must survive the round trip", got.State)
+	}
+	if got.GrantID == uuid.Nil {
+		t.Error("grant id is nil")
+	}
+}
+
+// B1 end to end through the real handler, with a real authenticated principal.
+// This is the shape the reviewer demonstrated: a 200 with a usable code for an
+// attacker-controlled redirect.
+func TestConsentHandler_RefusesAnUnregisteredRedirect(t *testing.T) {
+	store := approvalStore()
+	gin := newAuthorizeRouter(t, store)
+	NewHandler(NewService(store)).Register(gin.Group("/api/v2")) // distinct mount
+
+	body := approvalRequestDTO{
+		ClientID:            registeredClientID,
+		RedirectURI:         "https://attacker.example/exfiltrate",
+		Scopes:              []string{"mcp:read"},
+		State:               "s",
+		CodeChallenge:       "challenge",
+		CodeChallengeMethod: "S256",
+		GrantName:           "totally normal connection",
+		SiteScopeMode:       "all",
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/oauth/mcp/consent", strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	gin.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("POST /consent returned 200 for an unregistered redirect_uri; body = %s", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), `"code"`) {
+		t.Fatalf("a refused consent leaked a code: %s", w.Body.String())
+	}
+	for _, c := range store.calls {
+		if c == "CreateGrantWithCode" {
+			t.Fatal("the handler minted a grant for an unregistered redirect")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The Exchange layers that mutation showed were unproven (J, L, A).
+// ---------------------------------------------------------------------------
+
+// J. A stored challenge whose method is not S256 must refuse. Such a row cannot
+// be written by this code, but the check is the reason it cannot be redeemed if
+// one ever exists.
+func TestExchange_RefusesANonS256StoredChallenge(t *testing.T) {
+	const (
+		verifier = "verifier-for-the-non-s256-case-00000000000000"
+		clientID = registeredClientID
+	)
+	// The method is the ONLY thing wrong: the challenge is left as the correct
+	// S256 value, so verifyPKCE would SUCCEED. If the method check is removed
+	// the code redeems, which is what makes this test isolate the method rather
+	// than passing on a PKCE mismatch. (Setting the challenge to the raw
+	// verifier -- what 'plain' would really store -- made this test pass with
+	// the check deleted, because verifyPKCE refused it instead.)
+	row := redeemableCode(t, verifier, registeredRedirect, clientID)
+	row.CodeChallengeMethod = "plain"
+
+	store := &fakeStore{
+		codeOK: true, code: row,
+		clientOK: true, client: liveClient(registeredRedirect),
+	}
+	if _, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		ClientID: clientID, CodeVerifier: verifier,
+	}); err == nil {
+		t.Fatal("a 'plain' stored challenge was redeemed; only S256 may be")
+	}
+	if store.consumeCalls != 0 {
+		t.Error("the code was consumed despite the challenge method being refused")
+	}
+}
+
+// L. Expiry must refuse, and it must refuse before the consume.
+func TestExchange_RefusesAnExpiredCode(t *testing.T) {
+	const verifier = "verifier-for-the-expired-case-0000000000000000"
+	row := redeemableCode(t, verifier, registeredRedirect, registeredClientID)
+	row.IsExpired = true
+
+	store := &fakeStore{
+		codeOK: true, code: row,
+		clientOK: true, client: liveClient(registeredRedirect),
+	}
+	if _, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		ClientID: registeredClientID, CodeVerifier: verifier,
+	}); err == nil {
+		t.Fatal("an expired code was redeemed")
+	}
+	if store.consumeCalls != 0 {
+		t.Error("an expired code was still put through the compare-and-set")
+	}
+}
+
+// A. The belt-and-braces IsConsumed refusal. The compare-and-set is the real
+// guarantee, but this layer is what makes a replay report "already redeemed"
+// rather than a generic failure, and it was unproven.
+func TestExchange_RefusesAnAlreadyConsumedCodeAtTheLookup(t *testing.T) {
+	const verifier = "verifier-for-the-already-consumed-case-0000000"
+	store := &fakeStore{
+		codeOK: true, code: redeemableCode(t, verifier, registeredRedirect, registeredClientID),
+		clientOK: true, client: liveClient(registeredRedirect),
+		consumed: true, // the lookup will report IsConsumed
+	}
+	if _, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		ClientID: registeredClientID, CodeVerifier: verifier,
+	}); err == nil {
+		t.Fatal("an already-consumed code was redeemed")
+	}
+	if store.consumeCalls != 0 {
+		t.Error("an already-consumed code still reached the compare-and-set; the " +
+			"early refusal did nothing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// H3 -- the token endpoint authenticates the client when one registered a
+// secret, and client_id is required unconditionally.
+// ---------------------------------------------------------------------------
+
+func confidentialClient(secret string) sqlc.McpOauthClient {
+	h := hashCredential(secret)
+	c := liveClient(registeredRedirect)
+	c.TokenEndpointAuthMethod = "client_secret_basic"
+	c.ClientSecretHash = &h
+	return c
+}
+
+func TestExchange_RequiresClientID(t *testing.T) {
+	const verifier = "verifier-for-the-missing-client-id-000000000000"
+	store := &fakeStore{
+		codeOK: true, code: redeemableCode(t, verifier, registeredRedirect, registeredClientID),
+		clientOK: true, client: liveClient(registeredRedirect),
+	}
+	// client_id omitted entirely. This used to skip the code-to-client binding
+	// altogether: absence read as permission.
+	if _, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		CodeVerifier: verifier,
+	}); err == nil {
+		t.Fatal("an exchange with no client_id succeeded; omitting it must not " +
+			"skip the code-to-client binding")
+	}
+}
+
+func TestExchange_ConfidentialClientMustPresentItsSecret(t *testing.T) {
+	const (
+		verifier = "verifier-for-the-confidential-client-0000000000"
+		secret   = "the-registered-client-secret"
+	)
+
+	newStore := func() *fakeStore {
+		return &fakeStore{
+			codeOK: true, code: redeemableCode(t, verifier, registeredRedirect, registeredClientID),
+			clientOK: true, client: confidentialClient(secret),
+		}
+	}
+	base := TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		ClientID: registeredClientID, CodeVerifier: verifier,
+	}
+
+	t.Run("no secret at all", func(t *testing.T) {
+		store := newStore()
+		if _, err := NewService(store).Exchange(context.Background(), base); err == nil {
+			t.Fatal("a client registered client_secret_basic redeemed a code without " +
+				"presenting its secret; the stored hash is then decorative")
+		}
+		if store.consumeCalls != 0 {
+			t.Error("the code was consumed despite client authentication failing")
+		}
+	})
+
+	t.Run("wrong secret", func(t *testing.T) {
+		req := base
+		req.ClientSecret = "not-the-secret"
+		if _, err := NewService(newStore()).Exchange(context.Background(), req); err == nil {
+			t.Fatal("a wrong client_secret was accepted")
+		}
+	})
+
+	t.Run("correct secret still works", func(t *testing.T) {
+		req := base
+		req.ClientSecret = secret
+		got, err := NewService(newStore()).Exchange(context.Background(), req)
+		if err != nil {
+			t.Fatalf("a correctly authenticated confidential client was refused: %v", err)
+		}
+		if got.AccessToken == "" {
+			t.Fatal("no access token issued")
+		}
+	})
+}
+
+// A public ('none') client must still work without a secret -- the check must
+// not over-fire onto the PKCE-only path, which is the common one.
+func TestExchange_PublicClientNeedsNoSecret(t *testing.T) {
+	const verifier = "verifier-for-the-public-client-000000000000000"
+	store := &fakeStore{
+		codeOK: true, code: redeemableCode(t, verifier, registeredRedirect, registeredClientID),
+		clientOK: true, client: liveClient(registeredRedirect), // method "none"
+	}
+	got, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		ClientID: registeredClientID, CodeVerifier: verifier,
+	})
+	if err != nil {
+		t.Fatalf("a public PKCE client was refused: %v", err)
+	}
+	if got.AccessToken == "" {
+		t.Fatal("no access token issued to a valid public client")
+	}
+}
+
+// A non-'none' client whose stored hash is NULL is an impossible row under
+// mcp_oauth_clients_secret_matches_method_check. If one is ever seen it must
+// refuse, not be read as "no secret required".
+func TestExchange_ConfidentialClientWithNoStoredHashIsRefused(t *testing.T) {
+	const verifier = "verifier-for-the-impossible-row-000000000000000"
+	c := liveClient(registeredRedirect)
+	c.TokenEndpointAuthMethod = "client_secret_basic"
+	c.ClientSecretHash = nil // impossible per the CHECK
+
+	store := &fakeStore{
+		codeOK: true, code: redeemableCode(t, verifier, registeredRedirect, registeredClientID),
+		clientOK: true, client: c,
+	}
+	if _, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		ClientID: registeredClientID, ClientSecret: "anything", CodeVerifier: verifier,
+	}); err == nil {
+		t.Fatal("a confidential client with a NULL secret hash authenticated; a " +
+			"missing hash must refuse, never mean 'no secret required'")
+	}
+}

--- a/apps/api/internal/mcp/atomicity_test.go
+++ b/apps/api/internal/mcp/atomicity_test.go
@@ -1,0 +1,231 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ---------------------------------------------------------------------------
+// 1. THE TOKEN EXCHANGE IS ATOMIC.
+//
+// Burning the code before minting the token is the correct ORDER -- the reverse
+// risks two tokens from one code -- but as two separate commits a failure in
+// between left a state that is secure and useless: the code permanently
+// consumed, no token issued, and a client that did nothing wrong unable to
+// retry and forced to restart the whole browser flow with nothing explaining
+// why. Both steps now share one InTenantTx.
+//
+// The fake models the ROLLBACK rather than the happy path: when the token
+// insert fails it does not flip `consumed`, exactly as the real transaction
+// rolls the UPDATE back. A fake that consumed anyway would model two commits --
+// the defect itself -- and this test would pass against the broken code.
+// ---------------------------------------------------------------------------
+
+func TestExchange_TokenPersistenceFailureLeavesTheCodeRedeemable(t *testing.T) {
+	const (
+		verifier = "verifier-for-the-atomicity-case-0000000000000"
+		redirect = "https://claude.ai/cb"
+		clientID = "client-abc"
+	)
+	newStore := func() *fakeStore {
+		return &fakeStore{
+			codeOK: true, code: redeemableCode(t, verifier, redirect, clientID),
+			clientOK: true, client: liveClient(redirect),
+		}
+	}
+	req := TokenRequest{
+		GrantType: "authorization_code", Code: "the-code", RedirectURI: redirect,
+		ClientID: clientID, CodeVerifier: verifier,
+	}
+
+	// The token INSERT fails inside the redeem transaction.
+	store := newStore()
+	store.tokenPersistErr = &pgconn.PgError{Code: "53100", Message: "disk full"}
+
+	got, err := NewService(store).Exchange(context.Background(), req)
+	if err == nil {
+		t.Fatalf("a failed token persistence still reported success: %+v", got)
+	}
+	if got.AccessToken != "" {
+		t.Fatal("a failed exchange returned an access token")
+	}
+	if store.tokensMinted != 0 {
+		t.Fatalf("%d tokens were minted despite the insert failing", store.tokensMinted)
+	}
+
+	// THE ASSERTION THAT MATTERS. The consume must have rolled back with it, so
+	// the code is still redeemable and the client may retry the same request.
+	if store.consumed {
+		t.Fatal("the authorization code was left CONSUMED after the token insert " +
+			"failed. It can never be redeemed, the client did nothing wrong, and it " +
+			"must restart the entire browser flow. Consume and issue must share one " +
+			"transaction")
+	}
+
+	// And prove it really is retryable: the same code, against a healthy store,
+	// now succeeds. This is the half a rollback-less fake would fail.
+	healthy := newStore()
+	retried, err := NewService(healthy).Exchange(context.Background(), req)
+	if err != nil {
+		t.Fatalf("the code was not redeemable on retry after a transient failure: %v", err)
+	}
+	if retried.AccessToken == "" {
+		t.Fatal("the retry produced no access token")
+	}
+	if healthy.tokensMinted != 1 {
+		t.Fatalf("retry minted %d tokens, want 1", healthy.tokensMinted)
+	}
+}
+
+// The transient failure must surface as an infra error, not as a domain
+// refusal. A client reading "invalid_grant" concludes its code is bad and
+// restarts the flow; this one should retry the same request.
+func TestExchange_TransientFailureIsNotReportedAsAnInvalidGrant(t *testing.T) {
+	const (
+		verifier = "verifier-for-the-error-shape-case-000000000000"
+		redirect = "https://claude.ai/cb"
+		clientID = "client-abc"
+	)
+	store := &fakeStore{
+		codeOK: true, code: redeemableCode(t, verifier, redirect, clientID),
+		clientOK: true, client: liveClient(redirect),
+		tokenPersistErr: &pgconn.PgError{Code: "53100", Message: "disk full"},
+	}
+	_, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: redirect,
+		ClientID: clientID, CodeVerifier: verifier,
+	})
+	if err == nil {
+		t.Fatal("no error from a failed token insert")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Errorf("the underlying failure was lost; got %v", err)
+	}
+	if strings.Contains(err.Error(), "already used") {
+		t.Error("a transient infrastructure failure was reported as a spent code; " +
+			"the client would restart the flow instead of retrying")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. THE REGISTERED token_endpoint_auth_method IS ENFORCED.
+//
+// The column is NOT NULL over a closed set with no default, so the value is
+// always a decision somebody made. Accepting a secret through a transport the
+// client did not register makes the column decorative -- the same shape as a
+// column no statement could write, which m126 deleted rather than leave lying
+// around.
+// ---------------------------------------------------------------------------
+
+func TestExchange_CredentialTransportMustMatchTheRegisteredMethod(t *testing.T) {
+	const (
+		verifier = "verifier-for-the-transport-case-00000000000000"
+		secret   = "the-registered-client-secret"
+	)
+	cases := []struct {
+		name       string
+		registered string
+		presented  string
+		wantOK     bool
+	}{
+		{"basic client using basic", "client_secret_basic", "client_secret_basic", true},
+		{"post client using post", "client_secret_post", "client_secret_post", true},
+		{"basic client posting body credentials", "client_secret_basic", "client_secret_post", false},
+		{"post client using HTTP Basic", "client_secret_post", "client_secret_basic", false},
+		{"credentials presented twice", "client_secret_basic", AuthViaMultiple, false},
+		{"basic client presenting nothing", "client_secret_basic", "none", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := confidentialClient(secret)
+			client.TokenEndpointAuthMethod = tc.registered
+
+			store := &fakeStore{
+				codeOK: true, code: redeemableCode(t, verifier, registeredRedirect, registeredClientID),
+				clientOK: true, client: client,
+			}
+			_, err := NewService(store).Exchange(context.Background(), TokenRequest{
+				GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+				ClientID: registeredClientID, ClientSecret: secret,
+				CodeVerifier: verifier, ClientAuthVia: tc.presented,
+			})
+
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("a client using its OWN registered method was refused: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("a client registered %s authenticated via %s; the stored "+
+					"method governs nothing", tc.registered, tc.presented)
+			}
+			if store.consumeCalls != 0 {
+				t.Error("the code was consumed despite client authentication failing")
+			}
+		})
+	}
+}
+
+// A public client must not be able to present a secret at all. 'none' means
+// there is no stored hash to compare against, so accepting one would be
+// accepting a credential that nothing verifies.
+func TestExchange_PublicClientPresentingASecretIsRefused(t *testing.T) {
+	const verifier = "verifier-for-the-public-with-secret-0000000000"
+	store := &fakeStore{
+		codeOK: true, code: redeemableCode(t, verifier, registeredRedirect, registeredClientID),
+		clientOK: true, client: liveClient(registeredRedirect), // method "none"
+	}
+	if _, err := NewService(store).Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: registeredRedirect,
+		ClientID: registeredClientID, ClientSecret: "invented",
+		CodeVerifier: verifier, ClientAuthVia: "client_secret_post",
+	}); err == nil {
+		t.Fatal("a client registered token_endpoint_auth_method=none presented a " +
+			"secret and was accepted; there is no stored hash to compare it against")
+	}
+}
+
+// The handler must DERIVE the transport, and must refuse a request carrying
+// both. Driven through the real gin handler, because only the handler can see
+// the transport at all.
+func TestTokenHandler_RefusesCredentialsPresentedTwice(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &fakeStore{clientOK: true, client: liveClient(registeredRedirect)}
+	r := gin.New()
+	NewHandler(NewService(store)).RegisterPublic(r.Group("/api/v1"))
+
+	form := strings.NewReader("grant_type=authorization_code&code=c" +
+		"&redirect_uri=" + registeredRedirect +
+		"&client_id=" + registeredClientID +
+		"&client_secret=body-secret&code_verifier=v")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/oauth/mcp/token", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(registeredClientID, "header-secret")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("a request presenting credentials via BOTH Basic and the body "+
+			"succeeded; RFC 6749 2.3.1 forbids more than one method per request. "+
+			"body=%s", w.Body.String())
+	}
+	var body oauthErrorDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("not an OAuth error envelope: %s", w.Body.String())
+	}
+	if body.Err != "invalid_client" {
+		t.Errorf("error = %q, want invalid_client (%s)", body.Err, w.Body.String())
+	}
+}

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -110,6 +110,7 @@ type tokenRequestDTO struct {
 	Code         string `json:"code" form:"code"`
 	RedirectURI  string `json:"redirect_uri" form:"redirect_uri"`
 	ClientID     string `json:"client_id" form:"client_id"`
+	ClientSecret string `json:"client_secret" form:"client_secret"`
 	CodeVerifier string `json:"code_verifier" form:"code_verifier"`
 }
 

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -1,0 +1,161 @@
+package mcp
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// Wire shapes. RFC 7591 registration and RFC 6749 token responses are
+// snake_case by specification, so these are hand-shaped rather than reusing a
+// house DTO convention.
+// ---------------------------------------------------------------------------
+
+type registrationRequestDTO struct {
+	RedirectURIs            []string `json:"redirect_uris"`
+	ClientName              string   `json:"client_name"`
+	ClientURI               string   `json:"client_uri"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+}
+
+type registrationResponseDTO struct {
+	ClientID                string   `json:"client_id"`
+	ClientSecret            string   `json:"client_secret,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	ClientName              string   `json:"client_name,omitempty"`
+	ClientURI               string   `json:"client_uri,omitempty"`
+}
+
+func toRegistrationResponse(c RegisteredClient) registrationResponseDTO {
+	return registrationResponseDTO{
+		ClientID:                c.ClientID,
+		ClientSecret:            c.ClientSecret,
+		TokenEndpointAuthMethod: c.TokenEndpointAuthMethod,
+		RedirectURIs:            c.RedirectURIs,
+		ClientName:              c.ClientName,
+		ClientURI:               c.ClientURI,
+	}
+}
+
+// consentResponseDTO is what the dashboard renders as the consent screen.
+//
+// THE FIELD NAMES CARRY THE OBLIGATION. m124 obligation 7: registration is
+// unauthenticated, so client_name is an attacker-controlled string and two
+// registrations may both claim to be "Claude Desktop" with identical redirect
+// URIs -- the database cannot tell them apart and no constraint can fix it. The
+// `_unverified` suffix is here so a template author cannot render it as a
+// verified identity by accident, and redirect_host is supplied because the host
+// is the part of the request a human can actually judge.
+type consentResponseDTO struct {
+	ClientID             string   `json:"client_id"`
+	ClientNameUnverified string   `json:"client_name_unverified"`
+	ClientURIUnverified  string   `json:"client_uri_unverified"`
+	IdentityVerified     bool     `json:"identity_verified"`
+	RedirectURI          string   `json:"redirect_uri"`
+	RedirectHost         string   `json:"redirect_host"`
+	Scopes               []string `json:"scopes"`
+	State                string   `json:"state"`
+	CodeChallenge        string   `json:"code_challenge"`
+	CodeChallengeMethod  string   `json:"code_challenge_method"`
+}
+
+func toConsentResponse(c ConsentContext) consentResponseDTO {
+	scopes := make([]string, 0, len(c.Scopes))
+	for _, s := range c.Scopes {
+		scopes = append(scopes, string(s))
+	}
+	return consentResponseDTO{
+		ClientID:             c.ClientID,
+		ClientNameUnverified: c.ClientNameUnverified,
+		ClientURIUnverified:  c.ClientURIUnverified,
+		// Always false, and it is a literal rather than a field on
+		// ConsentContext so there is no code path that can set it true.
+		// Registration is unauthenticated; nothing about this identity is
+		// verified, ever.
+		IdentityVerified:    false,
+		RedirectURI:         c.RedirectURI,
+		RedirectHost:        c.RedirectHost,
+		Scopes:              scopes,
+		State:               c.State,
+		CodeChallenge:       c.CodeChallenge,
+		CodeChallengeMethod: c.CodeChallengeMethod,
+	}
+}
+
+type approvalRequestDTO struct {
+	ClientID            string   `json:"client_id"`
+	RedirectURI         string   `json:"redirect_uri"`
+	Scopes              []string `json:"scopes"`
+	State               string   `json:"state"`
+	CodeChallenge       string   `json:"code_challenge"`
+	CodeChallengeMethod string   `json:"code_challenge_method"`
+	GrantName           string   `json:"name"`
+	SiteScopeMode       string   `json:"site_scope_mode"`
+	ScopeTagIDs         []string `json:"scope_tag_ids"`
+	ScopeSiteIDs        []string `json:"scope_site_ids"`
+}
+
+type approvalResponseDTO struct {
+	GrantID     string `json:"grant_id"`
+	Code        string `json:"code"`
+	RedirectURI string `json:"redirect_uri"`
+	State       string `json:"state,omitempty"`
+}
+
+type tokenRequestDTO struct {
+	GrantType    string `json:"grant_type" form:"grant_type"`
+	Code         string `json:"code" form:"code"`
+	RedirectURI  string `json:"redirect_uri" form:"redirect_uri"`
+	ClientID     string `json:"client_id" form:"client_id"`
+	CodeVerifier string `json:"code_verifier" form:"code_verifier"`
+}
+
+type tokenResponseDTO struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+// oauthErrorDTO is the RFC 6749 section 5.2 error envelope. The OAuth
+// endpoints must answer in this shape rather than the house error envelope,
+// because a client library parses it.
+type oauthErrorDTO struct {
+	Err     string `json:"error"`
+	ErrDesc string `json:"error_description,omitempty"`
+}
+
+// oauthError maps a domain error onto the RFC 6749 wire vocabulary and status.
+//
+// The mapping is EXPLICIT AND CLOSED. An unrecognised domain code falls to
+// invalid_request with a 400 rather than to a permissive default, and an error
+// that is not a domain error at all is a 500 that says nothing -- an infra
+// failure must never be reported to a client as a successful-but-empty grant.
+func oauthError(err error) (int, oauthErrorDTO) {
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) {
+		return http.StatusInternalServerError, oauthErrorDTO{Err: "server_error"}
+	}
+
+	switch domErr.Code {
+	case ErrCodeInvalidScope:
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_scope", ErrDesc: domErr.Message}
+	case ErrCodeInvalidClient:
+		return http.StatusUnauthorized, oauthErrorDTO{Err: "invalid_client", ErrDesc: domErr.Message}
+	case ErrCodeInvalidGrant:
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_grant", ErrDesc: domErr.Message}
+	case ErrCodeUnsupportedResponse:
+		return http.StatusBadRequest, oauthErrorDTO{Err: "unsupported_response_type", ErrDesc: domErr.Message}
+	case ErrCodeRegistrationInvalid:
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_client_metadata", ErrDesc: domErr.Message}
+	case ErrCodeInvalidRedirectURI:
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_request", ErrDesc: domErr.Message}
+	case ErrCodeInvalidSiteScope, ErrCodeInvalidRequest:
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_request", ErrDesc: domErr.Message}
+	default:
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_request", ErrDesc: domErr.Message}
+	}
+}

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -1,0 +1,208 @@
+package mcp
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// Handler serves the OAuth surface for the read-only MCP endpoint.
+//
+// The routes split by who authenticates, and the split is the security
+// boundary rather than a routing convenience:
+//
+//   - RegisterPublic mounts /register and /token. Both are UNAUTHENTICATED by
+//     specification -- RFC 7591 registration precedes any human, and the token
+//     endpoint authenticates by presenting a code plus a PKCE verifier, not by
+//     a session. Neither may ever read a tenant from a session.
+//   - Register mounts /authorize and /consent. Both require an authenticated
+//     operator, because consent is the entire authorization: the grant belongs
+//     to the organisation of the human who approved it.
+type Handler struct {
+	svc *Service
+}
+
+func NewHandler(svc *Service) *Handler { return &Handler{svc: svc} }
+
+// RegisterPublic mounts the two unauthenticated OAuth endpoints.
+func (h *Handler) RegisterPublic(r *gin.RouterGroup) {
+	g := r.Group("/oauth/mcp")
+	g.POST("/register", h.register)
+	g.POST("/token", h.token)
+}
+
+// Register mounts the two operator-authenticated endpoints. The caller's group
+// is already behind session auth.
+func (h *Handler) Register(r *gin.RouterGroup) {
+	g := r.Group("/oauth/mcp")
+	g.GET("/authorize", h.authorize)
+	g.POST("/consent", h.consent)
+}
+
+// register is RFC 7591 dynamic client registration.
+func (h *Handler) register(c *gin.Context) {
+	var body registrationRequestDTO
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, oauthErrorDTO{
+			Err: "invalid_client_metadata", ErrDesc: "the request body is not valid JSON"})
+		return
+	}
+
+	out, err := h.svc.Register(c.Request.Context(), RegistrationRequest{
+		RedirectURIs:            body.RedirectURIs,
+		ClientName:              body.ClientName,
+		ClientURI:               body.ClientURI,
+		TokenEndpointAuthMethod: body.TokenEndpointAuthMethod,
+	})
+	if err != nil {
+		status, dto := oauthError(err)
+		c.JSON(status, dto)
+		return
+	}
+	c.JSON(http.StatusCreated, toRegistrationResponse(out))
+}
+
+// authorize validates the request and returns the consent screen's contents.
+// It mints nothing.
+func (h *Handler) authorize(c *gin.Context) {
+	if _, ok := domain.PrincipalFromContext(c.Request.Context()); !ok {
+		c.JSON(http.StatusUnauthorized, oauthErrorDTO{
+			Err: "access_denied", ErrDesc: "sign in to authorize a connection"})
+		return
+	}
+
+	out, err := h.svc.Authorize(c.Request.Context(), AuthorizeRequest{
+		ResponseType:        c.Query("response_type"),
+		ClientID:            c.Query("client_id"),
+		RedirectURI:         c.Query("redirect_uri"),
+		Scope:               c.Query("scope"),
+		State:               c.Query("state"),
+		CodeChallenge:       c.Query("code_challenge"),
+		CodeChallengeMethod: c.Query("code_challenge_method"),
+	})
+	if err != nil {
+		status, dto := oauthError(err)
+		c.JSON(status, dto)
+		return
+	}
+	c.JSON(http.StatusOK, toConsentResponse(out))
+}
+
+// consent records a human's approval and returns the code to hand back.
+func (h *Handler) consent(c *gin.Context) {
+	principal, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		c.JSON(http.StatusUnauthorized, oauthErrorDTO{
+			Err: "access_denied", ErrDesc: "sign in to authorize a connection"})
+		return
+	}
+
+	var body approvalRequestDTO
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, oauthErrorDTO{
+			Err: "invalid_request", ErrDesc: "the request body is not valid JSON"})
+		return
+	}
+
+	tagIDs, err := parseUUIDs(body.ScopeTagIDs)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, oauthErrorDTO{
+			Err: "invalid_request", ErrDesc: "scope_tag_ids contains a value that is not a UUID"})
+		return
+	}
+	siteIDs, err := parseUUIDs(body.ScopeSiteIDs)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, oauthErrorDTO{
+			Err: "invalid_request", ErrDesc: "scope_site_ids contains a value that is not a UUID"})
+		return
+	}
+
+	scopes := make([]Scope, 0, len(body.Scopes))
+	for _, s := range body.Scopes {
+		scopes = append(scopes, Scope(s))
+	}
+
+	out, err := h.svc.Approve(c.Request.Context(), ApprovalRequest{
+		TenantID: principal.TenantID,
+		UserID:   principal.UserID,
+		Consent: ConsentContext{
+			ClientID:            body.ClientID,
+			RedirectURI:         body.RedirectURI,
+			Scopes:              scopes,
+			State:               body.State,
+			CodeChallenge:       body.CodeChallenge,
+			CodeChallengeMethod: body.CodeChallengeMethod,
+		},
+		GrantName: body.GrantName,
+		SiteScope: SiteScopeRequest{
+			Mode:    SiteScopeMode(body.SiteScopeMode),
+			TagIDs:  tagIDs,
+			SiteIDs: siteIDs,
+		},
+	})
+	if err != nil {
+		status, dto := oauthError(err)
+		c.JSON(status, dto)
+		return
+	}
+
+	c.JSON(http.StatusOK, approvalResponseDTO{
+		GrantID:     out.GrantID.String(),
+		Code:        out.Code,
+		RedirectURI: out.RedirectURI,
+		State:       out.State,
+	})
+}
+
+// token is the RFC 6749 4.1.3 access token request. It accepts form encoding,
+// which is what the RFC specifies and what every client library sends, and
+// JSON for convenience.
+func (h *Handler) token(c *gin.Context) {
+	var body tokenRequestDTO
+	if err := c.ShouldBind(&body); err != nil {
+		c.JSON(http.StatusBadRequest, oauthErrorDTO{
+			Err: "invalid_request", ErrDesc: "the request could not be parsed"})
+		return
+	}
+
+	out, err := h.svc.Exchange(c.Request.Context(), TokenRequest{
+		GrantType:    body.GrantType,
+		Code:         body.Code,
+		RedirectURI:  body.RedirectURI,
+		ClientID:     body.ClientID,
+		CodeVerifier: body.CodeVerifier,
+	})
+	if err != nil {
+		status, dto := oauthError(err)
+		c.JSON(status, dto)
+		return
+	}
+
+	// RFC 6749 5.1: token responses must not be cached.
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+	c.JSON(http.StatusOK, tokenResponseDTO{
+		AccessToken: out.AccessToken,
+		TokenType:   out.TokenType,
+		ExpiresIn:   out.ExpiresIn,
+		Scope:       out.Scope,
+	})
+}
+
+// parseUUIDs refuses a malformed id rather than dropping it. A dropped id
+// silently narrows or widens the scope the operator thought they approved,
+// depending on the mode, and uuid.Nil is what a failed parse decays to.
+func parseUUIDs(in []string) ([]uuid.UUID, error) {
+	out := make([]uuid.UUID, 0, len(in))
+	for _, raw := range in {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -168,11 +168,20 @@ func (h *Handler) token(c *gin.Context) {
 		return
 	}
 
+	// RFC 6749 2.3.1 prefers HTTP Basic for client_secret_basic and permits the
+	// body for client_secret_post. Basic wins when both are present, so a body
+	// parameter cannot override a header the client actually authenticated with.
+	clientID, clientSecret := body.ClientID, body.ClientSecret
+	if id, secret, ok := c.Request.BasicAuth(); ok {
+		clientID, clientSecret = id, secret
+	}
+
 	out, err := h.svc.Exchange(c.Request.Context(), TokenRequest{
 		GrantType:    body.GrantType,
 		Code:         body.Code,
 		RedirectURI:  body.RedirectURI,
-		ClientID:     body.ClientID,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 		CodeVerifier: body.CodeVerifier,
 	})
 	if err != nil {

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -168,21 +169,40 @@ func (h *Handler) token(c *gin.Context) {
 		return
 	}
 
-	// RFC 6749 2.3.1 prefers HTTP Basic for client_secret_basic and permits the
-	// body for client_secret_post. Basic wins when both are present, so a body
-	// parameter cannot override a header the client actually authenticated with.
+	// DETERMINE HOW THE CREDENTIAL ARRIVED, and pass that to the service so the
+	// registered token_endpoint_auth_method can be enforced rather than merely
+	// recorded. Only the handler can see the transport.
+	//
+	// This used to let Basic silently win when both were present, which
+	// discarded the credential source entirely: a client_secret_basic
+	// registration could authenticate with body parameters and vice versa, and
+	// the stored decision governed nothing. RFC 6749 2.3.1 also forbids using
+	// more than one mechanism per request, so presenting both is refused rather
+	// than resolved by precedence.
 	clientID, clientSecret := body.ClientID, body.ClientSecret
-	if id, secret, ok := c.Request.BasicAuth(); ok {
-		clientID, clientSecret = id, secret
+	authVia := "none"
+	basicID, basicSecret, hasBasic := c.Request.BasicAuth()
+	hasPost := strings.TrimSpace(body.ClientSecret) != ""
+
+	switch {
+	case hasBasic && hasPost:
+		authVia = AuthViaMultiple
+	case hasBasic:
+		clientID, clientSecret, authVia = basicID, basicSecret, "client_secret_basic"
+	case hasPost:
+		authVia = "client_secret_post"
 	}
+	// client_id may still travel in the body for a public client, which sends no
+	// secret at all; that is the "none" path and it is unchanged.
 
 	out, err := h.svc.Exchange(c.Request.Context(), TokenRequest{
 		GrantType:    body.GrantType,
 		Code:         body.Code,
 		RedirectURI:  body.RedirectURI,
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		CodeVerifier: body.CodeVerifier,
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
+		CodeVerifier:  body.CodeVerifier,
+		ClientAuthVia: authVia,
 	})
 	if err != nil {
 		status, dto := oauthError(err)

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -70,6 +70,11 @@ type fakeStore struct {
 	// revealed.
 	raceLost bool
 
+	// tokenPersistErr makes the token INSERT fail inside the redeem
+	// transaction. The consume rolls back with it, which is the property the
+	// atomicity proof asserts.
+	tokenPersistErr error
+
 	recheck   sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow
 	recheckOK bool
 
@@ -144,16 +149,32 @@ func (f *fakeStore) LookupAuthorizationCode(_ context.Context, _ string) (sqlc.G
 	return row, nil
 }
 
-func (f *fakeStore) ConsumeAuthorizationCode(_ context.Context, _, _ uuid.UUID) (sqlc.McpAuthorizationCode, error) {
-	f.note("ConsumeAuthorizationCode")
+// RedeemAuthorizationCode models ONE TRANSACTION: the compare-and-set and the
+// token insert either both land or neither does.
+//
+// The rollback is what makes this fake honest. When tokenPersistErr is set the
+// insert fails, so `consumed` is NOT flipped -- exactly as the real transaction
+// would roll the UPDATE back. A fake that marked the code consumed and then
+// returned the error would model two commits, which is the defect being fixed,
+// and the test would pass against the broken code.
+func (f *fakeStore) RedeemAuthorizationCode(_ context.Context, _, _ uuid.UUID, tok sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error) {
+	f.note("RedeemAuthorizationCode")
 	f.consumeCalls++
+
+	// The compare-and-set runs first, inside the transaction.
 	if f.raceLost || f.consumed {
-		// The predicate `consumed_at IS NULL` matched nothing. :one turns that
-		// into ErrNoRows. This is the loser of a concurrent exchange.
-		return sqlc.McpAuthorizationCode{}, pgx.ErrNoRows
+		// `consumed_at IS NULL` matched nothing; :one turns that into ErrNoRows.
+		return sqlc.McpConnectionToken{}, pgx.ErrNoRows
 	}
+	// Then the insert. If it fails the whole transaction rolls back, so the
+	// consume never becomes visible and the code remains redeemable.
+	if f.tokenPersistErr != nil {
+		return sqlc.McpConnectionToken{}, f.tokenPersistErr
+	}
+
 	f.consumed = true
-	return sqlc.McpAuthorizationCode{ID: f.code.ID, TenantID: f.code.TenantID}, nil
+	f.tokensMinted++
+	return sqlc.McpConnectionToken{ID: uuid.New(), TenantID: tok.TenantID, GrantID: tok.GrantID}, nil
 }
 
 func (f *fakeStore) CreateGrantWithCode(_ context.Context, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
@@ -162,12 +183,6 @@ func (f *fakeStore) CreateGrantWithCode(_ context.Context, g sqlc.CreateMCPGrant
 	cp := mk(id)
 	return sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name},
 		sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
-}
-
-func (f *fakeStore) CreateConnectionToken(_ context.Context, arg sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error) {
-	f.note("CreateConnectionToken")
-	f.tokensMinted++
-	return sqlc.McpConnectionToken{ID: uuid.New(), TenantID: arg.TenantID, GrantID: arg.GrantID}, nil
 }
 
 func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -43,6 +43,17 @@ type fakeStore struct {
 	client   sqlc.McpOauthClient
 	clientOK bool
 
+	// registerRows is what the :execrows INSERT reports. Defaults to 0, so a
+	// test that means "registration succeeds" must SAY 1 -- the honest default,
+	// since a fake that silently succeeds is what hid the last defect.
+	registerRows int64
+	// registerErr forces the write itself to fail (e.g. 42501).
+	registerErr error
+	// registerReadBackMissing writes the row but makes the follow-up
+	// LookupClient find nothing: the insert reports success and the read-back
+	// comes up empty. A broken invariant, not an empty result.
+	registerReadBackMissing bool
+
 	code     sqlc.GetMCPAuthorizationCodeByHashForLookupRow
 	codeOK   bool
 	consumed bool // the compare-and-set has already won once
@@ -75,17 +86,35 @@ type fakeStore struct {
 
 func (f *fakeStore) note(s string) { f.calls = append(f.calls, s) }
 
-func (f *fakeStore) RegisterClient(_ context.Context, arg sqlc.RegisterMCPOAuthClientParams) (sqlc.McpOauthClient, error) {
+// RegisterClient models the :execrows query: it reports ROWS WRITTEN and can
+// never hand back the row, because the register GUC enables no SELECT policy
+// and RETURNING raises 42501 against the real database.
+//
+// THE PREVIOUS FAKE RETURNED A FULLY POPULATED ROW, which is why a P1 that
+// broke every single registration reached review with a green suite: the fake
+// said yes to something Postgres refuses outright. Modelling the count is only
+// half the repair -- registerRows and registerReadBackMissing exist so the
+// FAILURE modes are reachable too, since a fake that models the new shape but
+// not the new failures leaves exactly the same hole.
+func (f *fakeStore) RegisterClient(_ context.Context, arg sqlc.RegisterMCPOAuthClientParams) (int64, error) {
 	f.note("RegisterClient")
-	return sqlc.McpOauthClient{
-		ID:                      uuid.New(),
-		ClientID:                arg.ClientID,
-		ClientSecretHash:        arg.ClientSecretHash,
-		TokenEndpointAuthMethod: arg.TokenEndpointAuthMethod,
-		RedirectUris:            arg.RedirectUris,
-		ClientName:              arg.ClientName,
-		ClientUri:               arg.ClientUri,
-	}, nil
+	if f.registerErr != nil {
+		return 0, f.registerErr
+	}
+	// Record what was written so LookupClient can serve a faithful read-back.
+	if !f.registerReadBackMissing {
+		f.client = sqlc.McpOauthClient{
+			ID:                      uuid.New(),
+			ClientID:                arg.ClientID,
+			ClientSecretHash:        arg.ClientSecretHash,
+			TokenEndpointAuthMethod: arg.TokenEndpointAuthMethod,
+			RedirectUris:            arg.RedirectUris,
+			ClientName:              arg.ClientName,
+			ClientUri:               arg.ClientUri,
+		}
+		f.clientOK = true
+	}
+	return f.registerRows, nil
 }
 
 func (f *fakeStore) LookupClient(_ context.Context, _ string) (sqlc.McpOauthClient, error) {
@@ -669,7 +698,7 @@ func TestRegister_RefusesRedirectURIsThatCannotBeTrusted(t *testing.T) {
 }
 
 func TestRegister_PublicClientGetsNoSecretAndConfidentialDoes(t *testing.T) {
-	svc := NewService(&fakeStore{})
+	svc := NewService(&fakeStore{registerRows: 1})
 
 	pub, err := svc.Register(context.Background(), RegistrationRequest{
 		RedirectURIs: []string{"https://claude.ai/cb"}, TokenEndpointAuthMethod: "none",
@@ -698,7 +727,7 @@ func TestRegister_PublicClientGetsNoSecretAndConfidentialDoes(t *testing.T) {
 
 // Loopback http is the native-client case RFC 8252 requires and must still work.
 func TestRegister_AllowsLoopbackHTTPForNativeClients(t *testing.T) {
-	svc := NewService(&fakeStore{})
+	svc := NewService(&fakeStore{registerRows: 1})
 	for _, uri := range []string{"http://localhost:8765/cb", "http://127.0.0.1:1455/cb"} {
 		if _, err := svc.Register(context.Background(), RegistrationRequest{
 			RedirectURIs: []string{uri}, TokenEndpointAuthMethod: "none",

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -1,0 +1,702 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// fakeStore models the SQL contract of db/query/mcp_connections.sql, not a
+// convenient approximation of it. The two behaviours that decide this slice are
+// reproduced exactly:
+//
+//   - ConsumeAuthorizationCode is an atomic compare-and-set over
+//     `consumed_at IS NULL AND expires_at > now()`, declared :one, so a LOSING
+//     call returns pgx.ErrNoRows rather than a zero-value row. That is what
+//     makes "no row" mean refuse.
+//   - ReCheckAuthorization returns a ROW EVEN WHEN THE GRANT IS REVOKED, with
+//     Authorized=false. Branching on row presence would therefore still honour
+//     a revoked grant, which is the bug the test below exists to catch.
+//
+// It also records which calls happened, so a test can prove the consume ran at
+// all -- an UPDATE that silently matched zero rows is invisible otherwise, and
+// that invisibility is m124 obligation 1's entire hazard.
+// ---------------------------------------------------------------------------
+
+type fakeStore struct {
+	client   sqlc.McpOauthClient
+	clientOK bool
+
+	code     sqlc.GetMCPAuthorizationCodeByHashForLookupRow
+	codeOK   bool
+	consumed bool // the compare-and-set has already won once
+
+	// raceLost models the TOCTOU window that the compare-and-set exists to
+	// close: our lookup transaction committed while the code was still
+	// redeemable, and ANOTHER transaction consumed it before our consume ran.
+	// The lookup therefore reports a perfectly healthy, redeemable code and the
+	// consume still matches zero rows.
+	//
+	// Without this the replay tests never reach the consume at all -- they are
+	// refused by the earlier IsConsumed check and would pass even with the
+	// ErrNoRows branch deleted, which is precisely what planting that defect
+	// revealed.
+	raceLost bool
+
+	recheck   sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow
+	recheckOK bool
+
+	token   sqlc.GetMCPConnectionTokenByHashForLookupRow
+	tokenOK bool
+
+	scopeSites []uuid.UUID
+
+	// call log
+	consumeCalls int
+	tokensMinted int
+	calls        []string
+}
+
+func (f *fakeStore) note(s string) { f.calls = append(f.calls, s) }
+
+func (f *fakeStore) RegisterClient(_ context.Context, arg sqlc.RegisterMCPOAuthClientParams) (sqlc.McpOauthClient, error) {
+	f.note("RegisterClient")
+	return sqlc.McpOauthClient{
+		ID:                      uuid.New(),
+		ClientID:                arg.ClientID,
+		ClientSecretHash:        arg.ClientSecretHash,
+		TokenEndpointAuthMethod: arg.TokenEndpointAuthMethod,
+		RedirectUris:            arg.RedirectUris,
+		ClientName:              arg.ClientName,
+		ClientUri:               arg.ClientUri,
+	}, nil
+}
+
+func (f *fakeStore) LookupClient(_ context.Context, _ string) (sqlc.McpOauthClient, error) {
+	f.note("LookupClient")
+	if !f.clientOK {
+		return sqlc.McpOauthClient{}, pgx.ErrNoRows
+	}
+	return f.client, nil
+}
+
+func (f *fakeStore) LookupAuthorizationCode(_ context.Context, _ string) (sqlc.GetMCPAuthorizationCodeByHashForLookupRow, error) {
+	f.note("LookupAuthorizationCode")
+	if !f.codeOK {
+		return sqlc.GetMCPAuthorizationCodeByHashForLookupRow{}, pgx.ErrNoRows
+	}
+	row := f.code
+	// The lookup reports current state, exactly as the generated columns do.
+	// Under raceLost it reports the state as of OUR transaction: still
+	// redeemable, because the winner had not committed yet.
+	if f.raceLost {
+		row.IsConsumed = false
+		row.IsRedeemable = !row.IsExpired
+		return row, nil
+	}
+	row.IsConsumed = f.consumed
+	row.IsRedeemable = !f.consumed && !row.IsExpired
+	return row, nil
+}
+
+func (f *fakeStore) ConsumeAuthorizationCode(_ context.Context, _, _ uuid.UUID) (sqlc.McpAuthorizationCode, error) {
+	f.note("ConsumeAuthorizationCode")
+	f.consumeCalls++
+	if f.raceLost || f.consumed {
+		// The predicate `consumed_at IS NULL` matched nothing. :one turns that
+		// into ErrNoRows. This is the loser of a concurrent exchange.
+		return sqlc.McpAuthorizationCode{}, pgx.ErrNoRows
+	}
+	f.consumed = true
+	return sqlc.McpAuthorizationCode{ID: f.code.ID, TenantID: f.code.TenantID}, nil
+}
+
+func (f *fakeStore) CreateGrantWithCode(_ context.Context, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
+	f.note("CreateGrantWithCode")
+	id := uuid.New()
+	cp := mk(id)
+	return sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name},
+		sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
+}
+
+func (f *fakeStore) CreateConnectionToken(_ context.Context, arg sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error) {
+	f.note("CreateConnectionToken")
+	f.tokensMinted++
+	return sqlc.McpConnectionToken{ID: uuid.New(), TenantID: arg.TenantID, GrantID: arg.GrantID}, nil
+}
+
+func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
+	f.note("LookupConnectionToken")
+	if !f.tokenOK {
+		return sqlc.GetMCPConnectionTokenByHashForLookupRow{}, pgx.ErrNoRows
+	}
+	return f.token, nil
+}
+
+func (f *fakeStore) ReCheckAuthorization(_ context.Context, _, _ uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error) {
+	f.note("ReCheckAuthorization")
+	if !f.recheckOK {
+		return sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{}, pgx.ErrNoRows
+	}
+	return f.recheck, nil
+}
+
+func (f *fakeStore) ResolveScopeSites(_ context.Context, _ uuid.UUID, _ string, _, _ []uuid.UUID) ([]uuid.UUID, error) {
+	f.note("ResolveScopeSites")
+	return f.scopeSites, nil
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- THE EXIT GATE, END TO END THROUGH A REAL HANDLER.
+//
+// #571 proved the parser refuses. This proves the refusal survives the whole
+// request path: routing, the authenticated principal, the service, and the
+// RFC 6749 error envelope. A gate that holds in a unit test and is bypassed by
+// the handler that mounts it guards nothing.
+// ---------------------------------------------------------------------------
+
+func newAuthorizeRouter(t *testing.T, store Store) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := domain.WithPrincipal(c.Request.Context(), domain.Principal{
+			Type:     domain.PrincipalUser,
+			UserID:   uuid.New(),
+			TenantID: uuid.New(),
+			Role:     "owner",
+		})
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	NewHandler(NewService(store)).Register(r.Group("/api/v1"))
+	return r
+}
+
+func liveClient(redirect string) sqlc.McpOauthClient {
+	name := "Claude Desktop"
+	return sqlc.McpOauthClient{
+		ID:                      uuid.New(),
+		ClientID:                "client-abc",
+		TokenEndpointAuthMethod: "none",
+		RedirectUris:            []string{redirect},
+		ClientName:              &name,
+	}
+}
+
+func TestAuthorizeHandler_NoRecognisedScopeIsRefusedNotDefaulted(t *testing.T) {
+	const redirect = "https://claude.ai/api/mcp/auth_callback"
+
+	cases := []struct {
+		name  string
+		scope string
+	}{
+		{"scope parameter absent entirely", ""},
+		{"scope blank", "   "},
+		{"scope unrecognised", "fleet:admin"},
+		{"scope is a write the surface never grants", "mcp:write"},
+		{"scope case-mismatched", "MCP:READ"},
+		{"recognised scope mixed with an unrecognised one", "mcp:read fleet:destroy"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeStore{client: liveClient(redirect), clientOK: true}
+			r := newAuthorizeRouter(t, store)
+
+			q := url.Values{}
+			q.Set("response_type", "code")
+			q.Set("client_id", "client-abc")
+			q.Set("redirect_uri", redirect)
+			q.Set("code_challenge", "abc123challenge")
+			q.Set("code_challenge_method", "S256")
+			if tc.scope != "" {
+				q.Set("scope", tc.scope)
+			}
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/oauth/mcp/authorize?"+q.Encode(), nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body = %s\n"+
+					"a client naming no recognised scope MUST be refused by the "+
+					"handler, not handed a default", w.Code, w.Body.String())
+			}
+
+			var body oauthErrorDTO
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("response is not the RFC 6749 error envelope: %v (%s)", err, w.Body.String())
+			}
+			if body.Err != "invalid_scope" {
+				t.Errorf("error = %q, want %q (body %s)", body.Err, "invalid_scope", w.Body.String())
+			}
+
+			// The refusal must not have leaked a consent screen.
+			if strings.Contains(w.Body.String(), "client_name_unverified") {
+				t.Error("a refused authorize request still rendered consent context")
+			}
+		})
+	}
+}
+
+// The gate must not over-fire, and the consent screen must present the
+// registration-supplied identity as UNVERIFIED (m124 obligation 7).
+func TestAuthorizeHandler_ValidRequestReturnsUnverifiedConsentContext(t *testing.T) {
+	const redirect = "https://claude.ai/api/mcp/auth_callback"
+	store := &fakeStore{client: liveClient(redirect), clientOK: true}
+	r := newAuthorizeRouter(t, store)
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "client-abc")
+	q.Set("redirect_uri", redirect)
+	q.Set("scope", "mcp:read")
+	q.Set("code_challenge", "abc123challenge")
+	q.Set("code_challenge_method", "S256")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/oauth/mcp/authorize?"+q.Encode(), nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body %s", w.Code, w.Body.String())
+	}
+	var body consentResponseDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.IdentityVerified {
+		t.Error("consent context claims the client identity is verified; registration " +
+			"is unauthenticated and client_name is attacker-controlled")
+	}
+	if body.ClientNameUnverified != "Claude Desktop" {
+		t.Errorf("client_name_unverified = %q", body.ClientNameUnverified)
+	}
+	if body.RedirectHost != "claude.ai" {
+		t.Errorf("redirect_host = %q, want claude.ai; the host is the part a human can judge",
+			body.RedirectHost)
+	}
+	if len(body.Scopes) != 1 || body.Scopes[0] != "mcp:read" {
+		t.Errorf("scopes = %v", body.Scopes)
+	}
+}
+
+// A redirect_uri that is not an EXACT match must be refused. Every one of these
+// passes a prefix, suffix or host-only comparison, and each is a redirector.
+func TestAuthorize_RedirectURIIsExactMatchedOnly(t *testing.T) {
+	const registered = "https://claude.ai/api/mcp/auth_callback"
+	attacker := []string{
+		"https://claude.ai/api/mcp/auth_callback/../../evil",
+		"https://claude.ai/api/mcp/auth_callback.evil.com",
+		"https://claude.ai/api/mcp/auth_callback?next=https://evil.com",
+		"https://claude.ai.evil.com/api/mcp/auth_callback",
+		"https://evil.com/api/mcp/auth_callback",
+		"https://claude.ai/api/mcp/auth_callbac",
+		"http://claude.ai/api/mcp/auth_callback",
+		"",
+	}
+	svc := NewService(&fakeStore{client: liveClient(registered), clientOK: true})
+
+	for _, bad := range attacker {
+		t.Run(bad, func(t *testing.T) {
+			_, err := svc.Authorize(context.Background(), AuthorizeRequest{
+				ResponseType: "code", ClientID: "client-abc", RedirectURI: bad,
+				Scope: "mcp:read", CodeChallenge: "c", CodeChallengeMethod: "S256",
+			})
+			if err == nil {
+				t.Fatalf("redirect_uri %q was accepted; only an exact match may be", bad)
+			}
+		})
+	}
+}
+
+// PKCE is mandatory and S256 only. A missing method must not decay to 'plain'.
+func TestAuthorize_PKCEIsMandatoryAndS256Only(t *testing.T) {
+	const redirect = "https://claude.ai/cb"
+	svc := NewService(&fakeStore{client: liveClient(redirect), clientOK: true})
+
+	cases := []struct{ name, challenge, method string }{
+		{"no challenge at all", "", "S256"},
+		{"challenge but no method", "abc", ""},
+		{"plain is not supported", "abc", "plain"},
+		{"unknown method", "abc", "S512"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := svc.Authorize(context.Background(), AuthorizeRequest{
+				ResponseType: "code", ClientID: "client-abc", RedirectURI: redirect,
+				Scope: "mcp:read", CodeChallenge: tc.challenge, CodeChallengeMethod: tc.method,
+			}); err == nil {
+				t.Fatal("accepted a request without a valid S256 PKCE challenge")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- A CONSUMED AUTHORIZATION CODE CANNOT BE REPLAYED, AND THE CONSUME
+// ACTUALLY WROTE.
+//
+// m124 obligation 1. The half that fails silently is the consume matching zero
+// rows and raising no error; the test therefore asserts BOTH that the second
+// exchange is refused AND that the consume was really attempted and really won
+// exactly once. A version that never called consume at all would pass a
+// refusal-only assertion while leaving the code replayable in production.
+// ---------------------------------------------------------------------------
+
+func redeemableCode(t *testing.T, verifier, redirect, clientID string) sqlc.GetMCPAuthorizationCodeByHashForLookupRow {
+	t.Helper()
+	sum := sha256.Sum256([]byte(verifier))
+	return sqlc.GetMCPAuthorizationCodeByHashForLookupRow{
+		ID:                  uuid.New(),
+		TenantID:            uuid.New(),
+		GrantID:             uuid.New(),
+		ClientID:            clientID,
+		CodeChallenge:       base64.RawURLEncoding.EncodeToString(sum[:]),
+		CodeChallengeMethod: "S256",
+		RedirectUri:         redirect,
+		ExpiresAt:           time.Now().Add(5 * time.Minute),
+		IsRedeemable:        true,
+	}
+}
+
+func TestExchange_ConsumedCodeCannotBeReplayed(t *testing.T) {
+	const (
+		verifier = "a-high-entropy-code-verifier-value-0123456789"
+		redirect = "https://claude.ai/cb"
+		clientID = "client-abc"
+	)
+	store := &fakeStore{codeOK: true, code: redeemableCode(t, verifier, redirect, clientID)}
+	svc := NewService(store)
+
+	req := TokenRequest{
+		GrantType: "authorization_code", Code: "the-plaintext-code",
+		RedirectURI: redirect, ClientID: clientID, CodeVerifier: verifier,
+	}
+
+	// First exchange: succeeds and mints exactly one token.
+	first, err := svc.Exchange(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first exchange failed: %v", err)
+	}
+	if first.AccessToken == "" {
+		t.Fatal("first exchange returned an empty access token")
+	}
+
+	// THE CONSUME MUST HAVE ACTUALLY WRITTEN. If this is 0 the code was never
+	// consumed and single-use is a fiction, however the refusal below behaves.
+	if store.consumeCalls != 1 {
+		t.Fatalf("consume was attempted %d times on the first exchange, want 1", store.consumeCalls)
+	}
+	if !store.consumed {
+		t.Fatal("the compare-and-set did not mark the code consumed; the UPDATE " +
+			"matched zero rows and the code is still replayable")
+	}
+
+	// Second exchange of the SAME code: refused.
+	second, err := svc.Exchange(context.Background(), req)
+	if err == nil {
+		t.Fatalf("the code was redeemed a second time and returned %+v; "+
+			"single-use silently became multi-use", second)
+	}
+	if second.AccessToken != "" {
+		t.Fatal("a refused exchange still returned an access token")
+	}
+	if store.tokensMinted != 1 {
+		t.Fatalf("%d connection tokens were minted across two exchanges of one code, want 1",
+			store.tokensMinted)
+	}
+}
+
+// The compare-and-set is the guarantee, not the lookup. This drives the branch
+// a racing exchange takes: the lookup still reports the code redeemable (it was
+// when the transaction started) and the consume returns pgx.ErrNoRows. Reading
+// that as "already fine" is how the loser of a race also gets a token.
+func TestExchange_LosingCompareAndSetIsRefusedNotShrugged(t *testing.T) {
+	const (
+		verifier = "verifier-for-the-racing-exchange-000000000000"
+		redirect = "https://claude.ai/cb"
+		clientID = "client-abc"
+	)
+	// ANOTHER transaction consumed the code between our lookup and our consume.
+	// Our lookup therefore sees a healthy, redeemable code -- every check
+	// before the compare-and-set passes -- and only the UPDATE matches nothing.
+	// This is the ONLY path that exercises the ErrNoRows branch, which is why
+	// raceLost exists: the plain replay case is refused earlier, by IsConsumed.
+	store := &fakeStore{
+		codeOK:   true,
+		code:     redeemableCode(t, verifier, redirect, clientID),
+		raceLost: true,
+	}
+	svc := NewService(store)
+
+	got, err := svc.Exchange(context.Background(), TokenRequest{
+		GrantType: "authorization_code", Code: "c", RedirectURI: redirect,
+		ClientID: clientID, CodeVerifier: verifier,
+	})
+	if err == nil {
+		t.Fatalf("the losing exchange was granted %+v; a zero-row consume means "+
+			"REFUSE, never 'already fine'", got)
+	}
+	if got.AccessToken != "" {
+		t.Fatal("the losing exchange returned an access token")
+	}
+
+	// It must have genuinely attempted the compare-and-set -- otherwise this
+	// test is passing on an earlier check and proves nothing about the consume.
+	if store.consumeCalls != 1 {
+		t.Fatalf("consume was attempted %d times, want 1; this test must reach the "+
+			"compare-and-set or it is not testing it", store.consumeCalls)
+	}
+	if store.tokensMinted != 0 {
+		t.Fatalf("the losing exchange minted %d tokens, want 0", store.tokensMinted)
+	}
+}
+
+// The code is bound to the client and the redirect it was issued for, and PKCE
+// must actually verify. Each of these must refuse BEFORE any consume happens --
+// a failed exchange must not burn the code, or an attacker can grief a real
+// client by replaying garbage at the token endpoint.
+func TestExchange_RefusesBeforeConsumingOnEveryBindingFailure(t *testing.T) {
+	const (
+		verifier = "the-real-verifier-value-aaaaaaaaaaaaaaaaaaaaa"
+		redirect = "https://claude.ai/cb"
+		clientID = "client-abc"
+	)
+	cases := []struct {
+		name string
+		req  TokenRequest
+	}{
+		{"wrong grant_type", TokenRequest{GrantType: "password", Code: "c", RedirectURI: redirect, ClientID: clientID, CodeVerifier: verifier}},
+		{"no verifier", TokenRequest{GrantType: "authorization_code", Code: "c", RedirectURI: redirect, ClientID: clientID}},
+		{"wrong verifier", TokenRequest{GrantType: "authorization_code", Code: "c", RedirectURI: redirect, ClientID: clientID, CodeVerifier: "not-the-verifier"}},
+		{"wrong client", TokenRequest{GrantType: "authorization_code", Code: "c", RedirectURI: redirect, ClientID: "someone-else", CodeVerifier: verifier}},
+		{"wrong redirect", TokenRequest{GrantType: "authorization_code", Code: "c", RedirectURI: "https://evil.com/cb", ClientID: clientID, CodeVerifier: verifier}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeStore{codeOK: true, code: redeemableCode(t, verifier, redirect, clientID)}
+			svc := NewService(store)
+			if _, err := svc.Exchange(context.Background(), tc.req); err == nil {
+				t.Fatal("exchange succeeded on a binding failure")
+			}
+			if store.consumeCalls != 0 {
+				t.Errorf("the code was consumed (%d calls) despite the request being "+
+					"refused; a bad request must not burn a legitimate code",
+					store.consumeCalls)
+			}
+			if store.consumed {
+				t.Error("the code was marked consumed by a refused exchange")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- REVOCATION TAKES EFFECT ON THE NEXT REQUEST, NOT AT TOKEN EXPIRY.
+//
+// m124 obligation 4. ReCheckAuthorization returns a ROW for a revoked grant,
+// with Authorized=false, so a service branching on row presence still honours
+// it. The token's own expiry is deliberately far in the future in every case
+// here: if revocation only bit at expiry, these would pass.
+// ---------------------------------------------------------------------------
+
+func liveToken(tenantID uuid.UUID) sqlc.GetMCPConnectionTokenByHashForLookupRow {
+	return sqlc.GetMCPConnectionTokenByHashForLookupRow{
+		ID:        uuid.New(),
+		TenantID:  tenantID,
+		GrantID:   uuid.New(),
+		Status:    "active",
+		ExpiresAt: pgtype.Timestamptz{Time: time.Now().Add(90 * 24 * time.Hour), Valid: true},
+		IsLive:    true,
+	}
+}
+
+func TestAuthenticate_RevocationBitesOnTheNextRequest(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	tok := liveToken(tenantID)
+
+	store := &fakeStore{
+		tokenOK: true, token: tok,
+		recheckOK: true,
+		recheck: sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
+			GrantID: tok.GrantID, GrantStatus: "active",
+			SiteScopeMode: "all", TokenID: tok.ID, TokenStatus: "active",
+			TokenExpiresAt: tok.ExpiresAt,
+			Authorized:     true,
+		},
+		scopeSites: []uuid.UUID{siteID},
+	}
+	svc := NewService(store)
+
+	// Request 1: authorized.
+	got, err := svc.Authenticate(context.Background(), "the-bearer-token")
+	if err != nil {
+		t.Fatalf("a live connection was refused: %v", err)
+	}
+	if !got.Sites.Allows(siteID) {
+		t.Fatal("the resolved site set does not contain the granted site")
+	}
+
+	// The operator revokes. The TOKEN IS UNCHANGED and still unexpired -- only
+	// the grant's status moved. This is exactly the state where checking
+	// expiry, or checking that a row came back, still says "yes".
+	store.recheck.GrantStatus = "revoked"
+	store.recheck.Authorized = false
+
+	// Request 2: must be refused, on this request, not at expiry.
+	if _, err := svc.Authenticate(context.Background(), "the-bearer-token"); err == nil {
+		t.Fatal("a REVOKED grant was still honoured on the next request; revocation " +
+			"must not wait for token expiry")
+	}
+
+	// And prove the re-check actually ran on every request rather than being
+	// cached from the first.
+	n := 0
+	for _, c := range store.calls {
+		if c == "ReCheckAuthorization" {
+			n++
+		}
+	}
+	if n != 2 {
+		t.Fatalf("ReCheckAuthorization ran %d times across 2 requests, want 2; "+
+			"the grant must be re-checked on EVERY request", n)
+	}
+}
+
+// Authorized=false must refuse whatever else the row says. This is the
+// branch-on-presence bug stated directly: every field below looks healthy.
+func TestAuthenticate_BranchesOnAuthorizedNotOnRowPresence(t *testing.T) {
+	tenantID := uuid.New()
+	tok := liveToken(tenantID)
+	store := &fakeStore{
+		tokenOK: true, token: tok,
+		recheckOK: true,
+		recheck: sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
+			GrantID:        tok.GrantID,
+			GrantName:      "looks entirely fine",
+			GrantStatus:    "active",
+			SiteScopeMode:  "all",
+			TokenID:        tok.ID,
+			TokenStatus:    "active",
+			TokenExpiresAt: tok.ExpiresAt,
+			Authorized:     false, // the only field that matters
+		},
+		scopeSites: []uuid.UUID{uuid.New()},
+	}
+	if _, err := NewService(store).Authenticate(context.Background(), "tok"); err == nil {
+		t.Fatal("a row with Authorized=false was honoured; the service is branching " +
+			"on row presence")
+	}
+}
+
+// An empty resolved scope must NOT widen to every site (m124 obligation 2).
+// This is the tag-matches-no-site case, arriving through the real service path.
+func TestAuthenticate_EmptyResolvedScopeGrantsNoSites(t *testing.T) {
+	tenantID := uuid.New()
+	tok := liveToken(tenantID)
+	store := &fakeStore{
+		tokenOK: true, token: tok,
+		recheckOK: true,
+		recheck: sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
+			GrantID: tok.GrantID, GrantStatus: "active",
+			SiteScopeMode: "tags", ScopeTagIds: []uuid.UUID{uuid.New()},
+			TokenID: tok.ID, TokenStatus: "active",
+			TokenExpiresAt: tok.ExpiresAt, Authorized: true,
+		},
+		scopeSites: nil, // the tag matched no site
+	}
+	got, err := NewService(store).Authenticate(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if !got.Sites.IsEmpty() {
+		t.Fatal("an unresolved tag scope did not produce an empty site set")
+	}
+	if got.Sites.Allows(uuid.New()) {
+		t.Fatal("an EMPTY resolved scope allowed a site; empty must mean no sites, never all")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+func TestRegister_RefusesRedirectURIsThatCannotBeTrusted(t *testing.T) {
+	svc := NewService(&fakeStore{})
+	cases := []struct{ name, uri string }{
+		{"no redirect at all", ""},
+		{"relative", "/callback"},
+		{"plain http on a public host", "http://evil.com/cb"},
+		{"carries a fragment", "https://claude.ai/cb#tok"},
+		{"not a URI", "://::"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uris := []string{tc.uri}
+			if tc.uri == "" {
+				uris = nil
+			}
+			if _, err := svc.Register(context.Background(), RegistrationRequest{RedirectURIs: uris}); err == nil {
+				t.Fatalf("registration accepted redirect_uri %q", tc.uri)
+			}
+		})
+	}
+}
+
+func TestRegister_PublicClientGetsNoSecretAndConfidentialDoes(t *testing.T) {
+	svc := NewService(&fakeStore{})
+
+	pub, err := svc.Register(context.Background(), RegistrationRequest{
+		RedirectURIs: []string{"https://claude.ai/cb"}, TokenEndpointAuthMethod: "none",
+	})
+	if err != nil {
+		t.Fatalf("register public: %v", err)
+	}
+	if pub.ClientSecret != "" {
+		t.Error("a 'none' client was issued a secret; 'none' means there is no secret")
+	}
+
+	conf, err := svc.Register(context.Background(), RegistrationRequest{
+		RedirectURIs: []string{"https://claude.ai/cb"}, TokenEndpointAuthMethod: "client_secret_basic",
+	})
+	if err != nil {
+		t.Fatalf("register confidential: %v", err)
+	}
+	if conf.ClientSecret == "" {
+		t.Error("a confidential client got no secret; the secret comparison would " +
+			"then have nothing to compare against")
+	}
+	if conf.ClientID == pub.ClientID {
+		t.Error("two registrations shared a client_id")
+	}
+}
+
+// Loopback http is the native-client case RFC 8252 requires and must still work.
+func TestRegister_AllowsLoopbackHTTPForNativeClients(t *testing.T) {
+	svc := NewService(&fakeStore{})
+	for _, uri := range []string{"http://localhost:8765/cb", "http://127.0.0.1:1455/cb"} {
+		if _, err := svc.Register(context.Background(), RegistrationRequest{
+			RedirectURIs: []string{uri}, TokenEndpointAuthMethod: "none",
+		}); err != nil {
+			t.Errorf("registration refused legitimate native redirect %q: %v", uri, err)
+		}
+	}
+}

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -382,7 +382,10 @@ func TestExchange_ConsumedCodeCannotBeReplayed(t *testing.T) {
 		redirect = "https://claude.ai/cb"
 		clientID = "client-abc"
 	)
-	store := &fakeStore{codeOK: true, code: redeemableCode(t, verifier, redirect, clientID)}
+	store := &fakeStore{
+		codeOK: true, code: redeemableCode(t, verifier, redirect, clientID),
+		clientOK: true, client: liveClient(redirect),
+	}
 	svc := NewService(store)
 
 	req := TokenRequest{
@@ -443,6 +446,7 @@ func TestExchange_LosingCompareAndSetIsRefusedNotShrugged(t *testing.T) {
 		codeOK:   true,
 		code:     redeemableCode(t, verifier, redirect, clientID),
 		raceLost: true,
+		clientOK: true, client: liveClient(redirect),
 	}
 	svc := NewService(store)
 
@@ -491,7 +495,10 @@ func TestExchange_RefusesBeforeConsumingOnEveryBindingFailure(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			store := &fakeStore{codeOK: true, code: redeemableCode(t, verifier, redirect, clientID)}
+			store := &fakeStore{
+				codeOK: true, code: redeemableCode(t, verifier, redirect, clientID),
+				clientOK: true, client: liveClient(redirect),
+			}
 			svc := NewService(store)
 			if _, err := svc.Exchange(context.Background(), tc.req); err == nil {
 				t.Fatal("exchange succeeded on a binding failure")

--- a/apps/api/internal/mcp/register_test.go
+++ b/apps/api/internal/mcp/register_test.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ---------------------------------------------------------------------------
+// REGISTRATION IS A WRITE THEN A SEPARATE READ, AND BOTH HALVES CAN FAIL.
+//
+// The P1 this file exists for: RegisterMCPOAuthClient used RETURNING while the
+// only policy its GUC enables is FOR INSERT. Under FORCE ROW LEVEL SECURITY the
+// SELECT policy is enforced against the returned row as a WithCheckOption, so
+// the statement raised SQLSTATE 42501 at ExecWithCheckOptions and rolled the
+// transaction back. EVERY registration failed at runtime.
+//
+// It is not RETURNING *-specific -- returning the server-generated `id` alone
+// fails identically -- so "return fewer columns" is not the fix. The query is
+// now :execrows and hands back a COUNT, and the caller reads the row back in a
+// separate lookup transaction.
+//
+// Why the suite was green while every registration was broken: the fake
+// returned a fully populated row from the insert, which the database will not
+// do. These tests exercise the count and the read-back as distinct failures so
+// the fake cannot say yes to that shape again.
+// ---------------------------------------------------------------------------
+
+// The write reporting zero rows must stop the registration. :execrows was
+// chosen over :exec precisely so there is something to assert; an
+// INSERT ... VALUES with no ON CONFLICT writes one row or raises, so zero
+// should be unreachable -- which is exactly why reaching it must be loud.
+func TestRegister_ZeroRowsWrittenIsAFailureNotASuccess(t *testing.T) {
+	for _, rows := range []int64{0, 2} {
+		t.Run(strings.TrimSpace(string(rune('0'+rows)))+" rows", func(t *testing.T) {
+			store := &fakeStore{registerRows: rows}
+			got, err := NewService(store).Register(context.Background(), RegistrationRequest{
+				RedirectURIs:            []string{"https://claude.ai/cb"},
+				TokenEndpointAuthMethod: "none",
+			})
+			if err == nil {
+				t.Fatalf("a write reporting %d rows was reported as success, returning "+
+					"client_id %q; the caller would hold a credential for a row that "+
+					"does not exist", rows, got.ClientID)
+			}
+			if got.ClientID != "" || got.ClientSecret != "" {
+				t.Fatalf("a failed registration still returned credentials: %+v", got)
+			}
+		})
+	}
+}
+
+// The write failing outright must surface, not be swallowed. This is the shape
+// the real defect took: SQLSTATE 42501 on every call.
+func TestRegister_WriteErrorSurfaces(t *testing.T) {
+	store := &fakeStore{
+		registerRows: 1,
+		registerErr: &pgconn.PgError{
+			Code:    "42501",
+			Message: "new row violates row-level security policy for table \"mcp_oauth_clients\"",
+		},
+	}
+	got, err := NewService(store).Register(context.Background(), RegistrationRequest{
+		RedirectURIs:            []string{"https://claude.ai/cb"},
+		TokenEndpointAuthMethod: "none",
+	})
+	if err == nil {
+		t.Fatalf("a 42501 from the insert was reported as success: %+v", got)
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "42501" {
+		t.Errorf("the underlying SQLSTATE was lost; got %v", err)
+	}
+}
+
+// THE READ-BACK FINDING NOTHING IS A BROKEN INVARIANT, NOT AN EMPTY RESPONSE.
+// The insert said it wrote one row; if the row cannot then be read, something
+// is badly wrong. Rebuilding the response from the request body here would
+// report a fabricated success on top of a real failure -- the exact defect
+// class this package is built against.
+func TestRegister_ReadBackFindingNothingFailsLoudly(t *testing.T) {
+	store := &fakeStore{registerRows: 1, registerReadBackMissing: true}
+	got, err := NewService(store).Register(context.Background(), RegistrationRequest{
+		RedirectURIs:            []string{"https://claude.ai/cb"},
+		ClientName:              "Claude Desktop",
+		TokenEndpointAuthMethod: "none",
+	})
+	if err == nil {
+		t.Fatalf("the registration wrote a row, could not read it back, and still "+
+			"reported success: %+v", got)
+	}
+	if got.ClientID != "" || got.ClientSecret != "" {
+		t.Fatalf("a failed read-back still returned credentials: %+v", got)
+	}
+	// It must not have papered over the failure with the request's own values.
+	if strings.Contains(err.Error(), "Claude Desktop") {
+		t.Error("the error echoes the request body; the response must not be " +
+			"synthesised from the request when the read-back fails")
+	}
+
+	var sawLookup bool
+	for _, c := range store.calls {
+		if c == "LookupClient" {
+			sawLookup = true
+		}
+	}
+	if !sawLookup {
+		t.Error("the registration never attempted a read-back at all")
+	}
+}
+
+// The happy path: the response describes what the DATABASE holds, read back in
+// a second transaction, not what the caller sent. The two differ here on
+// purpose -- the name is padded and the auth method is defaulted -- so a
+// response built from the request body fails this test.
+func TestRegister_ResponseComesFromTheStoredRowNotTheRequest(t *testing.T) {
+	store := &fakeStore{registerRows: 1}
+	got, err := NewService(store).Register(context.Background(), RegistrationRequest{
+		RedirectURIs: []string{"https://claude.ai/cb"},
+		ClientName:   "  Claude Desktop  ", // trimmed on the way in
+		ClientURI:    "  https://claude.ai  ",
+		// token_endpoint_auth_method omitted: RFC 7591 defaults it to
+		// client_secret_basic, so the stored value differs from the request.
+	})
+	if err != nil {
+		t.Fatalf("a valid registration was refused: %v", err)
+	}
+
+	if got.ClientName != "Claude Desktop" {
+		t.Errorf("client_name = %q, want the STORED (trimmed) value", got.ClientName)
+	}
+	if got.ClientURI != "https://claude.ai" {
+		t.Errorf("client_uri = %q, want the STORED (trimmed) value", got.ClientURI)
+	}
+	if got.TokenEndpointAuthMethod != "client_secret_basic" {
+		t.Errorf("token_endpoint_auth_method = %q, want the stored default",
+			got.TokenEndpointAuthMethod)
+	}
+	if got.ClientSecret == "" {
+		t.Error("a client_secret_basic registration returned no secret")
+	}
+	if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "https://claude.ai/cb" {
+		t.Errorf("redirect_uris = %v", got.RedirectURIs)
+	}
+
+	// And it must be TWO round trips in the right order: the register
+	// transaction cannot read the table, so the read-back is a separate
+	// lookup transaction. Collapsing them back into one is the original bug.
+	var order []string
+	for _, c := range store.calls {
+		if c == "RegisterClient" || c == "LookupClient" {
+			order = append(order, c)
+		}
+	}
+	if len(order) != 2 || order[0] != "RegisterClient" || order[1] != "LookupClient" {
+		t.Fatalf("call order = %v, want [RegisterClient LookupClient]; the read-back "+
+			"must be a separate transaction because the register GUC enables no "+
+			"SELECT policy", order)
+	}
+}

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -18,7 +18,12 @@ import (
 // notably that a losing compare-and-set returns pgx.ErrNoRows rather than a
 // zero-value row.
 type Store interface {
-	RegisterClient(ctx context.Context, arg sqlc.RegisterMCPOAuthClientParams) (sqlc.McpOauthClient, error)
+	// RegisterClient returns ROWS WRITTEN, mirroring the :execrows query
+	// exactly. It deliberately does not return the row: the register GUC
+	// enables no SELECT policy, so RETURNING raises 42501 (see Repo's method).
+	// Modelling this as a count in the interface is what lets a fake reproduce
+	// a zero-row write, which a row-returning shape cannot express.
+	RegisterClient(ctx context.Context, arg sqlc.RegisterMCPOAuthClientParams) (int64, error)
 	LookupClient(ctx context.Context, clientID string) (sqlc.McpOauthClient, error)
 
 	LookupAuthorizationCode(ctx context.Context, codeHash string) (sqlc.GetMCPAuthorizationCodeByHashForLookupRow, error)
@@ -44,19 +49,40 @@ func NewRepo(pool *db.Pool) *Repo { return &Repo{pool: pool} }
 var _ Store = (*Repo)(nil)
 
 // RegisterClient inserts one RFC 7591 registration under
-// app.mcp_client_register. The policy is FOR INSERT, so this transaction
-// cannot read the table back.
-func (r *Repo) RegisterClient(ctx context.Context, arg sqlc.RegisterMCPOAuthClientParams) (sqlc.McpOauthClient, error) {
-	var out sqlc.McpOauthClient
+// app.mcp_client_register and returns the number of rows written.
+//
+// IT RETURNS A COUNT, NOT A ROW, AND THAT IS NOT A STYLE CHOICE. The only
+// policy this GUC enables is FOR INSERT, so the transaction genuinely cannot
+// read the table back -- and `RETURNING` is a read. Under FORCE ROW LEVEL
+// SECURITY the SELECT policy is enforced against the returned row as a
+// WithCheckOption, so any RETURNING here raises SQLSTATE 42501 at
+// ExecWithCheckOptions and the whole transaction rolls back. Every registration
+// would fail at runtime.
+//
+// THIS IS NOT `RETURNING *`-SPECIFIC. Returning one column fails identically --
+// even `RETURNING id`, which is server-generated and contains nothing the
+// caller supplied. Reading the fix as "return fewer columns" reproduces the
+// bug exactly.
+//
+// The obvious alternative -- setting app.mcp_client_lookup here too -- was
+// rejected on purpose. Registration is an UNAUTHENTICATED POST, so granting it
+// the lookup GUC would let any caller enumerate every registered client on the
+// installation, client_secret_hash included. That swaps "the database refuses"
+// for "the handler happens not to ask", which is the weaker guarantee.
+//
+// So the caller asserts the count and then reads the row back in a separate
+// InMCPClientLookupTx. One extra round trip is the cost of the split.
+func (r *Repo) RegisterClient(ctx context.Context, arg sqlc.RegisterMCPOAuthClientParams) (int64, error) {
+	var affected int64
 	err := r.pool.InMCPClientRegisterTx(ctx, func(tx pgx.Tx) error {
-		row, err := sqlc.New(tx).RegisterMCPOAuthClient(ctx, arg)
+		n, err := sqlc.New(tx).RegisterMCPOAuthClient(ctx, arg)
 		if err != nil {
 			return fmt.Errorf("register mcp oauth client: %w", err)
 		}
-		out = row
+		affected = n
 		return nil
 	})
-	return out, err
+	return affected, err
 }
 
 // LookupClient resolves a registration by client_id under

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -1,0 +1,249 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+// Store is the database surface the service depends on. It exists as an
+// interface so the single-use and revocation proofs can drive the exact Go
+// branch structure with a fake that models the SQL contract faithfully --
+// notably that a losing compare-and-set returns pgx.ErrNoRows rather than a
+// zero-value row.
+type Store interface {
+	RegisterClient(ctx context.Context, arg sqlc.RegisterMCPOAuthClientParams) (sqlc.McpOauthClient, error)
+	LookupClient(ctx context.Context, clientID string) (sqlc.McpOauthClient, error)
+
+	LookupAuthorizationCode(ctx context.Context, codeHash string) (sqlc.GetMCPAuthorizationCodeByHashForLookupRow, error)
+	ConsumeAuthorizationCode(ctx context.Context, tenantID, codeID uuid.UUID) (sqlc.McpAuthorizationCode, error)
+
+	CreateGrantWithCode(ctx context.Context, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
+	CreateConnectionToken(ctx context.Context, arg sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error)
+
+	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
+	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
+	ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error)
+}
+
+// Repo is the live Store. Every method names the tx helper it runs under, and
+// the pairing is the security boundary rather than a style choice -- see the
+// block comment above the four helpers in internal/db/db.go.
+type Repo struct {
+	pool *db.Pool
+}
+
+func NewRepo(pool *db.Pool) *Repo { return &Repo{pool: pool} }
+
+var _ Store = (*Repo)(nil)
+
+// RegisterClient inserts one RFC 7591 registration under
+// app.mcp_client_register. The policy is FOR INSERT, so this transaction
+// cannot read the table back.
+func (r *Repo) RegisterClient(ctx context.Context, arg sqlc.RegisterMCPOAuthClientParams) (sqlc.McpOauthClient, error) {
+	var out sqlc.McpOauthClient
+	err := r.pool.InMCPClientRegisterTx(ctx, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).RegisterMCPOAuthClient(ctx, arg)
+		if err != nil {
+			return fmt.Errorf("register mcp oauth client: %w", err)
+		}
+		out = row
+		return nil
+	})
+	return out, err
+}
+
+// LookupClient resolves a registration by client_id under
+// app.mcp_client_lookup. READ ONLY: the policy is FOR SELECT.
+//
+// The caller must exact-match the presented redirect_uri against
+// out.RedirectUris itself; there is deliberately no redirect_uri parameter to
+// push that into SQL.
+func (r *Repo) LookupClient(ctx context.Context, clientID string) (sqlc.McpOauthClient, error) {
+	var out sqlc.McpOauthClient
+	err := r.pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).GetMCPOAuthClientByClientIDForLookup(ctx, clientID)
+		if err != nil {
+			return err // pgx.ErrNoRows is meaningful to the caller
+		}
+		out = row
+		return nil
+	})
+	return out, err
+}
+
+// LookupAuthorizationCode resolves a PKCE code by hash under
+// app.mcp_code_lookup. READ ONLY.
+//
+// It deliberately does NOT consume. Consuming here is m124 obligation 1's
+// silent failure: the policy is FOR SELECT, the UPDATE would match zero rows,
+// raise no error, and leave the code replayable.
+func (r *Repo) LookupAuthorizationCode(ctx context.Context, codeHash string) (sqlc.GetMCPAuthorizationCodeByHashForLookupRow, error) {
+	var out sqlc.GetMCPAuthorizationCodeByHashForLookupRow
+	err := r.pool.InMCPCodeLookupTx(ctx, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).GetMCPAuthorizationCodeByHashForLookup(ctx, codeHash)
+		if err != nil {
+			return err
+		}
+		out = row
+		return nil
+	})
+	return out, err
+}
+
+// ConsumeAuthorizationCode performs the atomic compare-and-set, in its own
+// InTenantTx, as m124 obligation 1 requires.
+//
+// The query is :one over a predicate carrying `consumed_at IS NULL AND
+// expires_at > now()`, so pgx.ErrNoRows means the code was NOT consumed --
+// redeemed by a racing exchange, expired between the two transactions, or
+// refused by RLS. All three mean refuse, and the caller must never read "no
+// row" as "already fine".
+func (r *Repo) ConsumeAuthorizationCode(ctx context.Context, tenantID, codeID uuid.UUID) (sqlc.McpAuthorizationCode, error) {
+	var out sqlc.McpAuthorizationCode
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).ConsumeMCPAuthorizationCodeInTenantTx(ctx,
+			sqlc.ConsumeMCPAuthorizationCodeInTenantTxParams{TenantID: tenantID, ID: codeID})
+		if err != nil {
+			return err
+		}
+		out = row
+		return nil
+	})
+	return out, err
+}
+
+// CreateGrantWithCode mints the grant and its first authorization code in ONE
+// InTenantTx, so a crash between them cannot leave a grant nobody can redeem
+// or a code pointing at no grant. mkCode receives the new grant id.
+//
+// Not run under app.site_scope: mcp_grants_site_scope_insert is RESTRICTIVE FOR
+// INSERT, so a site-scoped collaborator inserting here would match nothing.
+// Minting a grant is an operator action and the handler gates it accordingly.
+func (r *Repo) CreateGrantWithCode(
+	ctx context.Context,
+	g sqlc.CreateMCPGrantParams,
+	mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams,
+) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
+	var (
+		grant sqlc.McpGrant
+		code  sqlc.McpAuthorizationCode
+	)
+	err := r.pool.InTenantTx(ctx, g.TenantID, func(tx pgx.Tx) error {
+		q := sqlc.New(tx)
+		gr, err := q.CreateMCPGrant(ctx, g)
+		if err != nil {
+			return fmt.Errorf("create mcp grant: %w", err)
+		}
+		cd, err := q.CreateMCPAuthorizationCode(ctx, mkCode(gr.ID))
+		if err != nil {
+			return fmt.Errorf("create mcp authorization code: %w", err)
+		}
+		grant, code = gr, cd
+		return nil
+	})
+	return grant, code, err
+}
+
+// CreateConnectionToken stores the hashed bearer token under InTenantTx.
+func (r *Repo) CreateConnectionToken(ctx context.Context, arg sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error) {
+	var out sqlc.McpConnectionToken
+	err := r.pool.InTenantTx(ctx, arg.TenantID, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).CreateMCPConnectionToken(ctx, arg)
+		if err != nil {
+			return fmt.Errorf("create mcp connection token: %w", err)
+		}
+		out = row
+		return nil
+	})
+	return out, err
+}
+
+// LookupConnectionToken resolves a bearer token by hash under
+// app.mcp_token_lookup. READ ONLY, and it resolves the TOKEN ONLY.
+//
+// Do not be tempted into `token JOIN grant` here: mcp_grants has no lookup
+// policy, only tenant isolation, so the join matches zero rows inside this
+// transaction and would fail every MCP request with nothing in any log.
+// Authentication is two queries -- this one to learn the tenant, then
+// ReCheckAuthorization under that tenant.
+func (r *Repo) LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
+	var out sqlc.GetMCPConnectionTokenByHashForLookupRow
+	err := r.pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).GetMCPConnectionTokenByHashForLookup(ctx, tokenHash)
+		if err != nil {
+			return err
+		}
+		out = row
+		return nil
+	})
+	return out, err
+}
+
+// ReCheckAuthorization re-reads grant and token state under the resolved
+// tenant. It runs on EVERY request so revocation bites on the next one rather
+// than at token expiry, and the caller must branch on the row's Authorized
+// column, never on row presence.
+func (r *Repo) ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error) {
+	var out sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).ReCheckMCPRequestAuthorizationInTenantTx(ctx,
+			sqlc.ReCheckMCPRequestAuthorizationInTenantTxParams{TenantID: tenantID, ID: tokenID})
+		if err != nil {
+			return err
+		}
+		out = row
+		return nil
+	})
+	return out, err
+}
+
+// ResolveScopeSites is the ONE audited chokepoint of m124 obligation 2. It runs
+// inside InTenantTx so that joining through `sites` under tenant isolation
+// drops every foreign UUID -- scope_site_ids is a uuid[] and PostgreSQL has no
+// foreign key over array elements, so the column accepts any UUID at all.
+//
+// An empty result means NO SITES. The caller enforces that; the database
+// cannot. See NewSiteSet, whose zero value allows nothing.
+func (r *Repo) ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error) {
+	var out []uuid.UUID
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := sqlc.New(tx).ResolveMCPGrantScopeSitesInTenantTx(ctx,
+			sqlc.ResolveMCPGrantScopeSitesInTenantTxParams{
+				TenantID: tenantID,
+				Column2:  mode,
+				Column3:  tagIDs,
+				Column4:  siteIDs,
+			})
+		if err != nil {
+			return fmt.Errorf("resolve mcp grant scope sites: %w", err)
+		}
+		out = rows
+		return nil
+	})
+	return out, err
+}
+
+// nullableText is the pgtype-free helper for the *string columns sqlc emits.
+func nullableText(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// uuidToPG converts a uuid to the pgtype form CreateMCPGrantParams wants,
+// mapping uuid.Nil to NULL rather than to a zero uuid that looks like a real
+// author.
+func uuidToPG(id uuid.UUID) pgtype.UUID {
+	if id == uuid.Nil {
+		return pgtype.UUID{}
+	}
+	return pgtype.UUID{Bytes: id, Valid: true}
+}

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -27,10 +27,14 @@ type Store interface {
 	LookupClient(ctx context.Context, clientID string) (sqlc.McpOauthClient, error)
 
 	LookupAuthorizationCode(ctx context.Context, codeHash string) (sqlc.GetMCPAuthorizationCodeByHashForLookupRow, error)
-	ConsumeAuthorizationCode(ctx context.Context, tenantID, codeID uuid.UUID) (sqlc.McpAuthorizationCode, error)
+
+	// RedeemAuthorizationCode consumes the code AND issues the token in ONE
+	// transaction. There is deliberately no way to do only half of it: a
+	// separate consume would let a failure between the two commits burn a code
+	// that never produced a token, stranding a client that did nothing wrong.
+	RedeemAuthorizationCode(ctx context.Context, tenantID, codeID uuid.UUID, tok sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error)
 
 	CreateGrantWithCode(ctx context.Context, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
-	CreateConnectionToken(ctx context.Context, arg sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error)
 
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
@@ -123,21 +127,45 @@ func (r *Repo) LookupAuthorizationCode(ctx context.Context, codeHash string) (sq
 	return out, err
 }
 
-// ConsumeAuthorizationCode performs the atomic compare-and-set, in its own
-// InTenantTx, as m124 obligation 1 requires.
+// RedeemAuthorizationCode consumes the code and issues the connection token in
+// ONE InTenantTx. Either both land or neither does.
 //
-// The query is :one over a predicate carrying `consumed_at IS NULL AND
-// expires_at > now()`, so pgx.ErrNoRows means the code was NOT consumed --
-// redeemed by a racing exchange, expired between the two transactions, or
-// refused by RLS. All three mean refuse, and the caller must never read "no
-// row" as "already fine".
-func (r *Repo) ConsumeAuthorizationCode(ctx context.Context, tenantID, codeID uuid.UUID) (sqlc.McpAuthorizationCode, error) {
-	var out sqlc.McpAuthorizationCode
+// THE CONSUME IS STILL THE COMPARE-AND-SET, and it still runs in a transaction
+// separate from the LOOKUP -- that separation is m124 obligation 1 and it is
+// not what changed here. The query is :one over a predicate carrying
+// `consumed_at IS NULL AND expires_at > now()`, so pgx.ErrNoRows means the code
+// was NOT consumed: redeemed by a racing exchange, expired between the lookup
+// and now, or refused by RLS. All three mean refuse, and the caller must never
+// read "no row" as "already fine".
+//
+// WHY THE TOKEN INSERT JOINED IT. These were two commits. Burning the code
+// before minting the token is the correct ORDER -- the reverse risks two tokens
+// from one code -- but as separate commits a failure in between left a state
+// that is safe and useless: the code permanently consumed, no token issued, and
+// a client that did nothing wrong unable to retry and forced to restart the
+// whole browser flow with nothing explaining why. One transaction removes the
+// window rather than documenting it.
+//
+// Ordering inside the transaction is unchanged and still matters: the
+// compare-and-set runs FIRST, so two concurrent exchanges still produce exactly
+// one winner. The loser's INSERT never runs because its UPDATE matched nothing.
+func (r *Repo) RedeemAuthorizationCode(
+	ctx context.Context,
+	tenantID, codeID uuid.UUID,
+	tok sqlc.CreateMCPConnectionTokenParams,
+) (sqlc.McpConnectionToken, error) {
+	var out sqlc.McpConnectionToken
 	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
-		row, err := sqlc.New(tx).ConsumeMCPAuthorizationCodeInTenantTx(ctx,
-			sqlc.ConsumeMCPAuthorizationCodeInTenantTxParams{TenantID: tenantID, ID: codeID})
+		q := sqlc.New(tx)
+		if _, err := q.ConsumeMCPAuthorizationCodeInTenantTx(ctx,
+			sqlc.ConsumeMCPAuthorizationCodeInTenantTxParams{TenantID: tenantID, ID: codeID}); err != nil {
+			return err // pgx.ErrNoRows is meaningful to the caller
+		}
+		row, err := q.CreateMCPConnectionToken(ctx, tok)
 		if err != nil {
-			return err
+			// Rolls the consume back with it. The code stays redeemable, which
+			// is the whole point of the single transaction.
+			return fmt.Errorf("create mcp connection token: %w", err)
 		}
 		out = row
 		return nil
@@ -175,20 +203,6 @@ func (r *Repo) CreateGrantWithCode(
 		return nil
 	})
 	return grant, code, err
-}
-
-// CreateConnectionToken stores the hashed bearer token under InTenantTx.
-func (r *Repo) CreateConnectionToken(ctx context.Context, arg sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error) {
-	var out sqlc.McpConnectionToken
-	err := r.pool.InTenantTx(ctx, arg.TenantID, func(tx pgx.Tx) error {
-		row, err := sqlc.New(tx).CreateMCPConnectionToken(ctx, arg)
-		if err != nil {
-			return fmt.Errorf("create mcp connection token: %w", err)
-		}
-		out = row
-		return nil
-	})
-	return out, err
 }
 
 // LookupConnectionToken resolves a bearer token by hash under

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1,0 +1,637 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// Lifetimes. The code is short-lived because it is a bearer credential in a
+// URL; the token's is the connection's own lifetime.
+const (
+	authorizationCodeTTL = 5 * time.Minute
+	connectionTokenTTL   = 90 * 24 * time.Hour
+	tokenPrefixLen       = 12
+)
+
+// Error codes. These are domain codes; the OAuth wire errors are mapped from
+// them in dto.go so that RFC 6749 section 5.2 naming lives at the edge.
+const (
+	ErrCodeInvalidClient       = "mcp_invalid_client"
+	ErrCodeInvalidRedirectURI  = "mcp_invalid_redirect_uri"
+	ErrCodeInvalidGrant        = "mcp_invalid_grant"
+	ErrCodeInvalidRequest      = "mcp_invalid_request"
+	ErrCodeUnsupportedResponse = "mcp_unsupported_response_type"
+	ErrCodeRegistrationInvalid = "mcp_invalid_client_metadata"
+)
+
+// Clock is injectable so expiry behaviour is testable without sleeping.
+type Clock func() time.Time
+
+// Service carries the OAuth surface. It holds no plaintext credential beyond
+// the response it is building: m124 obligation 6 says the plaintext is returned
+// once at creation and never read back, and there is no cache here.
+type Service struct {
+	store Store
+	now   Clock
+}
+
+func NewService(store Store) *Service {
+	return &Service{store: store, now: time.Now}
+}
+
+// WithClock returns a copy using the supplied clock. Test-only in practice.
+func (s *Service) WithClock(c Clock) *Service {
+	cp := *s
+	cp.now = c
+	return &cp
+}
+
+// ---------------------------------------------------------------------------
+// RFC 7591 dynamic client registration
+// ---------------------------------------------------------------------------
+
+// RegistrationRequest is the RFC 7591 client metadata a client POSTs. It is
+// UNAUTHENTICATED, so every string in here is attacker-controlled and none of
+// it may be presented as verified.
+type RegistrationRequest struct {
+	RedirectURIs            []string
+	ClientName              string
+	ClientURI               string
+	TokenEndpointAuthMethod string
+}
+
+// RegisteredClient is what registration returns. ClientSecret is present
+// exactly once, here, and is never readable again (m124 obligation 6).
+type RegisteredClient struct {
+	ClientID                string
+	ClientSecret            string
+	TokenEndpointAuthMethod string
+	RedirectURIs            []string
+	ClientName              string
+	ClientURI               string
+}
+
+// Register implements RFC 7591 dynamic client registration.
+func (s *Service) Register(ctx context.Context, req RegistrationRequest) (RegisteredClient, error) {
+	if len(req.RedirectURIs) == 0 {
+		return RegisteredClient{}, domain.Validation(ErrCodeRegistrationInvalid,
+			"redirect_uris is required and must name at least one URI")
+	}
+	for _, raw := range req.RedirectURIs {
+		if err := validateRedirectURI(raw); err != nil {
+			return RegisteredClient{}, err
+		}
+	}
+
+	// RFC 7591 section 2: an omitted token_endpoint_auth_method defaults to
+	// client_secret_basic. That default is the RFC's and it is the RESTRICTIVE
+	// direction -- it mints a secret the client must then present -- so
+	// honouring it does not widen anything. 'none' must be asked for explicitly,
+	// which is the case that matters, because 'none' is the no-secret path.
+	method := req.TokenEndpointAuthMethod
+	if method == "" {
+		method = "client_secret_basic"
+	}
+	switch method {
+	case "none", "client_secret_basic", "client_secret_post":
+	default:
+		return RegisteredClient{}, domain.Validation(ErrCodeRegistrationInvalid,
+			fmt.Sprintf("token_endpoint_auth_method %q is not supported", method))
+	}
+
+	clientID, err := randomToken(24)
+	if err != nil {
+		return RegisteredClient{}, fmt.Errorf("generate client_id: %w", err)
+	}
+
+	// 'none' if and only if there is no secret -- the schema's
+	// mcp_oauth_clients_secret_matches_method_check makes the incoherent row
+	// unrepresentable, and this is the Go side of the same invariant so we
+	// never attempt one.
+	var (
+		secret     string
+		secretHash *string
+	)
+	if method != "none" {
+		secret, err = randomToken(32)
+		if err != nil {
+			return RegisteredClient{}, fmt.Errorf("generate client_secret: %w", err)
+		}
+		h := hashCredential(secret)
+		secretHash = &h
+	}
+
+	row, err := s.store.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        secretHash,
+		TokenEndpointAuthMethod: method,
+		RedirectUris:            req.RedirectURIs,
+		ClientName:              nullableText(strings.TrimSpace(req.ClientName)),
+		ClientUri:               nullableText(strings.TrimSpace(req.ClientURI)),
+	})
+	if err != nil {
+		return RegisteredClient{}, fmt.Errorf("register client: %w", err)
+	}
+
+	return RegisteredClient{
+		ClientID:                row.ClientID,
+		ClientSecret:            secret, // once, here, never again
+		TokenEndpointAuthMethod: row.TokenEndpointAuthMethod,
+		RedirectURIs:            row.RedirectUris,
+		ClientName:              req.ClientName,
+		ClientURI:               req.ClientURI,
+	}, nil
+}
+
+// validateRedirectURI refuses anything that is not an absolute URI we are
+// willing to send a code to. A fragment is refused because RFC 6749 3.1.2
+// forbids one; a non-https non-loopback scheme is refused because the code
+// would travel in clear.
+func validateRedirectURI(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return domain.Validation(ErrCodeRegistrationInvalid,
+			fmt.Sprintf("redirect_uri %q is not a valid URI", raw))
+	}
+	if !u.IsAbs() || u.Host == "" && u.Scheme != "http" {
+		return domain.Validation(ErrCodeRegistrationInvalid,
+			fmt.Sprintf("redirect_uri %q must be absolute", raw))
+	}
+	if u.Fragment != "" || strings.Contains(raw, "#") {
+		return domain.Validation(ErrCodeRegistrationInvalid,
+			fmt.Sprintf("redirect_uri %q must not carry a fragment", raw))
+	}
+	host := u.Hostname()
+	isLoopback := host == "localhost" || host == "127.0.0.1" || host == "::1"
+	if u.Scheme != "https" && !(u.Scheme == "http" && isLoopback) {
+		return domain.Validation(ErrCodeRegistrationInvalid,
+			fmt.Sprintf("redirect_uri %q must use https, or http on loopback for a native client", raw))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// The authorization endpoint, and the consent screen's server side
+// ---------------------------------------------------------------------------
+
+// AuthorizeRequest is the parsed /authorize query.
+type AuthorizeRequest struct {
+	ResponseType        string
+	ClientID            string
+	RedirectURI         string
+	Scope               string
+	State               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// ConsentContext is what the consent screen renders. Every field carrying
+// client-supplied text is named so the template cannot forget what it is:
+// registration is unauthenticated, so ClientNameUnverified is an
+// attacker-controlled string and two clients may both claim to be "Claude
+// Desktop" (m124 obligation 7). The screen must show it as self-asserted and
+// must show RedirectHost, which is the part the user can actually judge.
+type ConsentContext struct {
+	ClientID             string
+	ClientNameUnverified string
+	ClientURIUnverified  string
+	RedirectURI          string
+	RedirectHost         string
+	Scopes               []Scope
+	State                string
+
+	// CodeChallenge travels through consent so the code can be minted with it
+	// on approval. It is public by construction -- already SHA-256 of the
+	// verifier -- so carrying it is not a secret leak.
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// Authorize validates an authorization request and returns what the consent
+// screen must render. It mints NOTHING: no grant and no code exist until a
+// human approves, which is what makes consent the authorization.
+func (s *Service) Authorize(ctx context.Context, req AuthorizeRequest) (ConsentContext, error) {
+	if req.ResponseType != "code" {
+		return ConsentContext{}, domain.Validation(ErrCodeUnsupportedResponse,
+			"response_type must be 'code'")
+	}
+	if strings.TrimSpace(req.ClientID) == "" {
+		return ConsentContext{}, domain.Validation(ErrCodeInvalidRequest, "client_id is required")
+	}
+
+	// PKCE is mandatory and S256 only. An absent method must NOT fall back to
+	// 'plain' -- m124 DECISION 5 keeps 'plain' out of the schema's closed set
+	// for the same reason, and a missing challenge is an absence, not a
+	// licence to skip the check.
+	if strings.TrimSpace(req.CodeChallenge) == "" {
+		return ConsentContext{}, domain.Validation(ErrCodeInvalidRequest,
+			"code_challenge is required; this server requires PKCE")
+	}
+	if req.CodeChallengeMethod != "S256" {
+		return ConsentContext{}, domain.Validation(ErrCodeInvalidRequest,
+			"code_challenge_method must be 'S256'")
+	}
+
+	// THE EXIT GATE. A client requesting no recognised scope is refused here,
+	// before any consent screen is drawn, and is never granted a default.
+	scopes, err := ParseRequestedScopes(req.Scope)
+	if err != nil {
+		return ConsentContext{}, err
+	}
+
+	client, err := s.store.LookupClient(ctx, req.ClientID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ConsentContext{}, domain.Unauthorized(ErrCodeInvalidClient, "unknown client_id")
+		}
+		return ConsentContext{}, fmt.Errorf("lookup client: %w", err)
+	}
+
+	// EXACT MATCH, in Go, against the stored array. Never a prefix, suffix or
+	// host-only comparison -- each of those is an open redirector, and the
+	// query takes no redirect_uri parameter precisely so this cannot be pushed
+	// into SQL and forgotten.
+	if !exactMatchRedirectURI(client.RedirectUris, req.RedirectURI) {
+		return ConsentContext{}, domain.Validation(ErrCodeInvalidRedirectURI,
+			"redirect_uri does not exactly match a registered redirect URI")
+	}
+
+	redirectHost := ""
+	if u, perr := url.Parse(req.RedirectURI); perr == nil {
+		redirectHost = u.Host
+	}
+
+	return ConsentContext{
+		ClientID:             client.ClientID,
+		ClientNameUnverified: derefString(client.ClientName),
+		ClientURIUnverified:  derefString(client.ClientUri),
+		RedirectURI:          req.RedirectURI,
+		RedirectHost:         redirectHost,
+		Scopes:               scopes,
+		State:                req.State,
+		CodeChallenge:        req.CodeChallenge,
+		CodeChallengeMethod:  req.CodeChallengeMethod,
+	}, nil
+}
+
+// exactMatchRedirectURI compares byte-for-byte against each registered URI.
+// Deliberately not url.Parse-and-compare-parts: normalisation is where
+// redirector bugs live.
+func exactMatchRedirectURI(registered []string, presented string) bool {
+	if presented == "" {
+		return false
+	}
+	for _, r := range registered {
+		if r == presented {
+			return true
+		}
+	}
+	return false
+}
+
+// ApprovalRequest is a human's consent, submitted by the authenticated
+// operator whose organisation the grant will belong to.
+type ApprovalRequest struct {
+	TenantID  uuid.UUID
+	UserID    uuid.UUID
+	Consent   ConsentContext
+	GrantName string
+	SiteScope SiteScopeRequest
+}
+
+// Approval is the result: the code to hand back to the client via the
+// redirect, plus the grant it belongs to.
+type Approval struct {
+	GrantID     uuid.UUID
+	Code        string
+	RedirectURI string
+	State       string
+}
+
+// Approve records the human's consent as a grant and mints the single-use PKCE
+// code. Grant and code are created in one transaction.
+func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, error) {
+	if req.TenantID == uuid.Nil {
+		return Approval{}, domain.Validation(ErrCodeInvalidRequest, "an organisation is required")
+	}
+	if strings.TrimSpace(req.GrantName) == "" {
+		return Approval{}, domain.Validation(ErrCodeInvalidRequest, "a connection name is required")
+	}
+
+	// Re-run the exit gate on the approval too. The consent screen's scope list
+	// arrives back over the wire and a resubmitted form is caller input like
+	// any other; re-parsing means a tampered approval cannot widen what the
+	// authorize call already refused.
+	if _, err := ParseRequestedScopes(scopesToString(req.Consent.Scopes)); err != nil {
+		return Approval{}, err
+	}
+	if err := ValidateSiteScopeRequest(req.SiteScope); err != nil {
+		return Approval{}, err
+	}
+	if req.Consent.CodeChallengeMethod != "S256" || strings.TrimSpace(req.Consent.CodeChallenge) == "" {
+		return Approval{}, domain.Validation(ErrCodeInvalidRequest,
+			"the approved request carries no S256 PKCE challenge")
+	}
+
+	code, err := randomToken(32)
+	if err != nil {
+		return Approval{}, fmt.Errorf("generate authorization code: %w", err)
+	}
+	codeHash := hashCredential(code)
+	expiresAt := s.now().UTC().Add(authorizationCodeTTL)
+
+	grant, _, err := s.store.CreateGrantWithCode(ctx,
+		sqlc.CreateMCPGrantParams{
+			TenantID:        req.TenantID,
+			Name:            strings.TrimSpace(req.GrantName),
+			Status:          string(GrantStatusActive),
+			SiteScopeMode:   string(req.SiteScope.Mode),
+			ScopeTagIds:     orEmpty(req.SiteScope.TagIDs),
+			ScopeSiteIds:    orEmpty(req.SiteScope.SiteIDs),
+			ClientID:        nullableText(req.Consent.ClientID),
+			CreatedByUserID: uuidToPG(req.UserID),
+		},
+		func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+			return sqlc.CreateMCPAuthorizationCodeParams{
+				TenantID:            req.TenantID,
+				GrantID:             grantID,
+				ClientID:            req.Consent.ClientID,
+				CodeHash:            codeHash,
+				CodeChallenge:       req.Consent.CodeChallenge,
+				CodeChallengeMethod: req.Consent.CodeChallengeMethod,
+				RedirectUri:         req.Consent.RedirectURI,
+				ExpiresAt:           expiresAt,
+			}
+		})
+	if err != nil {
+		return Approval{}, fmt.Errorf("create grant and code: %w", err)
+	}
+
+	return Approval{
+		GrantID:     grant.ID,
+		Code:        code, // returned once, to the redirect
+		RedirectURI: req.Consent.RedirectURI,
+		State:       req.Consent.State,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// The token endpoint
+// ---------------------------------------------------------------------------
+
+// TokenRequest is the RFC 6749 4.1.3 access token request.
+type TokenRequest struct {
+	GrantType    string
+	Code         string
+	RedirectURI  string
+	ClientID     string
+	CodeVerifier string
+}
+
+// IssuedToken is the token response. AccessToken is present exactly once.
+type IssuedToken struct {
+	AccessToken string
+	TokenType   string
+	ExpiresIn   int
+	Scope       string
+}
+
+// Exchange redeems a PKCE authorization code for a connection token.
+//
+// THE ORDER HERE IS THE SECURITY PROPERTY. Everything that can refuse is
+// checked first, then the code is consumed by an atomic compare-and-set in its
+// own transaction, and ONLY IF that consume actually wrote is a token minted.
+// A zero-row consume is a refusal, never a shrug.
+func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, error) {
+	if req.GrantType != "authorization_code" {
+		return IssuedToken{}, domain.Validation(ErrCodeInvalidRequest,
+			"grant_type must be 'authorization_code'")
+	}
+	if strings.TrimSpace(req.Code) == "" {
+		return IssuedToken{}, domain.Validation(ErrCodeInvalidRequest, "code is required")
+	}
+	if strings.TrimSpace(req.CodeVerifier) == "" {
+		return IssuedToken{}, domain.Validation(ErrCodeInvalidRequest,
+			"code_verifier is required; this server requires PKCE")
+	}
+
+	// 1. READ ONLY. This transaction must not write -- see repo.go.
+	row, err := s.store.LookupAuthorizationCode(ctx, hashCredential(req.Code))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+				"the authorization code is not valid")
+		}
+		return IssuedToken{}, fmt.Errorf("lookup authorization code: %w", err)
+	}
+
+	// 2. Bind the code to the client and the redirect it was issued for
+	// (RFC 6749 4.1.3). Both are exact comparisons.
+	if req.ClientID != "" && req.ClientID != row.ClientID {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+			"the authorization code was not issued to this client")
+	}
+	if req.RedirectURI != row.RedirectUri {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+			"redirect_uri does not match the one the code was issued for")
+	}
+
+	// 3. Replay and expiry, as the database computed them. Reported early so a
+	// replay is refused with a clear reason; the authoritative refusal is still
+	// the compare-and-set at step 5, because anything checked here is a TOCTOU
+	// window.
+	if row.IsConsumed {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+			"the authorization code has already been redeemed")
+	}
+	if row.IsExpired || !row.IsRedeemable {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+			"the authorization code is expired or not redeemable")
+	}
+
+	// 4. PKCE. S256 only, constant-time.
+	if row.CodeChallengeMethod != "S256" {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+			"the authorization code carries an unsupported challenge method")
+	}
+	if !verifyPKCE(req.CodeVerifier, row.CodeChallenge) {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+			"code_verifier does not match the code_challenge")
+	}
+
+	// 5. CONSUME, in its own InTenantTx. This is m124 obligation 1.
+	//
+	// pgx.ErrNoRows here means the row was NOT updated: a racing exchange won,
+	// or it expired between the transactions, or RLS refused the write. All
+	// three mean refuse. Treating "no row" as "already fine" is exactly how
+	// single-use becomes multi-use, so there is no such branch.
+	if _, err := s.store.ConsumeAuthorizationCode(ctx, row.TenantID, row.ID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+				"the authorization code could not be redeemed; it was already used or has expired")
+		}
+		return IssuedToken{}, fmt.Errorf("consume authorization code: %w", err)
+	}
+
+	// 6. Only now does a credential exist.
+	secret, err := randomToken(32)
+	if err != nil {
+		return IssuedToken{}, fmt.Errorf("generate connection token: %w", err)
+	}
+	expiresAt := s.now().UTC().Add(connectionTokenTTL)
+	if _, err := s.store.CreateConnectionToken(ctx, sqlc.CreateMCPConnectionTokenParams{
+		TenantID:    row.TenantID,
+		GrantID:     row.GrantID,
+		TokenPrefix: secret[:tokenPrefixLen],
+		TokenHash:   hashCredential(secret),
+		Status:      string(GrantStatusActive),
+		ExpiresAt:   pgtype.Timestamptz{Time: expiresAt, Valid: true},
+	}); err != nil {
+		return IssuedToken{}, fmt.Errorf("create connection token: %w", err)
+	}
+
+	return IssuedToken{
+		AccessToken: secret, // once, here, never again
+		TokenType:   "Bearer",
+		ExpiresIn:   int(connectionTokenTTL.Seconds()),
+		Scope:       string(ScopeRead),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Per-request re-authorization (m124 obligation 4)
+// ---------------------------------------------------------------------------
+
+// AuthorizedRequest is a successfully re-checked MCP request.
+type AuthorizedRequest struct {
+	TenantID uuid.UUID
+	GrantID  uuid.UUID
+	TokenID  uuid.UUID
+	Sites    SiteSet
+}
+
+// Authenticate resolves a bearer token and re-checks its grant against CURRENT
+// state on EVERY request, so revocation lands on the next request rather than
+// at token expiry.
+//
+// It is TWO queries and not a join: mcp_grants has no lookup policy, so
+// `token JOIN grant` inside the token-lookup transaction matches zero rows and
+// would fail every request with nothing in any log.
+func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRequest, error) {
+	if strings.TrimSpace(bearer) == "" {
+		return AuthorizedRequest{}, domain.Unauthorized(ErrCodeInvalidGrant, "a bearer token is required")
+	}
+
+	tok, err := s.store.LookupConnectionToken(ctx, hashCredential(bearer))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AuthorizedRequest{}, domain.Unauthorized(ErrCodeInvalidGrant, "the token is not valid")
+		}
+		return AuthorizedRequest{}, fmt.Errorf("lookup connection token: %w", err)
+	}
+
+	// Re-check under the now-known tenant. BRANCH ON Authorized, NOT ON ROW
+	// PRESENCE: a revoked grant still returns a row, and reading "I got a row"
+	// as "authorized" is how revocation silently stops working.
+	chk, err := s.store.ReCheckAuthorization(ctx, tok.TenantID, tok.ID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AuthorizedRequest{}, domain.Unauthorized(ErrCodeInvalidGrant,
+				"the grant behind this token no longer exists")
+		}
+		return AuthorizedRequest{}, fmt.Errorf("re-check mcp authorization: %w", err)
+	}
+	if !chk.Authorized {
+		return AuthorizedRequest{}, domain.Unauthorized(ErrCodeInvalidGrant,
+			"this connection has been revoked or has expired")
+	}
+
+	// Resolve the site scope at the one audited chokepoint, inside a tenant
+	// transaction so `sites` RLS drops any foreign UUID.
+	ids, err := s.store.ResolveScopeSites(ctx, tok.TenantID,
+		chk.SiteScopeMode, chk.ScopeTagIds, chk.ScopeSiteIds)
+	if err != nil {
+		return AuthorizedRequest{}, fmt.Errorf("resolve grant scope: %w", err)
+	}
+
+	// An empty resolved set means NO SITES. NewSiteSet's zero value allows
+	// nothing, so there is no widening path here even if ids is nil.
+	return AuthorizedRequest{
+		TenantID: tok.TenantID,
+		GrantID:  chk.GrantID,
+		TokenID:  chk.TokenID,
+		Sites:    NewSiteSet(ids),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Credential helpers
+// ---------------------------------------------------------------------------
+
+// hashCredential is lower-case hex SHA-256, matching the '^[0-9a-f]{64}$'
+// CHECK on every hash column and the construction used by internal/apikey and
+// internal/agent/signature.go.
+func hashCredential(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(sum[:])
+}
+
+// randomToken returns nBytes of crypto/rand as unpadded base64url. It returns
+// an error rather than falling back to anything: a credential built from a
+// failed entropy read is the defect class this project is named for.
+func randomToken(nBytes int) (string, error) {
+	buf := make([]byte, nBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("read entropy: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// verifyPKCE checks BASE64URL(SHA256(verifier)) == challenge, in constant time.
+func verifyPKCE(verifier, challenge string) bool {
+	sum := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	return subtle.ConstantTimeCompare([]byte(want), []byte(challenge)) == 1
+}
+
+func scopesToString(scopes []Scope) string {
+	parts := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		parts = append(parts, string(s))
+	}
+	return strings.Join(parts, " ")
+}
+
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// orEmpty normalises a nil slice to an empty one so the uuid[] column receives
+// '{}' rather than NULL. Empty names nothing and therefore grants nothing,
+// which is the restrictive direction; the schema's payload CHECK stops it
+// co-existing with a mode that would make it meaningful.
+func orEmpty(ids []uuid.UUID) []uuid.UUID {
+	if ids == nil {
+		return []uuid.UUID{}
+	}
+	return ids
+}

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -101,9 +101,15 @@ func (s *Service) Register(ctx context.Context, req RegistrationRequest) (Regist
 
 	// RFC 7591 section 2: an omitted token_endpoint_auth_method defaults to
 	// client_secret_basic. That default is the RFC's and it is the RESTRICTIVE
-	// direction -- it mints a secret the client must then present -- so
-	// honouring it does not widen anything. 'none' must be asked for explicitly,
-	// which is the case that matters, because 'none' is the no-secret path.
+	// direction -- it mints a secret that Exchange then REQUIRES the client to
+	// present, over HTTP Basic or in the body, and verifies against the stored
+	// hash in constant time. 'none' must be asked for explicitly, which is the
+	// case that matters, because 'none' is the no-secret PKCE-only path.
+	//
+	// That claim was false when it was first written: the token endpoint read no
+	// secret at all, so the default minted a credential nothing ever asked for
+	// and the sentence described a mode that did not exist (review finding H3).
+	// The check now exists; if it is ever removed, this comment must go with it.
 	method := req.TokenEndpointAuthMethod
 	if method == "" {
 		method = "client_secret_basic"
@@ -349,6 +355,35 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			"the approved request carries no S256 PKCE challenge")
 	}
 
+	// RE-RESOLVE THE CLIENT AND RE-MATCH THE REDIRECT, AGAINST THE STORED ARRAY.
+	//
+	// This is the minting path, and it is the one that has to hold. Everything
+	// in req.Consent arrives in the approval POST body, so the checks Authorize
+	// ran a request earlier are worth nothing here -- a body naming an
+	// unregistered client_id and an attacker's redirect_uri would otherwise mint
+	// a real code carrying the approving operator's tenant, and Exchange would
+	// then honour it because it compares the presented redirect against the one
+	// STORED ON THE CODE ROW. There is no foreign key to catch it either:
+	// mcp_authorization_codes.client_id deliberately carries none (m124
+	// DECISION 12), because the column records a historical fact.
+	//
+	// The invariant this restores is "this code may only travel to a URI this
+	// client registered", not merely "a consent screen was shown once".
+	client, err := s.store.LookupClient(ctx, req.Consent.ClientID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Approval{}, domain.Unauthorized(ErrCodeInvalidClient, "unknown client_id")
+		}
+		return Approval{}, fmt.Errorf("lookup client: %w", err)
+	}
+	// Exact match, against client.RedirectUris -- never against anything that
+	// came in with the request. A prefix, suffix or host-only comparison here is
+	// an open redirector, and so is trusting the body's own copy of the array.
+	if !exactMatchRedirectURI(client.RedirectUris, req.Consent.RedirectURI) {
+		return Approval{}, domain.Validation(ErrCodeInvalidRedirectURI,
+			"redirect_uri does not exactly match a registered redirect URI")
+	}
+
 	code, err := randomToken(32)
 	if err != nil {
 		return Approval{}, fmt.Errorf("generate authorization code: %w", err)
@@ -364,15 +399,16 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			SiteScopeMode:   string(req.SiteScope.Mode),
 			ScopeTagIds:     orEmpty(req.SiteScope.TagIDs),
 			ScopeSiteIds:    orEmpty(req.SiteScope.SiteIDs),
-			ClientID:        nullableText(req.Consent.ClientID),
+			// The RESOLVED client id, not the body's copy of it.
+			ClientID:        nullableText(client.ClientID),
 			CreatedByUserID: uuidToPG(req.UserID),
 		},
 		func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 			return sqlc.CreateMCPAuthorizationCodeParams{
-				TenantID:            req.TenantID,
-				GrantID:             grantID,
-				ClientID:            req.Consent.ClientID,
-				CodeHash:            codeHash,
+				TenantID: req.TenantID,
+				GrantID:  grantID,
+				ClientID: client.ClientID,
+				CodeHash: codeHash,
 				CodeChallenge:       req.Consent.CodeChallenge,
 				CodeChallengeMethod: req.Consent.CodeChallengeMethod,
 				RedirectUri:         req.Consent.RedirectURI,
@@ -401,6 +437,7 @@ type TokenRequest struct {
 	Code         string
 	RedirectURI  string
 	ClientID     string
+	ClientSecret string
 	CodeVerifier string
 }
 
@@ -443,9 +480,56 @@ func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, 
 
 	// 2. Bind the code to the client and the redirect it was issued for
 	// (RFC 6749 4.1.3). Both are exact comparisons.
-	if req.ClientID != "" && req.ClientID != row.ClientID {
+	//
+	// client_id IS REQUIRED, unconditionally. It used to be checked only when
+	// present, which meant OMITTING it skipped the code-to-client binding
+	// entirely -- absence read as permission, which is the shape this whole
+	// surface is built to refuse. RFC 6749 4.1.3 requires it whenever the
+	// client is not authenticating, and requiring it always is stricter than
+	// the RFC rather than looser.
+	if strings.TrimSpace(req.ClientID) == "" {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant, "client_id is required")
+	}
+	if req.ClientID != row.ClientID {
 		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
 			"the authorization code was not issued to this client")
+	}
+
+	// 2b. AUTHENTICATE THE CLIENT WHEN IT REGISTERED A SECRET.
+	//
+	// A client registered client_secret_basic or client_secret_post has a
+	// secret minted, hashed and stored under a CHECK. Never asking for it makes
+	// that whole apparatus decorative, and the registration default is
+	// client_secret_basic -- so the common case was the unauthenticated one.
+	// PKCE already limits the practical exploit; this is the defence in depth
+	// the registration path already believes it has.
+	client, err := s.store.LookupClient(ctx, req.ClientID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient, "unknown client_id")
+		}
+		return IssuedToken{}, fmt.Errorf("lookup client: %w", err)
+	}
+	if client.TokenEndpointAuthMethod != "none" {
+		// The schema's secret_matches_method_check guarantees a non-'none'
+		// client HAS a hash, so a nil here is an impossible row rather than a
+		// public client. Refuse rather than treat it as "no secret required" --
+		// that is the absence-means-permitted reflex m124 DECISION 11 names.
+		if client.ClientSecretHash == nil {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient,
+				"this client is misconfigured and cannot authenticate")
+		}
+		if strings.TrimSpace(req.ClientSecret) == "" {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient,
+				"client_secret is required for this client")
+		}
+		if subtle.ConstantTimeCompare(
+			[]byte(hashCredential(req.ClientSecret)),
+			[]byte(*client.ClientSecretHash),
+		) != 1 {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient,
+				"client authentication failed")
+		}
 	}
 	if req.RedirectURI != row.RedirectUri {
 		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -143,7 +143,10 @@ func (s *Service) Register(ctx context.Context, req RegistrationRequest) (Regist
 		secretHash = &h
 	}
 
-	row, err := s.store.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+	// THE WRITE. It returns a count, not a row: the register GUC enables no
+	// SELECT policy, so RETURNING would raise 42501 and roll the whole
+	// registration back. See Repo.RegisterClient.
+	affected, err := s.store.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
 		ClientID:                clientID,
 		ClientSecretHash:        secretHash,
 		TokenEndpointAuthMethod: method,
@@ -154,14 +157,45 @@ func (s *Service) Register(ctx context.Context, req RegistrationRequest) (Regist
 	if err != nil {
 		return RegisteredClient{}, fmt.Errorf("register client: %w", err)
 	}
+	// A ZERO-ROW WRITE IS A FAILURE, LOUDLY. The query is :execrows rather than
+	// :exec precisely so there is something to assert here. An INSERT ... VALUES
+	// with no ON CONFLICT writes one row or raises, so 0 should be unreachable
+	// -- which is exactly why reaching it must stop the registration rather than
+	// be shrugged off. A silent 0 here would hand back a client_id and a secret
+	// for a row that does not exist.
+	if affected != 1 {
+		return RegisteredClient{}, fmt.Errorf(
+			"register client %q: wrote %d rows, want exactly 1", clientID, affected)
+	}
 
+	// THE READ-BACK, in its own transaction under the lookup GUC. Two round
+	// trips is the deliberate cost of not granting the unauthenticated
+	// registration endpoint the ability to read this table.
+	stored, err := s.store.LookupClient(ctx, clientID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// The insert reported one row and the read found none. That is a
+			// broken invariant, not a client with no details, and it must NOT
+			// be papered over by rebuilding the response from req -- doing so
+			// would report a fabricated success on top of a real failure.
+			return RegisteredClient{}, fmt.Errorf(
+				"register client %q: wrote the registration but could not read it back", clientID)
+		}
+		return RegisteredClient{}, fmt.Errorf("read back registered client %q: %w", clientID, err)
+	}
+
+	// Built from the STORED row, so the response describes what the database
+	// actually holds rather than what the caller asked for. The two can differ
+	// -- trimming, and the auth method defaulted above -- and the stored value
+	// is the true one. ClientSecret is the sole exception: it exists only here,
+	// in memory, and there is no column to read it back from (m124 obligation 6).
 	return RegisteredClient{
-		ClientID:                row.ClientID,
+		ClientID:                stored.ClientID,
 		ClientSecret:            secret, // once, here, never again
-		TokenEndpointAuthMethod: row.TokenEndpointAuthMethod,
-		RedirectURIs:            row.RedirectUris,
-		ClientName:              req.ClientName,
-		ClientURI:               req.ClientURI,
+		TokenEndpointAuthMethod: stored.TokenEndpointAuthMethod,
+		RedirectURIs:            stored.RedirectUris,
+		ClientName:              derefString(stored.ClientName),
+		ClientURI:               derefString(stored.ClientUri),
 	}, nil
 }
 

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -473,7 +473,25 @@ type TokenRequest struct {
 	ClientID     string
 	ClientSecret string
 	CodeVerifier string
+
+	// ClientAuthVia is HOW the credential arrived, not whether it is valid:
+	// "client_secret_basic" (Authorization: Basic), "client_secret_post" (body
+	// parameters), "none" (no secret presented at all), or AuthViaMultiple when
+	// the client used more than one at once.
+	//
+	// It exists because token_endpoint_auth_method is NOT NULL over a closed set
+	// with no default -- the value is always a decision somebody made at
+	// registration -- and a stored decision that nothing honours is a field that
+	// looks like it governs behaviour and does not. The handler determines the
+	// source; only the handler can see the transport.
+	ClientAuthVia string
 }
+
+// AuthViaMultiple marks a request that presented credentials through more than
+// one mechanism. RFC 6749 section 2.3.1: "The client MUST NOT use more than one
+// authentication method in each request." Refusing is the only reading that
+// does not require guessing which one the client meant.
+const AuthViaMultiple = "multiple"
 
 // IssuedToken is the token response. AccessToken is present exactly once.
 type IssuedToken struct {
@@ -500,6 +518,17 @@ func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, 
 	if strings.TrimSpace(req.CodeVerifier) == "" {
 		return IssuedToken{}, domain.Validation(ErrCodeInvalidRequest,
 			"code_verifier is required; this server requires PKCE")
+	}
+	// RFC 6749 section 2.3.1: "The client MUST NOT use more than one
+	// authentication method in each request." This is a property of the REQUEST
+	// SHAPE, independent of whether the code is valid, so it is refused here
+	// with the other shape checks rather than after a credential lookup. A
+	// request carrying both a Basic header and body credentials gives no honest
+	// answer to "which method did the client use", and picking one by precedence
+	// would be a guess.
+	if req.ClientAuthVia == AuthViaMultiple {
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient,
+			"present client credentials through exactly one mechanism, not several")
 	}
 
 	// 1. READ ONLY. This transaction must not write -- see repo.go.
@@ -545,6 +574,25 @@ func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, 
 		return IssuedToken{}, fmt.Errorf("lookup client: %w", err)
 	}
 	if client.TokenEndpointAuthMethod != "none" {
+		// THE REGISTERED TRANSPORT IS ENFORCED, NOT MERELY RECORDED.
+		//
+		// token_endpoint_auth_method is NOT NULL over a closed set with no
+		// default precisely so the value is always a decision. Accepting a
+		// secret through a mechanism the client did not register would make the
+		// column decorative -- the same shape as a column no statement can
+		// write, which m126 deleted rather than leave lying around.
+		//
+		// RFC 6749 2.3.1 requires a server to support Basic and permits the body
+		// form; it does not require accepting whichever one shows up. A client
+		// that registered client_secret_basic and then posts its secret in a
+		// body has either been misconfigured or is not the client it claims to
+		// be, and both deserve a refusal rather than a token. The strict reading
+		// costs a registered client nothing, because it chose the value.
+		if req.ClientAuthVia != client.TokenEndpointAuthMethod {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient,
+				fmt.Sprintf("this client registered %s; credentials presented via %s are refused",
+					client.TokenEndpointAuthMethod, req.ClientAuthVia))
+		}
 		// The schema's secret_matches_method_check guarantees a non-'none'
 		// client HAS a hash, so a nil here is an impossible row rather than a
 		// public client. Refuse rather than treat it as "no secret required" --
@@ -564,6 +612,15 @@ func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, 
 			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient,
 				"client authentication failed")
 		}
+	} else if req.ClientAuthVia != "" && req.ClientAuthVia != "none" {
+		// A PUBLIC CLIENT PRESENTING A SECRET IS REFUSED. 'none' means there is
+		// no secret to compare against (m124 DECISION 11 makes the row shape
+		// unrepresentable), so accepting a credential here would be accepting
+		// one that nothing verifies -- absence of a stored secret read as
+		// "anything matches", which is the exact reflex that decision exists to
+		// prevent.
+		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidClient,
+			"this client registered token_endpoint_auth_method=none and must not present a secret")
 	}
 	if req.RedirectURI != row.RedirectUri {
 		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
@@ -593,35 +650,45 @@ func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, 
 			"code_verifier does not match the code_challenge")
 	}
 
-	// 5. CONSUME, in its own InTenantTx. This is m124 obligation 1.
+	// 5. REDEEM: consume the code and issue the token IN ONE TRANSACTION.
 	//
-	// pgx.ErrNoRows here means the row was NOT updated: a racing exchange won,
-	// or it expired between the transactions, or RLS refused the write. All
-	// three mean refuse. Treating "no row" as "already fine" is exactly how
-	// single-use becomes multi-use, so there is no such branch.
-	if _, err := s.store.ConsumeAuthorizationCode(ctx, row.TenantID, row.ID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
-				"the authorization code could not be redeemed; it was already used or has expired")
-		}
-		return IssuedToken{}, fmt.Errorf("consume authorization code: %w", err)
-	}
-
-	// 6. Only now does a credential exist.
+	// The credential is generated before the call because the insert needs its
+	// hash, but nothing has been persisted yet -- a failure here leaves no trace
+	// and the code stays redeemable.
 	secret, err := randomToken(32)
 	if err != nil {
 		return IssuedToken{}, fmt.Errorf("generate connection token: %w", err)
 	}
 	expiresAt := s.now().UTC().Add(connectionTokenTTL)
-	if _, err := s.store.CreateConnectionToken(ctx, sqlc.CreateMCPConnectionTokenParams{
-		TenantID:    row.TenantID,
-		GrantID:     row.GrantID,
-		TokenPrefix: secret[:tokenPrefixLen],
-		TokenHash:   hashCredential(secret),
-		Status:      string(GrantStatusActive),
-		ExpiresAt:   pgtype.Timestamptz{Time: expiresAt, Valid: true},
-	}); err != nil {
-		return IssuedToken{}, fmt.Errorf("create connection token: %w", err)
+
+	// ATOMIC BY CONSTRUCTION. These used to be two commits, and the ORDER was
+	// right -- burn the code, then mint -- because the reverse risks two tokens
+	// from one code. But two commits meant a failure in between left a state
+	// that is safe and useless: code permanently consumed, no token issued, and
+	// a blameless client unable to retry and forced to restart the whole browser
+	// flow with nothing to explain it. One transaction removes the window
+	// instead of documenting it.
+	//
+	// pgx.ErrNoRows means the compare-and-set matched nothing: a racing exchange
+	// won, it expired since the lookup, or RLS refused the write. All three mean
+	// refuse. Treating "no row" as "already fine" is exactly how single-use
+	// becomes multi-use, so there is no such branch.
+	if _, err := s.store.RedeemAuthorizationCode(ctx, row.TenantID, row.ID,
+		sqlc.CreateMCPConnectionTokenParams{
+			TenantID:    row.TenantID,
+			GrantID:     row.GrantID,
+			TokenPrefix: secret[:tokenPrefixLen],
+			TokenHash:   hashCredential(secret),
+			Status:      string(GrantStatusActive),
+			ExpiresAt:   pgtype.Timestamptz{Time: expiresAt, Valid: true},
+		}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
+				"the authorization code could not be redeemed; it was already used or has expired")
+		}
+		// The consume rolled back with the failure, so the code is still
+		// redeemable and the client may retry this exact request.
+		return IssuedToken{}, fmt.Errorf("redeem authorization code: %w", err)
 	}
 
 	return IssuedToken{

--- a/apps/api/tests/adr064_s6b_mcp_registration_roundtrip_test.go
+++ b/apps/api/tests/adr064_s6b_mcp_registration_roundtrip_test.go
@@ -1,0 +1,250 @@
+// adr064_s6b_mcp_registration_roundtrip_test.go: RFC 7591 dynamic client
+// registration executed against the REAL schema as wpmgr_app.
+//
+// WHY THIS FILE EXISTS. RegisterMCPOAuthClient originally used RETURNING while
+// the only policy app.mcp_client_register enables is FOR INSERT. Under FORCE
+// ROW LEVEL SECURITY the SELECT policy is applied to the returned row as a
+// WithCheckOption, so the statement raised SQLSTATE 42501 at
+// ExecWithCheckOptions and rolled the transaction back: EVERY registration
+// failed at runtime. It is not RETURNING *-specific -- returning the
+// server-generated id alone fails identically -- so "return fewer columns" is
+// not the fix.
+//
+// The whole Go suite was green throughout, because every proof above the SQL
+// layer runs against a fake store that returned a fully populated row from the
+// insert, which Postgres refuses outright. The absence of THIS test is what let
+// it through, so it stays regardless of the outcome.
+//
+// WHAT IS ACTUALLY IN QUESTION HERE. That the register transaction cannot read
+// the row is settled (42501). What nobody had established is that the LOOKUP
+// transaction can. Registration now writes under one GUC and reads back under
+// another, and if mcp_oauth_clients_lookup does not admit the row under
+// app.mcp_client_lookup then registration writes a row it can never read: the
+// endpoint returns an error having already created the client, leaving a live
+// orphan row on every attempt. That is worse than the bug it replaced.
+//
+// HOW IT IS TESTED. Through mcp.Repo and mcp.Service -- the same dispatch
+// production uses, the same generated queries, the same tx helpers. GUCs are
+// never hand-set and no connection is opened by this file. A test that opened
+// its own connection would leave every policy inert and pass regardless, which
+// has happened in this codebase before.
+//
+// The role is load-bearing: wpmgr_app is NOSUPERUSER NOBYPASSRLS, and either
+// privilege would make all of this pass vacuously. It is asserted, and printed.
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpAssertAndReportRole fails unless the transaction is wpmgr_app with neither
+// SUPERUSER nor BYPASSRLS, and logs what it found so the proof carries its own
+// evidence rather than asking the reader to trust it.
+func mcpAssertAndReportRole(t *testing.T, tx pgx.Tx, where string) {
+	t.Helper()
+	var role string
+	var super, bypass bool
+	if err := tx.QueryRow(context.Background(),
+		`SELECT current_user, rolsuper, rolbypassrls
+		   FROM pg_roles WHERE rolname = current_user`).Scan(&role, &super, &bypass); err != nil {
+		t.Fatalf("%s: read the connection's own role: %v", where, err)
+	}
+	t.Logf("%s: current_user=%s rolsuper=%t rolbypassrls=%t", where, role, super, bypass)
+	if super || bypass {
+		t.Fatalf("%s: running as %q with rolsuper=%v rolbypassrls=%v; either one "+
+			"bypasses every policy and this proof would pass without testing anything",
+			where, role, super, bypass)
+	}
+	if role != "wpmgr_app" {
+		t.Fatalf("%s: running as %q, not wpmgr_app, which is the role every real "+
+			"install connects as", where, role)
+	}
+}
+
+// TestMCPRegistrationRoundTripAsAppRole is the proof. Write under one GUC, read
+// back under another, both as wpmgr_app.
+func TestMCPRegistrationRoundTripAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+
+	// Confirm the role inside each of the two transactions the path actually
+	// uses, not on some other connection.
+	if err := pool.InMCPClientRegisterTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientRegisterTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open register tx: %v", err)
+	}
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	clientID := "test-client-" + uuid.NewString()
+	secretHash := strings.Repeat("a", 64) // matches the '^[0-9a-f]{64}$' CHECK
+	name := "Claude Desktop"
+	uri := "https://claude.ai"
+
+	// STEP 1: the write. Must report exactly one row.
+	affected, err := repo.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        &secretHash,
+		TokenEndpointAuthMethod: "client_secret_basic",
+		RedirectUris:            []string{"https://claude.ai/api/mcp/auth_callback"},
+		ClientName:              &name,
+		ClientUri:               &uri,
+	})
+	if err != nil {
+		t.Fatalf("STEP 1 RegisterClient failed as wpmgr_app: %v\n"+
+			"the registration INSERT itself is refused; this is the 42501 class", err)
+	}
+	if affected != 1 {
+		t.Fatalf("STEP 1 RegisterClient wrote %d rows, want exactly 1", affected)
+	}
+	t.Logf("STEP 1 ok: InMCPClientRegisterTx -> RegisterMCPOAuthClient wrote %d row", affected)
+
+	// STEP 2: THE QUESTION. Can the lookup transaction see what the register
+	// transaction wrote?
+	stored, err := repo.LookupClient(ctx, clientID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			t.Fatalf("STEP 2 FAILED: the row was written but mcp_oauth_clients_lookup "+
+				"does not admit it under app.mcp_client_lookup. Registration would "+
+				"create a live orphan row on every attempt and then return an error. "+
+				"client_id=%s", clientID)
+		}
+		t.Fatalf("STEP 2 LookupClient failed as wpmgr_app: %v", err)
+	}
+	t.Logf("STEP 2 ok: InMCPClientLookupTx -> GetMCPOAuthClientByClientIDForLookup "+
+		"returned the row (id=%s)", stored.ID)
+
+	// STEP 3: the row carries the real stored values, every column the RFC 7591
+	// response is built from. Named individually because "it returned a row" is
+	// the outcome most easily half-reported.
+	if stored.ClientID != clientID {
+		t.Errorf("client_id = %q, want %q", stored.ClientID, clientID)
+	}
+	if stored.ClientSecretHash == nil || *stored.ClientSecretHash != secretHash {
+		t.Errorf("client_secret_hash did not survive the round trip: %v", stored.ClientSecretHash)
+	}
+	if stored.TokenEndpointAuthMethod != "client_secret_basic" {
+		t.Errorf("token_endpoint_auth_method = %q", stored.TokenEndpointAuthMethod)
+	}
+	if len(stored.RedirectUris) != 1 || stored.RedirectUris[0] != "https://claude.ai/api/mcp/auth_callback" {
+		t.Errorf("redirect_uris = %v", stored.RedirectUris)
+	}
+	if stored.ClientName == nil || *stored.ClientName != name {
+		t.Errorf("client_name did not survive: %v", stored.ClientName)
+	}
+	if stored.ClientUri == nil || *stored.ClientUri != uri {
+		t.Errorf("client_uri did not survive: %v", stored.ClientUri)
+	}
+	if stored.ID == uuid.Nil {
+		t.Error("id is nil; the server-generated primary key did not come back")
+	}
+	t.Logf("STEP 3 ok: every column the RFC 7591 response is built from survived")
+}
+
+// TestMCPRegisterServiceEndToEndAsAppRole drives the whole thing through
+// mcp.Service.Register -- the function the handler calls -- so the count
+// assertion and the read-back run exactly as they will in production, and the
+// response is checked against what the DATABASE holds rather than what the
+// caller sent.
+func TestMCPRegisterServiceEndToEndAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	svc := mcp.NewService(mcp.NewRepo(pool))
+
+	// Padded on the way in and no auth method supplied, so the stored values
+	// differ from the request on three fields. A response echoed from the
+	// request body fails this.
+	got, err := svc.Register(ctx, mcp.RegistrationRequest{
+		RedirectURIs: []string{"https://claude.ai/api/mcp/auth_callback"},
+		ClientName:   "  Claude Desktop  ",
+		ClientURI:    "  https://claude.ai  ",
+	})
+	if err != nil {
+		t.Fatalf("Service.Register failed against a real database as wpmgr_app: %v", err)
+	}
+
+	if got.ClientID == "" {
+		t.Fatal("no client_id returned")
+	}
+	if got.ClientSecret == "" {
+		t.Error("client_secret_basic was defaulted per RFC 7591 but no secret was returned")
+	}
+	if got.TokenEndpointAuthMethod != "client_secret_basic" {
+		t.Errorf("token_endpoint_auth_method = %q, want the RFC 7591 default",
+			got.TokenEndpointAuthMethod)
+	}
+	if got.ClientName != "Claude Desktop" {
+		t.Errorf("client_name = %q, want the trimmed STORED value; an untrimmed "+
+			"value means the response was echoed from the request", got.ClientName)
+	}
+	if got.ClientURI != "https://claude.ai" {
+		t.Errorf("client_uri = %q, want the trimmed STORED value", got.ClientURI)
+	}
+
+	// And the row really is there, read independently.
+	stored, err := mcp.NewRepo(pool).LookupClient(ctx, got.ClientID)
+	if err != nil {
+		t.Fatalf("the registration reported success but the client cannot be read back: %v", err)
+	}
+	if stored.ClientID != got.ClientID {
+		t.Errorf("read-back client_id = %q, want %q", stored.ClientID, got.ClientID)
+	}
+	t.Logf("Service.Register end to end ok: client_id=%s stored and read back as wpmgr_app",
+		got.ClientID)
+}
+
+// TestMCPRegisterTxCannotReadTheTable pins the constraint that shaped the
+// design: the register GUC enables no SELECT policy, so a read inside that
+// transaction finds nothing. This is why RETURNING failed and why the read-back
+// must be a second transaction. If this ever starts returning rows, someone has
+// widened the registration grant and the unauthenticated POST can enumerate
+// every client on the installation, client_secret_hash included.
+func TestMCPRegisterTxCannotReadTheTable(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	clientID := "isolation-probe-" + uuid.NewString()
+	secretHash := strings.Repeat("b", 64)
+	if _, err := mcp.NewRepo(pool).RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        &secretHash,
+		TokenEndpointAuthMethod: "client_secret_post",
+		RedirectUris:            []string{"https://example.com/cb"},
+	}); err != nil {
+		t.Fatalf("seed registration: %v", err)
+	}
+
+	var visible int
+	if err := pool.InMCPClientRegisterTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "register-tx isolation probe")
+		return tx.QueryRow(ctx, `SELECT count(*) FROM mcp_oauth_clients`).Scan(&visible)
+	}); err != nil {
+		t.Fatalf("count inside the register tx: %v", err)
+	}
+	if visible != 0 {
+		t.Fatalf("the register transaction can see %d rows in mcp_oauth_clients; it "+
+			"must see none. Registration is an UNAUTHENTICATED POST, so a readable "+
+			"table here lets any caller enumerate every registered client and its "+
+			"client_secret_hash", visible)
+	}
+	t.Logf("register-tx isolation ok: 0 rows visible under app.mcp_client_register alone")
+}
+
+// compile-time guard: the fixture drives the real Store implementation.
+var _ mcp.Store = (*mcp.Repo)(nil)
+


### PR DESCRIPTION
Stacked on #572 (S6a-q query layer). **Base is `feat/adr064-s6a-q-mcp-query-layer`, not `main`.** Draft.

DCR (RFC 7591), the authorization endpoint with PKCE, the consent screen's server side, the token endpoint, and the four tx helpers.

## The four tx helpers

`internal/db/db.go` gains `InMCPClientRegisterTx`, `InMCPClientLookupTx`, `InMCPCodeLookupTx`, `InMCPTokenLookupTx` — four rather than one `InMCPTx`, because each opens exactly one table and the narrow name at the call site is what tells you which table you may touch. They share an unexported body so no call site can invent a fifth GUC in passing.

`repo.go` pairs every query with its helper and states the trap at both places it could be got wrong: the lookup policies are `FOR SELECT`, so an UPDATE inside one matches zero rows and raises no error under `FORCE ROW LEVEL SECURITY`. Authentication is two queries, not a join — `mcp_grants` has no lookup policy, so `token JOIN grant` inside the token-lookup transaction matches zero rows and would fail every MCP request silently.

## Proofs — each planted, watched to fail, restored

**Revocation.** Replacing the refusal with `_ = chk.Authorized` (branch on row presence, the stated bug):

```
--- FAIL: TestAuthenticate_RevocationBitesOnTheNextRequest
    a REVOKED grant was still honoured on the next request; revocation must not wait for token expiry
--- FAIL: TestAuthenticate_BranchesOnAuthorizedNotOnRowPresence
    a row with Authorized=false was honoured; the service is branching on row presence
FAIL  github.com/mosamlife/wpmgr/apps/api/internal/mcp  0.631s
```
exit 1. Restored → exit 0. The token in that test is deliberately unexpired, so a service that only checked expiry would pass; this catches it.

**Single use — and this one found a hole in my own proof.** Planting "treat `pgx.ErrNoRows` from the consume as already fine" **did not** redden the replay tests. Both were being refused earlier by the lookup's `IsConsumed` column and never reached the compare-and-set at all — they would have passed with the `ErrNoRows` branch deleted entirely. That is exactly the defect class this slice is guarding against, sitting inside the test written to catch it.

The fake now models the TOCTOU window the compare-and-set exists to close: `raceLost` makes the lookup report a healthy, redeemable code while the UPDATE matches nothing, which is the only path that exercises that branch. With the defect planted:

```
--- FAIL: TestExchange_LosingCompareAndSetIsRefusedNotShrugged
    the losing exchange was granted {AccessToken:D_Zqft8FMKuV3DxjYiiCdBHHRgYq8GWaR2n91EYKCcU
    TokenType:Bearer ExpiresIn:7776000 Scope:mcp:read}; a zero-row consume means REFUSE,
    never 'already fine'
```
exit 1 — a real access token minted for the loser of the race. Restored → exit 0, one consume attempted, zero tokens minted. The test also asserts `consumeCalls == 1` so it cannot silently go back to passing on an earlier check.

**The exit gate now runs end to end through the real Gin handler**, not just the parser: six absence/unrecognised cases each get 400 `invalid_scope` in the RFC 6749 envelope, and the test asserts no consent context leaks on refusal. The over-fire case still returns 200 with the scope granted.

## Other obligations carried

- `redirect_uri` is **exact-matched in Go** against the stored array. Eight redirector shapes are refused by test — path traversal, suffix extension (`...auth_callback.evil.com`), query-appended, subdomain (`claude.ai.evil.com`), truncation, scheme downgrade. There is no `redirect_uri` parameter on the client lookup, so this cannot drift into SQL.
- The consent DTO names the identity `client_name_unverified` and carries `identity_verified` as a **literal `false`** with no field able to set it true, plus `redirect_host` — the part a human can actually judge.
- PKCE mandatory, S256 only; an absent method does not decay to `plain`.
- An empty resolved site scope produces a `SiteSet` that allows nothing (obligation 2), proven through the real service path with a tag matching no site.
- A refused exchange never consumes the code, so a bad request cannot burn a legitimate one.

## Gates, each run unpiped

`go build ./...` exit 0 (pre-existing `ld:` alignment warning from `cmd/media-encoder`), `go vet ./...` exit 0, `go test ./internal/...` exit 0.

## Not here

No MCP protocol, no tool registry, no read tools — that is S6b-2. `Service.Authenticate` is the per-request gate those tools sit behind. The routes are **not mounted in `server.go`** yet; mounting belongs with the transport that uses them.

---

## Inherited debt: this package has NO integration coverage

`grep -rl 'mcp' apps/api/tests/*.go` returns nothing. The integration suite cannot reach `Approve`, `Exchange` or `Authenticate`, so **every proof on this PR is against `fakeStore`, and none runs as the `wpmgr_app` role.**

That matters specifically because the security boundary here is RLS-shaped and the fake cannot model it:

- The four GUC helpers (`InMCPClientRegisterTx`, `InMCPClientLookupTx`, `InMCPCodeLookupTx`, `InMCPTokenLookupTx`) are verified **by reading `repo.go`**, not by executing them. Nothing has yet proven that a write inside a `…ForLookup` transaction really does match zero rows as `wpmgr_app` — the exact failure m124 obligation 1 says is silent.
- `ResolveMCPGrantScopeSitesInTenantTx` dropping foreign UUIDs depends on `sites` RLS. The fake returns whatever it is handed, so the empty-set proof tests the Go half only.
- B1's fix (`LookupClient` + `exactMatchRedirectURI` in `Approve`) is proven through the real Gin handler but against the fake store.

**Whoever mounts these routes inherits the obligation** to add a tenant fixture and integration tests covering: the consume actually writing as `wpmgr_app`, a lookup-transaction write matching zero rows, and cross-tenant site resolution. That belongs with S6b-2's transport, since the routes are not mounted in `server.go` yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth support for MCP clients, including dynamic registration, authorization, consent, and token exchange.
  * Added PKCE protection, redirect URI validation, client authentication, token issuance, and single-use authorization codes.
  * Added authenticated access checks with tenant- and site-scoped permissions.
  * Added OAuth-compliant responses, errors, and cache-control headers.

* **Bug Fixes**
  * Improved registration reliability by validating stored client data before reporting success.
  * Ensured failed token exchanges do not consume authorization codes.

* **Tests**
  * Added comprehensive coverage for security, validation, authorization, registration, and end-to-end OAuth flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->