### PR TITLE
infra(urlmap): commit the LB url-map and gate route coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,45 @@ jobs:
         # can infer from a path.
         run: go test $(go list ./... | grep -Ev -e '/cmd/media-encoder' -e '/internal/media/encoder' -e '/apps/api/tests($|/)') ./tests/contract/...
 
+      # ---- Load-balancer route coverage -------------------------------------
+      # Twice in one day a route shipped, deployed, and was unreachable: the API
+      # mounted it and the url-map did not route it, so it fell through to the
+      # matcher default and the web SPA answered it. POST /mcp was the first;
+      # the OAuth discovery documents from #589 were about to be the second.
+      #
+      # Both failures return 200 text/html, so no status-code check after the
+      # deploy can see them — something answered, it was just the wrong
+      # something. This guard reads the route list out of the REAL Gin engine
+      # (apps/api/cmd/dump-routes, which mounts EVERY optional Deps handler) and
+      # proves each path has a rule in infra/urlmap.yaml pointing at the API
+      # backend. It needs no cloud credentials, which is the entire point of it
+      # running here: on every PR, before the deploy, instead of being something
+      # someone remembers to curl afterwards.
+      #
+      # It lives in this job rather than `security` because it needs the Go
+      # toolchain to build the engine, and this is the job that already has it
+      # set up and cached. The `security` job's setup-go comes after its guard
+      # steps, so the same two steps there would run on whatever Go the runner
+      # happened to ship.
+      #
+      # The live-versus-committed drift check is deliberately NOT in CI. It
+      # needs gcloud credentials, so wiring it in would gate the half that
+      # matters behind the half that cannot run on a fork PR. It is
+      # `make check-urlmap-drift`, run before an apply.
+      #
+      # Self-test FIRST, so a guard broken into failing open cannot pass by
+      # reporting success over its own errors.
+      - name: URL-map route coverage guard self-test
+        working-directory: ${{ github.workspace }}
+        run: scripts/check-urlmap-routes_test.sh
+
+      - name: URL-map route coverage guard (every mounted API route has a path rule)
+        working-directory: ${{ github.workspace }}
+        env:
+          GOWORK: "off"
+          CGO_ENABLED: "0"
+        run: scripts/check-urlmap-routes.sh
+
   # ---- JS / web ----
   js:
     name: JS (web)
@@ -422,6 +461,7 @@ jobs:
 
       - name: Version surface guard (openapi, changelog page, badge, agent, install pins)
         run: scripts/check-version-surfaces.sh
+
 
       # ---- License surfaces --------------------------------------------------
       # GH #547: the agent declared MIT in its plugin header and GPLv2 or later

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,27 @@ check-versions: ## Check every version-naming surface (docs, marketing, agent)
 check-versions-test: ## Run the version surface guard's regression suite
 	scripts/check-version-surfaces_test.sh
 
+# The load-balancer url-map. Twice in one day a route shipped, deployed and was
+# unreachable because the API mounted it and the LB did not route it — POST
+# /mcp, then very nearly the OAuth discovery documents. Both answer 200
+# text/html from the web SPA, so no status-code smoke test can see them.
+# check-urlmap proves every mounted route has a path rule and needs NO cloud
+# credentials, which is why it is the one wired into ci.yml. check-urlmap-drift
+# compares the committed file against live GCP and does need credentials, so it
+# is a separate target and not a CI gate. check-urlmap-test is the guard's own
+# regression suite; run it after editing the guard.
+.PHONY: check-urlmap
+check-urlmap: ## Check every API route is routed by infra/urlmap.yaml (no cloud access)
+	scripts/check-urlmap-routes.sh
+
+.PHONY: check-urlmap-test
+check-urlmap-test: ## Run the url-map route-coverage guard's regression suite
+	scripts/check-urlmap-routes_test.sh
+
+.PHONY: check-urlmap-drift
+check-urlmap-drift: ## Compare infra/urlmap.yaml against the live GCP url-map (needs gcloud)
+	scripts/check-urlmap-drift.sh
+
 # GH #547: the agent declared MIT in its plugin header and GPLv2 or later in
 # the wp.org readme.txt at the same time. This reconciles every place in
 # apps/agent (plus the repo-root LICENSE-AGENT carve-out) that names the

--- a/apps/api/cmd/dump-routes/main.go
+++ b/apps/api/cmd/dump-routes/main.go
@@ -1,0 +1,63 @@
+// Command dump-routes prints the COMPLETE production HTTP route surface of
+// the API, one route per line, sorted, in "METHOD\tPATH" form (gin's :param
+// syntax normalised to OpenAPI's {param} form).
+//
+// Why this exists: tests/contract/openapi_route_coverage_test.go's
+// buildFullEngine builds the real engine via server.New but leaves several
+// optional server.Deps fields nil (MCPDiscoveryH, MCPOAuthH, MCPTransportH,
+// BillingSuspensionGate were the ones found on inspection). server.New guards
+// every optional field with "if deps.X != nil" before registering its
+// routes, so those routes are silently ABSENT from engine.Routes() — the
+// contract test still passes because its allowlist never has to mention a
+// route it never sees. A coverage gate built on that engine would report
+// "fully covered" while the routes it can't see stay unmounted-in-the-gate's-
+// eyes even though they are live in production.
+//
+// This command builds the same real engine, through the same server.New,
+// but with every optional Deps field populated by a real or
+// minimal-but-non-nil handler (see routes.go's buildEngine), so no
+// nil-handler guard can hide a route from the dump.
+//
+// Usage (from apps/api, or any dir — it's a plain Go command):
+//
+//	go run ./cmd/dump-routes
+//
+// Output contract:
+//   - stdout carries ONLY "METHOD\tPATH" route lines, sorted, nothing else —
+//     safe to pipe directly into another tool.
+//   - any diagnostic (a Deps field that could not be populated, a build
+//     failure) goes to stderr, never stdout.
+//   - exit code is non-zero, with a stderr message, if the engine fails to
+//     build OR the route count is zero. An empty dump is always an error,
+//     never a silent empty success.
+//
+// No database connection and no network call is made: buildEngine constructs
+// every service against an empty, unconnected *db.Pool and this command only
+// ever reads engine.Routes().
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	engine, omitted, err := buildEngine()
+	for _, field := range omitted {
+		fmt.Fprintf(os.Stderr, "dump-routes: server.Deps.%s is nil — its route(s) are NOT in this dump\n", field)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dump-routes: failed to build engine:", err)
+		os.Exit(1)
+	}
+
+	lines := dumpRoutes(engine)
+	if len(lines) == 0 {
+		fmt.Fprintln(os.Stderr, "dump-routes: engine built but registered zero routes — this is always a bug, never treat it as a valid empty result")
+		os.Exit(1)
+	}
+
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+}

