### PR TITLE
feat(web): the AI-connection consent screen (ADR-064 S6b, design Step 7)

### DIFF
--- a/apps/web/src/features/mcp-consent/consent-context.test.ts
+++ b/apps/web/src/features/mcp-consent/consent-context.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  allScopesRecognised,
+  asSelfAsserted,
+  describeScope,
+  parseConsentContext,
+  SCOPE_READ,
+} from "./consent-context";
+
+// m124 obligation 7: the consent screen must present registration-supplied
+// identity as UNVERIFIED. RFC 7591 registration is unauthenticated, so
+// client_name and client_uri are attacker-controlled strings and two clients
+// may both call themselves "Claude Desktop".
+
+const VALID = {
+  client_id: "c_01HZ",
+  client_name_unverified: "Claude Desktop",
+  client_uri_unverified: "https://claude.ai",
+  identity_verified: false,
+  redirect_uri: "https://attacker.example/oauth/callback",
+  redirect_host: "attacker.example",
+  scopes: [SCOPE_READ],
+  state: "xyz",
+  code_challenge: "abc",
+  code_challenge_method: "S256",
+};
+
+describe("parseConsentContext — unverified identity", () => {
+  it("keeps the self-declared name on a field whose name says it is unverified", () => {
+    const ctx = parseConsentContext(VALID);
+    // The domain object has NO plain `clientName`. A template cannot reach the
+    // string without going through a field marked unverified and a union that
+    // forces the absent branch to be handled.
+    expect(ctx).not.toHaveProperty("clientName");
+    expect(ctx.clientNameUnverified).toEqual({ stated: true, value: "Claude Desktop" });
+    expect(ctx.identityVerified).toBe(false);
+  });
+
+  it("REFUSES a payload that claims the identity is verified", () => {
+    // There is no verified path. dto.go writes `IdentityVerified: false` as a
+    // literal precisely so no code path can set it true. A payload asserting
+    // otherwise is not a more-trusted client, it is a payload we do not
+    // understand, and an unreadable payload is a failed load.
+    expect(() => parseConsentContext({ ...VALID, identity_verified: true })).toThrow();
+  });
+
+  it("REFUSES a payload with no verified redirect host to show", () => {
+    // The redirect host is the only identity claim on the screen we stand
+    // behind. Without it the screen would have nothing true to lead with and
+    // the attacker-controlled name would become the answer to "who is asking".
+    expect(() => parseConsentContext({ ...VALID, redirect_host: "" })).toThrow();
+    const { redirect_host: _dropped, ...missing } = VALID;
+    expect(() => parseConsentContext(missing)).toThrow();
+  });
+
+  it("REFUSES a payload carrying no scopes rather than showing an empty permission list", () => {
+    // ParseRequestedScopes refuses a request naming no recognised scope, so an
+    // empty array here is incoherent. Rendering it as "this client may read
+    // nothing" would be a confident sentence about a payload we could not read.
+    expect(() => parseConsentContext({ ...VALID, scopes: [] })).toThrow();
+  });
+
+  it("REFUSES a payload that is not an object at all", () => {
+    expect(() => parseConsentContext(null)).toThrow();
+    expect(() => parseConsentContext("ok")).toThrow();
+    expect(() => parseConsentContext(undefined)).toThrow();
+  });
+
+  it("distinguishes a client that gave no name from one that gave a blank", () => {
+    // Both are an ABSENCE and both must reach the same explicit branch. A
+    // whitespace name is chosen by an attacker for exactly the effect a blank
+    // has: it looks like a rendering glitch rather than a warning.
+    expect(parseConsentContext({ ...VALID, client_name_unverified: "" }).clientNameUnverified)
+      .toEqual({ stated: false });
+    expect(parseConsentContext({ ...VALID, client_name_unverified: "   " }).clientNameUnverified)
+      .toEqual({ stated: false });
+    const { client_name_unverified: _omitted, ...noName } = VALID;
+    expect(parseConsentContext(noName).clientNameUnverified).toEqual({ stated: false });
+  });
+
+  it("never coerces an absent optional into a plausible value", () => {
+    const { state: _s, code_challenge: _c, code_challenge_method: _m, ...bare } = VALID;
+    const ctx = parseConsentContext(bare);
+    expect(ctx.state).toBeNull();
+    expect(ctx.codeChallenge).toBeNull();
+    expect(ctx.codeChallengeMethod).toBeNull();
+  });
+});
+
+describe("asSelfAsserted", () => {
+  it("reports presence and absence as distinct facts", () => {
+    expect(asSelfAsserted("Fleet")).toEqual({ stated: true, value: "Fleet" });
+    expect(asSelfAsserted("  Fleet  ")).toEqual({ stated: true, value: "Fleet" });
+    expect(asSelfAsserted("")).toEqual({ stated: false });
+    expect(asSelfAsserted(null)).toEqual({ stated: false });
+    expect(asSelfAsserted(undefined)).toEqual({ stated: false });
+  });
+});
+
+describe("describeScope", () => {
+  it("describes the one recognised scope in blunt, specific terms", () => {
+    const copy = describeScope(SCOPE_READ);
+    expect(copy.title).toContain("Read");
+    expect(copy.detail).toContain("plugins");
+  });
+
+  it("says an unrecognised scope is unrecognised rather than prettifying it", () => {
+    const copy = describeScope("mcp:write");
+    expect(copy.title.toLowerCase()).toContain("unrecognised");
+    expect(copy.detail).toContain("Do not approve");
+  });
+
+  it("treats any scope other than the one in the registry as unrecognised", () => {
+    expect(allScopesRecognised([SCOPE_READ])).toBe(true);
+    expect(allScopesRecognised([SCOPE_READ, "mcp:write"])).toBe(false);
+    // Matching is exact and case-sensitive server-side (RFC 6749 s3.3), so a
+    // normalised near-miss must not be described as the real scope.
+    expect(allScopesRecognised(["MCP:READ"])).toBe(false);
+  });
+});

--- a/apps/web/src/features/mcp-consent/consent-context.ts
+++ b/apps/web/src/features/mcp-consent/consent-context.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+
+// The consent screen's data model (ADR-064 S6b, design Step 7).
+//
+// WHY THIS FILE EXISTS SEPARATELY FROM THE SCREEN
+//
+// m124 obligation 7 (apps/api/migrations/20260826000000_m124_mcp_connection_surface.sql
+// lines 548-575) is a presentational obligation that no schema constraint can
+// discharge. RFC 7591 dynamic client registration is UNAUTHENTICATED, so
+// `client_name` and `client_uri` are attacker-controlled strings. The unique
+// index on mcp_oauth_clients is on client_id alone, so two registrations may
+// both call themselves "Claude Desktop" with identical redirect URIs and store
+// cleanly -- the review proved it. The database cannot tell them apart and a
+// uniqueness constraint on client_name would break the legitimate second
+// registration while an attacker simply picks a different string.
+//
+// So the defence is: (a) present the self-declared identity as self-declared,
+// (b) show the redirect destination, which IS verified server-side by exact
+// match against the stored array, with at least equal prominence, and (c) fail
+// closed when the payload is anything other than the shape the server promises.
+//
+// The types below make (a) and (c) hard to get wrong by accident rather than by
+// discipline. A raw `string` for the client name would let any template render
+// it as a verified identity; `SelfAsserted` forces the caller to handle the
+// "did not state one" branch, and there is no code path that produces a
+// verified identity because none exists.
+
+// ---------------------------------------------------------------------------
+// Wire shape
+// ---------------------------------------------------------------------------
+
+// Mirrors consentResponseDTO in apps/api/internal/mcp/dto.go exactly. The
+// `_unverified` suffixes are the API's own marking, carried through rather than
+// renamed, so a reader of this file and a reader of that one see the same word.
+//
+// STRICTNESS IS THE POINT. Every field the screen needs to make a true
+// statement is required here. A payload missing `redirect_host` cannot be
+// rendered honestly -- the host is the one part of the request a human can
+// judge -- so the parse fails and the screen refuses to offer approval, rather
+// than rendering a consent screen with a hole in it that a user then approves.
+// That is the house defect class (a failure or absence coerced into a plausible
+// value) applied to the one screen where the coerced value is authorization.
+export const consentWireSchema = z.object({
+  client_id: z.string().min(1),
+
+  // Optional on the wire: Go's `json:"client_name_unverified"` emits "" when
+  // the registration omitted a name, and an absent key is equally possible.
+  // Both are an ABSENCE and are normalised to one below -- never to a blank
+  // that renders as an unnamed but apparently legitimate client.
+  client_name_unverified: z.string().optional(),
+  client_uri_unverified: z.string().optional(),
+
+  // A LITERAL false, not a boolean.
+  //
+  // dto.go sets this field from a hard-coded `false` with the comment "there is
+  // no code path that can set it true. Registration is unauthenticated; nothing
+  // about this identity is verified, ever." Typing it as z.boolean() would let
+  // a payload asserting `true` parse, and then the only thing standing between
+  // that assertion and a verified-looking consent screen would be a template
+  // author remembering not to trust it. z.literal(false) makes the assertion
+  // unparseable: a payload claiming verification is a failed load, and a failed
+  // load is not approvable.
+  identity_verified: z.literal(false),
+
+  // Verified server-side by EXACT match against mcp_oauth_clients.redirect_uris
+  // -- never a prefix, suffix or host-only comparison, each of which is an open
+  // redirector (m124 obligation 7). This is the only identity claim on the
+  // screen that we actually stand behind, so it is required, not optional.
+  redirect_uri: z.string().min(1),
+  redirect_host: z.string().min(1),
+
+  // At least one. ParseRequestedScopes (apps/api/internal/mcp/scope.go) refuses
+  // a request naming no recognised scope -- absence is refusal, never
+  // "everything we have" -- so an empty array here is an incoherent payload,
+  // not a grant of nothing. Failing the parse is the fail-closed direction; the
+  // alternative is a screen that says the client may read nothing, over a grant
+  // whose real scope we could not read.
+  scopes: z.array(z.string().min(1)).min(1),
+
+  state: z.string().optional(),
+  code_challenge: z.string().optional(),
+  code_challenge_method: z.string().optional(),
+});
+
+export type ConsentWire = z.infer<typeof consentWireSchema>;
+
+// ---------------------------------------------------------------------------
+// Self-asserted identity
+// ---------------------------------------------------------------------------
+
+/**
+ * A string the client supplied about itself during unauthenticated
+ * registration. It is attacker-controlled and we vouch for none of it.
+ *
+ * Modelled as a discriminated union rather than `string | null` so that
+ * rendering it requires deciding what an absence says. `{ stated: false }` is
+ * not a blank to be interpolated; it is a fact to be reported -- "this client
+ * did not give a name" -- which is a different and more useful sentence than an
+ * empty space where a name would be.
+ */
+export type SelfAsserted =
+  | { readonly stated: true; readonly value: string }
+  | { readonly stated: false };
+
+/**
+ * Normalise a registration-supplied string into an explicit presence or
+ * absence.
+ *
+ * Whitespace-only counts as absent: a client_name of " " is not a name, and
+ * treating it as one produces a consent screen with an invisible identity,
+ * which reads to a user as a rendering glitch rather than as a warning. An
+ * attacker choosing that string is choosing it precisely for that effect.
+ */
+export function asSelfAsserted(raw: string | undefined | null): SelfAsserted {
+  if (raw === undefined || raw === null) return { stated: false };
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { stated: false };
+  return { stated: true, value: trimmed };
+}
+
+// ---------------------------------------------------------------------------
+// Domain shape
+// ---------------------------------------------------------------------------
+
+export interface ConsentContext {
+  readonly clientId: string;
+
+  /**
+   * SELF-DECLARED AND UNVERIFIED. Never render this as the answer to "who is
+   * asking" without saying, adjacent to it, that we did not verify it. The
+   * redirect destination is what we actually checked.
+   */
+  readonly clientNameUnverified: SelfAsserted;
+
+  /** SELF-DECLARED AND UNVERIFIED, as above. Never linked, only shown. */
+  readonly clientUriUnverified: SelfAsserted;
+
+  /**
+   * Always false, and typed as the literal so no branch can be written that
+   * depends on it being true. Kept on the domain object rather than dropped
+   * because its presence is what makes the absence of a verified path legible
+   * to the next reader.
+   */
+  readonly identityVerified: false;
+
+  /** Exact-matched server-side against the client's registered array. */
+  readonly redirectUri: string;
+  /** The host of the above. What a human can actually judge. */
+  readonly redirectHost: string;
+
+  readonly scopes: readonly string[];
+
+  readonly state: string | null;
+  readonly codeChallenge: string | null;
+  readonly codeChallengeMethod: string | null;
+}
+
+function orNull(raw: string | undefined): string | null {
+  if (raw === undefined) return null;
+  return raw.length === 0 ? null : raw;
+}
+
+/**
+ * Parse an authorize response into the consent screen's model.
+ *
+ * Throws on any payload that is not exactly what the server promises. The
+ * caller is a TanStack Query queryFn, so a throw becomes an error state and the
+ * screen renders PageError instead of an approvable form.
+ */
+export function parseConsentContext(raw: unknown): ConsentContext {
+  const wire = consentWireSchema.parse(raw);
+  return {
+    clientId: wire.client_id,
+    clientNameUnverified: asSelfAsserted(wire.client_name_unverified),
+    clientUriUnverified: asSelfAsserted(wire.client_uri_unverified),
+    identityVerified: false,
+    redirectUri: wire.redirect_uri,
+    redirectHost: wire.redirect_host,
+    scopes: wire.scopes,
+    state: orNull(wire.state),
+    codeChallenge: orNull(wire.code_challenge),
+    codeChallengeMethod: orNull(wire.code_challenge_method),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scope vocabulary
+// ---------------------------------------------------------------------------
+
+// recognisedScopes in apps/api/internal/mcp/scope.go holds exactly one entry.
+// The read-only surface is the entire security claim of the feature (m124
+// obligation 5): the surface is read-only because no write tool is exposed, not
+// because a column says so.
+export const SCOPE_READ = "mcp:read";
+
+export interface ScopeCopy {
+  readonly token: string;
+  readonly title: string;
+  readonly detail: string;
+}
+
+/**
+ * Blunt, specific copy for a granted scope -- the design's "Consent-screen
+ * candour", and its instruction that blunt beats euphemistic.
+ *
+ * An UNRECOGNISED scope is described as unrecognised rather than prettified or
+ * dropped. Dropping is the tempting behaviour and it is the same mistake
+ * ParseRequestedScopes refuses on the request side: it would let the operator
+ * consent to a scope set that is not the one the client asked for, and neither
+ * party would learn they disagreed.
+ */
+export function describeScope(token: string): ScopeCopy {
+  if (token === SCOPE_READ) {
+    return {
+      token,
+      title: "Read your fleet's data",
+      detail:
+        "Site names and URLs, WordPress and PHP versions, installed plugins and themes and their versions, update and vulnerability status, uptime and performance history, and backup history.",
+    };
+  }
+  return {
+    token,
+    title: "An unrecognised permission",
+    detail:
+      "This dashboard does not recognise this permission and cannot tell you what it allows. Do not approve this connection.",
+  };
+}
+
+/** True when every requested scope is one this screen can describe truthfully. */
+export function allScopesRecognised(scopes: readonly string[]): boolean {
+  return scopes.every((s) => s === SCOPE_READ);
+}

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -248,3 +248,105 @@ describe("ConsentScreen — a page of sites is not presented as the fleet", () =
     );
   });
 });
