### PR TITLE
feat(mcp): serve RFC 8414 and RFC 9728 OAuth discovery documents

### DIFF
--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -548,6 +548,12 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// registration rate limiter, so there is no assembly order that mounts the
 	// unauthenticated /register endpoint unlimited.
 	mcpOAuthH := mcp.NewHandler(mcpSvc)
+	// The discovery half. The issuer is DERIVED from cfg.PublicBaseURL and is
+	// never a constant: a self-hosted install has a different origin, and a
+	// document naming the wrong host sends clients somewhere real and wrong.
+	// An unset or unparseable value makes both documents answer 503 naming
+	// WPMGR_PUBLIC_BASE_URL rather than emit a plausible-looking lie.
+	mcpDiscoveryH := mcp.NewDiscoveryHandler(cfg.PublicBaseURL)
 
 	// A narrow tenant-creation capability handed to the auth domain (bootstrap +
 	// OIDC first-login) without coupling it to the tenant package internals.
@@ -2828,6 +2834,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 		SiteEventsH:      siteEventsH,
 		MCPTransportH:    mcpTransportH,
 		MCPOAuthH:        mcpOAuthH,
+		MCPDiscoveryH:    mcpDiscoveryH,
 		FilesH:           filesH,
 		UpdateH:          updateH,
 		BackupH:          backupH,