--- a/apps/api/cmd/dump-routes/main_test.go
+++ b/apps/api/cmd/dump-routes/main_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestBuildEngine_NoBlindSpotRoutes is the regression test for the defect
+// this command exists to fix: tests/contract/openapi_route_coverage_test.go's
+// buildFullEngine left MCPDiscoveryH (and, on closer inspection while
+// building this command, MCPTransportH, MCPOAuthH and
+// BillingSuspensionGate) nil, so server.New's "if deps.X != nil" guards
+// silently dropped their routes from engine.Routes(). A url-map coverage
+// gate built on that engine would report full coverage while these routes
+// stayed invisible to it.
+//
+// This test asserts the dump contains exactly the routes that nil-handler
+// blind spot hid, plus the two system routes, so a future change that
+// re-introduces a nil optional field here (or removes one of these routes'
+// registration) is caught here rather than discovered as a live 404.
+func TestBuildEngine_NoBlindSpotRoutes(t *testing.T) {
+	engine, omitted, err := buildEngine()
+	if err != nil {
+		t.Fatalf("buildEngine: %v", err)
+	}
+	if len(omitted) > 0 {
+		t.Errorf("buildEngine left %d server.Deps field(s) nil, so their routes are NOT in this dump: %v", len(omitted), omitted)
+	}
+
+	lines := dumpRoutes(engine)
+	set := make(map[string]bool, len(lines))
+	for _, l := range lines {
+		set[l] = true
+	}
+
+	required := []string{
+		"GET\t/.well-known/oauth-authorization-server",
+		"GET\t/.well-known/oauth-protected-resource",
+		"GET\t/.well-known/oauth-protected-resource/mcp",
+		"POST\t/mcp",
+		"GET\t/healthz",
+		"GET\t/readyz",
+	}
+	for _, r := range required {
+		if !set[r] {
+			t.Errorf("required route missing from dump: %q", r)
+		}
+	}
+}
+
+// TestDumpRoutes_NonEmpty guards against the empty-dump failure mode
+// specifically: an engine that builds without error but yields zero routes
+// must never be mistaken for "nothing to report" by a consumer.
+func TestDumpRoutes_NonEmpty(t *testing.T) {
+	engine, _, err := buildEngine()
+	if err != nil {
+		t.Fatalf("buildEngine: %v", err)
+	}
+	lines := dumpRoutes(engine)
+	if len(lines) == 0 {
+		t.Fatal("dumpRoutes returned zero routes for a successfully built engine — this must never happen")
+	}
+}
+
+// TestDumpRoutes_RouteCountRegression is a loud tripwire on the total route
+// count: a route count that drops is exactly the kind of silent regression
+// (a handler dropped from server.Deps, a Register call deleted) this command
+// exists to make visible. minRoutes is a floor, not an exact match — deliberately
+// generous — so the test fails loudly on a real drop instead of needing a
+// hand-maintained exact count that drifts on every legitimate addition (see
+// CLAUDE.md's "never hard-code a count" rule: this asserts a floor, not the
+// literal count, for that reason).
+func TestDumpRoutes_RouteCountRegression(t *testing.T) {
+	engine, _, err := buildEngine()
+	if err != nil {
+		t.Fatalf("buildEngine: %v", err)
+	}
+	lines := dumpRoutes(engine)
+
+	const minRoutes = 300 // measured at 442 when this test was written; see routes.go's buildEngine
+	if len(lines) < minRoutes {
+		t.Errorf("route count regression: got %d routes, want at least %d — a handler likely dropped out of server.Deps or lost its Register call", len(lines), minRoutes)
+	}
+}
+
+// TestDumpRoutes_SortedAndDeduped locks in the output contract a consumer
+// gate relies on: sorted, stable, no duplicate lines.
+func TestDumpRoutes_SortedAndDeduped(t *testing.T) {
+	engine, _, err := buildEngine()
+	if err != nil {
+		t.Fatalf("buildEngine: %v", err)
+	}
+	lines := dumpRoutes(engine)
+
+	if !sort.StringsAreSorted(lines) {
+		t.Error("dumpRoutes output is not sorted")
+	}
+	seen := map[string]bool{}
+	for _, l := range lines {
+		if seen[l] {
+			t.Errorf("duplicate route line in dump: %q", l)
+		}
+		seen[l] = true
+	}
+}
+
+// TestNormalizeGinPath pins the :param -> {param} rewrite the dump relies on
+// to match OpenAPI's path syntax.
+func TestNormalizeGinPath(t *testing.T) {
+	cases := map[string]string{
+		"/api/v1/sites/:siteId":                   "/api/v1/sites/{siteId}",
+		"/api/v1/sites/:siteId/backups/:backupId": "/api/v1/sites/{siteId}/backups/{backupId}",
+		"/healthz":                              "/healthz",
+		"/.well-known/oauth-protected-resource": "/.well-known/oauth-protected-resource",
+	}
+	for in, want := range cases {
+		if got := normalizeGinPath(in); got != want {
+			t.Errorf("normalizeGinPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/apps/api/cmd/dump-routes/routes.go
+++ b/apps/api/cmd/dump-routes/routes.go
@@ -1,0 +1,397 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"regexp"
+	"sort"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/activity"
+	"github.com/mosamlife/wpmgr/apps/api/internal/admin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agent"
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentrelease"
+	"github.com/mosamlife/wpmgr/apps/api/internal/apikey"
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/auth"
+	"github.com/mosamlife/wpmgr/apps/api/internal/autologin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/backup"
+	"github.com/mosamlife/wpmgr/apps/api/internal/billing"
+	clientpkg "github.com/mosamlife/wpmgr/apps/api/internal/client"
+	"github.com/mosamlife/wpmgr/apps/api/internal/config"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/diagnostics"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/email"
+	"github.com/mosamlife/wpmgr/apps/api/internal/files"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
+	"github.com/mosamlife/wpmgr/apps/api/internal/invitation"
+	"github.com/mosamlife/wpmgr/apps/api/internal/loginbrand"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	mediahandler "github.com/mosamlife/wpmgr/apps/api/internal/media/handler"
+	mediarepo "github.com/mosamlife/wpmgr/apps/api/internal/media/repo"
+	mediaservice "github.com/mosamlife/wpmgr/apps/api/internal/media/service"
+	"github.com/mosamlife/wpmgr/apps/api/internal/middleware"
+	"github.com/mosamlife/wpmgr/apps/api/internal/objectcache"
+	"github.com/mosamlife/wpmgr/apps/api/internal/org"
+	"github.com/mosamlife/wpmgr/apps/api/internal/perf"
+	"github.com/mosamlife/wpmgr/apps/api/internal/portal"
+	"github.com/mosamlife/wpmgr/apps/api/internal/pricing"
+	reportpkg "github.com/mosamlife/wpmgr/apps/api/internal/report"
+	"github.com/mosamlife/wpmgr/apps/api/internal/rum"
+	"github.com/mosamlife/wpmgr/apps/api/internal/scan"
+	"github.com/mosamlife/wpmgr/apps/api/internal/screenshot"
+	"github.com/mosamlife/wpmgr/apps/api/internal/security"
+	"github.com/mosamlife/wpmgr/apps/api/internal/server"
+	"github.com/mosamlife/wpmgr/apps/api/internal/settings"
+	"github.com/mosamlife/wpmgr/apps/api/internal/sharing"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+	siteevents "github.com/mosamlife/wpmgr/apps/api/internal/site/events"
+	"github.com/mosamlife/wpmgr/apps/api/internal/sitedestination"
+	"github.com/mosamlife/wpmgr/apps/api/internal/sitetag"
+	"github.com/mosamlife/wpmgr/apps/api/internal/tenant"
+	"github.com/mosamlife/wpmgr/apps/api/internal/update"
+	"github.com/mosamlife/wpmgr/apps/api/internal/uptime"
+	"github.com/mosamlife/wpmgr/apps/api/internal/vuln"
+)
+
+// ginParamRe matches a Gin path parameter segment (:name) so it can be
+// rewritten to OpenAPI's {name} form — same normalisation
+// tests/contract/openapi_route_coverage_test.go applies, kept in sync by
+// inspection since this command intentionally shares no code with the test
+// package (see doc.go: that package must never import a cmd, and a cmd must
+// not import a _test.go file).
+var ginParamRe = regexp.MustCompile(`:([A-Za-z0-9_]+)`)
+
+func normalizeGinPath(p string) string {
+	return ginParamRe.ReplaceAllString(p, "{$1}")
+}
+
+// dumpRoutes returns every route mounted on engine, normalised to
+// "METHOD\tPATH" form, deduplicated, and sorted for a stable diff. It applies
+// NO business logic about which routes matter to an API contract — that
+// judgement belongs to whatever consumes this output, not to the dumper.
+func dumpRoutes(engine *gin.Engine) []string {
+	seen := map[string]bool{}
+	var lines []string
+	for _, r := range engine.Routes() {
+		line := r.Method + "\t" + normalizeGinPath(r.Path)
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		lines = append(lines, line)
+	}
+	sort.Strings(lines)
+	return lines
+}
+
+// nilOptionalFields walks server.Deps by reflection and reports the name of
+// every nil-able field (pointer, interface, func, map, slice, chan) left nil.
+// server.New guards each optional field with "if deps.X != nil" before
+// registering its routes, so a nil field here is a silent gap in the dumped
+// route surface. buildEngine populates every field it can without live
+// third-party infrastructure; whatever this returns is exactly the set of
+// routes buildEngine cannot see, and buildEngine's caller is responsible for
+// surfacing it (main.go writes each to stderr).
+func nilOptionalFields(deps server.Deps) []string {
+	v := reflect.ValueOf(deps)
+	t := v.Type()
+	var out []string
+	for i := 0; i < t.NumField(); i++ {
+		f := v.Field(i)
+		switch f.Kind() {
+		case reflect.Ptr, reflect.Interface, reflect.Func, reflect.Map, reflect.Slice, reflect.Chan:
+			if f.IsNil() {
+				out = append(out, t.Field(i).Name)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// buildEngine builds the REAL production Gin engine via server.New, with
+// EVERY optional server.Deps field populated by a real or minimal-but-non-nil
+// handler, so no "if deps.X != nil" guard in server.New can suppress a route
+// from engine.Routes(). It is a deliberate near-duplicate of
+// tests/contract/openapi_route_coverage_test.go's buildFullEngine — kept
+// separate (rather than shared) because that test package must not be
+// imported by a cmd, and this command must not import a _test.go file. Where
+// the two diverge, it is because this command additionally wires
+// MCPTransportH, MCPOAuthH, MCPDiscoveryH and BillingSuspensionGate, which
+// buildFullEngine leaves nil: those four are exactly the fields that hid the
+// PR #589 OAuth-discovery routes and POST /mcp from the coverage test.
+//
+// No Postgres connection and no network call is ever made: every service is
+// constructed against an empty, unconnected *db.Pool, and this function only
+// ever reads engine.Routes() — it never issues a request through the engine.
+func buildEngine() (engine *gin.Engine, omittedDepsFields []string, err error) {
+	// Force release mode BEFORE any gin.New()/route registration: debug mode
+	// makes gin print a "[GIN-debug] METHOD path --> handler" line per route
+	// straight to os.Stdout, which would corrupt the "stdout carries ONLY
+	// route lines" contract this command promises its callers. server.New
+	// only does this itself when deps.Config.IsProduction() is true, which a
+	// zero-value config.Config{} (used below) is not.
+	gin.SetMode(gin.ReleaseMode)
+
+	pool := &db.Pool{}
+	logger := slog.Default()
+	clock := domain.SystemClock{}
+	validator := domain.NewValidator()
+	auditRec := audit.NewRecorder(pool, clock)
+
+	// --- auth / sessions / tenants -------------------------------------------
+	sessions := auth.NewSessionManagerWithStore(scs.New(), false)
+	tenantSvc := tenant.NewService(tenant.NewRepo(pool), validator, clock)
+	newTenant := func(ctx context.Context, name, slug string) (uuid.UUID, error) {
+		tt, err := tenantSvc.Create(ctx, tenant.CreateInput{Name: name, Slug: slug})
+		if err != nil {
+			return uuid.Nil, err
+		}
+		return tt.ID, nil
+	}
+	authRepo := auth.NewRepo(pool)
+	authSvc := auth.NewService(authRepo, auditRec, validator)
+	apiKeySvc := apikey.NewService(pool)
+	authn := middleware.NewAuthenticator(sessions, authSvc, apiKeySvc, pool)
+	oidcProvider := auth.NewOIDCProvider(config.OIDCConfig{})
+	authH := auth.NewHandler(authSvc, sessions, oidcProvider, newTenant)
+
+	siteSvc := site.NewService(site.NewRepo(pool), validator, clock)
+	siteH := site.NewHandler(siteSvc, auditRec, "")
+	siteEventsH := siteevents.NewHandler(pool, siteevents.NewHub())
+
+	// --- agent authentication. resolver/signer are narrow interfaces — nil is
+	// safe because this file only ever calls engine.Routes(), never issues a
+	// real signed request through the agent group, so no method is invoked. ---
+	agentAuthn := agent.NewAuthenticator(nil, clock, 0)
+	agentH := agent.NewHandler(siteSvc)
+
+	// --- org / sharing / invitations -----------------------------------------
+	orgH := org.NewHandler(pool, tenantCreatorAdapter{newTenant}, sessions, authSvc, auditRec)
+	sharingH := sharing.NewHandler(sharing.NewService(pool, authRepo, auditRec, nil, ""))
+	invitationSvc := invitation.NewService(pool, authRepo, auditRec, sessions, nil, "")
+	invitationH := invitation.NewHandler(invitationSvc)
+
+	// --- destinations / diagnostics / activity / security / login-brand ------
+	siteDestH := sitedestination.NewHandler(sitedestination.NewService(sitedestination.NewRepo(pool), nil, logger), auditRec)
+	diagSvc := diagnostics.NewService(diagnostics.NewRepo(pool))
+	diagnosticsH := diagnostics.NewHandler(diagSvc, auditRec)
+	diagnosticsAgentH := agent.NewDiagnosticsHandler(diagSvc)
+	errorsAgentH := agent.NewErrorsHandler(diagSvc)
+	activitySvc := activity.NewService(activity.NewRepo(pool), nil, nil)
+	activityH := activity.NewHandler(activitySvc)
+	activityAgentH := agent.NewActivityHandler(activitySvc)
+	securitySvc := security.NewService(security.NewRepo(pool))
+	securityH := security.NewHandler(securitySvc, auditRec)
+	securityAgentH := agent.NewSecurityLoginEventsHandler(securitySvc)
+	hibpAgentH := agent.NewHIBPHandler(securitySvc)
+	loginBrandH := loginbrand.NewHandler(loginbrand.NewService(loginbrand.NewRepo(pool)), auditRec)
+
+	// --- scans / vulnerabilities ----------------------------------------------
+	scanH := scan.NewHandler(scan.NewService(scan.NewRepo(pool), auditRec))
+	vulnH := vuln.NewHandler(vuln.NewService(vuln.NewRepo(pool), pool, nil, nil, nil, logger), nil, auditRec)
+
+	// --- agent-freshness dashboard (read-only) ---------------------------------
+	agentReleaseH := agentrelease.NewHandler(agentrelease.NewService(agentrelease.NewRepo(pool), agentrelease.NewReader(nil, 0)), false)
+
+	// --- updates ---------------------------------------------------------------
+	updateHub := update.NewHub()
+	updateSvc := update.NewService(update.NewRepo(pool), nil, nil, validator, clock)
+	updateH := update.NewHandler(updateSvc, updateHub, auditRec)
+	updateAgentH := agent.NewUpdateHandler(nil, nil, 0)
+
+	// --- backups -----------------------------------------------------------
+	backupHub := backup.NewHub()
+	backupSvc := backup.NewService(backup.NewRepo(pool), nil, nil, nil, clock, backup.Config{})
+	backupH := backup.NewHandler(backupSvc, backupHub, auditRec)
+	backupAgentH := backup.NewAgentHandler(backupSvc, auditRec)
+	restoreRunH := backup.NewRestoreRunHandler(backupSvc)
+	scheduleRunH := backup.NewScheduleRunHandler(backupSvc)
+	inspectionDeps := backup.InspectionDeps{Logger: logger}
+
+	// --- uptime / autologin ------------------------------------------------
+	uptimeSvc := uptime.NewService(uptime.NewRepo(pool), nil, nil)
+	uptimeH := uptime.NewHandler(uptimeSvc, auditRec)
+	autologinSvc := autologin.NewService(autologin.NewRepo(pool), nil, nil, nil, nil, nil, clock, autologin.Config{})
+	autologinH := autologin.NewMintHandler(autologinSvc)
+	autologinPolicyH := autologin.NewPolicyHandler(autologinSvc)
+	autologinAgentH := autologin.NewAgentHandler(autologinSvc)
+
+	// --- media optimizer -----------------------------------------------------
+	mediaSvc := mediaservice.NewService(mediarepo.NewRepo(pool), nil, nil, auditRec, clock, mediaservice.Config{}, logger)
+	mediaH := mediahandler.NewHandler(mediaSvc)
+	mediaAgentH := mediahandler.NewAgentHandler(mediaSvc)
+
+	// --- performance suite + object cache --------------------------------------
+	perfSvc := perf.NewService(perf.NewRepo(pool), nil, nil, logger)
+	perfH := perf.NewHandler(perfSvc, nil, auditRec)
+	perfAgentH := perf.NewAgentHandler(perfSvc, nil, nil)
+	fontResultsAgentH := perf.NewFontResultsAgentHandler(perf.NewRepo(pool))
+	ocH := objectcache.NewHandler(objectcache.NewService(objectcache.NewRepo(pool), nil, nil, nil, nil), auditRec)
+
+	// --- ADR-064 S4 governed org/site context ----------------------------------
+	govContextRepo := govcontext.NewRepo(pool)
+	govContextH := govcontext.NewHandler(govcontext.NewService(govContextRepo, auditRec, &govcontext.Resolver{Store: govContextRepo}))
+
+	// --- settings / files / screenshots -----------------------------------
+	settingsH := settings.NewHandler(settings.NewService(settings.NewRepo(pool), nil, nil, logger), auditRec)
+	filesH := files.NewHandler(files.NewService(pool), auditRec)
+	screenshotH := screenshot.NewHandler(screenshot.NewService(screenshot.NewRepo(pool), nil, nil, nil), siteGetterAdapter{siteSvc})
+
+	// --- email -----------------------------------------------------------------
+	emailSvc := email.NewService(email.NewRepo(pool), nil, logger)
+	emailH := email.NewHandler(emailSvc, auditRec)
+	emailAgentH := email.NewAgentHandler(emailSvc)
+	emailWebhookH := email.NewWebhookHandler(emailSvc, "", logger)
+	emailAgentSuppressionH := email.NewAgentSuppressionHandler(emailSvc)
+
+	// --- clients / reports / portal / tags -----------------------------------
+	clientSvc := clientpkg.NewService(clientpkg.NewRepo(pool))
+	clientH := clientpkg.NewHandler(clientSvc, auditRec)
+	clientMemberH := clientpkg.NewMemberHandler(pool, authRepo, invitationSvc, auditRec, "")
+	clientH.SetMemberHandler(clientMemberH)
+	reportH := reportpkg.NewHandler(reportpkg.NewService(reportpkg.NewRepo(pool), nil), auditRec)
+	portalH := portal.NewHandler(pool, nil, nil, nil, nil, nil)
+	siteTagSvc := sitetag.NewService(sitetag.NewRepo(pool))
+	siteTagH := sitetag.NewHandler(siteTagSvc, auditRec)
+
+	// --- admin (m33 + vuln-feed) -----------------------------------------------
+	adminH := admin.NewHandler(admin.NewService(admin.NewRepo(pool), nil), pool)
+	adminH.SetAuditRecorder(auditRec)
+	adminH.SetVulnFeed(nil, admin.NewVulnFeedKeyService(admin.NewInstanceSettingsRepo(pool), nil, "", nil, logger))
+	adminH.SetAgentMirror(admin.NewAgentMirrorCheckService(false, false, nil, nil))
+
+	// --- RUM (public) ------------------------------------------------------
+	rumH := rum.NewHandlerWithPublisher(rum.NewStorePostgres(pool), rum.NewBeaconKeyRepo(pool), nil, logger)
+
+	// --- billing / pricing (WPMGR_HOSTED path) -------------------------------
+	// enabled=true so BillingH/BillingWebhookH/PricingH/BillingSuspensionGate
+	// all mount for real, matching a hosted deploy's route set.
+	billingSvc := billing.New(pool, nil, true, clock, logger)
+	billingH := billing.NewHandler(billingSvc, nil, "https://cp.example.test")
+	billingWebhookH := billing.NewWebhookHandler(billingSvc, logger)
+	pricingSvc := pricing.NewService(billing.NewRegistry(), nil, logger)
+	pricingH := pricing.NewHandler(pricingSvc)
+
+	// --- MCP (S6b/S7): transport + OAuth + discovery -------------------------
+	// This is the piece tests/contract/openapi_route_coverage_test.go's
+	// buildFullEngine leaves nil. Constructed exactly as
+	// cmd/wpmgr/main.go wires it (mcp.NewService(mcp.NewRepo(pool)) etc.), so
+	// POST /mcp, the four OAuth paths and the three well-known discovery
+	// documents all mount.
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, "dump-routes")
+	mcpOAuthH := mcp.NewHandler(mcpSvc)
+	mcpDiscoveryH := mcp.NewDiscoveryHandler("https://cp.example.test")
+
+	deps := server.Deps{
+		Config:                 config.Config{},
+		Logger:                 logger,
+		Pool:                   pool,
+		Sessions:               sessions,
+		Auth:                   authn,
+		AuthH:                  authH,
+		MembersH:               auth.NewMembersHandler(authSvc, nil),
+		APIKeyH:                apikey.NewHandler(apiKeySvc, auditRec),
+		AuditH:                 audit.NewHandler(auditRec),
+		TenantH:                tenant.NewHandler(tenantSvc, auditRec),
+		SiteH:                  siteH,
+		SiteEventsH:            siteEventsH,
+		UpdateH:                updateH,
+		BackupH:                backupH,
+		BackupAgentH:           backupAgentH,
+		InspectionDeps:         inspectionDeps,
+		UptimeH:                uptimeH,
+		AutologinH:             autologinH,
+		AutologinPolicyH:       autologinPolicyH,
+		AutologinAgentH:        autologinAgentH,
+		AgentAuth:              agentAuthn,
+		AgentH:                 agentH,
+		UpdateAgentH:           updateAgentH,
+		SiteDestH:              siteDestH,
+		SettingsH:              settingsH,
+		DiagnosticsH:           diagnosticsH,
+		DiagnosticsAgentH:      diagnosticsAgentH,
+		ErrorsAgentH:           errorsAgentH,
+		ActivityH:              activityH,
+		ActivityAgentH:         activityAgentH,
+		SecurityH:              securityH,
+		SecurityAgentH:         securityAgentH,
+		LoginBrandH:            loginBrandH,
+		ScanH:                  scanH,
+		VulnH:                  vulnH,
+		AgentReleaseH:          agentReleaseH,
+		RestoreRunH:            restoreRunH,
+		ScheduleRunH:           scheduleRunH,
+		OrgH:                   orgH,
+		SharingH:               sharingH,
+		InvitationH:            invitationH,
+		GovContextH:            govContextH,
+		MediaH:                 mediaH,
+		MediaAgentH:            mediaAgentH,
+		PerfH:                  perfH,
+		PerfAgentH:             perfAgentH,
+		FontResultsAgentH:      fontResultsAgentH,
+		ObjectCacheH:           ocH,
+		ScreenshotH:            screenshotH,
+		AdminH:                 adminH,
+		RumH:                   rumH,
+		EmailH:                 emailH,
+		FilesH:                 filesH,
+		EmailAgentH:            emailAgentH,
+		EmailWebhookH:          emailWebhookH,
+		EmailAgentSuppressionH: emailAgentSuppressionH,
+		HIBPAgentH:             hibpAgentH,
+		ClientH:                clientH,
+		SiteTagH:               siteTagH,
+		ReportH:                reportH,
+		PortalH:                portalH,
+		BillingH:               billingH,
+		BillingWebhookH:        billingWebhookH,
+		PricingH:               pricingH,
+		MCPTransportH:          mcpTransportH,
+		MCPOAuthH:              mcpOAuthH,
+		MCPDiscoveryH:          mcpDiscoveryH,
+		BillingSuspensionGate:  billingSvc.SuspensionGate(),
+		ServiceName:            "wpmgr-dump-routes",
+		Version:                "dump-routes",
+	}
+
+	srv := server.New(deps)
+	e, ok := srv.Handler().(*gin.Engine)
+	if !ok {
+		return nil, nil, fmt.Errorf("server.New's Handler() is not a *gin.Engine (got %T)", srv.Handler())
+	}
+
+	return e, nilOptionalFields(deps), nil
+}
+
+// tenantCreatorAdapter adapts a (ctx, name, slug) func to org.TenantCreator's
+// Create method — mirrors cmd/wpmgr/main.go's orgTenantAdapter.
+type tenantCreatorAdapter struct {
+	create func(ctx context.Context, name, slug string) (uuid.UUID, error)
+}
+
+func (a tenantCreatorAdapter) Create(ctx context.Context, name, slug string) (uuid.UUID, error) {
+	return a.create(ctx, name, slug)
+}
+
+// siteGetterAdapter adapts *site.Service to screenshot.SiteGetter.
+type siteGetterAdapter struct {
+	svc *site.Service
+}
+
+func (a siteGetterAdapter) GetSiteURL(ctx context.Context, tenantID, siteID uuid.UUID) (string, bool, error) {
+	s, err := a.svc.Get(ctx, tenantID, siteID)
+	if err != nil {
+		return "", false, err
+	}
+	return s.URL, true, nil
+}

--- a/infra/urlmap-unrouted-routes.txt
+++ b/infra/urlmap-unrouted-routes.txt
@@ -1,0 +1,36 @@
+# infra/urlmap-unrouted-routes.txt
+#
+# Routes the API mounts that are DELIBERATELY not reachable through the public
+# load balancer, read by scripts/check-urlmap-routes.sh.
+#
+# This file distinguishes "missing from the url-map because nobody noticed" —
+# the defect that made POST /mcp and the OAuth discovery documents unreachable —
+# from "absent on purpose". Without that distinction the guard could only be
+# switched off.
+#
+# FORMAT. A path pattern on its own line, with a '# reason:' line DIRECTLY
+# above it. The reason is mandatory and the guard exits 2 without it. Patterns
+# use the same syntax as a url-map path rule: an exact path, or a trailing /*
+# for a prefix. A route's {param} segments match a wildcard, never a literal.
+#
+#   # reason: in-cluster only; served on the admin port, never exposed publicly
+#   /internal/debug/*
+#
+# TWO RULES THAT KEEP THIS HONEST, both enforced by the guard:
+#
+#   1. No silent skips. An entry without a reason is a hard error, not an
+#      ignored line. Adding to this file is meant to be visible in review,
+#      because the failure mode being defended against is someone learning to
+#      add to the ignore list instead of adding the path rule.
+#
+#   2. No stale entries. An entry matching no currently-mounted route fails the
+#      guard. An ignore list that outlives its routes grows until it excuses
+#      something that matters.
+#
+# EMPTY IS THE GOAL, and it is empty today: every route apps/api mounts is
+# expected to be reachable through the load balancer. wpmgr-api runs with
+# ingress=internal-and-cloud-load-balancing, so the url-map is the only path in
+# and there is no second, private door for an "internal" route to arrive
+# through. Before adding an entry, check that the route really is unreachable
+# by design rather than merely unrouted by accident — the second one is the bug
+# this guard was written for.

--- a/infra/urlmap.yaml
+++ b/infra/urlmap.yaml
@@ -1,0 +1,96 @@
+# infra/urlmap.yaml — the production global external ALB url-map, as source.
+#
+# WHAT THIS IS. `wpmgr-urlmap` (global) in project `wpmgr-prod`. Until this file
+# existed the url-map lived ONLY in GCP: nothing in this repo described which
+# paths reach the API, so nothing could review a gap and nothing could fail on
+# one. That cost us twice in one day:
+#
+#   1. POST /mcp shipped, deployed, and was unreachable. The API mounted it; the
+#      url-map did not route it, so it fell to `defaultService` and the web SPA
+#      answered it — 200 text/html, which reads as "something answered".
+#   2. The OAuth discovery documents (PR #589) would have done exactly the same
+#      thing: three root-mounted paths, no path rule, answered by the SPA.
+#
+# This file is the DESIRED state, not a snapshot. It is the live export plus the
+# three /.well-known paths from #589, which are not applied to GCP yet.
+#
+# APPLY IT (nobody has; do this as part of the next deploy):
+#   gcloud compute url-maps import wpmgr-urlmap --global \
+#     --source=infra/urlmap.yaml --project=wpmgr-prod
+#
+# `fingerprint:` IS DELIBERATELY ABSENT. `gcloud compute url-maps export` emits
+# one; it is an optimistic-locking token that changes on every single update, so
+# a committed fingerprint is stale the moment anyone applies anything and every
+# later diff is noise. `import` fetches the current one when the file omits it.
+# scripts/check-urlmap-drift.sh strips it from the live side before comparing.
+#
+# THE GUARD. scripts/check-urlmap-routes.sh proves every path the API actually
+# mounts is covered by a path rule below. It needs no cloud credentials and runs
+# on every PR. It derives the route list from the real Gin engine, never from a
+# hand-kept list, because a hand-kept list is the thing that drifts.
+#
+# BACKENDS. wpmgr-bes-api and wpmgr-bes-web are serverless NEGs onto Cloud Run
+# in asia-south1. wpmgr-api runs with ingress=internal-and-cloud-load-balancing,
+# so this url-map is the ONLY path into the API: a path missing from the rules
+# below is not slow or degraded, it is unreachable. The TLS cert wpmgr-cert-www
+# is MANAGED, so there is no ACME HTTP-01 challenge path to preserve here.
+
+defaultService: https://www.googleapis.com/compute/v1/projects/wpmgr-prod/global/backendServices/wpmgr-bes-web
+name: wpmgr-urlmap
+hostRules:
+- hosts:
+  - app.oscod.dev
+  - manage.wpmgr.app
+  pathMatcher: main
+- hosts:
+  - wpmgr.app
+  pathMatcher: landing
+- hosts:
+  - www.wpmgr.app
+  pathMatcher: www-redirect
+pathMatchers:
+- defaultService: https://www.googleapis.com/compute/v1/projects/wpmgr-prod/global/backendServices/wpmgr-bes-web
+  name: main
+  pathRules:
+  # Long-lived SSE streams. Same backend as everything else below; this rule is
+  # kept separate and FIRST because it is the seam where a streaming-specific
+  # backend service (different timeout / no response buffering) would be
+  # attached without touching the general API rule.
+  - paths:
+    - /api/v1/backups/*/events
+    - /api/v1/updates/*/events
+    service: https://www.googleapis.com/compute/v1/projects/wpmgr-prod/global/backendServices/wpmgr-bes-api
+  # Everything the API serves. Anything mounted by apps/api that is not matched
+  # here falls through to defaultService above and is answered by the web SPA.
+  - paths:
+    - /api/*
+    - /agent/*
+    - /auth/*
+    - /enroll
+    - /enroll/*
+    - /healthz
+    - /readyz
+    - /metrics
+    - /rum
+    - /rum/*
+    - /mcp
+    - /webhooks/*
+    # RFC 8414 / RFC 9728 OAuth discovery for the MCP server (PR #589).
+    # Root-mounted on the Gin engine by internal/mcp/discovery.go's Register,
+    # NOT under /api/*, because a GUI MCP client fetches these before it holds
+    # any credential and has no field in which to be told a different prefix.
+    # All three are EXACT paths: an exact rule does not cover its own subpaths,
+    # which is why the /mcp form below is listed separately from its parent.
+    - /.well-known/oauth-authorization-server
+    - /.well-known/oauth-protected-resource
+    # The RFC 9728 path-inserted form. MCP 2025-11-25 clients try this FIRST,
+    # before the bare /.well-known/oauth-protected-resource above.
+    - /.well-known/oauth-protected-resource/mcp
+    service: https://www.googleapis.com/compute/v1/projects/wpmgr-prod/global/backendServices/wpmgr-bes-api
+- defaultService: https://www.googleapis.com/compute/v1/projects/wpmgr-prod/global/backendServices/wpmgr-bes-marketing
+  name: landing
+- defaultUrlRedirect:
+    hostRedirect: wpmgr.app
+    redirectResponseCode: MOVED_PERMANENTLY_DEFAULT
+    stripQuery: false
+  name: www-redirect

--- a/infra/urlmap.yaml
+++ b/infra/urlmap.yaml
@@ -35,8 +35,12 @@
 # below is not slow or degraded, it is unreachable. The TLS cert wpmgr-cert-www
 # is MANAGED, so there is no ACME HTTP-01 challenge path to preserve here.
 
+# KEY ORDER MATCHES `gcloud compute url-maps export` EXACTLY (alphabetical:
+# defaultService, hostRules, name, pathMatchers). Do not tidy it into a more
+# readable order — scripts/check-urlmap-drift.sh does a strict ordered diff, so
+# a cosmetic reordering here shows up as drift forever and trains everyone to
+# ignore the drift output.
 defaultService: https://www.googleapis.com/compute/v1/projects/wpmgr-prod/global/backendServices/wpmgr-bes-web
-name: wpmgr-urlmap
 hostRules:
 - hosts:
   - app.oscod.dev
@@ -48,6 +52,7 @@ hostRules:
 - hosts:
   - www.wpmgr.app
   pathMatcher: www-redirect
+name: wpmgr-urlmap
 pathMatchers:
 - defaultService: https://www.googleapis.com/compute/v1/projects/wpmgr-prod/global/backendServices/wpmgr-bes-web
   name: main

--- a/scripts/check-urlmap-drift.sh
+++ b/scripts/check-urlmap-drift.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/check-urlmap-drift.sh
+#
+# The COMMITTED url-map versus the one actually live in GCP.
+#
+# DELIBERATELY SEPARATE from scripts/check-urlmap-routes.sh. That guard is the
+# valuable one — it proves every route the API mounts is routed, it needs no
+# cloud access, and it runs on every PR. This one needs credentials, so it
+# cannot run on a PR from a fork and must never be a precondition for the
+# credential-free check. Keeping them in one script would have gated the half
+# that matters behind the half that cannot always run.
+#
+# RUN IT (needs `gcloud auth login` and read access to the project):
+#   make check-urlmap-drift
+#   scripts/check-urlmap-drift.sh
+#
+# Exit 0 = live matches committed. Exit 1 = drift. Exit 2 = could not check.
+# "Could not check" is never reported as a pass.
+#
+# EXPECTED DRIFT RIGHT NOW: the three /.well-known OAuth discovery paths are in
+# the committed file and not yet applied to GCP, so this exits 1 until someone
+# runs the import command it prints. That is the file doing its job — it is the
+# desired state, not a snapshot.
+#
+# fingerprint: is stripped from the live side before comparing. It is an
+# optimistic-locking token that changes on every update, so comparing it would
+# report drift after every unrelated apply.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+
+URLMAP_FILE="${WPMGR_URLMAP_FILE:-$REPO_ROOT/infra/urlmap.yaml}"
+URLMAP_NAME="${WPMGR_URLMAP_NAME:-wpmgr-urlmap}"
+PROJECT="${WPMGR_GCP_PROJECT:-wpmgr-prod}"
+
+fatal() { printf 'check-urlmap-drift: FATAL: %s\n' "$1" >&2; exit 2; }
+
+[ -f "$URLMAP_FILE" ] || fatal "committed url-map not found: $URLMAP_FILE"
+
+GCLOUD="$(command -v gcloud || true)"
+# Resolve the binary rather than assuming it. A step that cannot find its
+# binary fails loudly; it is never skipped, because a skipped drift check that
+# prints nothing is indistinguishable from a clean one.
+[ -n "$GCLOUD" ] || fatal "gcloud not found on PATH. Install the Google Cloud SDK or run this where it is available.
+  This check is not optional-by-absence: it reports 'could not check', not 'no drift'."
+
+WORK="$(mktemp -d)" || fatal "could not create a temp dir"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+LIVE="$WORK/live.yaml"
+if ! "$GCLOUD" compute url-maps export "$URLMAP_NAME" --global --project="$PROJECT" > "$LIVE" 2>"$WORK/err"; then
+  printf 'check-urlmap-drift: FATAL: could not export %s from project %s.\n' "$URLMAP_NAME" "$PROJECT" >&2
+  sed 's/^/  | /' "$WORK/err" >&2
+  printf '  Check `gcloud auth list` and that the account can read compute url-maps.\n' >&2
+  exit 2
+fi
+
+if [ ! -s "$LIVE" ]; then
+  fatal "the live export was empty. Refusing to report 'no drift' over an empty comparison."
+fi
+
+# Normalise both sides: drop comments, blank lines and the fingerprint token,
+# then sort-independent compare is NOT used — ordering is significant in a
+# url-map (first matching path rule wins), so this is a strict ordered diff.
+normalise() {
+  sed -e 's/[[:space:]]*$//' -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' -e '/^fingerprint:/d' "$1"
+}
+
+normalise "$LIVE"        > "$WORK/live.norm"
+normalise "$URLMAP_FILE" > "$WORK/committed.norm"
+
+if [ ! -s "$WORK/committed.norm" ]; then
+  fatal "the committed url-map is empty after stripping comments: $URLMAP_FILE"
+fi
+
+if diff -u "$WORK/live.norm" "$WORK/committed.norm" > "$WORK/diff" 2>&1; then
+  printf 'check-urlmap-drift: OK — live %s in %s matches %s.\n' "$URLMAP_NAME" "$PROJECT" "$URLMAP_FILE"
+  exit 0
+fi
+
+printf '\ncheck-urlmap-drift: DRIFT between the live url-map and the committed one.\n' >&2
+printf '  -  live in GCP (%s / %s)\n' "$PROJECT" "$URLMAP_NAME" >&2
+printf '  +  committed (%s)\n\n' "$URLMAP_FILE" >&2
+sed 's/^/  /' "$WORK/diff" >&2
+printf '\nIf the committed file is the intended state, apply it:\n' >&2
+printf '  gcloud compute url-maps import %s --global --source=%s --project=%s\n' \
+  "$URLMAP_NAME" "$URLMAP_FILE" "$PROJECT" >&2
+printf 'If GCP is right and the file is stale, re-export and commit the result.\n\n' >&2
+exit 1

--- a/scripts/check-urlmap-routes.sh
+++ b/scripts/check-urlmap-routes.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# scripts/check-urlmap-routes.sh
+#
+# Every path the API actually mounts is covered by a path rule in the committed
+# load-balancer url-map, routing to the API backend.
+#
+# WHY THIS EXISTS. The url-map used to live only in GCP. Twice in one day a
+# route shipped, deployed, and was unreachable, because the API mounted it and
+# the load balancer did not route it:
+#
+#   1. POST /mcp — fell through to `defaultService` and the web SPA answered it.
+#   2. The OAuth discovery documents (PR #589) — three root-mounted paths that
+#      would have done the identical thing.
+#
+# Both failures return 200 text/html. A status-code smoke test CANNOT see them,
+# because something did answer; it was just the wrong something. That is this
+# project's signature defect wearing infrastructure. This guard is the check
+# that would have caught both, and it needs no cloud credentials, so it runs on
+# every PR rather than after a deploy when it is already too late.
+#
+# WHY IT IS A SCRIPT AND NOT A CI STEP. Build-gating logic in a YAML block
+# scalar is untested logic: nobody can run it, so nobody can check their work.
+# scripts/check-urlmap-routes_test.sh builds real fixture trees and asserts exit
+# codes against this file, so a hole that gets reopened turns a test red.
+#
+# RUN IT:
+#   make check-urlmap                 # routes from the live Gin engine
+#   scripts/check-urlmap-routes.sh
+#   scripts/check-urlmap-routes.sh --routes-file /tmp/routes.tsv   # offline
+#
+# Exit 0 when every mounted route is covered. Exit 1 on any real gap. Exit 2 on
+# a broken invocation (missing input, unreadable file, a route source that
+# produced nothing). There is no exit code that means "checked nothing, fine".
+#
+# WHERE THE ROUTE LIST COMES FROM, AND WHY NOT A HAND-KEPT ONE. A hand-kept
+# list is the thing that drifts: it is written once, by the person who already
+# knows about the route, and is never updated by the person who does not. The
+# route source here is the real Gin engine built through server.New, dumped as
+# METHOD<TAB>PATH. See --routes-cmd below.
+#
+# THE NIL-HANDLER TRAP, which is what makes the route source subtle.
+# apps/api/internal/server/server.go guards most registrations with
+# `if deps.X != nil`. apps/api/tests/contract/openapi_route_coverage_test.go's
+# buildFullEngine leaves several of those nil, so those routes never appear in
+# its engine.Routes(). Its allowlistLiveNotInSpec is EMPTY and it passes
+# green — while the three /.well-known routes it never mounts are exactly the
+# ones this guard exists to catch. A route source with a nil-handler blind spot
+# would report full coverage of a surface it cannot see. The dumper this script
+# calls must mount every optional handler; its own test asserts the well-known
+# and /mcp routes are present, which is what stops the blind spot returning.
+#
+# PORTABILITY. bash 3.2 (what macOS ships) and POSIX tools, so it behaves the
+# same on a darwin laptop with BSD grep/sed/awk and on the ubuntu CI runner with
+# the GNU ones. No mapfile, no associative arrays, no sed -i, no grep -P.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+
+URLMAP="$REPO_ROOT/infra/urlmap.yaml"
+ALLOWLIST="$REPO_ROOT/infra/urlmap-unrouted-routes.txt"
+ROUTES_FILE=""
+ROUTES_CMD=""
+MATCHER="main"
+API_BACKEND="wpmgr-bes-api"
+
+# The default route source. Overridable so the test suite can drive the guard
+# with fixture route lists, and so a caller can dump once and check twice.
+ROUTES_CMD_DEFAULT="${WPMGR_ROUTES_CMD:-go run ./cmd/dump-routes}"
+ROUTES_CMD_DIR="${WPMGR_ROUTES_CMD_DIR:-$REPO_ROOT/apps/api}"
+
+usage() {
+  cat <<'EOF'
+usage: check-urlmap-routes.sh [options]
+
+  --routes-file FILE   read METHOD<TAB>PATH lines from FILE ('-' for stdin)
+                       instead of running the route dumper
+  --routes-cmd CMD     run CMD to produce the route list (default: the Go
+                       dumper in apps/api)
+  --urlmap FILE        url-map YAML to check (default: infra/urlmap.yaml)
+  --allowlist FILE     deliberately-unrouted paths, with mandatory reasons
+                       (default: infra/urlmap-unrouted-routes.txt)
+  --matcher NAME       pathMatcher to check (default: main)
+  --api-backend NAME   backend service that means "reaches the API"
+                       (default: wpmgr-bes-api)
+  -h, --help           this text
+
+exit 0 = every mounted route is covered
+exit 1 = a real gap (uncovered route, or a stale allowlist entry)
+exit 2 = broken invocation (missing input, empty route list, unreadable file)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --routes-file) ROUTES_FILE="${2:-}"; shift 2 ;;
+    --routes-cmd)  ROUTES_CMD="${2:-}";  shift 2 ;;
+    --urlmap)      URLMAP="${2:-}";      shift 2 ;;
+    --allowlist)   ALLOWLIST="${2:-}";   shift 2 ;;
+    --matcher)     MATCHER="${2:-}";     shift 2 ;;
+    --api-backend) API_BACKEND="${2:-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) printf 'check-urlmap-routes: unknown argument: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+fail_setup() { printf 'check-urlmap-routes: FATAL: %s\n' "$1" >&2; exit 2; }
+
+TMPDIR_RUN="$(mktemp -d 2>/dev/null)" || fail_setup "could not create a temp dir"
+trap 'rm -rf "$TMPDIR_RUN"' EXIT INT TERM
+
+ROUTES_RAW="$TMPDIR_RUN/routes.raw"
+ROUTES_NORM="$TMPDIR_RUN/routes.norm"
+RULES="$TMPDIR_RUN/rules"
+UNCOVERED="$TMPDIR_RUN/uncovered"
+ALLOW_PATTERNS="$TMPDIR_RUN/allow"
+
+# ---------------------------------------------------------------------------
+# 1. The url-map. Parsed structurally, anchored on the pathMatchers ->
+#    pathRules -> service nesting, never on a first substring match: a guard
+#    here once read the first substring instead of the declaration and passed
+#    while both the things it was checking for were still present.
+# ---------------------------------------------------------------------------
+
+[ -n "$URLMAP" ]  || fail_setup "--urlmap was given an empty value"
+[ -f "$URLMAP" ]  || fail_setup "url-map not found: $URLMAP"
+[ -r "$URLMAP" ]  || fail_setup "url-map not readable: $URLMAP"
+
+awk -v want_matcher="$MATCHER" -v want_backend="$API_BACKEND" '
+  # Top-level key at column 0 opens or closes the pathMatchers block.
+  /^[A-Za-z_][A-Za-z0-9_]*:/ { in_matchers = ($0 ~ /^pathMatchers:[[:space:]]*$/); next }
+
+  !in_matchers { next }
+
+  # A new matcher entry.
+  /^-[[:space:]]/ { m++; rule = 0; collecting = 0 }
+
+  # The matcher name (two-space indent = a key of the matcher entry).
+  /^[[:space:]][[:space:]]name:[[:space:]]/ {
+    n = $0; sub(/^[[:space:]]*name:[[:space:]]*/, "", n); mname[m] = n; next
+  }
+
+  # A new path rule inside pathRules.
+  /^[[:space:]][[:space:]]-[[:space:]]*paths:[[:space:]]*$/ { rule++; collecting = 1; buf[m, rule] = ""; next }
+
+  # A path list item belonging to the current rule.
+  collecting && /^[[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*\// {
+    p = $0; sub(/^[[:space:]]*-[[:space:]]*/, "", p)
+    sub(/[[:space:]]+$/, "", p)
+    buf[m, rule] = buf[m, rule] p "\n"
+    next
+  }
+
+  # The rule closes with its service. Record which backend it points at.
+  /^[[:space:]][[:space:]][[:space:]][[:space:]]service:[[:space:]]/ {
+    s = $0; sub(/^[[:space:]]*service:[[:space:]]*/, "", s)
+    sub(/.*\//, "", s)                  # basename of the backendServices URL
+    svc[m, rule] = s; collecting = 0; next
+  }
+
+  END {
+    for (k in buf) {
+      split(k, parts, SUBSEP)
+      mi = parts[1]
+      if (mname[mi] != want_matcher) continue
+      if (svc[k] != want_backend) continue
+      printf "%s", buf[k]
+    }
+  }
+' "$URLMAP" | sed '/^$/d' | sort -u > "$RULES"
+
+RULE_COUNT="$(wc -l < "$RULES" | tr -d ' ')"
+if [ "$RULE_COUNT" -eq 0 ]; then
+  # The "guard that finds nothing goes green" failure, refused explicitly. An
+  # empty rule set would make every route trivially uncovered OR, with the
+  # comparison written the other way, make every route trivially covered.
+  # Neither is a checkable state, so neither is allowed to be a pass.
+  fail_setup "parsed 0 path rules for matcher '$MATCHER' -> backend '$API_BACKEND' from $URLMAP.
+  Either the matcher/backend names are wrong, or the YAML shape changed and the
+  parser no longer understands it. This is never a pass."
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The route list.
+# ---------------------------------------------------------------------------
+
+if [ -n "$ROUTES_FILE" ] && [ -n "$ROUTES_CMD" ]; then
+  fail_setup "--routes-file and --routes-cmd are mutually exclusive"
+fi
+
+if [ -n "$ROUTES_FILE" ]; then
+  if [ "$ROUTES_FILE" = "-" ]; then
+    cat > "$ROUTES_RAW"
+  else
+    [ -f "$ROUTES_FILE" ] || fail_setup "routes file not found: $ROUTES_FILE"
+    [ -r "$ROUTES_FILE" ] || fail_setup "routes file not readable: $ROUTES_FILE"
+    cat "$ROUTES_FILE" > "$ROUTES_RAW"
+  fi
+else
+  CMD="${ROUTES_CMD:-$ROUTES_CMD_DEFAULT}"
+  # A dumper that cannot run is FATAL, never a skip. A gate that cannot find
+  # its binary must fail loudly: skipping here would report success over the
+  # exact condition the gate exists to detect.
+  #
+  # An unusable working directory is folded into the SAME failure rather than
+  # checked separately, so there is one error path instead of two. An earlier
+  # revision checked the directory first and reported "directory not found"
+  # for an invocation whose command was what actually mattered; the message
+  # names the directory below, which is the part that was worth keeping.
+  ( cd "$ROUTES_CMD_DIR" 2>/dev/null && eval "$CMD" ) > "$ROUTES_RAW" 2>"$TMPDIR_RUN/routes.err"
+  RC=$?
+  if [ $RC -ne 0 ]; then
+    printf 'check-urlmap-routes: FATAL: route dumper failed (exit %d): %s\n' "$RC" "$CMD" >&2
+    printf '  in directory: %s\n' "$ROUTES_CMD_DIR" >&2
+    sed 's/^/  | /' "$TMPDIR_RUN/routes.err" >&2
+    exit 2
+  fi
+fi
+
+# METHOD<TAB>PATH -> just the distinct paths. The load balancer routes on path
+# only; it has no idea what methods a path serves, so method is dropped here.
+# Anything that is not a tab-separated pair beginning with '/' in field 2 is
+# ignored, and if that leaves nothing we fail below rather than pass.
+awk -F'\t' 'NF >= 2 && $2 ~ /^\// { print $2 }' "$ROUTES_RAW" | sort -u > "$ROUTES_NORM"
+
+ROUTE_COUNT="$(wc -l < "$ROUTES_NORM" | tr -d ' ')"
+if [ "$ROUTE_COUNT" -eq 0 ]; then
+  RAW_LINES="$(wc -l < "$ROUTES_RAW" | tr -d ' ')"
+  fail_setup "the route source produced 0 usable routes (raw lines: $RAW_LINES).
+  Expected METHOD<TAB>PATH lines. An empty route list would make this guard
+  vacuously green over an API whose every route is unroutable, so it is fatal."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The allowlist: routes deliberately NOT reachable through the load balancer.
+#
+# Format is a path pattern preceded by a '# reason:' line. The reason is
+# MANDATORY and enforced below. If adding an entry were cheap and silent, the
+# first person to add an internal route would learn to add it to the ignore
+# list, and this guard would quietly stop meaning anything. A stale entry —
+# one matching no live route — is an ERROR too, so the list cannot accumulate
+# entries that outlive the routes they excuse.
+# ---------------------------------------------------------------------------
+
+[ -n "$ALLOWLIST" ] || fail_setup "--allowlist was given an empty value"
+# A missing allowlist is a broken checkout, not "allow nothing": failing loudly
+# is right, because silently treating it as empty would redden honest work and
+# get the guard switched off.
+[ -f "$ALLOWLIST" ] || fail_setup "allowlist not found: $ALLOWLIST"
+[ -r "$ALLOWLIST" ] || fail_setup "allowlist not readable: $ALLOWLIST"
+
+: > "$ALLOW_PATTERNS"
+ALLOW_ERR=0
+PREV_WAS_REASON=0
+LINENO_A=0
+while IFS= read -r line || [ -n "$line" ]; do
+  LINENO_A=$((LINENO_A + 1))
+  case "$line" in
+    '#'*reason:*) PREV_WAS_REASON=1; continue ;;
+    '#'*)         continue ;;
+    '')           continue ;;
+  esac
+  trimmed="$(printf '%s' "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -n "$trimmed" ] || continue
+  case "$trimmed" in
+    /*) : ;;
+    *)  printf 'check-urlmap-routes: allowlist line %d is not a path: %s\n' "$LINENO_A" "$trimmed" >&2
+        ALLOW_ERR=1; PREV_WAS_REASON=0; continue ;;
+  esac
+  if [ "$PREV_WAS_REASON" -ne 1 ]; then
+    printf 'check-urlmap-routes: allowlist entry has no "# reason:" line above it: %s (line %d)\n' "$trimmed" "$LINENO_A" >&2
+    ALLOW_ERR=1
+  fi
+  printf '%s\n' "$trimmed" >> "$ALLOW_PATTERNS"
+  PREV_WAS_REASON=0
+done < "$ALLOWLIST"
+
+if [ "$ALLOW_ERR" -ne 0 ]; then
+  printf 'check-urlmap-routes: FATAL: the allowlist is malformed. Every entry needs a "# reason:" line directly above it.\n' >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Matching, using the load balancer's own semantics.
+#
+#   /api/*                  prefix rule  -> matches /api/ and everything under it
+#   /api/v1/backups/*/eve.. mid-path '*' -> matches exactly one path segment
+#   /enroll                 exact rule   -> matches ONLY /enroll, not /enroll/x
+#
+# That last line is the one that matters and is easy to get wrong: an exact
+# rule does not cover its own subpaths, which is why the url-map lists
+# /.well-known/oauth-protected-resource and .../mcp as two separate entries.
+#
+# A route's {param} is rewritten to a placeholder containing no slash, so it
+# matches a wildcard segment but NOT a literal one. That is deliberate and
+# conservative: a literal rule genuinely does not cover every value the
+# parameter can take, so reporting it uncovered is the honest answer.
+# ---------------------------------------------------------------------------
+
+pattern_to_regex() {
+  # Escape ERE metacharacters, then re-expand the wildcards.
+  printf '%s' "$1" | sed '
+    s/[][\.^$+?(){}|]/\\&/g
+    s@/\*$@/__TRAILING__@
+    s@\*@[^/]+@g
+    s@/__TRAILING__@/.*@
+  '
+}
+
+: > "$UNCOVERED"
+while IFS= read -r route; do
+  [ -n "$route" ] || continue
+  # {id} -> a slash-free placeholder.
+  probe="$(printf '%s' "$route" | sed 's/{[^}]*}/_PARAM_/g')"
+  covered=0
+  while IFS= read -r rule; do
+    [ -n "$rule" ] || continue
+    rx="^$(pattern_to_regex "$rule")\$"
+    if printf '%s\n' "$probe" | grep -Eq "$rx"; then covered=1; break; fi
+  done < "$RULES"
+  [ "$covered" -eq 1 ] || printf '%s\n' "$route" >> "$UNCOVERED"
+done < "$ROUTES_NORM"
+
+# ---------------------------------------------------------------------------
+# 5. Verdict.
+# ---------------------------------------------------------------------------
+
+STATUS=0
+REAL_GAPS="$TMPDIR_RUN/gaps"
+: > "$REAL_GAPS"
+USED_ALLOW="$TMPDIR_RUN/used"
+: > "$USED_ALLOW"
+
+while IFS= read -r route; do
+  [ -n "$route" ] || continue
+  excused=0
+  while IFS= read -r pat; do
+    [ -n "$pat" ] || continue
+    rx="^$(pattern_to_regex "$pat")\$"
+    probe="$(printf '%s' "$route" | sed 's/{[^}]*}/_PARAM_/g')"
+    if printf '%s\n' "$probe" | grep -Eq "$rx"; then
+      excused=1; printf '%s\n' "$pat" >> "$USED_ALLOW"; break
+    fi
+  done < "$ALLOW_PATTERNS"
+  [ "$excused" -eq 1 ] || printf '%s\n' "$route" >> "$REAL_GAPS"
+done < "$UNCOVERED"
+
+GAP_COUNT="$(wc -l < "$REAL_GAPS" | tr -d ' ')"
+if [ "$GAP_COUNT" -gt 0 ]; then
+  STATUS=1
+  printf '\ncheck-urlmap-routes: %s route(s) mounted by the API are NOT routed to %s.\n' "$GAP_COUNT" "$API_BACKEND" >&2
+  printf 'These fall through to the matcher default and are answered by the web SPA:\n' >&2
+  printf 'a 200 text/html that looks like success and is not.\n\n' >&2
+  sed 's/^/  MISSING  /' "$REAL_GAPS" >&2
+  printf '\nFix: add each path to a pathRule in %s that points at %s.\n' "$URLMAP" "$API_BACKEND" >&2
+  printf 'An exact path does not cover its subpaths — add /foo and /foo/* if both are served.\n' >&2
+  printf 'If a route is deliberately not public, add it to %s WITH a "# reason:" line.\n\n' "$ALLOWLIST" >&2
+fi
+
+# A stale allowlist entry is a real failure: it means the guard is carrying an
+# excuse for a route that no longer exists, which is how an ignore list grows
+# until it excuses something that matters.
+STALE=0
+while IFS= read -r pat; do
+  [ -n "$pat" ] || continue
+  if ! grep -qxF "$pat" "$USED_ALLOW" 2>/dev/null; then
+    if [ "$STALE" -eq 0 ]; then
+      printf 'check-urlmap-routes: stale allowlist entries in %s — they excuse no live route:\n' "$ALLOWLIST" >&2
+    fi
+    STALE=1; STATUS=1
+    printf '  STALE  %s\n' "$pat" >&2
+  fi
+done < "$ALLOW_PATTERNS"
+[ "$STALE" -eq 0 ] || printf 'Remove them: the route they were added for is gone.\n\n' >&2
+
+ALLOW_COUNT="$(wc -l < "$ALLOW_PATTERNS" | tr -d ' ')"
+if [ "$STATUS" -eq 0 ]; then
+  printf 'check-urlmap-routes: OK — %s mounted route(s) checked against %s path rule(s) in %s; %s deliberately unrouted.\n' \
+    "$ROUTE_COUNT" "$RULE_COUNT" "$MATCHER" "$ALLOW_COUNT"
+fi
+exit "$STATUS"

--- a/scripts/check-urlmap-routes_test.sh
+++ b/scripts/check-urlmap-routes_test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# scripts/check-urlmap-routes_test.sh
+#
+# The regression suite for scripts/check-urlmap-routes.sh.
+#
+# WHY THIS EXISTS. A guard nobody has watched fail is not known to guard
+# anything. Both incidents this guard was written for are cases in here, as
+# reproductions rather than as prose: case "incident-1" is POST /mcp shipping
+# unroutable, case "incident-2" is the OAuth discovery documents about to do
+# the same. If either stops going red, a test goes red instead.
+#
+# The other half of the suite is the part that is easy to skip: the cases the
+# guard must NOT redden. A guard that fails correct work gets switched off, and
+# then it guards nothing.
+#
+# RUN IT:
+#   make check-urlmap-test
+#   scripts/check-urlmap-routes_test.sh            # everything
+#   scripts/check-urlmap-routes_test.sh incident   # only cases matching "incident"
+#
+# Point it at a different implementation to prove the suite is not vacuous
+# (reintroduce a hole in a copy, watch the suite go red):
+#   WPMGR_URLMAP_GUARD=/tmp/guard-with-hole.sh scripts/check-urlmap-routes_test.sh
+#
+# PORTABILITY. bash 3.2 and POSIX tools; no mapfile, no associative arrays,
+# no sed -i, no grep -P.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${WPMGR_URLMAP_GUARD:-$HERE/check-urlmap-routes.sh}"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+FILTER="${1:-}"
+
+if [ ! -f "$GUARD" ]; then
+  printf 'check-urlmap-routes_test: guard not found: %s\n' "$GUARD" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+WORK="$(mktemp -d)" || exit 2
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# --- fixtures --------------------------------------------------------------
+
+# A url-map in the real shape, parameterised by which path rules it carries.
+# Written as a function rather than a static file so each case can express the
+# exact gap it is reproducing.
+make_urlmap() {
+  # $1 = output path; remaining args = paths for the API rule
+  out="$1"; shift
+  {
+    printf 'defaultService: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-web\n'
+    printf 'name: wpmgr-urlmap\n'
+    printf 'hostRules:\n'
+    printf -- '- hosts:\n'
+    printf -- '  - manage.wpmgr.app\n'
+    printf '  pathMatcher: main\n'
+    printf 'pathMatchers:\n'
+    printf -- '- defaultService: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-web\n'
+    printf '  name: main\n'
+    printf '  pathRules:\n'
+    printf -- '  - paths:\n'
+    for p in "$@"; do printf -- '    - %s\n' "$p"; done
+    printf '    service: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-api\n'
+    printf -- '- defaultService: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-marketing\n'
+    printf '  name: landing\n'
+  } > "$out"
+}
+
+# The path rules that were live in GCP before either incident was fixed.
+BASE_RULES='/api/* /agent/* /auth/* /enroll /enroll/* /healthz /readyz /metrics /rum /rum/* /webhooks/*'
+
+make_routes() {
+  out="$1"; shift
+  : > "$out"
+  for r in "$@"; do printf 'GET\t%s\n' "$r" >> "$out"; done
+}
+
+EMPTY_ALLOW="$WORK/allow-empty.txt"
+printf '# no entries\n' > "$EMPTY_ALLOW"
+
+# --- harness ---------------------------------------------------------------
+
+# run_case <name> <expected-exit> <must-contain|-> <must-not-contain|-> -- <guard args...>
+run_case() {
+  name="$1"; want="$2"; needle="$3"; anti="$4"; shift 5   # shift past the '--'
+  case "$name" in
+    *"$FILTER"*) : ;;
+    *) return 0 ;;
+  esac
+
+  outf="$WORK/out.$$"
+  "$GUARD" "$@" > "$outf" 2>&1
+  got=$?
+
+  ok=1
+  msg=""
+  if [ "$got" -ne "$want" ]; then
+    ok=0; msg="expected exit $want, got $got"
+  fi
+  if [ "$needle" != "-" ] && ! grep -qF "$needle" "$outf"; then
+    ok=0; msg="$msg; output missing: $needle"
+  fi
+  if [ "$anti" != "-" ] && grep -qF "$anti" "$outf"; then
+    ok=0; msg="$msg; output must not contain: $anti"
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1)); printf 'ok   %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1)); printf 'FAIL %s (%s)\n' "$name" "$msg"
+    sed 's/^/       | /' "$outf"
+  fi
+}
+
+# ===========================================================================
+# A. It fires — the two real incidents, reproduced.
+# ===========================================================================
+
+# Incident 1: POST /mcp shipped, deployed, unreachable. The API mounted it; the
+# url-map had no rule for it, so the web SPA answered it with 200 text/html.
+make_urlmap "$WORK/um-pre-mcp.yaml" $BASE_RULES
+make_routes "$WORK/rt-mcp.tsv" /healthz /api/v1/sites /mcp
+run_case "incident-1-mcp-unrouted" 1 "MISSING  /mcp" - -- \
+  --routes-file "$WORK/rt-mcp.tsv" --urlmap "$WORK/um-pre-mcp.yaml" --allowlist "$EMPTY_ALLOW"
+
+# Incident 2: the three OAuth discovery documents from PR #589, against the
+# url-map as it is live in GCP right now (which does have /mcp).
+make_urlmap "$WORK/um-live.yaml" $BASE_RULES /mcp
+make_routes "$WORK/rt-oauth.tsv" /healthz /mcp \
+  /.well-known/oauth-authorization-server \
+  /.well-known/oauth-protected-resource \
+  /.well-known/oauth-protected-resource/mcp
+run_case "incident-2-oauth-discovery-unrouted" 1 "MISSING  /.well-known/oauth-authorization-server" - -- \
+  --routes-file "$WORK/rt-oauth.tsv" --urlmap "$WORK/um-live.yaml" --allowlist "$EMPTY_ALLOW"
+
+# The RFC 9728 path-inserted form is a DISTINCT rule. A url-map that lists only
+# the parent must still go red for the /mcp child, because an exact path rule
+# does not cover its subpaths. This is the single subtlest thing in the file.
+make_urlmap "$WORK/um-parent-only.yaml" $BASE_RULES /mcp /.well-known/oauth-protected-resource
+make_routes "$WORK/rt-child.tsv" /.well-known/oauth-protected-resource/mcp
+run_case "exact-rule-does-not-cover-subpath" 1 "MISSING  /.well-known/oauth-protected-resource/mcp" - -- \
+  --routes-file "$WORK/rt-child.tsv" --urlmap "$WORK/um-parent-only.yaml" --allowlist "$EMPTY_ALLOW"
+
+# A brand-new top-level surface — the general shape of both incidents.
+make_urlmap "$WORK/um-base.yaml" $BASE_RULES
+make_routes "$WORK/rt-new.tsv" /healthz /graphql
+run_case "planted-new-toplevel-route" 1 "MISSING  /graphql" - -- \
+  --routes-file "$WORK/rt-new.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$EMPTY_ALLOW"
+
+# A rule pointing at the WEB backend does not count as coverage. This is the
+# "match the structure, not the first substring" case: /graphql is present in
+# the YAML, just routed to the wrong service.
+{
+  printf 'defaultService: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-web\n'
+  printf 'name: wpmgr-urlmap\n'
+  printf 'pathMatchers:\n'
+  printf -- '- defaultService: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-web\n'
+  printf '  name: main\n'
+  printf '  pathRules:\n'
+  printf -- '  - paths:\n'
+  printf -- '    - /graphql\n'
+  printf '    service: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-web\n'
+  printf -- '  - paths:\n'
+  printf -- '    - /api/*\n'
+  printf '    service: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-api\n'
+} > "$WORK/um-wrong-backend.yaml"
+make_routes "$WORK/rt-graphql.tsv" /graphql
+run_case "path-routed-to-web-backend-is-not-coverage" 1 "MISSING  /graphql" - -- \
+  --routes-file "$WORK/rt-graphql.tsv" --urlmap "$WORK/um-wrong-backend.yaml" --allowlist "$EMPTY_ALLOW"
+
+# ===========================================================================
+# B. It does not over-fire — cases that must stay green.
+# ===========================================================================
+
+# The committed url-map against a route set covering every surface it serves.
+make_routes "$WORK/rt-full.tsv" /healthz /readyz /metrics /mcp \
+  /.well-known/oauth-authorization-server \
+  /.well-known/oauth-protected-resource \
+  /.well-known/oauth-protected-resource/mcp \
+  /api/v1/sites /api/v1/sites/{id} /api/v1/backups/{id}/events \
+  /auth/login /agent/v1/checkin /enroll /enroll/{token} \
+  /rum /rum/ingest /webhooks/razorpay
+run_case "committed-urlmap-covers-every-surface" 0 "OK" "MISSING" -- \
+  --routes-file "$WORK/rt-full.tsv" --urlmap "$REPO_ROOT/infra/urlmap.yaml" \
+  --allowlist "$REPO_ROOT/infra/urlmap-unrouted-routes.txt"
+
+# A {param} segment must match a prefix rule. If it did not, roughly every
+# route in the API would be reported missing and the guard would be deleted
+# on its first run.
+make_routes "$WORK/rt-params.tsv" /api/v1/sites/{siteId}/backups/{backupId}/restore
+run_case "params-match-prefix-rule" 0 "OK" "MISSING" -- \
+  --routes-file "$WORK/rt-params.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$EMPTY_ALLOW"
+
+# A mid-path wildcard rule matches exactly one segment.
+make_urlmap "$WORK/um-mid.yaml" '/api/v1/backups/*/events'
+make_routes "$WORK/rt-mid.tsv" /api/v1/backups/{id}/events
+run_case "mid-path-wildcard-matches-one-segment" 0 "OK" "MISSING" -- \
+  --routes-file "$WORK/rt-mid.tsv" --urlmap "$WORK/um-mid.yaml" --allowlist "$EMPTY_ALLOW"
+
+# The deliberate-exclusion path: an internal route WITH a reason is green.
+printf '# reason: in-cluster admin probe, never exposed publicly\n/internal/debug\n' > "$WORK/allow-ok.txt"
+make_routes "$WORK/rt-internal.tsv" /healthz /internal/debug
+run_case "allowlisted-internal-route-is-green" 0 "OK" "MISSING" -- \
+  --routes-file "$WORK/rt-internal.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$WORK/allow-ok.txt"
+
+# ===========================================================================
+# C. The allowlist cannot become a silent ignore list.
+# ===========================================================================
+
+# No reason line -> fatal, not a silent skip.
+printf '/internal/debug\n' > "$WORK/allow-noreason.txt"
+make_routes "$WORK/rt-internal2.tsv" /internal/debug
+run_case "allowlist-entry-without-reason-is-fatal" 2 'no "# reason:" line' - -- \
+  --routes-file "$WORK/rt-internal2.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$WORK/allow-noreason.txt"
+
+# A plain comment is not a reason.
+printf '# internal thing\n/internal/debug\n' > "$WORK/allow-comment.txt"
+run_case "plain-comment-is-not-a-reason" 2 'no "# reason:" line' - -- \
+  --routes-file "$WORK/rt-internal2.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$WORK/allow-comment.txt"
+
+# An entry that excuses no live route is stale and fails, so the list cannot
+# accumulate excuses that outlive their routes.
+printf '# reason: route was removed in a refactor and nobody cleaned this up\n/gone/route\n' > "$WORK/allow-stale.txt"
+make_routes "$WORK/rt-nostale.tsv" /healthz
+run_case "stale-allowlist-entry-fails" 1 "STALE  /gone/route" - -- \
+  --routes-file "$WORK/rt-nostale.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$WORK/allow-stale.txt"
+
+# ===========================================================================
+# D. Finding nothing goes RED, never green. This project's signature defect is
+#    announcing success over its own errors, so every empty/missing input is a
+#    named case here.
+# ===========================================================================
+
+run_case "missing-urlmap-is-fatal" 2 "url-map not found" "OK" -- \
+  --routes-file "$WORK/rt-full.tsv" --urlmap "$WORK/does-not-exist.yaml" --allowlist "$EMPTY_ALLOW"
+
+run_case "missing-routes-file-is-fatal" 2 "routes file not found" "OK" -- \
+  --routes-file "$WORK/nope.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$EMPTY_ALLOW"
+
+run_case "missing-allowlist-is-fatal" 2 "allowlist not found" "OK" -- \
+  --routes-file "$WORK/rt-full.tsv" --urlmap "$REPO_ROOT/infra/urlmap.yaml" --allowlist "$WORK/nope.txt"
+
+# An empty route list is the vacuous-green trap: zero routes trivially satisfy
+# "every route is covered".
+: > "$WORK/rt-empty.tsv"
+run_case "empty-route-list-is-fatal" 2 "produced 0 usable routes" "OK" -- \
+  --routes-file "$WORK/rt-empty.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$EMPTY_ALLOW"
+
+# Route source produced output, but none of it parses as METHOD<TAB>PATH — a
+# dumper that changed its format, or printed a banner and exited.
+printf 'building...\nno routes today\n' > "$WORK/rt-garbage.tsv"
+run_case "unparseable-route-output-is-fatal" 2 "produced 0 usable routes" "OK" -- \
+  --routes-file "$WORK/rt-garbage.tsv" --urlmap "$WORK/um-base.yaml" --allowlist "$EMPTY_ALLOW"
+
+# A url-map with no rule pointing at the API backend at all. Depending on which
+# way the comparison is written this is either "everything missing" or
+# "everything fine"; neither is a checkable state, so it is fatal.
+{
+  printf 'name: wpmgr-urlmap\n'
+  printf 'pathMatchers:\n'
+  printf -- '- defaultService: https://www.googleapis.com/compute/v1/projects/p/global/backendServices/wpmgr-bes-web\n'
+  printf '  name: main\n'
+} > "$WORK/um-norules.yaml"
+run_case "urlmap-with-no-api-rules-is-fatal" 2 "parsed 0 path rules" "OK" -- \
+  --routes-file "$WORK/rt-full.tsv" --urlmap "$WORK/um-norules.yaml" --allowlist "$EMPTY_ALLOW"
+
+# A matcher name that does not exist — a typo in the invocation must not pass.
+run_case "unknown-matcher-is-fatal" 2 "parsed 0 path rules" "OK" -- \
+  --routes-file "$WORK/rt-full.tsv" --urlmap "$REPO_ROOT/infra/urlmap.yaml" \
+  --allowlist "$REPO_ROOT/infra/urlmap-unrouted-routes.txt" --matcher nosuchmatcher
+
+# A backend name that does not exist, likewise.
+run_case "unknown-backend-is-fatal" 2 "parsed 0 path rules" "OK" -- \
+  --routes-file "$WORK/rt-full.tsv" --urlmap "$REPO_ROOT/infra/urlmap.yaml" \
+  --allowlist "$REPO_ROOT/infra/urlmap-unrouted-routes.txt" --api-backend wpmgr-bes-nope
+
+# A route dumper that fails must be fatal, never a skip. "A gate that cannot
+# find its binary must fail loudly."
+run_case "failing-route-dumper-is-fatal" 2 "route dumper failed" "OK" -- \
+  --routes-cmd 'exit 7' --urlmap "$WORK/um-base.yaml" --allowlist "$EMPTY_ALLOW"
+
+run_case "missing-route-dumper-binary-is-fatal" 2 "route dumper failed" "OK" -- \
+  --routes-cmd 'wpmgr-no-such-binary-xyz' --urlmap "$WORK/um-base.yaml" --allowlist "$EMPTY_ALLOW"
+
+# ===========================================================================
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+[ "$PASS" -gt 0 ] || { printf 'no cases ran (filter %s matched nothing)\n' "$FILTER" >&2; exit 2; }
+exit 0