+
+
+describe("ConsentScreen — a registry that disappears under a selection", () => {
+  // resolveSiteScope reads `fleet` and `tagsBySiteId`. It never reads `tags`.
+  // So a registry going null AFTER a tag is ticked leaves the scope resolving
+  // to a real site set while the id lookup behind it has nothing to look in,
+  // and the submitted payload silently loses the tag the operator picked.
+  //
+  // The display path already refused to guess at null. This is its neighbour.
+
+  it("blocks approval when the registry drops away after a tag is selected", () => {
+    const onApprove = vi.fn();
+    const { rerender } = renderWithProviders(
+      <ConsentScreen {...props({ onApprove, tags: [{ id: "t1", name: "prod" }] })} />,
+    );
+
+    fireEvent.click(screen.getByText("Sites with a tag"));
+    fireEvent.click(screen.getByRole("checkbox", { name: /prod/i }));
+
+    // The selection is live and approvable while the registry is there.
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
+
+    // The registry disappears underneath the operator, selection intact.
+    rerender(<ConsentScreen {...props({ onApprove, tags: null })} />);
+
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    expect(screen.getByTestId("consent-tags-failed")).toBeTruthy();
+  });
+
+  it("submits nothing at all rather than a tag scope with an empty tag list", () => {
+    const onApprove = vi.fn();
+    const { rerender } = renderWithProviders(
+      <ConsentScreen {...props({ onApprove, tags: [{ id: "t1", name: "prod" }] })} />,
+    );
+
+    fireEvent.click(screen.getByText("Sites with a tag"));
+    fireEvent.click(screen.getByRole("checkbox", { name: /prod/i }));
+    rerender(<ConsentScreen {...props({ onApprove, tags: null })} />);
+
+    // Submit the form directly, past the disabled button, because the button
+    // being disabled is not the same guarantee as the payload being refused.
+    fireEvent.submit(screen.getByTestId("consent-approve").closest("form")!);
+
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+
+  it("refuses a selected tag that no longer resolves to an id", () => {
+    // The registry is present but has been reloaded without the tag -- deleted
+    // by someone else mid-flow. The ids resolve to [], which is the same
+    // absence wearing a different shape.
+    const onApprove = vi.fn();
+    const { rerender } = renderWithProviders(
+      <ConsentScreen {...props({ onApprove, tags: [{ id: "t1", name: "prod" }] })} />,
+    );
+
+    fireEvent.click(screen.getByText("Sites with a tag"));
+    fireEvent.click(screen.getByRole("checkbox", { name: /prod/i }));
+    rerender(<ConsentScreen {...props({ onApprove, tags: [{ id: "t9", name: "other" }] })} />);
+
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    fireEvent.submit(screen.getByTestId("consent-approve").closest("form")!);
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+
+  it("still submits a real tag scope when the registry is intact", () => {
+    // The over-fire case. A gate that blocks correct work gets removed.
+    const onApprove = vi.fn();
+    renderWithProviders(
+      <ConsentScreen {...props({ onApprove, tags: [{ id: "t1", name: "prod" }] })} />,
+    );
+
+    fireEvent.click(screen.getByText("Sites with a tag"));
+    fireEvent.click(screen.getByRole("checkbox", { name: /prod/i }));
+    fireEvent.submit(screen.getByTestId("consent-approve").closest("form")!);
+
+    expect(onApprove).toHaveBeenCalledWith({
+      name: "Claude Desktop",
+      siteScopeMode: "tags",
+      scopeTagIds: ["t1"],
+      scopeSiteIds: [],
+    });
+  });
+});
+
+describe("ConsentScreen — the site picker over a fleet we could not read", () => {
+  // The neighbour the sweep found: `sites={fleet?.sites ?? []}` rendered an
+  // empty picker with no explanation when the site load failed, which reads as
+  // "this organisation has no sites".
+
+  it("says the sites could not be loaded rather than showing an empty picker", () => {
+    renderWithProviders(<ConsentScreen {...props({ fleet: null, sitesLoading: false })} />);
+    expect(screen.getByTestId("consent-sites-failed").textContent).toMatch(
+      /not the same as having no sites/i,
+    );
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("does not show that message when the sites loaded", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    expect(screen.queryByTestId("consent-sites-failed")).toBeNull();
+  });
+});

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -203,7 +203,10 @@ describe("ConsentScreen — a page of sites is not presented as the fleet", () =
     fireEvent.click(screen.getByText("Every site"));
     const summary = screen.getByTestId("consent-scope-summary").textContent ?? "";
     expect(summary).not.toMatch(/That is \d+ sites? today/);
-    expect(summary).toMatch(/there are more than that/i);
+    expect(summary).toMatch(/cannot tell you whether there are others/i);
+    // And it must not assert that more exist: listComplete false means we
+    // cannot tell, not that a 201st site is out there.
+    expect(summary).not.toMatch(/there are more/i);
   });
 
   it("labels the enumeration as partial rather than letting it pose as the list", () => {

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -41,7 +41,7 @@ function props(over: Partial<ConsentScreenProps> = {}): ConsentScreenProps {
   return {
     consent: ATTACKER,
     tags: [{ id: "t1", name: "prod" }],
-    allSites: SITES,
+    fleet: { sites: SITES, complete: true },
     tagsBySiteId: { s1: ["prod"], s2: ["staging"] },
     sitesLoading: false,
     isApproving: false,
@@ -163,9 +163,9 @@ describe("ConsentScreen — an empty site scope is not everything", () => {
   });
 
   it("a failed site load blocks approval instead of resolving to zero or to all", () => {
-    renderWithProviders(<ConsentScreen {...props({ allSites: null, sitesLoading: false })} />);
+    renderWithProviders(<ConsentScreen {...props({ fleet: null, sitesLoading: false })} />);
     expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
-      /could not load your sites/i,
+      /could not read every site/i,
     );
     expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
   });
@@ -188,5 +188,60 @@ describe("ConsentScreen — an empty site scope is not everything", () => {
       scopeTagIds: [],
       scopeSiteIds: ["s1"],
     });
+  });
+});
+
+
+describe("ConsentScreen — a page of sites is not presented as the fleet", () => {
+  // The org has more sites than the page we hold. The screen must not let the
+  // operator believe the list in front of them is the whole fleet, because
+  // approving "every site" then grants read access to sites they never saw.
+  const CAPPED = { sites: SITES, complete: false };
+
+  it("mode 'all' over a capped list refuses to state a fleet size", () => {
+    renderWithProviders(<ConsentScreen {...props({ fleet: CAPPED })} />);
+    fireEvent.click(screen.getByText("Every site"));
+    const summary = screen.getByTestId("consent-scope-summary").textContent ?? "";
+    expect(summary).not.toMatch(/That is \d+ sites? today/);
+    expect(summary).toMatch(/there are more than that/i);
+  });
+
+  it("labels the enumeration as partial rather than letting it pose as the list", () => {
+    renderWithProviders(<ConsentScreen {...props({ fleet: CAPPED })} />);
+    fireEvent.click(screen.getByText("Every site"));
+    expect(screen.getByTestId("consent-list-partial").textContent).toMatch(
+      /not the whole list/i,
+    );
+  });
+
+  it("does NOT label the enumeration partial when the list really is complete", () => {
+    // The over-fire case. A warning that shows on correct work gets ignored,
+    // and then it warns about nothing.
+    renderWithProviders(<ConsentScreen {...props()} />);
+    fireEvent.click(screen.getByText("Every site"));
+    expect(screen.queryByTestId("consent-list-partial")).toBeNull();
+    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
+      /That is 2 sites today/,
+    );
+  });
+
+  it("warns that the site picker is not offering every site", () => {
+    renderWithProviders(<ConsentScreen {...props({ fleet: CAPPED })} />);
+    expect(screen.getByTestId("consent-picker-truncated").textContent).toMatch(
+      /not all of them/i,
+    );
+  });
+
+  it("does not warn on the picker when every site is offered", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    expect(screen.queryByTestId("consent-picker-truncated")).toBeNull();
+  });
+
+  it("says an all-sites grant covers sites added later", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    fireEvent.click(screen.getByText("Every site"));
+    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
+      /added later is covered/i,
+    );
   });
 });

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { ConsentScreen, type ConsentScreenProps } from "./consent-screen";
+import { parseConsentContext, SCOPE_READ } from "./consent-context";
+import type { ScopedSite } from "./site-scope";
+
+// The rendered half of m124 obligation 7 and of the empty-scope rule.
+//
+// THE ATTACK THESE TESTS PIN. An attacker performs an unauthenticated RFC 7591
+// registration with client_name "Claude Desktop" and a redirect_uri they
+// control. The database stores it cleanly -- the unique index is on client_id
+// alone -- and no constraint can refuse it. The consent screen is the only
+// thing between that registration and a user granting fleet read access to a
+// stranger.
+
+const ATTACKER = parseConsentContext({
+  client_id: "c_attacker",
+  // The attacker's chosen string. Identical to what a legitimate registration
+  // would send.
+  client_name_unverified: "Claude Desktop",
+  client_uri_unverified: "https://claude.ai",
+  identity_verified: false,
+  // The tell, and the only verified fact on the screen.
+  redirect_uri: "https://claude-desktop-oauth.example.net/cb",
+  redirect_host: "claude-desktop-oauth.example.net",
+  scopes: [SCOPE_READ],
+  state: "s",
+  code_challenge: "cc",
+  code_challenge_method: "S256",
+});
+
+const SITES: ScopedSite[] = [
+  { id: "s1", name: "Alpha", url: "https://alpha.example" },
+  { id: "s2", name: "Beta", url: "https://beta.example" },
+];
+
+function props(over: Partial<ConsentScreenProps> = {}): ConsentScreenProps {
+  return {
+    consent: ATTACKER,
+    tags: [{ id: "t1", name: "prod" }],
+    allSites: SITES,
+    tagsBySiteId: { s1: ["prod"], s2: ["staging"] },
+    sitesLoading: false,
+    isApproving: false,
+    approveError: null,
+    onApprove: vi.fn(),
+    onDeny: vi.fn(),
+    ...over,
+  };
+}
+
+describe("ConsentScreen — the self-declared name is never presented as verified", () => {
+  it("shows the verified redirect host and marks it as the thing we verified", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    const host = screen.getByTestId("consent-redirect-host");
+    expect(host.textContent).toBe("claude-desktop-oauth.example.net");
+    expect(screen.getByText(/We verified this/i)).toBeTruthy();
+  });
+
+  it("marks the attacker-supplied name as unverified, in the same region as the name", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    const nameNode = screen.getByTestId("consent-client-name");
+    expect(nameNode.textContent).toContain("Claude Desktop");
+    // The disclaimer must be a sibling of the name inside one labelled block,
+    // not a footnote somewhere else on the page. A user who reads the name and
+    // stops reading must already have seen it.
+    const block = nameNode.closest("section");
+    expect(block).not.toBeNull();
+    expect(block!.textContent).toMatch(/We did not verify this/i);
+    expect(block!.textContent).toMatch(/Anyone can register a client under any name/i);
+  });
+
+  it("puts the verified host BEFORE the self-declared name in reading order", () => {
+    // Order is the control. Every OAuth consent screen in the world leads with
+    // the client's chosen name, and that habit is what an impersonating
+    // registration is buying.
+    renderWithProviders(<ConsentScreen {...props()} />);
+    const host = screen.getByTestId("consent-redirect-host");
+    const name = screen.getByTestId("consent-client-name");
+    const position = host.compareDocumentPosition(name);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("never renders the self-declared homepage as a link", () => {
+    // A link is an endorsement and a click target we did not check.
+    renderWithProviders(<ConsentScreen {...props()} />);
+    const uri = screen.getByTestId("consent-client-uri");
+    expect(uri.tagName).not.toBe("A");
+    expect(uri.closest("a")).toBeNull();
+  });
+
+  it("says a client gave no name rather than rendering a blank", () => {
+    const nameless = parseConsentContext({
+      client_id: "c_x",
+      client_name_unverified: "",
+      identity_verified: false,
+      redirect_uri: "https://x.example/cb",
+      redirect_host: "x.example",
+      scopes: [SCOPE_READ],
+    });
+    renderWithProviders(<ConsentScreen {...props({ consent: nameless })} />);
+    expect(screen.getByTestId("consent-client-name-absent").textContent).toMatch(
+      /did not give a name/i,
+    );
+  });
+});
+
+describe("ConsentScreen — what it can do and what it cannot", () => {
+  it("states the read permission and the four things it cannot do", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    expect(screen.getByText(/Read your fleet's data/i)).toBeTruthy();
+    expect(screen.getByText(/It cannot change anything\./i)).toBeTruthy();
+    expect(screen.getByText(/It cannot approve anything\./i)).toBeTruthy();
+    expect(screen.getByText(/It cannot reach your sites directly\./i)).toBeTruthy();
+    expect(screen.getByText(/It cannot read your backups' contents\./i)).toBeTruthy();
+  });
+
+  it("refuses approval when a requested scope is not recognised", () => {
+    const odd = parseConsentContext({
+      client_id: "c_x",
+      identity_verified: false,
+      redirect_uri: "https://x.example/cb",
+      redirect_host: "x.example",
+      scopes: [SCOPE_READ, "mcp:write"],
+    });
+    renderWithProviders(<ConsentScreen {...props({ consent: odd })} />);
+    expect(screen.getByTestId("consent-unrecognised-scope")).toBeTruthy();
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("tells the user the grant lasts until revoked and where to revoke it", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    expect(screen.getByText(/does not expire on its own/i)).toBeTruthy();
+    expect(screen.getByText(/AI connections/i)).toBeTruthy();
+  });
+});
+
+describe("ConsentScreen — an empty site scope is not everything", () => {
+  it("starts with nothing selected and cannot be approved", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
+      /No sites are selected yet/i,
+    );
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("a tag matching no site says so, never that it covers everything", () => {
+    renderWithProviders(
+      <ConsentScreen
+        {...props({ tags: [{ id: "t9", name: "archived" }], tagsBySiteId: { s1: [], s2: [] } })}
+      />,
+    );
+    fireEvent.click(screen.getByText("Sites with a tag"));
+    fireEvent.click(screen.getByRole("checkbox", { name: /archived/i }));
+    const summary = screen.getByTestId("consent-scope-summary");
+    expect(summary.textContent).toMatch(/matches no sites/i);
+    expect(summary.textContent).toMatch(/read nothing/i);
+    expect(screen.queryByTestId("consent-scope-sites")).toBeNull();
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("a failed site load blocks approval instead of resolving to zero or to all", () => {
+    renderWithProviders(<ConsentScreen {...props({ allSites: null, sitesLoading: false })} />);
+    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
+      /could not load your sites/i,
+    );
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enumerates the covered sites rather than only counting them", () => {
+    renderWithProviders(<ConsentScreen {...props()} />);
+    fireEvent.click(screen.getByRole("checkbox", { name: /Alpha/i }));
+    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(/^1 site, listed below/);
+    expect(screen.getByTestId("consent-scope-sites").textContent).toContain("Alpha");
+  });
+
+  it("sends only the payload the chosen mode is allowed to carry", () => {
+    const onApprove = vi.fn();
+    renderWithProviders(<ConsentScreen {...props({ onApprove })} />);
+    fireEvent.click(screen.getByRole("checkbox", { name: /Alpha/i }));
+    fireEvent.submit(screen.getByTestId("consent-approve").closest("form")!);
+    expect(onApprove).toHaveBeenCalledWith({
+      name: "Claude Desktop",
+      siteScopeMode: "list",
+      scopeTagIds: [],
+      scopeSiteIds: ["s1"],
+    });
+  });
+});

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -253,7 +253,7 @@ function SiteScopeBlock({
   tags: readonly { id: string; name: string }[] | null;
   selectedTagNames: readonly string[];
   onToggleTag: (name: string) => void;
-  sites: readonly ScopedSite[];
+  sites: readonly ScopedSite[] | null;
   pickerComplete: boolean;
   selectedSiteIds: readonly string[];
   onToggleSite: (id: string) => void;
@@ -343,7 +343,7 @@ function SiteScopeBlock({
               This organisation has no tags yet, so there is nothing to scope by.
             </p>
           ) : (
-            (tags ?? []).map((tag) => (
+            tags.map((tag) => (
               <label key={tag.id} className="flex items-center gap-2 text-sm">
                 <Checkbox
                   checked={selectedTagNames.includes(tag.name)}
@@ -356,7 +356,18 @@ function SiteScopeBlock({
         </div>
       )}
 
-      {mode === "list" && !pickerComplete && (
+      {mode === "list" && sites === null && (
+        <p
+          role="alert"
+          data-testid="consent-sites-failed"
+          className="mt-3 rounded-md border border-[var(--color-destructive)]/30 p-3 text-sm text-[var(--color-destructive)]"
+        >
+          We could not load this organisation&apos;s sites, so there is nothing to pick
+          from. That is not the same as having no sites. Do not approve until this loads.
+        </p>
+      )}
+
+      {mode === "list" && sites !== null && !pickerComplete && (
         <p
           role="alert"
           data-testid="consent-picker-truncated"
@@ -367,7 +378,7 @@ function SiteScopeBlock({
         </p>
       )}
 
-      {mode === "list" && (
+      {mode === "list" && sites !== null && (
         <div className="mt-3 max-h-56 space-y-2 overflow-y-auto">
           {sites.map((site) => (
             <label key={site.id} className="flex items-start gap-2 text-sm">
@@ -467,6 +478,20 @@ function DurationBlock() {
 // The screen
 // ---------------------------------------------------------------------------
 
+/**
+ * Unwrap a tag payload that the approve gate has already proved is present.
+ *
+ * A throw rather than a default. The whole finding was a `?? []` standing where
+ * a refusal belonged, and replacing it with a different silent fallback would
+ * leave the same shape in place for the next refactor to trip over.
+ */
+function assertTagPayload(payload: readonly string[] | null): string[] {
+  if (payload === null) {
+    throw new Error("consent: refused to submit a tag scope with no tags");
+  }
+  return [...payload];
+}
+
 export const consentNameSchema = z.object({
   name: z.string().trim().min(1, "Give this connection a name so you can find it later."),
 });
@@ -535,7 +560,32 @@ export function ConsentScreen({
 
   const scopeOk = isScopeApprovable(scope);
   const scopesOk = allScopesRecognised(consent.scopes);
-  const canApprove = scopeOk && scopesOk && !isApproving;
+
+  // THE PAYLOAD THE SUBMIT PATH WOULD ACTUALLY SEND, resolved once and shared
+  // with the approve gate, so the button and the request cannot disagree.
+  //
+  // resolveSiteScope reads `fleet` and `tagsBySiteId`; it never reads `tags`.
+  // So a registry that goes null AFTER a tag is ticked leaves the scope
+  // resolving happily to a real site set while the id lookup behind it has
+  // nothing left to look in. `(tags ?? []).filter(...)` then yields [], and the
+  // operator's chosen tag is dropped from the request they are pressing the
+  // button on. Null refused to guess in the display path and still resolved to
+  // an empty array one function below it.
+  //
+  // Null here means "cannot build this payload", and empty means the same
+  // thing: a selected tag that no longer resolves to an id (deleted, or a
+  // registry reloaded without it) is an absence, not a request for nothing.
+  // m124's CHECK and internal/mcp/scope.go:177-182 both refuse mode 'tags'
+  // with an empty array, so this is the client half of a gate the server
+  // already holds -- and the half that keeps the button honest.
+  const tagPayload = useMemo((): readonly string[] | null => {
+    if (mode !== "tags") return [];
+    if (tags === null) return null;
+    const ids = tags.filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id);
+    return ids.length === 0 ? null : ids;
+  }, [mode, tags, selectedTagNames]);
+
+  const canApprove = scopeOk && scopesOk && tagPayload !== null && !isApproving;
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -552,10 +602,10 @@ export function ConsentScreen({
       // The payload each mode is allowed to carry, and only that payload.
       // mcp_grants_site_scope_payload_check refuses any other combination, so
       // sending the unused array populated would be a 400 the user cannot act on.
-      scopeTagIds:
-        mode === "tags"
-          ? (tags ?? []).filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id)
-          : [],
+      // Never `?? []`. canApprove is false whenever tagPayload is null, so this
+      // is unreachable with a null payload; it throws rather than defaulting so
+      // that stays true if the gate is ever refactored apart from it.
+      scopeTagIds: assertTagPayload(tagPayload),
       scopeSiteIds: mode === "list" ? [...selectedSiteIds] : [],
     });
   }
@@ -583,8 +633,8 @@ export function ConsentScreen({
             prev.includes(tagName) ? prev.filter((t) => t !== tagName) : [...prev, tagName],
           )
         }
-        sites={fleet?.sites ?? []}
-        pickerComplete={fleet?.complete ?? true}
+        sites={fleet === null ? null : fleet.sites}
+        pickerComplete={fleet === null ? true : fleet.complete}
         selectedSiteIds={selectedSiteIds}
         onToggleSite={(id) =>
           setSelectedSiteIds((prev) =>

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -250,7 +250,7 @@ function SiteScopeBlock({
   mode: SiteScopeMode;
   onModeChange: (mode: SiteScopeMode) => void;
   scope: ResolvedSiteScope;
-  tags: readonly { id: string; name: string }[];
+  tags: readonly { id: string; name: string }[] | null;
   selectedTagNames: readonly string[];
   onToggleTag: (name: string) => void;
   sites: readonly ScopedSite[];
@@ -295,6 +295,12 @@ function SiteScopeBlock({
               key={value}
               className={cn(
                 "cursor-pointer rounded-md border px-3 py-1.5 text-sm",
+                // The ring rides on the label because the input it belongs to
+                // is visually hidden; without this a keyboard user cannot see
+                // which option they are on.
+                "has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2",
+                "has-[:focus-visible]:ring-[var(--color-ring)] has-[:focus-visible]:ring-offset-2",
+                "has-[:focus-visible]:ring-offset-[var(--color-card)]",
                 mode === value
                   ? "border-[var(--color-primary)] bg-[var(--color-primary)]/10 font-medium"
                   : "border-[var(--color-border)]",
@@ -316,12 +322,28 @@ function SiteScopeBlock({
 
       {mode === "tags" && (
         <div className="mt-3 flex flex-wrap gap-3">
-          {tags.length === 0 ? (
-            <p className="text-sm text-[var(--color-muted-foreground)]">
+          {/* NULL IS NOT EMPTY. A failed tags request used to arrive here as an
+              empty array, and the screen then stated a fact about the
+              organisation that it did not know -- the same collapse of "we
+              could not ask" into "there are none" that the site list carries
+              a FleetSnapshot to avoid. Two queries, one screen, one consent
+              decision; they have to be honest in the same way. */}
+          {tags === null ? (
+            <p
+              role="alert"
+              data-testid="consent-tags-failed"
+              className="text-sm text-[var(--color-destructive)]"
+            >
+              We could not load this organisation&apos;s tags, so we cannot show you what
+              this would cover. That is not the same as having no tags. Do not approve
+              until this loads.
+            </p>
+          ) : tags.length === 0 ? (
+            <p data-testid="consent-tags-empty" className="text-sm text-[var(--color-muted-foreground)]">
               This organisation has no tags yet, so there is nothing to scope by.
             </p>
           ) : (
-            tags.map((tag) => (
+            (tags ?? []).map((tag) => (
               <label key={tag.id} className="flex items-center gap-2 text-sm">
                 <Checkbox
                   checked={selectedTagNames.includes(tag.name)}
@@ -451,7 +473,12 @@ export const consentNameSchema = z.object({
 
 export interface ConsentScreenProps {
   readonly consent: ConsentContext;
-  readonly tags: readonly { id: string; name: string }[];
+  /**
+   * The tenant's tag registry, or null when we could not load it. Null is NOT
+   * an empty registry: one is a fact about the organisation and the other is a
+   * fact about our request, and only one of them belongs on a consent screen.
+   */
+  readonly tags: readonly { id: string; name: string }[] | null;
   /**
    * What we loaded of the fleet, or null when the load has not finished or
    * failed. Null is NOT an empty snapshot, and an incomplete snapshot is NOT a
@@ -527,7 +554,7 @@ export function ConsentScreen({
       // sending the unused array populated would be a 400 the user cannot act on.
       scopeTagIds:
         mode === "tags"
-          ? tags.filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id)
+          ? (tags ?? []).filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id)
           : [],
       scopeSiteIds: mode === "list" ? [...selectedSiteIds] : [],
     });
@@ -609,7 +636,12 @@ export function ConsentScreen({
 /** The skeleton state. Deliberately has no approve control. */
 export function ConsentScreenSkeleton() {
   return (
-    <div className="mx-auto max-w-2xl space-y-4 p-4 sm:p-6" aria-busy="true">
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading the connection request"
+      className="mx-auto max-w-2xl space-y-4 p-4 sm:p-6"
+    >
       <Skeleton className="h-7 w-64" />
       <Skeleton className="h-40 w-full" />
       <Skeleton className="h-56 w-full" />

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -1,0 +1,583 @@
+import { useMemo, useState } from "react";
+import { AlertTriangle, ShieldAlert } from "lucide-react";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { PageError } from "@/components/feedback/page-error";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+import {
+  allScopesRecognised,
+  describeScope,
+  type ConsentContext,
+  type SelfAsserted,
+} from "./consent-context";
+import {
+  describeSiteScope,
+  isScopeApprovable,
+  resolveSiteScope,
+  type ResolvedSiteScope,
+  type ScopedSite,
+  type SiteScopeMode,
+} from "./site-scope";
+
+// The consent screen (design Step 7).
+//
+// The design specifies this screen as written from a checklist -- which client
+// is asking, what it may read, what it may propose, that it cannot approve
+// anything, how many sites and which, how long the grant lasts, where to revoke
+// -- and instructs that every sentence be written fresh from it, because "blunt
+// beats euphemistic here".
+//
+// Each checklist item is marked below with the section that discharges it.
+
+export const REVOKE_LOCATION = "Settings, under AI connections";
+
+// ---------------------------------------------------------------------------
+// Checklist item 1: which client is asking
+// ---------------------------------------------------------------------------
+
+/**
+ * The identity block.
+ *
+ * m124 obligation 7. This is the security control of the whole screen, so it is
+ * built so that the verified fact leads and the self-declared one follows,
+ * rather than the other way round which is how every OAuth consent screen in
+ * the world is laid out and is exactly the habit an impersonating registration
+ * relies on.
+ *
+ * The self-declared name is:
+ *   - never the heading;
+ *   - always inside quotation marks, so it reads as reported speech;
+ *   - always immediately followed by the statement that we did not verify it;
+ *   - never rendered as a link, even when client_uri is a URL, because a link
+ *     is an endorsement and a click target we did not check.
+ */
+function IdentityBlock({ consent }: { consent: ConsentContext }) {
+  return (
+    <section
+      aria-labelledby="consent-identity-heading"
+      className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4"
+    >
+      <h2
+        id="consent-identity-heading"
+        className="text-sm font-medium text-[var(--color-muted-foreground)]"
+      >
+        Who is asking
+      </h2>
+
+      {/* THE VERIFIED FACT, FIRST AND LARGEST. redirect_host is derived from
+          the redirect_uri the server exact-matched against the client's
+          registered array. It is the only part of this request we checked. */}
+      <p className="mt-2 text-xs uppercase tracking-wide text-[var(--color-muted-foreground)]">
+        We verified this
+      </p>
+      <p
+        data-testid="consent-redirect-host"
+        className="mt-1 break-all font-mono text-lg font-semibold text-[var(--color-foreground)]"
+      >
+        {consent.redirectHost}
+      </p>
+      <p className="mt-1 text-sm text-[var(--color-muted-foreground)]">
+        After you approve, this browser sends the connection back to{" "}
+        <span className="break-all font-mono">{consent.redirectUri}</span>. We matched that
+        address exactly against the one this client registered. It is the one thing on this
+        screen we can stand behind.
+      </p>
+
+      {/* THE SELF-DECLARED FACT, SECOND, MARKED. */}
+      <div className="mt-4 border-t border-[var(--color-border)] pt-4">
+        <p className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-[var(--color-muted-foreground)]">
+          <ShieldAlert aria-hidden="true" className="size-3.5" />
+          We did not verify this
+        </p>
+        <p data-testid="consent-client-name" className="mt-1 text-sm text-[var(--color-foreground)]">
+          <SelfAssertedName value={consent.clientNameUnverified} />
+        </p>
+        <p className="mt-1 text-sm text-[var(--color-muted-foreground)]">
+          Anyone can register a client under any name, including the name of software you
+          trust. We have no way to tell a real one from a copy. Judge this request by the
+          address above, not by the name.
+        </p>
+        <SelfAssertedSite value={consent.clientUriUnverified} />
+        <p className="mt-2 text-xs text-[var(--color-muted-foreground)]">
+          Client ID <span className="break-all font-mono">{consent.clientId}</span>
+        </p>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * A self-declared name, or the statement that there was not one.
+ *
+ * An absent name renders as a sentence, not as a blank. A blank is the house
+ * defect class -- an absence coerced into a plausible value -- and here the
+ * plausible value is "a client whose name simply did not fit on screen", which
+ * is a strictly worse thing for the user to believe than the truth.
+ */
+function SelfAssertedName({ value }: { value: SelfAsserted }) {
+  if (!value.stated) {
+    return (
+      <span data-testid="consent-client-name-absent" className="italic">
+        This client did not give a name.
+      </span>
+    );
+  }
+  return (
+    <>
+      It calls itself <span className="font-medium">&ldquo;{value.value}&rdquo;</span>.
+    </>
+  );
+}
+
+/** The self-declared homepage, shown as text and never as a link. */
+function SelfAssertedSite({ value }: { value: SelfAsserted }) {
+  if (!value.stated) return null;
+  return (
+    <p className="mt-2 text-sm text-[var(--color-muted-foreground)]">
+      It gives its homepage as{" "}
+      <span data-testid="consent-client-uri" className="break-all font-mono">
+        {value.value}
+      </span>
+      . Not shown as a link, because we did not check where it goes.
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Checklist items 2, 3 and 4: what it may read, what it may propose, and that
+// it cannot approve anything
+// ---------------------------------------------------------------------------
+
+function PermissionsBlock({ consent }: { consent: ConsentContext }) {
+  const recognised = allScopesRecognised(consent.scopes);
+  return (
+    <section
+      aria-labelledby="consent-permissions-heading"
+      className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4"
+    >
+      <h2 id="consent-permissions-heading" className="text-sm font-medium">
+        What this connection can do
+      </h2>
+
+      <ul className="mt-3 space-y-3">
+        {consent.scopes.map((token) => {
+          const copy = describeScope(token);
+          return (
+            <li key={token}>
+              <p className="text-sm font-medium">{copy.title}</p>
+              <p className="mt-0.5 text-sm text-[var(--color-muted-foreground)]">{copy.detail}</p>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* THE NEGATIVE HALF, GIVEN THE SAME WEIGHT AS THE POSITIVE HALF.
+          A user who believes an AI has write access declines something safe; a
+          user who believes the reverse approves something they should not. Both
+          errors are caused by a screen that only enumerates what is granted. */}
+      <div className="mt-4 border-t border-[var(--color-border)] pt-4">
+        <h3 className="text-sm font-medium">What it cannot do</h3>
+        <ul className="mt-2 space-y-2 text-sm text-[var(--color-muted-foreground)]">
+          <li>
+            <span className="font-medium text-[var(--color-foreground)]">
+              It cannot change anything.
+            </span>{" "}
+            No updates, no installs, no activations, no deletions, no edits to any site, and no
+            changes to this dashboard or your organisation. This connection is read-only.
+          </li>
+          <li>
+            <span className="font-medium text-[var(--color-foreground)]">
+              It cannot approve anything.
+            </span>{" "}
+            It can suggest work to you and nothing more. Anything that changes a site is
+            approved by a person, in this dashboard, on a screen this connection cannot reach.
+          </li>
+          <li>
+            <span className="font-medium text-[var(--color-foreground)]">
+              It cannot reach your sites directly.
+            </span>{" "}
+            It talks to this dashboard. It gets no WordPress logins, no admin access, no
+            database access and no file access.
+          </li>
+          <li>
+            <span className="font-medium text-[var(--color-foreground)]">
+              It cannot read your backups&apos; contents.
+            </span>{" "}
+            It can see that a backup exists and whether it succeeded. It cannot download one or
+            read what is inside it.
+          </li>
+        </ul>
+      </div>
+
+      {!recognised && (
+        <p
+          role="alert"
+          data-testid="consent-unrecognised-scope"
+          className="mt-4 flex items-start gap-2 rounded-md border border-[var(--color-destructive)]/30 p-3 text-sm text-[var(--color-destructive)]"
+        >
+          <AlertTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+          This client asked for a permission this dashboard does not recognise, so we cannot
+          tell you what approving it would allow. Do not approve it.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Checklist item 5: how many sites, and which
+// ---------------------------------------------------------------------------
+
+function SiteScopeBlock({
+  mode,
+  onModeChange,
+  scope,
+  tags,
+  selectedTagNames,
+  onToggleTag,
+  sites,
+  selectedSiteIds,
+  onToggleSite,
+}: {
+  mode: SiteScopeMode;
+  onModeChange: (mode: SiteScopeMode) => void;
+  scope: ResolvedSiteScope;
+  tags: readonly { id: string; name: string }[];
+  selectedTagNames: readonly string[];
+  onToggleTag: (name: string) => void;
+  sites: readonly ScopedSite[];
+  selectedSiteIds: readonly string[];
+  onToggleSite: (id: string) => void;
+}) {
+  // A COUNT ALONE IS NOT ENOUGH when the scope is a list or a tag, so the
+  // resolved sites are always enumerated rather than summarised. The union's
+  // `none` and `unresolved` members have no site list to enumerate and say so
+  // instead, in words that cannot be read as "everything".
+  const enumerable = scope.kind === "all" || scope.kind === "sites" ? scope.sites : [];
+
+  return (
+    <section
+      aria-labelledby="consent-sites-heading"
+      className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4"
+    >
+      <h2 id="consent-sites-heading" className="text-sm font-medium">
+        Which sites it can read
+      </h2>
+
+      <fieldset className="mt-3">
+        <legend className="sr-only">Site scope</legend>
+        <div className="flex flex-wrap gap-2">
+          {(
+            [
+              ["all", "Every site"],
+              ["tags", "Sites with a tag"],
+              ["list", "Sites I pick"],
+            ] as const
+          ).map(([value, label]) => (
+            <label
+              key={value}
+              className={cn(
+                "cursor-pointer rounded-md border px-3 py-1.5 text-sm",
+                mode === value
+                  ? "border-[var(--color-primary)] bg-[var(--color-primary)]/10 font-medium"
+                  : "border-[var(--color-border)]",
+              )}
+            >
+              <input
+                type="radio"
+                name="site-scope-mode"
+                className="sr-only"
+                value={value}
+                checked={mode === value}
+                onChange={() => onModeChange(value)}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {mode === "tags" && (
+        <div className="mt-3 flex flex-wrap gap-3">
+          {tags.length === 0 ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">
+              This organisation has no tags yet, so there is nothing to scope by.
+            </p>
+          ) : (
+            tags.map((tag) => (
+              <label key={tag.id} className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={selectedTagNames.includes(tag.name)}
+                  onChange={() => onToggleTag(tag.name)}
+                />
+                {tag.name}
+              </label>
+            ))
+          )}
+        </div>
+      )}
+
+      {mode === "list" && (
+        <div className="mt-3 max-h-56 space-y-2 overflow-y-auto">
+          {sites.map((site) => (
+            <label key={site.id} className="flex items-start gap-2 text-sm">
+              <Checkbox
+                checked={selectedSiteIds.includes(site.id)}
+                onChange={() => onToggleSite(site.id)}
+              />
+              <span>
+                <span className="font-medium">{site.name}</span>{" "}
+                <span className="text-[var(--color-muted-foreground)]">{site.url}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      <p
+        data-testid="consent-scope-summary"
+        className={cn(
+          "mt-4 text-sm",
+          isScopeApprovable(scope)
+            ? "text-[var(--color-foreground)]"
+            : "text-[var(--color-destructive)]",
+        )}
+      >
+        {describeSiteScope(scope)}
+      </p>
+
+      {enumerable.length > 0 && (
+        <ul
+          data-testid="consent-scope-sites"
+          className="mt-2 max-h-40 space-y-1 overflow-y-auto text-sm text-[var(--color-muted-foreground)]"
+        >
+          {enumerable.map((site) => (
+            <li key={site.id} className="break-all">
+              {site.name} <span className="font-mono text-xs">{site.url}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-3 text-xs text-[var(--color-muted-foreground)]">
+        This list is what this dashboard can see right now. Your organisation&apos;s records
+        decide what the connection actually reads on each request.
+      </p>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Checklist items 6 and 7: how long the grant lasts, and where to revoke
+// ---------------------------------------------------------------------------
+
+/**
+ * Duration and revocation.
+ *
+ * NO DATE IS SHOWN, because there is no expiry to show. mcp_grants (m124, lines
+ * 608-648) has a `status` of 'active' or 'revoked' and NO expires_at column,
+ * and consentResponseDTO carries no lifetime field. Rendering a date here would
+ * be inventing one, and rendering the word "never" as a lifetime would be
+ * dressing an absent field as a decision. The truthful statement is the one
+ * below: it lasts until it is revoked.
+ */
+function DurationBlock() {
+  return (
+    <section
+      aria-labelledby="consent-duration-heading"
+      className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4"
+    >
+      <h2 id="consent-duration-heading" className="text-sm font-medium">
+        How long this lasts, and how to stop it
+      </h2>
+      <p className="mt-2 text-sm text-[var(--color-muted-foreground)]">
+        This connection does not expire on its own. It lasts until you revoke it. The key the
+        client holds is short-lived and renews itself, so the connection keeps working until
+        you end it.
+      </p>
+      <p className="mt-2 text-sm text-[var(--color-muted-foreground)]">
+        You end it in {REVOKE_LOCATION}. Every request this connection makes is checked against
+        that setting, so revoking stops it at its next request rather than whenever its current
+        key would have expired.
+      </p>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The screen
+// ---------------------------------------------------------------------------
+
+export const consentNameSchema = z.object({
+  name: z.string().trim().min(1, "Give this connection a name so you can find it later."),
+});
+
+export interface ConsentScreenProps {
+  readonly consent: ConsentContext;
+  readonly tags: readonly { id: string; name: string }[];
+  /** Null when the site list has not loaded or its load failed. Never []. */
+  readonly allSites: readonly ScopedSite[] | null;
+  readonly tagsBySiteId: Readonly<Record<string, readonly string[]>>;
+  readonly sitesLoading: boolean;
+  readonly isApproving: boolean;
+  readonly approveError: Error | null;
+  readonly onApprove: (input: {
+    name: string;
+    siteScopeMode: SiteScopeMode;
+    scopeTagIds: string[];
+    scopeSiteIds: string[];
+  }) => void;
+  readonly onDeny: () => void;
+}
+
+export function ConsentScreen({
+  consent,
+  tags,
+  allSites,
+  tagsBySiteId,
+  sitesLoading,
+  isApproving,
+  approveError,
+  onApprove,
+  onDeny,
+}: ConsentScreenProps) {
+  // No default mode. 'all' is not a starting position on a screen whose whole
+  // job is to make the operator choose; the schema refuses an unset mode for
+  // the same reason (m124 DECISION 1, "there is deliberately no DEFAULT 'all'").
+  const [mode, setMode] = useState<SiteScopeMode>("list");
+  const [selectedTagNames, setSelectedTagNames] = useState<readonly string[]>([]);
+  const [selectedSiteIds, setSelectedSiteIds] = useState<readonly string[]>([]);
+  const [name, setName] = useState(
+    consent.clientNameUnverified.stated ? consent.clientNameUnverified.value : "",
+  );
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const scope = useMemo(
+    () =>
+      resolveSiteScope({
+        mode,
+        selectedTagNames,
+        selectedSiteIds,
+        allSites,
+        tagsBySiteId,
+        sitesLoading,
+      }),
+    [mode, selectedTagNames, selectedSiteIds, allSites, tagsBySiteId, sitesLoading],
+  );
+
+  const scopeOk = isScopeApprovable(scope);
+  const scopesOk = allScopesRecognised(consent.scopes);
+  const canApprove = scopeOk && scopesOk && !isApproving;
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const parsed = consentNameSchema.safeParse({ name });
+    if (!parsed.success) {
+      setNameError(parsed.error.issues[0]?.message ?? "Give this connection a name.");
+      return;
+    }
+    setNameError(null);
+    if (!canApprove) return;
+    onApprove({
+      name: parsed.data.name,
+      siteScopeMode: mode,
+      // The payload each mode is allowed to carry, and only that payload.
+      // mcp_grants_site_scope_payload_check refuses any other combination, so
+      // sending the unused array populated would be a 400 the user cannot act on.
+      scopeTagIds:
+        mode === "tags"
+          ? tags.filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id)
+          : [],
+      scopeSiteIds: mode === "list" ? [...selectedSiteIds] : [],
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="mx-auto max-w-2xl space-y-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-xl font-semibold">Approve an AI connection</h1>
+        <p className="mt-1 text-sm text-[var(--color-muted-foreground)]">
+          Something is asking to read your fleet through this dashboard. Read this before you
+          approve it.
+        </p>
+      </header>
+
+      <IdentityBlock consent={consent} />
+      <PermissionsBlock consent={consent} />
+      <SiteScopeBlock
+        mode={mode}
+        onModeChange={setMode}
+        scope={scope}
+        tags={tags}
+        selectedTagNames={selectedTagNames}
+        onToggleTag={(tagName) =>
+          setSelectedTagNames((prev) =>
+            prev.includes(tagName) ? prev.filter((t) => t !== tagName) : [...prev, tagName],
+          )
+        }
+        sites={allSites ?? []}
+        selectedSiteIds={selectedSiteIds}
+        onToggleSite={(id) =>
+          setSelectedSiteIds((prev) =>
+            prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id],
+          )
+        }
+      />
+      <DurationBlock />
+
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4">
+        <Label htmlFor="consent-name">Name this connection</Label>
+        <Input
+          id="consent-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-invalid={nameError !== null}
+          aria-describedby={nameError !== null ? "consent-name-error" : undefined}
+          className="mt-1.5"
+        />
+        {nameError !== null && (
+          <p id="consent-name-error" role="alert" className="mt-1.5 text-sm text-[var(--color-destructive)]">
+            {nameError}
+          </p>
+        )}
+        <p className="mt-1.5 text-xs text-[var(--color-muted-foreground)]">
+          Only you see this. The name above it is the client&apos;s own and we did not check it.
+        </p>
+      </div>
+
+      {approveError !== null && (
+        <PageError
+          what="We could not approve this connection."
+          why={approveError.message}
+        />
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button type="submit" disabled={!canApprove} data-testid="consent-approve">
+          {isApproving ? "Approving…" : "Approve and connect"}
+        </Button>
+        <Button type="button" variant="outline" onClick={onDeny} data-testid="consent-deny">
+          Do not connect
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/** The skeleton state. Deliberately has no approve control. */
+export function ConsentScreenSkeleton() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4 sm:p-6" aria-busy="true">
+      <Skeleton className="h-7 w-64" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-56 w-full" />
+      <Skeleton className="h-40 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -20,6 +20,7 @@ import {
   describeSiteScope,
   isScopeApprovable,
   resolveSiteScope,
+  type FleetSnapshot,
   type ResolvedSiteScope,
   type ScopedSite,
   type SiteScopeMode,
@@ -242,6 +243,7 @@ function SiteScopeBlock({
   selectedTagNames,
   onToggleTag,
   sites,
+  pickerComplete,
   selectedSiteIds,
   onToggleSite,
 }: {
@@ -252,6 +254,7 @@ function SiteScopeBlock({
   selectedTagNames: readonly string[];
   onToggleTag: (name: string) => void;
   sites: readonly ScopedSite[];
+  pickerComplete: boolean;
   selectedSiteIds: readonly string[];
   onToggleSite: (id: string) => void;
 }) {
@@ -259,7 +262,15 @@ function SiteScopeBlock({
   // resolved sites are always enumerated rather than summarised. The union's
   // `none` and `unresolved` members have no site list to enumerate and say so
   // instead, in words that cannot be read as "everything".
-  const enumerable = scope.kind === "all" || scope.kind === "sites" ? scope.sites : [];
+  const enumerable =
+    scope.kind === "all" ? scope.shown : scope.kind === "sites" ? scope.sites : [];
+
+  // Whether the enumeration below is the whole story. Rendered explicitly
+  // rather than inferred from the list's length, because "these are all of
+  // them" and "these are the ones we could load" look identical on screen and
+  // mean very different things to someone about to approve.
+  const listComplete =
+    scope.kind === "all" || scope.kind === "sites" ? scope.listComplete : true;
 
   return (
     <section
@@ -323,6 +334,17 @@ function SiteScopeBlock({
         </div>
       )}
 
+      {mode === "list" && !pickerComplete && (
+        <p
+          role="alert"
+          data-testid="consent-picker-truncated"
+          className="mt-3 rounded-md border border-[var(--color-destructive)]/30 p-3 text-sm text-[var(--color-destructive)]"
+        >
+          This organisation has more sites than we can list here, so the choices below
+          are not all of them. Anything you do not see is not covered by this grant.
+        </p>
+      )}
+
       {mode === "list" && (
         <div className="mt-3 max-h-56 space-y-2 overflow-y-auto">
           {sites.map((site) => (
@@ -352,6 +374,15 @@ function SiteScopeBlock({
         {describeSiteScope(scope)}
       </p>
 
+      {enumerable.length > 0 && !listComplete && (
+        <p
+          data-testid="consent-list-partial"
+          className="mt-2 text-sm font-medium text-[var(--color-destructive)]"
+        >
+          The sites below are the ones we could load, not the whole list.
+        </p>
+      )}
+
       {enumerable.length > 0 && (
         <ul
           data-testid="consent-scope-sites"
@@ -366,8 +397,8 @@ function SiteScopeBlock({
       )}
 
       <p className="mt-3 text-xs text-[var(--color-muted-foreground)]">
-        This list is what this dashboard can see right now. Your organisation&apos;s records
-        decide what the connection actually reads on each request.
+        Your organisation&apos;s records decide what this connection reads on each
+        request, not this list. The list is what this dashboard could load just now.
       </p>
     </section>
   );
@@ -421,8 +452,12 @@ export const consentNameSchema = z.object({
 export interface ConsentScreenProps {
   readonly consent: ConsentContext;
   readonly tags: readonly { id: string; name: string }[];
-  /** Null when the site list has not loaded or its load failed. Never []. */
-  readonly allSites: readonly ScopedSite[] | null;
+  /**
+   * What we loaded of the fleet, or null when the load has not finished or
+   * failed. Null is NOT an empty snapshot, and an incomplete snapshot is NOT a
+   * complete one -- see site-scope.ts.
+   */
+  readonly fleet: FleetSnapshot | null;
   readonly tagsBySiteId: Readonly<Record<string, readonly string[]>>;
   readonly sitesLoading: boolean;
   readonly isApproving: boolean;
@@ -439,7 +474,7 @@ export interface ConsentScreenProps {
 export function ConsentScreen({
   consent,
   tags,
-  allSites,
+  fleet,
   tagsBySiteId,
   sitesLoading,
   isApproving,
@@ -464,11 +499,11 @@ export function ConsentScreen({
         mode,
         selectedTagNames,
         selectedSiteIds,
-        allSites,
+        fleet,
         tagsBySiteId,
         sitesLoading,
       }),
-    [mode, selectedTagNames, selectedSiteIds, allSites, tagsBySiteId, sitesLoading],
+    [mode, selectedTagNames, selectedSiteIds, fleet, tagsBySiteId, sitesLoading],
   );
 
   const scopeOk = isScopeApprovable(scope);
@@ -521,7 +556,8 @@ export function ConsentScreen({
             prev.includes(tagName) ? prev.filter((t) => t !== tagName) : [...prev, tagName],
           )
         }
-        sites={allSites ?? []}
+        sites={fleet?.sites ?? []}
+        pickerComplete={fleet?.complete ?? true}
         selectedSiteIds={selectedSiteIds}
         onToggleSite={(id) =>
           setSelectedSiteIds((prev) =>

--- a/apps/web/src/features/mcp-consent/denial.test.ts
+++ b/apps/web/src/features/mcp-consent/denial.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+
+import { buildDenialTarget } from "./use-consent";
+import { parseConsentContext, SCOPE_READ } from "./consent-context";
+
+// REFUSAL IS A PROTOCOL MESSAGE.
+//
+// RFC 6749 section 4.1.2.1: when the operator denies the request, the
+// authorization server redirects back to the client with `error=access_denied`
+// and the original `state`. A screen that answers "no" with history.back()
+// leaves the initiating client waiting for a callback that never arrives, so
+// the user's refusal is invisible to the thing they refused.
+
+function ctx(over: Record<string, unknown> = {}) {
+  return parseConsentContext({
+    client_id: "c1",
+    client_name_unverified: "Some Client",
+    identity_verified: false,
+    redirect_uri: "https://client.example/oauth/cb",
+    redirect_host: "client.example",
+    scopes: [SCOPE_READ],
+    state: "opaque-csrf-token",
+    ...over,
+  });
+}
+
+describe("buildDenialTarget", () => {
+  it("returns access_denied to the client", () => {
+    const url = new URL(buildDenialTarget(ctx()));
+    expect(url.origin + url.pathname).toBe("https://client.example/oauth/cb");
+    expect(url.searchParams.get("error")).toBe("access_denied");
+  });
+
+  it("echoes the original state unchanged", () => {
+    // The client's own CSRF token, and the only way it can match this answer to
+    // the request it sent. Dropping it makes the refusal an unattributable
+    // stray callback.
+    const url = new URL(buildDenialTarget(ctx()));
+    expect(url.searchParams.get("state")).toBe("opaque-csrf-token");
+  });
+
+  it("omits state when the request carried none, rather than inventing one", () => {
+    const url = new URL(buildDenialTarget(ctx({ state: "" })));
+    expect(url.searchParams.has("state")).toBe(false);
+    expect(url.searchParams.get("error")).toBe("access_denied");
+  });
+
+  it("never carries an authorization code", () => {
+    const url = new URL(buildDenialTarget(ctx()));
+    expect(url.searchParams.has("code")).toBe(false);
+  });
+
+  it("uses the SERVER's exact-matched redirect URI, not one from the request", () => {
+    // internal/mcp/service.go only fills ConsentContext.RedirectURI after
+    // exactMatchRedirectURI proves it equals a registered URI. Building this
+    // from the browser's query string instead would make the refusal path an
+    // open redirector on a screen whose premise is that the request is
+    // untrusted.
+    const target = buildDenialTarget(ctx({ redirect_uri: "https://registered.example/cb" }));
+    expect(target.startsWith("https://registered.example/cb")).toBe(true);
+  });
+
+  it("preserves a query string the registered URI already carried", () => {
+    const url = new URL(
+      buildDenialTarget(ctx({ redirect_uri: "https://client.example/cb?tenant=acme" })),
+    );
+    expect(url.searchParams.get("tenant")).toBe("acme");
+    expect(url.searchParams.get("error")).toBe("access_denied");
+  });
+});

--- a/apps/web/src/features/mcp-consent/site-scope.test.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  describeSiteScope,
+  isScopeApprovable,
+  resolveSiteScope,
+  type ResolveInput,
+  type ScopedSite,
+} from "./site-scope";
+
+// m124 obligation 2: "An empty resolved set must mean NO SITES, never every
+// site." Closed three times in the backend on this stack; this file holds the
+// same line in the UI, where the failure is worse because the empty set is
+// approved by a human who was told the wrong thing.
+
+const SITES: ScopedSite[] = [
+  { id: "s1", name: "Alpha", url: "https://alpha.example" },
+  { id: "s2", name: "Beta", url: "https://beta.example" },
+];
+
+const TAGS_BY_SITE = { s1: ["prod"], s2: ["staging"] };
+
+function input(over: Partial<ResolveInput>): ResolveInput {
+  return {
+    mode: "list",
+    selectedTagNames: [],
+    selectedSiteIds: [],
+    allSites: SITES,
+    tagsBySiteId: TAGS_BY_SITE,
+    sitesLoading: false,
+    ...over,
+  };
+}
+
+/** Every word that must never appear in copy for a scope that is not mode 'all'. */
+const EVERYTHING_WORDS = /\ball\b|\bevery\b|\bany site\b/i;
+
+describe("resolveSiteScope — an empty resolution is never everything", () => {
+  it("a tag matching no site resolves to none, not to all", () => {
+    const scope = resolveSiteScope(
+      input({ mode: "tags", selectedTagNames: ["archived"] }),
+    );
+    expect(scope.kind).toBe("none");
+    expect(scope.kind === "none" && scope.because).toBe("no-matches");
+  });
+
+  it("the sentence for a tag matching no site cannot be read as everything", () => {
+    const scope = resolveSiteScope(
+      input({ mode: "tags", selectedTagNames: ["archived"] }),
+    );
+    const sentence = describeSiteScope(scope);
+    expect(sentence).toMatch(/matches no sites/i);
+    expect(sentence).toMatch(/read nothing/i);
+    // The load-bearing assertion. "all"/"every" appearing here would be the
+    // exact conflation the backend rule forbids.
+    expect(sentence.replace(/not the same as covering every site/i, "")).not.toMatch(
+      EVERYTHING_WORDS,
+    );
+  });
+
+  it("no selection at all resolves to none, not to all", () => {
+    expect(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })).kind).toBe("none");
+    expect(resolveSiteScope(input({ mode: "tags", selectedTagNames: [] })).kind).toBe("none");
+  });
+
+  it("picked site ids that this organisation does not own resolve to none", () => {
+    // scope_site_ids is a uuid[] with no foreign key over its elements, so a
+    // foreign id is representable. Locally it must vanish into `none`, never
+    // into an unfiltered read.
+    const scope = resolveSiteScope(input({ mode: "list", selectedSiteIds: ["not-ours"] }));
+    expect(scope.kind).toBe("none");
+  });
+
+  it("an empty resolution is not approvable", () => {
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "tags", selectedTagNames: ["gone"] })))).toBe(false);
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })))).toBe(false);
+  });
+
+  it("only mode 'all' ever produces kind 'all'", () => {
+    const modes = ["all", "tags", "list"] as const;
+    for (const mode of modes) {
+      const scope = resolveSiteScope(input({ mode, selectedTagNames: [], selectedSiteIds: [] }));
+      expect(scope.kind === "all").toBe(mode === "all");
+    }
+  });
+
+  it("an organisation with zero sites still gets 'all' from mode 'all', not 'none'", () => {
+    // The grant is genuinely open-ended and picks up the first site added, so
+    // collapsing it to `none` would understate what was granted -- the mirror
+    // image of the bug above and just as wrong.
+    const scope = resolveSiteScope(input({ mode: "all", allSites: [] }));
+    expect(scope.kind).toBe("all");
+    expect(describeSiteScope(scope)).toMatch(/added later/i);
+  });
+});
+
+describe("resolveSiteScope — an unread fleet is not an empty one", () => {
+  it("a site list that has not loaded is unresolved, not none and not all", () => {
+    const scope = resolveSiteScope(input({ allSites: null, sitesLoading: true }));
+    expect(scope.kind).toBe("unresolved");
+    expect(scope.kind === "unresolved" && scope.because).toBe("loading");
+  });
+
+  it("a FAILED site load is unresolved and blocks approval", () => {
+    const scope = resolveSiteScope(input({ allSites: null, sitesLoading: false }));
+    expect(scope.kind).toBe("unresolved");
+    expect(scope.kind === "unresolved" && scope.because).toBe("failed");
+    expect(isScopeApprovable(scope)).toBe(false);
+    expect(describeSiteScope(scope)).toMatch(/could not load/i);
+  });
+
+  it("mode 'all' does not paper over an unread fleet", () => {
+    // Tempting shortcut: mode 'all' does not need the site list to be correct,
+    // so return `all` regardless. It would then be impossible to tell the user
+    // how many sites that is, and the count is half the checklist item.
+    const scope = resolveSiteScope(input({ mode: "all", allSites: null, sitesLoading: false }));
+    expect(scope.kind).toBe("unresolved");
+  });
+});
+
+describe("resolveSiteScope — a real selection names its sites", () => {
+  it("a tag that matches enumerates exactly the matching sites", () => {
+    const scope = resolveSiteScope(input({ mode: "tags", selectedTagNames: ["prod"] }));
+    expect(scope.kind).toBe("sites");
+    expect(scope.kind === "sites" && scope.sites.map((s) => s.id)).toEqual(["s1"]);
+    const sentence = describeSiteScope(scope);
+    expect(sentence).toMatch(/^1 site, listed below/);
+    expect(sentence).toMatch(/No other site is covered/);
+  });
+
+  it("a count is never offered without the list behind it", () => {
+    const scope = resolveSiteScope(input({ mode: "list", selectedSiteIds: ["s1", "s2"] }));
+    expect(scope.kind === "sites" && scope.sites).toHaveLength(2);
+    expect(describeSiteScope(scope)).toMatch(/2 sites, listed below/);
+  });
+});

--- a/apps/web/src/features/mcp-consent/site-scope.test.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.test.ts
@@ -4,6 +4,7 @@ import {
   describeSiteScope,
   isScopeApprovable,
   resolveSiteScope,
+  snapshotFromPage,
   type ResolveInput,
   type ScopedSite,
 } from "./site-scope";
@@ -25,7 +26,7 @@ function input(over: Partial<ResolveInput>): ResolveInput {
     mode: "list",
     selectedTagNames: [],
     selectedSiteIds: [],
-    allSites: SITES,
+    fleet: { sites: SITES, complete: true },
     tagsBySiteId: TAGS_BY_SITE,
     sitesLoading: false,
     ...over,
@@ -88,7 +89,7 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
     // The grant is genuinely open-ended and picks up the first site added, so
     // collapsing it to `none` would understate what was granted -- the mirror
     // image of the bug above and just as wrong.
-    const scope = resolveSiteScope(input({ mode: "all", allSites: [] }));
+    const scope = resolveSiteScope(input({ mode: "all", fleet: { sites: [], complete: true } }));
     expect(scope.kind).toBe("all");
     expect(describeSiteScope(scope)).toMatch(/added later/i);
   });
@@ -96,24 +97,24 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
 
 describe("resolveSiteScope — an unread fleet is not an empty one", () => {
   it("a site list that has not loaded is unresolved, not none and not all", () => {
-    const scope = resolveSiteScope(input({ allSites: null, sitesLoading: true }));
+    const scope = resolveSiteScope(input({ fleet: null, sitesLoading: true }));
     expect(scope.kind).toBe("unresolved");
     expect(scope.kind === "unresolved" && scope.because).toBe("loading");
   });
 
   it("a FAILED site load is unresolved and blocks approval", () => {
-    const scope = resolveSiteScope(input({ allSites: null, sitesLoading: false }));
+    const scope = resolveSiteScope(input({ fleet: null, sitesLoading: false }));
     expect(scope.kind).toBe("unresolved");
     expect(scope.kind === "unresolved" && scope.because).toBe("failed");
     expect(isScopeApprovable(scope)).toBe(false);
-    expect(describeSiteScope(scope)).toMatch(/could not load/i);
+    expect(describeSiteScope(scope)).toMatch(/could not read every site/i);
   });
 
   it("mode 'all' does not paper over an unread fleet", () => {
     // Tempting shortcut: mode 'all' does not need the site list to be correct,
     // so return `all` regardless. It would then be impossible to tell the user
     // how many sites that is, and the count is half the checklist item.
-    const scope = resolveSiteScope(input({ mode: "all", allSites: null, sitesLoading: false }));
+    const scope = resolveSiteScope(input({ mode: "all", fleet: null, sitesLoading: false }));
     expect(scope.kind).toBe("unresolved");
   });
 });
@@ -124,13 +125,107 @@ describe("resolveSiteScope — a real selection names its sites", () => {
     expect(scope.kind).toBe("sites");
     expect(scope.kind === "sites" && scope.sites.map((s) => s.id)).toEqual(["s1"]);
     const sentence = describeSiteScope(scope);
-    expect(sentence).toMatch(/^1 site, listed below/);
-    expect(sentence).toMatch(/No other site is covered/);
+    expect(sentence).toMatch(/^1 site carries these tags today/);
+    // A TAG IS A RULE, NOT A LIST. A site given this tag tomorrow is covered
+    // without a second consent, so the copy may never present the enumeration
+    // as the fixed extent of the grant.
+    expect(sentence).toMatch(/given one of these tags later is covered/i);
   });
 
   it("a count is never offered without the list behind it", () => {
     const scope = resolveSiteScope(input({ mode: "list", selectedSiteIds: ["s1", "s2"] }));
     expect(scope.kind === "sites" && scope.sites).toHaveLength(2);
-    expect(describeSiteScope(scope)).toMatch(/2 sites, listed below/);
+    const sentence = describeSiteScope(scope);
+    expect(sentence).toMatch(/2 sites, listed below/);
+    // A hand-picked list IS exhaustive and fixed, and is the one basis allowed
+    // to say so.
+    expect(sentence).toMatch(/No other site is covered/);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// A page of sites is not a fleet.
+//
+// listSites is paged; useSites asks for DEFAULT_SITES_LIMIT rows and SiteList
+// is `{ items }` with no `total` and no `has_more`. So a full page and a full
+// page with more behind it are the same response, and an operator with more
+// sites than the page size would -- under a naive screen -- approve access to
+// sites the screen never showed them. Partial rendered as complete, on the one
+// screen where the cost is consent for something unseen.
+// ---------------------------------------------------------------------------
+
+describe("snapshotFromPage — a full page is never called complete", () => {
+  it("marks a short page complete: we asked for more and got fewer", () => {
+    expect(snapshotFromPage(SITES, 200).complete).toBe(true);
+  });
+
+  it("marks a FULL page incomplete, because nothing on the wire says otherwise", () => {
+    const full = Array.from({ length: 200 }, (_, i) => ({
+      id: `s${i}`,
+      name: `Site ${i}`,
+      url: `https://s${i}.example`,
+    }));
+    expect(snapshotFromPage(full, 200).complete).toBe(false);
+  });
+
+  it("marks an empty page complete", () => {
+    expect(snapshotFromPage([], 200).complete).toBe(true);
+  });
+});
+
+describe("an org larger than the page cap is never shown the page as the fleet", () => {
+  const CAPPED = { sites: SITES, complete: false };
+
+  it("mode 'all' states no total and says there are more", () => {
+    const scope = resolveSiteScope(input({ mode: "all", fleet: CAPPED }));
+    expect(scope.kind).toBe("all");
+    expect(scope.kind === "all" && scope.listComplete).toBe(false);
+    const sentence = describeSiteScope(scope);
+    // "That is N sites today" is the sentence that must NOT appear: it presents
+    // the page as the fleet size.
+    expect(sentence).not.toMatch(/That is \d+ sites? today/);
+    expect(sentence).toMatch(/there are more than that/i);
+    expect(sentence).toMatch(/added later is covered/i);
+  });
+
+  it("mode 'all' on a COMPLETE list may state the exact count", () => {
+    // The guard must not fire on honest work: when the page really is the whole
+    // fleet, refusing to give a number would be its own defect.
+    const scope = resolveSiteScope(input({ mode: "all" }));
+    expect(scope.kind === "all" && scope.listComplete).toBe(true);
+    expect(describeSiteScope(scope)).toMatch(/That is 2 sites today/);
+  });
+
+  it("mode 'tags' on a capped list gives a floor, never a total", () => {
+    const scope = resolveSiteScope(
+      input({ mode: "tags", selectedTagNames: ["prod"], fleet: CAPPED }),
+    );
+    expect(scope.kind === "sites" && scope.listComplete).toBe(false);
+    const sentence = describeSiteScope(scope);
+    expect(sentence).toMatch(/^At least 1 sites carry these tags/);
+    expect(sentence).toMatch(/could not check every site/i);
+  });
+
+  it("a tag matching nothing IN A CAPPED PAGE is unresolved, not a zero", () => {
+    // We have not looked at every site, so "matches nothing" is a claim we
+    // cannot make. Asserting a false zero here would be the mirror of the
+    // empty-means-all bug: it would tell the operator the grant reads nothing
+    // when it may read plenty.
+    const scope = resolveSiteScope(
+      input({ mode: "tags", selectedTagNames: ["archived"], fleet: CAPPED }),
+    );
+    expect(scope.kind).toBe("unresolved");
+    expect(isScopeApprovable(scope)).toBe(false);
+  });
+
+  it("a hand-picked list stays exhaustive even when the picker was capped", () => {
+    // What truncation costs mode 'list' is CHOICE, not accuracy: the grant is
+    // exactly the ids the operator ticked, all of which they saw.
+    const scope = resolveSiteScope(
+      input({ mode: "list", selectedSiteIds: ["s1"], fleet: CAPPED }),
+    );
+    expect(scope.kind === "sites" && scope.listComplete).toBe(true);
+    expect(describeSiteScope(scope)).toMatch(/No other site is covered/);
   });
 });

--- a/apps/web/src/features/mcp-consent/site-scope.test.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.test.ts
@@ -185,8 +185,13 @@ describe("an org larger than the page cap is never shown the page as the fleet",
     // "That is N sites today" is the sentence that must NOT appear: it presents
     // the page as the fleet size.
     expect(sentence).not.toMatch(/That is \d+ sites? today/);
-    expect(sentence).toMatch(/there are more than that/i);
+    expect(sentence).toMatch(/cannot tell you whether there are others/i);
     expect(sentence).toMatch(/added later is covered/i);
+    // AND IT MUST NOT ASSERT THAT MORE EXIST. `listComplete: false` means we
+    // cannot tell, not that there is a 201st site -- a page that came back
+    // exactly full with nothing behind it satisfies it and makes any such
+    // sentence false. The rows support a floor, not an inequality.
+    expect(sentence).not.toMatch(/there are more/i);
   });
 
   it("mode 'all' on a COMPLETE list may state the exact count", () => {
@@ -203,8 +208,12 @@ describe("an org larger than the page cap is never shown the page as the fleet",
     );
     expect(scope.kind === "sites" && scope.listComplete).toBe(false);
     const sentence = describeSiteScope(scope);
-    expect(sentence).toMatch(/^At least 1 sites carry these tags/);
+    // Count and noun agree. "At least 1 sites" is the tell of a template that
+    // never read its own number.
+    expect(sentence).toMatch(/^At least 1 site carries these tags/);
+    expect(sentence).not.toMatch(/1 sites/);
     expect(sentence).toMatch(/could not check every site/i);
+    expect(sentence).not.toMatch(/there are more/i);
   });
 
   it("a tag matching nothing IN A CAPPED PAGE is unresolved, not a zero", () => {
@@ -227,5 +236,41 @@ describe("an org larger than the page cap is never shown the page as the fleet",
     );
     expect(scope.kind === "sites" && scope.listComplete).toBe(true);
     expect(describeSiteScope(scope)).toMatch(/No other site is covered/);
+  });
+});
+
+
+describe("no branch asserts that more sites exist", () => {
+  // `listComplete: false` means "we cannot tell", never "there are more". Every
+  // sentence the screen can produce is checked against that, so a future copy
+  // edit cannot quietly reintroduce the inequality.
+  const CAPPED = { sites: SITES, complete: false };
+
+  const everySentence = [
+    resolveSiteScope(input({ mode: "all" })),
+    resolveSiteScope(input({ mode: "all", fleet: CAPPED })),
+    resolveSiteScope(input({ mode: "all", fleet: { sites: [], complete: true } })),
+    resolveSiteScope(input({ mode: "tags", selectedTagNames: ["prod"] })),
+    resolveSiteScope(input({ mode: "tags", selectedTagNames: ["prod"], fleet: CAPPED })),
+    resolveSiteScope(input({ mode: "tags", selectedTagNames: [] })),
+    resolveSiteScope(input({ mode: "list", selectedSiteIds: ["s1"] })),
+    resolveSiteScope(input({ mode: "list", selectedSiteIds: ["s1", "s2"] })),
+    resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })),
+    resolveSiteScope(input({ fleet: null, sitesLoading: true })),
+    resolveSiteScope(input({ fleet: null, sitesLoading: false })),
+  ].map(describeSiteScope);
+
+  it("never claims more sites exist than it can see", () => {
+    for (const sentence of everySentence) {
+      expect(sentence).not.toMatch(/there are more/i);
+      expect(sentence).not.toMatch(/more than that/i);
+    }
+  });
+
+  it("never disagrees with itself about singular and plural", () => {
+    for (const sentence of everySentence) {
+      expect(sentence).not.toMatch(/\b1 sites\b/);
+      expect(sentence).not.toMatch(/\b1 sites? carry\b/);
+    }
   });
 });

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -201,36 +201,43 @@ export function resolveSiteScope(input: ResolveInput): ResolvedSiteScope {
  *   - no branch other than `all` contains "all" or "every" as a claim about
  *     coverage;
  *   - no branch claims a complete list unless `listComplete` is true, and the
- *     open-ended bases ('all', 'tags') always say that future sites are covered.
+ *     open-ended bases ('all', 'tags') always say that future sites are covered;
+ *   - no branch ASSERTS THAT MORE EXIST. `listComplete: false` means "we cannot
+ *     tell", not "there are more" -- a page that came back exactly full with
+ *     nothing behind it satisfies it. The rows in hand support a floor and the
+ *     absence of a claim; they do not support the existence of a 201st site.
  */
+function siteCount(n: number): string {
+  return n === 1 ? "1 site" : `${n} sites`;
+}
+
 export function describeSiteScope(scope: ResolvedSiteScope): string {
   switch (scope.kind) {
     case "all": {
       const future = "Any site added later is covered too, without asking you again.";
       if (!scope.listComplete) {
-        // NO TOTAL. We hold `shown.length` rows and cannot see past them, so the
-        // only true quantity is a floor.
-        return `Every site in this organisation. We can only list ${scope.shown.length} of them here, and there are more than that. ${future}`;
+        // NO TOTAL, AND NO ASSERTION THAT ONE IS LARGER. We hold `shown.length`
+        // rows and cannot see past them. "There are more than that" would be a
+        // claim about the 201st site, which is exactly the row we do not have;
+        // a fleet of exactly 200 makes that sentence false. What the rows
+        // support is the floor and an admission of the limit.
+        return `Every site in this organisation. We can list ${siteCount(scope.shown.length)} here and cannot tell you whether there are others. ${future}`;
       }
-      return scope.shown.length === 1
-        ? `Every site in this organisation. That is 1 site today, listed below. ${future}`
-        : `Every site in this organisation. That is ${scope.shown.length} sites today, listed below. ${future}`;
+      return `Every site in this organisation. That is ${siteCount(scope.shown.length)} today, listed below. ${future}`;
     }
     case "sites": {
       if (scope.basis === "list") {
         // Exhaustive AND fixed: the operator picked these out of what they saw.
-        return scope.sites.length === 1
-          ? "1 site, listed below. No other site is covered, including sites added later."
-          : `${scope.sites.length} sites, listed below. No other site is covered, including sites added later.`;
+        return `${siteCount(scope.sites.length)}, listed below. No other site is covered, including sites added later.`;
       }
       const future =
         "Any site given one of these tags later is covered too, without asking you again.";
       if (!scope.listComplete) {
-        return `At least ${scope.sites.length} sites carry these tags. We could not check every site in this organisation, so there may be more. ${future}`;
+        const verb = scope.sites.length === 1 ? "carries" : "carry";
+        return `At least ${siteCount(scope.sites.length)} ${verb} these tags. We could not check every site in this organisation, so there may be others. ${future}`;
       }
-      return scope.sites.length === 1
-        ? `1 site carries these tags today, listed below. ${future}`
-        : `${scope.sites.length} sites carry these tags today, listed below. ${future}`;
+      const verb = scope.sites.length === 1 ? "carries" : "carry";
+      return `${siteCount(scope.sites.length)} ${verb} these tags today, listed below. ${future}`;
     }
     case "none":
       return scope.because === "no-selection"

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -1,0 +1,166 @@
+// Resolving "how many sites, and which" for the consent screen.
+//
+// THE RULE THIS FILE EXISTS TO HOLD: an empty resolved site set means NO SITES,
+// never every site.
+//
+// That conflation has been closed three times in the backend on this stack and
+// is named again in m124 obligation 2
+// (apps/api/migrations/20260826000000_m124_mcp_connection_surface.sql lines
+// 518-524): "An empty resolved set must mean NO SITES, never every site. The
+// CHECK above stops an empty payload being stored, but nothing stops Go from
+// computing an empty set (a tag that matches no site) and then treating it as
+// absence of a filter."
+//
+// The same trap is available in a UI, in a nastier form. `sites.length === 0`
+// reads naturally as "no filter applied", and the sentence that falls out of it
+// -- "this client will be able to read your sites" -- is indistinguishable from
+// the sentence for mode 'all'. A user would approve fleet-wide read access
+// believing they had scoped it to one tag.
+//
+// So the resolution is a discriminated union with a distinct `none` member, and
+// there is no code path from `none` to a sentence containing the word "all".
+//
+// WHAT THIS RESOLUTION IS AND IS NOT. It is a PREVIEW, computed from the site
+// list this dashboard can see. The authoritative resolution happens server-side
+// inside InTenantTx at one audited chokepoint, because a uuid[] column has no
+// foreign key over its elements and only a join through `sites` under RLS drops
+// ids belonging to another organisation. The screen must not claim otherwise.
+
+export type SiteScopeMode = "all" | "tags" | "list";
+
+// Mirrors SiteScopeModeAll / SiteScopeModeTags / SiteScopeModeList in
+// apps/api/internal/mcp/scope.go. There is deliberately no default mode: an
+// absent mode is refused server-side rather than read as 'all'.
+export const SITE_SCOPE_MODES: readonly SiteScopeMode[] = ["all", "tags", "list"];
+
+export interface ScopedSite {
+  readonly id: string;
+  readonly name: string;
+  readonly url: string;
+}
+
+export type ResolvedSiteScope =
+  /**
+   * Every site in the organisation, including sites added after this grant is
+   * created. `sites` is what exists today and is shown as a count, not as the
+   * definition -- the definition is open-ended and the copy must say so.
+   */
+  | { readonly kind: "all"; readonly sites: readonly ScopedSite[] }
+  /** A closed, non-empty set. `sites` is exhaustive. */
+  | { readonly kind: "sites"; readonly sites: readonly ScopedSite[] }
+  /**
+   * The selection is valid and resolves to NOTHING. Distinct from `all` by
+   * construction, and distinct from `unresolved`: we know the answer and the
+   * answer is zero.
+   */
+  | { readonly kind: "none"; readonly because: "no-selection" | "no-matches" }
+  /**
+   * We do not know yet, or we could not find out. NOT a zero and NOT an
+   * everything -- an unresolved scope must block approval, because approving it
+   * would be consenting to a set nobody has read.
+   */
+  | { readonly kind: "unresolved"; readonly because: "loading" | "failed" };
+
+export interface ResolveInput {
+  readonly mode: SiteScopeMode;
+  /** Tag names selected for mode 'tags'. */
+  readonly selectedTagNames: readonly string[];
+  /** Site ids selected for mode 'list'. */
+  readonly selectedSiteIds: readonly string[];
+  /**
+   * Every site the dashboard can see, or null when the site list has not
+   * loaded or its load failed. NULL IS NOT AN EMPTY ARRAY here, and the two
+   * produce different outcomes on purpose.
+   */
+  readonly allSites: readonly ScopedSite[] | null;
+  /** Tag names carried by each site, keyed by site id. */
+  readonly tagsBySiteId: Readonly<Record<string, readonly string[]>>;
+  readonly sitesLoading: boolean;
+}
+
+/**
+ * Resolve the operator's selection into the set of sites the grant will cover.
+ *
+ * Every branch that cannot name a set returns `unresolved` or `none`. No branch
+ * returns `all` except mode 'all'.
+ */
+export function resolveSiteScope(input: ResolveInput): ResolvedSiteScope {
+  const { mode, selectedTagNames, selectedSiteIds, allSites, tagsBySiteId } = input;
+
+  if (allSites === null) {
+    // Cannot see the fleet. Whether that is a pending load or a failed one, the
+    // honest answer is the same: we do not know which sites this covers.
+    return { kind: "unresolved", because: input.sitesLoading ? "loading" : "failed" };
+  }
+
+  if (mode === "all") {
+    // The only branch that may say "all". Note it is reached on the MODE, never
+    // on a set turning out to be empty: an organisation with zero sites still
+    // gets kind 'all', because the grant is genuinely open-ended and will pick
+    // up the first site added. The copy layer handles the "and you have none
+    // today" wrinkle without changing what was granted.
+    return { kind: "all", sites: allSites };
+  }
+
+  if (mode === "tags") {
+    if (selectedTagNames.length === 0) return { kind: "none", because: "no-selection" };
+    const wanted = new Set(selectedTagNames);
+    const matched = allSites.filter((site) =>
+      (tagsBySiteId[site.id] ?? []).some((tag) => wanted.has(tag)),
+    );
+    // A tag that matches no site. THIS is the case the backend rule is about,
+    // and it lands on `none`, never on a filter-less read.
+    if (matched.length === 0) return { kind: "none", because: "no-matches" };
+    return { kind: "sites", sites: matched };
+  }
+
+  // mode === "list"
+  if (selectedSiteIds.length === 0) return { kind: "none", because: "no-selection" };
+  const wanted = new Set(selectedSiteIds);
+  const matched = allSites.filter((site) => wanted.has(site.id));
+  // Selected ids that resolve to nothing this organisation owns. Same landing
+  // as above, for the same reason.
+  if (matched.length === 0) return { kind: "none", because: "no-matches" };
+  return { kind: "sites", sites: matched };
+}
+
+/**
+ * The sentence the screen shows for a resolved scope.
+ *
+ * Deliberately a pure function over the union so the copy for every branch is
+ * visible in one place and can be read against the rule. No branch other than
+ * `all` may contain the words "all" or "every".
+ */
+export function describeSiteScope(scope: ResolvedSiteScope): string {
+  switch (scope.kind) {
+    case "all":
+      return scope.sites.length === 1
+        ? "Every site in this organisation. That is 1 site today, and any site added later is covered too."
+        : `Every site in this organisation. That is ${scope.sites.length} sites today, and any site added later is covered too.`;
+    case "sites":
+      return scope.sites.length === 1
+        ? "1 site, listed below. No other site is covered, including sites added later."
+        : `${scope.sites.length} sites, listed below. No other site is covered, including sites added later.`;
+    case "none":
+      return scope.because === "no-selection"
+        ? "No sites are selected yet. Choose what this client may read before approving."
+        : "This selection matches no sites, so this connection would be able to read nothing. That is not the same as covering every site.";
+    case "unresolved":
+      return scope.because === "loading"
+        ? "Working out which sites this covers."
+        : "We could not load your sites, so we cannot tell you which sites this connection would cover. Do not approve until this loads.";
+  }
+}
+
+/**
+ * Whether a scope may be approved.
+ *
+ * `none` is refusable rather than blocked-with-a-warning: server-side, an empty
+ * payload is unstorable for mode 'list' and a tag matching nothing resolves to
+ * an empty set, so approving it creates a grant that reads nothing. Better to
+ * say that on this screen than to mint a credential that silently does nothing.
+ * `unresolved` is blocked because consenting to an unread set is not consent.
+ */
+export function isScopeApprovable(scope: ResolvedSiteScope): boolean {
+  return scope.kind === "all" || scope.kind === "sites";
+}

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -1,30 +1,53 @@
 // Resolving "how many sites, and which" for the consent screen.
 //
-// THE RULE THIS FILE EXISTS TO HOLD: an empty resolved site set means NO SITES,
-// never every site.
+// TWO RULES LIVE HERE, AND THEY PULL IN OPPOSITE DIRECTIONS.
 //
-// That conflation has been closed three times in the backend on this stack and
-// is named again in m124 obligation 2
-// (apps/api/migrations/20260826000000_m124_mcp_connection_surface.sql lines
-// 518-524): "An empty resolved set must mean NO SITES, never every site. The
-// CHECK above stops an empty payload being stored, but nothing stops Go from
-// computing an empty set (a tag that matches no site) and then treating it as
-// absence of a filter."
+// RULE 1: an empty resolved site set means NO SITES, never every site.
 //
-// The same trap is available in a UI, in a nastier form. `sites.length === 0`
-// reads naturally as "no filter applied", and the sentence that falls out of it
-// -- "this client will be able to read your sites" -- is indistinguishable from
-// the sentence for mode 'all'. A user would approve fleet-wide read access
+// m124 obligation 2 (apps/api/migrations/20260826000000_m124_mcp_connection_surface.sql
+// lines 518-524): "An empty resolved set must mean NO SITES, never every site.
+// The CHECK above stops an empty payload being stored, but nothing stops Go
+// from computing an empty set (a tag that matches no site) and then treating it
+// as absence of a filter." Closed three times in the backend.
+//
+// In a UI the trap is nastier: `sites.length === 0` reads naturally as "no
+// filter applied", and the sentence that falls out of it is indistinguishable
+// from the sentence for mode 'all'. A user would approve fleet-wide read access
 // believing they had scoped it to one tag.
 //
-// So the resolution is a discriminated union with a distinct `none` member, and
-// there is no code path from `none` to a sentence containing the word "all".
+// RULE 2: the list we hold is neither exhaustive nor fixed, and the copy must
+// not imply it is either.
 //
-// WHAT THIS RESOLUTION IS AND IS NOT. It is a PREVIEW, computed from the site
-// list this dashboard can see. The authoritative resolution happens server-side
-// inside InTenantTx at one audited chokepoint, because a uuid[] column has no
-// foreign key over its elements and only a join through `sites` under RLS drops
-// ids belonging to another organisation. The screen must not claim otherwise.
+//   NOT EXHAUSTIVE. listSites is a paged endpoint. useSites asks for
+//   DEFAULT_SITES_LIMIT (200) rows and SiteList is `{ items }` -- there is no
+//   `total` and no `has_more` on the wire, so a full page is indistinguishable
+//   from a full page with more behind it. An operator with more sites than the
+//   cap would, under a naive screen, approve access to sites the screen never
+//   showed them. That is a PARTIAL RESULT RENDERED AS A COMPLETE ONE, which is
+//   this project's signature defect, landed on the one screen where the cost is
+//   consent given for something the person was not shown.
+//
+//   NOT FIXED. The server resolves 'all' and 'tags' against CURRENT tenant data
+//   at read time, so those grants cover sites added after approval. A list
+//   presented as the definition of the grant would be wrong the moment a site
+//   is enrolled.
+//
+// The consequence for the copy is that mode 'all' and mode 'tags' MUST NOT
+// state a fleet size. What they state is the RULE ("every site", "every site
+// carrying this tag") plus a floor -- "at least N, which is what we could load"
+// -- which is true no matter what the API withheld, because we are holding
+// those N rows. Only mode 'list' enumerates exhaustively, because the operator
+// picked from what they saw and the grant is exactly that fixed set.
+//
+// A FLOOR IS NOT AN APPROXIMATION. "At least N" is backed by rows in hand. A
+// total is not available on the wire and is not guessed; see the PR for the
+// routing note.
+//
+// WHAT THIS RESOLUTION IS AND IS NOT. It is a PREVIEW. The authoritative
+// resolution happens server-side inside InTenantTx at one audited chokepoint,
+// because a uuid[] column has no foreign key over its elements and only a join
+// through `sites` under RLS drops ids belonging to another organisation. The
+// screen must not claim otherwise.
 
 export type SiteScopeMode = "all" | "tags" | "list";
 
@@ -39,15 +62,49 @@ export interface ScopedSite {
   readonly url: string;
 }
 
+/**
+ * What this dashboard managed to load of the tenant's fleet.
+ *
+ * `complete` is the load-bearing field. It is false whenever the page came back
+ * full, because a full page and a full page with more behind it are the same
+ * response. False does not mean "there are definitely more"; it means "we
+ * cannot say there are not", and the copy is written for that weaker claim.
+ */
+export interface FleetSnapshot {
+  readonly sites: readonly ScopedSite[];
+  readonly complete: boolean;
+}
+
+/**
+ * Build a snapshot from a page of sites and the page size that was requested.
+ *
+ * A short page is complete: we asked for `requestedLimit` and got fewer, so
+ * there is nothing behind it. A full page is NOT complete.
+ */
+export function snapshotFromPage(
+  sites: readonly ScopedSite[],
+  requestedLimit: number,
+): FleetSnapshot {
+  return { sites, complete: sites.length < requestedLimit };
+}
+
 export type ResolvedSiteScope =
   /**
-   * Every site in the organisation, including sites added after this grant is
-   * created. `sites` is what exists today and is shown as a count, not as the
-   * definition -- the definition is open-ended and the copy must say so.
+   * Every site in the organisation, now and in future. `shown` is what we could
+   * load, and it is a sample rather than a definition -- see `listComplete`.
    */
-  | { readonly kind: "all"; readonly sites: readonly ScopedSite[] }
-  /** A closed, non-empty set. `sites` is exhaustive. */
-  | { readonly kind: "sites"; readonly sites: readonly ScopedSite[] }
+  | { readonly kind: "all"; readonly shown: readonly ScopedSite[]; readonly listComplete: boolean }
+  /**
+   * A named set. `basis` decides whether it is fixed: 'list' is the operator's
+   * own pick and is exhaustive and fixed; 'tags' is a rule that future sites can
+   * fall into, and is only as complete as the page we resolved it against.
+   */
+  | {
+      readonly kind: "sites";
+      readonly sites: readonly ScopedSite[];
+      readonly basis: "tags" | "list";
+      readonly listComplete: boolean;
+    }
   /**
    * The selection is valid and resolves to NOTHING. Distinct from `all` by
    * construction, and distinct from `unresolved`: we know the answer and the
@@ -68,11 +125,11 @@ export interface ResolveInput {
   /** Site ids selected for mode 'list'. */
   readonly selectedSiteIds: readonly string[];
   /**
-   * Every site the dashboard can see, or null when the site list has not
-   * loaded or its load failed. NULL IS NOT AN EMPTY ARRAY here, and the two
-   * produce different outcomes on purpose.
+   * What we loaded of the fleet, or null when the load has not finished or
+   * failed. NULL IS NOT AN EMPTY SNAPSHOT here, and the two produce different
+   * outcomes on purpose.
    */
-  readonly allSites: readonly ScopedSite[] | null;
+  readonly fleet: FleetSnapshot | null;
   /** Tag names carried by each site, keyed by site id. */
   readonly tagsBySiteId: Readonly<Record<string, readonly string[]>>;
   readonly sitesLoading: boolean;
@@ -85,9 +142,9 @@ export interface ResolveInput {
  * returns `all` except mode 'all'.
  */
 export function resolveSiteScope(input: ResolveInput): ResolvedSiteScope {
-  const { mode, selectedTagNames, selectedSiteIds, allSites, tagsBySiteId } = input;
+  const { mode, selectedTagNames, selectedSiteIds, fleet, tagsBySiteId } = input;
 
-  if (allSites === null) {
+  if (fleet === null) {
     // Cannot see the fleet. Whether that is a pending load or a failed one, the
     // honest answer is the same: we do not know which sites this covers.
     return { kind: "unresolved", because: input.sitesLoading ? "loading" : "failed" };
@@ -97,50 +154,84 @@ export function resolveSiteScope(input: ResolveInput): ResolvedSiteScope {
     // The only branch that may say "all". Note it is reached on the MODE, never
     // on a set turning out to be empty: an organisation with zero sites still
     // gets kind 'all', because the grant is genuinely open-ended and will pick
-    // up the first site added. The copy layer handles the "and you have none
-    // today" wrinkle without changing what was granted.
-    return { kind: "all", sites: allSites };
+    // up the first site added.
+    return { kind: "all", shown: fleet.sites, listComplete: fleet.complete };
   }
 
   if (mode === "tags") {
     if (selectedTagNames.length === 0) return { kind: "none", because: "no-selection" };
     const wanted = new Set(selectedTagNames);
-    const matched = allSites.filter((site) =>
+    const matched = fleet.sites.filter((site) =>
       (tagsBySiteId[site.id] ?? []).some((tag) => wanted.has(tag)),
     );
-    // A tag that matches no site. THIS is the case the backend rule is about,
-    // and it lands on `none`, never on a filter-less read.
-    if (matched.length === 0) return { kind: "none", because: "no-matches" };
-    return { kind: "sites", sites: matched };
+    // A tag that matches no site IN THE PAGE WE HOLD. When the page is complete
+    // that is a real zero and lands on `none`. When it is not, we have not
+    // looked at every site, so "matches nothing" is a claim we cannot make --
+    // it is an unresolved scope, not an empty one, and it blocks approval
+    // rather than either granting everything or asserting a false zero.
+    if (matched.length === 0) {
+      return fleet.complete
+        ? { kind: "none", because: "no-matches" }
+        : { kind: "unresolved", because: "failed" };
+    }
+    return { kind: "sites", sites: matched, basis: "tags", listComplete: fleet.complete };
   }
 
   // mode === "list"
   if (selectedSiteIds.length === 0) return { kind: "none", because: "no-selection" };
   const wanted = new Set(selectedSiteIds);
-  const matched = allSites.filter((site) => wanted.has(site.id));
+  const matched = fleet.sites.filter((site) => wanted.has(site.id));
   // Selected ids that resolve to nothing this organisation owns. Same landing
   // as above, for the same reason.
   if (matched.length === 0) return { kind: "none", because: "no-matches" };
-  return { kind: "sites", sites: matched };
+  // ALWAYS complete. The operator picked these ids out of the list they were
+  // shown, so the grant is exactly the set on screen regardless of what the
+  // page withheld. What the truncation costs here is CHOICE, not accuracy, and
+  // the picker says so separately.
+  return { kind: "sites", sites: matched, basis: "list", listComplete: true };
 }
 
 /**
  * The sentence the screen shows for a resolved scope.
  *
  * Deliberately a pure function over the union so the copy for every branch is
- * visible in one place and can be read against the rule. No branch other than
- * `all` may contain the words "all" or "every".
+ * visible in one place and can be read against both rules above. Two invariants
+ * a reader should be able to check by eye:
+ *
+ *   - no branch other than `all` contains "all" or "every" as a claim about
+ *     coverage;
+ *   - no branch claims a complete list unless `listComplete` is true, and the
+ *     open-ended bases ('all', 'tags') always say that future sites are covered.
  */
 export function describeSiteScope(scope: ResolvedSiteScope): string {
   switch (scope.kind) {
-    case "all":
+    case "all": {
+      const future = "Any site added later is covered too, without asking you again.";
+      if (!scope.listComplete) {
+        // NO TOTAL. We hold `shown.length` rows and cannot see past them, so the
+        // only true quantity is a floor.
+        return `Every site in this organisation. We can only list ${scope.shown.length} of them here, and there are more than that. ${future}`;
+      }
+      return scope.shown.length === 1
+        ? `Every site in this organisation. That is 1 site today, listed below. ${future}`
+        : `Every site in this organisation. That is ${scope.shown.length} sites today, listed below. ${future}`;
+    }
+    case "sites": {
+      if (scope.basis === "list") {
+        // Exhaustive AND fixed: the operator picked these out of what they saw.
+        return scope.sites.length === 1
+          ? "1 site, listed below. No other site is covered, including sites added later."
+          : `${scope.sites.length} sites, listed below. No other site is covered, including sites added later.`;
+      }
+      const future =
+        "Any site given one of these tags later is covered too, without asking you again.";
+      if (!scope.listComplete) {
+        return `At least ${scope.sites.length} sites carry these tags. We could not check every site in this organisation, so there may be more. ${future}`;
+      }
       return scope.sites.length === 1
-        ? "Every site in this organisation. That is 1 site today, and any site added later is covered too."
-        : `Every site in this organisation. That is ${scope.sites.length} sites today, and any site added later is covered too.`;
-    case "sites":
-      return scope.sites.length === 1
-        ? "1 site, listed below. No other site is covered, including sites added later."
-        : `${scope.sites.length} sites, listed below. No other site is covered, including sites added later.`;
+        ? `1 site carries these tags today, listed below. ${future}`
+        : `${scope.sites.length} sites carry these tags today, listed below. ${future}`;
+    }
     case "none":
       return scope.because === "no-selection"
         ? "No sites are selected yet. Choose what this client may read before approving."
@@ -148,7 +239,7 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
     case "unresolved":
       return scope.because === "loading"
         ? "Working out which sites this covers."
-        : "We could not load your sites, so we cannot tell you which sites this connection would cover. Do not approve until this loads.";
+        : "We could not read every site in this organisation, so we cannot tell you which sites this connection would cover. Do not approve until this loads.";
   }
 }
 
@@ -160,6 +251,11 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
  * an empty set, so approving it creates a grant that reads nothing. Better to
  * say that on this screen than to mint a credential that silently does nothing.
  * `unresolved` is blocked because consenting to an unread set is not consent.
+ *
+ * A TRUNCATED LIST DOES NOT BLOCK. It is disclosed instead. Blocking would
+ * refuse every organisation past the page size, and the operator choosing "every
+ * site" has understood the rule they are granting; what they must not be given
+ * is a false count or a list that poses as the whole fleet.
  */
 export function isScopeApprovable(scope: ResolvedSiteScope): boolean {
   return scope.kind === "all" || scope.kind === "sites";

--- a/apps/web/src/features/mcp-consent/use-consent.ts
+++ b/apps/web/src/features/mcp-consent/use-consent.ts
@@ -224,3 +224,45 @@ export function buildRedirectTarget(result: ApproveResult): string {
   if (result.state !== null) url.searchParams.set("state", result.state);
   return url.toString();
 }
+
+/**
+ * Build the destination that tells the client the operator said no.
+ *
+ * REFUSAL IS A PROTOCOL MESSAGE, NOT A UI GESTURE. RFC 6749 section 4.1.2.1
+ * defines `access_denied` for exactly this. A screen that answers "no" by going
+ * back in history leaves the initiating client waiting for a callback that
+ * never arrives, so the user's refusal is invisible to the thing they refused.
+ * It is also unreachable in the common case: an OAuth client opens this URL in
+ * a new tab or a fresh window, where there is no history entry to return to,
+ * and `history.back()` there does nothing at all.
+ *
+ * `state` is echoed unchanged when the request carried one. It is the client's
+ * own CSRF token and the only way it can match this answer to the request it
+ * sent; dropping it turns a refusal into an unattributable stray callback. It
+ * is omitted when there was none, never invented.
+ *
+ * THE DESTINATION IS THE SERVER'S, NOT THE BROWSER'S. `consent.redirectUri`
+ * arrives on the authorize response, and internal/mcp/service.go only puts a
+ * value there after exactMatchRedirectURI has proved it equals one of the
+ * client's registered URIs. Building this from the query string instead would
+ * make the refusal path an open redirector, on a screen whose entire premise is
+ * that registration is unauthenticated and the request is untrusted.
+ */
+export function buildDenialTarget(consent: ConsentContext): string {
+  const url = new URL(consent.redirectUri);
+  url.searchParams.set("error", "access_denied");
+  url.searchParams.set("error_description", "The operator refused this connection.");
+  if (consent.state !== null) url.searchParams.set("state", consent.state);
+  return url.toString();
+}
+
+/**
+ * Hand the browser to a URL.
+ *
+ * A one-line indirection so the approval and the refusal paths leave through
+ * the same door, and so a test can watch that door. Nothing else in this
+ * feature should touch window.location.
+ */
+export function navigateTo(url: string): void {
+  window.location.assign(url);
+}

--- a/apps/web/src/features/mcp-consent/use-consent.ts
+++ b/apps/web/src/features/mcp-consent/use-consent.ts
@@ -1,0 +1,226 @@
+import { useMutation, useQuery, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
+
+import { parseConsentContext, type ConsentContext } from "./consent-context";
+import type { SiteScopeMode } from "./site-scope";
+
+// Data loading for the consent screen.
+//
+// WHY RAW fetch AND NOT THE GENERATED CLIENT. The OAuth endpoints are not in
+// packages/openapi/openapi.yaml. They are RFC 6749 / RFC 7591 shaped -- snake
+// case, an `error` / `error_description` envelope a client library parses, and
+// form-encoded on the token endpoint -- which apps/api/internal/mcp/dto.go
+// hand-shapes for exactly that reason ("hand-shaped rather than reusing a house
+// DTO convention"). The same house pattern is already used for other endpoints
+// outside the generated contract: features/backups/use-snapshot-environment.ts,
+// features/sharing/use-shares.ts and routes/accept.tsx all fetch a same-origin
+// /api/v1 path with credentials included. Whether these endpoints should be
+// added to the OpenAPI document is a contract question for the API owner and is
+// flagged rather than decided here.
+//
+// The zod parse in parseConsentContext is not a substitute for generated types;
+// it is the thing generated types would not give us. A generated type asserts a
+// shape at compile time and believes the server at runtime. On this screen the
+// runtime check IS the security control: a payload that does not carry a
+// verified redirect host, or that claims an identity is verified, must produce a
+// failed load rather than a rendered screen with a plausible hole in it.
+
+export const CONSENT_AUTHORIZE_PATH = "/api/v1/oauth/mcp/authorize";
+export const CONSENT_APPROVE_PATH = "/api/v1/oauth/mcp/consent";
+
+export const consentKeys = {
+  all: ["mcp-consent"] as const,
+  authorize: (params: AuthorizeParams) =>
+    [
+      ...consentKeys.all,
+      "authorize",
+      params.client_id,
+      params.redirect_uri,
+      params.scope,
+      params.state ?? "",
+      params.code_challenge ?? "",
+      params.code_challenge_method ?? "",
+    ] as const,
+};
+
+export interface AuthorizeParams {
+  readonly response_type: string;
+  readonly client_id: string;
+  readonly redirect_uri: string;
+  readonly scope: string;
+  readonly state?: string;
+  readonly code_challenge?: string;
+  readonly code_challenge_method?: string;
+}
+
+/**
+ * An RFC 6749 section 5.2 error the OAuth endpoints answer with.
+ *
+ * Kept as a named class with the machine-readable `code` intact rather than
+ * flattened into a generic Error, so the screen can tell "this client is not
+ * registered" from "we are broken" and say the right thing. The house rule is
+ * to branch on the code the server actually returns; every code below is one
+ * oauthError() in apps/api/internal/mcp/dto.go emits.
+ */
+export class OAuthRequestError extends Error {
+  readonly code: string;
+  readonly status: number;
+  constructor(code: string, description: string, status: number) {
+    super(description || code);
+    this.name = "OAuthRequestError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+async function readOAuthError(res: Response): Promise<OAuthRequestError> {
+  // A NON-JSON OR UNPARSEABLE BODY IS STILL A FAILURE. The catch below returns
+  // an error, never a success with empty fields -- an infra failure must not be
+  // reported to the user as a consent screen it can approve.
+  let code = "server_error";
+  let description = "";
+  try {
+    const body: unknown = await res.json();
+    if (body && typeof body === "object") {
+      const rec = body as Record<string, unknown>;
+      if (typeof rec.error === "string" && rec.error.length > 0) code = rec.error;
+      if (typeof rec.error_description === "string") description = rec.error_description;
+    }
+  } catch {
+    // Leave the defaults. `code` is already the pessimistic value.
+  }
+  return new OAuthRequestError(code, description, res.status);
+}
+
+/**
+ * Load the consent context for an authorization request.
+ *
+ * Every failure path throws. There is no path that resolves to a partial or
+ * empty ConsentContext, because the screen renders its approve control on
+ * success and a query that resolves with holes is a screen a user can approve
+ * without having been told what they are approving.
+ */
+export function useConsentContext(
+  params: AuthorizeParams | null,
+): UseQueryResult<ConsentContext, Error> {
+  return useQuery({
+    queryKey: params ? consentKeys.authorize(params) : [...consentKeys.all, "authorize", "none"],
+    enabled: params !== null,
+    // An authorization request is single-use and its context is not worth
+    // re-reading behind the user's back while they read the screen.
+    retry: false,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+    queryFn: async (): Promise<ConsentContext> => {
+      if (params === null) {
+        // Unreachable while `enabled` is false, and a throw rather than a
+        // fabricated empty context if that ever stops being true.
+        throw new Error("No authorization request to load.");
+      }
+      const qs = new URLSearchParams();
+      qs.set("response_type", params.response_type);
+      qs.set("client_id", params.client_id);
+      qs.set("redirect_uri", params.redirect_uri);
+      qs.set("scope", params.scope);
+      if (params.state) qs.set("state", params.state);
+      if (params.code_challenge) qs.set("code_challenge", params.code_challenge);
+      if (params.code_challenge_method) {
+        qs.set("code_challenge_method", params.code_challenge_method);
+      }
+
+      const res = await fetch(`${CONSENT_AUTHORIZE_PATH}?${qs.toString()}`, {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) throw await readOAuthError(res);
+      // A 200 with a body that is not the promised shape throws out of
+      // parseConsentContext. That is deliberate: see consent-context.ts.
+      return parseConsentContext((await res.json()) as unknown);
+    },
+  });
+}
+
+export interface ApproveInput {
+  readonly consent: ConsentContext;
+  readonly name: string;
+  readonly siteScopeMode: SiteScopeMode;
+  readonly scopeTagIds: readonly string[];
+  readonly scopeSiteIds: readonly string[];
+}
+
+export interface ApproveResult {
+  readonly grantId: string;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state: string | null;
+}
+
+/**
+ * Record the operator's approval and receive the authorization code to hand
+ * back to the client.
+ *
+ * The response's `redirect_uri` is the one the SERVER exact-matched against the
+ * client's registered array, and it is what the caller must navigate to -- not
+ * the value that arrived in the browser's query string. Using the echoed
+ * request value would make this screen the open redirector that the exact match
+ * exists to prevent.
+ */
+export function useApproveConsent(): UseMutationResult<ApproveResult, Error, ApproveInput> {
+  return useMutation({
+    mutationFn: async (input: ApproveInput): Promise<ApproveResult> => {
+      const res = await fetch(CONSENT_APPROVE_PATH, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({
+          client_id: input.consent.clientId,
+          redirect_uri: input.consent.redirectUri,
+          scopes: input.consent.scopes,
+          state: input.consent.state ?? "",
+          code_challenge: input.consent.codeChallenge ?? "",
+          code_challenge_method: input.consent.codeChallengeMethod ?? "",
+          name: input.name,
+          site_scope_mode: input.siteScopeMode,
+          scope_tag_ids: input.scopeTagIds,
+          scope_site_ids: input.scopeSiteIds,
+        }),
+      });
+      if (!res.ok) throw await readOAuthError(res);
+      const body = (await res.json()) as Record<string, unknown>;
+      const grantId = typeof body.grant_id === "string" ? body.grant_id : "";
+      const code = typeof body.code === "string" ? body.code : "";
+      const redirectUri = typeof body.redirect_uri === "string" ? body.redirect_uri : "";
+      // A 200 that did not carry a code or a destination is a failure, not an
+      // approval. Handing the browser an empty destination would strand the
+      // user on a blank page having already created a live grant.
+      if (code === "" || redirectUri === "") {
+        throw new OAuthRequestError(
+          "server_error",
+          "The connection was approved but the server did not return a destination to send the client back to.",
+          res.status,
+        );
+      }
+      return {
+        grantId,
+        code,
+        redirectUri,
+        state: typeof body.state === "string" && body.state.length > 0 ? body.state : null,
+      };
+    },
+  });
+}
+
+/**
+ * Build the destination to hand control back to the client.
+ *
+ * Uses the server-returned redirect_uri only. `state` is echoed when the server
+ * returned one and omitted when it did not -- never invented, because a client
+ * that sent no state and receives one has been handed a value it will not
+ * recognise.
+ */
+export function buildRedirectTarget(result: ApproveResult): string {
+  const url = new URL(result.redirectUri);
+  url.searchParams.set("code", result.code);
+  if (result.state !== null) url.searchParams.set("state", result.state);
+  return url.toString();
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -54,6 +54,7 @@ import { Route as AuthedSettingsApiKeysRouteImport } from './routes/_authed/sett
 import { Route as AuthedSettingsAccountRouteImport } from './routes/_authed/settings/account'
 import { Route as AuthedScheduleRunsRunIdRouteImport } from './routes/_authed/schedule-runs/$runId'
 import { Route as AuthedRestoresRestoreIdRouteImport } from './routes/_authed/restores/$restoreId'
+import { Route as AuthedConnectAiRouteImport } from './routes/_authed/connect.ai'
 import { Route as AuthedClientsClientIdRouteImport } from './routes/_authed/clients/$clientId'
 import { Route as AuthedAdminVulnFeedRouteImport } from './routes/_authed/admin/vuln-feed'
 import { Route as AuthedAdminRevenueRouteImport } from './routes/_authed/admin/revenue'
@@ -308,6 +309,11 @@ const AuthedRestoresRestoreIdRoute = AuthedRestoresRestoreIdRouteImport.update({
   path: '/restores/$restoreId',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedConnectAiRoute = AuthedConnectAiRouteImport.update({
+  id: '/connect/ai',
+  path: '/connect/ai',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedClientsClientIdRoute = AuthedClientsClientIdRouteImport.update({
   id: '/clients/$clientId',
   path: '/clients/$clientId',
@@ -493,6 +499,7 @@ export interface FileRoutesByFullPath {
   '/admin/revenue': typeof AuthedAdminRevenueRoute
   '/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
   '/clients/$clientId': typeof AuthedClientsClientIdRouteWithChildren
+  '/connect/ai': typeof AuthedConnectAiRoute
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
   '/settings/account': typeof AuthedSettingsAccountRoute
@@ -563,6 +570,7 @@ export interface FileRoutesByTo {
   '/admin/agent-mirror': typeof AuthedAdminAgentMirrorRoute
   '/admin/revenue': typeof AuthedAdminRevenueRoute
   '/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
+  '/connect/ai': typeof AuthedConnectAiRoute
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
   '/settings/account': typeof AuthedSettingsAccountRoute
@@ -637,6 +645,7 @@ export interface FileRoutesById {
   '/_authed/admin/revenue': typeof AuthedAdminRevenueRoute
   '/_authed/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
   '/_authed/clients/$clientId': typeof AuthedClientsClientIdRouteWithChildren
+  '/_authed/connect/ai': typeof AuthedConnectAiRoute
   '/_authed/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/_authed/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
   '/_authed/settings/account': typeof AuthedSettingsAccountRoute
@@ -713,6 +722,7 @@ export interface FileRouteTypes {
     | '/admin/revenue'
     | '/admin/vuln-feed'
     | '/clients/$clientId'
+    | '/connect/ai'
     | '/restores/$restoreId'
     | '/schedule-runs/$runId'
     | '/settings/account'
@@ -783,6 +793,7 @@ export interface FileRouteTypes {
     | '/admin/agent-mirror'
     | '/admin/revenue'
     | '/admin/vuln-feed'
+    | '/connect/ai'
     | '/restores/$restoreId'
     | '/schedule-runs/$runId'
     | '/settings/account'
@@ -856,6 +867,7 @@ export interface FileRouteTypes {
     | '/_authed/admin/revenue'
     | '/_authed/admin/vuln-feed'
     | '/_authed/clients/$clientId'
+    | '/_authed/connect/ai'
     | '/_authed/restores/$restoreId'
     | '/_authed/schedule-runs/$runId'
     | '/_authed/settings/account'
@@ -1235,6 +1247,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedRestoresRestoreIdRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/connect/ai': {
+      id: '/_authed/connect/ai'
+      path: '/connect/ai'
+      fullPath: '/connect/ai'
+      preLoaderRoute: typeof AuthedConnectAiRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/clients/$clientId': {
       id: '/_authed/clients/$clientId'
       path: '/clients/$clientId'
@@ -1587,6 +1606,7 @@ interface AuthedRouteChildren {
   AuthedUptimeRoute: typeof AuthedUptimeRoute
   AuthedVulnerabilitiesRoute: typeof AuthedVulnerabilitiesRoute
   AuthedClientsClientIdRoute: typeof AuthedClientsClientIdRouteWithChildren
+  AuthedConnectAiRoute: typeof AuthedConnectAiRoute
   AuthedRestoresRestoreIdRoute: typeof AuthedRestoresRestoreIdRoute
   AuthedScheduleRunsRunIdRoute: typeof AuthedScheduleRunsRunIdRoute
   AuthedSitesSiteIdRoute: typeof AuthedSitesSiteIdRouteWithChildren
@@ -1611,6 +1631,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedUptimeRoute: AuthedUptimeRoute,
   AuthedVulnerabilitiesRoute: AuthedVulnerabilitiesRoute,
   AuthedClientsClientIdRoute: AuthedClientsClientIdRouteWithChildren,
+  AuthedConnectAiRoute: AuthedConnectAiRoute,
   AuthedRestoresRestoreIdRoute: AuthedRestoresRestoreIdRoute,
   AuthedScheduleRunsRunIdRoute: AuthedScheduleRunsRunIdRoute,
   AuthedSitesSiteIdRoute: AuthedSitesSiteIdRouteWithChildren,

--- a/apps/web/src/routes/_authed/-connect.ai.test.tsx
+++ b/apps/web/src/routes/_authed/-connect.ai.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
+
+import { Route } from "./connect.ai";
+import { useConsentContext, OAuthRequestError } from "@/features/mcp-consent/use-consent";
+import { useSites } from "@/features/sites/use-sites";
+import { useTags } from "@/features/tags/use-tags";
+import type { ConsentContext } from "@/features/mcp-consent/consent-context";
+import type { Site, SiteTag } from "@wpmgr/api";
+
+// A FAILED LOAD MUST NOT RENDER AN APPROVABLE SCREEN.
+//
+// The house defect class is a failure or absence quietly coerced into a
+// plausible value. On this screen the plausible value is a consent form with
+// nothing in it, and the coercion costs the user fleet-wide read access to a
+// stranger, because a form with an enabled button is a form people press.
+
+vi.mock("@/features/mcp-consent/use-consent", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/mcp-consent/use-consent")>();
+  return { ...actual, useConsentContext: vi.fn() };
+});
+vi.mock("@/features/sites/use-sites", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/sites/use-sites")>();
+  return { ...actual, useSites: vi.fn() };
+});
+vi.mock("@/features/tags/use-tags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/tags/use-tags")>();
+  return { ...actual, useTags: vi.fn() };
+});
+
+const mockedConsent = vi.mocked(useConsentContext);
+const mockedSites = vi.mocked(useSites);
+const mockedTags = vi.mocked(useTags);
+
+const ConnectAiPage = Route.options.component!;
+
+// The route reads its OAuth parameters from the URL, so every case mounts the
+// real router at a real path rather than passing props.
+const LAUNCH =
+  "/connect/ai?response_type=code&client_id=c1&redirect_uri=https%3A%2F%2Fx.example%2Fcb&scope=mcp%3Aread";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: [] }));
+  mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: [] }));
+});
+
+describe("/connect/ai — a failed load is not approvable", () => {
+  it("renders an error and NO approve control when the authorize call fails", async () => {
+    mockedConsent.mockReturnValue(
+      mockQueryResult<ConsentContext>({
+        isError: true,
+        isSuccess: false,
+        error: new OAuthRequestError("invalid_client", "no such client", 401),
+      }),
+    );
+
+    renderWithProviders(<ConnectAiPage />, { withRouter: true, initialPath: LAUNCH });
+
+    expect(await screen.findByText(/nothing here to approve/i)).toBeTruthy();
+    expect(screen.queryByTestId("consent-approve")).toBeNull();
+    expect(screen.queryByTestId("consent-deny")).toBeNull();
+  });
+
+  it("renders no approve control when the call 'succeeds' with no data", async () => {
+    // The shape that gets missed: not an error, just nothing. A screen built
+    // from it would have empty identity, empty permissions and a live button.
+    mockedConsent.mockReturnValue(
+      mockQueryResult<ConsentContext>({ isError: false, isPending: false }),
+    );
+
+    renderWithProviders(<ConnectAiPage />, { withRouter: true, initialPath: LAUNCH });
+
+    expect(await screen.findByText(/nothing here to approve/i)).toBeTruthy();
+    expect(screen.queryByTestId("consent-approve")).toBeNull();
+  });
+
+  it("renders a skeleton with no approve control while loading", async () => {
+    mockedConsent.mockReturnValue(
+      mockQueryResult<ConsentContext>({ isPending: true }),
+    );
+
+    const { container } = renderWithProviders(<ConnectAiPage />, {
+      withRouter: true,
+      initialPath: LAUNCH,
+    });
+
+    await screen.findByRole("generic", { busy: true }).catch(() => null);
+    expect(container.querySelector('[data-testid="consent-approve"]')).toBeNull();
+  });
+
+  it("refuses an incomplete launch instead of filling in the missing parameters", async () => {
+    mockedConsent.mockReturnValue(
+      mockQueryResult<ConsentContext>({ isPending: false }),
+    );
+
+    // No `scope`. A screen that defaulted it to mcp:read would be consenting on
+    // the client's behalf to a permission the client never asked for.
+    renderWithProviders(<ConnectAiPage />, {
+      withRouter: true,
+      initialPath: "/connect/ai?response_type=code&client_id=c1&redirect_uri=https%3A%2F%2Fx.example%2Fcb",
+    });
+
+    expect(await screen.findByText(/connection request is incomplete/i)).toBeTruthy();
+    expect(screen.queryByTestId("consent-approve")).toBeNull();
+    // And it never asked the server, because there was no question to ask.
+    expect(mockedConsent).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/web/src/routes/_authed/-connect.ai.test.tsx
+++ b/apps/web/src/routes/_authed/-connect.ai.test.tsx
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 
 import { renderWithProviders } from "@/test/render";
 import { mockQueryResult } from "@/test/query-mocks";
 
 import { Route } from "./connect.ai";
-import { useConsentContext, OAuthRequestError } from "@/features/mcp-consent/use-consent";
+import {
+  useConsentContext,
+  navigateTo,
+  OAuthRequestError,
+} from "@/features/mcp-consent/use-consent";
+import { parseConsentContext, SCOPE_READ } from "@/features/mcp-consent/consent-context";
 import { useSites } from "@/features/sites/use-sites";
 import { useTags } from "@/features/tags/use-tags";
 import type { ConsentContext } from "@/features/mcp-consent/consent-context";
@@ -21,7 +26,7 @@ import type { Site, SiteTag } from "@wpmgr/api";
 vi.mock("@/features/mcp-consent/use-consent", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/features/mcp-consent/use-consent")>();
-  return { ...actual, useConsentContext: vi.fn() };
+  return { ...actual, useConsentContext: vi.fn(), navigateTo: vi.fn() };
 });
 vi.mock("@/features/sites/use-sites", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/sites/use-sites")>();
@@ -33,6 +38,7 @@ vi.mock("@/features/tags/use-tags", async (importOriginal) => {
 });
 
 const mockedConsent = vi.mocked(useConsentContext);
+const mockedNavigate = vi.mocked(navigateTo);
 const mockedSites = vi.mocked(useSites);
 const mockedTags = vi.mocked(useTags);
 
@@ -109,5 +115,53 @@ describe("/connect/ai — a failed load is not approvable", () => {
     expect(screen.queryByTestId("consent-approve")).toBeNull();
     // And it never asked the server, because there was no question to ask.
     expect(mockedConsent).toHaveBeenCalledWith(null);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Refusal reaches the client.
+// ---------------------------------------------------------------------------
+
+const CONSENT = parseConsentContext({
+  client_id: "c1",
+  client_name_unverified: "Some Client",
+  identity_verified: false,
+  redirect_uri: "https://client.example/cb",
+  redirect_host: "client.example",
+  scopes: [SCOPE_READ],
+  state: "opaque-csrf-token",
+});
+
+describe("/connect/ai — 'Do not connect' answers the client", () => {
+  it("redirects to the client with access_denied and the original state", async () => {
+    mockedConsent.mockReturnValue(mockQueryResult<ConsentContext>({ data: CONSENT }));
+
+    renderWithProviders(<ConnectAiPage />, { withRouter: true, initialPath: LAUNCH });
+
+    fireEvent.click(await screen.findByTestId("consent-deny"));
+
+    expect(mockedNavigate).toHaveBeenCalledTimes(1);
+    const target = new URL(mockedNavigate.mock.calls[0]![0]);
+    expect(target.origin + target.pathname).toBe("https://client.example/cb");
+    expect(target.searchParams.get("error")).toBe("access_denied");
+    expect(target.searchParams.get("state")).toBe("opaque-csrf-token");
+    expect(target.searchParams.has("code")).toBe(false);
+  });
+
+  it("does NOT use browser history, which is empty in a freshly opened tab", async () => {
+    // An OAuth client opens this URL in a new tab or window. There is no
+    // history entry to go back to, so history.back() there does nothing at all
+    // and the user's refusal simply vanishes.
+    const back = vi.spyOn(window.history, "back");
+    mockedConsent.mockReturnValue(mockQueryResult<ConsentContext>({ data: CONSENT }));
+
+    renderWithProviders(<ConnectAiPage />, { withRouter: true, initialPath: LAUNCH });
+
+    fireEvent.click(await screen.findByTestId("consent-deny"));
+
+    expect(back).not.toHaveBeenCalled();
+    expect(mockedNavigate).toHaveBeenCalledTimes(1);
+    back.mockRestore();
   });
 });

--- a/apps/web/src/routes/_authed/-connect.ai.test.tsx
+++ b/apps/web/src/routes/_authed/-connect.ai.test.tsx
@@ -95,7 +95,12 @@ describe("/connect/ai — a failed load is not approvable", () => {
       initialPath: LAUNCH,
     });
 
-    await screen.findByRole("generic", { busy: true }).catch(() => null);
+    // ASSERTED, NOT SWALLOWED. The previous version wrapped this in a .catch,
+    // which made the whole test unfailable -- it passed against a build with no
+    // skeleton at all. findByRole rejects on absence, and that rejection is now
+    // the test's verdict rather than something it recovers from.
+    const busy = await screen.findByRole("status", { busy: true });
+    expect(busy).toBeTruthy();
     expect(container.querySelector('[data-testid="consent-approve"]')).toBeNull();
   });
 
@@ -163,5 +168,42 @@ describe("/connect/ai — 'Do not connect' answers the client", () => {
     expect(back).not.toHaveBeenCalled();
     expect(mockedNavigate).toHaveBeenCalledTimes(1);
     back.mockRestore();
+  });
+});
+
+
+describe("/connect/ai — a failed tags load is not an empty tag registry", () => {
+  it("does not tell the operator the organisation has no tags", async () => {
+    // The same collapse the site list carries a FleetSnapshot to avoid: "we
+    // could not ask" rendered as "there are none", stated as a fact about the
+    // organisation on the screen where facts drive an irreversible decision.
+    mockedConsent.mockReturnValue(mockQueryResult<ConsentContext>({ data: CONSENT }));
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ isError: true, isSuccess: false, error: new Error("boom") }),
+    );
+
+    renderWithProviders(<ConnectAiPage />, { withRouter: true, initialPath: LAUNCH });
+
+    fireEvent.click(await screen.findByText("Sites with a tag"));
+
+    expect(screen.queryByTestId("consent-tags-empty")).toBeNull();
+    expect(screen.getByTestId("consent-tags-failed").textContent).toMatch(
+      /could not load this organisation's tags/i,
+    );
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("still says 'no tags yet' when the registry really is empty", async () => {
+    // The over-fire case. An org with no tags is a real state and must keep its
+    // own true sentence, or the fix has only moved the lie.
+    mockedConsent.mockReturnValue(mockQueryResult<ConsentContext>({ data: CONSENT }));
+    mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: [] }));
+
+    renderWithProviders(<ConnectAiPage />, { withRouter: true, initialPath: LAUNCH });
+
+    fireEvent.click(await screen.findByText("Sites with a tag"));
+
+    expect(screen.queryByTestId("consent-tags-failed")).toBeNull();
+    expect(screen.getByTestId("consent-tags-empty").textContent).toMatch(/no tags yet/i);
   });
 });

--- a/apps/web/src/routes/_authed/connect.ai.tsx
+++ b/apps/web/src/routes/_authed/connect.ai.tsx
@@ -3,19 +3,25 @@ import { useMemo } from "react";
 import { z } from "zod";
 
 import { PageError } from "@/components/feedback/page-error";
-import { useSites } from "@/features/sites/use-sites";
+import { DEFAULT_SITES_LIMIT, useSites } from "@/features/sites/use-sites";
 import { useTags } from "@/features/tags/use-tags";
 import {
   ConsentScreen,
   ConsentScreenSkeleton,
 } from "@/features/mcp-consent/consent-screen";
 import {
+  buildDenialTarget,
   buildRedirectTarget,
+  navigateTo,
   useApproveConsent,
   useConsentContext,
   type AuthorizeParams,
 } from "@/features/mcp-consent/use-consent";
-import type { ScopedSite } from "@/features/mcp-consent/site-scope";
+import {
+  snapshotFromPage,
+  type FleetSnapshot,
+  type ScopedSite,
+} from "@/features/mcp-consent/site-scope";
 
 // /connect/ai — the browser step of the MCP OAuth flow (ADR-064 S6b, design
 // Step 7).
@@ -77,12 +83,23 @@ function ConnectAiPage() {
   const approve = useApproveConsent();
 
   // NULL, NOT [], WHEN WE CANNOT SEE THE FLEET. resolveSiteScope treats the two
-  // differently on purpose: an empty array is a fleet with no sites, and null
-  // is a fleet we have not read. Collapsing them would let a failed site load
-  // render as a confident, approvable "0 sites".
-  const allSites: readonly ScopedSite[] | null = useMemo(() => {
+  // differently on purpose: an empty snapshot is a fleet with no sites, and
+  // null is a fleet we have not read. Collapsing them would let a failed site
+  // load render as a confident, approvable "0 sites".
+  //
+  // AND A FULL PAGE IS NOT A WHOLE FLEET. listSites is paged and SiteList is
+  // `{ items }` with no total and no has_more, so the only truthful reading of
+  // a full page is "at least this many". snapshotFromPage carries that fact
+  // forward instead of letting the screen treat the page as the fleet -- the
+  // partial-rendered-as-complete defect, on the screen where it costs consent.
+  const fleet: FleetSnapshot | null = useMemo(() => {
     if (sitesQuery.data === undefined) return null;
-    return sitesQuery.data.map((s) => ({ id: s.id, name: s.name, url: s.url }));
+    const sites: ScopedSite[] = sitesQuery.data.map((s) => ({
+      id: s.id,
+      name: s.name,
+      url: s.url,
+    }));
+    return snapshotFromPage(sites, DEFAULT_SITES_LIMIT);
   }, [sitesQuery.data]);
 
   const tagsBySiteId = useMemo(() => {
@@ -133,7 +150,7 @@ function ConnectAiPage() {
     <ConsentScreen
       consent={consentQuery.data}
       tags={tags}
-      allSites={allSites}
+      fleet={fleet}
       tagsBySiteId={tagsBySiteId}
       sitesLoading={sitesQuery.isPending}
       isApproving={approve.isPending}
@@ -145,13 +162,18 @@ function ConnectAiPage() {
             onSuccess: (result) => {
               // Hand control back to the destination the SERVER returned, never
               // to the value that arrived in this browser's query string.
-              window.location.assign(buildRedirectTarget(result));
+              navigateTo(buildRedirectTarget(result));
             },
           },
         );
       }}
       onDeny={() => {
-        window.history.back();
+        // REFUSAL TRAVELS BACK TO THE CLIENT. history.back() left the
+        // initiating client waiting for a callback that never came, and did
+        // nothing at all when this page was opened in a fresh tab -- which is
+        // how an OAuth client normally opens it. RFC 6749 section 4.1.2.1 has
+        // a way to say no; use it.
+        navigateTo(buildDenialTarget(consentQuery.data));
       }}
     />
   );

--- a/apps/web/src/routes/_authed/connect.ai.tsx
+++ b/apps/web/src/routes/_authed/connect.ai.tsx
@@ -108,10 +108,14 @@ function ConnectAiPage() {
     return out;
   }, [sitesQuery.data]);
 
-  const tags = useMemo(
-    () => (tagsQuery.data ?? []).map((t) => ({ id: t.id, name: t.name })),
-    [tagsQuery.data],
-  );
+  // NULL, NOT [], WHEN THE TAG REGISTRY DID NOT LOAD. `?? []` turned a failed
+  // request into the sentence "this organisation has no tags yet", which is a
+  // claim about the org made out of a fact about our own request. Same defect
+  // as the site list two hooks up, same screen, same consent decision.
+  const tags = useMemo(() => {
+    if (tagsQuery.data === undefined) return null;
+    return tagsQuery.data.map((t) => ({ id: t.id, name: t.name }));
+  }, [tagsQuery.data]);
 
   if (params === null) {
     return (

--- a/apps/web/src/routes/_authed/connect.ai.tsx
+++ b/apps/web/src/routes/_authed/connect.ai.tsx
@@ -1,0 +1,158 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { z } from "zod";
+
+import { PageError } from "@/components/feedback/page-error";
+import { useSites } from "@/features/sites/use-sites";
+import { useTags } from "@/features/tags/use-tags";
+import {
+  ConsentScreen,
+  ConsentScreenSkeleton,
+} from "@/features/mcp-consent/consent-screen";
+import {
+  buildRedirectTarget,
+  useApproveConsent,
+  useConsentContext,
+  type AuthorizeParams,
+} from "@/features/mcp-consent/use-consent";
+import type { ScopedSite } from "@/features/mcp-consent/site-scope";
+
+// /connect/ai — the browser step of the MCP OAuth flow (ADR-064 S6b, design
+// Step 7).
+//
+// ROUTE PLACEMENT. Under _authed/ deliberately. The API's authorize endpoint
+// answers 401 without a principal (apps/api/internal/mcp/handler.go), and a
+// consent screen that renders for a logged-out user would show an approve
+// button that can only ever fail. The pathless layout's beforeLoad sends them
+// to /login first and back here after.
+//
+// NO SIDEBAR ENTRY. This is a redirect target reached from an external client,
+// never navigated to from inside the app, so it stays out of
+// components/layout/sidebar.tsx along with the other callback and redirect
+// routes.
+
+// Only `response_type`, `client_id`, `redirect_uri` and `scope` are required to
+// even ask the question. They are optional in the schema so that a malformed
+// launch renders an explanation rather than a router-level parse failure the
+// user cannot read -- but a missing one is refused below, not defaulted.
+const searchSchema = z.object({
+  response_type: z.string().optional(),
+  client_id: z.string().optional(),
+  redirect_uri: z.string().optional(),
+  scope: z.string().optional(),
+  state: z.string().optional(),
+  code_challenge: z.string().optional(),
+  code_challenge_method: z.string().optional(),
+});
+
+export const Route = createFileRoute("/_authed/connect/ai")({
+  validateSearch: searchSchema,
+  component: ConnectAiPage,
+});
+
+function ConnectAiPage() {
+  const search = Route.useSearch();
+
+  // An INCOMPLETE REQUEST IS NOT A REQUEST. No parameter is filled in with a
+  // plausible default -- in particular `scope` is never defaulted, because
+  // ParseRequestedScopes refuses an absent scope rather than granting one, and
+  // a screen that quietly supplied "mcp:read" would be consenting on the
+  // client's behalf to something it never asked for.
+  const params: AuthorizeParams | null = useMemo(() => {
+    if (!search.client_id || !search.redirect_uri || !search.scope) return null;
+    return {
+      response_type: search.response_type ?? "code",
+      client_id: search.client_id,
+      redirect_uri: search.redirect_uri,
+      scope: search.scope,
+      state: search.state,
+      code_challenge: search.code_challenge,
+      code_challenge_method: search.code_challenge_method,
+    };
+  }, [search]);
+
+  const consentQuery = useConsentContext(params);
+  const sitesQuery = useSites({ view: "active" });
+  const tagsQuery = useTags();
+  const approve = useApproveConsent();
+
+  // NULL, NOT [], WHEN WE CANNOT SEE THE FLEET. resolveSiteScope treats the two
+  // differently on purpose: an empty array is a fleet with no sites, and null
+  // is a fleet we have not read. Collapsing them would let a failed site load
+  // render as a confident, approvable "0 sites".
+  const allSites: readonly ScopedSite[] | null = useMemo(() => {
+    if (sitesQuery.data === undefined) return null;
+    return sitesQuery.data.map((s) => ({ id: s.id, name: s.name, url: s.url }));
+  }, [sitesQuery.data]);
+
+  const tagsBySiteId = useMemo(() => {
+    const out: Record<string, readonly string[]> = {};
+    for (const site of sitesQuery.data ?? []) out[site.id] = site.tags ?? [];
+    return out;
+  }, [sitesQuery.data]);
+
+  const tags = useMemo(
+    () => (tagsQuery.data ?? []).map((t) => ({ id: t.id, name: t.name })),
+    [tagsQuery.data],
+  );
+
+  if (params === null) {
+    return (
+      <div className="mx-auto max-w-2xl p-4 sm:p-6">
+        <PageError
+          what="This connection request is incomplete."
+          why="It arrived without the details we need to tell you who is asking or what they want to read. Start the connection again from the app you are connecting, and if it keeps failing, that app is sending an incomplete request."
+        />
+      </div>
+    );
+  }
+
+  if (consentQuery.isPending) return <ConsentScreenSkeleton />;
+
+  // A FAILED LOAD RENDERS NO APPROVE CONTROL. This branch returns before
+  // ConsentScreen is ever constructed, so there is no state in which the user
+  // is looking at an approvable screen built from a payload we could not read.
+  if (consentQuery.isError || consentQuery.data === undefined) {
+    return (
+      <div className="mx-auto max-w-2xl p-4 sm:p-6">
+        <PageError
+          what="We could not check this connection request, so there is nothing here to approve."
+          why={
+            consentQuery.error instanceof Error
+              ? consentQuery.error.message
+              : "The server did not answer with a request we could read."
+          }
+          onRetry={() => void consentQuery.refetch()}
+          isRetrying={consentQuery.isFetching}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <ConsentScreen
+      consent={consentQuery.data}
+      tags={tags}
+      allSites={allSites}
+      tagsBySiteId={tagsBySiteId}
+      sitesLoading={sitesQuery.isPending}
+      isApproving={approve.isPending}
+      approveError={approve.error}
+      onApprove={(input) => {
+        approve.mutate(
+          { consent: consentQuery.data, ...input },
+          {
+            onSuccess: (result) => {
+              // Hand control back to the destination the SERVER returned, never
+              // to the value that arrived in this browser's query string.
+              window.location.assign(buildRedirectTarget(result));
+            },
+          },
+        );
+      }}
+      onDeny={() => {
+        window.history.back();
+      }}
+    />
+  );
+}


### PR DESCRIPTION
The browser step an OAuth MCP client sends an operator to before a grant exists. ADR-064 S6b, design Step 7. Without it a GUI client cannot complete the flow, so the read surface is unusable no matter how correct the server is.

Route is `/connect/ai`, under `_authed/` and out of the sidebar.

## The security obligation

m124 obligation 7 (`apps/api/migrations/20260826000000_m124_mcp_connection_surface.sql:548-575`). RFC 7591 registration is unauthenticated, so `client_name` and `client_uri` are attacker-controlled. The review proved two registrations may both claim the same name with identical redirect URIs and store cleanly, and the migration records that no index or constraint can fix it. The defence is presentational, so it is this screen or nothing.

What the screen does:

- The **verified redirect host leads**, under the heading "We verified this", at the largest type size in the block. The self-declared name comes second, under "We did not verify this", in quotation marks, followed by the sentence that anyone can register a client under any name.
- A test pins that **DOM order**, because leading with the client's chosen name is exactly the habit an impersonating registration is buying.
- `client_uri` renders as text, **never as a link** — a link is an endorsement and a click target nobody checked.
- `identity_verified` parses as `z.literal(false)`, mirroring the hard-coded literal in `dto.go`. A payload claiming verification is an unreadable payload, so it is a failed load rather than a trusted one.

The field names are the API's own marking (`client_name_unverified`, `client_uri_unverified`), carried through rather than renamed.

## Absence is never coerced

- A client that gave no name renders "This client did not give a name." Whitespace-only counts as absent.
- Absent `state` / `code_challenge` are `null`, not `""`.
- **No expiry date is shown**, because `mcp_grants` has no `expires_at` and `consentResponseDTO` carries no lifetime field. The screen says the grant lasts until revoked, which is what the schema supports.
- A missing `scope` on the launch URL is refused, not defaulted to `mcp:read` — `ParseRequestedScopes` refuses an absent scope, and defaulting would consent on the client's behalf.

## Empty is not everything

`resolveSiteScope` returns a discriminated union. `none` (a real zero) and `unresolved` (a fleet we could not read) are distinct from `all`, and only mode `'all'` can produce `'all'`. Neither `none` nor `unresolved` is approvable. This is the conflation m124 obligation 2 names and the backend has closed three times.

## Red before green

Each proof planted the naive version, ran it, restored, and re-ran.

| Planted | Red | Green after restore |
|---|---|---|
| `z.boolean()` for `identity_verified`; "Verified publisher" heading | 2 failed / 24 | 24 passed |
| tag-matches-nothing falls through to `{ kind: "all" }`; `allSites ?? []` | 8 failed / 25 | 25 passed |
| error branch dropped, context defaulted to plausible blanks | 3 failed / 4 | 4 passed |

## Gates

All run in the worktree, output in the agent report.

- `pnpm -C apps/web typecheck` — clean
- `pnpm -C apps/web lint` — 0 errors, 10 warnings (9 pre-existing; 1 new `react-refresh/only-export-components`, matching the existing pattern in several feature files)
- `pnpm -C apps/web test` — 154 files, 1813 tests, all passing
- `vite build` — succeeded; `routeTree.gen.ts` regenerated and committed
- `impeccable detect` on the new paths — clean

## For the API owner

The OAuth endpoints are not in `packages/openapi/openapi.yaml`. They are RFC-shaped and hand-written in `internal/mcp` (`dto.go` says so explicitly), so the data layer is a same-origin `fetch` with a zod parse, following the pattern already used by `use-snapshot-environment.ts`, `use-shares.ts` and `routes/accept.tsx`. The zod parse is not a stand-in for generated types here — it is the runtime fail-closed check that a generated type would not give. Whether these endpoints should join the generated contract is a call for the API owner.

Two coordination items, neither blocking:

1. `GET /api/v1/oauth/mcp/authorize` and `POST /api/v1/oauth/mcp/consent` are not yet mounted on the main router (only in `internal/mcp` tests). This screen cannot be exercised end to end until they are.
2. The revoke destination is named in prose ("Settings, under AI connections") and deliberately not linked, because that route is S16 and does not exist yet. Wire it when S16 lands; the string is a single exported constant.

## Out of scope

The ten-step connection wizard (S16), the connections list, rotate/revoke management.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated `/connect/ai` consent screen for AI connections.
  * Displays verified redirect details, permissions, limitations, and site access options.
  * Supports selecting all sites, tagged sites, or specific sites.
  * Requires a connection name before approval and provides approve or deny actions.
  * Shows clear warnings when site information is incomplete and explains that access can be revoked from Settings.
  * Safely redirects after approval or denial using OAuth parameters.

* **Bug Fixes**
  * Prevents approval for invalid, incomplete, or unrecognized permissions and site selections.

* **Tests**
  * Added comprehensive coverage for consent validation, site scopes, approval, and denial flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->