--- a/apps/api/internal/mcp/discovery.go
+++ b/apps/api/internal/mcp/discovery.go
@@ -1,0 +1,281 @@
+package mcp
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ---------------------------------------------------------------------------
+// Mounted paths — the single source of truth
+// ---------------------------------------------------------------------------
+
+// APIV1Prefix is the group the OAuth endpoints are mounted under. server.New
+// passes exactly engine.Group(APIV1Prefix) to Handler.RegisterPublic and
+// derives the operator group from the same prefix, so the constants below are
+// the paths that actually exist rather than a second description of them.
+//
+// THE POINT OF THESE CONSTANTS IS THAT THE DISCOVERY DOCUMENT CANNOT DRIFT
+// FROM THE ROUTER. A discovery document is a promise a client acts on without
+// ever seeing this repository: it opens a browser at authorization_endpoint
+// and posts to token_endpoint. A hand-written list here that fell one rename
+// behind the router would send every GUI client to a 404 at handshake time,
+// which is a failure the server never observes and the user cannot diagnose.
+// Both halves now read the same constants, and TestAdvertisedEndpointsAreMounted
+// walks the real gin route table to prove it.
+const APIV1Prefix = "/api/v1"
+
+// oauthGroupPath is the group Handler.RegisterPublic and Handler.Register open
+// under APIV1Prefix. Kept unexported: callers mount by calling those methods,
+// never by rebuilding the path.
+const oauthGroupPath = "/oauth/mcp"
+
+// The four OAuth paths, absolute, exactly as mounted.
+const (
+	RegisterPath  = APIV1Prefix + oauthGroupPath + "/register"
+	AuthorizePath = APIV1Prefix + oauthGroupPath + "/authorize"
+	TokenPath     = APIV1Prefix + oauthGroupPath + "/token"
+	ConsentPath   = APIV1Prefix + oauthGroupPath + "/consent"
+)
+
+// The two discovery paths, mounted on the ROOT engine.
+//
+// WellKnownProtectedResourceMCPPath is the RFC 9728 section 3.1 path-insertion
+// form for a resource whose identifier carries a path: an MCP endpoint at
+// https://host/mcp advertises its metadata at
+// https://host/.well-known/oauth-protected-resource/mcp. The MCP specification
+// (revision 2025-11-25, "Protected Resource Metadata Discovery Requirements")
+// has clients try that form FIRST and fall back to the root form, so BOTH are
+// served and both return the same document. Serving only the root form works
+// but costs every client an extra 404 on its first connection.
+const (
+	WellKnownAuthorizationServerPath  = "/.well-known/oauth-authorization-server"
+	WellKnownProtectedResourcePath    = "/.well-known/oauth-protected-resource"
+	WellKnownProtectedResourceMCPPath = WellKnownProtectedResourcePath + TransportPath
+)
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// DiscoveryHandler serves the two unauthenticated OAuth discovery documents a
+// GUI client fetches to find this server's authorization endpoints:
+//
+//   - RFC 8414 authorization server metadata, which the MCP revision floor
+//     (2025-03-26) requires a client to fetch at the ROOT of the origin hosting
+//     the MCP endpoint, with any path component of the MCP URL discarded;
+//   - RFC 9728 protected resource metadata, which revision 2025-11-25 made
+//     mandatory for MCP servers ("MCP servers MUST implement OAuth 2.0
+//     Protected Resource Metadata") and which points at the authorization
+//     server via authorization_servers.
+//
+// Both revisions are served at once because the two documents answer different
+// questions and a client of either revision finds what it looks for.
+type DiscoveryHandler struct {
+	// issuer is the ORIGIN of the configured public base URL: scheme, host and
+	// port, with no path. RFC 8414 section 3.3 requires the advertised issuer
+	// to be the exact prefix the well-known URI was built from, and this
+	// handler is mounted at the root of the origin.
+	issuer string
+	// base is the configured public base URL with any trailing slash removed.
+	// Endpoint URLs are built from it rather than from issuer so that a
+	// sub-path install still names reachable endpoints.
+	base string
+	// unusableReason is non-empty when the configured base URL was absent or
+	// could not be parsed into an origin. Both documents then answer 503 and
+	// name the variable to set.
+	//
+	// THE ABSENT CASE IS THE WHOLE REASON THIS FIELD EXISTS. Falling back to a
+	// constant issuer, to the request's own Host header, or to a relative URL
+	// would all produce a document that parses, validates and sends the client
+	// to somewhere real and wrong: a self-hosted install would hand out
+	// https://app.wpmgr.app as its own issuer, and the operator would see a
+	// client fail against someone else's server. A missing origin is an
+	// absence, and the answer to an absence is a refusal that names it.
+	unusableReason string
+}
+
+// NewDiscoveryHandler derives the issuer from configuration.
+//
+// publicBaseURL is cfg.PublicBaseURL (WPMGR_PUBLIC_BASE_URL), the one typed
+// value every outward-facing URL in this product is built from. It is NOT a
+// constant and NOT the request Host header: the Host header is attacker
+// controlled behind a proxy that does not pin it, and a constant is wrong for
+// every self-hosted install.
+func NewDiscoveryHandler(publicBaseURL string) *DiscoveryHandler {
+	raw := strings.TrimSpace(publicBaseURL)
+	if raw == "" {
+		return &DiscoveryHandler{
+			unusableReason: "WPMGR_PUBLIC_BASE_URL is not configured, so this server cannot state its own issuer",
+		}
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return &DiscoveryHandler{
+			unusableReason: "WPMGR_PUBLIC_BASE_URL is not an absolute http(s) URL, so this server cannot state its own issuer",
+		}
+	}
+	return &DiscoveryHandler{
+		issuer: u.Scheme + "://" + u.Host,
+		base:   u.Scheme + "://" + u.Host + strings.TrimSuffix(u.Path, "/"),
+	}
+}
+
+// Register mounts the discovery documents on the ROOT engine, unauthenticated.
+//
+// Unauthenticated is not a relaxation: a client fetches these BEFORE it holds
+// any credential — discovering how to get one is the entire purpose — and both
+// documents contain only this server's own public endpoint URLs and the
+// closed scope vocabulary. There is nothing here a caller could not learn by
+// reading the connect screen.
+func (h *DiscoveryHandler) Register(r gin.IRouter) {
+	wk := r.Group("/.well-known")
+
+	for _, p := range []string{
+		strings.TrimPrefix(WellKnownAuthorizationServerPath, "/.well-known"),
+	} {
+		wk.GET(p, h.authorizationServerMetadata)
+		wk.HEAD(p, h.authorizationServerMetadata)
+		wk.OPTIONS(p, h.preflight)
+		methodNotAllowedExcept(wk, p, http.MethodGet, http.MethodHead, http.MethodOptions)
+	}
+
+	for _, p := range []string{
+		strings.TrimPrefix(WellKnownProtectedResourcePath, "/.well-known"),
+		strings.TrimPrefix(WellKnownProtectedResourceMCPPath, "/.well-known"),
+	} {
+		wk.GET(p, h.protectedResourceMetadata)
+		wk.HEAD(p, h.protectedResourceMetadata)
+		wk.OPTIONS(p, h.preflight)
+		methodNotAllowedExcept(wk, p, http.MethodGet, http.MethodHead, http.MethodOptions)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Documents
+// ---------------------------------------------------------------------------
+
+// authorizationServerMetadataDTO is RFC 8414 section 2. Every field is one this
+// server actually implements; there is deliberately no jwks_uri (the connection
+// token is opaque and nothing here signs a JWT), no revocation_endpoint and no
+// introspection_endpoint, because neither is mounted and advertising an
+// unmounted endpoint is the drift this file exists to prevent.
+type authorizationServerMetadataDTO struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+}
+
+// protectedResourceMetadataDTO is RFC 9728 section 2.
+type protectedResourceMetadataDTO struct {
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers"`
+	ScopesSupported        []string `json:"scopes_supported"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported"`
+	ResourceName           string   `json:"resource_name"`
+}
+
+// AuthorizationServerMetadata builds the RFC 8414 document. Exported so the
+// drift test can compare it against the live route table without going through
+// HTTP first.
+func (h *DiscoveryHandler) AuthorizationServerMetadata() authorizationServerMetadataDTO {
+	return authorizationServerMetadataDTO{
+		Issuer:                h.issuer,
+		AuthorizationEndpoint: h.base + AuthorizePath,
+		TokenEndpoint:         h.base + TokenPath,
+		RegistrationEndpoint:  h.base + RegisterPath,
+		// Read from the same values Service.Authorize and Service.Exchange
+		// compare against. A second literal here is how a server comes to
+		// advertise a grant it refuses.
+		ResponseTypesSupported: SupportedResponseTypes(),
+		GrantTypesSupported:    SupportedGrantTypes(),
+		// S256 ONLY, and "plain" is deliberately absent — it is absent from the
+		// schema's closed set and Service.Authorize refuses it. Advertising it
+		// would be a lie a client acts on: it would send a plain challenge, get
+		// refused at /authorize, and have no way to learn why.
+		CodeChallengeMethodsSupported:     SupportedCodeChallengeMethods(),
+		TokenEndpointAuthMethodsSupported: SupportedTokenEndpointAuthMethods(),
+		// From the closed registry in scope.go, never a literal. S7's exit gate
+		// is that discovery never names authority the registry does not hold.
+		ScopesSupported: SupportedScopes(),
+	}
+}
+
+// ProtectedResourceMetadata builds the RFC 9728 document.
+func (h *DiscoveryHandler) ProtectedResourceMetadata() protectedResourceMetadataDTO {
+	return protectedResourceMetadataDTO{
+		// The canonical URI of this MCP server, per the MCP specification's
+		// "Canonical Server URI": the endpoint clients actually POST to.
+		Resource: h.base + TransportPath,
+		// This control plane is its own authorization server.
+		AuthorizationServers: []string{h.issuer},
+		ScopesSupported:      SupportedScopes(),
+		// TransportHandler.bearerToken reads the Authorization header and
+		// nothing else — no form field, no query parameter. Access tokens in a
+		// query string are forbidden by the MCP specification and this server
+		// would not read one anyway.
+		BearerMethodsSupported: []string{"header"},
+		ResourceName:           "WPMgr MCP",
+	}
+}
+
+func (h *DiscoveryHandler) authorizationServerMetadata(c *gin.Context) {
+	if h.refuseWhenUnconfigured(c) {
+		return
+	}
+	h.writeJSON(c, h.AuthorizationServerMetadata())
+}
+
+func (h *DiscoveryHandler) protectedResourceMetadata(c *gin.Context) {
+	if h.refuseWhenUnconfigured(c) {
+		return
+	}
+	h.writeJSON(c, h.ProtectedResourceMetadata())
+}
+
+// refuseWhenUnconfigured answers 503 when the origin is unknown, and reports
+// whether it answered.
+//
+// 503 rather than 404: 404 reads as "this server does not do OAuth", which
+// would send a client down the 2025-03-26 fallback path of guessing /authorize,
+// /token and /register at the origin root — endpoints that do not exist here.
+// 503 with a named variable tells the operator what to set.
+func (h *DiscoveryHandler) refuseWhenUnconfigured(c *gin.Context) bool {
+	if h.unusableReason == "" {
+		return false
+	}
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.JSON(http.StatusServiceUnavailable, oauthErrorDTO{
+		Err:     "server_error",
+		ErrDesc: h.unusableReason,
+	})
+	return true
+}
+
+// writeJSON emits the document with the content type RFC 8414 section 3.2 and
+// RFC 9728 section 3.2 both require.
+//
+// Access-Control-Allow-Origin is "*" because a browser-hosted MCP client
+// fetches these cross-origin before it holds any credential. It is safe here
+// and only here: the response carries no credential, no cookie is read on this
+// route (it is mounted on the root engine, outside the session group), and
+// Allow-Credentials is deliberately NOT set, so a browser will not attach one.
+func (h *DiscoveryHandler) writeJSON(c *gin.Context, doc any) {
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.JSON(http.StatusOK, doc)
+}
+
+func (h *DiscoveryHandler) preflight(c *gin.Context) {
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.Header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+	c.Header("Access-Control-Allow-Headers", "Authorization, "+ProtocolHeader)
+	c.Status(http.StatusNoContent)
+}

--- a/apps/api/internal/mcp/discovery_test.go
+++ b/apps/api/internal/mcp/discovery_test.go
@@ -1,0 +1,442 @@
+package mcp
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+const testBaseURL = "https://manage.example.com"
+
+// mountedEngine builds a gin engine with the MCP surface mounted EXACTLY as
+// internal/server/server.go mounts it.
+//
+// The three call sites it mirrors, so a reader can check the correspondence by
+// hand: server.go's `deps.MCPOAuthH.RegisterPublic(engine.Group(mcp.APIV1Prefix))`,
+// `deps.MCPOAuthH.Register(v1)` where v1 is `sessionAuthGroup.Group(mcp.APIV1Prefix)`,
+// and `deps.MCPTransportH.Register(engine)`. The session middleware on v1 is
+// irrelevant here: this test asks whether a ROUTE EXISTS, not whether it lets
+// an anonymous caller through.
+func mountedEngine(t *testing.T, withOAuth bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+
+	svc := NewService(nil)
+	if withOAuth {
+		oauthH := NewHandler(svc)
+		oauthH.RegisterPublic(engine.Group(APIV1Prefix))
+		oauthH.Register(engine.Group(APIV1Prefix))
+		NewTransportHandler(svc, slog.New(slog.DiscardHandler), "test").Register(engine)
+	}
+	NewDiscoveryHandler(testBaseURL).Register(engine)
+	return engine
+}
+
+func getDoc(t *testing.T, engine *gin.Engine, path string) (*http.Response, []byte) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	res := rec.Result()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	_ = res.Body.Close()
+	return res, body
+}
+
+// advertisedEndpoint is one promise the discovery documents make.
+type advertisedEndpoint struct {
+	field  string
+	rawURL string
+	method string
+}
+
+// unmountedAdvertisements returns one message per advertised endpoint that is
+// NOT actually served by engine. Empty means every promise is kept.
+//
+// It is a helper rather than a body of t.Errorf calls so the negative control
+// below can assert that it FINDS something when the routes are missing. A check
+// that has never been seen to fail is not known to check anything.
+func unmountedAdvertisements(engine *gin.Engine, endpoints []advertisedEndpoint) []string {
+	routes := engine.Routes()
+	var problems []string
+	for _, ep := range endpoints {
+		u, err := url.Parse(ep.rawURL)
+		if err != nil {
+			problems = append(problems, ep.field+" is not a URL: "+ep.rawURL)
+			continue
+		}
+		mounted := slices.ContainsFunc(routes, func(r gin.RouteInfo) bool {
+			return r.Path == u.Path && r.Method == ep.method
+		})
+		if !mounted {
+			problems = append(problems,
+				ep.field+" advertises "+ep.method+" "+u.Path+" but no such route is mounted")
+		}
+	}
+	return problems
+}
+
+// documentedEndpoints reads the two live documents and returns every endpoint
+// they promise, with the HTTP method a client will use against it.
+func documentedEndpoints(t *testing.T, engine *gin.Engine) []advertisedEndpoint {
+	t.Helper()
+
+	_, asBody := getDoc(t, engine, WellKnownAuthorizationServerPath)
+	var as authorizationServerMetadataDTO
+	if err := json.Unmarshal(asBody, &as); err != nil {
+		t.Fatalf("authorization server metadata is not JSON: %v (%s)", err, asBody)
+	}
+	_, prBody := getDoc(t, engine, WellKnownProtectedResourcePath)
+	var pr protectedResourceMetadataDTO
+	if err := json.Unmarshal(prBody, &pr); err != nil {
+		t.Fatalf("protected resource metadata is not JSON: %v (%s)", err, prBody)
+	}
+
+	return []advertisedEndpoint{
+		// A client opens a browser here. RFC 6749 section 3.1: GET.
+		{"authorization_endpoint", as.AuthorizationEndpoint, http.MethodGet},
+		// RFC 6749 section 3.2: the token endpoint is POST.
+		{"token_endpoint", as.TokenEndpoint, http.MethodPost},
+		// RFC 7591 section 3.1: registration is POST.
+		{"registration_endpoint", as.RegistrationEndpoint, http.MethodPost},
+		// RFC 9728's `resource` is the MCP endpoint itself, which this
+		// server serves over POST (Streamable HTTP, no SSE in phase 1).
+		{"resource", pr.Resource, http.MethodPost},
+	}
+}
+
+// TestAdvertisedEndpointsAreMounted is THE pin.
+//
+// Drift between a discovery document and the router is silent: nothing in this
+// process ever fetches its own metadata, so a renamed route leaves a document
+// that still parses, still validates against its RFC, and sends every GUI
+// client to a 404 at handshake time — the one moment nobody is watching a log.
+// This walks the real gin route table and fails on the rename, in the same test
+// run that made it.
+func TestAdvertisedEndpointsAreMounted(t *testing.T) {
+	engine := mountedEngine(t, true)
+	endpoints := documentedEndpoints(t, engine)
+	if len(endpoints) == 0 {
+		t.Fatal("no endpoints were advertised; the documents are empty and this test would pass vacuously")
+	}
+	for _, problem := range unmountedAdvertisements(engine, endpoints) {
+		t.Error(problem)
+	}
+}
+
+// TestAdvertisedEndpointsCheckFiresWhenRoutesAreMissing is the other half:
+// proof the check above can fail. The engine here serves the discovery
+// documents and mounts NONE of the endpoints they name, which is exactly the
+// production shape the load balancer hides — a document served, its endpoints
+// unreachable.
+func TestAdvertisedEndpointsCheckFiresWhenRoutesAreMissing(t *testing.T) {
+	engine := mountedEngine(t, false)
+	endpoints := documentedEndpoints(t, engine)
+	problems := unmountedAdvertisements(engine, endpoints)
+	if len(problems) != len(endpoints) {
+		t.Fatalf("expected all %d advertised endpoints to be reported unmounted, got %d: %v",
+			len(endpoints), len(problems), problems)
+	}
+}
+
+// TestAdvertisedURLsAreAbsoluteAndOnTheConfiguredOrigin catches the other way a
+// document sends a client somewhere wrong: a relative URL, or an origin that is
+// not the one configured. Both are "an absence coerced into a plausible value".
+func TestAdvertisedURLsAreAbsoluteAndOnTheConfiguredOrigin(t *testing.T) {
+	engine := mountedEngine(t, true)
+	for _, ep := range documentedEndpoints(t, engine) {
+		if !strings.HasPrefix(ep.rawURL, testBaseURL+"/") {
+			t.Errorf("%s = %q; want an absolute URL on the configured origin %s",
+				ep.field, ep.rawURL, testBaseURL)
+		}
+	}
+}
+
+// TestIssuerIsDerivedFromConfiguration pins that the issuer follows the
+// configured origin rather than a constant. A self-hosted install must never
+// see this project's own hostname in its own metadata.
+func TestIssuerIsDerivedFromConfiguration(t *testing.T) {
+	for _, base := range []string{
+		"https://manage.example.com",
+		"https://selfhost.internal:8443",
+		"http://localhost:8080",
+	} {
+		doc := NewDiscoveryHandler(base).AuthorizationServerMetadata()
+		if doc.Issuer != base {
+			t.Errorf("NewDiscoveryHandler(%q).Issuer = %q; want %q", base, doc.Issuer, base)
+		}
+		prDoc := NewDiscoveryHandler(base).ProtectedResourceMetadata()
+		if len(prDoc.AuthorizationServers) != 1 || prDoc.AuthorizationServers[0] != base {
+			t.Errorf("NewDiscoveryHandler(%q).AuthorizationServers = %v; want [%q]",
+				base, prDoc.AuthorizationServers, base)
+		}
+		if want := base + TransportPath; prDoc.Resource != want {
+			t.Errorf("NewDiscoveryHandler(%q).Resource = %q; want %q", base, prDoc.Resource, want)
+		}
+	}
+}
+
+// TestDiscoveryRefusesWhenOriginIsUnconfigured is the absence case.
+//
+// An unset WPMGR_PUBLIC_BASE_URL must NOT produce a document naming a fallback
+// host, a relative path or an empty issuer. A client cannot tell a wrong issuer
+// from a right one, so the only safe answer is a refusal that names the
+// variable.
+func TestDiscoveryRefusesWhenOriginIsUnconfigured(t *testing.T) {
+	for _, base := range []string{"", "   ", "manage.example.com", "/wpmgr", "ftp://manage.example.com"} {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		NewDiscoveryHandler(base).Register(engine)
+
+		for _, path := range []string{
+			WellKnownAuthorizationServerPath,
+			WellKnownProtectedResourcePath,
+			WellKnownProtectedResourceMCPPath,
+		} {
+			res, body := getDoc(t, engine, path)
+			if res.StatusCode != http.StatusServiceUnavailable {
+				t.Errorf("base %q, GET %s = %d; want 503", base, path, res.StatusCode)
+			}
+			if !strings.Contains(string(body), "WPMGR_PUBLIC_BASE_URL") {
+				t.Errorf("base %q, GET %s body %s; want it to name WPMGR_PUBLIC_BASE_URL", base, path, body)
+			}
+			if strings.Contains(string(body), "wpmgr.app") {
+				t.Errorf("base %q, GET %s leaked a fallback host: %s", base, path, body)
+			}
+		}
+	}
+}
+
+// TestDiscoveryVocabularyMatchesTheValidators is the anti-copy test.
+//
+// For each OAuth vocabulary the documents advertise, it drives the validator
+// the request path actually runs with every neighbouring value and asserts:
+// advertised ⟺ accepted. A hand-copied list that gained "plain", or a validator
+// that quietly started accepting one, fails here.
+func TestDiscoveryVocabularyMatchesTheValidators(t *testing.T) {
+	doc := NewDiscoveryHandler(testBaseURL).AuthorizationServerMetadata()
+
+	cases := []struct {
+		name       string
+		advertised []string
+		candidates []string
+		accepts    func(string) error
+	}{
+		{
+			name:       "code_challenge_methods_supported",
+			advertised: doc.CodeChallengeMethodsSupported,
+			// "plain" is the one that matters: RFC 7636 defines it, this
+			// server refuses it, and advertising it would have clients send
+			// a challenge that is rejected at /authorize with no way to
+			// learn why.
+			candidates: []string{"S256", "plain", "s256", "S512", ""},
+			accepts:    validateCodeChallengeMethod,
+		},
+		{
+			name:       "response_types_supported",
+			advertised: doc.ResponseTypesSupported,
+			candidates: []string{"code", "token", "id_token", "code id_token", ""},
+			accepts:    validateResponseType,
+		},
+		{
+			name:       "grant_types_supported",
+			advertised: doc.GrantTypesSupported,
+			// refresh_token is the notable absence: nothing here mints one.
+			candidates: []string{"authorization_code", "refresh_token", "client_credentials", "implicit", ""},
+			accepts:    validateGrantType,
+		},
+		{
+			name:       "token_endpoint_auth_methods_supported",
+			advertised: doc.TokenEndpointAuthMethodsSupported,
+			candidates: []string{"none", "client_secret_basic", "client_secret_post", "client_secret_jwt", "private_key_jwt", ""},
+			accepts:    validateTokenEndpointAuthMethod,
+		},
+	}
+
+	for _, tc := range cases {
+		if len(tc.advertised) == 0 {
+			t.Errorf("%s is empty; a client reading this document learns nothing and, for PKCE, MUST refuse to proceed", tc.name)
+		}
+		for _, candidate := range tc.candidates {
+			advertised := slices.Contains(tc.advertised, candidate)
+			accepted := tc.accepts(candidate) == nil
+			if advertised != accepted {
+				t.Errorf("%s: %q advertised=%v but the validator accepts=%v; the document and the code disagree",
+					tc.name, candidate, advertised, accepted)
+			}
+		}
+	}
+}
+
+// TestScopesComeFromTheRegistryNotALiteral pins S7's exit gate one layer out:
+// discovery must never name authority the closed registry in scope.go does not
+// hold.
+func TestScopesComeFromTheRegistryNotALiteral(t *testing.T) {
+	registry := SupportedScopes()
+	if len(registry) == 0 {
+		t.Fatal("SupportedScopes() is empty; this test would pass vacuously")
+	}
+
+	asDoc := NewDiscoveryHandler(testBaseURL).AuthorizationServerMetadata()
+	prDoc := NewDiscoveryHandler(testBaseURL).ProtectedResourceMetadata()
+
+	if !slices.Equal(asDoc.ScopesSupported, registry) {
+		t.Errorf("authorization server scopes_supported = %v; registry = %v", asDoc.ScopesSupported, registry)
+	}
+	if !slices.Equal(prDoc.ScopesSupported, registry) {
+		t.Errorf("protected resource scopes_supported = %v; registry = %v", prDoc.ScopesSupported, registry)
+	}
+
+	// Every advertised scope must survive the parser the /authorize endpoint
+	// runs. Advertising a scope that endpoint refuses is the same lie as
+	// advertising an unmounted endpoint.
+	for _, s := range asDoc.ScopesSupported {
+		if _, err := ParseRequestedScopes(s); err != nil {
+			t.Errorf("advertised scope %q is refused by ParseRequestedScopes: %v", s, err)
+		}
+	}
+	// And the whole advertised set requested at once must be accepted, which is
+	// what a client following the MCP scope-selection strategy sends.
+	if _, err := ParseRequestedScopes(strings.Join(asDoc.ScopesSupported, " ")); err != nil {
+		t.Errorf("the full advertised scope set is refused by ParseRequestedScopes: %v", err)
+	}
+	// Negative control: a scope the document does not name is refused.
+	if _, err := ParseRequestedScopes("mcp:write"); err == nil {
+		t.Error("ParseRequestedScopes accepted an unadvertised scope; the registry is not closed")
+	}
+}
+
+// TestProtectedResourceMetadataServedAtBothWellKnownPaths covers the MCP
+// 2025-11-25 discovery order: a client tries the RFC 9728 path-insertion form
+// for the MCP endpoint's path FIRST, then falls back to the root form. Serving
+// only one costs every client a 404 on its first connection.
+func TestProtectedResourceMetadataServedAtBothWellKnownPaths(t *testing.T) {
+	engine := mountedEngine(t, true)
+
+	if want := "/.well-known/oauth-protected-resource/mcp"; WellKnownProtectedResourceMCPPath != want {
+		t.Fatalf("path-insertion form = %q; want %q (RFC 9728 section 3.1 over the MCP endpoint path %q)",
+			WellKnownProtectedResourceMCPPath, want, TransportPath)
+	}
+
+	_, rootBody := getDoc(t, engine, WellKnownProtectedResourcePath)
+	res, insertedBody := getDoc(t, engine, WellKnownProtectedResourceMCPPath)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d; want 200", WellKnownProtectedResourceMCPPath, res.StatusCode)
+	}
+	if string(rootBody) != string(insertedBody) {
+		t.Errorf("the two protected-resource paths return different documents:\nroot: %s\ninserted: %s",
+			rootBody, insertedBody)
+	}
+}
+
+// TestDiscoveryDocumentsAreUnauthenticatedJSON pins the two properties the
+// production trap hides. The load balancer hands unrouted paths to the SPA,
+// which answers 200 with text/html for everything, so a 200 proves nothing:
+// the content type and a parseable body are the only evidence the route exists.
+func TestDiscoveryDocumentsAreUnauthenticatedJSON(t *testing.T) {
+	engine := mountedEngine(t, true)
+
+	for _, path := range []string{
+		WellKnownAuthorizationServerPath,
+		WellKnownProtectedResourcePath,
+		WellKnownProtectedResourceMCPPath,
+	} {
+		// No Authorization header, no cookie: exactly what a client sends
+		// before it holds any credential.
+		res, body := getDoc(t, engine, path)
+		if res.StatusCode != http.StatusOK {
+			t.Errorf("GET %s = %d; want 200 with no credential presented", path, res.StatusCode)
+		}
+		if ct := res.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+			t.Errorf("GET %s Content-Type = %q; want application/json", path, ct)
+		}
+		if res.Header.Get("Access-Control-Allow-Origin") != "*" {
+			t.Errorf("GET %s has no permissive CORS header; a browser-hosted client cannot read it", path)
+		}
+		if res.Header.Get("Access-Control-Allow-Credentials") != "" {
+			t.Errorf("GET %s sets Access-Control-Allow-Credentials; these documents must never be fetched with a cookie", path)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(body, &doc); err != nil {
+			t.Errorf("GET %s did not return a JSON object: %v (%s)", path, err, body)
+		}
+	}
+}
+
+// TestRequiredDiscoveryFieldsArePresent checks the fields each RFC makes
+// REQUIRED, and that none of them is an empty string wearing the shape of a
+// value.
+func TestRequiredDiscoveryFieldsArePresent(t *testing.T) {
+	engine := mountedEngine(t, true)
+
+	_, asBody := getDoc(t, engine, WellKnownAuthorizationServerPath)
+	var as map[string]any
+	if err := json.Unmarshal(asBody, &as); err != nil {
+		t.Fatalf("authorization server metadata: %v", err)
+	}
+	// RFC 8414 section 2: issuer, authorization_endpoint, token_endpoint and
+	// response_types_supported are REQUIRED. jwks_uri is deliberately absent —
+	// the connection token is opaque and nothing here signs a JWT.
+	for _, field := range []string{"issuer", "authorization_endpoint", "token_endpoint", "response_types_supported"} {
+		if v, ok := as[field]; !ok || v == "" {
+			t.Errorf("authorization server metadata is missing required field %q", field)
+		}
+	}
+	if _, ok := as["jwks_uri"]; ok {
+		t.Error("authorization server metadata advertises jwks_uri, but nothing here serves one")
+	}
+
+	_, prBody := getDoc(t, engine, WellKnownProtectedResourcePath)
+	var pr map[string]any
+	if err := json.Unmarshal(prBody, &pr); err != nil {
+		t.Fatalf("protected resource metadata: %v", err)
+	}
+	// RFC 9728 section 2 makes `resource` REQUIRED; the MCP specification
+	// additionally requires authorization_servers to name at least one.
+	if v, ok := pr["resource"]; !ok || v == "" {
+		t.Error("protected resource metadata is missing required field \"resource\"")
+	}
+	servers, ok := pr["authorization_servers"].([]any)
+	if !ok || len(servers) == 0 {
+		t.Error("protected resource metadata must name at least one authorization server")
+	}
+}
+
+// TestDiscoveryPathsAnswer405NotFoundForOtherVerbs keeps the house rule: a
+// wrong verb must never read as "not deployed".
+func TestDiscoveryPathsAnswer405NotFoundForOtherVerbs(t *testing.T) {
+	engine := mountedEngine(t, true)
+
+	for _, path := range []string{
+		WellKnownAuthorizationServerPath,
+		WellKnownProtectedResourcePath,
+		WellKnownProtectedResourceMCPPath,
+	} {
+		for _, verb := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+			req := httptest.NewRequest(verb, path, nil)
+			rec := httptest.NewRecorder()
+			engine.ServeHTTP(rec, req)
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s %s = %d; want 405", verb, path, rec.Code)
+			}
+		}
+		req := httptest.NewRequest(http.MethodOptions, path, nil)
+		rec := httptest.NewRecorder()
+		engine.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("OPTIONS %s = %d; want 204 preflight", path, rec.Code)
+		}
+	}
+}

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -68,7 +68,9 @@ const maxOAuthBodyBytes = 16 << 10
 // /authorize answering 405 for every verb including its own. server.New mounts
 // both from one Deps field, which is what keeps that unreachable.
 func (h *Handler) RegisterPublic(r *gin.RouterGroup) {
-	g := r.Group("/oauth/mcp")
+	// oauthGroupPath, not a literal: discovery.go advertises the absolute form
+	// of these paths and both halves must read the same constant.
+	g := r.Group(oauthGroupPath)
 	g.POST("/register", h.register)
 	g.POST("/token", h.token)
 
@@ -86,7 +88,7 @@ func (h *Handler) RegisterPublic(r *gin.RouterGroup) {
 // handlers below re-check the principal anyway, because a handler that trusts
 // its mount point is one refactor away from being anonymous.
 func (h *Handler) Register(r *gin.RouterGroup) {
-	g := r.Group("/oauth/mcp")
+	g := r.Group(oauthGroupPath)
 	g.GET("/authorize", h.authorize)
 	g.POST("/consent", h.consent)
 }

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -46,6 +47,98 @@ const (
 	// reads as "nothing to do" is how a scoping bug becomes invisible.
 	ErrCodeScopeEmpty = "mcp_scope_empty"
 )
+
+// The OAuth vocabulary this server implements, named once.
+//
+// THE VALIDATORS BELOW COMPARE AGAINST THESE, AND discovery.go ADVERTISES
+// THESE. That is the entire point: a discovery document is a promise, and the
+// way a server comes to advertise a grant type or a PKCE method it refuses is
+// by keeping two lists that agree on the day they are written. There is one
+// list, and TestDiscoveryVocabularyMatchesTheValidators drives the validators
+// with every plausible neighbouring value to prove the list is the set the code
+// actually accepts.
+const (
+	// ResponseTypeCode is the only response_type Service.Authorize accepts.
+	ResponseTypeCode = "code"
+	// GrantTypeAuthorizationCode is the only grant_type Service.Exchange
+	// accepts. There is no refresh_token grant: the connection token's lifetime
+	// is the connection's, and nothing here mints a refresh token.
+	GrantTypeAuthorizationCode = "authorization_code"
+	// CodeChallengeMethodS256 is the only PKCE method accepted, at /authorize
+	// and again at /token. "plain" is deliberately absent here, absent from the
+	// schema's closed set, and must stay absent from the discovery document.
+	CodeChallengeMethodS256 = "S256"
+	// TokenEndpointAuthMethodNone is the no-secret PKCE-only client type. It
+	// must be asked for explicitly; RFC 7591's default is the restrictive one.
+	TokenEndpointAuthMethodNone = "none"
+)
+
+// supportedTokenEndpointAuthMethods is the closed set Register accepts, in the
+// order the discovery document advertises them.
+var supportedTokenEndpointAuthMethods = []string{
+	TokenEndpointAuthMethodNone,
+	"client_secret_basic",
+	"client_secret_post",
+}
+
+// SupportedResponseTypes reports the response_type values Service.Authorize
+// accepts.
+func SupportedResponseTypes() []string { return []string{ResponseTypeCode} }
+
+// SupportedGrantTypes reports the grant_type values Service.Exchange accepts.
+func SupportedGrantTypes() []string { return []string{GrantTypeAuthorizationCode} }
+
+// SupportedCodeChallengeMethods reports the PKCE methods this server accepts.
+//
+// RFC 8414 section 2 makes this field how a client learns PKCE is available at
+// all, and the MCP specification has clients REFUSE to proceed when it is
+// absent. It must therefore be present and it must be exactly true.
+func SupportedCodeChallengeMethods() []string { return []string{CodeChallengeMethodS256} }
+
+// SupportedTokenEndpointAuthMethods reports the client authentication methods
+// Service.Register accepts.
+func SupportedTokenEndpointAuthMethods() []string {
+	return append([]string(nil), supportedTokenEndpointAuthMethods...)
+}
+
+// validateCodeChallengeMethod is the one place a PKCE method is judged at
+// authorization time. Extracted from Authorize so the discovery test can drive
+// it directly with every neighbouring value ("plain", "s256", "") and assert
+// the advertised list is exactly the set it accepts.
+func validateCodeChallengeMethod(method string) error {
+	if method != CodeChallengeMethodS256 {
+		return domain.Validation(ErrCodeInvalidRequest,
+			"code_challenge_method must be '"+CodeChallengeMethodS256+"'")
+	}
+	return nil
+}
+
+// validateResponseType and validateGrantType exist for the same reason.
+func validateResponseType(responseType string) error {
+	if responseType != ResponseTypeCode {
+		return domain.Validation(ErrCodeUnsupportedResponse,
+			"response_type must be '"+ResponseTypeCode+"'")
+	}
+	return nil
+}
+
+func validateGrantType(grantType string) error {
+	if grantType != GrantTypeAuthorizationCode {
+		return domain.Validation(ErrCodeInvalidRequest,
+			"grant_type must be '"+GrantTypeAuthorizationCode+"'")
+	}
+	return nil
+}
+
+// validateTokenEndpointAuthMethod judges a registration's requested client
+// authentication method against the closed set above.
+func validateTokenEndpointAuthMethod(method string) error {
+	if !slices.Contains(supportedTokenEndpointAuthMethods, method) {
+		return domain.Validation(ErrCodeRegistrationInvalid,
+			fmt.Sprintf("token_endpoint_auth_method %q is not supported", method))
+	}
+	return nil
+}
 
 // Clock is injectable so expiry behaviour is testable without sleeping.
 type Clock func() time.Time
@@ -121,11 +214,8 @@ func (s *Service) Register(ctx context.Context, req RegistrationRequest) (Regist
 	if method == "" {
 		method = "client_secret_basic"
 	}
-	switch method {
-	case "none", "client_secret_basic", "client_secret_post":
-	default:
-		return RegisteredClient{}, domain.Validation(ErrCodeRegistrationInvalid,
-			fmt.Sprintf("token_endpoint_auth_method %q is not supported", method))
+	if err := validateTokenEndpointAuthMethod(method); err != nil {
+		return RegisteredClient{}, err
 	}
 
 	clientID, err := randomToken(24)
@@ -274,9 +364,8 @@ type ConsentContext struct {
 // screen must render. It mints NOTHING: no grant and no code exist until a
 // human approves, which is what makes consent the authorization.
 func (s *Service) Authorize(ctx context.Context, req AuthorizeRequest) (ConsentContext, error) {
-	if req.ResponseType != "code" {
-		return ConsentContext{}, domain.Validation(ErrCodeUnsupportedResponse,
-			"response_type must be 'code'")
+	if err := validateResponseType(req.ResponseType); err != nil {
+		return ConsentContext{}, err
 	}
 	if strings.TrimSpace(req.ClientID) == "" {
 		return ConsentContext{}, domain.Validation(ErrCodeInvalidRequest, "client_id is required")
@@ -290,9 +379,8 @@ func (s *Service) Authorize(ctx context.Context, req AuthorizeRequest) (ConsentC
 		return ConsentContext{}, domain.Validation(ErrCodeInvalidRequest,
 			"code_challenge is required; this server requires PKCE")
 	}
-	if req.CodeChallengeMethod != "S256" {
-		return ConsentContext{}, domain.Validation(ErrCodeInvalidRequest,
-			"code_challenge_method must be 'S256'")
+	if err := validateCodeChallengeMethod(req.CodeChallengeMethod); err != nil {
+		return ConsentContext{}, err
 	}
 
 	// THE EXIT GATE. A client requesting no recognised scope is refused here,
@@ -391,7 +479,7 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 	if err := ValidateSiteScopeRequest(req.SiteScope); err != nil {
 		return Approval{}, err
 	}
-	if req.Consent.CodeChallengeMethod != "S256" || strings.TrimSpace(req.Consent.CodeChallenge) == "" {
+	if req.Consent.CodeChallengeMethod != CodeChallengeMethodS256 || strings.TrimSpace(req.Consent.CodeChallenge) == "" {
 		return Approval{}, domain.Validation(ErrCodeInvalidRequest,
 			"the approved request carries no S256 PKCE challenge")
 	}
@@ -515,9 +603,8 @@ type IssuedToken struct {
 // own transaction, and ONLY IF that consume actually wrote is a token minted.
 // A zero-row consume is a refusal, never a shrug.
 func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, error) {
-	if req.GrantType != "authorization_code" {
-		return IssuedToken{}, domain.Validation(ErrCodeInvalidRequest,
-			"grant_type must be 'authorization_code'")
+	if err := validateGrantType(req.GrantType); err != nil {
+		return IssuedToken{}, err
 	}
 	if strings.TrimSpace(req.Code) == "" {
 		return IssuedToken{}, domain.Validation(ErrCodeInvalidRequest, "code is required")
@@ -648,7 +735,7 @@ func (s *Service) Exchange(ctx context.Context, req TokenRequest) (IssuedToken, 
 	}
 
 	// 4. PKCE. S256 only, constant-time.
-	if row.CodeChallengeMethod != "S256" {
+	if row.CodeChallengeMethod != CodeChallengeMethodS256 {
 		return IssuedToken{}, domain.Unauthorized(ErrCodeInvalidGrant,
 			"the authorization code carries an unsupported challenge method")
 	}

--- a/apps/api/internal/server/server.go
+++ b/apps/api/internal/server/server.go
@@ -266,6 +266,20 @@ type Deps struct {
 	// unmounted route answers 404, which hides a wiring failure behind
 	// something that reads as a deliberate refusal.
 	MCPOAuthH *mcp.Handler
+	// MCPDiscoveryH serves the two unauthenticated OAuth discovery documents:
+	// GET /.well-known/oauth-authorization-server (RFC 8414) and GET
+	// /.well-known/oauth-protected-resource (RFC 9728), the second also at its
+	// RFC 9728 path-insertion form /.well-known/oauth-protected-resource/mcp.
+	//
+	// REQUIRED, mounted unconditionally, for a reason specific to these paths:
+	// an unmounted well-known path does not 404 in production. The load
+	// balancer hands anything its API rule does not match to the SPA, which
+	// answers 200 with text/html for every path, so a missing document
+	// presents as a document that exists and is unparseable. "It returns 200"
+	// therefore proves nothing about this route; only the content type and the
+	// body do. Adding these paths to the load balancer's API rule is a
+	// deployment step that has no representation in this repository.
+	MCPDiscoveryH *mcp.DiscoveryHandler
 	// BillingSuspensionGate is the M16 Phase C1 superadmin hard-lockout
 	// middleware (billing.Service.SuspensionGate) mounted on the tenant-scoped
 	// v1 group. nil ⇒ WPMGR_HOSTED is off; self-host never sees this check
@@ -462,7 +476,17 @@ func New(deps Deps) *Server {
 	// bounded by the two-layer limiter and body cap in
 	// internal/mcp/register_limit.go. Read that file before changing this.
 	if deps.MCPOAuthH != nil {
-		deps.MCPOAuthH.RegisterPublic(engine.Group("/api/v1"))
+		deps.MCPOAuthH.RegisterPublic(engine.Group(mcp.APIV1Prefix))
+	}
+
+	// S7 — the OAuth discovery documents, unauthenticated, on the ROOT engine.
+	//
+	// A GUI client (Claude Desktop, ChatGPT) has no field in which to be told
+	// where to authorize: it fetches a well-known document or it cannot
+	// complete the handshake. These must not sit behind the session group —
+	// they are fetched before any credential exists, which is the point.
+	if deps.MCPDiscoveryH != nil {
+		deps.MCPDiscoveryH.Register(engine)
 	}
 
 	// Agent-authenticated endpoints: the agent authenticator verifies an Ed25519
@@ -542,7 +566,7 @@ func New(deps Deps) *Server {
 	// Everything under /api/v1 requires session load + authentication + an active
 	// tenant; finer per-route RBAC is applied by each handler.
 	// Derive from sessionAuthGroup so session + auth middlewares are inherited.
-	v1 := sessionAuthGroup.Group("/api/v1")
+	v1 := sessionAuthGroup.Group(mcp.APIV1Prefix)
 	v1.Use(authz.RequireAuth(), authz.RequireTenant())
 	// M16 Phase C1 — superadmin hard-lockout: 402 {code:"account_suspended"}
 	// for a suspended tenant's requests, EXCEPT its own /billing/* routes (so


### PR DESCRIPTION
## Why

`0.61.147` is live and the MCP OAuth flow works end to end, but neither discovery document existed. Claude Desktop and ChatGPT have no field in which to be told where to authorize — they fetch a well-known document or the handshake cannot start.

Both paths already returned **HTTP 200** in production. That was the load balancer handing unrouted paths to the SPA, which answers `text/html` for everything. A 200 was evidence of nothing; only the content type and a parseable body are.

## What

Unauthenticated, on the root engine:

| Path | RFC |
|---|---|
| `GET /.well-known/oauth-authorization-server` | RFC 8414 |
| `GET /.well-known/oauth-protected-resource` | RFC 9728 |
| `GET /.well-known/oauth-protected-resource/mcp` | RFC 9728 §3.1 path insertion |

The third exists because MCP revision 2025-11-25 has clients try the path-inserted form **first** and fall back to the root form. Serving only the root costs every client a 404 on its first connection. Our floor of 2025-03-26 wants RFC 8414 at the origin root with the MCP URL's path discarded, which is the first row; both revisions are satisfied at once.

## The defect class this had to avoid

- **Issuer** is derived from `cfg.PublicBaseURL`, never a constant. A self-hosted install has a different origin, and a document naming the wrong host sends clients somewhere real and wrong. Unset or unparseable → **503 naming `WPMGR_PUBLIC_BASE_URL`**, not a plausible-looking document. 503 rather than 404 because a 404 sends a 2025-03-26 client down the fallback path of guessing `/authorize`, `/token`, `/register` at the origin root, which do not exist here.
- **Endpoint drift.** The four OAuth paths are now constants that the routers mount from and the documents advertise. They cannot disagree by construction.
- **Copied vocabularies.** `scopes_supported` reads the closed registry in `scope.go`. Response types, grant types, PKCE methods and token-endpoint auth methods are named once, and the request-path validators in `service.go` were refactored to compare against those same values instead of inline literals.
- **PKCE is advertised `S256` only.** `plain` is absent from the document because `Service.Authorize` refuses it. Advertising it would be a lie a client acts on.
- Nothing unmounted is advertised: no `jwks_uri` (the connection token is opaque), no `revocation_endpoint`, no `introspection_endpoint`, no `refresh_token` grant.

## The pin that matters

`TestAdvertisedEndpointsAreMounted` fetches both live documents, parses out every advertised URL, and walks the **real gin route table** asserting each path is mounted with the method a client will use. Drift here is otherwise silent — nothing in the process fetches its own metadata, so a renamed route leaves a document that still validates and 404s at handshake time.

Proof it fires (route renamed `/authorize` → `/authorise`, then restored):

```
--- FAIL: TestAdvertisedEndpointsAreMounted (0.00s)
    discovery_test.go:135: authorization_endpoint advertises GET /api/v1/oauth/mcp/authorize but no such route is mounted
```

`TestAdvertisedEndpointsCheckFiresWhenRoutesAreMissing` keeps that proof in the suite: it mounts the documents with none of their endpoints and requires every advertised endpoint to be reported.

## Checks

`cd apps/api`, each unpiped:

- `go build ./...` — clean (one pre-existing `ld:` alignment warning from `cmd/media-encoder`)
- `go vet ./...` — clean, no output
- `go test ./internal/... ./cmd/...` — all packages ok

## Deployment step, not in this repo

The url-map's API rule needs `/.well-known/*` (or the three exact paths) added, alongside the existing `/api/*`, `/mcp`, `/agent/*`, … Without it these keep reaching the SPA and the 200/text/html trap stays exactly as it is today.

## Not merging yet

`security-reviewer` pass pending — this is a new unauthenticated public surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth and protected-resource discovery endpoints for MCP integrations.
  * Discovery metadata now advertises supported authorization flows, scopes, and security methods.
  * Added support for standard `.well-known` paths with unauthenticated access, CORS, and JSON responses.

* **Bug Fixes**
  * Discovery endpoints now return a clear service-unavailable response when the public URL is missing or invalid.
  * Standardized OAuth route configuration to keep advertised and mounted endpoints aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->