### PR DESCRIPTION
## What

Brings the production load-balancer url-map into the repo and makes a missing route a failing check instead of something someone remembers to curl.

- `infra/urlmap.yaml` — the live export **plus** the three `/.well-known` OAuth discovery paths from #589. Desired state, not a snapshot.
- `scripts/check-urlmap-routes.sh` + `_test.sh` — the credential-free gate. Wired into `ci.yml`'s `go` job, self-test first.
- `scripts/check-urlmap-drift.sh` — live-versus-committed. Needs gcloud, deliberately **not** in CI.
- `apps/api/cmd/dump-routes` — the route source: the real Gin engine, every optional handler mounted.

**Nothing has been applied to GCP.** The apply command is at the bottom.

## Why

`POST /mcp` shipped, deployed and was unreachable. The API mounted it; the url-map did not route it, so it fell to `defaultService` and the web SPA answered it. The OAuth discovery documents were about to do the same. Both return **200 `text/html`** — no status-code smoke test can see either, because something answered, it was just the wrong something.

## The subtle part: where the route list comes from

A hand-kept list drifts, so the routes come from the engine. But the obvious engine is the wrong one.

`apps/api/tests/contract/openapi_route_coverage_test.go`'s `buildFullEngine` leaves `MCPDiscoveryH`, `MCPTransportH` and `MCPOAuthH` nil, and `server.New` guards every registration with `if deps.X != nil`. Those routes never materialise there. Its `allowlistLiveNotInSpec` is **empty** and `go test ./tests/contract/...` passes green — over a surface it cannot see, containing exactly the routes this gate exists to catch.

