### PR TITLE
fix(auth): enrich the PATCH /auth/me response with scope and role

### DIFF
--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -511,6 +511,15 @@ func (h *Handler) updateProfile(c *gin.Context) {
 		return
 	}
 	out := toMe(u, memberships, p.TenantID, h.hosted, h.managedStorageAllowed(c.Request.Context(), p.TenantID), "")
+	// Enrich exactly as me() does. PATCH /auth/me returns the SAME Me resource
+	// as GET /auth/me, and clients cache it under the same key — apps/web does
+	// setQueryData(authKeys.me, <patch response>). Omitting scope/role here
+	// does not return a smaller Me, it returns a WRONG one: a site-scoped
+	// collaborator who saves their display name would have me.scope silently
+	// become undefined, canWriteSiteContext would flip to false, and the
+	// context editor would go read-only until a hard reload. An absent field
+	// must never read as a denied permission.
+	enrichMePortal(c.Request.Context(), &out, p, h.svc.repo)
 	c.JSON(http.StatusOK, &out)
 }
 
@@ -683,7 +692,14 @@ func toMe(u User, memberships []Membership, active uuid.UUID, hosted, managedSto
 // enrichMePortal sets the Me.Scope, Me.Role, and Me.Portal fields from the
 // resolved principal. Portal branding (client name, logo, color, agency name)
 // is fetched via a best-effort DB query; failures leave the fields empty.
-// Called only from me() where the principal is fully resolved.
+//
+// Called from every handler that returns a Me built from a principal the auth
+// middleware already resolved — me() and updateProfile(). It is deliberately
+// NOT called from login/register/verifyEmail/oidcCallback or the 2FA
+// completions: those mint the session themselves via issueSessionOrChallenge,
+// so the middleware ran before any cookie existed and there is no resolved
+// principal to read scope/role from. Those clients refetch GET /auth/me once
+// the cookie is set (see apps/web/src/routes/login.tsx).
 func enrichMePortal(ctx context.Context, me *gen.Me, p domain.Principal, repo *Repo) {
 	if p.Scope != "" {
 		me.Scope = gen.NewOptMeScope(gen.MeScope(p.Scope))

--- a/apps/api/tests/adr064_governed_context_positive_control_test.go
+++ b/apps/api/tests/adr064_governed_context_positive_control_test.go
@@ -1,0 +1,84 @@
+package tests
+
+// ADR-064 governed context — the POSITIVE control for the site-scope RLS policy.
+//
+// adr064_governed_context_rls_integration_test.go proves every negative: a
+// site-scoped collaborator cannot author org context, cannot author another
+// site's context, cannot UPDATE, cannot DELETE. Nothing there proves the
+// positive, so a policy that refused EVERYONE would pass that whole suite
+// green. This file is the missing half: a collaborator granted siteA CAN
+// author siteA's own context.
+//
+// The two halves must stay together. canWriteSiteContext in apps/web enables
+// the context editor for exactly this principal, so an over-firing policy
+// would ship a button that always errors, and a suite of negatives would never
+// notice.
+//
+// The test runs as wpmgr_app through InScopedTenantTx — the same dispatch the
+// request path uses — because a test that opens its own connection is a
+// superuser test and leaves the policy inert. It asserts the positive AND a
+// negative control IN ONE RUN, so a green cannot mean "RLS was switched off".
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestADR064_SiteScopedCollaboratorMayAuthorTheirOwnSitesContext(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+	ctx := context.Background()
+
+	f := adr064SeedFixture(t, pool, admin)
+
+	err := adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+		_, e := tx.Exec(ctx,
+			`INSERT INTO site_context_versions
+			   (tenant_id, site_id, version, restrictions, guidance, author_type, author_id, provenance)
+			 VALUES ($1, $2, 2, $3, $4, 'system', NULL, 'manual')`,
+			f.tenant, f.siteA,
+			`{"never_touch_theme": true}`,
+			`{"brand_voice": "written by the collaborator"}`)
+		return e
+	})
+	if err != nil {
+		t.Fatalf("a collaborator granted siteA could NOT author siteA's own context: %v.\n"+
+			"canWriteSiteContext in apps/web enables the editor for exactly this principal; "+
+			"if the database refuses it, the fix ships a button that always errors", err)
+	}
+
+	var n int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*) FROM site_context_versions WHERE site_id = $1`, f.siteA).Scan(&n); err != nil {
+		t.Fatalf("read back siteA: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("siteA has %d context versions, want 2 (seed + collaborator write)", n)
+	}
+
+	// Negative control in the same run: the identical statement against siteB
+	// must be refused, so a green above cannot mean "the policy is inert".
+	var insertErr error
+	_ = adr064AsCollaborator(t, pool, f.tenant, []uuid.UUID{f.siteA}, func(tx pgx.Tx) error {
+		_, insertErr = tx.Exec(ctx,
+			`INSERT INTO site_context_versions
+			   (tenant_id, site_id, version, restrictions, guidance, author_type, author_id, provenance)
+			 VALUES ($1, $2, 2, $3, $4, 'system', NULL, 'manual')`,
+			f.tenant, f.siteB,
+			`{"never_touch_theme": true}`,
+			`{"brand_voice": "written by the collaborator"}`)
+		return insertErr
+	})
+	if insertErr == nil {
+		t.Fatal("NEGATIVE CONTROL FAILED: the same collaborator also wrote siteB's context, " +
+			"so the positive result above proves nothing about the policy")
+	}
+	if !adr064IsRowSecurityRefusal(insertErr) {
+		t.Fatalf("siteB refusal was not a row-security refusal: %v", insertErr)
+	}
+	t.Logf("negative control refused as expected: %v", insertErr)
+}

--- a/apps/api/tests/auth_me_patch_scope_integration_test.go
+++ b/apps/api/tests/auth_me_patch_scope_integration_test.go
@@ -1,0 +1,160 @@
+package tests
+
+// PATCH /auth/me must return the SAME Me resource GET /auth/me returns.
+//
+// Both responses are cached by apps/web under one key — useUpdateProfile does
+// setQueryData(authKeys.me, <the patch response>) — so a field present on the
+// GET and absent from the PATCH does not produce a smaller Me, it produces a
+// WRONG one. scope and role are set in exactly one place, enrichMePortal, and
+// updateProfile did not call it. A site-scoped collaborator who saved their
+// display name lost me.scope, canWriteSiteContext flipped to false, and the
+// governed-context editor went read-only until a hard reload.
+//
+// The test drives the REAL middleware.Authenticator against a REAL site_shares
+// row, so scope/role are resolved the way production resolves them rather than
+// injected by the test. The GET is the in-run control: it proves this principal
+// genuinely is site-scoped, so a green PATCH cannot be green because the
+// fixture forgot to make the user a collaborator.
+//
+// To watch it go red: drop the enrichMePortal call from updateProfile in
+// internal/auth/handler.go. The GET assertions stay green and the PATCH
+// assertions fail, which is exactly the shipped defect.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/apikey"
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/middleware"
+)
+
+// meWire is the slice of the Me response this test cares about.
+type meWire struct {
+	Scope string `json:"scope"`
+	Role  string `json:"role"`
+	User  struct {
+		ID   uuid.UUID `json:"id"`
+		Name string    `json:"name"`
+	} `json:"user"`
+}
+
+// seedSiteShare grants userID collaborator access to siteID at the given role.
+// No membership row is created: site_shares are EXCLUSIVE in
+// middleware.Authenticate, and it is the absence of a membership that sends the
+// principal down the ScopeSite branch.
+func seedSiteShare(t *testing.T, admin *db.Pool, tenant, site, user uuid.UUID, role string) {
+	t.Helper()
+	if _, err := admin.Exec(context.Background(),
+		`INSERT INTO site_shares (tenant_id, site_id, user_id, role) VALUES ($1, $2, $3, $4)`,
+		tenant, site, user, role); err != nil {
+		t.Fatalf("seed site_share: %v", err)
+	}
+}
+
+// authMeEngine mounts the auth routes behind the same Authenticator
+// internal/server/server.go puts in front of them.
+func authMeEngine(t *testing.T, pool *db.Pool, sessions *auth.SessionManager, authSvc *auth.Service) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	authn := middleware.NewAuthenticator(sessions, authSvc, apikey.NewService(pool), pool)
+
+	engine := gin.New()
+	engine.Use(sessions.LoadAndSave())
+	engine.Use(authn.Authenticate())
+	auth.NewHandler(authSvc, sessions, nil, makeCreateTenant(t, pool)).Register(engine)
+	return engine
+}
+
+func authMeDo(engine *gin.Engine, ctx context.Context, method, path, body string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(w, req)
+	return w
+}
+
+func decodeMe(t *testing.T, w *httptest.ResponseRecorder, what string) meWire {
+	t.Helper()
+	if w.Code != http.StatusOK {
+		t.Fatalf("%s: status %d, body %s", what, w.Code, w.Body.String())
+	}
+	var me meWire
+	if err := json.Unmarshal(w.Body.Bytes(), &me); err != nil {
+		t.Fatalf("%s: decode %q: %v", what, w.Body.String(), err)
+	}
+	return me
+}
+
+func TestAuthMe_PatchCarriesScopeAndRoleLikeGet(t *testing.T) {
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	tenant := seedTenant(t, pool, "patchme-"+uuid.NewString()[:8])
+	site := adr064SeedSite(t, admin, tenant)
+	user := seedUserRow(t, admin, "collaborator-"+uuid.NewString()[:8]+"@example.com")
+	seedSiteShare(t, admin, tenant, site, user, "operator")
+
+	sessions := auth.NewSessionManagerWithStore(scs.New(), false)
+	authSvc, _ := newAuthStack(pool)
+	engine := authMeEngine(t, pool, sessions, authSvc)
+
+	ctx, err := sessions.SCS().Load(context.Background(), "")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	if err := sessions.Login(ctx, user, tenant); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	// CONTROL. GET /auth/me already enriched before this change, so this half
+	// says what the principal really is. If these fail the fixture is wrong and
+	// nothing below means anything.
+	got := decodeMe(t, authMeDo(engine, ctx, http.MethodGet, "/auth/me", ""), "GET /auth/me")
+	if got.Scope != "site" {
+		t.Fatalf("fixture is not site-scoped: GET /auth/me scope = %q, want \"site\". "+
+			"The site_shares row did not take effect, so the PATCH assertions below would be vacuous", got.Scope)
+	}
+	if got.Role == "" {
+		t.Fatal("fixture is broken: GET /auth/me carries no role")
+	}
+
+	// THE ASSERTION. Same principal, same resource, one field changed.
+	patched := decodeMe(t,
+		authMeDo(engine, ctx, http.MethodPatch, "/auth/me", `{"name":"Renamed Collaborator"}`),
+		"PATCH /auth/me")
+
+	if patched.User.Name != "Renamed Collaborator" {
+		t.Fatalf("PATCH did not apply the name: got %q", patched.User.Name)
+	}
+	if patched.Scope != got.Scope {
+		t.Fatalf("PATCH /auth/me dropped scope: got %q, want %q (as GET returns).\n"+
+			"apps/web caches this response under authKeys.me, so this collaborator's "+
+			"canWriteSiteContext flips to false and the context editor goes read-only "+
+			"until a hard reload. An absent field must not read as a denied permission",
+			patched.Scope, got.Scope)
+	}
+	if patched.Role != got.Role {
+		t.Fatalf("PATCH /auth/me dropped role: got %q, want %q (as GET returns).\n"+
+			"routes/login.tsx branches on role === \"client\" to pick the portal",
+			patched.Role, got.Role)
+	}
+
+	// The name really changed, so this was a real write and not a no-op that
+	// happened to echo the GET back.
+	refetched := decodeMe(t, authMeDo(engine, ctx, http.MethodGet, "/auth/me", ""), "GET /auth/me after PATCH")
+	if refetched.User.Name != "Renamed Collaborator" {
+		t.Fatalf("the PATCH did not persist: refetched name %q", refetched.User.Name)
+	}
+	t.Logf("PATCH /auth/me returned scope=%q role=%q, matching GET", patched.Scope, patched.Role)
+}


### PR DESCRIPTION
Two findings from the security review of PR #566.

## 1. `PATCH /auth/me` silently revoked a write entitlement

`updateProfile` built its response with `toMe` alone while only `me()` called
`enrichMePortal`, so the patch response carried no `scope` and no `role`.

`apps/web` caches that response under the same key as the GET
(`setQueryData(authKeys.me, updated)` in `features/auth/use-auth.ts:222`), so a
site-scoped collaborator who saved their display name lost `me.scope`:
`canWriteSiteContext` flipped to `false` and the governed-context editor went
read-only until a hard reload. `staleTime` is 5 minutes and `setQueryData`
resets `dataUpdatedAt`, so it did not self-heal. It also broke the portal branch
on `role === "client"`.

Cosmetic until PR #566 made a write entitlement depend on those fields. An
absent field must never read as a considered denial.

Fixed on the API side, so every client benefits and no web change is needed.

### The other `Me`-returning endpoints are correct as they stand

The reviewer asked whether the same gap exists on login, register,
verify-email and the OIDC callback. It does not, and the asymmetry is
structural rather than an oversight.

`Me.scope` and `Me.role` come from `domain.Principal`, which
`internal/middleware/auth.go` resolves from an **existing session cookie**.
Every unenriched `toMe` call site is immediately preceded by
`issueSessionOrChallenge` — login (x2), register, verifyEmail, oidcCallback and
the three 2FA completions all mint the session *in that request*, so the
middleware ran before any cookie existed and there is no resolved principal to
read from. Enriching them would require re-resolving scope from scratch, and
those clients already refetch `GET /auth/me` once the cookie is set:
`apps/web/src/routes/login.tsx:126` does so explicitly, with a comment saying
why.

`me()` and `updateProfile()` are the only two handlers that read an
already-resolved principal and return a `Me`. `updateProfile` was the single
gap. One endpoint was wrong; one endpoint is fixed.

## 2. The RLS suite for governed context proved every negative and no positive

`adr064_governed_context_rls_integration_test.go` shows a collaborator cannot
write another site's context, cannot write org context, cannot UPDATE, cannot
DELETE. Nothing showed that a collaborator **can** write their own site's
context, so a policy that refused everyone would have passed the whole suite.

The reviewer's missing positive control is promoted here into
`apps/api/tests/adr064_governed_context_positive_control_test.go`. It runs as
`wpmgr_app` through `InScopedTenantTx` — the production dispatch, not a
hand-rolled connection — and asserts the positive **and** an in-run negative
control against siteB, so a pass cannot be a policy-inert pass. That pairing is
the point and should survive any later edit.

## Proofs

Fail-before, with the `enrichMePortal` call removed from `updateProfile`:

```
$ go test ./tests/ -run 'TestAuthMe_PatchCarriesScopeAndRoleLikeGet' -v -count=1
    auth_me_patch_scope_integration_test.go:141: PATCH /auth/me dropped scope: got "", want "site"
--- FAIL: TestAuthMe_PatchCarriesScopeAndRoleLikeGet (2.29s)
FAIL    github.com/mosamlife/wpmgr/apps/api/tests       3.294s
rc=1
```

Pass-after, both tests:

```
$ go test ./tests/ -run 'TestAuthMe_PatchCarriesScopeAndRoleLikeGet|TestADR064_SiteScopedCollaboratorMayAuthorTheirOwnSitesContext' -v -count=1
    adr064_governed_context_positive_control_test.go:83: negative control refused as expected: ERROR: new row
      violates row-level security policy "site_context_versions_site_scope" for table
      "site_context_versions" (SQLSTATE 42501)
--- PASS: TestADR064_SiteScopedCollaboratorMayAuthorTheirOwnSitesContext (2.42s)
    auth_me_patch_scope_integration_test.go:159: PATCH /auth/me returned scope="site" role="operator", matching GET
--- PASS: TestAuthMe_PatchCarriesScopeAndRoleLikeGet (2.35s)
ok      github.com/mosamlife/wpmgr/apps/api/tests       5.804s
rc=0
```

The new auth test drives the real `middleware.Authenticator` against a real
`site_shares` row rather than injecting a principal, and uses the GET as an
in-run control so a green PATCH cannot be green because the fixture forgot to
make the user a collaborator.

Gates, each run unpiped: `go build ./...` rc=0, `go vet ./...` rc=0,
`go test ./internal/...` rc=0.

The contract did not move: no `openapi.yaml` change, so no regeneration. `scope`
and `role` are already declared on the `Me` schema and already returned by
`GET /auth/me`; this only stops one handler from omitting them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated profile edits so responses retain the same portal scope, role, and branding details shown when loading the profile.
  - Fixed an issue where site-scoped collaborators could lose editing access after changing their display name.

- **Tests**
  - Added coverage confirming profile updates preserve access permissions.
  - Added validation that site-level security controls allow permitted changes and block unauthorized ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->