### PR TITLE
fix(infra): let env_file supply api and media-encoder secret values

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -42,6 +42,13 @@ services:
       GOWORK: "off"
       WPMGR_ENV: development
       WPMGR_LOG_LEVEL: debug
+      # Fixed dev session secret, so `make dev` boots with no .env. It lives in
+      # this overlay and NOT in the base file on purpose: the base file is what
+      # docs/install.md tells operators to run on their own hosts, and a value
+      # named in its `environment:` block would override the operator's .env
+      # rather than fall back to it. Anything loading this overlay is a local
+      # dev stack by definition. Never set WPMGR_ENV=production alongside it.
+      WPMGR_SESSION_SECRET: ${WPMGR_SESSION_SECRET:-ZGV2LW9ubHktc2Vzc2lvbi1zZWNyZXQtZG8tbm90LXVzZS1pbi1wcm9kdWN0aW9uLTQ4Ynl0ZXM=}
     volumes:
       - ../apps/api:/src/apps/api
       - go-mod-cache:/go/pkg/mod

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -162,10 +162,18 @@ services:
       # App role is non-superuser now, so it must NOT be allowed to bypass RLS.
       WPMGR_ALLOW_RLS_BYPASS_ROLE: "false"
       # --- Sessions -----------------------------------------------------------
-      # REQUIRED, >=32 bytes. The app refuses to boot on the placeholder or
-      # anything shorter. This is a FIXED DEV value — production MUST override it
-      # (e.g. via .env / secret manager): openssl rand -base64 48
-      WPMGR_SESSION_SECRET: ${WPMGR_SESSION_SECRET:-ZGV2LW9ubHktc2Vzc2lvbi1zZWNyZXQtZG8tbm90LXVzZS1pbi1wcm9kdWN0aW9uLTQ4Ynl0ZXM=}
+      # REQUIRED, >=32 bytes: `openssl rand -base64 48`, or let
+      # scripts/init-env.sh generate one. Supplied through env_file (../.env)
+      # ONLY — deliberately absent from this block.
+      #
+      # A key listed here wins over env_file unconditionally, so a value named
+      # in this block replaces the operator's .env value rather than falling
+      # back to it. Compose also resolves ${VAR:-default} against the project
+      # directory (infra/), not the repo root where .env lives, so a default
+      # written here would win every time. Absence is the fail-closed
+      # direction: with no value the api refuses to boot
+      # (config.ValidateSessionSecret) instead of running on a shared one.
+      # The zero-config dev value lives in infra/docker-compose.dev.yml.
       # --- OIDC (Dex) ---------------------------------------------------------
       # Issuer must match Dex's configured issuer AND be reachable from this
       # container; dex.localhost is mapped to host-gateway via extra_hosts below
@@ -184,7 +192,9 @@ services:
       # default here — an unset value means the install boots but nobody can
       # claim it yet, which is the deliberate fail-closed direction. quickstart
       # (scripts/init-env.sh) generates and persists this into .env on first run.
-      WPMGR_BOOTSTRAP_CLAIM_SECRET: ${WPMGR_BOOTSTRAP_CLAIM_SECRET:-}
+      # Supplied through env_file (../.env) only: naming the key here with an
+      # empty default would override that generated value with "" and leave the
+      # install permanently unclaimable.
       WPMGR_REDIS_ADDR: redis:6379
       # M5.6/ADR-033: presigned URLs the agent receives MUST be reachable from
       # OUTSIDE this Docker network — `seaweedfs:8333` (Docker service name)
@@ -289,8 +299,10 @@ services:
       WPMGR_S3_FORCE_PATH_STYLE: "true"
       WPMGR_RIVER_MEDIA_SCHEMA: ${WPMGR_RIVER_MEDIA_SCHEMA:-media_encoder}
       # CP signing key: required to dispatch the signed media_apply command back