`cmd/dump-routes` mounts every optional handler and reflects over `Deps` to report any nil-able field left unset (currently: none). Its test asserts the six routes that blind spot hid.

## Proof it fires

The **real** 332-route engine against the url-map **as it is live in GCP right now**:

```
$ ./scripts/check-urlmap-routes.sh --urlmap /tmp/urlmap-incident2.yaml
check-urlmap-routes: 3 route(s) mounted by the API are NOT routed to wpmgr-bes-api.
These fall through to the matcher default and are answered by the web SPA:
a 200 text/html that looks like success and is not.

  MISSING  /.well-known/oauth-authorization-server
  MISSING  /.well-known/oauth-protected-resource
  MISSING  /.well-known/oauth-protected-resource/mcp
EXIT=1
```

Exactly the three known-missing paths out of 332, and nothing else.

## Proof it does not over-fire

```
$ ./scripts/check-urlmap-routes.sh
check-urlmap-routes: OK — 332 mounted route(s) checked against 17 path rule(s) in main; 0 deliberately unrouted.
EXIT=0
```

The allowlist is **empty**. `wpmgr-api` runs `ingress=internal-and-cloud-load-balancing`, so the url-map is the only door in and there is no second private one for an "internal" route to arrive through. Nothing needed excusing.

## Proof the suite is not vacuous

