### PR TITLE
fix(auth): key the auth rate limiters on the peer address

### DIFF
--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -107,6 +107,23 @@ var version = "0.0.0-dev"
 func main() {
 	// Load config and initialize the logger as early as possible so all boot
 	// paths have structured output.
+	// A Load error exits rather than parking in the degraded mode used for
+	// Validate issues below, and that difference is deliberate rather than an
+	// oversight.
+	//
+	// Degraded mode exists to serve /readyz from a Config that parsed. A Load
+	// error means there is no such Config: the value was rejected precisely
+	// because it could not be turned into one, and there is nothing coherent to
+	// serve a diagnostic page out of. The error is written to stderr first, so
+	// it is readable in the container log even though the process then restarts.
+	//
+	// The tradeoff is real: an operator who mistypes one of the strictly-parsed
+	// values gets a restart loop rather than the readable page. That is accepted
+	// because those values are refused only when they cannot be read as intended
+	// at all, and booting on a guess at what was meant is the worse outcome —
+	// for the auth proxy hop count specifically, a guess either stops the
+	// sign-in rate limits binding or refuses every legitimate user, neither of
+	// which is visible from inside the process.
 	cfg, err := config.Load(os.Getenv("WPMGR_CONFIG_FILE"))
 	if err != nil {
 		slog.Error("fatal: config load failed", slog.Any("error", err))
@@ -2759,6 +2776,21 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// only in a redirect the browser follows away.
 	authH.SetLogger(logger)
 	authH.SetSecureCookies(cfg.IsProduction())
+	// Declare how many proxies in front of this process append to
+	// X-Forwarded-For, which is what the auth rate limiters key on.
+	//
+	// Logged unconditionally, and at Info, because a wrong value here is not
+	// visible from inside the process: too low and every client shares one
+	// limiter key and legitimate sign-ins are refused fleet-wide; too high and
+	// the limiters key on caller-supplied data. An operator whose auth starts
+	// refusing everyone must be able to find the effective value in the first
+	// screen of the log rather than by reading the source. The default suits
+	// the hosted topology; any other deployment sets WPMGR_AUTH_PROXY_HOPS.
+	authH.SetProxyHops(cfg.Auth.ProxyHops)
+	logger.Info("auth rate-limit peer address resolution",
+		"proxy_hops", cfg.Auth.ProxyHops,
+		"env_var", "WPMGR_AUTH_PROXY_HOPS",
+		"meaning", "number of proxies in front of this process that append to X-Forwarded-For; 0 means this process terminates connections directly and the peer address is the client")
 	// The social handshake is sealed rather than stored, so the start endpoint
 	// writes nothing to the session store an unauthenticated caller could fill.
 	// Fatal if it cannot be keyed: the alternative is an install whose sign-in

--- a/apps/api/internal/auth/clientaddr_limiter_key_test.go
+++ b/apps/api/internal/auth/clientaddr_limiter_key_test.go
@@ -1,0 +1,444 @@
+package auth
+
+// Regression pins for the address the authentication rate limiters key on.
+//
+// Two auth limiters make a DECISION from the requesting address:
+//
+//   - reset.go  "pwreset-consume:"+ip  (resetPerMinute)
+//   - twofa.go  "2fa-ip:"+ip           (twoFAIPLockoutPerMinute)
+//
+// Both must key on limiterAddr, which selects the entry the infrastructure
+// appended (see proxyHops in handler.go), not on clientAddr, which resolves the
+// leftmost forwarded entry and is therefore chosen by the caller.
+//
+// Coverage is deliberately in three layers, because the first two each miss
+// something the other catches:
+//
+//  1. limiterAddr's own behaviour — chain shapes, duplicate header lines, IPv6.
+//  2. The registered route — TestResetPasswordRouteKeysOnAppendedClient drives
+//     the real gin route through h.Register into the real Service and the real
+//     limiter, so the wiring is covered and not just the helper.
+//  3. TestDecisionSitesUseLimiterAddr parses the source and pins that all four
+//     decision sites call limiterAddr. Layer 2 cannot reach the three 2FA sites
+//     without a database (their limiter sits behind a challenge lookup), so
+//     without this a revert of those three would be silent.
+//
+// On over-firing: a single-client arm CANNOT detect a remedy that keys every
+// caller onto one shared value — such a remedy still refuses past the cap and
+// still serves below it, so every single-client pin here passes while the whole
+// fleet is locked out. Only TestResetRouteSeparatesDistinctClients catches it,
+// because catching it requires two distinct legitimate clients in one arm. Do
+// not read the controls in the other tests as over-fire protection; they are
+// not, and they were once wrongly described that way.
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/autologin"
+)
+
+const (
+	// simulatedClient is the address the balancer observes and appends. It is
+	// the value every limiter key must reduce to.
+	simulatedClient = "203.0.113.200"
+	// simulatedOtherClient is a second, unrelated legitimate client. Used to
+	// prove distinct callers get distinct buckets.
+	simulatedOtherClient = "203.0.113.201"
+	// simulatedBalancer is the balancer's own frontend address, appended last.
+	simulatedBalancer = "192.0.2.1"
+)
+
+func engineAsProductionBuildsIt() *gin.Engine {
+	gin.SetMode(gin.ReleaseMode)
+	return gin.New()
+}
+
+// simulateBalancerFor builds the X-Forwarded-For chain as it arrives at the
+// container: whatever the caller sent, then the observed client address, then
+// the balancer's own.
+func simulateBalancerFor(client, callerSupplied string) string {
+	if callerSupplied == "" {
+		return client + ", " + simulatedBalancer
+	}
+	return callerSupplied + ", " + client + ", " + simulatedBalancer
+}
+
+func simulateBalancer(callerSupplied string) string {
+	return simulateBalancerFor(simulatedClient, callerSupplied)
+}
+
+func probeOnce(t *testing.T, client *http.Client, method, url, fwd string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fwd != "" {
+		req.Header.Set("X-Forwarded-For", fwd)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	buf := make([]byte, 256)
+	n, _ := resp.Body.Read(buf)
+	return resp.StatusCode, string(buf[:n])
+}
+
+// TestLimiterAddrSelectsTheAppendedClientEntry: whatever the caller prepends,
+// the limiter address must reduce to the entry the balancer appended.
+func TestLimiterAddrSelectsTheAppendedClientEntry(t *testing.T) {
+	e := engineAsProductionBuildsIt()
+	e.GET("/probe", func(c *gin.Context) {
+		c.String(http.StatusOK, "%s", limiterAddr(c).String())
+	})
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	for _, callerSupplied := range []string{
+		"",
+		"203.0.113.9",
+		"198.51.100.7, 10.0.0.1",
+		"1.2.3.4, 203.0.113.9, 10.0.0.1",
+		// A caller echoing the real shape back, to check the selection is
+		// positional from the right rather than a value match.
+		simulatedClient + ", " + simulatedBalancer,
+		// A caller padding to exactly proxyHops, which is the shape that would
+		// defeat the short-chain fallback if the fallback were load-bearing.
+		"9.9.9.9, 9.9.9.10",
+	} {
+		_, got := probeOnce(t, srv.Client(), "GET", srv.URL+"/probe", simulateBalancer(callerSupplied))
+		if got != simulatedClient {
+			t.Errorf("caller-supplied prefix %q produced limiter address %s, want %s",
+				callerSupplied, got, simulatedClient)
+		}
+	}
+}
+
+// TestLimiterAddrReadsEveryForwardedHeaderLine pins that a caller cannot hide
+// the appended entries by sending the header more than once. Header.Get returns
+// only the first line; the chain is every line joined.
+func TestLimiterAddrReadsEveryForwardedHeaderLine(t *testing.T) {
+	e := engineAsProductionBuildsIt()
+	e.GET("/probe", func(c *gin.Context) {
+		c.String(http.StatusOK, "%s", limiterAddr(c).String())
+	})
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	for _, callerLines := range [][]string{
+		{"9.9.9.9"},
+		{"9.9.9.9", "9.9.9.10"},
+		{"9.9.9.9, 9.9.9.10"},
+	} {
+		req, err := http.NewRequest("GET", srv.URL+"/probe", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Every caller line first, then the line the infrastructure appends.
+		for _, l := range callerLines {
+			req.Header.Add("X-Forwarded-For", l)
+		}
+		req.Header.Add("X-Forwarded-For", simulatedClient+", "+simulatedBalancer)
+
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, 128)
+		n, _ := resp.Body.Read(buf)
+		resp.Body.Close()
+		if got := string(buf[:n]); got != simulatedClient {
+			t.Errorf("caller lines %q produced limiter address %s, want %s; "+
+				"only the first header line was read", callerLines, got, simulatedClient)
+		}
+	}
+}
+
+// TestLimiterAddrHandlesIPv6Forms pins the v6 spellings. There is a v6
+// forwarding rule in front of this service, so v6 is real traffic; if these
+// fell back to the peer address every v6 client would share one bucket.
+func TestLimiterAddrHandlesIPv6Forms(t *testing.T) {
+	e := engineAsProductionBuildsIt()
+	e.GET("/probe", func(c *gin.Context) {
+		c.String(http.StatusOK, "%s", limiterAddr(c).String())
+	})
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	cases := []struct{ entry, want string }{
+		{"2001:db8::1", "2001:db8::1"},
+		{"[2001:db8::1]", "2001:db8::1"},
+		{"[2001:db8::1]:443", "2001:db8::1"},
+		{"198.51.100.7:443", "198.51.100.7"},
+		{" 2001:db8::2 ", "2001:db8::2"},
+	}
+	for _, tc := range cases {
+		fwd := "9.9.9.9, " + tc.entry + ", " + simulatedBalancer
+		_, got := probeOnce(t, srv.Client(), "GET", srv.URL+"/probe", fwd)
+		if got != tc.want {
+			t.Errorf("appended entry %q produced limiter address %s, want %s", tc.entry, got, tc.want)
+		}
+	}
+}
+
+// TestLimiterAddrFallsBackToPeerOnShortChain pins that an honest short chain
+// resolves from the connection rather than from caller data. This is a
+// correctness pin, not a security guard — see the note on limiterAddr.
+func TestLimiterAddrFallsBackToPeerOnShortChain(t *testing.T) {
+	e := engineAsProductionBuildsIt()
+	e.GET("/probe", func(c *gin.Context) {
+		c.String(http.StatusOK, "%s|%s", limiterAddr(c).String(), c.RemoteIP())
+	})
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	for _, fwd := range []string{"", "198.51.100.5"} {
+		_, got := probeOnce(t, srv.Client(), "GET", srv.URL+"/probe", fwd)
+		addr, peer, ok := strings.Cut(got, "|")
+		if !ok {
+			t.Fatalf("malformed probe response %q", got)
+		}
+		if addr != peer {
+			t.Errorf("chain %q gave limiter address %s, want the peer address %s", fwd, addr, peer)
+		}
+	}
+}
+
+// newResetRoute builds the real /auth/password/reset route: the real Handler,
+// the real Service, the real limiter. Requests past the cap are refused by the
+// limiter before any database access, which is what makes this reachable
+// without one. Requests below the cap continue into the repo layer, which is
+// absent here, so Recovery turns those into 500s — the 429/500 split is the
+// signal this test reads.
+func newResetRoute(t *testing.T, lim *autologin.MemoryLimiter) *httptest.Server {
+	t.Helper()
+	gin.SetMode(gin.ReleaseMode)
+	e := gin.New()
+	e.Use(gin.Recovery())
+	h := &Handler{svc: &Service{limiter: lim}}
+	h.Register(e)
+	srv := httptest.NewServer(e)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func postReset(t *testing.T, srv *httptest.Server, fwd string) int {
+	t.Helper()
+	body := strings.NewReader(`{"token":"not-a-real-token","password":"correct-horse-battery"}`)
+	req, err := http.NewRequest("POST", srv.URL+"/auth/password/reset", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", fwd)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestResetPasswordRouteKeysOnAppendedClient drives the REGISTERED route, not a
+// stand-in handler. Reverting the decision site to clientAddr makes this fail.
+func TestResetPasswordRouteKeysOnAppendedClient(t *testing.T) {
+	attempts := resetPerMinute * 4
+
+	run := func(vary bool) (refused int) {
+		lim := autologin.NewMemoryLimiter()
+		defer lim.Stop()
+		srv := newResetRoute(t, lim)
+		for i := 0; i < attempts; i++ {
+			callerSupplied := ""
+			if vary {
+				callerSupplied = fmt.Sprintf("203.0.113.%d", i+1)
+			}
+			if postReset(t, srv, simulateBalancer(callerSupplied)) == http.StatusTooManyRequests {
+				refused++
+			}
+		}
+		return refused
+	}
+
+	variedRefused := run(true)
+	ctrlRefused := run(false)
+	t.Logf("through the registered route: varied refused=%d | control refused=%d (cap=%d/min over %d attempts)",
+		variedRefused, ctrlRefused, resetPerMinute, attempts)
+
+	if ctrlRefused == 0 {
+		t.Fatalf("CONTROL BROKEN: the route refused nothing on the control arm; this test proves nothing")
+	}
+	if variedRefused != ctrlRefused {
+		t.Errorf("varying the caller-supplied prefix changed the outcome through the real route: "+
+			"refused %d vs control %d", variedRefused, ctrlRefused)
+	}
+}
+
+// TestResetRouteSeparatesDistinctClients is the over-fire guard, and it needs
+// TWO legitimate clients to work. A remedy that keyed every caller onto one
+// value would close the bypass and pass every single-client test in this file
+// while locking out the entire fleet; this is the pin that refuses it.
+func TestResetRouteSeparatesDistinctClients(t *testing.T) {
+	lim := autologin.NewMemoryLimiter()
+	defer lim.Stop()
+	srv := newResetRoute(t, lim)
+
+	// Each client sends exactly its own cap. Independent buckets ⇒ nothing is
+	// refused. A shared bucket ⇒ the second client is refused outright.
+	var refusedFor = map[string]int{}
+	for _, client := range []string{simulatedClient, simulatedOtherClient} {
+		for i := 0; i < resetPerMinute; i++ {
+			if postReset(t, srv, simulateBalancerFor(client, "")) == http.StatusTooManyRequests {
+				refusedFor[client]++
+			}
+		}
+	}
+	t.Logf("refusals within cap: %s=%d %s=%d",
+		simulatedClient, refusedFor[simulatedClient], simulatedOtherClient, refusedFor[simulatedOtherClient])
+
+	for client, n := range refusedFor {
+		if n > 0 {
+			t.Errorf("OVER-FIRES: client %s was refused %d times inside its own cap of %d; "+
+				"distinct clients are sharing a bucket", client, n, resetPerMinute)
+		}
+	}
+}
+
+// TestTwoFAPerIPLimiterKeysOnAppendedClient covers the 2FA key format and
+// constant. The registered 2FA routes reach their limiter only after a
+// challenge lookup, so this drives the limiter directly; the wiring of those
+// three sites is pinned by TestDecisionSitesUseLimiterAddr instead.
+func TestTwoFAPerIPLimiterKeysOnAppendedClient(t *testing.T) {
+	attempts := twoFAIPLockoutPerMinute * 4
+
+	run := func(vary bool) (allowed, refused int) {
+		lim := autologin.NewMemoryLimiter()
+		defer lim.Stop()
+		e := engineAsProductionBuildsIt()
+		e.POST("/auth/2fa/verify", func(c *gin.Context) {
+			ip := limiterAddr(c)
+			if ip.IsValid() {
+				if ok, _ := lim.Allow(context.Background(), "2fa-ip:"+ip.String(), twoFAIPLockoutPerMinute); !ok {
+					c.String(http.StatusTooManyRequests, "429")
+					return
+				}
+			}
+			c.String(http.StatusOK, "200")
+		})
+		srv := httptest.NewServer(e)
+		defer srv.Close()
+
+		for i := 0; i < attempts; i++ {
+			callerSupplied := ""
+			if vary {
+				callerSupplied = fmt.Sprintf("198.51.100.%d", (i%254)+1)
+			}
+			code, _ := probeOnce(t, srv.Client(), "POST", srv.URL+"/auth/2fa/verify", simulateBalancer(callerSupplied))
+			if code == http.StatusTooManyRequests {
+				refused++
+			} else {
+				allowed++
+			}
+		}
+		return allowed, refused
+	}
+
+	variedAllowed, variedRefused := run(true)
+	ctrlAllowed, ctrlRefused := run(false)
+	t.Logf("varied: allowed=%d refused=%d | control: allowed=%d refused=%d (cap=%d/min over %d attempts)",
+		variedAllowed, variedRefused, ctrlAllowed, ctrlRefused, twoFAIPLockoutPerMinute, attempts)
+
+	if ctrlRefused == 0 {
+		t.Fatalf("CONTROL BROKEN: the limiter refused nothing on the control arm (allowed=%d of %d)",
+			ctrlAllowed, attempts)
+	}
+	if variedRefused == 0 {
+		t.Errorf("limiter did not bind: %d of %d attempts from ONE peer were allowed", variedAllowed, attempts)
+	}
+	if variedAllowed != ctrlAllowed {
+		t.Errorf("varying the caller-supplied prefix changed the outcome: allowed %d vs control %d",
+			variedAllowed, ctrlAllowed)
+	}
+}
+
+// decisionSites are the handlers whose address feeds a rate-limit decision.
+var decisionSites = map[string][]string{
+	"handler.go":       {"resetPassword"},
+	"twofa_handler.go": {"twoFATOTPComplete", "twoFARecoveryComplete", "twoFAWebAuthnFinish"},
+}
+
+// TestDecisionSitesUseLimiterAddr pins the wiring of every decision site,
+// including the three that a unit test cannot reach without a database.
+//
+// Without this, reverting those three to clientAddr reintroduces the defect and
+// every test in this package still passes.
+func TestDecisionSitesUseLimiterAddr(t *testing.T) {
+	fset := token.NewFileSet()
+	checked := 0
+
+	for file, funcs := range decisionSites {
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		want := map[string]bool{}
+		for _, fn := range funcs {
+			want[fn] = true
+		}
+
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Name == nil || !want[fd.Name.Name] {
+				continue
+			}
+			delete(want, fd.Name.Name)
+			checked++
+
+			var uses []string
+			ast.Inspect(fd, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if id, ok := call.Fun.(*ast.Ident); ok {
+					if id.Name == "limiterAddr" || id.Name == "clientAddr" {
+						uses = append(uses, id.Name)
+					}
+				}
+				return true
+			})
+
+			for _, u := range uses {
+				if u == "clientAddr" {
+					t.Errorf("%s: %s calls clientAddr; a decision site must use limiterAddr, "+
+						"because clientAddr resolves an entry the caller supplies", file, fd.Name.Name)
+				}
+			}
+			if len(uses) == 0 {
+				t.Errorf("%s: %s derives no address at all; expected a limiterAddr call",
+					file, fd.Name.Name)
+			}
+		}
+
+		for fn := range want {
+			t.Errorf("%s: decision site %s not found — it was renamed or removed, and this pin "+
+				"stopped covering it", file, fn)
+		}
+	}
+
+	if checked != 4 {
+		t.Fatalf("checked %d decision sites, want 4; the pin is not covering what it claims", checked)
+	}
+}

--- a/apps/api/internal/auth/clientaddr_limiter_key_test.go
+++ b/apps/api/internal/auth/clientaddr_limiter_key_test.go
@@ -63,6 +63,20 @@ func engineAsProductionBuildsIt() *gin.Engine {
 	return gin.New()
 }
 
+// handlerWithHops builds a Handler that resolves addresses for a deployment
+// with n appending proxies.
+func handlerWithHops(n int) *Handler {
+	h := &Handler{}
+	h.SetProxyHops(n)
+	return h
+}
+
+// defaultHopsHandler matches the hosted topology (a load balancer appending the
+// client address then its own), which is the default and what most pins here
+// exercise. Deployments with a different shape are covered by
+// TestLimiterAddrHonoursConfiguredHopCount.
+var defaultHopsHandler = handlerWithHops(2)
+
 // simulateBalancerFor builds the X-Forwarded-For chain as it arrives at the
 // container: whatever the caller sent, then the observed client address, then
 // the balancer's own.
@@ -101,7 +115,7 @@ func probeOnce(t *testing.T, client *http.Client, method, url, fwd string) (int,
 func TestLimiterAddrSelectsTheAppendedClientEntry(t *testing.T) {
 	e := engineAsProductionBuildsIt()
 	e.GET("/probe", func(c *gin.Context) {
-		c.String(http.StatusOK, "%s", limiterAddr(c).String())
+		c.String(http.StatusOK, "%s", defaultHopsHandler.limiterAddr(c).String())
 	})
 	srv := httptest.NewServer(e)
 	defer srv.Close()
@@ -132,7 +146,7 @@ func TestLimiterAddrSelectsTheAppendedClientEntry(t *testing.T) {
 func TestLimiterAddrReadsEveryForwardedHeaderLine(t *testing.T) {
 	e := engineAsProductionBuildsIt()
 	e.GET("/probe", func(c *gin.Context) {
-		c.String(http.StatusOK, "%s", limiterAddr(c).String())
+		c.String(http.StatusOK, "%s", defaultHopsHandler.limiterAddr(c).String())
 	})
 	srv := httptest.NewServer(e)
 	defer srv.Close()
@@ -172,7 +186,7 @@ func TestLimiterAddrReadsEveryForwardedHeaderLine(t *testing.T) {
 func TestLimiterAddrHandlesIPv6Forms(t *testing.T) {
 	e := engineAsProductionBuildsIt()
 	e.GET("/probe", func(c *gin.Context) {
-		c.String(http.StatusOK, "%s", limiterAddr(c).String())
+		c.String(http.StatusOK, "%s", defaultHopsHandler.limiterAddr(c).String())
 	})
 	srv := httptest.NewServer(e)
 	defer srv.Close()
@@ -199,7 +213,7 @@ func TestLimiterAddrHandlesIPv6Forms(t *testing.T) {
 func TestLimiterAddrFallsBackToPeerOnShortChain(t *testing.T) {
 	e := engineAsProductionBuildsIt()
 	e.GET("/probe", func(c *gin.Context) {
-		c.String(http.StatusOK, "%s|%s", limiterAddr(c).String(), c.RemoteIP())
+		c.String(http.StatusOK, "%s|%s", defaultHopsHandler.limiterAddr(c).String(), c.RemoteIP())
 	})
 	srv := httptest.NewServer(e)
 	defer srv.Close()
@@ -216,6 +230,83 @@ func TestLimiterAddrFallsBackToPeerOnShortChain(t *testing.T) {
 	}
 }
 
+// TestLimiterAddrHonoursConfiguredHopCount is the pin that the positional rule
+// is not hard-wired to one deployment.
+//
+// Before the hop count was configurable this selection was fixed at 2, which is
+// correct only for the hosted topology. On a single-proxy install it made honest
+// clients — who send no forwarded header of their own, producing a chain of one
+// — fall back to the proxy's address and share a single limiter key, locking
+// them out, while a caller supplying one entry still chose its own key. That is
+// strictly worse than not fixing anything, so each supported shape is pinned.
+func TestLimiterAddrHonoursConfiguredHopCount(t *testing.T) {
+	cases := []struct {
+		name  string
+		hops  int
+		chain string // as it arrives at this process
+		want  string // "" means "the peer address"
+	}{
+		{"two appending proxies, honest client", 2, simulatedClient + ", " + simulatedBalancer, simulatedClient},
+		{"two appending proxies, caller prepends", 2, "9.9.9.9, " + simulatedClient + ", " + simulatedBalancer, simulatedClient},
+
+		// One appending proxy: the honest chain is just the client, and it must
+		// resolve to the client rather than collapsing onto the peer.
+		{"one appending proxy, honest client", 1, simulatedClient, simulatedClient},
+		{"one appending proxy, caller prepends", 1, "9.9.9.9, " + simulatedClient, simulatedClient},
+
+		// Nothing appends: the header is caller-supplied in its entirety and
+		// carries no evidence, so it must be ignored and the peer used.
+		{"no proxy, no header", 0, "", ""},
+		{"no proxy, caller supplies a full chain", 0, "9.9.9.9, 8.8.8.8", ""},
+		{"no proxy, caller mimics the hosted shape", 0, simulatedClient + ", " + simulatedBalancer, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := handlerWithHops(tc.hops)
+			e := engineAsProductionBuildsIt()
+			e.GET("/probe", func(c *gin.Context) {
+				c.String(http.StatusOK, "%s|%s", h.limiterAddr(c).String(), c.RemoteIP())
+			})
+			srv := httptest.NewServer(e)
+			defer srv.Close()
+
+			_, body := probeOnce(t, srv.Client(), "GET", srv.URL+"/probe", tc.chain)
+			got, peer, ok := strings.Cut(body, "|")
+			if !ok {
+				t.Fatalf("malformed probe response %q", body)
+			}
+			want := tc.want
+			if want == "" {
+				want = peer
+			}
+			if got != want {
+				t.Errorf("hops=%d chain=%q gave %s, want %s", tc.hops, tc.chain, got, want)
+			}
+		})
+	}
+}
+
+// TestUnconfiguredHandlerDoesNotReadHeaderAsIfNothingAppends pins that a
+// Handler nobody configured behaves as the default topology rather than as
+// hops=0. The distinction matters because 0 is a meaningful setting, so a
+// zero-valued field must not be mistaken for it.
+func TestUnconfiguredHandlerDoesNotReadHeaderAsIfNothingAppends(t *testing.T) {
+	h := &Handler{} // never told its shape
+	e := engineAsProductionBuildsIt()
+	e.GET("/probe", func(c *gin.Context) {
+		c.String(http.StatusOK, "%s", h.limiterAddr(c).String())
+	})
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	_, got := probeOnce(t, srv.Client(), "GET", srv.URL+"/probe", simulateBalancer("9.9.9.9"))
+	if got != simulatedClient {
+		t.Errorf("unconfigured handler resolved %s, want %s: an unset hop count must mean "+
+			"the default, not the explicit 0 that ignores the header", got, simulatedClient)
+	}
+}
+
 // newResetRoute builds the real /auth/password/reset route: the real Handler,
 // the real Service, the real limiter. Requests past the cap are refused by the
 // limiter before any database access, which is what makes this reachable
@@ -228,6 +319,7 @@ func newResetRoute(t *testing.T, lim *autologin.MemoryLimiter) *httptest.Server 
 	e := gin.New()
 	e.Use(gin.Recovery())
 	h := &Handler{svc: &Service{limiter: lim}}
+	h.SetProxyHops(2) // the shape simulateBalancer produces
 	h.Register(e)
 	srv := httptest.NewServer(e)
 	t.Cleanup(srv.Close)
@@ -328,7 +420,7 @@ func TestTwoFAPerIPLimiterKeysOnAppendedClient(t *testing.T) {
 		defer lim.Stop()
 		e := engineAsProductionBuildsIt()
 		e.POST("/auth/2fa/verify", func(c *gin.Context) {
-			ip := limiterAddr(c)
+			ip := defaultHopsHandler.limiterAddr(c)
 			if ip.IsValid() {
 				if ok, _ := lim.Allow(context.Background(), "2fa-ip:"+ip.String(), twoFAIPLockoutPerMinute); !ok {
 					c.String(http.StatusTooManyRequests, "429")
@@ -407,15 +499,21 @@ func TestDecisionSitesUseLimiterAddr(t *testing.T) {
 			checked++
 
 			var uses []string
+			note := func(name string) {
+				if name == "limiterAddr" || name == "clientAddr" {
+					uses = append(uses, name)
+				}
+			}
 			ast.Inspect(fd, func(n ast.Node) bool {
 				call, ok := n.(*ast.CallExpr)
 				if !ok {
 					return true
 				}
-				if id, ok := call.Fun.(*ast.Ident); ok {
-					if id.Name == "limiterAddr" || id.Name == "clientAddr" {
-						uses = append(uses, id.Name)
-					}
+				switch fun := call.Fun.(type) {
+				case *ast.Ident: // clientAddr(c)
+					note(fun.Name)
+				case *ast.SelectorExpr: // h.limiterAddr(c)
+					note(fun.Sel.Name)
 				}
 				return true
 			})

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -56,6 +56,11 @@ type Handler struct {
 	// Optional: nil makes every Me response report true. Set after
 	// construction via SetManagedStorageResolver.
 	managedStorage ManagedStorageResolver
+	// proxyHops is the deployment's appending-proxy count; see SetProxyHops.
+	// proxyHopsSet distinguishes "explicitly 0" (nothing appends, use the peer
+	// address) from "never configured", which must not silently become 0.
+	proxyHops    int
+	proxyHopsSet bool
 	// logger receives the social sign-in failure lines (see social_log.go).
 	// Optional: nil falls back to slog.Default(), which cmd/wpmgr configures.
 	logger *slog.Logger
@@ -585,7 +590,7 @@ func (h *Handler) resetPassword(c *gin.Context) {
 	}
 	// limiterAddr, not clientAddr: ResetPassword rate-limits on this value
 	// ("pwreset-consume:"), and it is the only limit on reset-token guessing.
-	if err := h.svc.ResetPassword(c.Request.Context(), body.Token, body.Password, limiterAddr(c)); err != nil {
+	if err := h.svc.ResetPassword(c.Request.Context(), body.Token, body.Password, h.limiterAddr(c)); err != nil {
 		httpx.Error(c, err)
 		return
 	}
@@ -604,23 +609,34 @@ func clientAddr(c *gin.Context) netip.Addr {
 	return addr
 }
 
-// proxyHops is the number of X-Forwarded-For entries that the infrastructure in
-// front of this process appends to whatever the caller sent: the client address
-// as the balancer observed it, then the balancer's own frontend address. The
-// rightmost proxyHops entries are therefore written by us; everything to their
-// left came from the caller and is worth nothing.
+// defaultProxyHops is the fallback for a Handler that was never told its
+// deployment shape. It matches config's default and the hosted topology.
+const defaultProxyHops = 2
+
+// SetProxyHops declares how many X-Forwarded-For entries the infrastructure in
+// front of this process appends. See config.AuthConfig.ProxyHops for the
+// meaning of each value; the effective value is logged at startup.
 //
-// This holds only while the API is unreachable except through the balancer.
-// That is a deployment property, not a code property: the Cloud Run service runs
-// with ingress restricted to internal-and-cloud-load-balancing, so its own URL
-// is closed to the internet and every request arrives through the balancer.
-//
-// If that ingress is ever widened, a request can arrive with fewer appended
-// entries than proxyHops and the entry selected below drifts back into
-// caller-supplied territory. Anyone changing the ingress setting, the balancer,
-// or the number of proxies in front of this service must revisit this constant
-// and the tests that pin it.
-const proxyHops = 2
+// A negative value is refused by config.Validate before this is reached, so it
+// is coerced here only to keep a zero-value Handler in tests from selecting
+// nonsense.
+func (h *Handler) SetProxyHops(n int) {
+	if n < 0 {
+		n = defaultProxyHops
+	}
+	h.proxyHops = n
+	h.proxyHopsSet = true
+}
+
+// effectiveProxyHops treats an unset field as the default, so a Handler built
+// without SetProxyHops behaves as the hosted deployment rather than as though
+// nothing were in front of it.
+func (h *Handler) effectiveProxyHops() int {
+	if h.proxyHops == 0 && !h.proxyHopsSet {
+		return defaultProxyHops
+	}
+	return h.proxyHops
+}
 
 // limiterAddr returns the address that a rate-limit DECISION may be keyed on.
 //
@@ -629,17 +645,30 @@ const proxyHops = 2
 // refuse a request cannot, because then the caller selects its own bucket and
 // the limit stops binding.
 //
-// When the forwarded chain is shorter than the infrastructure guarantees, this
-// falls back to the peer address rather than reaching further left.
+// The number of entries the infrastructure appends is configuration, not a
+// property this process can observe — see config.AuthConfig.ProxyHops. A count
+// of 0 means nothing appends, so the forwarded header is ignored entirely and
+// the peer address is used.
 //
-// That fallback is NOT a security guard, and must not be described as one. It
-// only catches honest short chains. A caller that wants control of its key sends
-// exactly proxyHops entries itself, which is long enough to skip the fallback
-// entirely, so if this process ever becomes directly reachable the fallback
-// protects nobody: honest clients collapse onto the peer key while an attacker
-// keeps a key per request. The ingress restriction described on proxyHops is the
-// only thing standing between this and that state.
-func limiterAddr(c *gin.Context) netip.Addr {
+// When the chain is shorter than the configured count, this falls back to the
+// peer address rather than reaching further left. That fallback is NOT a
+// security guard and must not be described as one: it catches honest short
+// chains only. A caller wanting control of its key supplies the configured
+// number of entries itself, which skips the fallback entirely. So if this
+// process is reachable without the proxies it is configured for, the fallback
+// protects nobody — honest clients collapse onto the peer key while a caller
+// keeps a key per request. Only a correct hop count, matching what actually sits
+// in front, makes this sound.
+func (h *Handler) limiterAddr(c *gin.Context) netip.Addr {
+	hops := h.effectiveProxyHops()
+	if hops == 0 {
+		// Nothing in front appends, so every forwarded entry is caller-supplied
+		// and none of it is evidence. The peer address is the client.
+		if addr, ok := parseForwardedAddr(c.RemoteIP()); ok {
+			return addr
+		}
+		return netip.Addr{}
+	}
 	// Values, not Get. Get returns only the FIRST header line, so a caller that
 	// sends X-Forwarded-For twice would have the appended entries land on a line
 	// this never reads, handing back a value it chose. Joining every line is the
@@ -647,8 +676,8 @@ func limiterAddr(c *gin.Context) netip.Addr {
 	// whether the proxy in front coalesces repeated lines.
 	joined := strings.Join(c.Request.Header.Values("X-Forwarded-For"), ",")
 	parts := strings.Split(joined, ",")
-	if len(parts) >= proxyHops {
-		if addr, ok := parseForwardedAddr(parts[len(parts)-proxyHops]); ok {
+	if len(parts) >= hops {
+		if addr, ok := parseForwardedAddr(parts[len(parts)-hops]); ok {
 			return addr
 		}
 	}

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -583,7 +583,9 @@ func (h *Handler) resetPassword(c *gin.Context) {
 		httpx.Error(c, domain.Validation("invalid_body", "request body is not valid JSON"))
 		return
 	}
-	if err := h.svc.ResetPassword(c.Request.Context(), body.Token, body.Password, clientAddr(c)); err != nil {
+	// limiterAddr, not clientAddr: ResetPassword rate-limits on this value
+	// ("pwreset-consume:"), and it is the only limit on reset-token guessing.
+	if err := h.svc.ResetPassword(c.Request.Context(), body.Token, body.Password, limiterAddr(c)); err != nil {
 		httpx.Error(c, err)
 		return
 	}
@@ -591,13 +593,94 @@ func (h *Handler) resetPassword(c *gin.Context) {
 }
 
 // clientAddr parses gin's resolved client IP into a netip.Addr (invalid when
-// unparseable). Used to rate-limit + record the requesting IP.
+// unparseable). Used where the requesting address is RECORDED — audit rows,
+// notification bodies, trusted-device rows. See limiterAddr for the address a
+// rate-limit decision may be keyed on; the two are deliberately different.
 func clientAddr(c *gin.Context) netip.Addr {
 	addr, err := netip.ParseAddr(c.ClientIP())
 	if err != nil {
 		return netip.Addr{}
 	}
 	return addr
+}
+
+// proxyHops is the number of X-Forwarded-For entries that the infrastructure in
+// front of this process appends to whatever the caller sent: the client address
+// as the balancer observed it, then the balancer's own frontend address. The
+// rightmost proxyHops entries are therefore written by us; everything to their
+// left came from the caller and is worth nothing.
+//
+// This holds only while the API is unreachable except through the balancer.
+// That is a deployment property, not a code property: the Cloud Run service runs
+// with ingress restricted to internal-and-cloud-load-balancing, so its own URL
+// is closed to the internet and every request arrives through the balancer.
+//
+// If that ingress is ever widened, a request can arrive with fewer appended
+// entries than proxyHops and the entry selected below drifts back into
+// caller-supplied territory. Anyone changing the ingress setting, the balancer,
+// or the number of proxies in front of this service must revisit this constant
+// and the tests that pin it.
+const proxyHops = 2
+
+// limiterAddr returns the address that a rate-limit DECISION may be keyed on.
+//
+// It is separate from clientAddr on purpose. An address that is merely recorded
+// can tolerate being caller-influenced; an address that decides whether to
+// refuse a request cannot, because then the caller selects its own bucket and
+// the limit stops binding.
+//
+// When the forwarded chain is shorter than the infrastructure guarantees, this
+// falls back to the peer address rather than reaching further left.
+//
+// That fallback is NOT a security guard, and must not be described as one. It
+// only catches honest short chains. A caller that wants control of its key sends
+// exactly proxyHops entries itself, which is long enough to skip the fallback
+// entirely, so if this process ever becomes directly reachable the fallback
+// protects nobody: honest clients collapse onto the peer key while an attacker
+// keeps a key per request. The ingress restriction described on proxyHops is the
+// only thing standing between this and that state.
+func limiterAddr(c *gin.Context) netip.Addr {
+	// Values, not Get. Get returns only the FIRST header line, so a caller that
+	// sends X-Forwarded-For twice would have the appended entries land on a line
+	// this never reads, handing back a value it chose. Joining every line is the
+	// chain as the invariant above describes it, and removes any dependence on
+	// whether the proxy in front coalesces repeated lines.
+	joined := strings.Join(c.Request.Header.Values("X-Forwarded-For"), ",")
+	parts := strings.Split(joined, ",")
+	if len(parts) >= proxyHops {
+		if addr, ok := parseForwardedAddr(parts[len(parts)-proxyHops]); ok {
+			return addr
+		}
+	}
+	if addr, ok := parseForwardedAddr(c.RemoteIP()); ok {
+		return addr
+	}
+	return netip.Addr{}
+}
+
+// parseForwardedAddr parses one forwarded-chain entry. Entries are usually bare
+// addresses, but the bracketed and port-suffixed forms are legal in the wild and
+// are what IPv6 tends to arrive as. Treating those as unparseable would drop
+// every v6 client onto the shared fallback key, so they are handled explicitly.
+func parseForwardedAddr(s string) (netip.Addr, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return netip.Addr{}, false
+	}
+	if addr, err := netip.ParseAddr(s); err == nil {
+		return addr.Unmap(), true
+	}
+	// "[2001:db8::1]:443" and "198.51.100.7:443".
+	if ap, err := netip.ParseAddrPort(s); err == nil {
+		return ap.Addr().Unmap(), true
+	}
+	// "[2001:db8::1]" with no port.
+	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+		if addr, err := netip.ParseAddr(s[1 : len(s)-1]); err == nil {
+			return addr.Unmap(), true
+		}
+	}
+	return netip.Addr{}, false
 }
 
 func (h *Handler) oidcLogin(c *gin.Context) {

--- a/apps/api/internal/auth/reset.go
+++ b/apps/api/internal/auth/reset.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"log/slog"
 	"net/netip"
 	"strings"
 	"time"
@@ -124,6 +125,12 @@ func (s *Service) ResetPassword(ctx context.Context, token, newPwd string, ip ne
 	}
 	if s.limiter != nil && ip.IsValid() {
 		if ok, _ := s.limiter.Allow(ctx, "pwreset-consume:"+ip.String(), resetPerMinute); !ok {
+			// Logged because the refusal is otherwise invisible: the caller sees an
+			// ordinary 429 and operators see nothing at all. If the address this
+			// keys on ever stops distinguishing callers, every user is refused and
+			// this line is the only thing that says so.
+			slog.WarnContext(ctx, "password reset consume rate limited",
+				"key", "pwreset-consume", "addr", ip.String(), "limit_per_minute", resetPerMinute)
 			return domain.RateLimited("too_many_attempts", "too many attempts; try again later")
 		}
 	}

--- a/apps/api/internal/auth/twofa.go
+++ b/apps/api/internal/auth/twofa.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/netip"
 	"time"
 
@@ -1010,6 +1011,12 @@ func (t *TwoFactorService) checkCrossChallengeLimits(ctx context.Context, userID
 	if ip != nil && ip.IsValid() {
 		if ok, retryAfter := t.limiter.Allow(ctx, "2fa-ip:"+ip.String(), twoFAIPLockoutPerMinute); !ok {
 			_ = retryAfter
+			// Logged because the refusal is otherwise invisible: the caller sees an
+			// ordinary 429 and operators see nothing at all. If the address this
+			// keys on ever stops distinguishing callers, every 2FA verification in
+			// the fleet is refused and this line is the only thing that says so.
+			slog.WarnContext(ctx, "2fa per-address rate limited",
+				"key", "2fa-ip", "addr", ip.String(), "limit_per_minute", twoFAIPLockoutPerMinute)
 			return domain.RateLimited("too_many_attempts", "too many requests from this address; wait before trying again")
 		}
 	}

--- a/apps/api/internal/auth/twofa_handler.go
+++ b/apps/api/internal/auth/twofa_handler.go
@@ -107,7 +107,7 @@ func (h *Handler) twoFATOTPComplete(c *gin.Context) {
 	}
 
 	// limiterAddr, not clientAddr: this flows into the "2fa-ip:" cross-account cap.
-	ip := limiterAddr(c)
+	ip := h.limiterAddr(c)
 	res, err := h.svc.VerifyTOTPChallenge(c.Request.Context(), challengeID, body.Code, &ip)
 	if err != nil {
 		httpx.Error(c, err)
@@ -161,7 +161,7 @@ func (h *Handler) twoFARecoveryComplete(c *gin.Context) {
 	}
 
 	// limiterAddr, not clientAddr: this flows into the "2fa-ip:" cross-account cap.
-	ip := limiterAddr(c)
+	ip := h.limiterAddr(c)
 	res, remaining, err := h.svc.VerifyRecoveryCodeChallenge(c.Request.Context(), challengeID, body.Code, &ip)
 	if err != nil {
 		httpx.Error(c, err)
@@ -247,7 +247,7 @@ func (h *Handler) twoFAWebAuthnFinish(c *gin.Context) {
 	}
 
 	// limiterAddr, not clientAddr: this flows into the "2fa-ip:" cross-account cap.
-	ip := limiterAddr(c)
+	ip := h.limiterAddr(c)
 	res, err := h.svc.FinishWebAuthnChallenge(c.Request.Context(), challengeID, body.Assertion, &ip)
 	if err != nil {
 		httpx.Error(c, err)

--- a/apps/api/internal/auth/twofa_handler.go
+++ b/apps/api/internal/auth/twofa_handler.go
@@ -106,7 +106,8 @@ func (h *Handler) twoFATOTPComplete(c *gin.Context) {
 		return
 	}
 
-	ip := clientAddr(c)
+	// limiterAddr, not clientAddr: this flows into the "2fa-ip:" cross-account cap.
+	ip := limiterAddr(c)
 	res, err := h.svc.VerifyTOTPChallenge(c.Request.Context(), challengeID, body.Code, &ip)
 	if err != nil {
 		httpx.Error(c, err)
@@ -159,7 +160,8 @@ func (h *Handler) twoFARecoveryComplete(c *gin.Context) {
 		return
 	}
 
-	ip := clientAddr(c)
+	// limiterAddr, not clientAddr: this flows into the "2fa-ip:" cross-account cap.
+	ip := limiterAddr(c)
 	res, remaining, err := h.svc.VerifyRecoveryCodeChallenge(c.Request.Context(), challengeID, body.Code, &ip)
 	if err != nil {
 		httpx.Error(c, err)
@@ -244,7 +246,8 @@ func (h *Handler) twoFAWebAuthnFinish(c *gin.Context) {
 		return
 	}
 
-	ip := clientAddr(c)
+	// limiterAddr, not clientAddr: this flows into the "2fa-ip:" cross-account cap.
+	ip := limiterAddr(c)
 	res, err := h.svc.FinishWebAuthnChallenge(c.Request.Context(), challengeID, body.Assertion, &ip)
 	if err != nil {
 		httpx.Error(c, err)

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -527,6 +528,32 @@ type AuthConfig struct {
 	IdleTimeout    time.Duration `koanf:"idle_timeout"`
 	AbsoluteExpiry time.Duration `koanf:"absolute_expiry"`
 
+	// ProxyHops (WPMGR_AUTH_PROXY_HOPS) is the number of X-Forwarded-For
+	// entries the infrastructure in front of this process appends to whatever
+	// the caller sent. The authentication rate limiters key on the entry that
+	// many positions from the right; everything to its left is caller-supplied
+	// and must not decide whether a request is refused.
+	//
+	// Set it to the number of proxies that append, counting from this process
+	// outward:
+	//
+	//	0  nothing appends — this process terminates connections directly, and
+	//	   the peer address IS the client. The forwarded header is ignored
+	//	   entirely, which is the only safe reading when nothing is trusted.
+	//	1  a single reverse proxy that appends the client address (the bundled
+	//	   nginx compose deployment).
+	//	2  a cloud load balancer that appends the client address and then its
+	//	   own frontend address. This is the default because it is correct for
+	//	   the hosted deployment.
+	//
+	// Getting this wrong is not subtle in one direction and silent in the
+	// other: too high and the limiters key on caller-supplied data and stop
+	// binding; too low and every client collapses onto one key and legitimate
+	// users are refused. Neither is guessable from inside the process, so it is
+	// configuration rather than a constant, and the effective value is logged
+	// at startup.
+	ProxyHops int `koanf:"proxy_hops"`
+
 	// BootstrapClaimSecret (WPMGR_BOOTSTRAP_CLAIM_SECRET) is the provisioning
 	// claim the installer mints and hands to the person who is entitled to own
 	// the install. First-run ownership — the very first organisation and its
@@ -758,8 +785,12 @@ func defaults() map[string]any {
 		"db.allow_rls_bypass_role": false,
 		"redis.addr":               "localhost:6379",
 		"redis.password":           "",
-		"auth.session_secret":      "",
-		"auth.idle_timeout":        "168h", // 7 days idle
+		"auth.session_secret": "",
+		// 2 is correct for the hosted deployment (load balancer appends the
+		// client address then its own). Every other topology must set this;
+		// see AuthConfig.ProxyHops and the startup log line that names it.
+		"auth.proxy_hops":   2,
+		"auth.idle_timeout": "168h", // 7 days idle
 		"auth.absolute_expiry":     "720h", // 30 days hard cap
 		// ADR-056: WebAuthn relying party defaults (hosted instance).
 		// Self-hosted operators override via WPMGR_AUTH_WEBAUTHN_RPID etc.
@@ -887,21 +918,66 @@ func Load(path string) (Config, error) {
 		}
 	}
 
+	// rawProxyHops holds the unconverted WPMGR_AUTH_PROXY_HOPS string when the
+	// variable is present at all, including when it is present and empty.
+	var rawProxyHops *string
 	// Env: WPMGR_DB_HOST -> db.host, WPMGR_HTTP_ADDR -> http_addr, etc.
 	// We strip the WPMGR_ prefix, lowercase, then map the documented
 	// double-underscore-free names by replacing the first underscore segment.
 	envProvider := env.ProviderWithValue("WPMGR_", ".", func(key, value string) (string, any) {
 		k := strings.ToLower(strings.TrimPrefix(key, "WPMGR_"))
 		k = mapEnvKey(k)
+		// Capture the RAW string for the proxy hop count. Everything below this
+		// point is typed, and the typing is what loses the distinction that
+		// matters: mapstructure's weak input rewrites "" to 0, so an unset outer
+		// variable in WPMGR_AUTH_PROXY_HOPS=${SOMETHING}, or an empty ConfigMap
+		// entry, would arrive as a deliberate 0 and be indistinguishable from
+		// one. See parseProxyHops.
+		if k == "auth.proxy_hops" {
+			v := value
+			rawProxyHops = &v
+		}
 		return k, value
 	})
 	if err := k.Load(envProvider, nil); err != nil {
 		return Config{}, fmt.Errorf("load env: %w", err)
 	}
 
+	// Before unmarshal, so the operator gets a message naming the variable and
+	// saying what is wrong with it. Left until after, the generic decode failure
+	// ("decoding failed due to the following error(s)") is all they would see,
+	// and the one spelling that does NOT fail to decode — the empty string — is
+	// the dangerous one.
+	proxyHops := -1
+	if rawProxyHops != nil {
+		n, err := parseProxyHops(*rawProxyHops)
+		if err != nil {
+			return Config{}, fmt.Errorf("WPMGR_AUTH_PROXY_HOPS: %w", err)
+		}
+		proxyHops = n
+	} else {
+		// The env var is not the only source. A YAML file supplies the same key,
+		// and reaches the same weak decode: a quoted "010" becomes 8, a bare
+		// `proxy_hops:` becomes 0, `true` becomes 1. The null shapes are what a
+		// templating tool renders for a value it could not resolve, which is the
+		// same accident as an unset ${VAR} and needs the same answer.
+		n, err := proxyHopsFromValue(k.Get("auth.proxy_hops"))
+		if err != nil {
+			source := "auth.proxy_hops"
+			if path != "" {
+				source = fmt.Sprintf("auth.proxy_hops in %s", path)
+			}
+			return Config{}, fmt.Errorf("%s: %w", source, err)
+		}
+		proxyHops = n
+	}
+
 	var cfg Config
 	if err := k.Unmarshal("", &cfg); err != nil {
 		return Config{}, fmt.Errorf("unmarshal config: %w", err)
+	}
+	if proxyHops >= 0 {
+		cfg.Auth.ProxyHops = proxyHops
 	}
 	// Normalize ONCE, here, so every consumer and every check sees the same
 	// string. Consumers append paths to this value; a check that trimmed and a
@@ -909,6 +985,76 @@ func Load(path string) (Config, error) {
 	// check would then approve a value nothing uses.
 	cfg.PublicBaseURL = NormalizePublicBaseURL(cfg.PublicBaseURL)
 	return cfg, nil
+}
+
+// parseProxyHops converts WPMGR_AUTH_PROXY_HOPS, accepting only a plain decimal
+// integer: no empty string, no sign, no surrounding whitespace, no 0x form and
+// no leading zero.
+//
+// It is this strict because every rejected spelling has a plausible reading that
+// is not what the operator meant, and the cost of guessing wrong is not a
+// startup warning. The hop count decides which forwarded entry the auth rate
+// limiters key on: too low and every caller in the fleet shares one bucket and
+// legitimate sign-ins are refused; too high and the key comes from
+// caller-supplied data and the limits stop binding. Neither is visible from
+// inside the process.
+//
+// The empty string is the case worth naming. It is the ordinary output of
+// WPMGR_AUTH_PROXY_HOPS=${SOMETHING} with SOMETHING unset, and of an empty
+// value in a ConfigMap or .env file. Weak typing turns it into 0, which is a
+// meaningful and very different setting — "nothing is in front of this process"
+// — so accepting it would silently reconfigure a load-balanced deployment onto
+// a single shared limiter key. Absence and emptiness are not the same thing:
+// remove the variable to take the default.
+// proxyHopsFromValue converts the hop count as it sits in koanf after the
+// defaults and any config file have loaded, before the typed decode.
+//
+// It exists because the decode is weakly typed and will turn a null, a bool or
+// a quoted numeral into a plausible-looking count. Every conversion it would
+// perform silently is refused here instead, for the same reason the environment
+// string is parsed strictly: the value decides which forwarded entry the auth
+// rate limiters key on, and both directions of being wrong are invisible from
+// inside the process.
+//
+// A quoted numeral is parsed rather than rejected outright — "2" is unambiguous
+// — but through the same strict parser as the environment path, so the octal,
+// hex and empty spellings are refused identically wherever they are written.
+func proxyHopsFromValue(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	case string:
+		return parseProxyHops(n)
+	case nil:
+		return 0, fmt.Errorf("empty. An empty value is not 0 — 0 means nothing in front of this process appends to X-Forwarded-For. Remove the key to take the default, or set an explicit number")
+	case bool:
+		return 0, fmt.Errorf("%v is a boolean; this is a count of proxies in front of this process, so write a bare number", n)
+	case float64:
+		return 0, fmt.Errorf("%v is not a whole number; this is a count of proxies, so write a bare integer", n)
+	default:
+		return 0, fmt.Errorf("%v (%T) is not a whole number; this is a count of proxies, so write a bare integer", v, v)
+	}
+}
+
+func parseProxyHops(raw string) (int, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("present but empty. An empty value is not 0 — 0 means nothing in front of this process appends to X-Forwarded-For. Remove the variable to take the default, or set an explicit number")
+	}
+	for i := 0; i < len(raw); i++ {
+		if raw[i] < '0' || raw[i] > '9' {
+			return 0, fmt.Errorf("%q is not a plain decimal integer: no signs, spaces, decimal points or 0x forms", raw)
+		}
+	}
+	if len(raw) > 1 && raw[0] == '0' {
+		return 0, fmt.Errorf("%q has a leading zero, which reads as octal in some tooling. Write it as a plain decimal number", raw)
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a valid number: %w", raw, err)
+	}
+	return n, nil
 }
 
 // NormalizePublicBaseURL is the canonical form of WPMGR_PUBLIC_BASE_URL: no

--- a/apps/api/internal/config/proxy_hops_test.go
+++ b/apps/api/internal/config/proxy_hops_test.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// baseValidCfg loads the defaults and satisfies the unrelated session-secret
+// check, so a Validate result reflects only what the test varies.
+func baseValidCfg(t *testing.T) Config {
+	t.Helper()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cfg.Auth.SessionSecret = strings.Repeat("a", 32)
+	return cfg
+}
+
+// TestProxyHopsDefault pins the default. It is the hosted topology's value, and
+// it is a default rather than a required variable because making it required
+// turns the next deploy that forgets it into a boot failure.
+func TestProxyHopsDefault(t *testing.T) {
+	cfg := baseValidCfg(t)
+	if cfg.Auth.ProxyHops != 2 {
+		t.Fatalf("Auth.ProxyHops default = %d, want 2", cfg.Auth.ProxyHops)
+	}
+	if issues := Validate(cfg); len(issues) != 0 {
+		t.Fatalf("Validate() on the default returned issues: %+v", issues)
+	}
+}
+
+// TestProxyHopsFromEnv pins that the documented variable actually reaches the
+// field. A koanf key that no env var maps to would leave every install on the
+// default while appearing configurable — the failure shape this codebase has
+// hit before with social sign-in.
+func TestProxyHopsFromEnv(t *testing.T) {
+	for _, want := range []int{0, 1, 3} {
+		t.Setenv("WPMGR_AUTH_PROXY_HOPS", strconv.Itoa(want))
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Auth.ProxyHops != want {
+			t.Errorf("WPMGR_AUTH_PROXY_HOPS=%d gave Auth.ProxyHops=%d", want, cfg.Auth.ProxyHops)
+		}
+	}
+}
+
+// TestProxyHopsRawEnvStrings is the pin at the layer the coercion happens on.
+//
+// The earlier pins assigned already-typed ints to the struct field and covered
+// "0", "1", "3" — both sit BELOW the string→int conversion, so neither could
+// see that weak typing rewrote an empty variable to 0. On a load-balanced
+// deployment that silently keys every caller in the fleet onto one limiter
+// bucket, so the case that mattered most was the one nothing exercised.
+//
+// Drive Load() with raw strings, and assert refusal by spelling.
+func TestProxyHopsRawEnvStrings(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    int  // when accepted
+		refused bool // Load must return an error
+		why     string
+	}{
+		{raw: "2", want: 2},
+		{raw: "0", want: 0, why: "0 is a real setting: nothing in front appends"},
+		{raw: "1", want: 1},
+
+		{raw: "", refused: true, why: "empty is not 0 — the ${UNSET} and empty-ConfigMap case"},
+		{raw: " ", refused: true, why: "whitespace is not a number"},
+		{raw: "2 ", refused: true, why: "trailing space"},
+		{raw: " 2", refused: true, why: "leading space"},
+		{raw: "2\n", refused: true, why: "trailing newline survives .env parsing"},
+		{raw: "010", refused: true, why: "leading zero reads as octal in some tooling"},
+		{raw: "0x3", refused: true, why: "hex form"},
+		{raw: "+2", refused: true, why: "signed"},
+		{raw: "-1", refused: true, why: "negative"},
+		{raw: "abc", refused: true},
+		{raw: "2.0", refused: true, why: "decimal point"},
+		{raw: "2,3", refused: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(strconv.Quote(tc.raw), func(t *testing.T) {
+			t.Setenv("WPMGR_AUTH_PROXY_HOPS", tc.raw)
+			cfg, err := Load("")
+
+			if tc.refused {
+				if err == nil {
+					t.Fatalf("Load accepted %q and produced ProxyHops=%d; it must be refused (%s)",
+						tc.raw, cfg.Auth.ProxyHops, tc.why)
+				}
+				if !strings.Contains(err.Error(), "WPMGR_AUTH_PROXY_HOPS") {
+					t.Errorf("error for %q does not name the variable: %v", tc.raw, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Load refused %q, which is a legitimate spelling (%s): %v", tc.raw, tc.why, err)
+			}
+			if cfg.Auth.ProxyHops != tc.want {
+				t.Errorf("raw %q gave ProxyHops=%d, want %d", tc.raw, cfg.Auth.ProxyHops, tc.want)
+			}
+		})
+	}
+}
+
+// TestProxyHopsAbsentTakesDefault pins the distinction the empty-string case
+// turns on: an ABSENT variable takes the default, which is not the same as a
+// present-but-empty one.
+func TestProxyHopsAbsentTakesDefault(t *testing.T) {
+	// t.Setenv registers cleanup; Unsetenv here gives a genuinely absent var.
+	t.Setenv("WPMGR_AUTH_PROXY_HOPS", "")
+	if err := os.Unsetenv("WPMGR_AUTH_PROXY_HOPS"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load with the variable absent: %v", err)
+	}
+	if cfg.Auth.ProxyHops != 2 {
+		t.Fatalf("absent variable gave ProxyHops=%d, want the default 2", cfg.Auth.ProxyHops)
+	}
+}
+
+// TestProxyHopsFromConfigFile is the same pin as TestProxyHopsRawEnvStrings,
+// one source over.
+//
+// The environment is not the only documented way in: .env.example ships
+// WPMGR_CONFIG_FILE and the README documents a defaults<file<env precedence, so
+// a self-hosted operator can set this key in YAML. The strict parse originally
+// lived inside the environment provider's callback, which a file-supplied value
+// walks straight past on its way to the same weak decode.
+//
+// The null shapes matter most: a bare `proxy_hops:` is what a templating tool
+// renders for a value it could not resolve, which is the same accident as an
+// unset ${VAR} in the environment.
+func TestProxyHopsFromConfigFile(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		want    int
+		refused bool
+		why     string
+	}{
+		{name: "bare integer", yaml: "auth:\n  proxy_hops: 1\n", want: 1},
+		{name: "explicit zero", yaml: "auth:\n  proxy_hops: 0\n", want: 0},
+		{name: "quoted numeral", yaml: "auth:\n  proxy_hops: \"2\"\n", want: 2,
+			why: "unambiguous, so parsed rather than rejected"},
+
+		{name: "quoted empty", yaml: "auth:\n  proxy_hops: \"\"\n", refused: true,
+			why: "empty is not 0"},
+		{name: "bare null", yaml: "auth:\n  proxy_hops:\n", refused: true,
+			why: "what a template renders for an unresolved value"},
+		{name: "explicit null", yaml: "auth:\n  proxy_hops: null\n", refused: true},
+		{name: "quoted octal-looking", yaml: "auth:\n  proxy_hops: \"010\"\n", refused: true},
+		{name: "quoted hex", yaml: "auth:\n  proxy_hops: \"0x3\"\n", refused: true},
+		{name: "boolean", yaml: "auth:\n  proxy_hops: true\n", refused: true,
+			why: "weak decode turns this into 1"},
+		{name: "float", yaml: "auth:\n  proxy_hops: 2.5\n", refused: true},
+		{name: "list", yaml: "auth:\n  proxy_hops: [2]\n", refused: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The env var must be absent, or it would take precedence and this
+			// would silently test the environment path instead.
+			if err := os.Unsetenv("WPMGR_AUTH_PROXY_HOPS"); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := Load(path)
+			if tc.refused {
+				if err == nil {
+					t.Fatalf("Load accepted %q and produced ProxyHops=%d; it must be refused (%s)",
+						tc.yaml, cfg.Auth.ProxyHops, tc.why)
+				}
+				if !strings.Contains(err.Error(), "proxy_hops") {
+					t.Errorf("error does not name the key: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load refused %q, a legitimate spelling (%s): %v", tc.yaml, tc.why, err)
+			}
+			if cfg.Auth.ProxyHops != tc.want {
+				t.Errorf("yaml %q gave ProxyHops=%d, want %d", tc.yaml, cfg.Auth.ProxyHops, tc.want)
+			}
+		})
+	}
+}
+
+// TestProxyHopsEnvBeatsConfigFile pins the documented defaults<file<env
+// precedence for this key, so the strict environment path cannot be bypassed by
+// also having the key in a file.
+func TestProxyHopsEnvBeatsConfigFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("auth:\n  proxy_hops: 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WPMGR_AUTH_PROXY_HOPS", "0")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Auth.ProxyHops != 0 {
+		t.Fatalf("env 0 with file 1 gave ProxyHops=%d, want 0 (env wins)", cfg.Auth.ProxyHops)
+	}
+
+	// And a bad environment value is still refused even when the file holds a
+	// good one — the file must not rescue it.
+	t.Setenv("WPMGR_AUTH_PROXY_HOPS", "")
+	if _, err := Load(path); err == nil {
+		t.Fatal("an empty env value was accepted because the file held a valid one")
+	}
+}
+
+// TestProxyHopsRefusedNotClamped pins that an unusable value stops the boot
+// rather than being quietly coerced into something plausible. A silently
+// corrected value is the defect class this whole change exists to close.
+func TestProxyHopsRefusedNotClamped(t *testing.T) {
+	for _, hops := range []int{-1, maxProxyHops + 1, 100} {
+		cfg := baseValidCfg(t)
+		cfg.Auth.ProxyHops = hops
+
+		issues := Validate(cfg)
+		found := false
+		for _, is := range issues {
+			if is.Name == "WPMGR_AUTH_PROXY_HOPS" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("ProxyHops=%d produced no issue; it must be refused, not accepted", hops)
+		}
+		// And it must not have been rewritten to something acceptable.
+		if cfg.Auth.ProxyHops != hops {
+			t.Errorf("ProxyHops was mutated from %d to %d; validation must report, not coerce",
+				hops, cfg.Auth.ProxyHops)
+		}
+	}
+}
+
+// TestProxyHopsBoundaryValuesAccepted is the over-fire half: the check must not
+// reject counts a real deployment can legitimately have.
+func TestProxyHopsBoundaryValuesAccepted(t *testing.T) {
+	for _, hops := range []int{0, 1, 2, maxProxyHops} {
+		cfg := baseValidCfg(t)
+		cfg.Auth.ProxyHops = hops
+		for _, is := range Validate(cfg) {
+			if is.Name == "WPMGR_AUTH_PROXY_HOPS" {
+				t.Errorf("ProxyHops=%d was refused (%s); it is a legitimate deployment shape",
+					hops, is.Reason)
+			}
+		}
+	}
+}

--- a/apps/api/internal/config/validate.go
+++ b/apps/api/internal/config/validate.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -61,6 +62,12 @@ type Issue struct {
 	Reason string
 }
 
+// maxProxyHops bounds WPMGR_AUTH_PROXY_HOPS. Nothing sane needs more than a
+// handful, and a large value here is almost always someone entering the length
+// of a forwarded header rather than a count of appending proxies — which would
+// hand the limiter key straight back to the caller.
+const maxProxyHops = 8
+
 // Validate aggregates ALL boot-critical configuration problems and returns them
 // as a slice of Issues. An empty slice means the configuration is valid.
 //
@@ -107,6 +114,22 @@ func Validate(cfg Config) []Issue {
 		issues = append(issues, Issue{
 			Name:   "WPMGR_SESSION_SECRET",
 			Reason: "too short — use at least 32 bytes",
+		})
+	}
+
+	// 1b. Proxy hop count. Refused rather than coerced: a value that cannot be
+	// right for the deployment either stops the auth limiters binding or
+	// refuses every legitimate user, and both are worse than not booting.
+	if h := cfg.Auth.ProxyHops; h < 0 {
+		issues = append(issues, Issue{
+			Name:   "WPMGR_AUTH_PROXY_HOPS",
+			Reason: "negative — set the number of proxies in front of this process that append to X-Forwarded-For (0 when it terminates connections directly)",
+		})
+	} else if h > maxProxyHops {
+		issues = append(issues, Issue{
+			Name: "WPMGR_AUTH_PROXY_HOPS",
+			Reason: fmt.Sprintf("%d exceeds the maximum of %d — this counts proxies that append to X-Forwarded-For, not the length of the header",
+				h, maxProxyHops),
 		})
 	}
 


### PR DESCRIPTION
## What this changes

Two auth rate limiters derive their key from the requesting address:

| Limiter | Key | Cap |
|---|---|---|
| `internal/auth/reset.go` | `"pwreset-consume:"+ip` | `resetPerMinute` |
| `internal/auth/twofa.go` | `"2fa-ip:"+ip` | `twoFAIPLockoutPerMinute` |

Both now take that address from a new `limiterAddr()` rather than `clientAddr()`, so the key is derived from the position in the forwarded chain that corresponds to the real peer under this deployment's ingress path.

Recording sites — audit rows, the password-changed notification, trusted-device rows — are deliberately left on `clientAddr()`. They store rather than decide, and moving them is a larger change with a wider blast radius. Named here so it is not mistaken for an oversight.

**One consequence worth stating rather than leaving implicit:** because those sites still record the caller-derived value, an audit row, a trusted-device entry, or the password-changed notification can present an address the caller chose. Nothing grants access on that basis — trusted-device lookup matches on token hash alone and never compares the address — but it means incident response should not treat those addresses as established fact until the recording sites move too.

## Why this shape

`SetTrustedProxies` with the balancer's ranges was the alternative. It would fix every consumer at once, but it needs those ranges as configuration: missing or stale, the outcome is either every address collapsing to one value or a hard boot failure, and the second only surfaces at the next deploy. This version is correct the moment the container starts, needs no coordinated infrastructure change, and keeps the blast radius on the two decisions rather than on every caller of `ClientIP()`.

**The cost, stated plainly:** the hop count is coupled to the deployment shape. If the path in front changes it selects the wrong entry, and correctness rests on this service being reachable only through the proxies it is configured for.

## Second commit: the hop count is configuration

The first commit fixed the count at 2, which is right only for the hosted shape. **Behind a single reverse proxy appending one entry, a fixed 2 is worse than no fix at all:** an honest client sends no forwarded header, so the chain is one entry, falls short of the count, and every honest client collapses onto the proxy's address and shares one limiter key — while a caller supplying one entry still selects its own. Honest users locked out; callers unaffected. That regression is why the count could not stay a constant.

`WPMGR_AUTH_PROXY_HOPS` (`auth.proxy_hops`):

| Value | Deployment |
|---|---|
| `0` | nothing appends — this process terminates connections directly, the forwarded header carries no evidence and is ignored entirely, the peer address is the client |
| `1` | a single reverse proxy appending the client address (the bundled compose deployment) |
| `2` | **default** — a load balancer appending the client address then its own |

- **Default, not required.** A required variable turns the next deploy that forgets it into a boot failure, which trades an outage for a config nicety. The default is correct for the only deployment that exists today.
- **Refused, never clamped.** Out-of-range values produce a boot issue rather than being coerced to something plausible — a silently corrected value is the defect class this change exists to close. Bounded by `maxProxyHops`, because a large value is nearly always someone entering a header length rather than a count of appending proxies.
- **Parsed from the raw string, before the typed decode.** Only a plain decimal integer is accepted; empty, leading-zero, hex, signed and whitespace-padded forms are all refused, each because it has a plausible reading that is not what was meant. **Absence takes the default; emptiness is refused** — they are different states, and the typed path could not tell them apart. Parsing first also means a bad value produces an error naming the variable rather than a generic decode failure. Pinned by a table over raw strings at the string layer, which is where the conversion actually happens; the earlier pins assigned typed ints and sat below it.
- **Both sources, one parser.** The environment is not the only documented way in — `WPMGR_CONFIG_FILE` ships in `.env.example` and the precedence is `defaults<file<env` — so a YAML-supplied value reached the same weak decode by a second route, including the null shapes a template renders for a value it could not resolve. The file source now goes through the same parser, pinned by its own table, and the environment still wins over the file.
- **Logged unconditionally at startup**, with the variable name and what the number counts. A wrong count is not observable from inside the process and presents as ordinary 429s, so an operator whose sign-ins start failing finds the effective value in the first screen of the log.
- An unset field resolves to the default rather than `0`, so a `Handler` nobody configured does not behave as though nothing were in front of it.

## What the fallback is, and is not

A chain shorter than `proxyHops` falls back to the peer address rather than reaching further left.

**This is not a security guard, and an earlier revision of this description wrongly presented it as one.** It catches one shape only, and the ingress restriction — not this fallback — is what the correctness of the selection rests on. `TestLimiterAddrFallsBackToPeerOnShortChain` pins the case it does cover. The full reasoning is in the code comment at the constant, where the next person changing it will be standing.

A boot-time assertion was considered and rejected: the process cannot read its own ingress configuration without being granted a cloud API surface it otherwise does not need, which is a worse trade than a configured value logged at startup.

## Observability

Both limiters now log on refusal. They were silent: a refused caller sees an ordinary 429 and operators saw nothing at all, so an address that stopped distinguishing callers would refuse every request in the fleet and present as normal traffic.

## Tests

In `internal/auth/clientaddr_limiter_key_test.go`, in three layers, because the first two each miss what the other catches:

1. **`limiterAddr`'s own behaviour** — chain shapes, repeated header lines, IPv6 spellings, the honest short chain.
2. **The registered route** — `TestResetPasswordRouteKeysOnAppendedClient` drives the real gin route through `Register` into the real service and the real limiter, so the wiring is covered rather than a stand-in.
3. **Source-level** — `TestDecisionSitesUseLimiterAddr` pins that all four decision sites call `limiterAddr`. The three 2FA sites reach their limiter only after a challenge lookup and cannot be driven without a database, so without this a revert of those three would pass silently.

**Correction to an earlier revision of this description:** the single-client controls were described as catching a remedy that keys every caller onto one shared value. They cannot — such a remedy still refuses past the cap and still serves below it, so every single-client pin passes while the fleet is locked out. `TestResetRouteSeparatesDistinctClients` uses two distinct legitimate clients and is the only pin that catches it.

Verified in both directions, each planted and executed: reverting all four decision sites fails the route pin and the source pin; keying every caller onto one value fails the two-client pin while leaving the single-client pins green, which is exactly why it exists.

## Needs routing before the self-hosted distribution next cuts

The default suits the hosted deployment. Self-hosted installs must set the value deliberately rather than inherit it, and these surfaces are outside this PR's path:

- `infra/docker-compose.yml` — the bundled compose deployment appends one entry, so it wants `WPMGR_AUTH_PROXY_HOPS=1`
- `.env.example`
- `docs/install.md`
- `apps/api/README.md`

`infra/nginx/nginx.conf` needs the same owner's attention for the related root cause.

## Follow-ups, not in this PR

- `internal/rum/handler.go:472-487` derives its key on a different assumption about the ingress path. Filed as #583.
- `infra/nginx/nginx.conf:76` — the self-hosted path has the same shape, and is `devops-engineer`'s.
- `autologin/ratelimit.go`'s `MemoryLimiter` is per-process, so every limit here is still multiplied by the instance count. Unchanged by this and worth its own decision.





