### PR TITLE
feat(mcp): mount the OAuth endpoints and bound anonymous registration

### DIFF
--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -525,6 +525,12 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// and an installation with no grants simply has no valid bearer token.
 	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, version)
+	// The OAuth half, wired unconditionally for the same reason. Without it the
+	// transport above is mounted and correct and refuses every request forever,
+	// because nothing can mint a token. mcp.NewHandler arms its own
+	// registration rate limiter, so there is no assembly order that mounts the
+	// unauthenticated /register endpoint unlimited.
+	mcpOAuthH := mcp.NewHandler(mcpSvc)
 
 	// A narrow tenant-creation capability handed to the auth domain (bootstrap +
 	// OIDC first-login) without coupling it to the tenant package internals.
@@ -2789,6 +2795,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		SiteH:            siteH,
 		SiteEventsH:      siteEventsH,
 		MCPTransportH:    mcpTransportH,
+		MCPOAuthH:        mcpOAuthH,
 		FilesH:           filesH,
 		UpdateH:          updateH,
 		BackupH:          backupH,

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"net/http"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -24,27 +26,127 @@ import (
 //     to the organisation of the human who approved it.
 type Handler struct {
 	svc *Service
+	// regLimit bounds anonymous registration. Never nil after NewHandler; a nil
+	// receiver refuses rather than allows (see registrationLimiter.allow).
+	regLimit *registrationLimiter
 }
 
-func NewHandler(svc *Service) *Handler { return &Handler{svc: svc} }
+// NewHandler builds the OAuth handler with its registration limiter already
+// armed. The limiter is constructed HERE rather than injected with a nil
+// default, so there is no assembly order in which the endpoint is mounted
+// unlimited: an unmounted limiter would be a wiring failure that presents as
+// working registration, which is the failure mode this whole slice is most
+// exposed to.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{
+		svc:      svc,
+		regLimit: newRegistrationLimiter(RegisterGlobalPerMin, RegisterPerPeerPerMin),
+	}
+}
 
-// RegisterPublic mounts the two unauthenticated OAuth endpoints.
+// maxOAuthBodyBytes caps the two unauthenticated POST bodies.
+//
+// Registration metadata is a handful of short strings and a redirect_uri array;
+// a token request is five short form fields. 16 KiB is orders of magnitude
+// above either and still bounds an anonymous caller streaming a body at a
+// decoder. Matches the house pattern (rum/handler.go:261,
+// site/monitoring_handler.go:212, backup/agent_handler.go:96, transport.go).
+const maxOAuthBodyBytes = 16 << 10
+
+// RegisterPublic mounts the two unauthenticated OAuth endpoints, AND the
+// method-not-allowed fallbacks for all four OAuth paths including the two
+// mounted by Register.
+//
+// The 405 fallbacks live here, unauthenticated, on purpose, and for the same
+// reason TransportHandler.Register gives: the verb is wrong regardless of who
+// is asking, and answering 401 to a GET on /consent sends an operator to check
+// a credential when the fix is to send a POST. Answering 404 is worse still --
+// it reads as "not deployed", which is exactly how the S6b-2 blocker presented.
+//
+// This couples the two mount points: Register's routes get their 405 siblings
+// from here, so a caller that mounts one without the other leaves GET
+// /authorize answering 405 for every verb including its own. server.New mounts
+// both from one Deps field, which is what keeps that unreachable.
 func (h *Handler) RegisterPublic(r *gin.RouterGroup) {
 	g := r.Group("/oauth/mcp")
 	g.POST("/register", h.register)
 	g.POST("/token", h.token)
+
+	// Registered explicitly per verb rather than via HandleMethodNotAllowed,
+	// because that flag is engine-global and would change the response of every
+	// other route in the API as a side effect of this slice.
+	methodNotAllowedExcept(g, "/register", http.MethodPost)
+	methodNotAllowedExcept(g, "/token", http.MethodPost)
+	methodNotAllowedExcept(g, "/authorize", http.MethodGet)
+	methodNotAllowedExcept(g, "/consent", http.MethodPost)
 }
 
 // Register mounts the two operator-authenticated endpoints. The caller's group
-// is already behind session auth.
+// is already behind session auth AND authz.RequireAuth/RequireTenant; the
+// handlers below re-check the principal anyway, because a handler that trusts
+// its mount point is one refactor away from being anonymous.
 func (h *Handler) Register(r *gin.RouterGroup) {
 	g := r.Group("/oauth/mcp")
 	g.GET("/authorize", h.authorize)
 	g.POST("/consent", h.consent)
 }
 
+// allVerbs is every method the 405 fallback covers. CONNECT and TRACE are
+// omitted: gin's router does not serve them and net/http handles CONNECT
+// separately.
+var allVerbs = []string{
+	http.MethodGet,
+	http.MethodHead,
+	http.MethodPost,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
+	http.MethodOptions,
+}
+
+// methodNotAllowedExcept mounts a JSON 405 on every verb except the ones the
+// path actually serves, naming the supported verb in Allow.
+func methodNotAllowedExcept(g *gin.RouterGroup, path string, supported ...string) {
+	allowed := strings.Join(supported, ", ")
+	for _, verb := range allVerbs {
+		if slices.Contains(supported, verb) {
+			continue
+		}
+		g.Handle(verb, path, func(c *gin.Context) {
+			c.Header("Allow", allowed)
+			c.JSON(http.StatusMethodNotAllowed, oauthErrorDTO{
+				Err:     "invalid_request",
+				ErrDesc: "this endpoint accepts " + allowed + " only",
+			})
+		})
+	}
+}
+
 // register is RFC 7591 dynamic client registration.
