### PR TITLE
feat(mcp): S7 tool registry and policy filtering

### DIFF
--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -99,13 +100,38 @@ type fakeStore struct {
 	sitesMore bool
 	sitesErr  error
 
-	// call log
+	// call log. mu guards all four -- see note().
+	mu           sync.Mutex
 	consumeCalls int
 	tokensMinted int
 	calls        []string
 }
 
-func (f *fakeStore) note(s string) { f.calls = append(f.calls, s) }
+// note records one store call.
+//
+// THE MUTEX IS NOT DECORATION. Every fakeStore method calls this, so any test
+// that drives the transport concurrently races here -- and `go test -race` then
+// reports the FIXTURE, which is indistinguishable at first glance from a race in
+// the code under test and is enough to stop a concurrency proof from being run
+// at all. A security review of this surface hit exactly that and could not run
+// its concurrent attack under -race. Two lines buy every future concurrency
+// proof on the busiest fake in this package.
+//
+// It guards the counters too: they are incremented from the same paths.
+func (f *fakeStore) note(s string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, s)
+}
+
+// callLog returns a COPY of the call log, safe to read while other goroutines
+// are still calling the store. A test that ranges over f.calls directly is
+// correct only while it is sequential; this is what a concurrent one must use.
+func (f *fakeStore) callLog() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
 
 // RegisterClient models the :execrows query: it reports ROWS WRITTEN and can
 // never hand back the row, because the register GUC enables no SELECT policy