-      # to the agent. Share the same key the api uses (.env override in prod).
-      WPMGR_AGENT_SIGNING_PRIVATE_KEY: ${WPMGR_AGENT_SIGNING_PRIVATE_KEY:-}
+      # to the agent. Share the same key the api uses, which means taking it
+      # from env_file (../.env) exactly as the api does — naming the key here
+      # with an empty default would override .env with "" and leave this
+      # service unable to sign media_apply while the api signs fine.
       # Public CP base URL the agent reaches callbacks at (presign/encode-ready/
       # job-status). Same value the api uses.
       WPMGR_PUBLIC_BASE_URL: ${WPMGR_PUBLIC_BASE_URL:-}


### PR DESCRIPTION
## What

Three environment keys in `infra/docker-compose.yml` took their value from the
compose file rather than from the operator's `.env`, even though both affected
services already declare `env_file: ../.env`.

Removed from the `environment:` blocks so `env_file` is authoritative:

| Service | Key |
|---|---|
| `api` | `WPMGR_SESSION_SECRET` |
| `api` | `WPMGR_BOOTSTRAP_CLAIM_SECRET` |
| `media-encoder` | `WPMGR_AGENT_SIGNING_PRIVATE_KEY` |

## Why it did not work before

Two mechanisms compound:

1. A key listed in a service's `environment:` block wins over `env_file`
   unconditionally — it does not fall back to it.
2. Compose resolves `${VAR:-default}` against the **project directory**, which
   is `infra/` for the documented `docker compose -f infra/docker-compose.yml`
   invocation, not the repo root where `.env` lives. There is no `infra/.env`,
   so the default arm was always taken.

The two keys carrying empty defaults were replacing a value the operator *had*
set with `""`. `scripts/init-env.sh` generates and persists both, and neither
reached the container. The compose comment on `WPMGR_BOOTSTRAP_CLAIM_SECRET`
already described the intended behaviour; the empty default defeated it.

## Proof

Rendered `docker compose -f infra/docker-compose.yml config` against a scratch
tree with sentinel values in `.env`, before and after. Method identical on both
sides.

```
SERVICE.KEY                                    BEFORE                   AFTER
api.WPMGR_SESSION_SECRET                       BAKED DEFAULT WINS       OPERATOR VALUE HONOURED
api.WPMGR_BOOTSTRAP_CLAIM_SECRET               EMPTY -> clobbered       OPERATOR VALUE HONOURED
media-encoder.WPMGR_AGENT_SIGNING_PRIVATE_KEY  EMPTY -> clobbered       OPERATOR VALUE HONOURED
```

Cases it must not break, all rendered:

- **No `.env` at all** — all three keys absent from the rendered environment, so
  the api stops at `config.ValidateSessionSecret` (`config.go:761` defaults
  `auth.session_secret` to `""`, `main.go:238` fails the boot). Absence is loud.
- **`make dev`, no `.env`** — base + `docker-compose.dev.yml` renders
  `WPMGR_SESSION_SECRET` (len 76) with `WPMGR_ENV=development`. Zero-config dev
  still boots; the dev value moved into the overlay, which no install loads.
- **base + `docker-compose.prod.yml`** — all three honour the operator value.

## Not covered here

Four more keys resolve the same way and are **deliberately left alone**, because
each is paired with state that an existing install has already initialised, so
flipping them is an availability change rather than a config fix:

- `WPMGR_DB_APP_PASSWORD`, `WPMGR_DB_OWNER_PASSWORD` — paired with the role
  passwords baked into the existing `postgres-data` volume.
- `WPMGR_S3_ACCESS_KEY`, `WPMGR_S3_SECRET_KEY` — paired with
  `infra/seaweedfs/s3.json`.
- `WPMGR_OIDC_CLIENT_SECRET` — paired with `infra/dex/config.yaml:53`.

These need a decision on upgrade sequencing before they move.

## Not run

Nothing nginx-adjacent is touched, so `nginx -t` and
`infra/nginx/routing_smoke_test.sh` were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup validation by requiring session, bootstrap, and agent signing secrets to be explicitly configured.
  * Removed insecure empty or implicit production defaults for sensitive credentials.

* **Development**
  * Added a development-only session secret fallback so local environments continue to start without additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->