### PR TITLE
feat(config): refuse non-confidential session secrets at boot

### DIFF
--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -692,9 +692,9 @@ func (c Config) IsProduction() bool {
 	return strings.EqualFold(c.Env, "production") || strings.EqualFold(c.Env, "prod")
 }
 
-// ValidateSessionSecret refuses weak/placeholder session secrets. The secret
-// keys the session store; an empty, placeholder, or short value is a security
-// hole, so the server must not boot with one.
+// ValidateSessionSecret refuses weak/placeholder/published session secrets. The
+// secret keys the session store; an empty, placeholder, short, or publicly
+// known value is a security hole, so the server must not boot with one.
 func (c Config) ValidateSessionSecret() error {
 	s := c.Auth.SessionSecret
 	if s == "" {
@@ -702,6 +702,13 @@ func (c Config) ValidateSessionSecret() error {
 	}
 	if strings.HasPrefix(s, "change-me") {
 		return fmt.Errorf("WPMGR_SESSION_SECRET still holds the placeholder value: set a real random secret of at least 32 bytes")
+	}
+	// Before the length check, deliberately. A published secret is long and
+	// well-formed, so it would otherwise sail past every remaining check; and if
+	// a future published value ever were short, "this one is public" is the more
+	// useful thing to tell the operator than "this one is short".
+	if reason := publishedSessionSecretRefusal(s); reason != "" {
+		return fmt.Errorf("WPMGR_SESSION_SECRET %s", reason)
 	}
 	if len(s) < 32 {
 		return fmt.Errorf("WPMGR_SESSION_SECRET is too short (%d bytes): use at least 32 bytes", len(s))

--- a/apps/api/internal/config/published_secrets.go
+++ b/apps/api/internal/config/published_secrets.go
@@ -26,9 +26,13 @@ import (
 // never remove one: an operator who copied it years ago is exactly the person
 // this check is for.
 var publishedSessionSecrets = []string{
-	// infra/docker-compose.yml carried this as the api service's built-in
-	// WPMGR_SESSION_SECRET fallback. Decoded, it reads
-	// "dev-only-session-secret-do-not-use-in-production-48bytes".
+	// The api service's built-in WPMGR_SESSION_SECRET fallback. It sat in
+	// infra/docker-compose.yml, where every stack inherited it; it now sits in
+	// infra/docker-compose.dev.yml, where only the dev overlay does. Decoded, it
+	// reads "dev-only-session-secret-do-not-use-in-production-48bytes".
+	//
+	// It stays listed regardless of where it lives, because the operator this
+	// check is for is the one still holding a copy of it.
 	"ZGV2LW9ubHktc2Vzc2lvbi1zZWNyZXQtZG8tbm90LXVzZS1pbi1wcm9kdWN0aW9uLTQ4Ynl0ZXM=",
 }
 
@@ -122,13 +126,22 @@ func isPublishedSessionSecret(raw string) bool {
 // defaults() supplies env="development" when nothing is set, so an unconfigured
 // production install and a developer's laptop are the same string. Validate
 // already reaches for the environment this way for WPMGR_SITE_DEST_AGE_SECRET.
+//
+// Exactly one spelling is accepted, case-insensitively. Not "dev", not "local",
+// not "test". Nothing in this repository sets any of them — the dev overlay,
+// .env.example, the Makefile and the docs all write "development" or
+// "production" — so the aliases bought nothing, and each one widened the
+// exemption for free. "test" in particular is the same shape as the case this
+// whole check exists to reject: a plausible label on a real box that is not a
+// statement of "I accept a publicly known session secret here". The exemption
+// should be no wider than the thing it was meant to permit.
 func explicitDevelopmentEnv() bool {
 	v, ok := os.LookupEnv("WPMGR_ENV")
 	if !ok {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(v)) {
-	case "development", "dev", "local", "test":
+	case "development":
 		return true
 	default:
 		return false
@@ -157,13 +170,12 @@ func explicitDevelopmentEnv() bool {
 // never exempts. That is the direction a wrong answer has to fail in: an
 // unlabelled install is treated as real, because it usually is.
 //
-// The exemption exists because it has to. The dev overlay
-// (infra/docker-compose.dev.yml) does not set WPMGR_SESSION_SECRET, so a
-// zero-config `make dev` inherits the published fallback from the base compose
-// file and would be unable to boot at all. That overlay does set
-// WPMGR_ENV=development explicitly, which is the signal this keys on. A guard
-// that breaks the standard local-dev bring-up gets switched off, and then it
-// guards nothing.
+// The exemption exists because it has to. infra/docker-compose.dev.yml supplies
+// this fallback secret to the api service, so a zero-config `make dev` runs on a
+// published value by design and would otherwise be unable to boot at all. That
+// same overlay sets WPMGR_ENV=development explicitly, which is the signal this
+// keys on. A guard that breaks the standard local-dev bring-up gets switched
+// off, and then it guards nothing.
 //
 // Config.Advisories still reports the exempted case, so a developer sitting on
 // the published secret is told so on every boot rather than never.

--- a/apps/api/internal/config/published_secrets.go
+++ b/apps/api/internal/config/published_secrets.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"strings"
+)
+
+// publishedSessionSecrets lists WPMGR_SESSION_SECRET values that exist in this
+// repository's tracked files and are therefore readable by anyone. A value here
+// is not a secret in any sense: it is a shared constant that every install
+// copying it holds in common, which makes every session cookie it keys forgeable
+// by anyone who can read the repo.
+//
+// The values are written out in full, deliberately. Obfuscating or hashing them
+// would make this list unusable for the one thing it exists for — letting a
+// person compare it against what their own deployment actually has — and would
+// hide from the next reader what these strings are. They are already public;
+// repeating them here costs nothing and is what makes the check auditable.
+//
+// Entries are matched by isPublishedSessionSecret, which also catches the same
+// bytes written under a different base64 alphabet or pasted in decoded form.
+//
+// Add an entry whenever a session secret is committed to a tracked file, and
+// never remove one: an operator who copied it years ago is exactly the person
+// this check is for.
+var publishedSessionSecrets = []string{
+	// infra/docker-compose.yml carried this as the api service's built-in
+	// WPMGR_SESSION_SECRET fallback. Decoded, it reads
+	// "dev-only-session-secret-do-not-use-in-production-48bytes".
+	"ZGV2LW9ubHktc2Vzc2lvbi1zZWNyZXQtZG8tbm90LXVzZS1pbi1wcm9kdWN0aW9uLTQ4Ynl0ZXM=",
+}
+
+// base64Alphabets are the four spellings a given byte string can arrive in.
+// Padding and the URL-safe alphabet are cosmetic: an operator who re-encoded the
+// same bytes, or whose tooling stripped the "=", holds the identical key.
+var base64Alphabets = []*base64.Encoding{
+	base64.StdEncoding,
+	base64.RawStdEncoding,
+	base64.URLEncoding,
+	base64.RawURLEncoding,
+}
+
+// base64Decodings returns every distinct byte string s decodes to across the
+// four alphabets. A value that is not base64 at all yields nothing, which is the
+// ordinary case for a passphrase-style secret and is not an error.
+func base64Decodings(s string) [][]byte {
+	var out [][]byte
+	for _, enc := range base64Alphabets {
+		b, err := enc.DecodeString(s)
+		if err != nil || len(b) == 0 {
+			continue
+		}
+		dup := false
+		for _, seen := range out {
+			if bytes.Equal(seen, b) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// isPublishedSessionSecret reports whether raw is one of the known-published
+// session secrets, in any spelling that yields the same key material.
+//
+// Three comparisons, because a secret can arrive in three shapes:
+//
+//  1. Byte-for-byte the published text. This is the load-bearing one. The
+//     control plane never base64-decodes WPMGR_SESSION_SECRET — it feeds the
+//     string's own bytes to the handshake codec and to
+//     cryptbox.DeriveAgeIdentity ([]byte(sessionSecret) in cmd/wpmgr/main.go) —
+//     so the text IS the key, and an exact text match is an exact key match.
+//
+//  2. The same bytes under a different base64 alphabet or without padding.
+//     Because the app uses the text rather than the decoding, these are not
+//     literally the same key; they are, however, trivially derived from a
+//     published value by anyone holding it, so they are refused too.
+//
+//  3. The published constant's decoded plaintext, pasted directly. Anyone who
+//     ran the value through `base64 -d` to see what it was may have pasted the
+//     result back, and that plaintext is just as public as the encoding.
+//
+// Comparison is plain equality, not constant-time: every value involved is
+// already published, so there is no secret here to leak by timing.
+func isPublishedSessionSecret(raw string) bool {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return false
+	}
+	candidateDecodings := base64Decodings(s)
+	for _, published := range publishedSessionSecrets {
+		if s == published {
+			return true // shape 1
+		}
+		for _, pub := range base64Decodings(published) {
+			if s == string(pub) {
+				return true // shape 3
+			}
+			for _, cand := range candidateDecodings {
+				if bytes.Equal(cand, pub) {
+					return true // shape 2
+				}
+			}
+		}
+	}
+	return false
+}
+
+// explicitDevelopmentEnv reports whether the operator has *declared* this
+// process to be a development one, by setting WPMGR_ENV to a development value
+// in the environment. An absent WPMGR_ENV is not a declaration and never
+// satisfies this, which is the entire point of the function.
+//
+// It deliberately reads the process environment rather than Config.Env. By the
+// time Config exists the two cases this must separate have already been merged:
+// defaults() supplies env="development" when nothing is set, so an unconfigured
+// production install and a developer's laptop are the same string. Validate
+// already reaches for the environment this way for WPMGR_SITE_DEST_AGE_SECRET.
+func explicitDevelopmentEnv() bool {
+	v, ok := os.LookupEnv("WPMGR_ENV")
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "development", "dev", "local", "test":
+		return true
+	default:
+		return false
+	}
+}
+
+// publishedSessionSecretRefusal returns the operator-facing reason the session
+// secret must be refused, or "" when it is acceptable.
+//
+// # Why this is not gated on IsProduction, unlike ValidateAgentSigningKey
+//
+// The obvious shape for this check is the one ValidateAgentSigningKey uses:
+// refuse the committed dev value in production, allow it everywhere else. That
+// shape is wrong here, and the reason is worth stating because it is invisible
+// from inside this package.
+//
+// Nothing in infra/docker-compose.yml or infra/docker-compose.prod.yml sets
+// WPMGR_ENV. A self-hosted operator who brings the stack up therefore gets
+// WPMGR_ENV unset, which defaults() turns into "development" and IsProduction()
+// reads as false. Gating on IsProduction() would skip the check for precisely
+// the population that has the problem — a real install, serving real sessions,
+// that never declared an environment — while catching nobody else.
+//
+// So the refusal is universal, and the exemption is narrow: it applies only when
+// the operator has explicitly said this is a development environment. Absence
+// never exempts. That is the direction a wrong answer has to fail in: an
+// unlabelled install is treated as real, because it usually is.
+//
+// The exemption exists because it has to. The dev overlay
+// (infra/docker-compose.dev.yml) does not set WPMGR_SESSION_SECRET, so a
+// zero-config `make dev` inherits the published fallback from the base compose
+// file and would be unable to boot at all. That overlay does set
+// WPMGR_ENV=development explicitly, which is the signal this keys on. A guard
+// that breaks the standard local-dev bring-up gets switched off, and then it
+// guards nothing.
+//
+// Config.Advisories still reports the exempted case, so a developer sitting on
+// the published secret is told so on every boot rather than never.
+func publishedSessionSecretRefusal(secret string) string {
+	if !isPublishedSessionSecret(secret) {
+		return ""
+	}
+	if explicitDevelopmentEnv() {
+		return ""
+	}
+	return "is set to a session secret published in this project's public repository, " +
+		"where it shipped as a docker-compose fallback value. It is well-formed but not " +
+		"confidential: every install using it shares one session key, so anyone who has read " +
+		"the repository can mint sessions here. Generate a private one — " +
+		"openssl rand -base64 48 — set WPMGR_SESSION_SECRET to it, and restart. " +
+		"Existing sessions will be signed out, which is the intended effect. " +
+		"If this really is a development machine, set WPMGR_ENV=development"
+}
+
+// publishedSessionSecretAdvisory returns a non-fatal warning for the case
+// publishedSessionSecretRefusal deliberately lets through: a declared
+// development environment running on a published secret. It boots, and it says
+// so every time, so the state is never silent.
+func publishedSessionSecretAdvisory(secret string) string {
+	if !isPublishedSessionSecret(secret) || !explicitDevelopmentEnv() {
+		return ""
+	}
+	return "is a session secret published in this project's public repository. " +
+		"Permitted here only because WPMGR_ENV declares a development environment. " +
+		"Never deploy this value: generate one with openssl rand -base64 48"
+}

--- a/apps/api/internal/config/published_secrets_test.go
+++ b/apps/api/internal/config/published_secrets_test.go
@@ -118,14 +118,14 @@ func TestLoadRefusesPublishedSessionSecretWhenEnvIsPresentButEmpty(t *testing.T)
 // TestLoadAllowsPublishedSessionSecretInDeclaredDevelopment is the OVER-FIRE
 // proof, at the env layer.
 //
-// infra/docker-compose.dev.yml sets WPMGR_ENV=development explicitly and does
-// NOT set WPMGR_SESSION_SECRET, so a zero-config `make dev` inherits the
-// published fallback from the base compose file. If this test fails, `make dev`
-// cannot boot, and a guard that breaks local development gets deleted.
+// infra/docker-compose.dev.yml supplies BOTH the published fallback secret and
+// WPMGR_ENV=development, so a zero-config `make dev` runs on a published value
+// by design. If this test fails, `make dev` cannot boot, and a guard that breaks
+// local development gets deleted.
 //
 // It must still be loud: the advisory is what keeps the exempted state visible.
 func TestLoadAllowsPublishedSessionSecretInDeclaredDevelopment(t *testing.T) {
-	for _, env := range []string{"development", "dev", "local", "test", "Development"} {
+	for _, env := range []string{"development", "Development", "  development  "} {
 		t.Run(env, func(t *testing.T) {
 			cfg := loadWithEnv(t, publishedSecret, strptr(env))
 			if err := cfg.ValidateSessionSecret(); err != nil {
@@ -144,6 +144,39 @@ func TestLoadAllowsPublishedSessionSecretInDeclaredDevelopment(t *testing.T) {
 			}
 			if !advised {
 				t.Error("Advisories() said nothing about running on a published session secret; the exemption would be completely silent")
+			}
+		})
+	}
+}
+
+// TestLoadRefusesPublishedSessionSecretForNearMissEnvLabels pins the width of
+// the exemption. Exactly one WPMGR_ENV spelling unlocks a published secret;
+// everything that merely looks like a development label does not.
+//
+// These are the refusal cases for aliases the exemption once accepted. They are
+// what stops the aliases creeping back: widening explicitDevelopmentEnv
+// again turns each of these red. "test" and "local" are the same shape as the
+// case this check exists for — a plausible label on a real box, not a statement
+// that a publicly known session secret is acceptable there.
+func TestLoadRefusesPublishedSessionSecretForNearMissEnvLabels(t *testing.T) {
+	for _, env := range []string{"dev", "local", "test", "", "staging", "developmentt", "prod"} {
+		name := env
+		if name == "" {
+			name = "present but empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			cfg := loadWithEnv(t, publishedSecret, strptr(env))
+			if err := cfg.ValidateSessionSecret(); err == nil {
+				t.Fatalf("ValidateSessionSecret() = nil with WPMGR_ENV=%q; only an explicit \"development\" may exempt a published secret", env)
+			}
+			var flagged bool
+			for _, is := range Validate(cfg) {
+				if is.Name == "WPMGR_SESSION_SECRET" {
+					flagged = true
+				}
+			}
+			if !flagged {
+				t.Fatalf("Validate() reported no issue with WPMGR_ENV=%q; the boot gate disagrees with ValidateSessionSecret", env)
 			}
 		})
 	}
@@ -223,8 +256,10 @@ func TestExplicitDevelopmentEnvRequiresPresence(t *testing.T) {
 	if !explicitDevelopmentEnv() {
 		t.Fatal("explicitDevelopmentEnv() = false with WPMGR_ENV=development; make dev cannot boot")
 	}
-	t.Setenv("WPMGR_ENV", "staging")
-	if explicitDevelopmentEnv() {
-		t.Fatal("explicitDevelopmentEnv() = true for staging")
+	for _, env := range []string{"staging", "dev", "local", "test", "production", ""} {
+		t.Setenv("WPMGR_ENV", env)
+		if explicitDevelopmentEnv() {
+			t.Fatalf("explicitDevelopmentEnv() = true for WPMGR_ENV=%q; the exemption must be exactly one spelling wide", env)
+		}
 	}
 }

--- a/apps/api/internal/config/published_secrets_test.go
+++ b/apps/api/internal/config/published_secrets_test.go
@@ -1,0 +1,230 @@
+package config
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+)
+
+// publishedSecret is the value under test, taken from the denylist itself so
+// the test cannot drift from the thing it is guarding.
+var publishedSecret = publishedSessionSecrets[0]
+
+// unsetEnv removes a variable for the duration of the test and restores whatever
+// was there afterwards. t.Setenv registers the restore; the Unsetenv that
+// follows is what actually produces the absent case, which is the one that
+// matters most here — an unset WPMGR_ENV is the state every self-hosted install
+// boots in, and it must never be read as a declaration of development.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	t.Setenv(key, "")
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+}
+
+// loadWithEnv drives the real loader with the given environment. This is the
+// layer that matters: a test that hands ValidateSessionSecret a Go string never
+// touches mapEnvKey, koanf, or the defaults merge, and so cannot show that an
+// operator's WPMGR_SESSION_SECRET actually reaches the check.
+func loadWithEnv(t *testing.T, secret string, env *string) Config {
+	t.Helper()
+	t.Setenv("WPMGR_SESSION_SECRET", secret)
+	if env == nil {
+		unsetEnv(t, "WPMGR_ENV")
+	} else {
+		t.Setenv("WPMGR_ENV", *env)
+	}
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Auth.SessionSecret != secret {
+		t.Fatalf("Auth.SessionSecret = %q, want the value from the environment %q", cfg.Auth.SessionSecret, secret)
+	}
+	return cfg
+}
+
+func strptr(s string) *string { return &s }
+
+// TestLoadRefusesPublishedSessionSecret is the core guard, driven end to end
+// from the environment.
+//
+// WPMGR_ENV is deliberately ABSENT, because that is the exact state of a
+// self-hosted install: neither infra/docker-compose.yml nor
+// infra/docker-compose.prod.yml sets it, so defaults() supplies "development"
+// and IsProduction() is false. A production-only check would pass this case
+// silently, which is why this one is not production-only.
+func TestLoadRefusesPublishedSessionSecret(t *testing.T) {
+	cfg := loadWithEnv(t, publishedSecret, nil)
+
+	err := cfg.ValidateSessionSecret()
+	if err == nil {
+		t.Fatal("ValidateSessionSecret() = nil for a session secret published in the public repo; the api would boot on it")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "WPMGR_SESSION_SECRET") {
+		t.Errorf("error does not name the variable an operator has to change: %q", msg)
+	}
+	if !strings.Contains(msg, "published") {
+		t.Errorf("error does not say the secret is published, so it reads like a malformed-value complaint: %q", msg)
+	}
+	if !strings.Contains(msg, "openssl rand -base64 48") {
+		t.Errorf("error does not tell the operator how to generate a replacement: %q", msg)
+	}
+	// The message is the deliverable for an operator staring at a stopped
+	// container, so keep it visible in `go test -v`.
+	t.Logf("operator sees: %s", msg)
+
+	// The aggregate surface must agree; it is the one main uses to decide
+	// whether to park in serveDegraded.
+	issues := Validate(cfg)
+	var found *Issue
+	for i := range issues {
+		if issues[i].Name == "WPMGR_SESSION_SECRET" {
+			found = &issues[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("Validate() reported no WPMGR_SESSION_SECRET issue; the boot gate would let the published secret through even though ValidateSessionSecret refuses it")
+	}
+	if !strings.Contains(found.Reason, "published") {
+		t.Errorf("Validate() reason does not identify the secret as published: %q", found.Reason)
+	}
+}
+
+// TestLoadRefusesPublishedSessionSecretInProduction covers the explicit
+// production declaration.
+func TestLoadRefusesPublishedSessionSecretInProduction(t *testing.T) {
+	cfg := loadWithEnv(t, publishedSecret, strptr("production"))
+	if err := cfg.ValidateSessionSecret(); err == nil {
+		t.Fatal("ValidateSessionSecret() = nil with WPMGR_ENV=production and a published secret")
+	}
+}
+
+// TestLoadRefusesPublishedSessionSecretWhenEnvIsPresentButEmpty is the
+// absence-coerced-into-a-plausible-value case for the exemption itself.
+// WPMGR_ENV= (present, empty) is the ordinary output of WPMGR_ENV=${SOMETHING}
+// with SOMETHING unset. It is not a declaration of development and must not
+// unlock the published secret.
+func TestLoadRefusesPublishedSessionSecretWhenEnvIsPresentButEmpty(t *testing.T) {
+	cfg := loadWithEnv(t, publishedSecret, strptr(""))
+	if err := cfg.ValidateSessionSecret(); err == nil {
+		t.Fatal("ValidateSessionSecret() = nil with an empty WPMGR_ENV; an unset-and-interpolated variable must not read as a development declaration")
+	}
+}
+
+// TestLoadAllowsPublishedSessionSecretInDeclaredDevelopment is the OVER-FIRE
+// proof, at the env layer.
+//
+// infra/docker-compose.dev.yml sets WPMGR_ENV=development explicitly and does
+// NOT set WPMGR_SESSION_SECRET, so a zero-config `make dev` inherits the
+// published fallback from the base compose file. If this test fails, `make dev`
+// cannot boot, and a guard that breaks local development gets deleted.
+//
+// It must still be loud: the advisory is what keeps the exempted state visible.
+func TestLoadAllowsPublishedSessionSecretInDeclaredDevelopment(t *testing.T) {
+	for _, env := range []string{"development", "dev", "local", "test", "Development"} {
+		t.Run(env, func(t *testing.T) {
+			cfg := loadWithEnv(t, publishedSecret, strptr(env))
+			if err := cfg.ValidateSessionSecret(); err != nil {
+				t.Fatalf("ValidateSessionSecret() = %v with WPMGR_ENV=%s; zero-config local development must still boot", err, env)
+			}
+			for _, is := range Validate(cfg) {
+				if is.Name == "WPMGR_SESSION_SECRET" {
+					t.Fatalf("Validate() returned a boot-blocking issue in declared development: %+v", is)
+				}
+			}
+			var advised bool
+			for _, is := range Advisories(cfg) {
+				if is.Name == "WPMGR_SESSION_SECRET" && strings.Contains(is.Reason, "published") {
+					advised = true
+				}
+			}
+			if !advised {
+				t.Error("Advisories() said nothing about running on a published session secret; the exemption would be completely silent")
+			}
+		})
+	}
+}
+
+// TestPublishedSessionSecretSpellings proves the match is on key material, not
+// on one exact string. An operator who re-encoded the same bytes, whose tooling
+// dropped the padding, or who pasted the decoded plaintext holds a value that is
+// just as public as the original.
+func TestPublishedSessionSecretSpellings(t *testing.T) {
+	decoded, err := base64.StdEncoding.DecodeString(publishedSecret)
+	if err != nil {
+		t.Fatalf("the denylist entry is not valid std base64: %v", err)
+	}
+	spellings := map[string]string{
+		"as published":           publishedSecret,
+		"unpadded std":           base64.RawStdEncoding.EncodeToString(decoded),
+		"url alphabet":           base64.URLEncoding.EncodeToString(decoded),
+		"unpadded url alphabet":  base64.RawURLEncoding.EncodeToString(decoded),
+		"decoded plaintext":      string(decoded),
+		"trailing newline":       publishedSecret + "\n",
+		"surrounding whitespace": "  " + publishedSecret + "  ",
+		"plaintext with newline": string(decoded) + "\n",
+	}
+	for name, secret := range spellings {
+		t.Run(name, func(t *testing.T) {
+			cfg := loadWithEnv(t, secret, nil)
+			if err := cfg.ValidateSessionSecret(); err == nil {
+				t.Fatalf("ValidateSessionSecret() = nil for the published key material spelled as %s", name)
+			}
+		})
+	}
+}
+
+// TestPublishedSessionSecretDoesNotOverFire is the other half of the guard: a
+// check that reddens correct configurations gets switched off. Every value here
+// is a legitimate secret and must boot with WPMGR_ENV absent.
+func TestPublishedSessionSecretDoesNotOverFire(t *testing.T) {
+	legitimate := map[string]string{
+		// The shape `openssl rand -base64 48` produces.
+		"random base64":    "9f8Ck2mVQr7tYxLpN3sHwZbA6dJeR1uOiG5kTvXyM0qPcFnB4aSlEhWjD2gZrUt8",
+		"random raw bytes": strings.Repeat("Xq7", 16),
+		"exactly 32 bytes": strings.Repeat("a", 32),
+		"passphrase style": "correct-horse-battery-staple-and-then-some-more-entropy",
+		// Decodes cleanly as base64 but to entirely different bytes: proves the
+		// decoded comparison matches key material rather than "looks like base64".
+		"other valid base64": base64.StdEncoding.EncodeToString([]byte(strings.Repeat("not-the-published-value-", 3))),
+	}
+	for name, secret := range legitimate {
+		t.Run(name, func(t *testing.T) {
+			cfg := loadWithEnv(t, secret, nil)
+			if err := cfg.ValidateSessionSecret(); err != nil {
+				t.Fatalf("ValidateSessionSecret() = %v for a legitimate secret (%s); this guard would block correct configurations", err, name)
+			}
+			for _, is := range Validate(cfg) {
+				if is.Name == "WPMGR_SESSION_SECRET" {
+					t.Fatalf("Validate() flagged a legitimate secret (%s): %+v", name, is)
+				}
+			}
+			for _, is := range Advisories(cfg) {
+				if is.Name == "WPMGR_SESSION_SECRET" {
+					t.Fatalf("Advisories() warned about a legitimate secret (%s): %+v", name, is)
+				}
+			}
+		})
+	}
+}
+
+// TestExplicitDevelopmentEnvRequiresPresence pins the exemption's core property
+// directly: absence is never a declaration.
+func TestExplicitDevelopmentEnvRequiresPresence(t *testing.T) {
+	unsetEnv(t, "WPMGR_ENV")
+	if explicitDevelopmentEnv() {
+		t.Fatal("explicitDevelopmentEnv() = true with WPMGR_ENV unset; the default-to-development merge would exempt every unlabelled install")
+	}
+	t.Setenv("WPMGR_ENV", "development")
+	if !explicitDevelopmentEnv() {
+		t.Fatal("explicitDevelopmentEnv() = false with WPMGR_ENV=development; make dev cannot boot")
+	}
+	t.Setenv("WPMGR_ENV", "staging")
+	if explicitDevelopmentEnv() {
+		t.Fatal("explicitDevelopmentEnv() = true for staging")
+	}
+}

--- a/apps/api/internal/config/validate.go
+++ b/apps/api/internal/config/validate.go
@@ -103,6 +103,14 @@ func Validate(cfg Config) []Issue {
 			Name:   "WPMGR_SESSION_SECRET",
 			Reason: "still holds the placeholder value — set a real random secret of at least 32 bytes",
 		})
+	// Ordered ahead of the length case to match ValidateSessionSecret: a
+	// published secret is long and well-formed, and "public" is the more useful
+	// diagnosis than "short" whenever both could apply.
+	case publishedSessionSecretRefusal(s) != "":
+		issues = append(issues, Issue{
+			Name:   "WPMGR_SESSION_SECRET",
+			Reason: publishedSessionSecretRefusal(s),
+		})
 	case len(s) < 32:
 		issues = append(issues, Issue{
 			Name:   "WPMGR_SESSION_SECRET",
@@ -187,6 +195,17 @@ func Validate(cfg Config) []Issue {
 // provider.
 func Advisories(cfg Config) []Issue {
 	issues := validateSocialConfig(cfg)
+
+	// The declared-development half of the published-session-secret check. That
+	// case boots on purpose (see publishedSessionSecretRefusal), so this is what
+	// stops it being silent: the developer is told on every boot, and the state
+	// cannot quietly follow a copied compose file into a real deployment.
+	if reason := publishedSessionSecretAdvisory(cfg.Auth.SessionSecret); reason != "" {
+		issues = append(issues, Issue{
+			Name:   "WPMGR_SESSION_SECRET",
+			Reason: reason,
+		})
+	}
 
 	// The public base URL is checked here rather than inside the social
 	// validator, because it is not a social question. The derived redirect_uri


### PR DESCRIPTION
Adds a boot-time denylist to `WPMGR_SESSION_SECRET` validation.

## Why

The variable was checked for emptiness, a `change-me` prefix and a 32-byte minimum. A value that is well-formed but not actually confidential satisfies all three, so the control plane booted on it without complaint. This closes that gap independently of how the value reached the process.

## What

- `apps/api/internal/config/published_secrets.go` (new) — the denylist, the matcher, and the exemption rule, each with its reasoning in the file.
- Wired into both existing surfaces: `Config.ValidateSessionSecret` (the hard boot gate in `cmd/wpmgr/main.go`) and `config.Validate` (the aggregate gate that parks the server in `serveDegraded`). Ordered ahead of the length check, so an operator is told the value is not confidential rather than that it is short.
- `Advisories` reports the one exempted case, so it is never silent.

Matching is on key material, not one exact string: the same bytes under a different base64 alphabet, without padding, with surrounding whitespace, or pasted in decoded form are all refused.

## The production-only question

`ValidateAgentSigningKey` gates its equivalent denylist on `IsProduction()`. That shape is wrong here. Nothing in the compose files sets `WPMGR_ENV`, so `defaults()` supplies `development` and an install that never declared an environment reads as non-production — precisely the deployments the check exists for. The refusal is therefore universal, and the exemption is an explicit `WPMGR_ENV=development`. **Absence never exempts**, and neither does any near-miss label: `dev`, `local`, `test`, `staging` and the empty string are all refused, with tests pinning each.

## Over-fire

`infra/docker-compose.dev.yml` supplies both the fallback secret and `WPMGR_ENV: development`, so a zero-config `make dev` is exempted and still boots — with a boot-time advisory. A guard that breaks `make dev` gets switched off, and then it guards nothing.

Measured with `docker compose ... config`, with the local `.env` moved aside so the render reflects a fresh operator rather than this machine:

| stack | `WPMGR_ENV` | `WPMGR_SESSION_SECRET` | result |
|---|---|---|---|
| base only (`make up`) | absent | **absent** | operator's own value is honoured |
| base + dev overlay (`make dev`) | `development` | fallback constant | exempted, boots, advisory |

## Residual, updated after #586

An earlier revision of this description flagged that an operator who copied `.env.example` would be advised rather than refused, since that file ships `WPMGR_ENV=development`. #586 moved the fallback secret out of the base compose file into the dev overlay, so that operator no longer receives the published constant from compose at all — confirmed by the render above, where the base stack now sets neither variable.

What remains for this layer is the case the check was written for: an operator who upgrades the api image while keeping an older compose file, or who copied the constant into their own `.env` or secret manager. If they never declared an environment they are refused. The one gap left is the narrow combination of `WPMGR_ENV=development` **and** a separately-carried published constant, which is advised rather than refused — deliberately, since that is indistinguishable from a developer's machine.

## Tests

Driven through `config.Load("")` from the process environment rather than by handing the validator a Go string, so they exercise `mapEnvKey`, the koanf merge and the defaults layer — the path an operator's value actually takes. Covers the refusal, explicit production, the present-but-empty `WPMGR_ENV`, the near-miss labels, the alternate spellings, the dev exemption plus its advisory, and five legitimate secrets that must not be flagged.

Red/green executed twice: once for the refusal (disabled → guard tests fail and the constant validates clean) and once for the narrowing (aliases restored → the near-miss test fails on exactly `dev`, `local` and `test`). Restored, all pass.

`go build ./...`, `go vet ./...` and `go test ./internal/... ./cmd/...` all pass (suite exit 0). No RLS, tenancy, email or object-storage path is touched, so `make test-integration` is not implicated.

## Coordination

Rebased onto `81647caa` (post-#586). #584 also edits `internal/config/config.go` and `internal/config/validate.go`; measured with `git merge-tree --write-tree`, it reports **no conflicts** — the new logic lives in its own file specifically to keep the import blocks and `Load` off the shared surface.