### PR TITLE
infra: set the proxy hop count for the bundled deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,31 @@ WPMGR_REDIS_PASSWORD=
 # Session lifetimes. Format: Go duration. e.g. 168h (idle), 720h (absolute).
 WPMGR_AUTH_IDLE_TIMEOUT=168h
 WPMGR_AUTH_ABSOLUTE_EXPIRY=720h
+# How many proxy entries are appended to X-Forwarded-For IN FRONT OF the api
+# before a request reaches it. It picks which entry in the forwarded chain the
+# authentication rate limiters treat as the real client, so a wrong value
+# degrades them silently, in one of two directions:
+#   too HIGH — honest requests carry a shorter chain than expected, the api
+#     falls back to the peer address (your reverse proxy), and every honest
+#     user collapses onto ONE shared rate-limit key: one person's failed
+#     logins lock out everybody.
+#   too LOW  — a caller can append an entry of their own choosing and be
+#     counted as somebody else.
+# Count the proxies that APPEND AN ENTRY, not the network hops:
+#   0 = nothing is in front of the api; use the peer address directly. Correct
+#       if clients reach WPMGR_API_PORT (8081) straight, with no proxy at all.
+#   1 = this compose stack, and the shipped default. The bundled nginx (the
+#       `web` container, WPMGR_WEB_PORT) is the only thing that appends, and it
+#       appends exactly one entry.
+#   2 = the bundled nginx PLUS one more appending proxy in front of it (a TLS
+#       terminator, a CDN, a corporate load balancer) that you have NOT
+#       declared to nginx as trusted.
+# If instead you DO declare that front proxy trusted — mount a file of
+# `set_real_ip_from <cidr>;` lines into /etc/nginx/trusted-proxies/ on the web
+# container, see infra/nginx/nginx.conf — the bundled nginx resolves the real
+# client itself and still emits exactly one entry, so this stays 1.
+# Format: non-negative integer.
+WPMGR_AUTH_PROXY_HOPS=1
 # OIDC relying party (self-host via Dex). Empty issuer => email+password only.
 # A non-empty issuer that fails discovery HARD-FAILS boot. Format: URLs / strings.
 # NOTE: WPMGR_OIDC_REDIRECT_URL uses the HOST-facing port (WPMGR_API_PORT=8081),

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -174,6 +174,20 @@ services:
       # direction: with no value the api refuses to boot
       # (config.ValidateSessionSecret) instead of running on a shared one.
       # The zero-config dev value lives in infra/docker-compose.dev.yml.