Planting a hole in a copy (removing the empty-route-list fatal) turns exactly the two cases that cover it red, and prints the vacuous-green output the fatal exists to prevent:

```
$ WPMGR_URLMAP_GUARD=/tmp/guard-with-hole.sh ./scripts/check-urlmap-routes_test.sh
FAIL empty-route-list-is-fatal (expected exit 2, got 0)
       | check-urlmap-routes: OK — 0 mounted route(s) checked against 11 path rule(s) in main
FAIL unparseable-route-output-is-fatal (expected exit 2, got 0)
18 passed, 4 failed
```

That run also found a real fragility in the guard — a directory pre-check that pre-empted the dumper-failure message — now folded into one error path.

## Finding nothing goes red

22 cases, all green. The fail-closed ones: empty route list, unparseable dumper output, missing url-map / routes file / allowlist, url-map with no API rules, unknown matcher, unknown backend, failing dumper, missing dumper binary. All exit 2. There is no exit code meaning "checked nothing, fine".

The allowlist cannot decay into a silent ignore list: an entry without a `# reason:` line is exit 2, and a stale entry that excuses no live route fails.

## What you need to run

Review `infra/urlmap.yaml`, then as part of the next deploy:

```
gcloud compute url-maps import wpmgr-urlmap --global \
  --source=infra/urlmap.yaml --project=wpmgr-prod
```

Then `make check-urlmap-drift` should go green — it exits 1 until that import runs, which is the file doing its job.

Verify the discovery documents against the running system afterwards, on content and not on status:

```
curl -s https://manage.wpmgr.app/.well-known/oauth-protected-resource/mcp | head -c 200
```

JSON is the pass. HTML is the SPA still answering.

## Follow-up, not in this PR

`buildFullEngine` in `tests/contract` still has the nil-handler blind spot for three handlers. It is a second instance of the class of bug this gate catches and is a `backend-architect` change, not an infra one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive API route coverage checks for the load balancer URL map.
  * Added validation for drift between the committed URL map and live configuration.
  * Added route enumeration and support for documenting intentionally unrouted endpoints.
  * Added Makefile commands for running URL map checks and regression tests.

* **Tests**
  * Added regression coverage for missing routes, wildcard matching, allowlists, malformed inputs, and failed checks.
  * Integrated URL map validation into CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->