@@ -175,7 +201,9 @@ func (f *fakeStore) LookupAuthorizationCode(_ context.Context, _ string) (sqlc.G
 // and the test would pass against the broken code.
 func (f *fakeStore) RedeemAuthorizationCode(_ context.Context, _, _ uuid.UUID, tok sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error) {
 	f.note("RedeemAuthorizationCode")
+	f.mu.Lock()
 	f.consumeCalls++
+	f.mu.Unlock()
 
 	// The compare-and-set runs first, inside the transaction.
 	if f.raceLost || f.consumed {

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -1,0 +1,244 @@
+package mcp
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// S7: the capability half of the tool policy.
+//
+// This file answers "WHICH TOOLS may this connection reach". registry.go
+// answers "WHICH TOOLS EXIST, and what does each require". The two are
+// deliberately separate types so that neither can be read as the other, and
+// deliberately joined at exactly one place (AuthorizeTool) that both tools/list
+// and tools/call go through.
+//
+// SiteSet in model.go is the shape this copies. Its zero value allows nothing
+// and it has no method answering "does this mean everything", because the
+// failure being designed against is an empty set read as an unrestricted one.
+// CapabilitySet has the same two properties, for the same reason, on the other
+// axis.
+// ---------------------------------------------------------------------------
+
+// ErrCodeToolNotAvailable is the SINGLE domain code for every reason a tool is
+// not reachable by this connection. See the disclosure note on AuthorizeTool
+// for why there is one code and not three.
+const ErrCodeToolNotAvailable = "mcp_tool_not_available"
+
+// ErrCodeCapabilityUnmapped is the fail-closed refusal for a recognised OAuth
+// scope that no capability mapping covers. It is an internal misconfiguration,
+// not a caller error.
+const ErrCodeCapabilityUnmapped = "mcp_capability_unmapped"
+
+// ErrCodeCapabilityWiderThanDefault is the refusal for a per-connection
+// narrowing request that names a capability the org's default does not hold.
+const ErrCodeCapabilityWiderThanDefault = "mcp_capability_wider_than_default"
+
+// Capability is one discrete thing an MCP connection may do. It is NOT an
+// authz.Permission: an authz.Permission is checked against a user principal and
+// an MCP request has no user principal, only a grant. Keeping the two types
+// distinct stops a tool's declared operator permission from being mistaken for
+// something this path enforces. See ToolPolicy.OperatorPermission.
+type Capability string
+
+// CapSitesRead is the only capability the Phase 1 surface has: read the fleet
+// inventory. The vocabulary is closed (capabilityVocabulary below) for the same
+// reason recognisedScopes is closed -- an unrecognised capability must be a
+// refusal, never a token quietly dropped from a set that is then honoured.
+const CapSitesRead Capability = "mcp.sites.read"
+
+// capabilityVocabulary is the CLOSED set of capabilities this surface knows.
+// A Capability outside it is not a weaker grant, it is an unknown one, and an
+// unknown grant is refused.
+var capabilityVocabulary = map[Capability]struct{}{
+	CapSitesRead: {},
+}
+
+// KnownCapability reports whether c is in the vocabulary.
+func KnownCapability(c Capability) bool {
+	_, ok := capabilityVocabulary[c]
+	return ok
+}
+
+// AllCapabilities lists the vocabulary, sorted, so tests and operator surfaces
+// enumerate it deterministically.
+func AllCapabilities() []Capability {
+	out := make([]Capability, 0, len(capabilityVocabulary))
+	for c := range capabilityVocabulary {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// scopeCapabilities maps each RECOGNISED OAuth scope to the capabilities it
+// confers. It is the org-default source, and it is a total function over
+// recognisedScopes by test (TestEveryRecognisedScopeHasACapabilityMapping).
+//
+// THE TOTALITY IS THE POINT, and it is why CapabilitiesForScopes returns an
+// error rather than skipping. If a write scope is ever added to
+// recognisedScopes and this map is not updated, the tempting behaviour is to
+// yield a smaller set -- which is fail-closed and therefore feels safe. It is
+// still wrong: the operator consented to a scope, the surface silently conferred
+// nothing for it, and neither party is told. That is the same shape as a scope
+// token silently dropped from an otherwise-honoured request, which scope.go
+// already refuses. An unmapped scope is a misconfiguration and it says so.
+var scopeCapabilities = map[Scope][]Capability{
+	ScopeRead: {CapSitesRead},
+}
+
+// CapabilitySet is a RESOLVED set of capabilities.
+//
+// It is a struct and not a []Capability on purpose, and the reasoning is
+// SiteSet's verbatim: a bare slice has a zero value that reads as "no filter
+// applied" at every call site that forgets to check it. This type's zero value
+// allows NOTHING, and there is deliberately NO method answering "does this mean
+// everything". Empty means no capabilities, which means no tools.
+type CapabilitySet struct {
+	caps map[Capability]struct{}
+}
+
+// NewCapabilitySet builds a set from capabilities that are already known to be
+// in the vocabulary. Unknown entries are DROPPED here rather than admitted,
+// because admitting one would put a name outside the vocabulary into a set that
+// AuthorizeTool then compares against -- and the only way a comparison against
+// an unknown name can matter is if something later decided to trust it.
+//
+// Dropping is safe HERE and is not the silent-coercion failure, because
+// dropping only ever removes authority. The place where an unknown name must
+// REFUSE rather than drop is the caller-facing narrowing request, and
+// NarrowTo does exactly that.
+func NewCapabilitySet(caps []Capability) CapabilitySet {
+	set := CapabilitySet{caps: make(map[Capability]struct{}, len(caps))}
+	for _, c := range caps {
+		if !KnownCapability(c) {
+			continue
+		}
+		set.caps[c] = struct{}{}
+	}
+	return set
+}
+
+// Allows reports whether this connection holds c. On an empty or zero-value set
+// it returns false for every capability, which is the entire point.
+func (s CapabilitySet) Allows(c Capability) bool {
+	_, ok := s.caps[c]
+	return ok
+}
+
+// Len is the number of capabilities held.
+func (s CapabilitySet) Len() int { return len(s.caps) }
+
+// IsEmpty reports that this connection holds no capability at all. The caller
+// must handle it as "reaches nothing", and must never widen it.
+func (s CapabilitySet) IsEmpty() bool { return len(s.caps) == 0 }
+
+// Sorted lists the held capabilities for logs and operator surfaces.
+func (s CapabilitySet) Sorted() []Capability {
+	out := make([]Capability, 0, len(s.caps))
+	for c := range s.caps {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// OrgDefaultCapabilities is the WIDEST capability set any connection in this
+// organisation may hold, derived from the scopes the surface granted it.
+//
+// There is no capabilities column on mcp_grants and that is m124 DECISION 1:
+// minting one would create the place a write capability could appear without a
+// migration and without a review. So the org default is DERIVED from the closed
+// scope registry rather than stored, and it cannot exceed what
+// scopeCapabilities maps. When a differentiated-read column does arrive it
+// arrives NOT NULL with no default and a closed CHECK, and it narrows this --
+// it never replaces it as the ceiling.
+//
+// An empty or nil scope list yields an EMPTY set and an error, never a
+// permissive one. Absence is refusal here exactly as it is in
+// ParseRequestedScopes.
+func OrgDefaultCapabilities(scopes []Scope) (CapabilitySet, error) {
+	if len(scopes) == 0 {
+		return CapabilitySet{}, domain.Forbidden(ErrCodeCapabilityUnmapped,
+			"this connection holds no scope, so it confers no capability")
+	}
+
+	out := make([]Capability, 0, len(scopes))
+	for _, s := range scopes {
+		caps, ok := scopeCapabilities[s]
+		if !ok {
+			// Refuse, do not skip. See the comment on scopeCapabilities.
+			return CapabilitySet{}, domain.Forbidden(ErrCodeCapabilityUnmapped,
+				fmt.Sprintf("scope %q confers no capability on this server", s))
+		}
+		out = append(out, caps...)
+	}
+	set := NewCapabilitySet(out)
+	if set.IsEmpty() {
+		// Cannot happen while every mapping is non-empty, and it is checked
+		// rather than assumed because "cannot happen" returning a silently
+		// empty grant is this project's signature defect. An empty set here
+		// would be a working connection that reaches no tool and is told
+		// nothing about why.
+		return CapabilitySet{}, domain.Forbidden(ErrCodeCapabilityUnmapped,
+			"the scopes on this connection resolved to no capability")
+	}
+	return set, nil
+}
+
+// NarrowTo applies PER-CONNECTION NARROWING to an org default.
+//
+// The rule is one-directional: a connection can only ever be NARROWER than its
+// org's default, never wider. So this is an intersection, and a requested
+// capability the default does not hold is a REFUSAL of the whole narrowing --
+// not a token quietly dropped from an otherwise-honoured request.
+//
+// DROPPING WOULD BE THE BUG. It "still works" for a well-behaved caller and it
+// is even fail-closed, because the result is a subset either way. It is still
+// wrong: the operator asked for a connection covering {A, B}, the surface built
+// one covering {A}, and neither party ever learns they disagreed. That is the
+// same reasoning ParseRequestedScopes gives for refusing an unrecognised scope
+// rather than ignoring it, one layer down.
+//
+// An EMPTY requested list is refused. "Narrow me to nothing" is a connection
+// that can do nothing, which is almost certainly a caller that meant to say
+// something and said nothing -- and reading it as "narrow me to nothing" would
+// mint a live credential that silently reaches no tool. It is not read as "keep
+// the default" either; that would be an absence widening a grant.
+func (s CapabilitySet) NarrowTo(requested []Capability) (CapabilitySet, error) {
+	if len(requested) == 0 {
+		return CapabilitySet{}, domain.Validation(ErrCodeCapabilityWiderThanDefault,
+			"a capability narrowing must name at least one capability; "+
+				"an empty list is not a way to request the organisation default")
+	}
+
+	kept := make([]Capability, 0, len(requested))
+	for _, c := range requested {
+		if !s.Allows(c) {
+			// Naming the offending capability back is safe: it is the caller's
+			// own input, and this path is the OPERATOR configuring a connection
+			// in the dashboard, not the model calling a tool. The
+			// non-disclosure rule on AuthorizeTool governs the model-facing
+			// path and does not apply here.
+			return CapabilitySet{}, domain.Validation(ErrCodeCapabilityWiderThanDefault,
+				fmt.Sprintf("capability %q is not held by this organisation's default, "+
+					"so a connection cannot be granted it; a connection may only ever be "+
+					"narrower than the organisation default", c))
+		}
+		kept = append(kept, c)
+	}
+
+	narrowed := NewCapabilitySet(kept)
+	if narrowed.IsEmpty() {
+		// Every requested capability passed s.Allows, so each is in the
+		// vocabulary and NewCapabilitySet dropped none. Reaching here means the
+		// loop accepted every entry and kept none, which cannot happen --
+		// checked rather than assumed, for the reason above.
+		return CapabilitySet{}, domain.Validation(ErrCodeCapabilityWiderThanDefault,
+			"the requested narrowing resolved to no capability")
+	}
+	return narrowed, nil
+}

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -90,6 +90,26 @@ var scopeCapabilities = map[Scope][]Capability{
 	ScopeRead: {CapSitesRead},
 }
 
+// grantScopes returns the OAuth scopes a live grant holds.
+//
+// IT IS A CONSTANT, AND THAT IS THE WHOLE REASON THIS FUNCTION EXISTS RATHER
+// THAN A LITERAL AT THE CALL SITE. mcp_grants has no scopes column (m124
+// DECISION 1 declines to mint one), so there is nothing per-grant to read; every
+// grant that can authenticate holds ScopeRead, because ParseRequestedScopes
+// refuses anything recognisedScopes does not carry and recognisedScopes carries
+// exactly one entry.
+//
+// That reasoning is load-bearing and it EXPIRES the moment a second scope is
+// recognised: a connection granted only the new scope would still be handed
+// ScopeRead's capabilities, which is a widening rather than a narrowing and is
+// therefore the direction that matters. Naming it here gives
+// TestGrantScopesIsExactOnlyWhileOneScopeExists something to point at, and gives
+// whoever adds that scope one obvious place to replace with a real per-grant
+// read.
+func grantScopes() []Scope {
+	return []Scope{ScopeRead}
+}
+
 // CapabilitySet is a RESOLVED set of capabilities.
 //
 // It is a struct and not a []Capability on purpose, and the reasoning is

--- a/apps/api/internal/mcp/policy_test.go
+++ b/apps/api/internal/mcp/policy_test.go
@@ -115,6 +115,37 @@ func TestEveryRecognisedScopeHasACapabilityMapping(t *testing.T) {
 	}
 }
 
+// TestGrantScopesIsExactOnlyWhileOneScopeExists is a TRIPWIRE, not a property
+// test. It asserts the precondition that makes grantScopes' constant honest.
+//
+// Authenticate hands OrgDefaultCapabilities a constant instead of the grant's
+// own scopes, which is exact only while every live grant holds the same single
+// scope. Adding a second recognised scope silently converts that constant into
+// a WIDENING: a connection granted only the new scope keeps being handed
+// ScopeRead's capabilities, and no other test in this package notices, because
+// TestEveryRecognisedScopeHasACapabilityMapping pins the map's totality rather
+// than Authenticate's input.
+//
+// So this fails the moment recognisedScopes grows. The fix when it does is NOT
+// to update the number here: it is to store the grant's scopes and read them,
+// then delete this test.
+func TestGrantScopesIsExactOnlyWhileOneScopeExists(t *testing.T) {
+	if len(recognisedScopes) != 1 {
+		t.Fatalf("recognisedScopes now holds %d scopes, so grantScopes()'s constant is no longer "+
+			"exact: a connection granted only one of them is still handed %v's capabilities by "+
+			"Authenticate, which WIDENS it. Read the grant's own scopes instead of a constant "+
+			"(mcp_grants needs the column first -- see m124 DECISION 1), then delete this test. "+
+			"Do not just update the count.", len(recognisedScopes), ScopeRead)
+	}
+	got := grantScopes()
+	if len(got) != 1 || got[0] != ScopeRead {
+		t.Fatalf("grantScopes() = %v, want exactly [%v]", got, ScopeRead)
+	}
+	if _, ok := recognisedScopes[got[0]]; !ok {
+		t.Fatalf("grantScopes() returns %v, which is not a recognised scope", got[0])
+	}
+}
+
 // TestOrgDefaultForTheReadScope pins the actual Phase 1 answer.
 func TestOrgDefaultForTheReadScope(t *testing.T) {
 	set, err := OrgDefaultCapabilities([]Scope{ScopeRead})

--- a/apps/api/internal/mcp/policy_test.go
+++ b/apps/api/internal/mcp/policy_test.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// The capability set: zero value allows nothing, and there is no widening path.
+// ---------------------------------------------------------------------------
+
+// TestZeroCapabilitySetAllowsNothing is the SiteSet proof on the other axis.
+// The whole reason CapabilitySet is a struct is that a []Capability's zero
+// value reads as "no filter" at any call site that forgets to check it.
+func TestZeroCapabilitySetAllowsNothing(t *testing.T) {
+	var zero CapabilitySet
+	empty := NewCapabilitySet(nil)
+
+	for _, s := range []CapabilitySet{zero, empty, NewCapabilitySet([]Capability{})} {
+		if !s.IsEmpty() || s.Len() != 0 {
+			t.Fatalf("set reports IsEmpty=%v Len=%d, want empty", s.IsEmpty(), s.Len())
+		}
+		for _, c := range AllCapabilities() {
+			if s.Allows(c) {
+				t.Fatalf("an empty capability set allowed %q", c)
+			}
+		}
+		// An unknown name must not be allowed either -- an unrecognised
+		// capability is not a weaker grant, it is no grant.
+		if s.Allows("mcp.anything.at.all") {
+			t.Fatal("an empty capability set allowed an unknown capability")
+		}
+	}
+}
+
+// TestUnknownCapabilityIsNotAdmitted proves NewCapabilitySet drops names
+// outside the vocabulary rather than carrying them. Dropping only ever removes
+// authority here; the place where an unknown name must REFUSE is NarrowTo, and
+// TestNarrowToRefusesWiderThanDefault covers that.
+func TestUnknownCapabilityIsNotAdmitted(t *testing.T) {
+	s := NewCapabilitySet([]Capability{CapSitesRead, "mcp.sites.restart", ""})
+	if s.Len() != 1 {
+		t.Fatalf("Len = %d, want 1; unknown names were admitted: %v", s.Len(), s.Sorted())
+	}
+	if s.Allows("mcp.sites.restart") || s.Allows("") {
+		t.Fatal("an unknown capability was admitted into the set")
+	}
+	if !s.Allows(CapSitesRead) {
+		t.Fatal("the known capability was dropped")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Org default
+// ---------------------------------------------------------------------------
+
+// TestOrgDefaultRefusesAbsence: no scopes means no capabilities AND an error,
+// never the full set. Absence is refusal, exactly as in ParseRequestedScopes.
+func TestOrgDefaultRefusesAbsence(t *testing.T) {
+	for _, scopes := range [][]Scope{nil, {}} {
+		set, err := OrgDefaultCapabilities(scopes)
+		if err == nil {
+			t.Fatalf("OrgDefaultCapabilities(%v) succeeded with %v", scopes, set.Sorted())
+		}
+		if !set.IsEmpty() {
+			t.Fatalf("the refusal path returned a non-empty set: %v", set.Sorted())
+		}
+		de, ok := domain.AsDomain(err)
+		if !ok || de.Code != ErrCodeCapabilityUnmapped {
+			t.Fatalf("err = %v, want %s", err, ErrCodeCapabilityUnmapped)
+		}
+	}
+}
+
+// TestOrgDefaultRefusesAnUnmappedScope: a scope with no capability mapping is
+// refused, NOT skipped. Skipping is fail-closed and still wrong -- see the
+// comment on scopeCapabilities.
+func TestOrgDefaultRefusesAnUnmappedScope(t *testing.T) {
+	set, err := OrgDefaultCapabilities([]Scope{ScopeRead, "mcp:write"})
+	if err == nil {
+		t.Fatalf("an unmapped scope was silently skipped; got %v", set.Sorted())
+	}
+	if !set.IsEmpty() {
+		t.Fatalf("the refusal path returned a non-empty set: %v", set.Sorted())
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Code != ErrCodeCapabilityUnmapped {
+		t.Fatalf("err = %v, want %s", err, ErrCodeCapabilityUnmapped)
+	}
+}
+
+// TestEveryRecognisedScopeHasACapabilityMapping is the drift guard that makes
+// scopeCapabilities total over recognisedScopes. Without it, adding a scope and
+// forgetting the mapping turns every connection holding it into a 500 at
+// Authenticate -- discovered in production rather than here.
+func TestEveryRecognisedScopeHasACapabilityMapping(t *testing.T) {
+	if len(recognisedScopes) == 0 {
+		t.Fatal("recognisedScopes is empty; this guard would pass vacuously")
+	}
+	for s := range recognisedScopes {
+		caps, ok := scopeCapabilities[s]
+		if !ok {
+			t.Errorf("recognised scope %q has no capability mapping", s)
+			continue
+		}
+		if len(caps) == 0 {
+			t.Errorf("recognised scope %q maps to no capability, so it confers nothing", s)
+		}
+		for _, c := range caps {
+			if !KnownCapability(c) {
+				t.Errorf("scope %q maps to %q, which is not in the capability vocabulary", s, c)
+			}
+		}
+	}
+}
+
+// TestOrgDefaultForTheReadScope pins the actual Phase 1 answer.
+func TestOrgDefaultForTheReadScope(t *testing.T) {
+	set, err := OrgDefaultCapabilities([]Scope{ScopeRead})
+	if err != nil {
+		t.Fatalf("OrgDefaultCapabilities: %v", err)
+	}
+	if !set.Allows(CapSitesRead) {
+		t.Fatalf("mcp:read did not confer %q; got %v", CapSitesRead, set.Sorted())
+	}
+	// Duplication adds no authority, matching ParseRequestedScopes.
+	dup, err := OrgDefaultCapabilities([]Scope{ScopeRead, ScopeRead})
+	if err != nil || dup.Len() != set.Len() {
+		t.Fatalf("a repeated scope changed the set: %v vs %v (err %v)", dup.Sorted(), set.Sorted(), err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-connection narrowing
+// ---------------------------------------------------------------------------
+
+// TestNarrowToHonoursANarrowerConnection: a connection narrower than the org
+// default keeps exactly what it asked for.
+func TestNarrowToHonoursANarrowerConnection(t *testing.T) {
+	// A two-capability default, built directly so the proof does not depend on
+	// the Phase 1 vocabulary happening to hold more than one entry.
+	def := NewCapabilitySet(AllCapabilities())
+	if def.IsEmpty() {
+		t.Fatal("the vocabulary is empty; this proof would be vacuous")
+	}
+
+	first := AllCapabilities()[0]
+	narrowed, err := def.NarrowTo([]Capability{first})
+	if err != nil {
+		t.Fatalf("NarrowTo: %v", err)
+	}
+	if !narrowed.Allows(first) {
+		t.Fatalf("the requested capability was not kept: %v", narrowed.Sorted())
+	}
+	if narrowed.Len() != 1 {
+		t.Fatalf("narrowing produced %d capabilities, want 1: %v", narrowed.Len(), narrowed.Sorted())
+	}
+	// The default is untouched: narrowing must not mutate the ceiling it
+	// narrows, or one connection's configuration would silently reshape another's.
+	if def.Len() != len(AllCapabilities()) {
+		t.Fatalf("NarrowTo mutated the org default: %v", def.Sorted())
+	}
+}
+
+// TestNarrowToRefusesWiderThanDefault is the other half of the narrowing proof
+// the slice owes: a per-connection set WIDER than the org default is REFUSED,
+// never granted, and never quietly reduced to the intersection.
+func TestNarrowToRefusesWiderThanDefault(t *testing.T) {
+	// A default that holds nothing at all: every request is wider.
+	narrowDefault := NewCapabilitySet(nil)
+	if _, err := narrowDefault.NarrowTo([]Capability{CapSitesRead}); err == nil {
+		t.Fatal("an empty default granted a capability it does not hold")
+	}
+
+	// A default that holds CapSitesRead, asked for something outside the
+	// vocabulary entirely. Refuse, do not drop.
+	def := NewCapabilitySet([]Capability{CapSitesRead})
+	got, err := def.NarrowTo([]Capability{CapSitesRead, "mcp.sites.restart"})
+	if err == nil {
+		t.Fatalf("a capability outside the default was silently dropped; got %v", got.Sorted())
+	}
+	if !got.IsEmpty() {
+		t.Fatalf("the refusal path returned a non-empty set: %v", got.Sorted())
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Code != ErrCodeCapabilityWiderThanDefault {
+		t.Fatalf("err = %v, want %s", err, ErrCodeCapabilityWiderThanDefault)
+	}
+}
+
+// TestNarrowToRefusesAnEmptyRequest: "narrow me to nothing" is not read as
+// "keep the default" (an absence widening a grant) and is not read as a live
+// connection that reaches nothing. It is refused.
+func TestNarrowToRefusesAnEmptyRequest(t *testing.T) {
+	def := NewCapabilitySet([]Capability{CapSitesRead})
+	for _, req := range [][]Capability{nil, {}} {
+		got, err := def.NarrowTo(req)
+		if err == nil {
+			t.Fatalf("NarrowTo(%v) succeeded with %v", req, got.Sorted())
+		}
+		if got.Allows(CapSitesRead) {
+			t.Fatal("an empty narrowing request returned the org default")
+		}
+	}
+}

--- a/apps/api/internal/mcp/policy_test.go
+++ b/apps/api/internal/mcp/policy_test.go
@@ -14,6 +14,13 @@ import (
 // The whole reason CapabilitySet is a struct is that a []Capability's zero
 // value reads as "no filter" at any call site that forgets to check it.
 func TestZeroCapabilitySetAllowsNothing(t *testing.T) {
+	// The loops below range over AllCapabilities(), so an empty vocabulary
+	// would make this report PASS having checked nothing. Same class as the
+	// registry guards -- see nonEmptyRegistry in registry_test.go.
+	if len(AllCapabilities()) == 0 {
+		t.Fatal("the capability vocabulary is empty, so the loops below check nothing")
+	}
+
 	var zero CapabilitySet
 	empty := NewCapabilitySet(nil)
 

--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -139,6 +139,16 @@ const (
 	// reasonCapabilityNotHeld: the entry exists and this connection's
 	// capability set does not hold what it requires.
 	reasonCapabilityNotHeld refusalReason = "capability_not_held"
+	// reasonSiteScopeEmpty: the entry exists, the capability IS held, and the
+	// connection's resolved site scope is empty, so a site-keyed tool has
+	// nothing it may read.
+	//
+	// Unlike the two above this one is also disclosed to the caller, by name,
+	// as mcp_scope_empty -- see the asymmetry note on visible(). It still needs
+	// a reason constant because the OPERATOR log must carry it: an operator
+	// debugging a scope problem got nothing at all before this existed, on
+	// either the wire or the log.
+	reasonSiteScopeEmpty refusalReason = "site_scope_empty"
 )
 
 // visible reports whether auth may SEE AND CALL entry. tools/list and
@@ -304,7 +314,10 @@ func AuthorizeTool(name string, auth AuthorizedRequest) (ToolPolicy, refusalReas
 			// Only a caller who passed visible() reaches here, so naming the
 			// reason discloses nothing beyond that caller's own tools/list.
 			if entry.RequiresSiteScope && auth.Sites.IsEmpty() {
-				return ToolPolicy{}, "", domain.Forbidden(ErrCodeScopeEmpty,
+				// The reason is returned, NOT "". An empty reason here made the
+				// refusal invisible to the operator log, which is half of what
+				// justifies blurring the other two reasons on the wire.
+				return ToolPolicy{}, reasonSiteScopeEmpty, domain.Forbidden(ErrCodeScopeEmpty,
 					"this connection's site scope resolves to no sites, so there is nothing it may read. "+
 						"This is a refusal, not an empty fleet: check the grant's site scope.")
 			}

--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -1,0 +1,344 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// S7: THE TOOL REGISTRY.
+//
+// S7's exit gate: a capability absent from the registry is unreachable by a
+// schema-guessing model, and DISCOVERY NEVER GRANTS.
+//
+// That second clause is the whole structural claim of this file, and it is a
+// claim about wiring rather than about any single check. Before S7, tools/list
+// returned the closed list and tools/call switched on the tool name with a
+// `default` arm -- so the filter lived on the DISCOVERY path and the INVOCATION
+// path trusted it to have run. That arrangement is correct only for a client
+// that calls tools/list first and believes the answer. A model that guesses a
+// plausible name never takes the discovery path at all, so nothing it guesses
+// is ever filtered.
+//
+// The fix is not a second check bolted onto tools/call. It is that BOTH paths
+// resolve through the SAME function over the SAME closed list:
+//
+//	tools/list  -> VisibleTools(auth)  -> visible(entry, auth)
+//	tools/call  -> AuthorizeTool(name, auth) -> visible(entry, auth)
+//
+// so a tool cannot be callable and invisible. There is no path from a tool name
+// to an invocation that does not pass visible(); the dispatch function itself
+// hangs off the registry entry, so tools/call has no switch and therefore no
+// `default` arm to fall through.
+//
+// THE LIST STAYS CLOSED AND STAYS A FUNCTION. registryTools() returns a fresh
+// slice built from a literal, exactly as Tools() did before this slice, and for
+// the same reason: the read-only claim of this feature is "no write tool is
+// exposed", and that claim is only as strong as the list being closed. There is
+// deliberately NO package-level registry var and NO Register() entry point, so
+// no init function anywhere in the binary can append a tool into the surface at
+// runtime.
+// ---------------------------------------------------------------------------
+
+// toolInvoker runs one tool. It hangs off the registry entry so that adding a
+// tool to the registry without wiring an implementation is a nil that
+// TestEveryRegistryEntryIsInvocable catches, rather than a name that resolves
+// to a `default` arm.
+type toolInvoker func(ctx context.Context, svc *Service, auth AuthorizedRequest, args json.RawMessage) (string, error)
+
+// ToolPolicy is one registry entry: the tool, and everything reaching it
+// requires.
+type ToolPolicy struct {
+	// Name is the wire name. Matching is exact and case-sensitive: a model that
+	// guesses "list-sites" or "listSites" has guessed a name that is not in the
+	// registry, and near-miss normalisation would be exactly the coercion of an
+	// absent value into a plausible one that this codebase is governed by.
+	Name        string
+	Description string
+	InputSchema json.RawMessage
+
+	// Capability is what the connection must hold. Zero-value Capability ("")
+	// is not in the vocabulary, so an entry that forgets to declare one is
+	// unreachable rather than universally reachable.
+	Capability Capability
+
+	// OperatorPermission is the authz permission an OPERATOR would need to do
+	// this by hand in the dashboard. It is DECLARATIVE ON THIS PATH AND IT IS
+	// IMPORTANT TO SAY SO: an MCP request carries a grant, not a user
+	// principal, so there is nothing here for authz.RequirePermission to check
+	// against and no such check runs. What it does do is (a) pin every tool to
+	// a permission that really exists in the control plane's vocabulary, which
+	// TestEveryToolDeclaresAKnownOperatorPermission enforces, and (b) land in
+	// the operator-facing log on every call, so the audit trail says which
+	// dashboard authority the model just exercised.
+	//
+	// It is a separate field from Capability and not a substitute for it. If it
+	// were ever read as the gate, a connection would be granted whatever its
+	// creating operator could do, which is precisely the widening this surface
+	// exists to prevent.
+	OperatorPermission authz.Permission
+
+	// RequiresSiteScope marks a tool that reads site-keyed data. Such a tool is
+	// UNCALLABLE by a connection whose resolved SiteSet is empty -- that is the
+	// per-connection narrowing on the site axis, and unlike the capability axis
+	// it is stored today (mcp_grants.site_scope_mode and its payload).
+	//
+	// A connection scoped to sites it cannot see is not a connection that reads
+	// every site; SiteSet's zero value allows nothing and this flag is what
+	// turns that into a NAMED refusal at the registry gate rather than an empty
+	// result deeper in that reads as a healthy org owning nothing.
+	//
+	// It does NOT hide the tool from tools/list. See the asymmetry note on
+	// visible() for why visibility follows the capability axis alone.
+	RequiresSiteScope bool
+
+	invoke toolInvoker
+}
+
+// registryTools is THE closed list. Every tool this server has, with everything
+// reaching it requires, in one literal.
+//
+// Adding an entry here is the only way a tool becomes reachable, and it is a
+// reviewed diff on a file whose package comment says the surface is read-only.
+// A write tool arrives with its own capability, its own migration for the
+// stored narrowing, and its own review -- never by being appended here.
+func registryTools() []ToolPolicy {
+	return []ToolPolicy{{
+		Name: ToolListSites,
+		Description: "List the WordPress sites this connection may read, with their " +
+			"connection state, health, WordPress/PHP/agent versions, and an explicit " +
+			"inventory staleness stamp. Sites whose plugin/theme inventory has never " +
+			"been collected are reported as never_collected rather than being given a " +
+			"substitute date.",
+		InputSchema:        listSitesSchema,
+		Capability:         CapSitesRead,
+		OperatorPermission: authz.PermSiteRead,
+		RequiresSiteScope:  true,
+		invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, _ json.RawMessage) (string, error) {
+			return svc.ListSitesForModel(ctx, auth)
+		},
+	}}
+}
+
+// ---------------------------------------------------------------------------
+// The one predicate both paths use
+// ---------------------------------------------------------------------------
+
+// refusalReason is the OPERATOR-FACING classification of why a tool was not
+// reachable. It is precise, it is logged, and it is NEVER sent to the caller.
+// See AuthorizeTool.
+type refusalReason string
+
+const (
+	// reasonUnregistered: no entry of that name exists. The model guessed.
+	reasonUnregistered refusalReason = "unregistered"
+	// reasonCapabilityNotHeld: the entry exists and this connection's
+	// capability set does not hold what it requires.
+	reasonCapabilityNotHeld refusalReason = "capability_not_held"
+)
+
+// visible reports whether auth may SEE AND CALL entry. tools/list and
+// tools/call both go through it, which is what makes "callable" and "visible"
+// the same predicate rather than two that agree by convention.
+//
+// IT TESTS THE CAPABILITY AXIS AND NOT THE SITE AXIS, and the asymmetry is
+// deliberate. The two axes answer different questions and are disclosable to
+// different degrees:
+//
+//   - CAPABILITY answers "may this connection reach this tool at all". A
+//     connection that does not hold the capability is not entitled to know the
+//     tool exists, so the tool is absent from tools/list and its name gets the
+//     uniform refusal.
+//
+//   - SITE SCOPE answers "is there any data for it to read". A connection whose
+//     org enabled the tool and whose capability set covers it IS entitled to
+//     know the tool exists -- it would have been listed but for an empty site
+//     scope, which is a fact about its own grant. Gating VISIBILITY on it would
+//     turn the most common benign misconfiguration in this surface into an
+//     unexplainable dead end, and would buy nothing: the only names it hides
+//     are ones the caller's own capability set already entitles it to see.
+//
+// So site scope is enforced at INVOCATION, by AuthorizeTool, with the named
+// mcp_scope_empty refusal that says exactly what is wrong. That keeps the
+// invariant that matters -- nothing is callable that was not visible -- while
+// leaving the actionable half actionable.
+func visible(entry ToolPolicy, auth AuthorizedRequest) (bool, refusalReason) {
+	if !auth.Capabilities.Allows(entry.Capability) {
+		return false, reasonCapabilityNotHeld
+	}
+	return true, ""
+}
+
+// VisibleTools is the tools/list answer: the descriptors for exactly the tools
+// this connection may call. A tool it may not call is ABSENT, not present and
+// marked unavailable -- a disabled entry in a list is still a disclosure that
+// the tool exists.
+//
+// It returns a fresh, possibly empty slice. An empty tools/list is a truthful
+// answer for a connection that reaches nothing, and it is not an error: the
+// client is entitled to know its own surface is empty. The refusal with a
+// reason happens when it CALLS something.
+func VisibleTools(auth AuthorizedRequest) []ToolDescriptor {
+	entries := registryTools()
+	out := make([]ToolDescriptor, 0, len(entries))
+	for _, e := range entries {
+		if ok, _ := visible(e, auth); !ok {
+			continue
+		}
+		out = append(out, ToolDescriptor{
+			Name:        e.Name,
+			Description: e.Description,
+			InputSchema: e.InputSchema,
+		})
+	}
+	return out
+}
+
+// visibleToolNames lists what this connection was actually shown. Safe to
+// return in an error body: it is exactly the tools/list answer this connection
+// is already entitled to, so it discloses nothing new, and it lets a model that
+// mistyped a name it legitimately holds correct in one round trip.
+func visibleToolNames(auth AuthorizedRequest) []string {
+	ts := VisibleTools(auth)
+	out := make([]string, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, t.Name)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// AuthorizeTool -- the tools/call gate, and the disclosure decision
+// ---------------------------------------------------------------------------
+
+// AuthorizeTool resolves a tool name for INVOCATION. It is the only way to get
+// a callable ToolPolicy, and it applies the same visible() predicate tools/list
+// applies, so a name that was never shown is not callable.
+//
+// ------------------------------------------------------------------------
+// THE DISCLOSURE DECISION, AND THE TENSION IT RESOLVES.
+//
+// The brief for this slice asks for "typed refusals that name the reason", and
+// non-disclosure pulls directly against that. "Your organisation has not
+// enabled sites.restart" is a precise, actionable, well-typed refusal -- and it
+// confirms that sites.restart EXISTS to a caller who was never shown it. Repeat
+// that against a wordlist and the refusal messages enumerate the entire tool
+// surface of a product the caller has no entitlement to see, including tools
+// that are unreleased, gated, or being trialled by one organisation.
+//
+// The line drawn here is: A NAME THE CONNECTION WAS NOT SHOWN GETS ONE
+// INDISTINGUISHABLE ANSWER. Unregistered and registered-but-capability-not-held
+// return the same code, the same message and the same data. There is no
+// existence oracle, because there is no observable difference between "no such
+// tool" and "not yours".
+//
+// This is the same call authz.RequireSiteAccess makes one layer down, where a
+// site the caller may not reach answers 404 and not 403 SPECIFICALLY so that
+// probing ids cannot enumerate the fleet. A different answer here would undo
+// that at the MCP boundary for anyone holding any valid connection token.
+//
+// THE REFUSAL IS STILL TYPED -- just not on the caller's axis. The operator
+// gets the precise reason, on the operator's own surface, where the audience is
+// entitled to it: refusalReason is returned to the transport, which logs it
+// with the tenant, the grant and the attempted name. An operator debugging
+// "why can't my client call this" reads one log line and gets the exact answer;
+// an attacker probing names gets one sentence, identical every time.
+//
+// WHAT REMAINS DISCLOSABLE, AND WHY IT IS NOT A LEAK. A tool the connection CAN
+// see fails with its real reason. Two such reasons exist and both are facts
+// about the caller's own grant, for a tool tools/list already showed it:
+//
+//   - the named mcp_scope_empty refusal, when a site-keyed tool has an empty
+//     resolved site scope. This is the actionable case an operator actually
+//     hits, and blurring it would send them hunting a capability problem they
+//     do not have. See the asymmetry note on visible().
+//   - invalid arguments, which carries the schema so a model corrects in one
+//     round trip.
+//
+// The error body also carries the connection's OWN visible tool list, which is
+// exactly the tools/list answer it is already entitled to.
+// ------------------------------------------------------------------------
+//
+// The returned ToolPolicy is not "found"; it is "found AND permitted AND
+// invocable", and there is deliberately no way for a caller to obtain the first
+// without the rest.
+func AuthorizeTool(name string, auth AuthorizedRequest) (ToolPolicy, refusalReason, error) {
+	var found bool
+	var entry ToolPolicy
+	for _, e := range registryTools() {
+		if e.Name == name {
+			entry, found = e, true
+			break
+		}
+	}
+
+	reason := reasonUnregistered
+	if found {
+		var ok bool
+		if ok, reason = visible(entry, auth); ok {
+			if entry.invoke == nil {
+				// A registry entry with no implementation is a build defect,
+				// and it is refused as an INTERNAL failure rather than as a
+				// permission one. Reporting it as "not available to this
+				// connection" would tell an operator their grant is wrong when
+				// the truth is that the server is broken, and they would go and
+				// widen a scope that was never the problem.
+				return ToolPolicy{}, "", fmt.Errorf("registry entry %q has no implementation", name)
+			}
+
+			// THE SITE AXIS, ENFORCED AT THE GATE AND NOT ONLY IN THE SERVICE.
+			//
+			// ListSitesForModel makes this same check, and the redundancy is
+			// deliberate in the same way the Go mirror of a schema CHECK is:
+			// the service check protects the one tool that has it, this one
+			// protects every tool that ever declares RequiresSiteScope,
+			// including the next one whose author forgets. A site-keyed read
+			// reached with an empty resolved scope must REFUSE and say so, not
+			// return an empty result that reads as a healthy org owning
+			// nothing.
+			//
+			// Only a caller who passed visible() reaches here, so naming the
+			// reason discloses nothing beyond that caller's own tools/list.
+			if entry.RequiresSiteScope && auth.Sites.IsEmpty() {
+				return ToolPolicy{}, "", domain.Forbidden(ErrCodeScopeEmpty,
+					"this connection's site scope resolves to no sites, so there is nothing it may read. "+
+						"This is a refusal, not an empty fleet: check the grant's site scope.")
+			}
+			return entry, "", nil
+		}
+	}
+
+	// ONE answer for all three reasons. The reason is returned alongside for
+	// the operator log and never reaches the wire.
+	return ToolPolicy{}, reason, domain.Forbidden(ErrCodeToolNotAvailable,
+		fmt.Sprintf("tool %q is not available to this connection. This answer is the same "+
+			"whether no such tool exists or whether this connection's capabilities do "+
+			"not cover it -- the server does not distinguish those to a caller. Call "+
+			"tools/list for the tools this connection may use; a tool absent from that "+
+			"list is not reachable by naming it here.", name))
+}
+
+// Tools returns the FULL registry surface as descriptors, unfiltered by any
+// connection.
+//
+// IT IS NOT THE tools/list ANSWER and no request path may use it -- VisibleTools
+// is. It exists for operator-facing surfaces and for the drift tests, which
+// need to enumerate what the server has rather than what one grant may reach.
+// It returns a fresh slice from the closed literal for the same reason
+// registryTools does.
+func Tools() []ToolDescriptor {
+	entries := registryTools()
+	out := make([]ToolDescriptor, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, ToolDescriptor{
+			Name:        e.Name,
+			Description: e.Description,
+			InputSchema: e.InputSchema,
+		})
+	}
+	return out
+}

--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -107,7 +107,7 @@ type ToolPolicy struct {
 // A write tool arrives with its own capability, its own migration for the
 // stored narrowing, and its own review -- never by being appended here.
 func registryTools() []ToolPolicy {
-	return []ToolPolicy{{
+	entries := []ToolPolicy{{
 		Name: ToolListSites,
 		Description: "List the WordPress sites this connection may read, with their " +
 			"connection state, health, WordPress/PHP/agent versions, and an explicit " +
@@ -122,6 +122,36 @@ func registryTools() []ToolPolicy {
 			return svc.ListSitesForModel(ctx, auth)
 		},
 	}}
+
+	// EVERY ENTRY GETS ITS OWN COPY OF ITS SCHEMA BYTES.
+	//
+	// A fresh slice of entries is not enough. json.RawMessage is a []byte, so
+	// assigning listSitesSchema into the literal shares one backing array with
+	// every entry this function has ever returned and ever will. The closure
+	// property was therefore half-built: nobody could add a tool, and anybody
+	// holding a returned descriptor could rewrite what an existing tool claims
+	// to accept -- for every later caller, including the tools/list of every
+	// other connection on the instance.
+	//
+	// It is the same failure the SiteSet and CapabilitySet reasoning is built
+	// around, one level in: the container is safe and the contents leak. The
+	// container being immutable is the thing that makes the sharing invisible,
+	// which is why it survived a security review.
+	for i := range entries {
+		entries[i].InputSchema = cloneSchema(entries[i].InputSchema)
+	}
+	return entries
+}
+
+// cloneSchema copies schema bytes so a caller cannot mutate the package's
+// copy. A nil schema stays nil rather than becoming an empty non-nil slice:
+// "no schema" and "an empty schema" are different, and
+// TestRegistryEntriesAreWellFormed refuses the first.
+func cloneSchema(s json.RawMessage) json.RawMessage {
+	if s == nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), s...)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -1,0 +1,283 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// S7 EXIT GATE -- a capability absent from the registry is unreachable by a
+// schema-guessing model, and discovery never grants.
+// ---------------------------------------------------------------------------
+
+// authWith builds an AuthorizedRequest directly, which is how a test reaches
+// the registry gate with a chosen capability set. Both fields are set
+// explicitly: the zero value of each allows nothing, so a test that forgot one
+// would prove the gate works for a reason it did not intend.
+func authWith(caps CapabilitySet, siteIDs ...uuid.UUID) AuthorizedRequest {
+	return AuthorizedRequest{
+		TenantID:     uuid.New(),
+		GrantID:      uuid.New(),
+		TokenID:      uuid.New(),
+		Sites:        NewSiteSet(siteIDs),
+		Capabilities: caps,
+	}
+}
+
+// TestExitGate_GuessedToolNameIsUnreachable is THE proof for this slice.
+//
+// A connection holds NO capability. tools/list therefore shows it nothing. It
+// then names a tool anyway -- the registered name, and a set of plausible
+// guesses a model would produce from the product's vocabulary. Every one must
+// refuse.
+//
+// The registered name is in the table on purpose and it is the load-bearing
+// case. A gate that only refuses names it has never heard of is not a gate: it
+// is a typo checker. The failure this test exists to catch is a tools/call path
+// that resolves a REAL registry entry and dispatches on it without asking
+// whether this connection may reach it, which is exactly what the pre-S7 switch
+// statement did.
+func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
+	// No capability, but a non-empty site scope -- so nothing about this
+	// refusal can be attributed to the site axis.
+	auth := authWith(CapabilitySet{}, uuid.New())
+
+	if got := VisibleTools(auth); len(got) != 0 {
+		t.Fatalf("a connection holding no capability was shown %d tools: %+v", len(got), got)
+	}
+
+	for _, name := range []string{
+		ToolListSites, // REGISTERED, and still unreachable. See above.
+		"list_sites_all",
+		"sites.restart",
+		"restart_site",
+		"update_plugin",
+		"run_backup",
+		"delete_site",
+		"", // the empty name, which must not match a zero-value entry
+	} {
+		t.Run(name, func(t *testing.T) {
+			entry, reason, err := AuthorizeTool(name, auth)
+			if err == nil {
+				t.Fatalf("AuthorizeTool(%q) GRANTED: entry=%+v", name, entry)
+			}
+			if entry.invoke != nil {
+				t.Fatalf("AuthorizeTool(%q) returned an invocable entry alongside its error", name)
+			}
+			de, ok := domain.AsDomain(err)
+			if !ok || de.Code != ErrCodeToolNotAvailable {
+				t.Fatalf("AuthorizeTool(%q) err = %v, want a %s domain error", name, err, ErrCodeToolNotAvailable)
+			}
+			if reason == "" {
+				t.Fatalf("AuthorizeTool(%q) produced no operator-facing reason", name)
+			}
+		})
+	}
+}
+
+// TestExitGate_RefusalIsNotAnExistenceOracle is the disclosure half.
+//
+// The registered name and a name that has never existed must be
+// INDISTINGUISHABLE on the wire: same code, same message, same data. If they
+// diverge, a caller enumerates the product's tool surface with a wordlist.
+//
+// The operator-facing reason must diverge, because that is where the typed
+// refusal actually lives.
+func TestExitGate_RefusalIsNotAnExistenceOracle(t *testing.T) {
+	auth := authWith(CapabilitySet{}, uuid.New())
+
+	_, realReason, realErr := AuthorizeTool(ToolListSites, auth)
+	_, fakeReason, fakeErr := AuthorizeTool("definitely_not_a_tool_xyzzy", auth)
+
+	realDE, ok1 := domain.AsDomain(realErr)
+	fakeDE, ok2 := domain.AsDomain(fakeErr)
+	if !ok1 || !ok2 {
+		t.Fatalf("both refusals must be domain errors; got %v and %v", realErr, fakeErr)
+	}
+	if realDE.Code != fakeDE.Code {
+		t.Fatalf("caller-visible code differs: registered=%q unregistered=%q -- this is an existence oracle",
+			realDE.Code, fakeDE.Code)
+	}
+
+	// The only permitted difference in the message is the echoed name, which is
+	// the caller's own input. Strip it and the two must be identical.
+	realMsg := strings.Replace(realDE.Message, ToolListSites, "NAME", 1)
+	fakeMsg := strings.Replace(fakeDE.Message, "definitely_not_a_tool_xyzzy", "NAME", 1)
+	if realMsg != fakeMsg {
+		t.Fatalf("caller-visible message differs beyond the echoed name -- this is an existence oracle:\n"+
+			"registered:   %s\nunregistered: %s", realMsg, fakeMsg)
+	}
+
+	if realReason == fakeReason {
+		t.Fatalf("the OPERATOR-facing reason must distinguish the two cases; both were %q", realReason)
+	}
+	if realReason != reasonCapabilityNotHeld {
+		t.Fatalf("registered-but-not-held reason = %q, want %q", realReason, reasonCapabilityNotHeld)
+	}
+	if fakeReason != reasonUnregistered {
+		t.Fatalf("unregistered reason = %q, want %q", fakeReason, reasonUnregistered)
+	}
+}
+
+// TestExitGate_VisibilityAndCallabilityAgree walks the whole registry against
+// a connection holding each capability in turn and asserts the two paths never
+// disagree: everything visible is callable, and everything callable was
+// visible.
+//
+// This is the invariant that made the pre-S7 arrangement unsafe. It held then
+// only for a client that called tools/list and believed the answer; here it is
+// a property of the code, because both paths call visible().
+func TestExitGate_VisibilityAndCallabilityAgree(t *testing.T) {
+	site := uuid.New()
+
+	// Every subset of the vocabulary that a single capability can produce, plus
+	// the empty set and the full set.
+	sets := []CapabilitySet{{}, NewCapabilitySet(AllCapabilities())}
+	for _, c := range AllCapabilities() {
+		sets = append(sets, NewCapabilitySet([]Capability{c}))
+	}
+
+	for _, caps := range sets {
+		auth := authWith(caps, site)
+
+		seen := map[string]bool{}
+		for _, d := range VisibleTools(auth) {
+			seen[d.Name] = true
+			if _, _, err := AuthorizeTool(d.Name, auth); err != nil {
+				t.Fatalf("caps=%v: %q was VISIBLE but not callable: %v", caps.Sorted(), d.Name, err)
+			}
+		}
+
+		for _, e := range registryTools() {
+			_, _, err := AuthorizeTool(e.Name, auth)
+			if err == nil && !seen[e.Name] {
+				t.Fatalf("caps=%v: %q was CALLABLE but never shown by tools/list", caps.Sorted(), e.Name)
+			}
+		}
+	}
+}
+
+// TestSiteScopeIsRefusedByName proves the deliberate asymmetry: the site axis
+// does NOT hide a tool, and it refuses by name rather than uniformly.
+//
+// A connection holding the capability with an EMPTY site scope must still see
+// list_sites (its org enabled it, its capabilities cover it), and calling it
+// must produce the named mcp_scope_empty refusal -- not the uniform
+// not-available one, which would send an operator hunting a capability problem
+// they do not have.
+func TestSiteScopeIsRefusedByName(t *testing.T) {
+	auth := authWith(NewCapabilitySet([]Capability{CapSitesRead})) // no sites
+
+	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolListSites {
+		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", got)
+	}
+
+	_, _, err := AuthorizeTool(ToolListSites, auth)
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Code != ErrCodeScopeEmpty {
+		t.Fatalf("err = %v, want a %s domain error", err, ErrCodeScopeEmpty)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Registry drift guards
+// ---------------------------------------------------------------------------
+
+// TestRegistryEntriesAreWellFormed is the drift guard. Each clause catches a
+// way an entry can be added that compiles, passes every other test, and is
+// wrong at runtime.
+func TestRegistryEntriesAreWellFormed(t *testing.T) {
+	entries := registryTools()
+	if len(entries) == 0 {
+		// An empty registry would make every proof above pass vacuously.
+		t.Fatal("the registry is empty; every exit-gate proof above is vacuous")
+	}
+
+	names := map[string]bool{}
+	for _, e := range entries {
+		if strings.TrimSpace(e.Name) == "" {
+			t.Errorf("a registry entry has a blank name")
+			continue
+		}
+		if names[e.Name] {
+			// Two entries with one name means AuthorizeTool's first match wins
+			// and the second is dead -- including if the second is the
+			// restrictive one.
+			t.Errorf("%q is registered twice", e.Name)
+		}
+		names[e.Name] = true
+
+		if e.invoke == nil {
+			t.Errorf("%q has no implementation; it would resolve and then fail internally", e.Name)
+		}
+		if !KnownCapability(e.Capability) {
+			// The zero-value Capability lands here, which is the point: an
+			// entry that forgets to declare one must be unreachable, and this
+			// says so at test time rather than leaving it silently dead.
+			t.Errorf("%q declares capability %q, which is not in the vocabulary", e.Name, e.Capability)
+		}
+		if !authz.KnownPermission(e.OperatorPermission) {
+			t.Errorf("%q declares operator permission %q, which is not in the control plane's vocabulary",
+				e.Name, e.OperatorPermission)
+		}
+		if len(e.InputSchema) == 0 || !json.Valid(e.InputSchema) {
+			t.Errorf("%q has an absent or invalid input schema", e.Name)
+		}
+		if strings.TrimSpace(e.Description) == "" {
+			t.Errorf("%q has no description", e.Name)
+		}
+	}
+}
+
+// TestRegistryIsClosed proves the surface cannot be widened at runtime.
+// registryTools returns a FRESH slice, so mutating what one caller got must not
+// be observable by the next -- the property that makes "no write tool is
+// exposed" a claim about the code rather than about discipline.
+func TestRegistryIsClosed(t *testing.T) {
+	before := len(registryTools())
+
+	stolen := registryTools()
+	stolen = append(stolen, ToolPolicy{Name: "smuggled_write_tool", Capability: CapSitesRead})
+	stolen[0].Name = "hijacked"
+	_ = stolen
+
+	after := registryTools()
+	if len(after) != before {
+		t.Fatalf("registry length moved from %d to %d after a caller appended to its slice", before, len(after))
+	}
+	for _, e := range after {
+		if e.Name == "hijacked" || e.Name == "smuggled_write_tool" {
+			t.Fatalf("a caller mutated the registry: %q is now registered", e.Name)
+		}
+	}
+
+	// Tools() is the unfiltered operator view and must be closed the same way.
+	t1 := Tools()
+	t1 = append(t1, ToolDescriptor{Name: "smuggled"})
+	if len(Tools()) != before {
+		t.Fatalf("Tools() is not a fresh slice")
+	}
+	_ = t1
+}
+
+// TestVisibleToolNamesDiscloseOnlyTheConnectionsOwnSurface guards the error
+// body. It carries a tool list, and that list must be the connection's own
+// tools/list answer -- never the full registry, which is what the pre-S7
+// "unknown tool" error returned.
+func TestVisibleToolNamesDiscloseOnlyTheConnectionsOwnSurface(t *testing.T) {
+	auth := authWith(CapabilitySet{}, uuid.New())
+	if got := visibleToolNames(auth); len(got) != 0 {
+		t.Fatalf("a connection holding no capability was told about %v", got)
+	}
+
+	full := authWith(NewCapabilitySet(AllCapabilities()), uuid.New())
+	if got := visibleToolNames(full); len(got) != len(registryTools()) {
+		t.Fatalf("a fully-capable connection saw %d of %d tools", len(got), len(registryTools()))
+	}
+}

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -16,6 +16,27 @@ import (
 // schema-guessing model, and discovery never grants.
 // ---------------------------------------------------------------------------
 
+// nonEmptyRegistry returns the registry, having first asserted it is not empty.
+//
+// EVERY GUARD IN THIS FILE THAT LOOPS OVER THE REGISTRY GOES THROUGH IT. A
+// range over an empty slice succeeds having checked nothing, so a guard written
+// as a bare loop reports PASS on an empty registry -- which is CLAUDE.md's rule
+// verbatim: a guard that finds nothing must go red, not green.
+//
+// This is the second vacuous-guard finding on this file (TestRegistryIsClosed
+// was the first, and it was misnamed rather than empty), so the fix is one
+// accessor the guards share rather than one assertion pasted into each, which
+// would drift the moment somebody adds a guard and forgets.
+func nonEmptyRegistry(t *testing.T) []ToolPolicy {
+	t.Helper()
+	entries := registryTools()
+	if len(entries) == 0 {
+		t.Fatal("the registry is empty, so every guard that ranges over it would " +
+			"pass having checked nothing")
+	}
+	return entries
+}
+
 // authWith builds an AuthorizedRequest directly, which is how a test reaches
 // the registry gate with a chosen capability set. Both fields are set
 // explicitly: the zero value of each allows nothing, so a test that forgot one
@@ -154,7 +175,7 @@ func TestExitGate_VisibilityAndCallabilityAgree(t *testing.T) {
 			}
 		}
 
-		for _, e := range registryTools() {
+		for _, e := range nonEmptyRegistry(t) {
 			_, _, err := AuthorizeTool(e.Name, auth)
 			if err == nil && !seen[e.Name] {
 				t.Fatalf("caps=%v: %q was CALLABLE but never shown by tools/list", caps.Sorted(), e.Name)
@@ -193,11 +214,7 @@ func TestSiteScopeIsRefusedByName(t *testing.T) {
 // way an entry can be added that compiles, passes every other test, and is
 // wrong at runtime.
 func TestRegistryEntriesAreWellFormed(t *testing.T) {
-	entries := registryTools()
-	if len(entries) == 0 {
-		// An empty registry would make every proof above pass vacuously.
-		t.Fatal("the registry is empty; every exit-gate proof above is vacuous")
-	}
+	entries := nonEmptyRegistry(t)
 
 	names := map[string]bool{}
 	for _, e := range entries {
@@ -247,7 +264,7 @@ func TestRegistryEntriesAreWellFormed(t *testing.T) {
 // test. A test whose name claims the stronger property is worse than no test,
 // because the next reader stops looking.
 func TestRegistryIsNotAliasedAcrossCalls(t *testing.T) {
-	before := len(registryTools())
+	before := len(nonEmptyRegistry(t))
 
 	stolen := registryTools()
 	stolen = append(stolen, ToolPolicy{Name: "smuggled_write_tool", Capability: CapSitesRead})
@@ -273,6 +290,61 @@ func TestRegistryIsNotAliasedAcrossCalls(t *testing.T) {
 	_ = t1
 }
 
+// TestSchemaBytesAreNotSharedAcrossCallers is the other half of the closure
+// property, and the half that was missing.
+//
+// A fresh slice of descriptors is not enough. json.RawMessage is a []byte, so
+// before this the schema bytes were shared with every descriptor the package
+// ever handed out: nobody could add a tool, and anybody holding one returned
+// descriptor could rewrite what an existing tool claims to accept, for every
+// later caller on the instance. The container was immutable, which is exactly
+// what made the sharing invisible.
+func TestSchemaBytesAreNotSharedAcrossCallers(t *testing.T) {
+	first := Tools()
+	if len(first) == 0 {
+		t.Fatal("Tools() is empty, so this guard checks nothing")
+	}
+	if len(first[0].InputSchema) == 0 {
+		t.Fatal("the first tool has no schema, so this guard checks nothing")
+	}
+
+	original := string(first[0].InputSchema)
+
+	// A caller scribbles on the schema it was handed.
+	for i := range first[0].InputSchema {
+		first[0].InputSchema[i] = 'X'
+	}
+
+	if got := string(Tools()[0].InputSchema); got != original {
+		t.Fatalf("mutating one caller's schema changed the package's copy:\n got  %s\n want %s", got, original)
+	}
+
+	// VisibleTools and AuthorizeTool hand out the same bytes and must be
+	// independent too.
+	auth := authWith(NewCapabilitySet(AllCapabilities()), uuid.New())
+	vis := VisibleTools(auth)
+	if len(vis) == 0 {
+		t.Fatal("a fully-capable connection saw no tools, so this half checks nothing")
+	}
+	for i := range vis[0].InputSchema {
+		vis[0].InputSchema[i] = 'Y'
+	}
+	if got := string(VisibleTools(auth)[0].InputSchema); got != original {
+		t.Fatalf("VisibleTools shares schema bytes across callers:\n got  %s\n want %s", got, original)
+	}
+
+	entry, _, err := AuthorizeTool(ToolListSites, auth)
+	if err != nil {
+		t.Fatalf("AuthorizeTool: %v", err)
+	}
+	for i := range entry.InputSchema {
+		entry.InputSchema[i] = 'Z'
+	}
+	if got := string(Tools()[0].InputSchema); got != original {
+		t.Fatalf("AuthorizeTool shares schema bytes with the registry:\n got  %s\n want %s", got, original)
+	}
+}
+
 // TestNoRegisteredToolIsWriteShaped is the closure half the aliasing test above
 // does NOT cover, kept here so the registry file carries its own read-only
 // guard rather than relying on a transport test to catch a registry change.
@@ -287,7 +359,7 @@ func TestNoRegisteredToolIsWriteShaped(t *testing.T) {
 		"install", "uninstall", "activate", "deactivate", "write",
 		"set_", "purge", "restore", "rollback", "run_", "exec",
 	}
-	for _, e := range registryTools() {
+	for _, e := range nonEmptyRegistry(t) {
 		lower := strings.ToLower(e.Name)
 		for _, verb := range forbidden {
 			if strings.Contains(lower, verb) {
@@ -313,8 +385,12 @@ func TestVisibleToolNamesDiscloseOnlyTheConnectionsOwnSurface(t *testing.T) {
 		t.Fatalf("a connection holding no capability was told about %v", got)
 	}
 
+	// len(got) == len(registry) is satisfied by 0 == 0, so the registry is
+	// asserted non-empty first: otherwise this guard reports PASS on a server
+	// with no tools at all.
+	want := len(nonEmptyRegistry(t))
 	full := authWith(NewCapabilitySet(AllCapabilities()), uuid.New())
-	if got := visibleToolNames(full); len(got) != len(registryTools()) {
-		t.Fatalf("a fully-capable connection saw %d of %d tools", len(got), len(registryTools()))
+	if got := visibleToolNames(full); len(got) != want {
+		t.Fatalf("a fully-capable connection saw %d of %d tools", len(got), want)
 	}
 }

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -235,11 +235,18 @@ func TestRegistryEntriesAreWellFormed(t *testing.T) {
 	}
 }
 
-// TestRegistryIsClosed proves the surface cannot be widened at runtime.
-// registryTools returns a FRESH slice, so mutating what one caller got must not
-// be observable by the next -- the property that makes "no write tool is
-// exposed" a claim about the code rather than about discipline.
-func TestRegistryIsClosed(t *testing.T) {
+// TestRegistryIsNotAliasedAcrossCalls proves registryTools returns a FRESH
+// slice, so mutating what one caller got is not observable by the next.
+//
+// IT IS NAMED FOR WHAT IT TESTS. It was called TestRegistryIsClosed, which
+// overclaimed: a review mutation that added a write-shaped delete_site tool to
+// the literal passed this test unchanged, and was caught by
+// TestToolsList_IsToolsOnlyAndReadOnly instead. Aliasing and closure are
+// different properties -- this one covers runtime mutation of a returned slice,
+// and the read-only claim about the literal's CONTENTS belongs to that other
+// test. A test whose name claims the stronger property is worse than no test,
+// because the next reader stops looking.
+func TestRegistryIsNotAliasedAcrossCalls(t *testing.T) {
 	before := len(registryTools())
 
 	stolen := registryTools()
@@ -264,6 +271,36 @@ func TestRegistryIsClosed(t *testing.T) {
 		t.Fatalf("Tools() is not a fresh slice")
 	}
 	_ = t1
+}
+
+// TestNoRegisteredToolIsWriteShaped is the closure half the aliasing test above
+// does NOT cover, kept here so the registry file carries its own read-only
+// guard rather than relying on a transport test to catch a registry change.
+//
+// It is a NAME-SHAPE heuristic and says so: it cannot tell what a tool does, it
+// can only refuse verbs a read tool has no business declaring. That is enough
+// to make a write tool arrive as a visible, deliberate act -- someone has to
+// delete a case from this list, in a diff, with a reason.
+func TestNoRegisteredToolIsWriteShaped(t *testing.T) {
+	forbidden := []string{
+		"create", "update", "delete", "remove", "restart", "reboot",
+		"install", "uninstall", "activate", "deactivate", "write",
+		"set_", "purge", "restore", "rollback", "run_", "exec",
+	}
+	for _, e := range registryTools() {
+		lower := strings.ToLower(e.Name)
+		for _, verb := range forbidden {
+			if strings.Contains(lower, verb) {
+				t.Errorf("tool %q contains the write-shaped verb %q. The MCP surface is read-only "+
+					"BY CONSTRUCTION (m124 DECISION 1) -- a write tool arrives with its own "+
+					"capability, its own migration and its own security review, never by being "+
+					"appended to registryTools.", e.Name, verb)
+			}
+		}
+		if e.OperatorPermission == authz.PermSiteWrite {
+			t.Errorf("tool %q declares the site:write operator permission on a read-only surface", e.Name)
+		}
+	}
 }
 
 // TestVisibleToolNamesDiscloseOnlyTheConnectionsOwnSurface guards the error

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -784,16 +784,30 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	// construction -- ParseRequestedScopes refuses anything else and
 	// recognisedScopes holds exactly that one entry.
 	//
-	// WHAT IS NOT WIRED YET, SAID PLAINLY RATHER THAN IMPLIED: there is no
-	// stored per-connection capability narrowing, so this value IS the org
-	// default. CapabilitySet.NarrowTo is the mechanism that applies one, and it
-	// refuses a request wider than the default rather than granting it; the
-	// COLUMN it would read from arrives with its own migration, NOT NULL, no
-	// default, closed CHECK, exactly as DECISION 1 requires. Writing a
-	// half-wired narrowing that silently defaults to the ceiling would be the
-	// absence-read-as-a-value failure this whole surface is built against, so
-	// the gap is a comment and a returned error, not a nil treated as permissive.
-	caps, err := OrgDefaultCapabilities([]Scope{ScopeRead})
+	// WHAT IS NOT WIRED YET, SAID PLAINLY RATHER THAN IMPLIED. Two gaps, and
+	// the second is a LATENT WIDENING rather than a missing narrowing:
+	//
+	//  1. There is no stored per-connection capability narrowing, so this value
+	//     IS the org default. CapabilitySet.NarrowTo is the mechanism that
+	//     applies one, and it refuses a request wider than the default rather
+	//     than granting it; the COLUMN it would read from arrives with its own
+	//     migration, NOT NULL, no default, closed CHECK, as DECISION 1
+	//     requires.
+	//
+	//  2. THE SCOPE LIST BELOW IS A CONSTANT, NOT THE GRANT'S OWN SCOPES.
+	//     mcp_grants has no scopes column, so there is nothing per-grant to
+	//     read; grantScopes() returns the one scope every live grant holds by
+	//     construction. That is exact TODAY and only because recognisedScopes
+	//     holds exactly one entry. The day a second scope joins it, a
+	//     connection granted ONLY that scope would still be handed ScopeRead's
+	//     capabilities here -- a widening, and one no existing test catches,
+	//     because TestEveryRecognisedScopeHasACapabilityMapping pins the map's
+	//     totality and not this function's input.
+	//
+	//     TestGrantScopesIsExactOnlyWhileOneScopeExists goes red the moment
+	//     recognisedScopes grows, so whoever adds the second scope is forced to
+	//     come here and read a grant's scopes instead of a constant.
+	caps, err := OrgDefaultCapabilities(grantScopes())
 	if err != nil {
 		// A capability set that cannot be resolved is a REFUSAL, never an
 		// empty-but-proceeding one. An AuthorizedRequest with a zero-value

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -434,22 +434,22 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 
 	grant, _, err := s.store.CreateGrantWithCode(ctx,
 		sqlc.CreateMCPGrantParams{
-			TenantID:        req.TenantID,
-			Name:            strings.TrimSpace(req.GrantName),
-			Status:          string(GrantStatusActive),
-			SiteScopeMode:   string(req.SiteScope.Mode),
-			ScopeTagIds:     orEmpty(req.SiteScope.TagIDs),
-			ScopeSiteIds:    orEmpty(req.SiteScope.SiteIDs),
+			TenantID:      req.TenantID,
+			Name:          strings.TrimSpace(req.GrantName),
+			Status:        string(GrantStatusActive),
+			SiteScopeMode: string(req.SiteScope.Mode),
+			ScopeTagIds:   orEmpty(req.SiteScope.TagIDs),
+			ScopeSiteIds:  orEmpty(req.SiteScope.SiteIDs),
 			// The RESOLVED client id, not the body's copy of it.
 			ClientID:        nullableText(client.ClientID),
 			CreatedByUserID: uuidToPG(req.UserID),
 		},
 		func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 			return sqlc.CreateMCPAuthorizationCodeParams{
-				TenantID: req.TenantID,
-				GrantID:  grantID,
-				ClientID: client.ClientID,
-				CodeHash: codeHash,
+				TenantID:            req.TenantID,
+				GrantID:             grantID,
+				ClientID:            client.ClientID,
+				CodeHash:            codeHash,
 				CodeChallenge:       req.Consent.CodeChallenge,
 				CodeChallengeMethod: req.Consent.CodeChallengeMethod,
 				RedirectUri:         req.Consent.RedirectURI,
@@ -715,7 +715,17 @@ type AuthorizedRequest struct {
 	TenantID uuid.UUID
 	GrantID  uuid.UUID
 	TokenID  uuid.UUID
-	Sites    SiteSet
+
+	// Sites is the resolved site scope: the PER-CONNECTION narrowing on the
+	// site axis. Zero value allows nothing.
+	Sites SiteSet
+
+	// Capabilities is the resolved capability set: which tools this connection
+	// may reach. Zero value allows nothing, so an AuthorizedRequest built by a
+	// literal in a test -- or by any future code path that forgets to set it --
+	// reaches NO tool rather than every tool. That is why it is a CapabilitySet
+	// and not a []string.
+	Capabilities CapabilitySet
 }
 
 // Authenticate resolves a bearer token and re-checks its grant against CURRENT
@@ -762,13 +772,45 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 		return AuthorizedRequest{}, fmt.Errorf("resolve grant scope: %w", err)
 	}
 
+	// Resolve the CAPABILITY set (S7). Two axes narrow an MCP connection and
+	// they are independent: the site axis above says WHICH SITES, this one says
+	// WHICH TOOLS.
+	//
+	// THE ORG DEFAULT IS DERIVED, NOT STORED, AND THAT IS m124 DECISION 1. There
+	// is deliberately no capabilities column on mcp_grants, because minting one
+	// would create the place a write capability could appear without a
+	// migration and without a review. So the ceiling is computed from the closed
+	// scope registry, and every live grant on this surface holds ScopeRead by
+	// construction -- ParseRequestedScopes refuses anything else and
+	// recognisedScopes holds exactly that one entry.
+	//
+	// WHAT IS NOT WIRED YET, SAID PLAINLY RATHER THAN IMPLIED: there is no
+	// stored per-connection capability narrowing, so this value IS the org
+	// default. CapabilitySet.NarrowTo is the mechanism that applies one, and it
+	// refuses a request wider than the default rather than granting it; the
+	// COLUMN it would read from arrives with its own migration, NOT NULL, no
+	// default, closed CHECK, exactly as DECISION 1 requires. Writing a
+	// half-wired narrowing that silently defaults to the ceiling would be the
+	// absence-read-as-a-value failure this whole surface is built against, so
+	// the gap is a comment and a returned error, not a nil treated as permissive.
+	caps, err := OrgDefaultCapabilities([]Scope{ScopeRead})
+	if err != nil {
+		// A capability set that cannot be resolved is a REFUSAL, never an
+		// empty-but-proceeding one. An AuthorizedRequest with a zero-value
+		// CapabilitySet reaches no tool, so proceeding would produce a
+		// connection that authenticates and then refuses everything with no
+		// explanation anywhere.
+		return AuthorizedRequest{}, fmt.Errorf("resolve grant capabilities: %w", err)
+	}
+
 	// An empty resolved set means NO SITES. NewSiteSet's zero value allows
 	// nothing, so there is no widening path here even if ids is nil.
 	return AuthorizedRequest{
-		TenantID: tok.TenantID,
-		GrantID:  chk.GrantID,
-		TokenID:  chk.TokenID,
-		Sites:    NewSiteSet(ids),
+		TenantID:     tok.TenantID,
+		GrantID:      chk.GrantID,
+		TokenID:      chk.TokenID,
+		Sites:        NewSiteSet(ids),
+		Capabilities: caps,
 	}, nil
 }
 

--- a/apps/api/internal/mcp/tools.go
+++ b/apps/api/internal/mcp/tools.go
@@ -15,8 +15,12 @@ import (
 //
 // Resources and prompts are out of scope for Phase 1 -- not refused on
 // principle, but unbudgeted and undesigned, and shipping them half-specified
-// is worse than their absence. The registry and its per-site policy filtering
-// are S7; this file is a flat, positively-enumerated list of one.
+// is worse than their absence.
+//
+// THE LIST ITSELF MOVED TO registry.go AT S7, along with what each tool
+// requires and the single predicate tools/list and tools/call both resolve
+// through. This file keeps the descriptor type, the schemas, and the rendering
+// of the one read tool's result.
 //
 // Every tool here must be expressible at the FLOOR revision. Header-less
 // clients are floor clients by definition, so a capability that exists only at
@@ -63,23 +67,6 @@ var listSitesSchema = json.RawMessage(`{
   "properties": {},
   "additionalProperties": false
 }`)
-
-// Tools returns the Phase 1 tool surface. It is a function returning a fresh
-// slice rather than an exported package var so no caller can append a tool
-// into the surface at runtime -- the read-only claim of this feature is
-// exactly "no write tool is exposed", and that claim is only as strong as the
-// list being closed.
-func Tools() []ToolDescriptor {
-	return []ToolDescriptor{{
-		Name: ToolListSites,
-		Description: "List the WordPress sites this connection may read, with their " +
-			"connection state, health, WordPress/PHP/agent versions, and an explicit " +
-			"inventory staleness stamp. Sites whose plugin/theme inventory has never " +
-			"been collected are reported as never_collected rather than being given a " +
-			"substitute date.",
-		InputSchema: listSitesSchema,
-	}}
-}
 
 // ---------------------------------------------------------------------------
 // The site record, and the staleness stamp

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -68,12 +68,19 @@ const (
 	// inline, so the model corrects in one round trip.
 	codeInvalidToolArguments = -32003
 
-	// codeToolNotAvailable is the SINGLE code for every reason a named tool is
-	// not reachable by this connection: it does not exist, this connection's
-	// capabilities do not cover it, or its site scope is empty. One code for
-	// three reasons is deliberate and is the whole disclosure decision -- see
-	// the note on AuthorizeTool. A client branching on the number learns
-	// "ask tools/list", which is the only correct action in all three cases.
+	// codeToolNotAvailable is the single code for the TWO reasons a named tool
+	// is not reachable that a caller must not be able to tell apart: no such
+	// tool exists, or this connection's capabilities do not cover it. One code
+	// for two reasons is deliberate and is the whole disclosure decision -- see
+	// the note on AuthorizeTool. A client branching on the number learns "ask
+	// tools/list", which is the only correct action in both cases.
+	//
+	// AN EMPTY SITE SCOPE IS NOT ONE OF THEM and does not answer -32004. It
+	// answers codeScopeEmpty (-32002) above, by name, because a connection
+	// whose capability set already covers the tool is entitled to know the tool
+	// exists -- see the asymmetry note on visible(). An earlier version of this
+	// comment claimed -32004 covered the scope-empty case too. It never did:
+	// TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList asserts -32002.
 	codeToolNotAvailable = -32004
 )
 
@@ -285,15 +292,34 @@ func (h *TransportHandler) serve(c *gin.Context) {
 
 	// A request with no id is a NOTIFICATION: it takes no response body. 202
 	// with an empty body is what the Streamable HTTP transport specifies.
-	isNotification := len(req.ID) == 0
+	//
+	// THE CHECK IS BEFORE DISPATCH, AND THAT ORDERING IS THE POINT.
+	//
+	// It used to be after: dispatch ran, the tool EXECUTED, and then the 202
+	// swallowed the result. An id-less tools/call was therefore a
+	// fire-and-forget invocation channel -- the caller triggered the work and
+	// received an empty body, so nothing it did was observable in its own
+	// response.
+	//
+	// That is harmless only while every tool is a read. The moment a write tool
+	// lands it is exactly the shape the proposal machinery exists to prevent: an
+	// effect with no answer, no result to show a user, and no record the caller
+	// ever sees. Fixing it after that tool ships would mean fixing it under
+	// pressure, so it is fixed now, while the only thing it can suppress is a
+	// list of sites.
+	//
+	// Returning early also costs nothing correct. Every method this server
+	// implements that is legitimately sent as a notification
+	// (notifications/initialized, ping) is a no-op whose only product IS the
+	// response, and initialize is required by the spec to carry an id.
+	if len(req.ID) == 0 {
+		c.Status(http.StatusAccepted)
+		return
+	}
 
 	resp, status, handled := h.dispatch(c, auth, neg, req)
 	if !handled {
 		return // dispatch already wrote the response
-	}
-	if isNotification {
-		c.Status(http.StatusAccepted)
-		return
 	}
 	c.JSON(status, resp)
 }
@@ -457,11 +483,22 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 
 	entry, reason, err := AuthorizeTool(p.Name, auth)
 	if err != nil {
-		if de, ok := domain.AsDomain(err); ok && de.Code == ErrCodeToolNotAvailable {
-			// THE PRECISE REASON GOES HERE AND ONLY HERE. The operator log
-			// distinguishes "no such tool" from "capability not held" from
-			// "site scope empty"; the wire answer below does not, so there is
-			// no existence oracle. See the disclosure note on AuthorizeTool.
+		// THE OPERATOR LOG IS WRITTEN FOR EVERY REFUSAL WITH A REASON, not
+		// only for the ones the wire blurs.
+		//
+		// It used to be written only inside the not-available branch, which
+		// left the scope-empty refusal with NO operator line anywhere: it
+		// returned early to toolError, and toolError logs nothing for a domain
+		// error. That made a comment two lines up ("the operator log
+		// distinguishes ... site scope empty") false, and the false half was
+		// load-bearing -- "the operator can still tell them apart" is part of
+		// what justifies blurring the other two on the wire. An operator
+		// debugging a scope problem got nothing on either side.
+		//
+		// So: log first, on the reason, and let the wire answer be decided
+		// separately below. The three reasons are distinguished HERE; only two
+		// of them are blurred on the wire.
+		if reason != "" {
 			h.log.WarnContext(ctx, "mcp tool refused",
 				slog.String("tenant_id", auth.TenantID.String()),
 				slog.String("grant_id", auth.GrantID.String()),
@@ -470,6 +507,9 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 				slog.Int("held_capabilities", auth.Capabilities.Len()),
 				slog.Int("scoped_sites", auth.Sites.Len()),
 			)
+		}
+
+		if de, ok := domain.AsDomain(err); ok && de.Code == ErrCodeToolNotAvailable {
 			// available_tools is this connection's OWN tools/list answer, so it
 			// discloses nothing it was not already shown, and it lets a model
 			// that mistyped a name it legitimately holds correct in one round
@@ -481,9 +521,10 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 			})
 			return newErrorResponse(req.ID, codeToolNotAvailable, de.Message, data)
 		}
-		// A non-domain error from AuthorizeTool is a registry defect (an entry
-		// with no implementation). It is reported as internal, never as a
-		// permission refusal.
+		// Everything else keeps its own named answer: mcp_scope_empty becomes
+		// -32002 through toolError, and a non-domain error (a registry entry
+		// with no implementation) becomes the internal code. Neither is
+		// reported as a permission refusal.
 		return h.toolError(req.ID, err)
 	}
 

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -67,6 +67,14 @@ const (
 	// codeInvalidToolArguments carries the offending argument and the schema
 	// inline, so the model corrects in one round trip.
 	codeInvalidToolArguments = -32003
+
+	// codeToolNotAvailable is the SINGLE code for every reason a named tool is
+	// not reachable by this connection: it does not exist, this connection's
+	// capabilities do not cover it, or its site scope is empty. One code for
+	// three reasons is deliberate and is the whole disclosure decision -- see
+	// the note on AuthorizeTool. A client branching on the number learns
+	// "ask tools/list", which is the only correct action in all three cases.
+	codeToolNotAvailable = -32004
 )
 
 // TransportHandler serves the single MCP endpoint. It is separate from Handler
@@ -309,7 +317,12 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{}), http.StatusOK, true
 
 	case "tools/list":
-		return newResponse(req.ID, map[string]any{"tools": Tools()}), http.StatusOK, true
+		// VisibleTools, NOT Tools. Tools() is the whole registry and is not a
+		// request-path value; VisibleTools filters by this connection's
+		// capability set and site scope through the SAME predicate tools/call
+		// applies. An empty list here is a truthful answer for a connection
+		// that reaches nothing, not an error.
+		return newResponse(req.ID, map[string]any{"tools": VisibleTools(auth)}), http.StatusOK, true
 
 	case "tools/call":
 		return h.callTool(ctx, auth, req), http.StatusOK, true
@@ -416,32 +429,79 @@ type toolCallParams struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
+// callTool is S7's EXIT GATE, and the gate is the absence of a `default` arm.
+//
+// This function used to switch on the tool name with a `default` that answered
+// "unknown tool" and listed every tool the server has. Two things were wrong
+// with it, and only the second is a vulnerability:
+//
+//  1. It enumerated the whole surface to any caller holding any valid token.
+//
+//  2. MORE IMPORTANTLY, the filtering lived on tools/list alone. The switch
+//     matched a registered name and dispatched -- with no reference to what
+//     this connection may reach. So a model that never called tools/list, and
+//     simply guessed a name, was dispatched on it. The permission check was on
+//     the discovery path, and discovery is not something an attacker has to
+//     use.
+//
+// There is now NO switch and therefore no arm to fall through. The name is
+// resolved by AuthorizeTool, which applies the same visible() predicate
+// tools/list applies, and the implementation hangs off the registry entry that
+// resolution returned. A name that AuthorizeTool did not authorize has no
+// invoke function to reach.
 func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest, req jsonrpcRequest) jsonrpcResponse {
 	var p toolCallParams
 	if err := json.Unmarshal(req.Params, &p); err != nil {
 		return newErrorResponse(req.ID, codeInvalidParams, "tools/call params could not be parsed", nil)
 	}
 
-	switch p.Name {
-	case ToolListSites:
-		text, err := h.svc.ListSitesForModel(ctx, auth)
-		if err != nil {
-			return h.toolError(req.ID, err)
+	entry, reason, err := AuthorizeTool(p.Name, auth)
+	if err != nil {
+		if de, ok := domain.AsDomain(err); ok && de.Code == ErrCodeToolNotAvailable {
+			// THE PRECISE REASON GOES HERE AND ONLY HERE. The operator log
+			// distinguishes "no such tool" from "capability not held" from
+			// "site scope empty"; the wire answer below does not, so there is
+			// no existence oracle. See the disclosure note on AuthorizeTool.
+			h.log.WarnContext(ctx, "mcp tool refused",
+				slog.String("tenant_id", auth.TenantID.String()),
+				slog.String("grant_id", auth.GrantID.String()),
+				slog.String("requested_tool", p.Name),
+				slog.String("refusal_reason", string(reason)),
+				slog.Int("held_capabilities", auth.Capabilities.Len()),
+				slog.Int("scoped_sites", auth.Sites.Len()),
+			)
+			// available_tools is this connection's OWN tools/list answer, so it
+			// discloses nothing it was not already shown, and it lets a model
+			// that mistyped a name it legitimately holds correct in one round
+			// trip.
+			data, _ := json.Marshal(map[string]any{
+				"argument":        "name",
+				"supplied":        p.Name,
+				"available_tools": visibleToolNames(auth),
+			})
+			return newErrorResponse(req.ID, codeToolNotAvailable, de.Message, data)
 		}
-		return newResponse(req.ID, map[string]any{
-			"content": []map[string]any{{"type": "text", "text": text}},
-		})
-	default:
-		// A tool the grant does not cover is ABSENT from tools/list, so there
-		// is nothing to refuse; an unknown name here is a client error.
-		data, _ := json.Marshal(map[string]any{
-			"argument":    "name",
-			"supplied":    p.Name,
-			"known_tools": toolNames(),
-		})
-		return newErrorResponse(req.ID, codeInvalidToolArguments,
-			fmt.Sprintf("unknown tool %q", p.Name), data)
+		// A non-domain error from AuthorizeTool is a registry defect (an entry
+		// with no implementation). It is reported as internal, never as a
+		// permission refusal.
+		return h.toolError(req.ID, err)
 	}
+
+	h.log.InfoContext(ctx, "mcp tool call",
+		slog.String("tenant_id", auth.TenantID.String()),
+		slog.String("grant_id", auth.GrantID.String()),
+		slog.String("tool", entry.Name),
+		slog.String("capability", string(entry.Capability)),
+		slog.String("operator_permission", string(entry.OperatorPermission)),
+	)
+
+	text, err := entry.invoke(ctx, h.svc, auth, p.Arguments)
+	if err != nil {
+		return h.toolError(req.ID, err)
+	}
+	return newResponse(req.ID, map[string]any{
+		"content": []map[string]any{{"type": "text", "text": text}},
+	})
 }
 
 // toolError maps a domain refusal onto a named JSON-RPC code, and an infra
@@ -456,15 +516,6 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 	}
 	h.log.Error("mcp tool call failed", slog.String("error", err.Error()))
 	return newErrorResponse(id, codeInternalError, "the tool call failed", nil)
-}
-
-func toolNames() []string {
-	ts := Tools()
-	out := make([]string, 0, len(ts))
-	for _, t := range ts {
-		out = append(out, t.Name)
-	}
-	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -883,6 +883,59 @@ func TestToolsCall_ReadPathReturnsStampedSites(t *testing.T) {
 	}
 }
 
+// TestNotification_ToolsCallWithNoIdDoesNotExecuteTheTool.
+//
+// A JSON-RPC request with no id is a notification and takes no response body.
+// The transport used to DISPATCH FIRST and apply that rule afterwards, so an
+// id-less tools/call ran the tool and then answered 202 with an empty body: the
+// caller triggered the work and saw nothing of it.
+//
+// Harmless while every tool is a read. The moment a write tool lands it is a
+// fire-and-forget invocation channel -- an effect with no answer and no record
+// the caller ever sees, which is the shape the proposal machinery exists to
+// prevent. The assertion that matters is therefore NOT the status code, which
+// was always 202; it is that the store was never touched.
+func TestNotification_ToolsCallWithNoIdDoesNotExecuteTheTool(t *testing.T) {
+	allowed := uuid.New()
+	store := liveGrantStore(allowed)
+	row := siteRow("should-never-be-read", nil)
+	row.ID = allowed
+	store.sites = []sqlc.ListSitesRow{row}
+
+	r := newTransportRouter(t, store)
+	w := post(t, r, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("HTTP %d, want 202: %s", w.Code, w.Body.String())
+	}
+	if body := strings.TrimSpace(w.Body.String()); body != "" {
+		t.Errorf("a notification returned a body: %q", body)
+	}
+
+	// THE REAL ASSERTION. ListSitesForRead must never have been called.
+	for _, c := range store.callLog() {
+		if c == "ListSitesForRead" {
+			t.Fatalf("an id-less tools/call EXECUTED the tool; the call log is %v", store.callLog())
+		}
+	}
+
+	// Positive control: the same call WITH an id does execute, so the proof
+	// above is the notification rule and not a broken fixture.
+	w2 := post(t, r, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("the id-carrying control got HTTP %d: %s", w2.Code, w2.Body.String())
+	}
+	var executed bool
+	for _, c := range store.callLog() {
+		if c == "ListSitesForRead" {
+			executed = true
+		}
+	}
+	if !executed {
+		t.Fatal("the id-carrying control did not execute the tool either; the fixture is broken")
+	}
+}
+
 // jsonPart returns the JSON payload half of a tool result, i.e. everything
 // from the first '{' that begins the payload object. The instructions are
 // PREPENDED, so the payload is the tail.

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -1,0 +1,327 @@
+// adr064_s7_mcp_tool_registry_rls_test.go: the S7 tool registry and its policy
+// filtering, driven through mcp.Service.Authenticate against the REAL schema as
+// wpmgr_app.
+//
+// WHY THIS FILE EXISTS. The S7 unit proofs in internal/mcp build an
+// AuthorizedRequest by literal and hand it a chosen CapabilitySet. Everything
+// they establish about the gate is real, and none of it touches the two things
+// that are only decidable by executing:
+//
+//  1. THAT Authenticate ACTUALLY POPULATES Capabilities. The unit tests
+//     construct the field directly, so a wiring defect -- Authenticate
+//     returning an AuthorizedRequest whose CapabilitySet is the zero value --
+//     is invisible to every one of them, and its symptom in production is a
+//     connection that authenticates and then reaches no tool. The mirror defect
+//     is worse and equally invisible: a future refactor that hands out a
+//     capability set nobody narrowed.
+//
+//  2. THAT THE SITE AXIS IS RESOLVED BY THE DATABASE, NOT BY GO. The registry
+//     refuses a site-keyed tool when the resolved SiteSet is empty. Whether it
+//     IS empty is decided by ResolveScopeSites inside InTenantTx, under the
+//     sites RLS policy. Four hours before this file was written, a reviewer read
+//     that resolution closely, found no defect, and the first real-database run
+//     found two swapped arguments that made every site-scoped and tag-scoped
+//     grant resolve to ZERO sites -- which through the S7 gate would now present
+//     as "your connection may call nothing", with the error blaming the user.
+//
+// HOW IT IS TESTED. Through mcp.Service.Authenticate -- the same method the
+// transport calls on every request -- over a token minted through
+// mcp.Repo.RedeemAuthorizationCode, the same way the token endpoint mints one.
+// No connection is opened by this file and no GUC is hand-set.
+//
+// The role is load-bearing: wpmgr_app is NOSUPERUSER NOBYPASSRLS, and either
+// privilege would make the site-axis half pass vacuously. It is asserted, and
+// printed.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// s7GrantWithBearer mints a grant AND a live connection token for it, returning
+// the grant and the plaintext bearer.
+//
+// Everything goes through mcp.Repo: CreateGrantWithCode is what the consent
+// endpoint calls, RedeemAuthorizationCode is what the token endpoint calls. No
+// row is inserted by this file and no connection is opened by it.
+func s7GrantWithBearer(
+	t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string, siteIDs []uuid.UUID,
+) (sqlc.McpGrant, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	clientID := "s7-client-" + uuid.NewString()
+	secretHash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	affected, err := repo.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        &secretHash,
+		TokenEndpointAuthMethod: "client_secret_basic",
+		RedirectUris:            []string{"https://claude.ai/api/mcp/auth_callback"},
+	})
+	if err != nil || affected != 1 {
+		t.Fatalf("register client: affected=%d err=%v", affected, err)
+	}
+
+	if siteIDs == nil {
+		// Both arrays are NOT NULL with a '{}' default, so nil is a 23502.
+		siteIDs = []uuid.UUID{}
+	}
+	codePlain := "s7-code-" + uuid.NewString()
+	codeSum := sha256.Sum256([]byte(codePlain))
+
+	grant, code, err := repo.CreateGrantWithCode(ctx, sqlc.CreateMCPGrantParams{
+		TenantID:      tenantID,
+		Name:          "s7 grant",
+		Status:        "active",
+		SiteScopeMode: mode,
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  siteIDs,
+		ClientID:      &clientID,
+	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+		return sqlc.CreateMCPAuthorizationCodeParams{
+			TenantID:            tenantID,
+			GrantID:             grantID,
+			ClientID:            clientID,
+			CodeHash:            hex.EncodeToString(codeSum[:]),
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
+			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
+		}
+	})
+	if err != nil {
+		t.Fatalf("create grant for tenant %s: %v", tenantID, err)
+	}
+
+	// The bearer's hash is what the lookup index is queried on. The
+	// construction is the one every credential column's CHECK requires:
+	// lower-case hex SHA-256.
+	bearer := "s7-bearer-" + uuid.NewString()
+	bearerSum := sha256.Sum256([]byte(bearer))
+
+	tok, err := repo.RedeemAuthorizationCode(ctx, tenantID, code.ID,
+		sqlc.CreateMCPConnectionTokenParams{
+			TenantID:    tenantID,
+			GrantID:     grant.ID,
+			TokenPrefix: "s7test",
+			TokenHash:   hex.EncodeToString(bearerSum[:]),
+			Status:      "active",
+		})
+	if err != nil {
+		t.Fatalf("mint connection token: %v", err)
+	}
+	if tok.Status != "active" {
+		t.Fatalf("minted token status = %q, want active", tok.Status)
+	}
+	return grant, bearer
+}
+
+// TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole is question 1: a real
+// bearer, resolved by the real Authenticate against the real schema, must come
+// back holding a capability -- and the registry must then admit the tool.
+//
+// THE ZERO-VALUE ASSERTION IS THE POINT. CapabilitySet's zero value allows
+// nothing, which is the safe direction and is exactly why a wiring defect here
+// is silent: everything still refuses, and it refuses for a reason that reads
+// like a scoping problem the operator does not have.
+func TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo)
+
+	tenant := seedTenant(t, pool, "mcp-s7-caps-"+uuid.NewString()[:8])
+
+	// Assert the role inside the transaction the resolution actually uses.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (ResolveScopeSites path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://s7a.example.com", Name: "s7-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{s1.ID})
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate with a live bearer: %v", err)
+	}
+	if auth.TenantID != tenant {
+		t.Fatalf("Authenticate resolved tenant %s, want %s", auth.TenantID, tenant)
+	}
+
+	// (1) The capability set is populated, not the zero value.
+	if auth.Capabilities.IsEmpty() {
+		t.Fatalf("Authenticate returned a ZERO-VALUE CapabilitySet; every tool would refuse " +
+			"with a message that reads like a site-scope problem")
+	}
+	if !auth.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatalf("the resolved capability set does not hold %q: %v",
+			mcp.CapSitesRead, auth.Capabilities.Sorted())
+	}
+	t.Logf("Authenticate resolved %d capabilities and %d sites as wpmgr_app",
+		auth.Capabilities.Len(), auth.Sites.Len())
+
+	// (2) The site axis was resolved by the database, and resolved to the one
+	// site this grant names. A zero here is the swapped-argument defect.
+	if auth.Sites.Len() != 1 || !auth.Sites.Allows(s1.ID) {
+		t.Fatalf("site scope resolved to %d sites and Allows(%s)=%v; want exactly the one granted site",
+			auth.Sites.Len(), s1.ID, auth.Sites.Allows(s1.ID))
+	}
+
+	// (3) The registry admits the tool for this real connection, and tools/list
+	// shows it.
+	visible := mcp.VisibleTools(auth)
+	if len(visible) != 1 || visible[0].Name != mcp.ToolListSites {
+		t.Fatalf("tools/list for a fully-scoped connection returned %+v", visible)
+	}
+
+	// (4) And the tool actually runs end to end for it, returning this org's
+	// site. This is the positive control: without it, every refusal proof below
+	// could be passing because nothing works at all.
+	text, err := svc.ListSitesForModel(ctx, auth)
+	if err != nil {
+		t.Fatalf("ListSitesForModel for a fully-scoped connection: %v", err)
+	}
+	if len(text) == 0 {
+		t.Fatal("list_sites returned empty text")
+	}
+	t.Logf("list_sites returned %d bytes for the granted connection", len(text))
+}
+
+// TestS7GuessedToolNameIsRefusedForARealConnectionAsAppRole is the exit gate
+// executed against the real database rather than against a literal.
+//
+// The connection is REAL and FULLY CAPABLE. It is not a contrived
+// no-capability request: it holds mcp:read, it is scoped to a site, and
+// list_sites works for it (proved above). What it must not be able to do is
+// reach a name the registry does not carry -- and it must not be able to tell
+// that name apart from one the registry DOES carry.
+func TestS7GuessedToolNameIsRefusedForARealConnectionAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo)
+
+	tenant := seedTenant(t, pool, "mcp-s7-guess-"+uuid.NewString()[:8])
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://s7g.example.com", Name: "s7-guess"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{s1.ID})
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+
+	// The registered tool IS reachable for this connection -- so a refusal
+	// below is the gate, not a broken fixture.
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+		t.Fatalf("the registered tool was refused for a fully-scoped connection: %v", err)
+	}
+
+	for _, guess := range []string{
+		"restart_site", "update_plugin", "run_backup", "delete_site",
+		"list_sites_all", "listSites", "LIST_SITES", "list_sites ",
+	} {
+		if _, _, err := mcp.AuthorizeTool(guess, auth); err == nil {
+			t.Fatalf("GUESSED NAME %q WAS GRANTED to a real connection", guess)
+		}
+	}
+	t.Logf("all guessed names refused for a real, fully-capable connection")
+}
+
+// TestS7EmptySiteScopeRefusesByNameAsAppRole is the site axis, executed.
+//
+// The grant names a site belonging to ANOTHER organisation. The column accepts
+// it -- scope_site_ids is a uuid[] and PostgreSQL has no foreign key over array
+// elements -- so the only thing that drops it is resolving inside InTenantTx
+// under the sites policy. The connection therefore authenticates with a
+// capability it holds and a site scope that resolves to nothing, and the
+// registry must refuse the site-keyed tool BY NAME rather than uniformly, and
+// must still list it.
+func TestS7EmptySiteScopeRefusesByNameAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo)
+
+	tenantA := seedTenant(t, pool, "mcp-s7-scope-a-"+uuid.NewString()[:8])
+	tenantB := seedTenant(t, pool, "mcp-s7-scope-b-"+uuid.NewString()[:8])
+
+	siteB, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenantB, URL: "https://s7b.example.com", Name: "s7-foreign"})
+	if err != nil {
+		t.Fatalf("create foreign site: %v", err)
+	}
+
+	// Org A's grant names ONLY org B's site.
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenantA, "list", []uuid.UUID{siteB.ID})
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+
+	// The foreign id was dropped by RLS, so the scope is empty.
+	if !auth.Sites.IsEmpty() {
+		t.Fatalf("CROSS-TENANT LEAK: org A's grant resolved to %d sites naming org B's site %s",
+			auth.Sites.Len(), siteB.ID)
+	}
+	// But the capability is held: this is not a capability failure.
+	if !auth.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatalf("the capability was lost along with the site scope: %v", auth.Capabilities.Sorted())
+	}
+	t.Logf("org A's grant naming org B's site resolved to %d sites, capability still held",
+		auth.Sites.Len())
+
+	// The tool is STILL LISTED -- the site axis does not hide it, because this
+	// connection's org and capability set already entitle it to know the tool
+	// exists. Hiding it here would send the operator hunting a capability
+	// problem they do not have.
+	visible := mcp.VisibleTools(auth)
+	if len(visible) != 1 || visible[0].Name != mcp.ToolListSites {
+		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", visible)
+	}
+
+	// And calling it refuses BY NAME, with the code that says "site scope",
+	// not the uniform not-available one.
+	_, _, err = mcp.AuthorizeTool(mcp.ToolListSites, auth)
+	if err == nil {
+		t.Fatal("a site-keyed tool was authorized for a connection whose site scope is empty")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Code != mcp.ErrCodeScopeEmpty {
+		t.Fatalf("err = %v, want the named %s refusal", err, mcp.ErrCodeScopeEmpty)
+	}
+
+	// The service refuses too, so the gate is not the only thing standing
+	// between an empty scope and a result that reads as a healthy empty org.
+	if _, err := svc.ListSitesForModel(ctx, auth); err == nil {
+		t.Fatal("ListSitesForModel returned a result for an empty site scope")
+	}
+}


### PR DESCRIPTION
S7 of ADR-064. Each connection sees only the tools its org, site scope and
capability set permit.

## The exit gate

> A capability absent from the registry is unreachable by a schema-guessing
> model. Discovery never grants.

Before this, the filtering lived on the discovery path alone. `tools/list`
returned the closed list; `tools/call` switched on the tool name with a
`default` arm and dispatched on any registered name without reference to what
the connection may reach. That is correct only for a client that calls
`tools/list` first and believes the answer — and a model that guesses a
plausible name never takes the discovery path at all.

There is now no switch and no arm to fall through. Both paths resolve through
the same predicate over the same closed list:

```
tools/list -> VisibleTools(auth)        -> visible()
tools/call -> AuthorizeTool(name, auth) -> visible()
```

The implementation hangs off the registry entry that resolution returns, so a
name `AuthorizeTool` did not authorize has no `invoke` function to reach.
`TestExitGate_VisibilityAndCallabilityAgree` walks the registry against every
capability subset and asserts the two paths never disagree in either direction.

The list stays a function returning a fresh slice from a literal — no
package-level registry var, no `Register()` entry point — so the read-only claim
remains a property of the code rather than of discipline
(`TestRegistryIsClosed`).

## Two narrowing axes

**Capability.** `CapabilitySet` copies `SiteSet` exactly: zero value allows
nothing, and there is deliberately no method answering "does this mean
everything". The org default is *derived* from the closed scope registry rather
than stored, because m124 DECISION 1 deliberately mints no capabilities column.
A recognised scope with no capability mapping is **refused, not skipped** —
skipping is fail-closed and still wrong, because the operator consented to a
scope that silently conferred nothing. `NarrowTo` is the per-connection
narrowing: intersection only, and a request wider than the org default is
refused rather than quietly reduced to the intersection.

There is **no stored per-connection narrowing yet**, and the code says so in as
many words at `Authenticate` rather than defaulting a nil to the ceiling. The
column arrives with its own migration, `NOT NULL`, no default, closed `CHECK`,
as DECISION 1 requires.

**Site.** Already stored, already resolved inside `InTenantTx`. Now enforced at
the registry gate as well as in the service, so the next tool declaring
`RequiresSiteScope` gets it whether or not its author remembers.

## The disclosure decision

Typed refusals and non-disclosure pull against each other, and the resolution is
argued in full in the block comment on `AuthorizeTool`.

*"Your org has not enabled `sites.restart`"* is a precise, actionable, well-typed
refusal — and it confirms that `sites.restart` exists to a caller who was never
shown it. Repeat against a wordlist and the refusals enumerate the product's
whole tool surface.

**An unregistered name and a registered-but-not-permitted one are
indistinguishable on the wire**: same code (`-32004`), same message, same data.
`TestExitGate_RefusalIsNotAnExistenceOracle` asserts this by stripping the
echoed name and comparing. This is the same call `authz.RequireSiteAccess` makes
one layer down in answering 404 rather than 403.

The refusal is still typed — on the operator's axis. `refusalReason` reaches the
structured log with the tenant, the grant and the attempted name, so an operator
debugging "why can't my client call this" reads one line and gets the exact
answer, while a prober gets one sentence, identical every time.

**The site axis is deliberately asymmetric and stays disclosable.** A connection
whose org enabled the tool and whose capability set covers it is entitled to
know the tool exists — it would have been listed but for an empty site scope,
which is a fact about its own grant. So an empty site scope does not hide the
tool and refuses by name with the existing `mcp_scope_empty` code. Blurring it
would send an operator hunting a capability problem they do not have, and would
hide only names their own capability set already entitles them to see. This also
preserves the S6b-2 proof that an empty scope is a named refusal and not an
empty list.

The error body carries `available_tools` — the connection's *own* `tools/list`
answer, never the full registry, which is what the pre-S7 "unknown tool" error
returned.

## Red before green

With `visible()` bypassed on the call path (the pre-S7 arrangement):

```
$ go test ./internal/mcp/ -run TestExitGate -v
--- FAIL: TestExitGate_GuessedToolNameIsUnreachable/list_sites
    AuthorizeTool("list_sites") GRANTED: entry={Name:list_sites ... invoke:0x102b9edf0}
    --- PASS: .../list_sites_all
    --- PASS: .../sites.restart
    --- PASS: .../restart_site
    ...
--- FAIL: TestExitGate_RefusalIsNotAnExistenceOracle
--- FAIL: TestExitGate_VisibilityAndCallabilityAgree
    caps=[]: "list_sites" was CALLABLE but never shown by tools/list
FAIL
```

It fails on the **registered** name while every guessed name still passes. That
is the point: a gate that only refuses names it has never heard of is a typo
checker, not a gate. Restored:

```
$ go test ./internal/mcp/ -run TestExitGate -v
--- PASS: TestExitGate_GuessedToolNameIsUnreachable (all 8 subtests)
--- PASS: TestExitGate_RefusalIsNotAnExistenceOracle
--- PASS: TestExitGate_VisibilityAndCallabilityAgree
ok  	github.com/mosamlife/wpmgr/apps/api/internal/mcp	0.636s
```

## Integration proof

`apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go`, as `wpmgr_app`
(`NOSUPERUSER NOBYPASSRLS`, asserted inside the transaction the resolution
uses). The unit proofs build the `CapabilitySet` by literal, so a wiring defect
that leaves it zero-valued is invisible to all of them — and its production
symptom is a connection that authenticates and then reaches nothing, with the
error blaming the user's site scope.

It drives `mcp.Service.Authenticate` over a real bearer minted through
`RedeemAuthorizationCode`, and covers: capabilities actually populated by
`Authenticate`; the site axis resolved by the database (a grant naming another
org's site resolves to zero and the capability survives); guessed names refused
for a real, fully-capable connection; and a positive control that `list_sites`
genuinely works, so the refusals are not passing because nothing works at all.

## Checks

- `go build ./...`, `go vet ./...`, `go test ./internal/... ./cmd/...` — all
  green, each run unpiped.
- `gofmt -l` clean on every file touched. (`internal/mcp/handler.go` is listed
  by `gofmt -l` on `main` already and is untouched here.)
- `make test-integration` running now; result reported on this PR.

## Review

Draft on purpose. This decides what an AI client may reach — `security-reviewer`
pass before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability-based access control for MCP tools.
  * Tool lists now show only tools available to the active connection and site scope.
  * Added a centralized tool registry with consistent descriptions and input schemas.
  * Added clear tool-unavailable responses without revealing inaccessible tool details.
* **Bug Fixes**
  * Notifications now return immediately without executing tool calls.
  * Prevented access to guessed or unauthorized tool names.
* **Tests**
  * Added comprehensive coverage for authorization, visibility, scoping, schema isolation, and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->