+      # --- Forwarded-client trust ---------------------------------------------
+      # WPMGR_AUTH_PROXY_HOPS is absent from this block for exactly the reason
+      # given above, and ships as WPMGR_AUTH_PROXY_HOPS=1 in .env.example,
+      # reaching this service through `env_file: ../.env`. Do not add it here:
+      # an entry would pin every install to the literal default and discard the
+      # operator's value. Note this key does NOT fail closed the way the secrets
+      # above do — a wrong value still boots and silently mis-identifies the
+      # client behind the proxy, so the env_file path is the only thing making
+      # it configurable at all.
+      #
+      # 1 rather than the api's built-in default of 2, because the bundled nginx
+      # (the `web` service) appends exactly one X-Forwarded-For entry. See
+      # .env.example for how to derive it for another topology, and
+      # infra/nginx/nginx.conf for the trusted-front-proxy case.
       # --- OIDC (Dex) ---------------------------------------------------------
       # Issuer must match Dex's configured issuer AND be reachable from this
       # container; dex.localhost is mapped to host-gateway via extra_hosts below

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -68,12 +68,42 @@ server {
     resolver 127.0.0.11 valid=10s ipv6=off;
     set $api_upstream "api:8080";
 
+    # ---- Client identity: this nginx is the trust boundary ----------------
+    # For a self-hosted install THIS nginx is the edge, so it must NOT extend a
+    # caller-supplied X-Forwarded-For. $proxy_add_x_forwarded_for appends the
+    # peer to whatever arrived and never strips it, which lets any caller
+    # prepend entries of their choosing and so decide which entry the API reads
+    # as "the client". X-Forwarded-For is therefore SET from $remote_addr, not
+    # appended to: what the API receives is observed by nginx, never asserted
+    # by the caller. This nginx appends exactly ONE entry, which is what
+    # WPMGR_AUTH_PROXY_HOPS=1 (see .env.example) counts.
+    #
+    # Chained proxy in front? This server block listens on plain :80, so an
+    # internet-facing install usually terminates TLS somewhere ahead of it.
+    # Overwriting would otherwise replace the real client with that proxy's own
+    # address. Declare the front proxy — and only it — as trusted by mounting a
+    # file into /etc/nginx/trusted-proxies/ holding set_real_ip_from lines:
+    #
+    #   set_real_ip_from 10.0.0.0/8;   # the front proxy's address or CIDR
+    #
+    # ngx_http_realip_module then rewrites $remote_addr to the real client
+    # taken from that proxy's X-Forwarded-For, so the header written below
+    # still carries one entry and it is still the real client. A spoofed header
+    # from any source NOT listed is ignored, so the trust boundary holds.
+    #
+    # The directory is EMPTY by default: no source is trusted, $remote_addr is
+    # the real peer, and nginx is the edge. A wildcard include that matches
+    # nothing is valid nginx, so the default needs no file and no mount.
+    include /etc/nginx/trusted-proxies/*.conf;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
     # Common proxy headers (inherited by the proxied locations below, since none
     # of them redefine proxy_set_header).
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $wpmgr_conn_upgrade;


### PR DESCRIPTION
Sets the proxy hop count for the bundled self-hosted deployment, and tightens how the bundled nginx populates the forwarded-client headers.

## What changed

- **`.env.example`** — ships `WPMGR_AUTH_PROXY_HOPS=1` with a comment covering what the number counts, how to derive it for a different topology, and that `0` means "nothing is in front of this, use the peer address".
- **`infra/docker-compose.yml`** — a note recording why the variable is deliberately *not* in the api `environment:` block.
- **`infra/nginx/nginx.conf`** — `X-Forwarded-For` is set from `$remote_addr` rather than extended. A chained front proxy can be declared trusted via `set_real_ip_from` files mounted into `/etc/nginx/trusted-proxies/` (empty by default).

## Why 1, verified not assumed

The bundled nginx appends exactly one entry. Measured through the real config against a stub upstream that echoes what it received:

```
--- honest client, no inbound X-Forwarded-For
$ curl -s http://127.0.0.1:18099/api/v1/ping
UPSTREAM_SAW X-Forwarded-For=[192.168.65.1] X-Real-IP=[192.168.65.1]
```

One entry, so the hop count is 1.

## Header handling: before / after

Same harness, same commands, the only difference being the config under test.

**Before** — an inbound header is extended and never stripped:

```
$ curl -s -H 'X-Forwarded-For: 1.2.3.4' http://127.0.0.1:18099/api/v1/ping
UPSTREAM_SAW X-Forwarded-For=[1.2.3.4, 192.168.65.1]

$ curl -s -H 'X-Forwarded-For: 9.9.9.9, 8.8.8.8' http://127.0.0.1:18099/api/v1/ping
UPSTREAM_SAW X-Forwarded-For=[9.9.9.9, 8.8.8.8, 192.168.65.1]
```

**After** — the upstream sees only what nginx observed:

```
$ curl -s -H 'X-Forwarded-For: 1.2.3.4' http://127.0.0.1:18099/api/v1/ping
UPSTREAM_SAW X-Forwarded-For=[192.168.65.1]

$ curl -s -H 'X-Forwarded-For: 9.9.9.9, 8.8.8.8' http://127.0.0.1:18099/api/v1/ping
UPSTREAM_SAW X-Forwarded-For=[192.168.65.1]
```

The honest-client case (no inbound header) is byte-identical before and after, so the change does not alter correct traffic.

## Chained proxy in front

This server block listens on plain `:80`, so an internet-facing install normally terminates TLS ahead of it. Overwriting alone would replace the real client with that terminator's address, so the trusted-proxy path is proven too — genuine client container, no forged header, front proxy appending as a terminator does:

```
front proxy (chained terminator) IP: 172.19.0.4

RUN A — no trusted-proxies file (shipped default)
UPSTREAM_SAW X-Forwarded-For=[172.19.0.4]     <-- genuine client was 172.19.0.5: real client lost

RUN B — front declared trusted: set_real_ip_from 172.19.0.4;
UPSTREAM_SAW X-Forwarded-For=[172.19.0.5]     <-- genuine client recovered

RUN C — trust file in place, untrusted caller forges XFF straight at web
UPSTREAM_SAW X-Forwarded-For=[172.19.0.5]     <-- forged 6.6.6.6 discarded
```

The chain stays one entry in both topologies, so `1` remains correct either way.

## Why the value is not in the compose `environment:` block

A key in `environment:` beats the same key from `env_file`, and `${VAR:-default}` interpolation resolves against the project directory (`infra/`), not the repo root where `.env` lives. Both verified against the real compose file, with `.env` set to `3`:

```
$ docker compose -f infra/docker-compose.yml config          # as shipped here
operator set 3 in .env -> api sees '3'

$ docker compose -f infra/docker-compose.yml -f override.yml config   # with the rejected placement
.env says 3; with the rejected environment: placement api sees '1'
```

So the `environment:` placement would have pinned every install to the literal default and silently discarded the operator's value. Keeping it in `.env.example` on the `env_file` path is what makes it actually configurable.

## Checks

- `nginx -t` against the modified config: syntax ok.
- `infra/nginx/routing_smoke_test.sh` — result reported in a follow-up comment.
- The wildcard `include` matching zero files is valid nginx, so the default needs no mount.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable proxy-hop handling through `WPMGR_AUTH_PROXY_HOPS`, with a default of one proxy.
  - Improved client IP detection when requests pass through trusted reverse proxies.
  - Rate limiting now uses the appropriate originating client address in supported proxy configurations.

- **Documentation**
  - Documented configuration behavior for direct access, the bundled proxy, and additional front-end proxies.
  - Clarified how trusted proxy settings help prevent spoofed client addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->