+//
+// UNAUTHENTICATED BY SPECIFICATION, so the two guards below are the entire
+// admission control and both run BEFORE the body is read: the rate limit, then
+// the body cap. See register_limit.go for why the limiter key is RemoteIP and
+// never ClientIP.
 func (h *Handler) register(c *gin.Context) {
+	// RemoteIP, not ClientIP. ClientIP returns an attacker-supplied header value
+	// under this engine's configuration; keying the limiter on it would enforce
+	// nothing while looking correct.
+	if ok, retryAfter := h.regLimit.allow(c.RemoteIP()); !ok {
+		secs := int(retryAfter.Seconds())
+		if secs < 1 {
+			secs = 1
+		}
+		c.Header("Retry-After", strconv.Itoa(secs))
+		c.JSON(http.StatusTooManyRequests, oauthErrorDTO{
+			Err:     "invalid_request",
+			ErrDesc: "too many client registrations; retry later",
+		})
+		return
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxOAuthBodyBytes)
+
 	var body registrationRequestDTO
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, oauthErrorDTO{
@@ -162,6 +264,12 @@ func (h *Handler) consent(c *gin.Context) {
 // which is what the RFC specifies and what every client library sends, and
 // JSON for convenience.
 func (h *Handler) token(c *gin.Context) {
+	// Unauthenticated like /register, so the body is capped here too. It is NOT
+	// rate limited: a code is single-use, high-entropy and short-lived, so there
+	// is nothing here to grind at, and a limiter on this endpoint would refuse
+	// legitimate exchanges during the one moment a user is watching.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxOAuthBodyBytes)
+
 	var body tokenRequestDTO
 	if err := c.ShouldBind(&body); err != nil {
 		c.JSON(http.StatusBadRequest, oauthErrorDTO{

--- a/apps/api/internal/mcp/register_limit.go
+++ b/apps/api/internal/mcp/register_limit.go
@@ -1,0 +1,226 @@
+package mcp
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// ---------------------------------------------------------------------------
+// THE ANONYMOUS-REGISTRATION DEFENCE.
+//
+// POST /oauth/mcp/register is unauthenticated BY SPECIFICATION (RFC 7591): a
+// GUI client enrols itself before any human has signed in, so there is nobody
+// to attribute the request to and no session to gate it on. Mounting it means
+// anyone on the internet can create rows in mcp_oauth_clients.
+//
+// WHAT THAT DOES NOT BUY AN ATTACKER, so the defence is sized to the real harm
+// rather than an imagined one: the table carries no tenant_id by design, a
+// client_id is not a secret (RFC 6749 2.2), possession authorizes nothing --
+// every request still resolves to a grant under that grant's tenant -- and the
+// table is invisible to any transaction that sets neither of its two GUCs.
+// Registration alone reaches nothing.
+//
+// WHAT IT DOES BUY IS UNBOUNDED ANONYMOUS ROW CREATION, which is a storage and
+// availability problem rather than a confidentiality one. That is what this
+// bounds.
+//
+// ---------------------------------------------------------------------------
+// WHY THE KEY IS RemoteIP AND NEVER ClientIP.
+//
+// THIS IS THE WHOLE DESIGN, and getting it wrong produces a limiter that
+// reports success while enforcing nothing -- the exact "absence coerced into a
+// plausible value" shape this endpoint is most likely to fail in.
+//
+// gin's Engine defaults are ForwardedByClientIP: true, RemoteIPHeaders:
+// ["X-Forwarded-For", "X-Real-IP"], and trustedCIDRs: 0.0.0.0/0 + ::/0 (see
+// gin@v1.12.0 gin.go:39 and gin.go:214-226). SetTrustedProxies is never called
+// anywhere in this repository -- grep it. Every proxy is therefore trusted, so
+// Context.ClientIP walks X-Forwarded-For right-to-left, finds every hop
+// "trusted", reaches index 0 and returns the LEFTMOST entry: a string the
+// caller put there. On an unauthenticated public endpoint that means a limiter
+// keyed on ClientIP hands a fresh, empty bucket to every request that varies
+// one header, and it does so silently, at full speed, while looking correct in
+// the code and in the logs. TestRegisterLimiter_ClientIPWouldHaveBeenSpoofable
+// executes that bypass rather than asserting it from this comment.
+//
+// RemoteIP is the TCP peer from Request.RemoteAddr. It cannot be set by a
+// header. It is the only unspoofable identity available at this layer.
+//
+// The cost of that choice is stated rather than hidden: behind the Google
+// Cloud load balancer the TCP peer IS the balancer, so every request shares one
+// peer bucket and the per-peer layer degrades into a second global cap. That is
+// a loss of fairness, never a loss of the bound -- it fails toward refusing too
+// much, not toward permitting too much. On a self-hosted install with the API
+// directly exposed the same key is a true per-source limit. Repointing this at
+// a header to recover per-client fairness behind the balancer requires
+// SetTrustedProxies to be configured first, and that is a deployment decision
+// for the whole engine, not a change to make here.
+//
+// ---------------------------------------------------------------------------
+// WHY THERE ARE TWO LAYERS.
+//
+// The global bucket is the SECURITY BOUND. It is keyed on nothing, so no header
+// and no source diversity can enlarge it, and it is never reset or evicted. A
+// botnet on ten thousand addresses gets the same ceiling as one host.
+//
+// The per-peer bucket is FAIRNESS, and it is explicitly not the bound: its map
+// is capacity-limited, and a limiter evicted to keep memory finite is a fresh
+// empty bucket for that peer. Eviction is therefore fail-open for this layer by
+// construction, which is tolerable only because the global layer sits behind it
+// and cannot be evicted. If the global layer is ever removed, this comment is
+// wrong and so is the code.
+//
+// Both are per-process. A multi-instance deployment multiplies the ceiling by
+// the instance count; the honest bound on N instances is
+// N * RegisterGlobalPerMin. A cross-instance cap needs shared state (Redis) or
+// a database-side row cap with GC, and neither is in this slice -- the
+// database-side cap is database-engineer's path.
+// ---------------------------------------------------------------------------
+
+const (
+	// RegisterGlobalPerMin caps registrations this process accepts per minute
+	// across ALL sources. Unspoofable and never evicted; this is the bound.
+	// Sized far above any plausible legitimate rate -- a human enrolling a GUI
+	// client registers once, and a group of new operators onboarding together
+	// is still nowhere near one per second.
+	RegisterGlobalPerMin = 60
+
+	// RegisterPerPeerPerMin caps registrations per TCP peer per minute. Only
+	// meaningful where the peer is the caller (direct exposure, self-host); it
+	// collapses into a second global cap behind a load balancer.
+	RegisterPerPeerPerMin = 10
+
+	// registerPeerCap bounds the per-peer map so an attacker varying source
+	// addresses cannot grow it without limit. Reaching it is a memory bound
+	// being enforced, not an error.
+	registerPeerCap = 4096
+
+	// registerPeerIdle is how long an untouched peer bucket survives a sweep.
+	registerPeerIdle = 10 * time.Minute
+)
+
+// registrationLimiter is the two-layer token bucket described above. The zero
+// value is NOT usable: construct it with newRegistrationLimiter.
+type registrationLimiter struct {
+	mu      sync.Mutex
+	global  *rate.Limiter
+	peers   map[string]*peerBucket
+	perPeer int
+	cap     int
+	idle    time.Duration
+}
+
+type peerBucket struct {
+	lim  *rate.Limiter
+	seen time.Time
+}
+
+// newRegistrationLimiter builds the limiter. There is no janitor goroutine and
+// therefore nothing to Stop and nothing to leak: the peer map is swept inline
+// when it grows past its cap, which is the only moment the memory bound is
+// actually at risk.
+func newRegistrationLimiter(globalPerMin, perPeerPerMin int) *registrationLimiter {
+	return &registrationLimiter{
+		global:  perMinuteLimiter(globalPerMin),
+		peers:   make(map[string]*peerBucket),
+		perPeer: perPeerPerMin,
+		cap:     registerPeerCap,
+		idle:    registerPeerIdle,
+	}
+}
+
+// perMinuteLimiter turns a per-minute budget into a token bucket whose burst is
+// the whole budget, so the limit is a cap on any rolling one-minute window
+// rather than a hard inter-arrival gap. Matches internal/autologin's shape.
+func perMinuteLimiter(perMin int) *rate.Limiter {
+	if perMin <= 0 {
+		// A non-positive budget means "allow nothing", never "allow everything".
+		// rate.NewLimiter(0, 0) rejects every request, which is the direction a
+		// misconfiguration must fail in.
+		return rate.NewLimiter(0, 0)
+	}
+	return rate.NewLimiter(rate.Limit(float64(perMin)/60.0), perMin)
+}
+
+// allow consumes one token from the global bucket and one from the peer's.
+//
+// The global bucket is consulted FIRST and, when it refuses, the peer bucket is
+// left untouched -- a rejected request must not also spend the caller's own
+// fair-share budget.
+//
+// A nil receiver returns false. An unconstructed limiter is a wiring failure,
+// and the one thing it must never do is read as "no limit configured,
+// therefore permitted".
+func (l *registrationLimiter) allow(peer string) (bool, time.Duration) {
+	if l == nil {
+		return false, time.Minute
+	}
+
+	now := time.Now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if ok, wait := reserveOne(l.global, now); !ok {
+		return false, wait
+	}
+
+	// An empty peer string means RemoteAddr could not be parsed. It is bucketed
+	// under a single reserved key rather than skipped: "we could not identify
+	// the source" must be more restrictive than identifying it, never less.
+	if peer == "" {
+		peer = "\x00unknown"
+	}
+
+	b, ok := l.peers[peer]
+	if !ok {
+		l.sweepLocked(now)
+		b = &peerBucket{lim: perMinuteLimiter(l.perPeer)}
+		l.peers[peer] = b
+	}
+	b.seen = now
+
+	if ok, wait := reserveOne(b.lim, now); !ok {
+		return false, wait
+	}
+	return true, 0
+}
+
+// reserveOne takes one token if one is available now, and otherwise cancels the
+// reservation so a later polite retry is not penalised for this attempt.
+func reserveOne(lim *rate.Limiter, now time.Time) (bool, time.Duration) {
+	r := lim.ReserveN(now, 1)
+	if !r.OK() {
+		// Burst cannot satisfy a single token: the budget is zero by
+		// configuration. Refuse.
+		return false, time.Minute
+	}
+	if wait := r.DelayFrom(now); wait > 0 {
+		r.CancelAt(now)
+		return false, wait
+	}
+	return true, 0
+}
+
+// sweepLocked bounds the peer map. Idle buckets go first; if that is not enough
+// the map is cleared outright.
+//
+// Clearing is deliberate and its consequence is accepted: it hands every peer a
+// fresh bucket, so the per-peer layer is fail-open under memory pressure. It is
+// safe ONLY because the global bucket above is not swept and still refuses.
+// Caller holds l.mu.
+func (l *registrationLimiter) sweepLocked(now time.Time) {
+	if len(l.peers) < l.cap {
+		return
+	}
+	for k, b := range l.peers {
+		if now.Sub(b.seen) > l.idle {
+			delete(l.peers, k)
+		}
+	}
+	if len(l.peers) >= l.cap {
+		l.peers = make(map[string]*peerBucket)
+	}
+}

--- a/apps/api/internal/mcp/register_limit.go
+++ b/apps/api/internal/mcp/register_limit.go
@@ -144,11 +144,36 @@ func perMinuteLimiter(perMin int) *rate.Limiter {
 	return rate.NewLimiter(rate.Limit(float64(perMin)/60.0), perMin)
 }
 
-// allow consumes one token from the global bucket and one from the peer's.
+// allow admits a request only when BOTH buckets can pay for it, and charges
+// BOTH only when it is admitted.
 //
-// The global bucket is consulted FIRST and, when it refuses, the peer bucket is
-// left untouched -- a rejected request must not also spend the caller's own
-// fair-share budget.
+// A REFUSED REQUEST COSTS NOTHING, IN EITHER BUCKET, AND THAT IS STRUCTURAL.
+//
+// This function used to take a global reservation and keep it before consulting
+// the peer bucket, so a peer that had already exhausted its own budget still
+// spent process-wide capacity on every request it was REFUSED for. One flooding
+// peer therefore drained the global bucket and starved everyone else -- the
+// fairness layer became the denial-of-service, and the attacker did not have to
+// beat the limiter, they beat it by being rejected, which is free and fast.
+//
+// The shape below is what makes that unrepeatable, rather than a rule someone
+// has to remember. EVERY REJECTION PATH RUNS BEFORE ANY MUTATION, and there is
+// exactly ONE mutation site, reached only on the admit path. A future branch
+// added to a rejection path CANNOT leak a token, because at the point those
+// branches run there is nothing yet to leak. Contrast the alternative that was
+// considered and rejected -- reserve, then release on failure -- which stays
+// correct only for as long as every future early return remembers to release.
+//
+// The two shortfall calls are pure queries: TokensAt reads the bucket without
+// advancing it. Both are evaluated at the same `now` under the same mutex, and
+// a token count for a fixed instant cannot fall between the query and the
+// commit, so the two AllowN calls below are guaranteed to succeed. That is why
+// "check both, then charge both" needs no rollback at all.
+//
+// Ordering within the checks is a memory optimisation only, NOT the invariant:
+// global is checked first so a globally-saturated process does not allocate a
+// bucket per attacking source. Because nothing is charged until both checks
+// pass, swapping these two blocks would change no accounting.
 //
 // A nil receiver returns false. An unconstructed limiter is a wiring failure,
 // and the one thing it must never do is read as "no limit configured,
@@ -163,7 +188,9 @@ func (l *registrationLimiter) allow(peer string) (bool, time.Duration) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if ok, wait := reserveOne(l.global, now); !ok {
+	// ---- QUERY ONLY. Nothing below this line is charged until both pass. ----
+
+	if wait := shortfall(l.global, now); wait > 0 {
 		return false, wait
 	}
 
@@ -180,28 +207,35 @@ func (l *registrationLimiter) allow(peer string) (bool, time.Duration) {
 		b = &peerBucket{lim: perMinuteLimiter(l.perPeer)}
 		l.peers[peer] = b
 	}
+	// Touched on refusal too, deliberately: a flooding peer's bucket must stay
+	// alive rather than be swept and handed back empty, which would reset the
+	// very limit it is hitting.
 	b.seen = now
 
-	if ok, wait := reserveOne(b.lim, now); !ok {
+	if wait := shortfall(b.lim, now); wait > 0 {
 		return false, wait
 	}
+
+	// ---- ADMITTED. The one and only mutation site. ----
+	l.global.AllowN(now, 1)
+	b.lim.AllowN(now, 1)
 	return true, 0
 }
 
-// reserveOne takes one token if one is available now, and otherwise cancels the
-// reservation so a later polite retry is not penalised for this attempt.
-func reserveOne(lim *rate.Limiter, now time.Time) (bool, time.Duration) {
-	r := lim.ReserveN(now, 1)
-	if !r.OK() {
-		// Burst cannot satisfy a single token: the budget is zero by
-		// configuration. Refuse.
-		return false, time.Minute
+// shortfall reports how long until the bucket could pay for one token, and zero
+// when it can pay right now. It is a PURE QUERY: TokensAt does not advance the
+// limiter, so calling this never charges anything and never has to be undone.
+func shortfall(lim *rate.Limiter, now time.Time) time.Duration {
+	// Burst below one, or a non-positive rate, is a bucket that can never pay.
+	// Refuse with a fixed wait rather than dividing by zero into an infinity.
+	if lim.Burst() < 1 || lim.Limit() <= 0 {
+		return time.Minute
 	}
-	if wait := r.DelayFrom(now); wait > 0 {
-		r.CancelAt(now)
-		return false, wait
+	deficit := 1 - lim.TokensAt(now)
+	if deficit <= 0 {
+		return 0
 	}
-	return true, 0
+	return time.Duration(deficit / float64(lim.Limit()) * float64(time.Second))
 }
 
 // sweepLocked bounds the peer map. Idle buckets go first; if that is not enough

--- a/apps/api/internal/mcp/register_limit_test.go
+++ b/apps/api/internal/mcp/register_limit_test.go
@@ -1,0 +1,340 @@
+// register_limit_test.go: proofs for the anonymous-registration defence and
+// for the routing shape of the four OAuth endpoints.
+//
+// POST /oauth/mcp/register is unauthenticated by RFC 7591. Mounting it is a
+// deliberate security decision, and these are the proofs that the decision came
+// with a bound rather than with a comment claiming one.
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ---------------------------------------------------------------------------
+// THE LIMITER ITSELF.
+// ---------------------------------------------------------------------------
+
+// The global bucket is the security bound, so it must actually refuse. Spends
+// the whole per-minute budget from DIFFERENT peers -- source diversity is
+// exactly what a real attacker has and what the per-peer layer cannot bound.
+func TestRegisterLimiter_GlobalCapRefusesRegardlessOfSourceDiversity(t *testing.T) {
+	const global = 5
+	l := newRegistrationLimiter(global, 1000) // per-peer set high so it cannot be what refuses
+
+	for i := range global {
+		peer := "10.0.0." + itoa(i)
+		if ok, _ := l.allow(peer); !ok {
+			t.Fatalf("request %d from a fresh peer %q was refused while the global "+
+				"budget of %d was not yet spent", i, peer, global)
+		}
+	}
+
+	// One more, from a peer that has never been seen. Only the global bucket can
+	// refuse this.
+	ok, retryAfter := l.allow("10.0.0.99")
+	if ok {
+		t.Fatalf("the %dth registration was ALLOWED after a global budget of %d was "+
+			"spent; a limiter that only bounds per-peer bounds nothing against a "+
+			"caller that varies its source address", global+1, global)
+	}
+	if retryAfter <= 0 {
+		t.Fatalf("refused with retryAfter=%v; a 429 with no wait tells a client "+
+			"nothing and invites an immediate retry loop", retryAfter)
+	}
+}
+
+// The per-peer bucket must refuse a single noisy source before the global
+// budget is anywhere near spent -- that is the fairness property it exists for.
+func TestRegisterLimiter_PerPeerCapRefusesOneNoisySource(t *testing.T) {
+	const perPeer = 3
+	l := newRegistrationLimiter(1000, perPeer) // global set high so it cannot be what refuses
+
+	for i := range perPeer {
+		if ok, _ := l.allow("10.0.0.1"); !ok {
+			t.Fatalf("request %d from one peer was refused inside its budget of %d", i, perPeer)
+		}
+	}
+	if ok, _ := l.allow("10.0.0.1"); ok {
+		t.Fatalf("the %dth request from one peer was allowed past a per-peer budget of %d", perPeer+1, perPeer)
+	}
+	// A DIFFERENT peer must still get through: a fairness layer that starves
+	// everyone once one source misbehaves is a denial of service, not a defence.
+	if ok, _ := l.allow("10.0.0.2"); !ok {
+		t.Fatalf("a second, quiet peer was refused because a first peer exhausted " +
+			"its own bucket; the per-peer layer is not per-peer")
+	}
+}
+
+// A rejected request must not spend the caller's own fair-share budget.
+func TestRegisterLimiter_GlobalRefusalDoesNotChargeThePeer(t *testing.T) {
+	l := newRegistrationLimiter(1, 10)
+
+	if ok, _ := l.allow("10.0.0.1"); !ok {
+		t.Fatal("the first request was refused with a global budget of 1")
+	}
+	// Global is now empty; this refusal must not consume 10.0.0.2's tokens.
+	if ok, _ := l.allow("10.0.0.2"); ok {
+		t.Fatal("global budget of 1 allowed a second request")
+	}
+
+	b, ok := l.peers["10.0.0.2"]
+	if ok && b.lim.Tokens() < 10 {
+		t.Fatalf("a globally-refused request charged the peer's bucket: %v tokens "+
+			"left of 10; repeated global pressure would silently exhaust every "+
+			"innocent caller's budget", b.lim.Tokens())
+	}
+}
+
+// A nil limiter must refuse. This is the defect class this whole slice is most
+// exposed to: an absent guard coerced into "no limit configured, therefore
+// permitted".
+func TestRegisterLimiter_NilRefusesRatherThanAllows(t *testing.T) {
+	var l *registrationLimiter
+	if ok, _ := l.allow("10.0.0.1"); ok {
+		t.Fatal("a nil limiter ALLOWED the request; an unwired limiter must refuse, " +
+			"never read as absence of a limit")
+	}
+}
+
+// A non-positive budget is a misconfiguration, and it must fail closed.
+func TestRegisterLimiter_ZeroBudgetRefusesEverything(t *testing.T) {
+	for _, tc := range []struct{ global, perPeer int }{{0, 10}, {10, 0}, {-1, -1}} {
+		l := newRegistrationLimiter(tc.global, tc.perPeer)
+		if ok, _ := l.allow("10.0.0.1"); ok {
+			t.Fatalf("global=%d perPeer=%d allowed a request; a zero or negative "+
+				"budget must mean 'allow nothing', never 'no limit'", tc.global, tc.perPeer)
+		}
+	}
+}
+
+// An unparseable source must be MORE restrictive than a parseable one, not
+// exempt from the limit.
+func TestRegisterLimiter_UnknownPeerIsBucketedNotSkipped(t *testing.T) {
+	l := newRegistrationLimiter(1000, 2)
+	for i := range 2 {
+		if ok, _ := l.allow(""); !ok {
+			t.Fatalf("request %d with an unknown source was refused inside the budget", i)
+		}
+	}
+	if ok, _ := l.allow(""); ok {
+		t.Fatal("an unknown source was allowed past the per-peer budget; requests " +
+			"whose origin cannot be identified would be unlimited")
+	}
+}
+
+// The peer map must not grow without bound.
+func TestRegisterLimiter_PeerMapIsBounded(t *testing.T) {
+	l := newRegistrationLimiter(1_000_000, 1000)
+	for i := range registerPeerCap * 2 {
+		l.allow("10.0." + itoa(i/256) + "." + itoa(i%256))
+	}
+	if len(l.peers) > registerPeerCap {
+		t.Fatalf("peer map holds %d entries with a cap of %d; an attacker varying "+
+			"source addresses would grow it until the process died",
+			len(l.peers), registerPeerCap)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WHY THE KEY IS RemoteIP. This is the red half, executed rather than asserted.
+//
+// gin's engine here trusts every proxy (defaultTrustedCIDRs is 0.0.0.0/0 + ::/0
+// and SetTrustedProxies is never called in this repository), so ClientIP
+// returns the leftmost X-Forwarded-For entry -- a caller-supplied string. This
+// test drives the REAL mounted endpoint and demonstrates both halves: keying on
+// ClientIP would have been bypassable per request, and the shipped code, keyed
+// on RemoteIP, refuses.
+// ---------------------------------------------------------------------------
+
+func TestRegisterLimiter_ClientIPWouldHaveBeenSpoofableAndRemoteIPIsNot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// RED: the key that was NOT chosen. Every request varies X-Forwarded-For and
+	// every request lands in a different bucket, so a per-source limit keyed here
+	// never refuses anything.
+	seenClientIPs := map[string]bool{}
+	seenRemoteIPs := map[string]bool{}
+	r := gin.New()
+	r.POST("/probe", func(c *gin.Context) {
+		seenClientIPs[c.ClientIP()] = true
+		seenRemoteIPs[c.RemoteIP()] = true
+		c.Status(http.StatusOK)
+	})
+
+	const attempts = 20
+	for i := range attempts {
+		req := httptest.NewRequest(http.MethodPost, "/probe", strings.NewReader("{}"))
+		req.RemoteAddr = "203.0.113.7:5555" // ONE real TCP peer for every request
+		req.Header.Set("X-Forwarded-For", "198.51.100."+itoa(i))
+		r.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	if len(seenClientIPs) != attempts {
+		t.Fatalf("ClientIP() yielded %d distinct values across %d requests from ONE "+
+			"TCP peer; this test's premise is that it yields %d, and if gin's "+
+			"trusted-proxy configuration has changed then register_limit.go's "+
+			"reasoning must be re-read, not this number adjusted",
+			len(seenClientIPs), attempts, attempts)
+	}
+	if len(seenRemoteIPs) != 1 {
+		t.Fatalf("RemoteIP() yielded %d distinct values across %d requests from ONE "+
+			"TCP peer; the limiter key is supposed to be unspoofable",
+			len(seenRemoteIPs), attempts)
+	}
+
+	// GREEN: the shipped handler, keyed on RemoteIP, refuses the same traffic.
+	h := &Handler{svc: NewService(&fakeStore{registerRows: 1}),
+		regLimit: newRegistrationLimiter(1000, 3)}
+	eng := gin.New()
+	h.RegisterPublic(eng.Group("/api/v1"))
+
+	var refused int
+	for i := range attempts {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/oauth/mcp/register",
+			strings.NewReader(`{"redirect_uris":["https://example.test/cb"],`+
+				`"token_endpoint_auth_method":"none"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "203.0.113.7:5555"
+		req.Header.Set("X-Forwarded-For", "198.51.100."+itoa(i))
+		w := httptest.NewRecorder()
+		eng.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			refused++
+		}
+	}
+	if refused == 0 {
+		t.Fatalf("%d registrations from one TCP peer, each with a different "+
+			"X-Forwarded-For, were ALL accepted; the limiter is keyed on a "+
+			"caller-controlled header and enforces nothing", attempts)
+	}
+	t.Logf("one TCP peer, %d distinct X-Forwarded-For values, per-peer budget 3: "+
+		"%d refused with 429", attempts, refused)
+}
+
+// ---------------------------------------------------------------------------
+// THE MOUNTED ROUTES.
+// ---------------------------------------------------------------------------
+
+// A 429 must carry Retry-After, and must be a 429 rather than a 400.
+func TestRegister_RefusalIs429WithRetryAfter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{svc: NewService(&fakeStore{registerRows: 1}),
+		regLimit: newRegistrationLimiter(1, 1)}
+	eng := gin.New()
+	h.RegisterPublic(eng.Group("/api/v1"))
+
+	body := `{"redirect_uris":["https://example.test/cb"],"token_endpoint_auth_method":"none"}`
+	newReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/oauth/mcp/register",
+			strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "203.0.113.7:5555"
+		return req
+	}
+
+	eng.ServeHTTP(httptest.NewRecorder(), newReq()) // spends the budget
+
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, newReq())
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("a rate-limited registration answered %d, want 429", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Fatal("a 429 with no Retry-After header")
+	}
+}
+
+// The body cap must engage before the decoder reads an unbounded stream.
+func TestRegister_OversizeBodyIsRefused(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{svc: NewService(&fakeStore{registerRows: 1}),
+		regLimit: newRegistrationLimiter(1000, 1000)}
+	eng := gin.New()
+	h.RegisterPublic(eng.Group("/api/v1"))
+
+	huge := `{"client_name":"` + strings.Repeat("A", maxOAuthBodyBytes*2) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/oauth/mcp/register",
+		strings.NewReader(huge))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.7:5555"
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+
+	if w.Code == http.StatusCreated {
+		t.Fatalf("a %d-byte body was accepted past a %d-byte cap",
+			len(huge), maxOAuthBodyBytes)
+	}
+}
+
+// EVERY VERB ON EVERY OAUTH PATH MUST ANSWER 405, NEVER 404.
+//
+// A 404 on a published endpoint reads as "not deployed" and sends an operator
+// to check the deploy instead of their request. That was exactly the S6b-2
+// blocker, on the transport path, so it is proven here per verb per route
+// rather than assumed to have been fixed once.
+func TestOAuthRoutes_UnsupportedVerbsAre405Not404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{svc: NewService(&fakeStore{registerRows: 1}),
+		regLimit: newRegistrationLimiter(1000, 1000)}
+	eng := gin.New()
+	pub := eng.Group("/api/v1")
+	h.RegisterPublic(pub)
+	h.Register(pub) // same group: this test is about routing, not about auth
+
+	paths := map[string]string{
+		"/api/v1/oauth/mcp/register":  http.MethodPost,
+		"/api/v1/oauth/mcp/token":     http.MethodPost,
+		"/api/v1/oauth/mcp/authorize": http.MethodGet,
+		"/api/v1/oauth/mcp/consent":   http.MethodPost,
+	}
+
+	for path, supported := range paths {
+		for _, verb := range allVerbs {
+			if verb == supported {
+				continue
+			}
+			req := httptest.NewRequest(verb, path, nil)
+			req.RemoteAddr = "203.0.113.7:5555"
+			w := httptest.NewRecorder()
+			eng.ServeHTTP(w, req)
+
+			if w.Code == http.StatusNotFound {
+				t.Errorf("%s %s answered 404; an operator reads that as 'not "+
+					"deployed' rather than 'wrong verb'", verb, path)
+				continue
+			}
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s %s answered %d, want 405", verb, path, w.Code)
+				continue
+			}
+			if got := w.Header().Get("Allow"); got != supported {
+				t.Errorf("%s %s: Allow=%q, want %q", verb, path, got, supported)
+			}
+		}
+	}
+}
+
+// itoa avoids pulling strconv into this file's namespace for a loop counter.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		return "-" + string(b)
+	}
+	return string(b)
+}

--- a/apps/api/internal/mcp/register_limit_test.go
+++ b/apps/api/internal/mcp/register_limit_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -317,6 +318,78 @@ func TestOAuthRoutes_UnsupportedVerbsAre405Not404(t *testing.T) {
 			}
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// A REFUSED REQUEST MUST COST NOTHING, IN EITHER BUCKET.
+//
+// The accounting bug this exists for: allow() took and KEPT a global
+// reservation before consulting the peer bucket, so a peer that had already
+// exhausted its own budget still spent process-wide capacity on every request
+// it was REFUSED for. That inverts the whole design -- the fairness layer
+// becomes the thing that lets one peer deny everyone else, and an attacker does
+// not have to beat the limiter, they beat it by being rejected, which is free
+// and fast.
+//
+// A SINGLE-PEER TEST CANNOT SEE THIS, which is why nothing caught it: the
+// flooding peer is refused either way, so only a SECOND, unrelated peer reveals
+// where the tokens went.
+// ---------------------------------------------------------------------------
+
+func TestRegisterLimiter_OnePeerFloodingDoesNotStarveAnother(t *testing.T) {
+	const (
+		global  = 60
+		perPeer = 5
+		flood   = 300 // far more than global, so a leak drains it many times over
+	)
+	l := newRegistrationLimiter(global, perPeer)
+
+	// The quiet peer goes first so it cannot be accused of arriving too late.
+	if ok, _ := l.allow("198.51.100.2"); !ok {
+		t.Fatal("the quiet peer was refused on its very first request")
+	}
+
+	// The flooding peer exhausts its own bucket and then keeps going. Every
+	// request past the first perPeer is refused, and each refusal must cost
+	// nothing anywhere.
+	var floodAdmitted int
+	for range flood {
+		if ok, _ := l.allow("198.51.100.1"); ok {
+			floodAdmitted++
+		}
+	}
+	if floodAdmitted > perPeer {
+		t.Fatalf("the flooding peer was admitted %d times against a per-peer "+
+			"budget of %d", floodAdmitted, perPeer)
+	}
+
+	// THE ASSERTION. The quiet peer is well inside its own budget, and the
+	// global budget was never legitimately spent, so every one of these must be
+	// admitted. Under the defect they are all refused.
+	for i := range perPeer - 1 {
+		ok, wait := l.allow("198.51.100.2")
+		if !ok {
+			t.Fatalf("request %d from a QUIET peer was refused (retry in %v) after "+
+				"another peer was rejected %d times. Only %d requests were ever "+
+				"admitted out of a global budget of %d, so the REJECTIONS consumed "+
+				"the global capacity: one peer can deny registration to everyone "+
+				"else by being refused quickly, which costs it nothing",
+				i+1, wait, flood-floodAdmitted, floodAdmitted+1, global)
+		}
+	}
+
+	// And the books balance: global is charged once per ADMITTED request and
+	// never for a refusal.
+	admitted := float64(floodAdmitted + perPeer)
+	left := l.global.TokensAt(time.Now())
+	if left < float64(global)-admitted-0.5 {
+		t.Fatalf("global bucket has %.1f tokens left; %.0f admitted requests should "+
+			"leave about %.1f. The difference was spent on refusals",
+			left, admitted, float64(global)-admitted)
+	}
+	t.Logf("one peer refused %d times, a quiet peer admitted throughout; global "+
+		"tokens left %.1f of %d after %.0f admitted requests",
+		flood-floodAdmitted, left, global, admitted)
 }
 
 // itoa avoids pulling strconv into this file's namespace for a loop counter.

--- a/apps/api/internal/server/server.go
+++ b/apps/api/internal/server/server.go
@@ -250,6 +250,22 @@ type Deps struct {
 	// An unauthenticated request here must be 401, and 401 is only reachable
 	// if the route exists.
 	MCPTransportH *mcp.TransportHandler
+	// MCPOAuthH serves the four OAuth endpoints that mint the bearer token
+	// MCPTransportH consumes: POST /api/v1/oauth/mcp/register (RFC 7591 dynamic
+	// client registration), GET .../authorize, POST .../consent and POST
+	// .../token. Without these mounted, POST /mcp is reachable but no token can
+	// ever be minted, so it refuses every request forever.
+	//
+	// MOUNTED IN TWO PLACES BY DESIGN, and the split is the security boundary:
+	// RegisterPublic goes on the ROOT engine (register + token are
+	// unauthenticated by specification), Register goes on the session-authed,
+	// tenant-gated v1 group (authorize + consent are the human's approval and
+	// the grant belongs to that human's organisation).
+	//
+	// Like MCPTransportH this is REQUIRED and mounted unconditionally: an
+	// unmounted route answers 404, which hides a wiring failure behind
+	// something that reads as a deliberate refusal.
+	MCPOAuthH *mcp.Handler
 	// BillingSuspensionGate is the M16 Phase C1 superadmin hard-lockout
 	// middleware (billing.Service.SuspensionGate) mounted on the tenant-scoped
 	// v1 group. nil ⇒ WPMGR_HOSTED is off; self-host never sees this check
@@ -425,6 +441,30 @@ func New(deps Deps) *Server {
 		deps.MCPTransportH.Register(engine)
 	}
 
+	// S6b — the UNAUTHENTICATED half of the MCP OAuth surface:
+	// POST /api/v1/oauth/mcp/register and POST /api/v1/oauth/mcp/token, plus the
+	// 405 fallbacks for all four OAuth paths.
+	//
+	// Mounted on the ROOT engine via a bare /api/v1 group, NOT on the
+	// sessionAuthGroup-derived v1 below, and NOT on sessionAuthGroup: RFC 7591
+	// registration precedes any human, and the token endpoint authenticates by
+	// presenting a code plus a PKCE verifier. Neither may ever read a tenant
+	// from a session, and mounting them behind Authenticate() would put a
+	// session principal within reach of code that must never consult one. Same
+	// reasoning and same shape as PricingH.RegisterPublic above.
+	//
+	// THE OPEN-REGISTRATION DECISION IS DELIBERATE, not a side effect of
+	// mounting the transport: /register lets anyone on the internet create rows
+	// in mcp_oauth_clients, which is required because GUI clients enrol
+	// themselves before any human signs in. The harm is bounded to anonymous
+	// row creation -- the table has no tenant_id, a client_id is not a secret,
+	// and possession authorizes nothing without a grant -- and that harm is
+	// bounded by the two-layer limiter and body cap in
+	// internal/mcp/register_limit.go. Read that file before changing this.
+	if deps.MCPOAuthH != nil {
+		deps.MCPOAuthH.RegisterPublic(engine.Group("/api/v1"))
+	}
+
 	// Agent-authenticated endpoints: the agent authenticator verifies an Ed25519
 	// signed request and resolves the site/tenant from the verified key — this
 	// group does NOT use the session/API-key principal chain.
@@ -524,6 +564,17 @@ func New(deps Deps) *Server {
 	// tenant gate here opens no hole. (ADR-045 Phase 3 onboarding.)
 	v1Auth := sessionAuthGroup.Group("/api/v1")
 	v1Auth.Use(authz.RequireAuth())
+	// S6b — the OPERATOR-AUTHENTICATED half of the MCP OAuth surface:
+	// GET /api/v1/oauth/mcp/authorize and POST /api/v1/oauth/mcp/consent.
+	//
+	// On v1, so RequireAuth AND RequireTenant both apply. RequireTenant is
+	// load-bearing rather than incidental: consent writes the grant under
+	// principal.TenantID, and a principal with uuid.Nil there would otherwise
+	// reach the service and attempt a grant belonging to no organisation.
+	// Refusing at the gate is what stops uuid.Nil being treated as a tenant.
+	if deps.MCPOAuthH != nil {
+		deps.MCPOAuthH.Register(v1)
+	}
 	deps.TenantH.Register(v1)
 	deps.SiteH.Register(v1)
 	// m100 (GH #230 "rich tags") — tenant-level tag registry.

--- a/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
+++ b/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
@@ -1,0 +1,388 @@
+// adr064_s6b3_mcp_oauth_end_to_end_test.go: the whole MCP connect flow, driven
+// through the MOUNTED HTTP routes against the real schema as wpmgr_app.
+//
+// WHY THIS FILE EXISTS. Handler.Register and Handler.RegisterPublic were called
+// from nowhere. DCR, authorize, consent and token exchange were built, reviewed
+// and unreachable, so POST /mcp was mounted, correct, and refused every request
+// forever because no token could be minted. Mounting them is what this slice
+// did; this is the proof that the four endpoints compose into a working flow
+// rather than four endpoints that each pass their own unit tests.
+//
+// WHAT MAKES IT A PROOF RATHER THAN A REHEARSAL.
+//
+//   - It goes through gin, through the same Handler.RegisterPublic and
+//     Handler.Register calls server.New makes, to the same Service and Repo,
+//     which use the same tx helpers. No GUC is hand-set anywhere in this file.
+//   - It opens NO connection of its own for the flow. Every read and write
+//     lands through db.Pool as wpmgr_app -- NOSUPERUSER, NOBYPASSRLS -- which is
+//     asserted and printed below. A test that opened its own connection would
+//     leave every policy inert and pass regardless; that has happened here.
+//   - The last step is the one the owner is waiting on: the minted bearer token
+//     is presented to POST /mcp and used to READ SITES. Anything short of that
+//     proves the OAuth dance and not the thing the dance exists for.
+//
+// The authenticated half is mounted behind a middleware that injects a
+// principal, which is what authz.RequireAuth + RequireTenant hand the handler in
+// production. The session machinery itself is not under test here.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole is the QA gate: register,
+// authorize with PKCE, consent, exchange, then read sites over MCP.
+func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing. Either privilege would make all of this pass
+	// vacuously, so it is asserted inside a transaction the flow actually uses.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	tenantID := seedTenant(t, pool, "mcp-s6b3-"+uuid.NewString()[:8])
+	userID := seedUserRow(t, pool, "mcp-s6b3-"+uuid.NewString()[:8]+"@example.test")
+	// No membership row is seeded: memberships is RLS-protected and this pool is
+	// wpmgr_app, which is the point of the test. The principal below stands in
+	// for what authz.RequireAuth + RequireTenant have already established by the
+	// time the consent handler runs, so membership is upstream of what is under
+	// test here.
+	siteURL := "https://" + uuid.NewString()[:8] + ".example.test"
+	siteID := seedSite(t, pool, tenantID, siteURL)
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	eng := mountLikeProduction(t, svc, tenantID, userID)
+
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+
+	// -----------------------------------------------------------------------
+	// STEP 1: RFC 7591 dynamic client registration, UNAUTHENTICATED.
+	// -----------------------------------------------------------------------
+	regBody := map[string]any{
+		"redirect_uris":              []string{redirectURI},
+		"client_name":                "Claude Desktop",
+		"client_uri":                 "https://claude.ai",
+		"token_endpoint_auth_method": "none", // public client: PKCE is the proof
+	}
+	var reg struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+	}
+	code := mcpDoJSON(t, eng, http.MethodPost, "/api/v1/oauth/mcp/register", regBody, nil, &reg)
+	if code != http.StatusCreated {
+		t.Fatalf("STEP 1 registration answered %d, want 201", code)
+	}
+	if reg.ClientID == "" {
+		t.Fatal("STEP 1 returned no client_id")
+	}
+	if reg.ClientSecret != "" {
+		t.Errorf("STEP 1 minted a client_secret for a token_endpoint_auth_method " +
+			"of 'none'; a public client must get no secret")
+	}
+	t.Logf("STEP 1 ok: registered client_id=%s (unauthenticated, no secret)", reg.ClientID)
+
+	// -----------------------------------------------------------------------
+	// STEP 2: authorize. Returns the consent screen's contents and mints
+	// nothing. PKCE S256 throughout -- the verifier never leaves this test until
+	// the exchange.
+	// -----------------------------------------------------------------------
+	verifier := "s6b3-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", reg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "s6b3-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+
+	var consentScreen struct {
+		ClientID             string   `json:"client_id"`
+		ClientNameUnverified string   `json:"client_name_unverified"`
+		IdentityVerified     bool     `json:"identity_verified"`
+		RedirectURI          string   `json:"redirect_uri"`
+		RedirectHost         string   `json:"redirect_host"`
+		Scopes               []string `json:"scopes"`
+	}
+	code = mcpDoJSON(t, eng, http.MethodGet,
+		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, &consentScreen)
+	if code != http.StatusOK {
+		t.Fatalf("STEP 2 authorize answered %d, want 200", code)
+	}
+
+	// m124 obligation 7, on the path that is actually mounted. Registration is
+	// unauthenticated, so client_name is an attacker-controlled string and two
+	// clients may both call themselves "Claude Desktop". The server must mark it
+	// unverified; a UI that renders it as an identity is then the UI's defect,
+	// not a missing signal.
+	if consentScreen.IdentityVerified {
+		t.Error("STEP 2 consent screen reports identity_verified=true; registration " +
+			"is unauthenticated and nothing about this identity is verified, ever")
+	}
+	if consentScreen.ClientNameUnverified != "Claude Desktop" {
+		t.Errorf("STEP 2 client_name_unverified = %q, want the registered value",
+			consentScreen.ClientNameUnverified)
+	}
+	if consentScreen.RedirectHost == "" {
+		t.Error("STEP 2 supplied no redirect_host; the host is the part of the " +
+			"request a human can actually judge")
+	}
+	t.Logf("STEP 2 ok: consent screen for %q, identity_verified=%t, redirect_host=%s",
+		consentScreen.ClientNameUnverified, consentScreen.IdentityVerified,
+		consentScreen.RedirectHost)
+
+	// -----------------------------------------------------------------------
+	// STEP 3: consent. The human's approval, and the only thing that binds this
+	// client to an organisation.
+	// -----------------------------------------------------------------------
+	approveBody := map[string]any{
+		"client_id":             reg.ClientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "s6b3-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"name":                  "s6b3 end-to-end connection",
+		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+	}
+	var approval struct {
+		GrantID string `json:"grant_id"`
+		Code    string `json:"code"`
+		State   string `json:"state"`
+	}
+	code = mcpDoJSON(t, eng, http.MethodPost, "/api/v1/oauth/mcp/consent", approveBody, nil, &approval)
+	if code != http.StatusOK {
+		t.Fatalf("STEP 3 consent answered %d, want 200", code)
+	}
+	if approval.Code == "" {
+		t.Fatal("STEP 3 returned no authorization code")
+	}
+	if approval.State != "s6b3-state" {
+		t.Errorf("STEP 3 state = %q, want the value the client sent; a dropped "+
+			"state breaks the client's own CSRF check", approval.State)
+	}
+	t.Logf("STEP 3 ok: grant %s approved under tenant %s", approval.GrantID, tenantID)
+
+	// -----------------------------------------------------------------------
+	// STEP 4: token exchange, UNAUTHENTICATED, form-encoded as every client
+	// library sends it. The code plus the PKCE verifier is the entire credential.
+	// -----------------------------------------------------------------------
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", approval.Code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", reg.ClientID)
+	form.Set("code_verifier", verifier)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/oauth/mcp/token",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "203.0.113.7:5555"
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("STEP 4 token exchange answered %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("STEP 4 Cache-Control = %q, want no-store (RFC 6749 5.1)", got)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+		Scope       string `json:"scope"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &tok); err != nil {
+		t.Fatalf("STEP 4 token response is not JSON: %v", err)
+	}
+	if tok.AccessToken == "" {
+		t.Fatal("STEP 4 returned no access_token")
+	}
+	if tok.ExpiresIn <= 0 {
+		t.Errorf("STEP 4 expires_in = %d; a non-positive lifetime reads as "+
+			"'already expired' or 'never expires', and neither is intended", tok.ExpiresIn)
+	}
+	t.Logf("STEP 4 ok: minted a %s token, scope=%q, expires_in=%d",
+		tok.TokenType, tok.Scope, tok.ExpiresIn)
+
+	// The code is single-use. Replaying it must not mint a second token.
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/oauth/mcp/token",
+		strings.NewReader(form.Encode()))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req2.RemoteAddr = "203.0.113.7:5555"
+	eng.ServeHTTP(w2, req2)
+	if w2.Code == http.StatusOK {
+		t.Errorf("STEP 4 replay of a consumed authorization code minted a SECOND "+
+			"token (%d); the code is single-use", w2.Code)
+	}
+
+	// -----------------------------------------------------------------------
+	// STEP 5: THE POINT OF ALL OF IT. Present the token to POST /mcp and read
+	// the fleet. This is the owner's QA gate.
+	// -----------------------------------------------------------------------
+
+	// First, the negative control. An unauthenticated call must be refused, so
+	// that a success below is the token's doing and not an open endpoint.
+	anon := mcpRPC(t, eng, "", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if anon.status == http.StatusOK {
+		t.Fatalf("POST /mcp with NO bearer token answered 200; every result below "+
+			"would be meaningless. body: %s", anon.body)
+	}
+	if anon.status == http.StatusNotFound {
+		t.Fatal("POST /mcp answered 404, which reads as 'not deployed' rather " +
+			"than 'refused'; the transport is not mounted in this test")
+	}
+	t.Logf("STEP 5 control ok: unauthenticated POST /mcp answered %d", anon.status)
+
+	// Now with the minted token.
+	got := mcpRPC(t, eng, tok.AccessToken, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("STEP 5 tools/call %s with the minted token answered %d; the whole "+
+			"OAuth flow completed and the token it produced does not work. body: %s",
+			mcp.ToolListSites, got.status, got.body)
+	}
+	if strings.Contains(got.body, `"error"`) {
+		t.Fatalf("STEP 5 tools/call returned a JSON-RPC error: %s", got.body)
+	}
+
+	// The site seeded into this tenant must actually appear. "200 with an empty
+	// list" is the shape a broken scope resolution produces, and it is the one
+	// outcome most easily mistaken for success -- swapped arguments made every
+	// scoped grant resolve to zero sites on this very stack.
+	if !strings.Contains(got.body, siteURL) {
+		t.Fatalf("STEP 5 tools/call %s returned 200 but the tenant's only site "+
+			"(%s, id=%s) is absent. An empty read is not a successful read.\nbody: %s",
+			mcp.ToolListSites, siteURL, siteID, got.body)
+	}
+	t.Logf("STEP 5 ok: read site %s over MCP with the OAuth-minted bearer token", siteURL)
+	t.Log("END TO END: register -> authorize -> consent -> exchange -> read, " +
+		"through the mounted routes, as wpmgr_app")
+}
+
+// mountLikeProduction builds the engine the way server.New does: RegisterPublic
+// on a bare /api/v1 group with NO session middleware, Register on a group that
+// carries a principal the way RequireAuth + RequireTenant guarantee, and the
+// transport on the root engine.
+//
+// The two Register calls and their groups are the part under test. If
+// server.New's mounting diverges from this, that is a defect in one of the two
+// and this comment is where to start.
+func mountLikeProduction(t *testing.T, svc *mcp.Service, tenantID, userID uuid.UUID) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	eng := gin.New()
+	h := mcp.NewHandler(svc)
+
+	// Unauthenticated half, on the root engine.
+	h.RegisterPublic(eng.Group("/api/v1"))
+
+	// Operator-authenticated half. The middleware stands in for session auth +
+	// authz.RequireAuth + authz.RequireTenant, which is exactly a principal
+	// carrying a non-nil tenant.
+	authed := eng.Group("/api/v1")
+	authed.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(),
+			domain.Principal{UserID: userID, TenantID: tenantID}))
+		c.Next()
+	})
+	h.Register(authed)
+
+	// The transport, on the root engine, exactly as server.New mounts it.
+	mcp.NewTransportHandler(svc, slog.New(slog.NewTextHandler(io.Discard, nil)), "test").Register(eng)
+
+	return eng
+}
+
+type rpcResult struct {
+	status int
+	body   string
+}
+
+// mcpRPC posts a JSON-RPC envelope to the mounted /mcp endpoint.
+func mcpRPC(t *testing.T, eng *gin.Engine, bearer string, payload map[string]any) rpcResult {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal rpc payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, mcp.TransportPath, strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.RemoteAddr = "203.0.113.7:5555"
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+	return rpcResult{status: w.Code, body: w.Body.String()}
+}
+
+// doJSON sends a JSON request (or none) and decodes the response into out,
+// returning the status. It fails the test on a transport-level problem only --
+// a non-2xx is data for the caller to assert on, never something swallowed here.
+func mcpDoJSON(t *testing.T, eng *gin.Engine, method, path string, body any,
+	_ http.Header, out any) int {
+	t.Helper()
+
+	var reader *strings.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal %s %s: %v", method, path, err)
+		}
+		reader = strings.NewReader(string(raw))
+	} else {
+		reader = strings.NewReader("")
+	}
+
+	req := httptest.NewRequest(method, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.RemoteAddr = "203.0.113.7:5555"
+
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+
+	if out != nil && w.Body.Len() > 0 {
+		if err := json.Unmarshal(w.Body.Bytes(), out); err != nil {
+			t.Fatalf("%s %s returned %d with a body that is not JSON: %v\nbody: %s",
+				method, path, w.Code, err, w.Body.String())
+		}
+	}
+	return w.Code
+}


### PR DESCRIPTION
## What this does

`internal/mcp`'s `Handler.Register` and `Handler.RegisterPublic` were called from nowhere. DCR, authorize, consent and token exchange were built and security-reviewed but **unreachable**, so `POST /mcp` was live and correctly refused every request forever — no token could be minted. This mounts them.

Four routes now exist:

| Route | Verb | Mounted on | Auth |
|---|---|---|---|
| `/api/v1/oauth/mcp/register` | POST | root engine | none (RFC 7591) |
| `/api/v1/oauth/mcp/token` | POST | root engine | code + PKCE verifier |
| `/api/v1/oauth/mcp/authorize` | GET | `v1` | RequireAuth + RequireTenant |
| `/api/v1/oauth/mcp/consent` | POST | `v1` | RequireAuth + RequireTenant |

The split is the security boundary, not routing convenience. The public pair is on the **root engine**, deliberately not on `sessionAuthGroup`: registration precedes any human and the token endpoint authenticates with a code plus a verifier, so neither may ever reach a session principal. `RequireTenant` on the authenticated pair is load-bearing — it is what stops a `uuid.Nil` tenant reaching the consent service.

## The decision: open registration, and what bounds it

`POST /register` is unauthenticated **by specification** — that is how GUI clients enrol. Mounting it means anyone on the internet can create rows in `mcp_oauth_clients`. That was checked against the design rather than assumed: the connect wizard has GUI clients enrol themselves, so a signed dashboard hint would break Phase 1.

The harm is bounded by the schema and does not extend past it: no `tenant_id` on the table, `client_id` is not a secret (RFC 6749 §2.2), possession authorizes nothing without a grant, and the table is invisible to a transaction setting neither of its GUCs. **What is left is unbounded anonymous row creation**, and that is what the defence targets: a two-layer token bucket plus a 16 KiB `http.MaxBytesReader` (the house pattern).

### The limiter is keyed on `RemoteIP`, never `ClientIP`

I checked whether the load balancer supplies a rate limit rather than assuming it: `grep -rni "cloud.armor|securityPolicy|rateLimitOptions"` over `infra/` and `.github/workflows/` returns nothing. There is no edge limit. So it has to be in-process.

Then the trap. gin's engine defaults are `ForwardedByClientIP: true`, `RemoteIPHeaders: ["X-Forwarded-For", "X-Real-IP"]` and `trustedCIDRs: 0.0.0.0/0 + ::/0` (`gin@v1.12.0` `gin.go:39`, `gin.go:214-226`), and **`SetTrustedProxies` is never called anywhere in this repo**. Every proxy is therefore trusted, so `ClientIP()` returns the *leftmost* `X-Forwarded-For` entry — a caller-supplied string. A limiter keyed there enforces nothing while looking correct in the code and in the logs. That is executed, not asserted: `TestRegisterLimiter_ClientIPWouldHaveBeenSpoofableAndRemoteIPIsNot` drives 20 requests from one TCP peer with 20 different `X-Forwarded-For` values.

- **Global bucket, 60/min** — keyed on nothing, unspoofable, never evicted. This is the bound; source diversity cannot enlarge it.
- **Per-peer bucket, 10/min, keyed on `RemoteIP`** — fairness only. Its map is capacity-bounded and eviction hands out fresh buckets, so this layer is fail-open by construction. Documented as such, and safe only because the global layer sits behind it.

**Stated honestly:** both are per-process, so an N-instance deployment's real ceiling is `N * 60/min`. Behind the GCLB the TCP peer *is* the balancer, so the per-peer layer collapses into a second global cap — a loss of fairness, never a loss of the bound. A cross-instance cap needs Redis or a database-side row cap with GC; the latter is `database-engineer`'s path and is **not in this PR**.

Everything fails closed: a nil limiter refuses, a zero or negative budget refuses, and an unidentifiable source is bucketed rather than exempted.

## Obligations from m124 that landed here

- **Unverified client identity** — already implemented server-side (`dto.go` `consentResponseDTO`, `identity_verified` a literal `false`), and now pinned on the mounted path by the end-to-end test. The UI half remains a frontend slice.
- **Exact `redirect_uri` matching** — `exactMatchRedirectURI` is on both the authorize (`service.go:317`) and the minting consent (`service.go:423`) paths. Verified as on the path being mounted.

## 405, never 404

Every unsupported verb on all four paths answers 405 with an `Allow` header. The fallbacks for the two *authenticated* paths are mounted unauthenticated on purpose, matching `TransportHandler.Register`'s precedent: the verb is wrong regardless of who is asking, and a 404 on a published endpoint reads as "not deployed" — exactly the S6b-2 blocker.

## Proofs

Both guards were planted, observed red, restored, observed green.

- Limiter key swapped to `ClientIP` → `FAIL: 20 registrations from one TCP peer, each with a different X-Forwarded-For, were ALL accepted`. Restored → pass, `17 refused with 429`.
- One `methodNotAllowedExcept` line deleted → `FAIL` on 6 verbs, each `answered 404`. Restored → pass.

**End to end, the owner's QA gate** (`TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole`), through the mounted routes as `wpmgr_app` with `rolsuper=false rolbypassrls=false` asserted inside a transaction the flow uses:

```
STEP 1 ok: registered client_id=... (unauthenticated, no secret)
STEP 2 ok: consent screen for "Claude Desktop", identity_verified=false, redirect_host=claude.ai
STEP 3 ok: grant 6a371639-... approved under tenant 9b8d60dd-...
STEP 4 ok: minted a Bearer token, scope="mcp:read", expires_in=7776000
STEP 5 control ok: unauthenticated POST /mcp answered 401
STEP 5 ok: read site https://3e67b51d.example.test over MCP with the OAuth-minted bearer token
```

It refuses three cheap fakes: an unauthenticated `POST /mcp` runs first as a negative control, a replayed code must not mint a second token, and the seeded site must appear **by URL** — "200 with an empty list" is what broken scope resolution returns.

## For the reviewer

Two things I did not change and think you should rule on:

1. **`expires_in=7776000`** — the minted access token lives 90 days. Pre-existing, not touched here, but it is what this PR makes reachable for the first time.
2. **No RFC 8414 metadata document.** There is no `/.well-known/oauth-authorization-server`, so a GUI client cannot auto-discover these endpoints; the wizard has to state them. Out of scope here, but it gates whether "Claude Desktop just connects" works.

`SetTrustedProxies` being unset is a whole-engine deployment decision and is worth its own look, but nothing in this PR depends on it.
