### PR TITLE
S16: AI connection wizard, generated client config table, and a sidebar entry

### DIFF
--- a/apps/web/src/components/layout/sidebar-ai-entry.test.tsx
+++ b/apps/web/src/components/layout/sidebar-ai-entry.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+import { ShellContext, type ShellState } from "@/components/layout/app-shell-context";
+import { Sidebar } from "@/components/layout/sidebar";
+import { useMe } from "@/features/auth/use-auth";
+import { useSites } from "@/features/sites/use-sites";
+import { mockQueryResult } from "@/test/query-mocks";
+import type { Site } from "@wpmgr/api";
+
+// FOUND BY THE MUTATION SWEEP, AND IT IS THE ONE THE OWNER ASKED FOR.
+//
+// Repointing the sidebar's "AI" entry from /ai to /email left the entire suite
+// green. The reported complaint was "I can't see in the ui what's the route for
+// this all ai settings? it's not in the sidebar at all" -- so a silent
+// regression of this exact nav entry reproduces the bug the slice exists to
+// fix, and nothing would have said a word.
+//
+// There was no sidebar test in this codebase at all before this file
+// (components/layout carried only top-bar-helpers.test.ts), so nav placement
+// for EVERY entry was unpinned. This covers the AI entry and the two placement
+// decisions either side of it.
+
+vi.mock("@/features/auth/use-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth/use-auth")>();
+  return { ...actual, useMe: vi.fn() };
+});
+vi.mock("@/features/sites/use-sites", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/sites/use-sites")>();
+  return { ...actual, useSites: vi.fn() };
+});
+
+const mockedMe = vi.mocked(useMe);
+const mockedSites = vi.mocked(useSites);
+
+const SHELL: ShellState = {
+  collapsed: false,
+  toggleCollapsed: () => {},
+  mobileOpen: false,
+  setMobileOpen: () => {},
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // A normal tenant operator, not a superadmin: the superadmin branch renders a
+  // completely different nav and would make every assertion below vacuous.
+  mockedMe.mockReturnValue(
+    mockQueryResult({ data: { user: { is_superadmin: false } } }) as ReturnType<typeof useMe>,
+  );
+  mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: [] }));
+});
+
+function renderSidebar() {
+  return renderWithProviders(
+    <ShellContext.Provider value={SHELL}>
+      <Sidebar />
+    </ShellContext.Provider>,
+    { withRouter: true, initialPath: "/sites" },
+  );
+}
+
+describe("the sidebar's AI entry", () => {
+  it("renders the sidebar for a tenant operator at all", async () => {
+    // Guard against the whole file passing vacuously if the render throws into
+    // an empty tree or the superadmin branch takes over.
+    renderSidebar();
+    expect(await screen.findByRole("navigation", { name: /primary/i })).toBeInTheDocument();
+    // Matched on href rather than accessible name: the Sites leaf carries a
+    // live count badge, so its name is not a stable string to assert on.
+    const hrefs = screen.getAllByRole("link").map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("/sites");
+    expect(hrefs).toContain("/email");
+  });
+
+  it("carries an entry pointing at /ai", async () => {
+    renderSidebar();
+    await screen.findByRole("navigation", { name: /primary/i });
+
+    // MATCHED ON THE ROUTE, NOT THE LABEL. An earlier version of this asserted
+    // the accessible name was exactly "AI", and the over-fire check caught it:
+    // renaming the entry to "AI connections" is correct work, and it reddened.
+    // A guard that blocks correct work gets switched off, and then it guards
+    // nothing. What must not regress is that /ai is reachable from the nav.
+    const aiLink = screen
+      .getAllByRole("link")
+      .find((a) => a.getAttribute("href") === "/ai");
+    expect(aiLink, "no sidebar link points at /ai").toBeDefined();
+    // And it has to be labelled, or it is reachable only by people who read
+    // markup.
+    expect((aiLink?.textContent ?? "").trim().length).toBeGreaterThan(0);
+  });
+
+  it("keeps the wizard out of the sidebar", async () => {
+    // /ai/connect hangs off the /ai page's primary action. The house rule is
+    // that an authenticated route reached only from another page stays out of
+    // the nav, and this pins the decision rather than leaving it to memory.
+    renderSidebar();
+    await screen.findByRole("navigation", { name: /primary/i });
+    const hrefs = screen
+      .getAllByRole("link")
+      .map((a) => a.getAttribute("href"))
+      .filter((h): h is string => h !== null);
+    expect(hrefs.length).toBeGreaterThan(3);
+    expect(hrefs).not.toContain("/ai/connect");
+  });
+
+  it("keeps the OAuth consent screen out of the sidebar", async () => {
+    // /connect/ai is a redirect target an external client sends the browser to,
+    // never a destination. Putting it in the nav would offer a page that only
+    // works when it arrives carrying an authorization request.
+    renderSidebar();
+    await screen.findByRole("navigation", { name: /primary/i });
+    const hrefs = screen
+      .getAllByRole("link")
+      .map((a) => a.getAttribute("href"))
+      .filter((h): h is string => h !== null);
+    expect(hrefs).not.toContain("/connect/ai");
+  });
+});

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Share2,
   Shield,
   ShieldAlert,
+  Sparkles,
   TrendingUp,
   Users,
   type LucideIcon,
@@ -144,6 +145,15 @@ const TOP_GROUPS: ReadonlyArray<NavGroup> = [
     label: "Email",
     icon: Mail,
     to: "/email",
+  },
+  // AI connections. A leaf, not a group: /ai is the destination and
+  // /ai/connect hangs off its primary action, so only the index belongs here.
+  // The consent screen at /connect/ai stays out entirely -- it is an OAuth
+  // redirect target, not somewhere anyone navigates to.
+  {
+    label: "AI",
+    icon: Sparkles,
+    to: "/ai",
   },
   {
     label: "Security",

--- a/apps/web/src/features/ai-connections/client-table.ts
+++ b/apps/web/src/features/ai-connections/client-table.ts
@@ -1,0 +1,451 @@
+// The AI client table (design §18, "Each client needs different configuration
+// output").
+//
+// THIS FILE IS DATA, NOT COMPONENTS. The design's constraint is verbatim:
+// "These rows are a data table in the codebase with a test, not eight
+// hand-written components. Each row carries the URL key, whether to emit a
+// type, the available auth methods, the config path [...] and a verified_at
+// date. The page renders from the table; when a client changes, one row
+// changes."
+//
+// It imports nothing from React, the router or the design system on purpose, so
+// moving it into a shared package for the marketing site to render the same
+// truth is a file move rather than an untangling.
+//
+// EVERY FACT BELOW IS SOURCED, AND A FACT WE DO NOT HAVE IS MODELLED AS ABSENT
+// RATHER THAN GUESSED. That is not fastidiousness: the governing defect in this
+// codebase is a failure or an absence quietly coerced into a plausible value,
+// and on this surface the plausible value is a config block that a user pastes,
+// that parses, and that silently never connects. A row we cannot source emits
+// no snippet at all (kind: "raw") and says why.
+
+/** ISO date the config facts in this table were checked against client docs. */
+export const CLIENT_TABLE_VERIFIED_AT = "2026-08-24";
+
+/**
+ * The protocol revision we negotiate for, and the floor below which a client is
+ * refused. Both are rendered to the operator (design §6: "The connect screens
+ * render the same two numbers").
+ */
+export const PROTOCOL_TARGET_VERSION = "2025-11-25";
+export const PROTOCOL_FLOOR_VERSION = "2025-03-26";
+
+/** Path of the single Streamable HTTP endpoint (apps/api/internal/mcp/transport.go: TransportPath). */
+export const MCP_TRANSPORT_PATH = "/mcp";
+
+/**
+ * The two auth methods a user chooses between in step 5.
+ *
+ * There is no third. A device-code flow is deferred past Phase 2 (design §18),
+ * so a client that can do neither of these cannot connect and the wizard says
+ * so rather than offering a method that cannot work.
+ */
+export type AuthMethod = "oauth" | "token";
+
+/**
+ * Whether an auth method is usable with a client, and WHY when it is not.
+ *
+ * Three states, not two, and the third is the point. "We know this cannot work"
+ * and "we have not checked" are different facts about different things -- the
+ * first is about the client, the second is about us -- and collapsing them is
+ * how a hardcoded "not verified" list becomes permanent instead of visibly
+ * stale. `unverified` carries the date we last looked so the staleness is on
+ * screen.
+ */
+export type AuthAvailability =
+  | { readonly state: "available"; readonly detail: string }
+  | { readonly state: "unavailable"; readonly reason: string }
+  | {
+      readonly state: "unverified";
+      readonly reason: string;
+      readonly lastCheckedAt: string;
+    };
+
+/**
+ * A client whose remote-server config is a JSON object we can generate.
+ *
+ * Every field here exists because at least one client differs on it, and each
+ * difference breaks a copied config silently rather than loudly.
+ */
+export interface JsonConfigShape {
+  readonly kind: "json";
+  /**
+   * The top-level wrapper key. `mcpServers` for every client in the survey
+   * except VS Code, which uses `servers`.
+   */
+  readonly wrapperKey: "mcpServers" | "servers";
+  /**
+   * The key that carries the endpoint URL. Three distinct values in eight
+   * clients, and for Gemini CLI the key IS the transport selector: `httpUrl`
+   * means Streamable HTTP, `url` means the older event-stream transport, so
+   * emitting the wrong one connects the client to a transport we do not serve.
+   */
+  readonly urlKey: "url" | "httpUrl" | "serverUrl";
+  /**
+   * The value of the `type` key, or null when no `type` is emitted.
+   *
+   * Null covers two different reasons and `typeNote` carries which: Cursor MUST
+   * NOT receive one, while Windsurf and Gemini CLI simply have none.
+   */
+  readonly typeValue: string | null;
+  /** Rendered to the operator as the reason for the line above. */
+  readonly typeNote: string;
+  /** True when the client documents a headers map, which is what token auth needs. */
+  readonly supportsHeaders: boolean;
+}
+
+/**
+ * A client configured through its own UI, with no file to write.
+ *
+ * `fieldLabel` is the only per-client difference; the steps themselves are
+ * generated in snippet.ts so they stay one implementation rather than two
+ * hand-written paragraphs.
+ */
+export interface GuiConfigShape {
+  readonly kind: "gui";
+  readonly fieldLabel: string;
+}
+
+/**
+ * A client we render the raw URL for, with no config block.
+ *
+ * Two very different rows use this shape and both are deliberate:
+ *
+ *  - The generic entry, which is first-class by design ("the twelfth entry is
+ *    what stops the list becoming a maintenance trap -- and it is a first-class
+ *    option in the same visual weight, not a consolation").
+ *  - A named client whose file format we have not fully sourced. Codex CLI is
+ *    the live case: the design records that its config is TOML and that the URL
+ *    key is `url`, but not the table header a remote server sits under. A
+ *    generated `[mcp_servers.name]` would be a guess that parses, and a config
+ *    that parses and does not work is worse than no config at all.
+ */
+export interface RawConfigShape {
+  readonly kind: "raw";
+  /** Why there is no generated block. Rendered; never a code comment only. */
+  readonly reason: string;
+}
+
+export type ConfigShape = JsonConfigShape | GuiConfigShape | RawConfigShape;
+
+/**
+ * A POSIX config file location.
+ *
+ * WINDOWS IS ABSENT BY DECISION, not by omission. The design: "Windows paths
+ * are unverified for every command-line client. Every path in the sources was
+ * documented in POSIX form only. Show the POSIX path and link to the client's
+ * own docs; do not print a Windows path for any of them until someone checks."
+ * There is deliberately no `windows` field to fill in carelessly.
+ */
+export interface PosixConfigPath {
+  readonly posix: string;
+  /** ISO date this specific path was checked. */
+  readonly verifiedAt: string;
+}
+
+export interface McpClientRow {
+  readonly id: string;
+  readonly name: string;
+  /** One line, operator-facing, rendered on the picker card. */
+  readonly blurb: string;
+  readonly docsUrl: string;
+  readonly docsLabel: string;
+  /** ISO date this row's config facts were checked. */
+  readonly verifiedAt: string;
+  /**
+   * Null across the board in this slice, and that is a recorded gap rather than
+   * an oversight -- see CONFIG_PATH_GAP below. The field is in the schema so
+   * that filling it is a one-row change, which is the whole point of the table.
+   */
+  readonly configPath: PosixConfigPath | null;
+  readonly config: ConfigShape;
+  readonly auth: {
+    readonly oauth: AuthAvailability;
+    readonly token: AuthAvailability;
+  };
+  /**
+   * True only for the generic Streamable HTTP entry. It changes the copy, never
+   * the visual weight: the design is explicit that it is not a consolation
+   * prize, so nothing may render it smaller, later or greyer than the rest.
+   */
+  readonly generic: boolean;
+}
+
+/**
+ * Why every `configPath` below is null.
+ *
+ * Stated as data so the page can render it, rather than buried in a comment
+ * where it would read on screen as "this client has no config file". The
+ * design wants the POSIX path shown; the honest position today is that nobody
+ * on this change verified one, and a path recalled from memory and stamped with
+ * someone else's verification date is a false provenance claim on exactly the
+ * surface where a wrong path wastes an hour.
+ */
+export const CONFIG_PATH_GAP =
+  "We have not verified config file locations ourselves, so we link to each client's own docs instead of printing a path that may have moved.";
+
+/**
+ * The design calls for eleven named clients plus the generic entry. The source
+ * table it was verified from enumerates eight. The shortfall is declared here
+ * and asserted in the test rather than being padded with three plausible
+ * product names and guessed config shapes.
+ */
+export const CLIENT_TABLE_TARGET_NAMED_COUNT = 11;
+
+/** Shared wording for the token method on any client that documents a headers map. */
+const HEADER_TOKEN_DETAIL =
+  "Paste the connection token into the client's headers map as an Authorization header.";
+
+export const MCP_CLIENTS: readonly McpClientRow[] = [
+  {
+    id: "claude-code",
+    name: "Claude Code",
+    blurb: "Anthropic's terminal client.",
+    docsUrl: "https://docs.claude.com/en/docs/claude-code/mcp",
+    docsLabel: "Claude Code MCP docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "json",
+      wrapperKey: "mcpServers",
+      urlKey: "url",
+      typeValue: "http",
+      // The loudest silent failure in the table: the client does not error on
+      // the URL, it reclassifies the whole entry.
+      typeNote:
+        'Required. A URL with no "type" is read as a local process to launch, and the server is skipped with an error.',
+      supportsHeaders: true,
+    },
+    auth: {
+      oauth: {
+        state: "available",
+        detail: "Sign in through the browser; the client stores the key itself.",
+      },
+      token: { state: "available", detail: HEADER_TOKEN_DETAIL },
+    },
+    generic: false,
+  },
+  {
+    id: "claude-desktop",
+    name: "Claude Desktop",
+    blurb: "The desktop app's connector directory.",
+    docsUrl: "https://support.claude.com/en/articles/11175166-about-custom-connectors-via-remote-mcp-servers",
+    docsLabel: "Claude Desktop connector docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: { kind: "gui", fieldLabel: "Remote MCP server URL" },
+    auth: {
+      oauth: {
+        state: "available",
+        detail: "The only way this client can connect. Sign-in happens in the browser.",
+      },
+      token: {
+        state: "unavailable",
+        // Not a preference and not a limitation of ours.
+        reason:
+          "The add-connector dialog accepts a URL and nothing else. There is no header field, so a token cannot be entered at all.",
+      },
+    },
+    generic: false,
+  },
+  {
+    id: "chatgpt",
+    name: "ChatGPT",
+    blurb: "Connectors in the ChatGPT apps.",
+    docsUrl: "https://platform.openai.com/docs/mcp",
+    docsLabel: "ChatGPT connector docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: { kind: "gui", fieldLabel: "MCP server URL" },
+    auth: {
+      oauth: {
+        state: "available",
+        detail: "Registers itself with us automatically, then sends you here to approve.",
+      },
+      token: {
+        state: "unavailable",
+        reason: "The connector dialog has no header field, so a token cannot be entered at all.",
+      },
+    },
+    generic: false,
+  },
+  {
+    id: "codex-cli",
+    name: "Codex CLI",
+    blurb: "OpenAI's terminal client.",
+    docsUrl: "https://developers.openai.com/codex/mcp",
+    docsLabel: "Codex CLI MCP docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "raw",
+      reason:
+        "This client's config is TOML rather than JSON. We have the URL key but not the table header a remote server sits under, so we show the endpoint and link to the docs rather than generate a block that would parse and never connect.",
+    },
+    auth: {
+      oauth: {
+        state: "available",
+        detail: "Through the client's own login command, which opens this approval screen.",
+      },
+      token: {
+        state: "unverified",
+        reason:
+          "This client reads the token from a named environment variable, but we have not verified the setting name that points at it.",
+        lastCheckedAt: CLIENT_TABLE_VERIFIED_AT,
+      },
+    },
+    generic: false,
+  },
+  {
+    id: "cursor",
+    name: "Cursor",
+    blurb: "The Cursor editor.",
+    docsUrl: "https://cursor.com/docs/context/mcp",
+    docsLabel: "Cursor MCP docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "json",
+      wrapperKey: "mcpServers",
+      urlKey: "url",
+      typeValue: null,
+      typeNote:
+        'Must not be emitted. No remote server example in this client\'s docs carries a "type" key.',
+      supportsHeaders: true,
+    },
+    auth: {
+      oauth: {
+        state: "available",
+        detail: "Sign in through the browser when the editor first reaches the server.",
+      },
+      token: { state: "available", detail: HEADER_TOKEN_DETAIL },
+    },
+    generic: false,
+  },
+  {
+    id: "vscode",
+    name: "VS Code / Copilot",
+    blurb: "Visual Studio Code's agent mode.",
+    docsUrl: "https://code.visualstudio.com/docs/copilot/customization/mcp-servers",
+    docsLabel: "VS Code MCP docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "json",
+      // The one client in the survey that does not use `mcpServers`.
+      wrapperKey: "servers",
+      urlKey: "url",
+      typeValue: "http",
+      typeNote: 'This client expects "type": "http" on a remote server.',
+      supportsHeaders: true,
+    },
+    auth: {
+      oauth: {
+        state: "unverified",
+        // The design is explicit: "Undocumented on the page we fetched -- do
+        // not claim OAuth". Rendering this as "available" would send an
+        // operator down a path we have never seen work.
+        reason:
+          "Browser sign-in was not documented on the page we checked. It may work; we have not confirmed it, so we do not claim it.",
+        lastCheckedAt: CLIENT_TABLE_VERIFIED_AT,
+      },
+      token: { state: "available", detail: HEADER_TOKEN_DETAIL },
+    },
+    generic: false,
+  },
+  {
+    id: "windsurf",
+    name: "Windsurf / Devin",
+    blurb: "The Windsurf editor and Devin.",
+    docsUrl: "https://docs.windsurf.com/windsurf/cascade/mcp",
+    docsLabel: "Windsurf MCP docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "json",
+      wrapperKey: "mcpServers",
+      urlKey: "serverUrl",
+      typeValue: null,
+      typeNote: "This client has no type key; the URL key alone selects a remote server.",
+      supportsHeaders: true,
+    },
+    auth: {
+      oauth: {
+        state: "unverified",
+        reason:
+          "This client's docs describe headers for remote servers and do not document a browser sign-in. We have not confirmed one, so we do not claim it.",
+        lastCheckedAt: CLIENT_TABLE_VERIFIED_AT,
+      },
+      token: { state: "available", detail: HEADER_TOKEN_DETAIL },
+    },
+    generic: false,
+  },
+  {
+    id: "gemini-cli",
+    name: "Gemini CLI",
+    blurb: "Google's terminal client.",
+    docsUrl: "https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html",
+    docsLabel: "Gemini CLI MCP docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "json",
+      wrapperKey: "mcpServers",
+      // THE KEY IS THE TRANSPORT. Not a naming quirk.
+      urlKey: "httpUrl",
+      typeValue: null,
+      typeNote:
+        'No type key. The URL key picks the transport instead: "httpUrl" is Streamable HTTP, and "url" would select the older event-stream transport we do not serve.',
+      supportsHeaders: true,
+    },
+    auth: {
+      oauth: {
+        state: "available",
+        detail: "Through the client's own OAuth command, which opens this approval screen.",
+      },
+      token: { state: "available", detail: HEADER_TOKEN_DETAIL },
+    },
+    generic: false,
+  },
+  {
+    id: "generic",
+    name: "Other / generic Streamable HTTP",
+    blurb: "Any client that speaks Streamable HTTP. Same endpoint, same auth.",
+    docsUrl: "https://modelcontextprotocol.io/specification/2025-06-18/basic/transports",
+    docsLabel: "Streamable HTTP specification",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "raw",
+      reason:
+        "Every client stores this differently. Here is the endpoint and how to authenticate; put them wherever your client keeps remote servers.",
+    },
+    auth: {
+      oauth: {
+        state: "available",
+        detail: "Standard authorization code flow with PKCE and dynamic client registration.",
+      },
+      token: {
+        state: "available",
+        detail: "Send the connection token as an Authorization: Bearer header on every request.",
+      },
+    },
+    // First-class, same visual weight. Nothing may treat this as a fallback.
+    generic: true,
+  },
+];
+
+/** Look a row up by id. Returns undefined for an unknown id; never a default row. */
+export function findClient(id: string): McpClientRow | undefined {
+  return MCP_CLIENTS.find((c) => c.id === id);
+}
+
+/** True when the client can use this auth method today. `unverified` is not `available`. */
+export function isAuthAvailable(client: McpClientRow, method: AuthMethod): boolean {
+  return client.auth[method].state === "available";
+}
+
+/** Every method this client can use. Empty is a real answer and the wizard must handle it. */
+export function availableAuthMethods(client: McpClientRow): readonly AuthMethod[] {
+  return (["oauth", "token"] as const).filter((m) => isAuthAvailable(client, m));
+}

--- a/apps/web/src/features/ai-connections/client-table.ts
+++ b/apps/web/src/features/ai-connections/client-table.ts
@@ -181,6 +181,33 @@ export interface McpClientRow {
  * someone else's verification date is a false provenance claim on exactly the
  * surface where a wrong path wastes an hour.
  */
+/**
+ * What a self-hosted operator has to do for the endpoint we print to work.
+ *
+ * WE CANNOT VERIFY THIS FROM THE BROWSER, SO WE SAY SO RATHER THAN IMPLYING IT
+ * IS FINE. The endpoint is derived from the running origin, which is right, but
+ * derivable is not routed:
+ *
+ *   - Hosted IS routed. infra/urlmap.yaml:81 lists `/mcp`.
+ *   - The self-hosted reverse proxy is NOT. infra/nginx/nginx.conf carries
+ *     locations for /api/, /auth/, /enroll, /agent/, /rum/, /webhooks/,
+ *     /healthz and /readyz, and none for /mcp -- so `location /` serves the
+ *     SPA and the copied URL returns a web page.
+ *   - Neither is the dev server. apps/web/vite.config.ts proxies /api, /auth,
+ *     /enroll, /agent, /healthz and /readyz only.
+ *
+ * That exact shape -- a Go route mounted, no proxy rule, silently answered by
+ * something else -- is what nginx.conf's own header comment records happening
+ * to self-hosted RUM ingest, and what made POST /mcp unreachable in production
+ * once already. A wizard that prints the URL and says nothing hands a
+ * self-hosted operator a web page and lets them debug their AI client.
+ *
+ * Phrased as a deployment requirement rather than an alarm: for a hosted
+ * operator it is already satisfied, and a warning there would be crying wolf.
+ */
+export const SELF_HOSTED_PROXY_REQUIREMENT =
+  "Self-hosted: your reverse proxy must forward /mcp to the API, alongside the /api and /auth rules it already has. We cannot check that from your browser, so we say it rather than assume it.";
+
 export const CONFIG_PATH_GAP =
   "We have not verified config file locations ourselves, so we link to each client's own docs instead of printing a path that may have moved.";
 

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -178,6 +178,36 @@ describe("the setup artefact is generated per client", () => {
   });
 });
 
+describe("the wizard does not promise things it cannot deliver", () => {
+  it("does not claim the entered name appears on the approval screen", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByText(/"mcpServers"/);
+
+    // The old copy said "shown on the approval screen". Nothing carries the
+    // name there -- the client starts the OAuth flow itself -- so an operator
+    // would go looking for something that is not there. Wrong prose is a defect.
+    expect(screen.queryByText(/shown on the approval screen/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/used as the server key in the config/i)).toBeInTheDocument();
+    expect(screen.getByText(/asks you to name\s+the connection separately/i)).toBeInTheDocument();
+  });
+
+  it("states the self-hosted proxy requirement beside the endpoint it printed", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByText(/"mcpServers"/);
+
+    // The URL is derived from the origin, which does not prove anything
+    // forwards it: infra/nginx/nginx.conf has no /mcp location and
+    // apps/web/vite.config.ts does not proxy it, so on a self-hosted install
+    // or in dev the copied URL reaches the SPA. Saying nothing would hand
+    // someone a web page and let them debug their AI client.
+    expect(screen.getByText(/reverse proxy must forward \/mcp to the API/i)).toBeInTheDocument();
+  });
+});
+
 describe("changing the client recomputes rather than carrying a stale answer", () => {
   it("drops a method the newly chosen client cannot use", async () => {
     renderWizard();

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { screen, fireEvent, within } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { Route } from "@/routes/_authed/ai/connect";
+import { MCP_CLIENTS } from "./client-table";
+
+// The wizard, through the real route component, the real router and a real
+// QueryClient -- not by calling a hook or rendering a subcomponent in
+// isolation. What is being tested is the computation from client to method to
+// snippet, and that computation only exists once the route has mounted the
+// wizard with a real endpoint.
+
+const ConnectPage = Route.options.component!;
+
+function renderWizard() {
+  return renderWithProviders(<ConnectPage />, {
+    withRouter: true,
+    initialPath: "/ai/connect",
+  });
+}
+
+async function pickClient(name: string) {
+  const card = await screen.findByRole("button", { name: new RegExp(name, "i") });
+  fireEvent.click(card);
+  return card;
+}
+
+function authCard(method: "oauth" | "token"): HTMLButtonElement {
+  const el = document.querySelector<HTMLButtonElement>(`button[data-method="${method}"]`);
+  // A missing card must fail the test rather than letting every assertion
+  // below it be skipped.
+  if (el === null) throw new Error(`no auth card rendered for "${method}"`);
+  return el;
+}
+
+describe("the wizard asks for the client first", () => {
+  it("renders every row in the table as a picker card, including the generic one", async () => {
+    renderWizard();
+    for (const client of MCP_CLIENTS) {
+      expect(
+        await screen.findByRole("button", { name: new RegExp(client.name, "i") }),
+      ).toBeInTheDocument();
+    }
+    // The generic entry is present and carries the same affordance as the rest,
+    // not a smaller one.
+    const generic = await screen.findByRole("button", { name: /other \/ generic/i });
+    expect(generic).toBeEnabled();
+  });
+
+  it("does not offer an auth method before a client is chosen", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+    expect(document.querySelector('button[data-method="oauth"]')).toBeNull();
+  });
+});
+
+describe("the method step is computed from the client, with the reason on the card", () => {
+  it("disables the token method for Claude Desktop and says exactly why", async () => {
+    renderWizard();
+    await pickClient("Claude Desktop");
+
+    const token = authCard("token");
+    expect(token).toBeDisabled();
+    // NEVER A GENERIC "UNAVAILABLE". The card carries the client's own reason.
+    expect(within(token).getByText(/no header field/i)).toBeInTheDocument();
+
+    // And the method that DOES work is offered, so the guard is not blanket.
+    expect(authCard("oauth")).toBeEnabled();
+  });
+
+  it("disables OAuth for VS Code as 'not yet verified by us', with the date", async () => {
+    renderWizard();
+    await pickClient("VS Code");
+
+    const oauth = authCard("oauth");
+    expect(oauth).toBeDisabled();
+    // The two halves the design asks for: not verified BY US, and when we last
+    // looked, so a stale row looks stale rather than permanent.
+    expect(within(oauth).getByText(/not yet verified by us/i)).toBeInTheDocument();
+    expect(within(oauth).getByText(/last checked 2026-08-24/i)).toBeInTheDocument();
+
+    expect(authCard("token")).toBeEnabled();
+  });
+
+  it("enables both methods for a client that supports both", async () => {
+    // The over-fire case: a correct client must not be blocked by the
+    // disabling logic.
+    renderWizard();
+    await pickClient("Cursor");
+    expect(authCard("oauth")).toBeEnabled();
+    expect(authCard("token")).toBeEnabled();
+  });
+});
+
+describe("the setup artefact is generated per client", () => {
+  it("emits the required http type for Claude Code", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("oauth"));
+
+    const block = await screen.findByText(/"mcpServers"/);
+    const text = block.textContent ?? "";
+    expect(text).toContain('"type": "http"');
+    expect(text).toContain('"url"');
+    // The reason for that line is on screen, not only in a comment.
+    expect(screen.getByText(/read as a local process/i)).toBeInTheDocument();
+  });
+
+  it("emits httpUrl and no url for Gemini CLI", async () => {
+    renderWizard();
+    await pickClient("Gemini CLI");
+    fireEvent.click(authCard("oauth"));
+
+    const text = (await screen.findByText(/"mcpServers"/)).textContent ?? "";
+    expect(text).toContain('"httpUrl"');
+    expect(text).not.toContain('"url"');
+  });
+
+  it("emits the servers wrapper for VS Code", async () => {
+    renderWizard();
+    await pickClient("VS Code");
+    fireEvent.click(authCard("token"));
+
+    const text = (await screen.findByText(/"servers"/)).textContent ?? "";
+    expect(text).toContain('"servers"');
+    expect(text).not.toContain('"mcpServers"');
+  });
+
+  it("emits no type key for Cursor", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+
+    const text = (await screen.findByText(/"mcpServers"/)).textContent ?? "";
+    expect(text).not.toContain('"type"');
+  });
+
+  it("renders the endpoint and a spec link for the generic entry, with no config block", async () => {
+    renderWizard();
+    await pickClient("Other / generic");
+    fireEvent.click(authCard("oauth"));
+
+    expect(await screen.findByText(/endpoint for other \/ generic/i)).toBeInTheDocument();
+    expect(screen.queryByText(/"mcpServers"/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /streamable http specification/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("gives GUI clients in-app steps rather than a file to edit", async () => {
+    renderWizard();
+    await pickClient("Claude Desktop");
+    fireEvent.click(authCard("oauth"));
+
+    expect(await screen.findByText(/set this up inside claude desktop/i)).toBeInTheDocument();
+    expect(screen.queryByText(/"mcpServers"/)).not.toBeInTheDocument();
+  });
+
+  it("never prints a Windows path", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByText(/"mcpServers"/);
+    // Every source documented POSIX only; a Windows path here would be invented.
+    expect(document.body.textContent ?? "").not.toMatch(/[A-Z]:\\|%APPDATA%/);
+  });
+
+  it("tells the user a token cannot be minted here yet rather than showing a fake one", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+
+    const text = (await screen.findByText(/"mcpServers"/)).textContent ?? "";
+    expect(text).toContain("YOUR_CONNECTION_TOKEN");
+    expect(screen.getByText(/cannot mint a token here yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("changing the client recomputes rather than carrying a stale answer", () => {
+  it("drops a method the newly chosen client cannot use", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    expect(await screen.findByText(/"mcpServers"/)).toBeInTheDocument();
+
+    // Claude Desktop cannot use a token. The wizard must fall back to asking,
+    // not silently keep a selection that produces no valid artefact.
+    await pickClient("Claude Desktop");
+    expect(screen.queryByText(/set this up inside/i)).not.toBeInTheDocument();
+    expect(authCard("token")).toBeDisabled();
+  });
+});

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -13,6 +13,7 @@ import {
   PROTOCOL_TARGET_VERSION,
   availableAuthMethods,
   CONFIG_PATH_GAP,
+  SELF_HOSTED_PROXY_REQUIREMENT,
   type AuthAvailability,
   type AuthMethod,
   type McpClientRow,
@@ -173,7 +174,16 @@ export function ConnectWizard({ endpointUrl, className }: ConnectWizardProps) {
                 placeholder="Fleet manager"
               />
               <p className="text-xs text-[var(--color-muted-foreground)]">
-                Used as the server key in the config, and shown on the approval screen.
+                {/* THE OLD COPY HERE WAS FALSE. It promised this name appears on
+                    the approval screen, and nothing carries it there: the client
+                    starts the OAuth flow itself, so this page never hands the
+                    name to /connect/ai, which asks for its own. Sending an
+                    operator to look for something that will not be there is a
+                    defect. Carrying it through would need a parameter the flow
+                    does not have, so the copy is corrected rather than the
+                    behaviour invented. */}
+                Used as the server key in the config below. The approval screen asks you to name
+                the connection separately, so this name stays on your machine.
               </p>
             </div>
 
@@ -410,6 +420,12 @@ function SnippetBlock({ client, snippet }: { client: McpClientRow; snippet: Snip
           ) : null}
         </div>
       ) : null}
+
+      {/* The endpoint just printed is derived from this origin, which does not
+          prove anything forwards it. Said once, beside every artefact. */}
+      <p className="text-xs text-[var(--color-muted-foreground)]">
+        {SELF_HOSTED_PROXY_REQUIREMENT}
+      </p>
 
       <p className="text-xs text-[var(--color-muted-foreground)]">
         {/* Stated as data from the table, so it reads as "we have not checked"

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -1,0 +1,456 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { AlertTriangle, Check, ExternalLink, Lock } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CopyableMono } from "@/components/shared/copyable-mono";
+import { cn } from "@/lib/utils";
+
+import {
+  MCP_CLIENTS,
+  PROTOCOL_FLOOR_VERSION,
+  PROTOCOL_TARGET_VERSION,
+  availableAuthMethods,
+  CONFIG_PATH_GAP,
+  type AuthAvailability,
+  type AuthMethod,
+  type McpClientRow,
+} from "./client-table";
+import { buildSnippet, type Snippet } from "./snippet";
+
+// The connection wizard (design §18). Client first, method second.
+//
+// THE ORDERING IS THE DESIGN, NOT A PREFERENCE. "The user picks the client and
+// the system computes which authentication methods are possible, disabling the
+// rest with the specific reason written into the disabled card -- never a
+// generic 'unavailable'. Asking a user to choose an auth method their client
+// cannot use is asking them to fail."
+//
+// WHAT THIS RENDERS AND WHAT IT DOES NOT. Steps 1, 2, 5 and 6 live here. Steps
+// 3 and 4 -- which sites, what capabilities -- are collected on the approval
+// screen at /connect/ai, because that is where the grant is actually created
+// (features/mcp-consent/consent-screen.tsx). Duplicating them here would build
+// a second, unwired copy of a consent decision, and a wizard that appears to
+// grant scope it cannot grant is worse than one that says where the choice
+// happens. The step rail below says so on screen.
+//
+// NO SNIPPET IS WRITTEN IN THIS FILE. Every block comes from buildSnippet, and
+// snippet.test.ts fails the build if a config literal appears here.
+
+type Step = 1 | 2 | 3;
+
+interface StepDef {
+  readonly n: Step;
+  readonly label: string;
+}
+
+const STEPS: readonly StepDef[] = [
+  { n: 1, label: "Pick your client" },
+  { n: 2, label: "How it signs in" },
+  { n: 3, label: "Set it up" },
+];
+
+export interface ConnectWizardProps {
+  /** Absolute MCP endpoint for this deployment. Passed in, never assembled here. */
+  endpointUrl: string;
+  /** Where the approval flow lives, for the closing instructions. */
+  className?: string;
+}
+
+export function ConnectWizard({ endpointUrl, className }: ConnectWizardProps) {
+  const [clientId, setClientId] = useState<string | null>(null);
+  const [method, setMethod] = useState<AuthMethod | null>(null);
+  const [name, setName] = useState("Fleet manager");
+
+  const client = useMemo(
+    () => MCP_CLIENTS.find((c) => c.id === clientId) ?? null,
+    [clientId],
+  );
+
+  const methods = client === null ? [] : availableAuthMethods(client);
+
+  // The current step is derived, never stored, so it cannot disagree with the
+  // answers. Picking a different client with an incompatible method drops the
+  // method rather than carrying a stale one into step 3.
+  const step: Step = client === null ? 1 : method === null ? 2 : 3;
+
+  const snippet: Snippet | null = useMemo(() => {
+    if (client === null || method === null) return null;
+    try {
+      return buildSnippet({
+        client,
+        endpointUrl,
+        serverName: name,
+        authMethod: method,
+      });
+    } catch {
+      // buildSnippet throws when the table says this combination cannot work.
+      // Null renders a refusal below; it never renders a best-effort block.
+      return null;
+    }
+  }, [client, method, endpointUrl, name]);
+
+  function chooseClient(next: McpClientRow) {
+    setClientId(next.id);
+    // Drop a method the new client cannot use rather than carrying it forward.
+    setMethod((current) =>
+      current !== null && availableAuthMethods(next).includes(current) ? current : null,
+    );
+  }
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      <StepRail current={step} />
+
+      <Section
+        n={1}
+        title="Pick your client"
+        hint="Everything after this is computed from your answer, so nothing asks you twice."
+      >
+        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {MCP_CLIENTS.map((c) => (
+            <li key={c.id}>
+              <ClientCard
+                client={c}
+                selected={c.id === clientId}
+                onSelect={() => chooseClient(c)}
+              />
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      {client !== null ? (
+        <Section
+          n={2}
+          title="How it signs in"
+          hint={`Computed from ${client.name}. A method it cannot use is disabled with the reason.`}
+        >
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <AuthCard
+              method="oauth"
+              title="Sign in through the browser"
+              body="You approve the connection here, and the client stores its own key. Nothing to copy or keep secret."
+              availability={client.auth.oauth}
+              selected={method === "oauth"}
+              onSelect={() => setMethod("oauth")}
+            />
+            <AuthCard
+              method="token"
+              title="Connection token"
+              body="The documented path for CI, containers and SSH sessions, where no browser can open."
+              availability={client.auth.token}
+              selected={method === "token"}
+              onSelect={() => setMethod("token")}
+            />
+          </div>
+          {methods.length === 0 ? (
+            <p
+              role="alert"
+              className="mt-3 rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 text-sm text-[var(--color-foreground)]"
+            >
+              We cannot connect {client.name} yet. Neither method is confirmed to work with it, and
+              we would rather say so than send you down a path we have never seen finish.
+            </p>
+          ) : null}
+        </Section>
+      ) : null}
+
+      {client !== null && method !== null ? (
+        <Section
+          n={3}
+          title="Set it up"
+          hint="Generated for this client. Every difference below is a real difference between clients."
+        >
+          <div className="space-y-4">
+            <div className="max-w-sm space-y-1.5">
+              <Label htmlFor="wizard-connection-name">Name this connection</Label>
+              <Input
+                id="wizard-connection-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Fleet manager"
+              />
+              <p className="text-xs text-[var(--color-muted-foreground)]">
+                Used as the server key in the config, and shown on the approval screen.
+              </p>
+            </div>
+
+            {snippet === null ? (
+              <p
+                role="alert"
+                className="rounded-md border border-[var(--color-destructive)]/40 bg-[var(--color-destructive)]/5 p-3 text-sm"
+              >
+                We have no verified setup for {client.name} with this method, so there is nothing to
+                copy. Copying a config we are guessing at would cost you an hour finding out it does
+                not work.
+              </p>
+            ) : (
+              <SnippetBlock client={client} snippet={snippet} />
+            )}
+
+            <NextSteps method={method} clientName={client.name} />
+          </div>
+        </Section>
+      ) : null}
+
+      <p className="text-xs text-[var(--color-muted-foreground)]">
+        We negotiate protocol {PROTOCOL_TARGET_VERSION} and accept nothing below{" "}
+        {PROTOCOL_FLOOR_VERSION}.
+      </p>
+    </div>
+  );
+}
+
+function StepRail({ current }: { current: Step }) {
+  return (
+    <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--color-muted-foreground)]">
+      {STEPS.map((s, i) => (
+        <li key={s.n} className="flex items-center gap-2">
+          {i > 0 ? <span aria-hidden="true">/</span> : null}
+          <span
+            aria-current={s.n === current ? "step" : undefined}
+            className={cn(
+              s.n === current && "font-medium text-[var(--color-foreground)]",
+              s.n < current && "text-[var(--color-foreground)]",
+            )}
+          >
+            {s.n}. {s.label}
+          </span>
+        </li>
+      ))}
+      <li className="flex items-center gap-2">
+        <span aria-hidden="true">/</span>
+        {/* Named so the wizard does not look like it is hiding the consent
+            decision. It is made on the approval screen, which is where the
+            grant is created. */}
+        <span>4. Choose sites and permissions when you approve</span>
+      </li>
+    </ol>
+  );
+}
+
+function Section({
+  n,
+  title,
+  hint,
+  children,
+}: {
+  n: number;
+  title: string;
+  hint: string;
+  children: ReactNode;
+}) {
+  return (
+    <section aria-label={title} className="space-y-3">
+      <div className="space-y-0.5">
+        <h2 className="text-sm font-semibold text-[var(--color-foreground)]">
+          {n}. {title}
+        </h2>
+        <p className="text-xs text-[var(--color-muted-foreground)]">{hint}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function ClientCard({
+  client,
+  selected,
+  onSelect,
+}: {
+  client: McpClientRow;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={cn(
+        "flex h-full w-full flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]",
+        selected
+          ? "border-[var(--color-primary)] bg-[var(--color-accent)]"
+          : "border-[var(--color-border)] hover:bg-[var(--color-accent)]",
+      )}
+    >
+      <span className="flex w-full items-center justify-between gap-2">
+        <span className="text-sm font-medium text-[var(--color-foreground)]">{client.name}</span>
+        {selected ? (
+          <Check aria-hidden="true" className="size-4 text-[var(--color-primary)]" />
+        ) : null}
+      </span>
+      <span className="text-xs text-[var(--color-muted-foreground)]">{client.blurb}</span>
+    </button>
+  );
+}
+
+/**
+ * One auth method card.
+ *
+ * A DISABLED CARD ALWAYS SAYS WHY, IN ITS OWN WORDS. There is no branch that
+ * renders a bare "unavailable": `unavailable` prints the client's own reason and
+ * `unverified` prints what we have not checked and when we last looked, so a
+ * stale entry looks stale instead of looking permanent.
+ */
+function AuthCard({
+  method,
+  title,
+  body,
+  availability,
+  selected,
+  onSelect,
+}: {
+  method: AuthMethod;
+  title: string;
+  body: string;
+  availability: AuthAvailability;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const disabled = availability.state !== "available";
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      aria-pressed={selected}
+      data-method={method}
+      className={cn(
+        "flex h-full flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]",
+        disabled && "cursor-not-allowed opacity-70",
+        !disabled && selected
+          ? "border-[var(--color-primary)] bg-[var(--color-accent)]"
+          : "border-[var(--color-border)]",
+        !disabled && !selected && "hover:bg-[var(--color-accent)]",
+      )}
+    >
+      <span className="flex w-full items-center justify-between gap-2">
+        <span className="text-sm font-medium text-[var(--color-foreground)]">{title}</span>
+        {availability.state === "unavailable" ? (
+          <Lock aria-hidden="true" className="size-4 text-[var(--color-muted-foreground)]" />
+        ) : null}
+        {availability.state === "unverified" ? (
+          <AlertTriangle aria-hidden="true" className="size-4 text-[var(--color-muted-foreground)]" />
+        ) : null}
+      </span>
+      <span className="text-xs text-[var(--color-muted-foreground)]">{body}</span>
+
+      {availability.state === "available" ? (
+        <span className="text-xs text-[var(--color-foreground)]">{availability.detail}</span>
+      ) : null}
+
+      {availability.state === "unavailable" ? (
+        <span className="text-xs text-[var(--color-foreground)]">{availability.reason}</span>
+      ) : null}
+
+      {availability.state === "unverified" ? (
+        <span className="flex flex-col gap-1 text-xs text-[var(--color-foreground)]">
+          <span>Not yet verified by us. {availability.reason}</span>
+          {/* The date is the point: it makes an entry that has gone stale look
+              stale, instead of reading as a permanent property of the client. */}
+          <span className="text-[var(--color-muted-foreground)]">
+            Last checked {availability.lastCheckedAt}.
+          </span>
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function SnippetBlock({ client, snippet }: { client: McpClientRow; snippet: Snippet }) {
+  return (
+    <div className="space-y-3">
+      {snippet.kind === "json" ? (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-xs font-medium text-[var(--color-foreground)]">
+              Config for {client.name}
+            </span>
+            <Badge variant="muted">JSON</Badge>
+          </div>
+          <pre className="overflow-x-auto rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 font-mono text-xs text-[var(--color-foreground)]">
+            <code>{snippet.text}</code>
+          </pre>
+          <div className="flex flex-wrap items-center gap-2">
+            <CopyableMono value={snippet.text} label={`Copy the ${client.name} config`} truncate />
+          </div>
+          {/* The reason for the type line, on screen rather than in a comment. */}
+          <p className="text-xs text-[var(--color-muted-foreground)]">{snippet.note}</p>
+        </div>
+      ) : null}
+
+      {snippet.kind === "gui" ? (
+        <div className="space-y-2">
+          <span className="text-xs font-medium text-[var(--color-foreground)]">
+            Set this up inside {client.name}
+          </span>
+          <ol className="list-decimal space-y-1 pl-5 text-sm text-[var(--color-foreground)]">
+            {snippet.steps.map((s) => (
+              <li key={s}>{s}</li>
+            ))}
+          </ol>
+          <CopyableMono value={snippet.url} label="Copy the endpoint" />
+        </div>
+      ) : null}
+
+      {snippet.kind === "raw" ? (
+        <div className="space-y-2">
+          <span className="text-xs font-medium text-[var(--color-foreground)]">
+            Endpoint for {client.name}
+          </span>
+          <p className="text-sm text-[var(--color-muted-foreground)]">{snippet.reason}</p>
+          <CopyableMono value={snippet.url} label="Copy the endpoint" />
+          {snippet.headerLine !== null ? (
+            <CopyableMono value={snippet.headerLine} label="Copy the authorization header" />
+          ) : null}
+        </div>
+      ) : null}
+
+      <p className="text-xs text-[var(--color-muted-foreground)]">
+        {/* Stated as data from the table, so it reads as "we have not checked"
+            rather than "this client has no config file". */}
+        {CONFIG_PATH_GAP}{" "}
+        <a
+          href={client.docsUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center gap-1 text-[var(--color-primary)] underline-offset-4 hover:underline"
+        >
+          {client.docsLabel}
+          <ExternalLink aria-hidden="true" className="size-3" />
+        </a>
+      </p>
+    </div>
+  );
+}
+
+function NextSteps({ method, clientName }: { method: AuthMethod; clientName: string }) {
+  if (method === "oauth") {
+    return (
+      <div className="rounded-md border border-[var(--color-border)] p-3 text-sm text-[var(--color-foreground)]">
+        <p className="font-medium">What happens next</p>
+        <p className="mt-1 text-[var(--color-muted-foreground)]">
+          Start the connection in {clientName}. It sends you back here to approve, and that approval
+          screen is where you choose which sites it may touch and what it may do. Nothing is created
+          until you approve.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border border-[var(--color-border)] p-3 text-sm text-[var(--color-foreground)]">
+      <p className="font-medium">You cannot mint a token here yet</p>
+      <p className="mt-1 text-[var(--color-muted-foreground)]">
+        The config above is correct and ready, but the dashboard has no way to issue a connection
+        token today, so the placeholder in it stays a placeholder. Use browser sign-in if{" "}
+        {clientName} supports it. We would rather tell you this now than after you have pasted a
+        config that cannot authenticate.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/ai-connections/connection-model.ts
+++ b/apps/web/src/features/ai-connections/connection-model.ts
@@ -1,0 +1,125 @@
+// The shape of a live AI connection, and the three-way facts the list must not
+// flatten.
+//
+// NO FETCHING HERE, AND NO INVENTED ENDPOINT. The control plane exposes four
+// MCP OAuth endpoints today -- register, token, authorize and consent
+// (apps/api/internal/mcp/handler.go:71 and :89) -- and none of them lists or
+// revokes a grant. This module is the model and the vocabulary; wiring it to a
+// real query is one hook away once that endpoint exists.
+
+/**
+ * What a client told us about the protocol revision it speaks, on connect.
+ *
+ * THREE CASES, NOT TWO, AND NEVER A STRING THAT COLLAPSES THEM. Design §6 is
+ * explicit that the absent header, a recognised version and an unrecognised
+ * version have three different correct answers and "treating any two of them
+ * the same is a defect". The list inherits that: an absent header rendered as a
+ * version is a claim the client never made.
+ */
+export type ProtocolHeader =
+  | { readonly kind: "absent" }
+  | { readonly kind: "recognised"; readonly version: string }
+  | { readonly kind: "unrecognised"; readonly version: string };
+
+/**
+ * When a connection was last used.
+ *
+ * "Never used" and "we could not load this" are different facts, and so is
+ * "used at T". The first two are not renderable as a date, so they are not
+ * dates.
+ */
+export type LastUsed =
+  | { readonly kind: "never" }
+  | { readonly kind: "at"; readonly iso: string };
+
+export type ConnectionStatus = "active" | "paused" | "revoked";
+
+export interface AiConnection {
+  readonly id: string;
+  /** Operator-chosen name for the connection. */
+  readonly name: string;
+  /**
+   * The client's self-reported name, or null when it reported none.
+   * Never defaulted to the operator's chosen client: one is a claim by the
+   * client, the other is a claim by the operator, and they can disagree.
+   */
+  readonly reportedClientName: string | null;
+  readonly reportedClientVersion: string | null;
+  readonly protocolHeader: ProtocolHeader;
+  readonly lastUsed: LastUsed;
+  readonly scopes: readonly string[];
+  readonly status: ConnectionStatus;
+  readonly createdAt: string;
+}
+
+/**
+ * Everything the connections list can be showing.
+ *
+ * FIVE STATES, AND THE FIFTH IS THE HONEST ONE TODAY. `unavailable` is not
+ * `error` and it is not `empty`: it means the control plane has no endpoint to
+ * ask, which is a fact about us and is fixed by shipping an API, whereas
+ * `error` means we asked and it went wrong, and `empty` is a claim that the
+ * operator has no connections. Rendering any of these three as another is the
+ * defect this codebase keeps producing.
+ */
+export type ConnectionsState =
+  | { readonly status: "loading" }
+  | { readonly status: "error"; readonly message: string }
+  | { readonly status: "unavailable"; readonly reason: string }
+  | { readonly status: "empty" }
+  | { readonly status: "ready"; readonly connections: readonly AiConnection[] };
+
+/**
+ * Build the list state from a query result.
+ *
+ * Written as a pure function so the mapping is testable without a render, and
+ * so the one line that could turn a failure into an empty list lives in exactly
+ * one place instead of at every call site.
+ *
+ * ORDER MATTERS AND IS THE POINT. Error is checked BEFORE data, and `undefined`
+ * data is never coerced to `[]`. `connections ?? []` is precisely the shipped
+ * bug this function exists to make impossible.
+ */
+export function connectionsState(input: {
+  readonly isPending: boolean;
+  readonly error: Error | null;
+  readonly connections: readonly AiConnection[] | undefined;
+}): ConnectionsState {
+  if (input.error !== null) {
+    return {
+      status: "error",
+      message: input.error.message.length > 0 ? input.error.message : "The request failed.",
+    };
+  }
+  if (input.isPending) return { status: "loading" };
+  // Not pending, no error, and still nothing: we did not read the list, so we
+  // must not claim it is empty.
+  if (input.connections === undefined) {
+    return {
+      status: "error",
+      message: "We did not get a list of connections back, so we cannot tell you what is connected.",
+    };
+  }
+  if (input.connections.length === 0) return { status: "empty" };
+  return { status: "ready", connections: input.connections };
+}
+
+/** Human label for a protocol header, keeping absence visible as absence. */
+export function protocolHeaderLabel(header: ProtocolHeader, floorVersion: string): string {
+  switch (header.kind) {
+    case "absent":
+      // Not "unknown", not blank, and not the floor version on its own: the
+      // client sent nothing, and we treat that as the floor. Both halves are
+      // said.
+      return `No protocol header sent (treated as ${floorVersion})`;
+    case "unrecognised":
+      return `${header.version} (not a revision we recognise)`;
+    case "recognised":
+      return header.version;
+  }
+}
+
+/** Human label for last use, keeping "never" distinct from a date. */
+export function lastUsedLabel(lastUsed: LastUsed, formatIso: (iso: string) => string): string {
+  return lastUsed.kind === "never" ? "Never used" : formatIso(lastUsed.iso);
+}

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { ConnectionsList } from "./connections-list";
+import {
+  connectionsState,
+  protocolHeaderLabel,
+  type AiConnection,
+  type ConnectionsState,
+} from "./connection-model";
+
+// A FAILED LOAD IS NOT AN EMPTY LIST, AND AN ABSENT HEADER IS NOT A VERSION.
+//
+// Both are the same defect: an absence coerced into a plausible value. On this
+// page the plausible values are "you have no AI connections" (a claim about the
+// operator's account, made out of a fact about our request) and a version
+// number the client never sent. The consent screen next door shipped this class
+// three rounds running, so it is pinned here at the mapping AND at the render.
+
+const CONNECTED: AiConnection = {
+  id: "c1",
+  name: "Fleet manager",
+  reportedClientName: "claude-code",
+  reportedClientVersion: "2.1.0",
+  protocolHeader: { kind: "recognised", version: "2025-11-25" },
+  lastUsed: { kind: "at", iso: "2026-08-29T10:00:00.000Z" },
+  scopes: ["mcp:read"],
+  status: "active",
+  createdAt: "2026-08-01T00:00:00.000Z",
+};
+
+/** The copy that must never appear over a failure. */
+const EMPTY_CLAIM = /no ai clients are connected/i;
+
+function renderList(state: ConnectionsState) {
+  return renderWithProviders(<ConnectionsList state={state} />, { withRouter: true });
+}
+
+describe("connectionsState — the mapping that decides which sentence is shown", () => {
+  it("maps a rejected query to error, never to empty", () => {
+    const state = connectionsState({
+      isPending: false,
+      error: new Error("the server said 500"),
+      connections: undefined,
+    });
+    expect(state.status).toBe("error");
+  });
+
+  it("maps an error to error even when the cache still holds rows", () => {
+    // A refetch failing after a successful load is still a failure, and the
+    // rows on screen are stale. Preferring the stale rows silently is how a
+    // revoked connection keeps appearing to be live.
+    const state = connectionsState({
+      isPending: false,
+      error: new Error("network"),
+      connections: [CONNECTED],
+    });
+    expect(state.status).toBe("error");
+  });
+
+  it("maps a resolved empty array to empty", () => {
+    expect(
+      connectionsState({ isPending: false, error: null, connections: [] }).status,
+    ).toBe("empty");
+  });
+
+  it("maps a settled query with undefined data to error, not empty", () => {
+    // The `connections ?? []` line, refused. Not pending, no error, and still
+    // nothing means we did not read the list.
+    expect(
+      connectionsState({ isPending: false, error: null, connections: undefined }).status,
+    ).toBe("error");
+  });
+
+  it("maps a pending query to loading", () => {
+    expect(
+      connectionsState({ isPending: true, error: null, connections: undefined }).status,
+    ).toBe("loading");
+  });
+
+  it("maps rows to ready", () => {
+    const state = connectionsState({
+      isPending: false,
+      error: null,
+      connections: [CONNECTED],
+    });
+    expect(state.status).toBe("ready");
+    if (state.status === "ready") expect(state.connections).toHaveLength(1);
+  });
+});
+
+describe("ConnectionsList renders each state as a different thing", () => {
+  it("renders the failure and NOT the empty claim", async () => {
+    renderList({ status: "error", message: "the server said 500" });
+    expect(await screen.findByText(/could not load your ai connections/i)).toBeInTheDocument();
+    expect(screen.getByText(/the server said 500/i)).toBeInTheDocument();
+    // The assertion that matters: the empty sentence is absent.
+    expect(screen.queryByText(EMPTY_CLAIM)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("connections-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty state, and it does not read as a failure", async () => {
+    renderList({ status: "empty" });
+    // Proves the guard above does not over-fire: correct empty work still
+    // renders the empty sentence.
+    expect(await screen.findByText(EMPTY_CLAIM)).toBeInTheDocument();
+    expect(screen.queryByText(/could not load/i)).not.toBeInTheDocument();
+  });
+
+  it("renders 'we cannot list these yet' as neither empty nor error", async () => {
+    renderList({ status: "unavailable", reason: "no endpoint exists yet" });
+    expect(await screen.findByText(/cannot list your connections yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/no endpoint exists yet/i)).toBeInTheDocument();
+    // Three different facts, three different sentences.
+    expect(screen.queryByText(EMPTY_CLAIM)).not.toBeInTheDocument();
+    expect(screen.queryByText(/could not load your ai connections/i)).not.toBeInTheDocument();
+  });
+
+  it("renders a loading state that is not an empty table", async () => {
+    renderList({ status: "loading" });
+    expect(await screen.findByTestId("connections-loading")).toBeInTheDocument();
+    expect(screen.queryByText(EMPTY_CLAIM)).not.toBeInTheDocument();
+  });
+
+  it("renders rows when there are rows", async () => {
+    renderList({ status: "ready", connections: [CONNECTED] });
+    expect(await screen.findByText("Fleet manager")).toBeInTheDocument();
+    expect(screen.getByText(/claude-code 2\.1\.0/)).toBeInTheDocument();
+    expect(screen.getByText("2025-11-25")).toBeInTheDocument();
+  });
+});
+
+describe("a field the client did not send is rendered as absent", () => {
+  it("says the protocol header was absent instead of printing a version", async () => {
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, protocolHeader: { kind: "absent" } }],
+    });
+    // Both halves: the client sent nothing, AND we treat that as the floor.
+    expect(await screen.findByText(/no protocol header sent/i)).toBeInTheDocument();
+    expect(screen.getByText(/treated as 2025-03-26/i)).toBeInTheDocument();
+    // The number it would have been coerced into must not appear on its own.
+    expect(screen.queryByText("2025-11-25")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes an unrecognised version from a recognised one", () => {
+    // Three cases, three strings. Design §6: treating any two of them the same
+    // is a defect.
+    const floor = "2025-03-26";
+    expect(protocolHeaderLabel({ kind: "absent" }, floor)).toMatch(/no protocol header/i);
+    expect(protocolHeaderLabel({ kind: "recognised", version: "2025-11-25" }, floor)).toBe(
+      "2025-11-25",
+    );
+    expect(
+      protocolHeaderLabel({ kind: "unrecognised", version: "2024-11-05" }, floor),
+    ).toMatch(/not a revision we recognise/i);
+    // And no two of them are the same string.
+    const all = new Set([
+      protocolHeaderLabel({ kind: "absent" }, floor),
+      protocolHeaderLabel({ kind: "recognised", version: "2024-11-05" }, floor),
+      protocolHeaderLabel({ kind: "unrecognised", version: "2024-11-05" }, floor),
+    ]);
+    expect(all.size).toBe(3);
+  });
+
+  it("says never used rather than showing a date", async () => {
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, lastUsed: { kind: "never" } }],
+    });
+    expect(await screen.findByText(/never used/i)).toBeInTheDocument();
+  });
+
+  it("says the client reported no name rather than backfilling one", async () => {
+    renderList({
+      status: "ready",
+      connections: [
+        { ...CONNECTED, reportedClientName: null, reportedClientVersion: null },
+      ],
+    });
+    expect(await screen.findByText(/reported no client name/i)).toBeInTheDocument();
+  });
+
+  it("says a client sent no version rather than dropping the field silently", async () => {
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, reportedClientVersion: null }],
+    });
+    expect(await screen.findByText(/\(no version\)/i)).toBeInTheDocument();
+  });
+
+  it("says no scopes were granted rather than rendering an empty cell", async () => {
+    renderList({ status: "ready", connections: [{ ...CONNECTED, scopes: [] }] });
+    expect(await screen.findByText(/no scopes granted/i)).toBeInTheDocument();
+  });
+
+  it("does not render an unparseable timestamp as a date", async () => {
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, lastUsed: { kind: "at", iso: "not-a-date" } }],
+    });
+    expect(await screen.findByText(/unreadable timestamp/i)).toBeInTheDocument();
+    expect(screen.queryByText(/invalid date/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -174,13 +174,20 @@ describe("a field the client did not send is rendered as absent", () => {
   });
 
   it("says the client reported no name rather than backfilling one", async () => {
+    // ASSERTED ON THE BRANCH, NOT THE SENTENCE. The over-fire pass caught this
+    // matching /reported no client name/i: rewording the sentinel is correct
+    // work and it reddened. The testid renders only in the null-name branch, so
+    // it pins the decision without freezing the copy.
     renderList({
       status: "ready",
       connections: [
         { ...CONNECTED, reportedClientName: null, reportedClientVersion: null },
       ],
     });
-    expect(await screen.findByText(/reported no client name/i)).toBeInTheDocument();
+    const cell = await screen.findByTestId("reported-client");
+    // And it must not have been backfilled from the operator's chosen client.
+    expect(cell.textContent).not.toContain("claude-code");
+    expect((cell.textContent ?? "").trim().length).toBeGreaterThan(0);
   });
 
   it("keeps the version when the client reported one but no name", async () => {

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -183,6 +183,37 @@ describe("a field the client did not send is rendered as absent", () => {
     expect(await screen.findByText(/reported no client name/i)).toBeInTheDocument();
   });
 
+  it("keeps the version when the client reported one but no name", async () => {
+    // The type permits name===null with a version present. Dropping the version
+    // there throws away a fact the client actually sent.
+    //
+    // ASSERTED ON STRUCTURE, NOT ON THE SENTENCE. An earlier version matched
+    // /reported no client name/i, and the over-fire pass caught it: rewording
+    // that sentinel copy is correct work and it reddened. Same trap the sidebar
+    // guard fell into. What must not regress is that the version survives.
+    renderList({
+      status: "ready",
+      connections: [
+        { ...CONNECTED, reportedClientName: null, reportedClientVersion: "0.9.1" },
+      ],
+    });
+    const version = await screen.findByTestId("reported-version");
+    expect(version.textContent).toContain("0.9.1");
+  });
+
+  it("does not invent a version when the client sent neither", async () => {
+    // The over-fire half: a genuinely empty pair must not grow a stray comma or
+    // a fabricated number.
+    renderList({
+      status: "ready",
+      connections: [
+        { ...CONNECTED, reportedClientName: null, reportedClientVersion: null },
+      ],
+    });
+    expect(await screen.findByTestId("reported-client")).toBeInTheDocument();
+    expect(screen.queryByTestId("reported-version")).not.toBeInTheDocument();
+  });
+
   it("says a client sent no version rather than dropping the field silently", async () => {
     renderList({
       status: "ready",

--- a/apps/web/src/features/ai-connections/connections-list.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.tsx
@@ -170,8 +170,21 @@ export function ConnectionsList({
                     what the software claimed about itself, the other is what a
                     human selected, and they can disagree. */}
                 {c.reportedClientName === null ? (
-                  <span className="text-[var(--color-muted-foreground)]">
+                  // A NAMELESS CLIENT CAN STILL HAVE REPORTED A VERSION. The
+                  // type permits it, and dropping the version would throw away
+                  // a fact the client actually sent -- the same defect as
+                  // rendering an absent header as a version, pointing the other
+                  // way. Both halves are said.
+                  <span
+                    data-testid="reported-client"
+                    className="text-[var(--color-muted-foreground)]"
+                  >
                     Reported no client name
+                    {c.reportedClientVersion === null ? null : (
+                      <span data-testid="reported-version">
+                        , version {c.reportedClientVersion}
+                      </span>
+                    )}
                   </span>
                 ) : (
                   <span className="text-[var(--color-foreground)]">

--- a/apps/web/src/features/ai-connections/connections-list.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.tsx
@@ -1,0 +1,254 @@
+import type { ReactNode } from "react";
+import { PlugZap } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageError } from "@/components/feedback/page-error";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { PROTOCOL_FLOOR_VERSION } from "./client-table";
+import {
+  lastUsedLabel,
+  protocolHeaderLabel,
+  type AiConnection,
+  type ConnectionsState,
+} from "./connection-model";
+
+// The AI connections list (design §18 step 10).
+//
+// FIVE STATES, RENDERED AS FIVE DIFFERENT THINGS. The failure this component
+// exists to not have is the one this codebase keeps shipping: a failed load
+// rendering as a confident empty list. "You have no AI connections" is a claim
+// about the operator's account; "we could not load this" is a claim about our
+// own request; "the control plane cannot list these yet" is a claim about us
+// too, but a different one with a different fix. Three sentences, never one.
+//
+// Every cell below follows the same rule at field level. An absent protocol
+// header is rendered as an absent protocol header, never as a version string.
+
+export interface ConnectionsListProps {
+  state: ConnectionsState;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+  /** Rendered in the empty state so the operator has somewhere to go. */
+  connectAction?: ReactNode;
+  onRotate?: (connection: AiConnection) => void;
+  onPause?: (connection: AiConnection) => void;
+  onRevoke?: (connection: AiConnection) => void;
+}
+
+function formatIso(iso: string): string {
+  const d = new Date(iso);
+  // An unparseable timestamp is shown as unparseable, not as "Invalid Date"
+  // and not as now.
+  if (Number.isNaN(d.getTime())) return "Unreadable timestamp";
+  return d.toLocaleString();
+}
+
+export function ConnectionsList({
+  state,
+  onRetry,
+  isRetrying,
+  connectAction,
+  onRotate,
+  onPause,
+  onRevoke,
+}: ConnectionsListProps) {
+  if (state.status === "loading") {
+    return (
+      <div className="space-y-2" data-testid="connections-loading">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+        <span className="sr-only">Loading connections</span>
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    // NOT AN EMPTY TABLE. This branch returns before any table is constructed,
+    // so there is no state in which a reader is looking at a "no connections"
+    // row list built out of a request that failed.
+    return (
+      <PageError
+        what="We could not load your AI connections."
+        why={state.message}
+        onRetry={onRetry}
+        isRetrying={isRetrying}
+      />
+    );
+  }
+
+  if (state.status === "unavailable") {
+    return (
+      <div
+        role="status"
+        className="rounded-lg border border-[var(--color-border)] p-6 text-sm"
+        data-testid="connections-unavailable"
+      >
+        <p className="font-medium text-[var(--color-foreground)]">
+          We cannot list your connections yet
+        </p>
+        <p className="mt-1 text-[var(--color-muted-foreground)]">{state.reason}</p>
+        <p className="mt-2 text-[var(--color-muted-foreground)]">
+          This is a gap on our side, not a statement that you have none. Connections you approve do
+          work; we just cannot show them here yet.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.status === "empty") {
+    return (
+      <div
+        className="flex flex-col items-start gap-3 rounded-lg border border-[var(--color-border)] p-6"
+        data-testid="connections-empty"
+      >
+        <PlugZap
+          aria-hidden="true"
+          strokeWidth={1.5}
+          className="size-5 text-[var(--color-muted-foreground)]"
+        />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-[var(--color-foreground)]">
+            No AI clients are connected
+          </p>
+          <p className="text-sm text-[var(--color-muted-foreground)]">
+            Connect one and it can read your fleet. It can propose changes, and it can never approve
+            them.
+          </p>
+        </div>
+        {connectAction}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Connection</TableHead>
+            <TableHead>Client reported</TableHead>
+            <TableHead>Protocol</TableHead>
+            <TableHead>Last used</TableHead>
+            <TableHead>Scopes</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {state.connections.map((c) => (
+            <TableRow key={c.id}>
+              <TableCell>
+                <span className="font-medium text-[var(--color-foreground)]">{c.name}</span>
+                <span className="ml-2">
+                  <Badge
+                    variant={
+                      c.status === "active"
+                        ? "success"
+                        : c.status === "paused"
+                          ? "muted"
+                          : "destructive"
+                    }
+                  >
+                    {c.status}
+                  </Badge>
+                </span>
+              </TableCell>
+
+              <TableCell>
+                {/* A CLIENT THAT REPORTED NOTHING SAYS SO. Never backfilled
+                    from the client the operator picked in the wizard: one is
+                    what the software claimed about itself, the other is what a
+                    human selected, and they can disagree. */}
+                {c.reportedClientName === null ? (
+                  <span className="text-[var(--color-muted-foreground)]">
+                    Reported no client name
+                  </span>
+                ) : (
+                  <span className="text-[var(--color-foreground)]">
+                    {c.reportedClientName}
+                    {c.reportedClientVersion === null ? (
+                      <span className="text-[var(--color-muted-foreground)]"> (no version)</span>
+                    ) : (
+                      ` ${c.reportedClientVersion}`
+                    )}
+                  </span>
+                )}
+              </TableCell>
+
+              <TableCell>
+                <span
+                  className={
+                    c.protocolHeader.kind === "recognised"
+                      ? "text-[var(--color-foreground)]"
+                      : "text-[var(--color-muted-foreground)]"
+                  }
+                >
+                  {protocolHeaderLabel(c.protocolHeader, PROTOCOL_FLOOR_VERSION)}
+                </span>
+              </TableCell>
+
+              <TableCell>
+                <span
+                  className={
+                    c.lastUsed.kind === "never"
+                      ? "text-[var(--color-muted-foreground)]"
+                      : "text-[var(--color-foreground)]"
+                  }
+                >
+                  {lastUsedLabel(c.lastUsed, formatIso)}
+                </span>
+              </TableCell>
+
+              <TableCell>
+                {c.scopes.length === 0 ? (
+                  <span className="text-[var(--color-muted-foreground)]">No scopes granted</span>
+                ) : (
+                  <span className="font-mono text-xs">{c.scopes.join(" ")}</span>
+                )}
+              </TableCell>
+
+              <TableCell className="text-right">
+                <span className="inline-flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={onRotate === undefined}
+                    onClick={() => onRotate?.(c)}
+                  >
+                    Rotate
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={onPause === undefined}
+                    onClick={() => onPause?.(c)}
+                  >
+                    {c.status === "paused" ? "Resume" : "Pause"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={onRevoke === undefined}
+                    onClick={() => onRevoke?.(c)}
+                  >
+                    Revoke
+                  </Button>
+                </span>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/web/src/features/ai-connections/endpoint.test.ts
+++ b/apps/web/src/features/ai-connections/endpoint.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { mcpEndpointUrl } from "./endpoint";
+import { MCP_TRANSPORT_PATH } from "./client-table";
+
+// FOUND BY THE MUTATION SWEEP. Replacing the origin lookup with a literal
+// `https://app.wpmgr.app` was caught only by tsc (the `origin` binding went
+// unused), and tsc catching it is an accident of that particular mutation --
+// a literal written in place of the whole expression would have compiled
+// cleanly and printed the wrong endpoint to every self-hosted install, as
+// confidently as the right one. This file pins the property itself.
+
+describe("mcpEndpointUrl is derived from this deployment's origin", () => {
+  it("returns the running origin plus the transport path", () => {
+    // jsdom serves a real origin, and it is not the managed host. If the
+    // implementation ever hardcodes one, this equality breaks.
+    expect(window.location.origin.length).toBeGreaterThan(0);
+    expect(mcpEndpointUrl()).toBe(`${window.location.origin}${MCP_TRANSPORT_PATH}`);
+  });
+
+  it("does not emit the managed hostname when running somewhere else", () => {
+    expect(window.location.origin).not.toContain("app.wpmgr.app");
+    expect(mcpEndpointUrl()).not.toContain("app.wpmgr.app");
+  });
+
+  it("ignores the fallback while a window is present", () => {
+    // The fallback is for a windowless environment only; letting it win here
+    // would let a caller override the real origin by accident.
+    expect(mcpEndpointUrl("https://somewhere.else")).toBe(
+      `${window.location.origin}${MCP_TRANSPORT_PATH}`,
+    );
+  });
+
+  it("carries no hostname literal in its executable source", () => {
+    // The equality above only fails while jsdom's origin differs from whatever
+    // literal someone writes. This closes that gap directly.
+    //
+    // COMMENTS ARE STRIPPED FIRST. The doc comment on mcpEndpointUrl quotes the
+    // managed URL as the thing not to write, and a scan that cannot tell code
+    // from prose reddens correct work -- which is how a guard gets switched off.
+    const source = readFileSync(
+      join(process.cwd(), "src", "features", "ai-connections", "endpoint.ts"),
+      "utf8",
+    );
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+    // The scan has to still be looking at something.
+    expect(code).toContain("window.location.origin");
+    expect(code).not.toMatch(/https?:\/\/[a-z0-9.-]+/i);
+  });
+});

--- a/apps/web/src/features/ai-connections/endpoint.ts
+++ b/apps/web/src/features/ai-connections/endpoint.ts
@@ -1,0 +1,24 @@
+import { MCP_TRANSPORT_PATH } from "./client-table";
+
+/**
+ * The MCP endpoint for THIS deployment.
+ *
+ * DERIVED FROM THE ORIGIN, NOT HARDCODED. The dashboard is served same-origin
+ * with the API (packages/openapi-client base URL is ""), so the transport this
+ * browser is talking to is this browser's origin plus the transport path. A
+ * literal https://app.wpmgr.app/mcp would print the wrong endpoint to every
+ * self-hosted install, and print it as confidently as the right one.
+ *
+ * `fallbackOrigin` is used only where there is no window (unit tests, and any
+ * future prerender). It is an explicit argument rather than a silent default so
+ * a caller that reaches it has said so.
+ */
+export function mcpEndpointUrl(fallbackOrigin = ""): string {
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : fallbackOrigin;
+  // A relative path is still truthful when we have no origin; a made-up host
+  // would not be.
+  return `${origin}${MCP_TRANSPORT_PATH}`;
+}

--- a/apps/web/src/features/ai-connections/snippet.test.ts
+++ b/apps/web/src/features/ai-connections/snippet.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from "vitest";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import {
   MCP_CLIENTS,
@@ -375,8 +375,13 @@ describe("no hand-written config snippet in the UI (S16 exit gate)", () => {
   // client-table.ts and snippet.ts are the table and its generator; they are
   // the only files allowed to contain these literals.
   const GENERATORS = new Set(["client-table.ts", "snippet.ts"]);
+  // basename(), not split("/"): on Windows the separator is "\\", so the split
+  // form returns the whole path, the exclusion never matches, and the two
+  // generator files get scanned as if they were UI -- reddening a correct tree
+  // on one platform only. A guard that fails by OS is a guard that gets
+  // switched off.
   const files = [...sourceFiles(FEATURE_ROOT), ...sourceFiles(ROUTES_ROOT)].filter(
-    (f) => !GENERATORS.has(f.split("/").pop() ?? ""),
+    (f) => !GENERATORS.has(basename(f)),
   );
 
   it("finds the files it is supposed to be guarding", () => {

--- a/apps/web/src/features/ai-connections/snippet.test.ts
+++ b/apps/web/src/features/ai-connections/snippet.test.ts
@@ -1,0 +1,400 @@
+// The table's test. This is S16's exit gate: every published snippet is
+// generated from the tested table, never hand-written.
+//
+// It has three jobs, and the second and third are the ones that survive
+// refactors:
+//
+//   1. Assert each recorded per-client difference by name, so a row edited to a
+//      wrong value fails with the client's name in the message.
+//   2. Walk the WHOLE table and assert the generated shape agrees with the row
+//      that produced it, so a NEW row is covered on the day it is added rather
+//      than on the day someone remembers to write a case for it.
+//   3. Scan the shipped feature sources for a hand-written config block, so the
+//      exit gate is enforced rather than merely stated.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  MCP_CLIENTS,
+  CLIENT_TABLE_TARGET_NAMED_COUNT,
+  availableAuthMethods,
+  findClient,
+  isAuthAvailable,
+  type AuthMethod,
+  type McpClientRow,
+} from "./client-table";
+import {
+  buildSnippet,
+  serverKey,
+  TOKEN_PLACEHOLDER,
+  UnsupportedAuthMethodError,
+  type Snippet,
+} from "./snippet";
+
+const ENDPOINT = "https://app.wpmgr.app/mcp";
+
+/**
+ * Narrow away `undefined` by failing the test.
+ *
+ * `!` would silence the compiler and then produce a confusing runtime error;
+ * this fails with the reason, and it never lets an absent value flow into an
+ * assertion that would then pass against `undefined`.
+ */
+function must<T>(value: T | undefined, what: string): T {
+  if (value === undefined) throw new Error(`expected ${what}, got undefined`);
+  return value;
+}
+
+function snippetFor(
+  id: string,
+  method: AuthMethod,
+  token: string | null = null,
+): Snippet {
+  const client = findClient(id);
+  // A missing row must fail the test, never fall through to a default row and
+  // assert against something else's shape.
+  if (client === undefined) throw new Error(`no client row with id "${id}"`);
+  return buildSnippet({
+    client,
+    endpointUrl: ENDPOINT,
+    serverName: "wpmgr",
+    authMethod: method,
+    token,
+  });
+}
+
+function jsonDoc(s: Snippet): Record<string, Record<string, Record<string, unknown>>> {
+  if (s.kind !== "json") throw new Error(`expected a json snippet, got "${s.kind}"`);
+  return JSON.parse(s.text) as Record<string, Record<string, Record<string, unknown>>>;
+}
+
+/** The single server object inside a generated JSON block. */
+function serverObject(s: Snippet, wrapper: string): Record<string, unknown> {
+  const doc = jsonDoc(s);
+  const inner = must(doc[wrapper], `a "${wrapper}" wrapper key in the generated block`);
+  const keys = Object.keys(inner);
+  expect(keys).toHaveLength(1);
+  return must(inner[must(keys[0], "a server key")], "a server object");
+}
+
+// ---------------------------------------------------------------------------
+// 1. The recorded per-client differences, each asserted by name.
+// ---------------------------------------------------------------------------
+
+describe("per-client config differences (design §18, verified 2026-08-24)", () => {
+  it("wraps every client in mcpServers except VS Code, which uses servers", () => {
+    // NOT A VACUOUS LOOP. Without this the `continue` below would let the whole
+    // case pass by checking nothing if every row stopped being a json client.
+    const jsonClients = MCP_CLIENTS.filter((c) => c.config.kind === "json");
+    expect(jsonClients.length).toBeGreaterThanOrEqual(5);
+
+    for (const client of MCP_CLIENTS) {
+      if (client.config.kind !== "json") continue;
+      const expected = client.id === "vscode" ? "servers" : "mcpServers";
+      expect(client.config.wrapperKey, `${client.name} wrapper key`).toBe(expected);
+      // Asserted on the OUTPUT too, not only the row, because the row is only
+      // half the claim; the generator has to honour it.
+      const first = must(availableAuthMethods(client)[0], `${client.name} to have an auth method`);
+      const doc = jsonDoc(snippetFor(client.id, first));
+      expect(Object.keys(doc), `${client.name} generated wrapper`).toEqual([expected]);
+    }
+  });
+
+  it("Claude Code emits the required http type", () => {
+    const server = serverObject(snippetFor("claude-code", "oauth"), "mcpServers");
+    // A URL with no type is read as a local process and skipped with an error.
+    expect(server.type).toBe("http");
+    expect(server.url).toBe(ENDPOINT);
+  });
+
+  it("Cursor emits no type key at all", () => {
+    const server = serverObject(snippetFor("cursor", "oauth"), "mcpServers");
+    expect(Object.keys(server)).not.toContain("type");
+    expect(server.url).toBe(ENDPOINT);
+  });
+
+  it("VS Code emits type http under the servers wrapper", () => {
+    const server = serverObject(snippetFor("vscode", "token"), "servers");
+    expect(server.type).toBe("http");
+    expect(server.url).toBe(ENDPOINT);
+  });
+
+  it("Gemini CLI uses httpUrl, because the key picks the transport", () => {
+    const server = serverObject(snippetFor("gemini-cli", "oauth"), "mcpServers");
+    expect(server.httpUrl).toBe(ENDPOINT);
+    // `url` would select the older event-stream transport, which we do not
+    // serve. Emitting both would be worse than emitting the wrong one.
+    expect(Object.keys(server)).not.toContain("url");
+  });
+
+  it("Windsurf uses serverUrl", () => {
+    const server = serverObject(snippetFor("windsurf", "token"), "mcpServers");
+    expect(server.serverUrl).toBe(ENDPOINT);
+    expect(Object.keys(server)).not.toContain("url");
+  });
+
+  it("Claude Desktop and ChatGPT are OAuth only, with the reason recorded", () => {
+    for (const id of ["claude-desktop", "chatgpt"]) {
+      // must(), not `expect(...).toBeDefined()` followed by a `continue`: the
+      // continue form passes vacuously if the row is ever removed.
+      const client = must(findClient(id), `a row for "${id}"`);
+      expect(availableAuthMethods(client)).toEqual(["oauth"]);
+      const token = client.auth.token;
+      expect(token.state).toBe("unavailable");
+      // Never a generic "unavailable": the disabled card carries the specific
+      // reason, which for both of these is the absent header field.
+      if (token.state === "unavailable") {
+        expect(token.reason).toMatch(/header field/i);
+      }
+    }
+  });
+
+  it("the generic Streamable HTTP entry exists and is first-class", () => {
+    const generic = MCP_CLIENTS.filter((c) => c.generic);
+    expect(generic).toHaveLength(1);
+    const row = must(generic[0], "the generic row");
+    expect(row.id).toBe("generic");
+    // Both methods, a spec link, and no "if all else fails" framing.
+    expect(availableAuthMethods(row)).toEqual(["oauth", "token"]);
+    expect(row.docsUrl).toMatch(/^https:\/\//);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The whole-table walk. New rows are covered automatically.
+// ---------------------------------------------------------------------------
+
+describe("every row in the table", () => {
+  it("has rows to walk", () => {
+    // A broken import or an emptied table must redden here rather than turning
+    // every it.each below into a silent zero-case pass.
+    expect(MCP_CLIENTS.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it("declares the gap between the shipped rows and the eleven the design calls for", () => {
+    // The design specifies eleven named clients plus the generic entry; the
+    // source it was verified against enumerates eight. The shortfall is a
+    // recorded, visible number rather than three padded-out product names with
+    // guessed config shapes.
+    const named = MCP_CLIENTS.filter((c) => !c.generic).length;
+    expect(named).toBeLessThanOrEqual(CLIENT_TABLE_TARGET_NAMED_COUNT);
+    expect(named).toBe(8);
+  });
+
+  it.each(MCP_CLIENTS.map((c) => [c.name, c] as const))(
+    "%s carries complete, sourced metadata",
+    (_name, client: McpClientRow) => {
+      expect(client.id).toMatch(/^[a-z0-9-]+$/);
+      expect(client.name.length).toBeGreaterThan(0);
+      expect(client.blurb.length).toBeGreaterThan(0);
+      expect(client.docsUrl).toMatch(/^https:\/\//);
+      expect(client.docsLabel.length).toBeGreaterThan(0);
+      expect(client.verifiedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      // Every unverified state carries the date we last checked, so staleness
+      // is visible on the card instead of becoming permanent.
+      for (const method of ["oauth", "token"] as const) {
+        const a = client.auth[method];
+        if (a.state === "unverified") {
+          expect(a.lastCheckedAt, `${client.name}.${method}`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+          expect(a.reason.length).toBeGreaterThan(0);
+        }
+        if (a.state === "unavailable") {
+          // A specific reason, never a generic "unavailable".
+          expect(a.reason.length, `${client.name}.${method} reason`).toBeGreaterThan(20);
+          expect(a.reason.toLowerCase()).not.toBe("unavailable");
+        }
+      }
+    },
+  );
+
+  it.each(MCP_CLIENTS.map((c) => [c.name, c] as const))(
+    "%s generates a snippet that agrees with its own row",
+    (_name, client: McpClientRow) => {
+      const methods = availableAuthMethods(client);
+      expect(methods.length, `${client.name} has no usable auth method`).toBeGreaterThan(0);
+
+      for (const method of methods) {
+        const snippet = buildSnippet({
+          client,
+          endpointUrl: ENDPOINT,
+          serverName: "Fleet manager",
+          authMethod: method,
+        });
+
+        if (client.config.kind === "json") {
+          const cfg = client.config;
+          if (snippet.kind !== "json") throw new Error("expected json");
+          const doc = jsonDoc(snippet);
+          expect(Object.keys(doc)).toEqual([cfg.wrapperKey]);
+          const server = serverObject(snippet, cfg.wrapperKey);
+
+          // The URL lands under the row's key and under no other URL key.
+          expect(server[cfg.urlKey]).toBe(ENDPOINT);
+          for (const other of ["url", "httpUrl", "serverUrl"] as const) {
+            if (other === cfg.urlKey) continue;
+            expect(Object.keys(server), `${client.name} emitted a second URL key`).not.toContain(
+              other,
+            );
+          }
+
+          // `type` present exactly when the row says so.
+          if (cfg.typeValue === null) {
+            expect(Object.keys(server), `${client.name} must not emit type`).not.toContain("type");
+          } else {
+            expect(server.type, `${client.name} type`).toBe(cfg.typeValue);
+          }
+
+          // Token auth produces a real Authorization header, never an empty one.
+          if (method === "token") {
+            const headers = server.headers as Record<string, string> | undefined;
+            expect(headers, `${client.name} token config needs headers`).toBeDefined();
+            expect(headers?.Authorization).toBe(`Bearer ${TOKEN_PLACEHOLDER}`);
+          } else {
+            expect(Object.keys(server)).not.toContain("headers");
+          }
+
+          // The server key is slugged from the connection name.
+          expect(
+            Object.keys(must(doc[cfg.wrapperKey], `the ${cfg.wrapperKey} wrapper`)),
+          ).toEqual(["fleet-manager"]);
+
+          // No Windows path may be printed until someone verifies one.
+          expect(snippet.text).not.toMatch(/[A-Z]:\\|%APPDATA%/);
+        }
+
+        if (client.config.kind === "gui") {
+          if (snippet.kind !== "gui") throw new Error("expected gui");
+          expect(snippet.url).toBe(ENDPOINT);
+          expect(snippet.steps.length).toBeGreaterThanOrEqual(3);
+          // The endpoint has to actually appear in the instructions.
+          expect(snippet.steps.join(" ")).toContain(ENDPOINT);
+        }
+
+        if (client.config.kind === "raw") {
+          if (snippet.kind !== "raw") throw new Error("expected raw");
+          expect(snippet.url).toBe(ENDPOINT);
+          expect(snippet.reason.length).toBeGreaterThan(20);
+          expect(snippet.headerLine).toBe(
+            method === "token" ? `Authorization: Bearer ${TOKEN_PLACEHOLDER}` : null,
+          );
+        }
+      }
+    },
+  );
+
+  it("has at least one client that cannot use a method, so the refusal case is real", () => {
+    // Without this, the per-client refusal cases below would every one of them
+    // pass by having nothing to refuse.
+    const refusable = MCP_CLIENTS.filter(
+      (c) => availableAuthMethods(c).length < 2,
+    );
+    expect(refusable.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(MCP_CLIENTS.map((c) => [c.name, c] as const))(
+    "%s refuses a snippet for a method it cannot use",
+    (_name, client: McpClientRow) => {
+      for (const method of ["oauth", "token"] as const) {
+        if (isAuthAvailable(client, method)) continue;
+        // Not a best-effort block: the copy button must have nothing to copy.
+        expect(() =>
+          buildSnippet({
+            client,
+            endpointUrl: ENDPOINT,
+            serverName: "wpmgr",
+            authMethod: method,
+          }),
+        ).toThrow(UnsupportedAuthMethodError);
+      }
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. Token handling and slugging.
+// ---------------------------------------------------------------------------
+
+describe("token substitution", () => {
+  it("emits the placeholder when no token has been minted yet", () => {
+    const server = serverObject(snippetFor("cursor", "token", null), "mcpServers");
+    const headers = server.headers as Record<string, string>;
+    // An empty value would produce a config that parses and fails auth with no
+    // clue why.
+    expect(headers.Authorization).toBe(`Bearer ${TOKEN_PLACEHOLDER}`);
+  });
+
+  it("emits the real token once there is one", () => {
+    const server = serverObject(snippetFor("cursor", "token", "wpm_live_abc123"), "mcpServers");
+    const headers = server.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer wpm_live_abc123");
+  });
+
+  it("never puts a credential in the URL", () => {
+    const snippet = snippetFor("claude-code", "token", "wpm_live_abc123");
+    if (snippet.kind !== "json") throw new Error("expected json");
+    const server = serverObject(snippet, "mcpServers");
+    expect(String(server.url)).not.toContain("wpm_live_abc123");
+  });
+});
+
+describe("serverKey", () => {
+  it("slugs a name", () => {
+    expect(serverKey("Fleet manager")).toBe("fleet-manager");
+    expect(serverKey("  CI / nightly  ")).toBe("ci-nightly");
+  });
+
+  it("falls back to wpmgr for a name that slugs to nothing", () => {
+    // The one correct default in this feature: the key names OUR server.
+    expect(serverKey("///")).toBe("wpmgr");
+    expect(serverKey("")).toBe("wpmgr");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The exit gate itself: no hand-written config block anywhere in the UI.
+// ---------------------------------------------------------------------------
+
+const FEATURE_ROOT = join(process.cwd(), "src", "features", "ai-connections");
+const ROUTES_ROOT = join(process.cwd(), "src", "routes", "_authed", "ai");
+
+/** Every non-test .ts/.tsx file under `dir`. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) sourceFiles(full, out);
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+describe("no hand-written config snippet in the UI (S16 exit gate)", () => {
+  // client-table.ts and snippet.ts are the table and its generator; they are
+  // the only files allowed to contain these literals.
+  const GENERATORS = new Set(["client-table.ts", "snippet.ts"]);
+  const files = [...sourceFiles(FEATURE_ROOT), ...sourceFiles(ROUTES_ROOT)].filter(
+    (f) => !GENERATORS.has(f.split("/").pop() ?? ""),
+  );
+
+  it("finds the files it is supposed to be guarding", () => {
+    // A moved directory or a broken walk would otherwise make this whole
+    // describe pass by checking nothing at all.
+    expect(existsSync(FEATURE_ROOT)).toBe(true);
+    expect(existsSync(join(FEATURE_ROOT, "client-table.ts"))).toBe(true);
+    expect(files.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each([
+    ["mcpServers", /\bmcpServers\b/],
+    ["servers wrapper", /"servers"\s*:/],
+    ["httpUrl", /\bhttpUrl\b/],
+    ["serverUrl", /\bserverUrl\b/],
+    ['"type": "http"', /"type"\s*:\s*"http"/],
+  ] as const)("no UI file writes %s by hand", (_label, pattern) => {
+    const offenders = files.filter((f) => pattern.test(readFileSync(f, "utf8")));
+    expect(offenders.map((f) => f.replace(process.cwd(), ""))).toEqual([]);
+  });
+});

--- a/apps/web/src/features/ai-connections/snippet.ts
+++ b/apps/web/src/features/ai-connections/snippet.ts
@@ -1,0 +1,169 @@
+// Setup-artefact generation for step 6 of the connection wizard.
+//
+// THE EXIT GATE FOR THIS SLICE IS THAT EVERY PUBLISHED SNIPPET COMES FROM HERE.
+// Nothing in the UI may hand-write a config block for a client, because a
+// hand-written block is a copy of the table that drifts from it silently. The
+// test beside this file walks MCP_CLIENTS and asserts the shape of what every
+// row produces, so "one row changes when a client changes" stays true.
+//
+// No React, no DOM, no clipboard. Pure input to pure output, so the marketing
+// site can render the same strings from the same table.
+
+import {
+  isAuthAvailable,
+  type AuthMethod,
+  type McpClientRow,
+} from "./client-table";
+
+/**
+ * The literal a user replaces with their own token.
+ *
+ * A PLACEHOLDER, NOT AN EMPTY STRING. An empty value would produce a config
+ * that looks complete, parses, and fails authentication with no clue why. It is
+ * also never a real token in the OAuth case: for OAuth there is no token at
+ * step 6, because the key is not minted until step 7.
+ */
+export const TOKEN_PLACEHOLDER = "YOUR_CONNECTION_TOKEN";
+
+/** The header every Streamable HTTP client sends a bearer credential in. */
+export const AUTH_HEADER_NAME = "Authorization";
+
+export type Snippet =
+  | {
+      readonly kind: "json";
+      readonly language: "json";
+      readonly text: string;
+      /** Surfaced beside the block so the reason for the type line is on screen. */
+      readonly note: string;
+    }
+  | {
+      readonly kind: "gui";
+      readonly steps: readonly string[];
+      /** The endpoint, so the page can offer it as its own copy target. */
+      readonly url: string;
+    }
+  | {
+      readonly kind: "raw";
+      readonly url: string;
+      readonly reason: string;
+      /** The exact header to send, or null when this method needs no header. */
+      readonly headerLine: string | null;
+    };
+
+export interface SnippetInput {
+  readonly client: McpClientRow;
+  /** Absolute endpoint URL, e.g. https://app.wpmgr.app/mcp. Never assembled here. */
+  readonly endpointUrl: string;
+  /** The connection's name, used as the server key inside the config. */
+  readonly serverName: string;
+  readonly authMethod: AuthMethod;
+  /** A minted token, or null to emit the placeholder. */
+  readonly token?: string | null;
+}
+
+/**
+ * Thrown when a snippet is requested for a combination the table says cannot
+ * work.
+ *
+ * A NAMED THROW RATHER THAN A BEST-EFFORT BLOCK. The failure this guards is
+ * precise: a copy button emitting a snippet for the wrong client shape, which
+ * the user cannot tell from a right one until it silently does not connect.
+ * Returning something plausible here is the whole defect class, so this refuses
+ * instead.
+ */
+export class UnsupportedAuthMethodError extends Error {
+  readonly clientId: string;
+  readonly method: AuthMethod;
+  constructor(client: McpClientRow, method: AuthMethod) {
+    super(
+      `${client.name} cannot use ${method === "oauth" ? "browser sign-in" : "a connection token"}.`,
+    );
+    this.name = "UnsupportedAuthMethodError";
+    this.clientId = client.id;
+    this.method = method;
+  }
+}
+
+/**
+ * Turn a connection name into a config key.
+ *
+ * Config keys sit in JSON objects and in shell-adjacent contexts, so anything
+ * outside `[a-z0-9-]` is folded to a dash. An empty result falls back to
+ * "wpmgr" -- the one place a default is correct, because the key names OUR
+ * server and is not a user-supplied fact about anything.
+ */
+export function serverKey(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "wpmgr";
+}
+
+/** The exact `Authorization` header value for a token. */
+export function bearerHeaderValue(token: string | null | undefined): string {
+  return `Bearer ${token != null && token.length > 0 ? token : TOKEN_PLACEHOLDER}`;
+}
+
+export function buildSnippet(input: SnippetInput): Snippet {
+  const { client, endpointUrl, serverName, authMethod } = input;
+
+  // Refuse before generating anything. See UnsupportedAuthMethodError.
+  if (!isAuthAvailable(client, authMethod)) {
+    throw new UnsupportedAuthMethodError(client, authMethod);
+  }
+
+  const config = client.config;
+
+  if (config.kind === "gui") {
+    // Generated from the row, not written per client, so eight GUI clients
+    // would still be one implementation.
+    return {
+      kind: "gui",
+      url: endpointUrl,
+      steps: [
+        `Open ${client.name} and go to its connectors or MCP settings.`,
+        `Add a remote server and paste ${endpointUrl} into the "${config.fieldLabel}" field.`,
+        "Save. The client will send you to this dashboard to approve the connection.",
+      ],
+    };
+  }
+
+  if (config.kind === "raw") {
+    return {
+      kind: "raw",
+      url: endpointUrl,
+      reason: config.reason,
+      headerLine:
+        authMethod === "token"
+          ? `${AUTH_HEADER_NAME}: ${bearerHeaderValue(input.token)}`
+          : null,
+    };
+  }
+
+  // JSON. Built as an object and stringified rather than concatenated, so a
+  // value containing a quote cannot break out of the block.
+  const server: Record<string, unknown> = {};
+  // `type` first when present: it is the key that decides how the whole entry
+  // is interpreted, and it reads better above the URL it qualifies.
+  if (config.typeValue !== null) server.type = config.typeValue;
+  server[config.urlKey] = endpointUrl;
+  if (authMethod === "token") {
+    if (!config.supportsHeaders) {
+      // Unreachable while the table keeps token unavailable for header-less
+      // clients, and a throw rather than a silently header-less config if that
+      // ever stops being true.
+      throw new UnsupportedAuthMethodError(client, "token");
+    }
+    server.headers = { [AUTH_HEADER_NAME]: bearerHeaderValue(input.token) };
+  }
+
+  const doc = { [config.wrapperKey]: { [serverKey(serverName)]: server } };
+
+  return {
+    kind: "json",
+    language: "json",
+    text: JSON.stringify(doc, null, 2),
+    note: config.typeNote,
+  };
+}

--- a/apps/web/src/lib/dev-proxy-paths.test.ts
+++ b/apps/web/src/lib/dev-proxy-paths.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { DEV_PROXY_PATHS, isProxied } from "./dev-proxy-paths";
+
+// THE GO SERVER IS THE SOURCE OF TRUTH, NOT THIS ARRAY.
+//
+// A test that asserted DEV_PROXY_PATHS contains "/mcp" would restate the source
+// and catch nothing. This reads the paths the API actually mounts on the ROOT
+// engine and asserts each one is forwarded, so the failure it is built for --
+// someone adds a root-mounted route and no proxy rule -- reddens here on the
+// commit that introduces it.
+//
+// Root-mounted is the dangerous category. Anything under /api/v1 is already
+// covered by the "/api" prefix and always has been; the three incidents were
+// all routes hung off the bare engine, where the SPA's catch-all answers them
+// with 200 and an HTML body that no client reports as an error.
+
+const API_MCP = join(process.cwd(), "..", "api", "internal", "mcp");
+const TRANSPORT_GO = join(API_MCP, "transport.go");
+const DISCOVERY_GO = join(API_MCP, "discovery.go");
+
+/**
+ * Fail the test rather than silence the compiler.
+ *
+ * `!` would let a renamed Go constant flow in as undefined and assert against
+ * nothing; this names what was missing.
+ */
+function must(value: string | undefined, what: string): string {
+  if (value === undefined) throw new Error(`expected ${what}, got undefined`);
+  return value;
+}
+
+/** Pull `const Name = "/literal"` values out of Go source. */
+function goStringConsts(source: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const re = /(\w+)\s*=\s*"([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) out[m[1] ?? ""] = m[2] ?? "";
+  return out;
+}
+
+describe("the dev proxy forwards every root-mounted API path", () => {
+  it("can see the Go source it is checking against", () => {
+    // Without this the whole file passes by reading nothing — the exact shape
+    // ("a guard that finds nothing must go red") this project keeps producing.
+    expect(existsSync(TRANSPORT_GO), `missing ${TRANSPORT_GO}`).toBe(true);
+    expect(existsSync(DISCOVERY_GO), `missing ${DISCOVERY_GO}`).toBe(true);
+  });
+
+  it("forwards the MCP transport path the API mounts on the root engine", () => {
+    const consts = goStringConsts(readFileSync(TRANSPORT_GO, "utf8"));
+    // Read, not assumed. If the constant is renamed or moved this fails loudly
+    // rather than silently checking undefined.
+    const transportPath = must(consts.TransportPath, "TransportPath in transport.go");
+    expect(transportPath).toBe("/mcp");
+    expect(isProxied(transportPath)).toBe(true);
+  });
+
+  it("forwards all three OAuth discovery documents", () => {
+    const src = readFileSync(DISCOVERY_GO, "utf8");
+    const consts = goStringConsts(src);
+
+    const authServer = must(
+      consts.WellKnownAuthorizationServerPath,
+      "WellKnownAuthorizationServerPath in discovery.go",
+    );
+    const protectedResource = must(
+      consts.WellKnownProtectedResourcePath,
+      "WellKnownProtectedResourcePath in discovery.go",
+    );
+    expect(authServer).toBe("/.well-known/oauth-authorization-server");
+    expect(protectedResource).toBe("/.well-known/oauth-protected-resource");
+
+    // The third is built by concatenation in Go
+    // (WellKnownProtectedResourcePath + TransportPath), so it is composed here
+    // the same way rather than pasted as a literal.
+    const protectedResourceMCP = `${protectedResource}/mcp`;
+
+    for (const p of [authServer, protectedResource, protectedResourceMCP]) {
+      expect(isProxied(p), `${p} is not forwarded by the dev proxy`).toBe(true);
+    }
+  });
+
+  it("finds every /.well-known path the discovery handler declares", () => {
+    // Belt and braces on the named constants above: if a FOURTH document is
+    // added, this catches it without anyone editing this test.
+    const src = readFileSync(DISCOVERY_GO, "utf8");
+    const declared = [...src.matchAll(/"(\/\.well-known\/[^"]*)"/g)].map((m) => m[1] ?? "");
+    expect(declared.length).toBeGreaterThanOrEqual(2);
+    for (const p of declared) {
+      expect(isProxied(p), `${p} is declared in discovery.go but not proxied`).toBe(true);
+    }
+  });
+});
+
+describe("isProxied implements Vite's matching rule", () => {
+  it("treats a ^-prefixed key as a regular expression", () => {
+    expect(isProxied("/mcp")).toBe(true);
+    // Exact, so a future SPA route beginning with /mcp is not swallowed.
+    expect(isProxied("/mcpanything")).toBe(false);
+  });
+
+  it("treats a plain key as a prefix", () => {
+    expect(isProxied("/api/v1/sites")).toBe(true);
+    expect(isProxied("/.well-known/oauth-protected-resource/mcp")).toBe(true);
+  });
+
+  it("does not forward SPA routes", () => {
+    // The over-fire half: proxying an app route would break the dashboard in
+    // dev, which is a worse failure than the one this guards.
+    for (const p of ["/", "/ai", "/ai/connect", "/sites", "/login", "/connect/ai"]) {
+      expect(isProxied(p), `${p} must be served by the SPA, not proxied`).toBe(false);
+    }
+  });
+
+  it("keeps the pre-existing surfaces forwarded", () => {
+    for (const p of ["/api", "/auth/callback", "/enroll", "/agent/x", "/healthz", "/readyz"]) {
+      expect(isProxied(p)).toBe(true);
+    }
+    expect(DEV_PROXY_PATHS.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/apps/web/src/lib/dev-proxy-paths.ts
+++ b/apps/web/src/lib/dev-proxy-paths.ts
@@ -1,0 +1,50 @@
+// Which paths the dev server forwards to the API.
+//
+// EXTRACTED FROM vite.config.ts SO IT CAN BE TESTED. A proxy entry nobody tests
+// is exactly what let this ship three times: the Go route is mounted, no proxy
+// rule exists, and the request is answered by something else with a 200. It
+// cost self-hosted RUM ingest silently, then POST /mcp in production, then the
+// OAuth discovery documents. The test beside this file reads the Go source and
+// fails when a root-mounted path is not covered here, so the next one is caught
+// by CI rather than by a developer wondering why their AI client gets HTML.
+//
+// The client uses same-origin relative paths (baseUrl ""), so every real API
+// surface must be forwarded or it falls through to the SPA's index.html.
+
+/**
+ * Proxy keys, in Vite's own format.
+ *
+ * A key beginning with `^` is a regular expression; anything else is a prefix.
+ * Both forms are deliberate below:
+ *
+ *   - `^/mcp$` is EXACT. A bare `/mcp` prefix would also capture any future
+ *     `/mcpsomething` SPA route, and the transport is one exact path.
+ *   - `/.well-known` is a PREFIX, covering all three discovery documents and
+ *     any added later. The SPA serves nothing under it, so breadth here is
+ *     safety rather than sloppiness.
+ */
+export const DEV_PROXY_PATHS: readonly string[] = [
+  "/api",
+  "/auth",
+  "/enroll",
+  "/agent",
+  "/healthz",
+  "/readyz",
+  // Root-mounted on the Gin engine, not under /api/v1 — which is precisely why
+  // they were missed. internal/mcp/transport.go mounts POST /mcp;
+  // internal/mcp/discovery.go mounts the three /.well-known/oauth-* documents.
+  "^/mcp$",
+  "/.well-known",
+];
+
+/**
+ * Whether `path` would be forwarded to the API by the dev server.
+ *
+ * Implements Vite's matching rule so the test asks the same question the dev
+ * server does, rather than a restatement of the array above.
+ */
+export function isProxied(path: string): boolean {
+  return DEV_PROXY_PATHS.some((key) =>
+    key.startsWith("^") ? new RegExp(key).test(path) : path.startsWith(key),
+  );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as AuthedSettingsIndexRouteImport } from './routes/_authed/settin
 import { Route as AuthedEmailIndexRouteImport } from './routes/_authed/email/index'
 import { Route as AuthedClientsIndexRouteImport } from './routes/_authed/clients/index'
 import { Route as AuthedBackupsIndexRouteImport } from './routes/_authed/backups/index'
+import { Route as AuthedAiIndexRouteImport } from './routes/_authed/ai/index'
 import { Route as AuthedAdminIndexRouteImport } from './routes/_authed/admin/index'
 import { Route as PortalSitesSiteIdRouteImport } from './routes/portal/sites.$siteId'
 import { Route as AuthedWelcomeCheckoutRouteImport } from './routes/_authed/welcome.checkout'
@@ -56,6 +57,7 @@ import { Route as AuthedScheduleRunsRunIdRouteImport } from './routes/_authed/sc
 import { Route as AuthedRestoresRestoreIdRouteImport } from './routes/_authed/restores/$restoreId'
 import { Route as AuthedConnectAiRouteImport } from './routes/_authed/connect.ai'
 import { Route as AuthedClientsClientIdRouteImport } from './routes/_authed/clients/$clientId'
+import { Route as AuthedAiConnectRouteImport } from './routes/_authed/ai/connect'
 import { Route as AuthedAdminVulnFeedRouteImport } from './routes/_authed/admin/vuln-feed'
 import { Route as AuthedAdminRevenueRouteImport } from './routes/_authed/admin/revenue'
 import { Route as AuthedAdminAgentMirrorRouteImport } from './routes/_authed/admin/agent-mirror'
@@ -233,6 +235,11 @@ const AuthedBackupsIndexRoute = AuthedBackupsIndexRouteImport.update({
   path: '/backups/',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedAiIndexRoute = AuthedAiIndexRouteImport.update({
+  id: '/ai/',
+  path: '/ai/',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedAdminIndexRoute = AuthedAdminIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -317,6 +324,11 @@ const AuthedConnectAiRoute = AuthedConnectAiRouteImport.update({
 const AuthedClientsClientIdRoute = AuthedClientsClientIdRouteImport.update({
   id: '/clients/$clientId',
   path: '/clients/$clientId',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedAiConnectRoute = AuthedAiConnectRouteImport.update({
+  id: '/ai/connect',
+  path: '/ai/connect',
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedAdminVulnFeedRoute = AuthedAdminVulnFeedRouteImport.update({
@@ -498,6 +510,7 @@ export interface FileRoutesByFullPath {
   '/admin/agent-mirror': typeof AuthedAdminAgentMirrorRoute
   '/admin/revenue': typeof AuthedAdminRevenueRoute
   '/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
+  '/ai/connect': typeof AuthedAiConnectRoute
   '/clients/$clientId': typeof AuthedClientsClientIdRouteWithChildren
   '/connect/ai': typeof AuthedConnectAiRoute
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
@@ -515,6 +528,7 @@ export interface FileRoutesByFullPath {
   '/welcome/checkout': typeof AuthedWelcomeCheckoutRoute
   '/portal/sites/$siteId': typeof PortalSitesSiteIdRoute
   '/admin/': typeof AuthedAdminIndexRoute
+  '/ai/': typeof AuthedAiIndexRoute
   '/backups/': typeof AuthedBackupsIndexRoute
   '/clients/': typeof AuthedClientsIndexRoute
   '/email/': typeof AuthedEmailIndexRoute
@@ -570,6 +584,7 @@ export interface FileRoutesByTo {
   '/admin/agent-mirror': typeof AuthedAdminAgentMirrorRoute
   '/admin/revenue': typeof AuthedAdminRevenueRoute
   '/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
+  '/ai/connect': typeof AuthedAiConnectRoute
   '/connect/ai': typeof AuthedConnectAiRoute
   '/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
   '/schedule-runs/$runId': typeof AuthedScheduleRunsRunIdRoute
@@ -585,6 +600,7 @@ export interface FileRoutesByTo {
   '/welcome/checkout': typeof AuthedWelcomeCheckoutRoute
   '/portal/sites/$siteId': typeof PortalSitesSiteIdRoute
   '/admin': typeof AuthedAdminIndexRoute
+  '/ai': typeof AuthedAiIndexRoute
   '/backups': typeof AuthedBackupsIndexRoute
   '/clients': typeof AuthedClientsIndexRoute
   '/email': typeof AuthedEmailIndexRoute
@@ -644,6 +660,7 @@ export interface FileRoutesById {
   '/_authed/admin/agent-mirror': typeof AuthedAdminAgentMirrorRoute
   '/_authed/admin/revenue': typeof AuthedAdminRevenueRoute
   '/_authed/admin/vuln-feed': typeof AuthedAdminVulnFeedRoute
+  '/_authed/ai/connect': typeof AuthedAiConnectRoute
   '/_authed/clients/$clientId': typeof AuthedClientsClientIdRouteWithChildren
   '/_authed/connect/ai': typeof AuthedConnectAiRoute
   '/_authed/restores/$restoreId': typeof AuthedRestoresRestoreIdRoute
@@ -661,6 +678,7 @@ export interface FileRoutesById {
   '/_authed/welcome/checkout': typeof AuthedWelcomeCheckoutRoute
   '/portal/sites/$siteId': typeof PortalSitesSiteIdRoute
   '/_authed/admin/': typeof AuthedAdminIndexRoute
+  '/_authed/ai/': typeof AuthedAiIndexRoute
   '/_authed/backups/': typeof AuthedBackupsIndexRoute
   '/_authed/clients/': typeof AuthedClientsIndexRoute
   '/_authed/email/': typeof AuthedEmailIndexRoute
@@ -721,6 +739,7 @@ export interface FileRouteTypes {
     | '/admin/agent-mirror'
     | '/admin/revenue'
     | '/admin/vuln-feed'
+    | '/ai/connect'
     | '/clients/$clientId'
     | '/connect/ai'
     | '/restores/$restoreId'
@@ -738,6 +757,7 @@ export interface FileRouteTypes {
     | '/welcome/checkout'
     | '/portal/sites/$siteId'
     | '/admin/'
+    | '/ai/'
     | '/backups/'
     | '/clients/'
     | '/email/'
@@ -793,6 +813,7 @@ export interface FileRouteTypes {
     | '/admin/agent-mirror'
     | '/admin/revenue'
     | '/admin/vuln-feed'
+    | '/ai/connect'
     | '/connect/ai'
     | '/restores/$restoreId'
     | '/schedule-runs/$runId'
@@ -808,6 +829,7 @@ export interface FileRouteTypes {
     | '/welcome/checkout'
     | '/portal/sites/$siteId'
     | '/admin'
+    | '/ai'
     | '/backups'
     | '/clients'
     | '/email'
@@ -866,6 +888,7 @@ export interface FileRouteTypes {
     | '/_authed/admin/agent-mirror'
     | '/_authed/admin/revenue'
     | '/_authed/admin/vuln-feed'
+    | '/_authed/ai/connect'
     | '/_authed/clients/$clientId'
     | '/_authed/connect/ai'
     | '/_authed/restores/$restoreId'
@@ -883,6 +906,7 @@ export interface FileRouteTypes {
     | '/_authed/welcome/checkout'
     | '/portal/sites/$siteId'
     | '/_authed/admin/'
+    | '/_authed/ai/'
     | '/_authed/backups/'
     | '/_authed/clients/'
     | '/_authed/email/'
@@ -1142,6 +1166,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedBackupsIndexRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/ai/': {
+      id: '/_authed/ai/'
+      path: '/ai'
+      fullPath: '/ai/'
+      preLoaderRoute: typeof AuthedAiIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/admin/': {
       id: '/_authed/admin/'
       path: '/'
@@ -1259,6 +1290,13 @@ declare module '@tanstack/react-router' {
       path: '/clients/$clientId'
       fullPath: '/clients/$clientId'
       preLoaderRoute: typeof AuthedClientsClientIdRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/ai/connect': {
+      id: '/_authed/ai/connect'
+      path: '/ai/connect'
+      fullPath: '/ai/connect'
+      preLoaderRoute: typeof AuthedAiConnectRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/admin/vuln-feed': {
@@ -1605,6 +1643,7 @@ interface AuthedRouteChildren {
   AuthedSharedWithMeRoute: typeof AuthedSharedWithMeRoute
   AuthedUptimeRoute: typeof AuthedUptimeRoute
   AuthedVulnerabilitiesRoute: typeof AuthedVulnerabilitiesRoute
+  AuthedAiConnectRoute: typeof AuthedAiConnectRoute
   AuthedClientsClientIdRoute: typeof AuthedClientsClientIdRouteWithChildren
   AuthedConnectAiRoute: typeof AuthedConnectAiRoute
   AuthedRestoresRestoreIdRoute: typeof AuthedRestoresRestoreIdRoute
@@ -1612,6 +1651,7 @@ interface AuthedRouteChildren {
   AuthedSitesSiteIdRoute: typeof AuthedSitesSiteIdRouteWithChildren
   AuthedUpdatesRunIdRoute: typeof AuthedUpdatesRunIdRoute
   AuthedWelcomeCheckoutRoute: typeof AuthedWelcomeCheckoutRoute
+  AuthedAiIndexRoute: typeof AuthedAiIndexRoute
   AuthedBackupsIndexRoute: typeof AuthedBackupsIndexRoute
   AuthedClientsIndexRoute: typeof AuthedClientsIndexRoute
   AuthedEmailIndexRoute: typeof AuthedEmailIndexRoute
@@ -1630,6 +1670,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedSharedWithMeRoute: AuthedSharedWithMeRoute,
   AuthedUptimeRoute: AuthedUptimeRoute,
   AuthedVulnerabilitiesRoute: AuthedVulnerabilitiesRoute,
+  AuthedAiConnectRoute: AuthedAiConnectRoute,
   AuthedClientsClientIdRoute: AuthedClientsClientIdRouteWithChildren,
   AuthedConnectAiRoute: AuthedConnectAiRoute,
   AuthedRestoresRestoreIdRoute: AuthedRestoresRestoreIdRoute,
@@ -1637,6 +1678,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedSitesSiteIdRoute: AuthedSitesSiteIdRouteWithChildren,
   AuthedUpdatesRunIdRoute: AuthedUpdatesRunIdRoute,
   AuthedWelcomeCheckoutRoute: AuthedWelcomeCheckoutRoute,
+  AuthedAiIndexRoute: AuthedAiIndexRoute,
   AuthedBackupsIndexRoute: AuthedBackupsIndexRoute,
   AuthedClientsIndexRoute: AuthedClientsIndexRoute,
   AuthedEmailIndexRoute: AuthedEmailIndexRoute,

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { Route } from "./index";
+import { MCP_TRANSPORT_PATH } from "@/features/ai-connections/client-table";
+
+// FOUND BY THE MUTATION SWEEP. This route had no test at all, so the one
+// decision it makes -- pass `unavailable` to the list rather than `empty` --
+// was pinned by nothing. The sweep's "red" for that mutation was vitest
+// exiting 1 on "No test files found", which is a guard finding nothing and
+// being scored as a catch: the exact failure mode this project calls its
+// signature defect, reproduced inside the tool checking for it.
+//
+// The component-level states are covered in
+// features/ai-connections/connections-list.test.tsx. What is covered HERE is
+// the wiring: which state this page actually hands down.
+
+const AiPage = Route.options.component!;
+
+function renderPage() {
+  return renderWithProviders(<AiPage />, { withRouter: true, initialPath: "/ai" });
+}
+
+describe("/ai", () => {
+  it("says we cannot list connections yet, and never that the operator has none", async () => {
+    renderPage();
+    expect(await screen.findByTestId("connections-unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/cannot list your connections yet/i)).toBeInTheDocument();
+
+    // The sentence that would be a claim about the operator's account made out
+    // of a gap in our own API.
+    expect(screen.queryByText(/no ai clients are connected/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("connections-empty")).not.toBeInTheDocument();
+    // Nor a failure, which would send someone to retry something that cannot
+    // succeed.
+    expect(screen.queryByText(/could not load your ai connections/i)).not.toBeInTheDocument();
+  });
+
+  it("names the missing endpoint as the reason rather than staying vague", async () => {
+    renderPage();
+    await screen.findByTestId("connections-unavailable");
+    expect(screen.getByText(/does not expose an endpoint/i)).toBeInTheDocument();
+  });
+
+  it("publishes this deployment's endpoint, not a hardcoded host", async () => {
+    renderPage();
+    await screen.findByTestId("connections-unavailable");
+    const expected = `${window.location.origin}${MCP_TRANSPORT_PATH}`;
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("offers a route into the wizard, which is how that page is reached at all", async () => {
+    renderPage();
+    // /ai/connect is deliberately absent from the sidebar, so this link is its
+    // only entry point. If it goes, the wizard becomes unreachable in exactly
+    // the way the whole slice exists to fix.
+    const links = await screen.findAllByRole("link", { name: /connect an ai client/i });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0]).toHaveAttribute("href", "/ai/connect");
+  });
+});

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -51,6 +51,15 @@ describe("/ai", () => {
     expect(screen.getByText(expected)).toBeInTheDocument();
   });
 
+  it("states the self-hosted proxy requirement beside the endpoint", async () => {
+    renderPage();
+    await screen.findByTestId("connections-unavailable");
+    // Deriving /mcp from the origin does not prove anything forwards it.
+    // infra/urlmap.yaml routes it on hosted; infra/nginx/nginx.conf and
+    // apps/web/vite.config.ts do not.
+    expect(screen.getByText(/reverse proxy must forward \/mcp to the API/i)).toBeInTheDocument();
+  });
+
   it("offers a route into the wizard, which is how that page is reached at all", async () => {
     renderPage();
     // /ai/connect is deliberately absent from the sidebar, so this link is its

--- a/apps/web/src/routes/_authed/ai/connect.tsx
+++ b/apps/web/src/routes/_authed/ai/connect.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { PageHeader } from "@/components/shared/page-header";
+import { ConnectWizard } from "@/features/ai-connections/connect-wizard";
+import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
+
+// /ai/connect — the connection wizard (design §18).
+//
+// NO SIDEBAR ENTRY, DELIBERATELY. It is reached from the primary action on
+// /ai, which is the house rule for an authenticated route that hangs off
+// another page rather than being a destination of its own.
+//
+// NOT TO BE CONFUSED WITH /connect/ai, which is the OAuth consent screen an
+// external client redirects into. This route is the operator-facing setup
+// guide; that one is the approval. They are different halves of step 6 and
+// step 7 and neither links into the middle of the other.
+
+export const Route = createFileRoute("/_authed/ai/connect")({
+  component: ConnectAiClientPage,
+});
+
+function ConnectAiClientPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Connect an AI client"
+        subline="Pick your client first. Everything after that is computed from it, because the setup differs per client in ways that fail quietly."
+        backTo={{ to: "/ai", label: "AI connections" }}
+      />
+      <ConnectWizard endpointUrl={mcpEndpointUrl()} />
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authed/ai/index.tsx
+++ b/apps/web/src/routes/_authed/ai/index.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import { CopyableMono } from "@/components/shared/copyable-mono";
+import { ConnectionsList } from "@/features/ai-connections/connections-list";
+import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
+import {
+  PROTOCOL_FLOOR_VERSION,
+  PROTOCOL_TARGET_VERSION,
+} from "@/features/ai-connections/client-table";
+import type { ConnectionsState } from "@/features/ai-connections/connection-model";
+
+// /ai — the AI area's front door, and the answer to "what is the route for all
+// this AI stuff? it's not in the sidebar at all".
+//
+// ROUTE PLACEMENT. Under _authed/ because every connection here is
+// tenant-scoped; outside it this page would render for logged-out users and
+// 403 on every call. It IS in the sidebar, unlike /connect/ai next door, which
+// stays out because it is an OAuth redirect target rather than a destination.
+//
+// WHY THE LIST IS `unavailable` RATHER THAN EMPTY. The control plane exposes
+// four MCP OAuth endpoints -- register and token (unauthenticated), authorize
+// and consent (operator-authenticated) -- registered at
+// apps/api/internal/mcp/handler.go:71 and :89. There is no endpoint that lists
+// grants and none that revokes one. The honest render for that is a fifth
+// state that names the gap. Passing `{ status: "empty" }` here, or fetching an
+// endpoint that does not exist and letting the 404 fall through to an empty
+// array, would both put the sentence "no AI clients are connected" on screen as
+// a fact about the operator's account when it is a fact about our API surface.
+
+export const Route = createFileRoute("/_authed/ai/")({
+  component: AiConnectionsPage,
+});
+
+const LIST_UNAVAILABLE: ConnectionsState = {
+  status: "unavailable",
+  reason:
+    "The control plane does not expose an endpoint for listing AI connections yet, so we have nothing to read. Until it does, we will not guess.",
+};
+
+function AiConnectionsPage() {
+  const endpoint = mcpEndpointUrl();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="AI connections"
+        subline="Let an AI client read your fleet through one endpoint. It can propose changes; it can never approve them."
+        actions={
+          <Button asChild>
+            <Link to="/ai/connect">Connect an AI client</Link>
+          </Button>
+        }
+      />
+
+      <section aria-label="Endpoint" className="space-y-2">
+        <h2 className="text-sm font-semibold text-[var(--color-foreground)]">Your endpoint</h2>
+        <p className="text-sm text-[var(--color-muted-foreground)]">
+          One URL, for every client. We negotiate protocol {PROTOCOL_TARGET_VERSION} and refuse
+          anything below {PROTOCOL_FLOOR_VERSION}.
+        </p>
+        <CopyableMono value={endpoint} label="Copy the MCP endpoint" />
+      </section>
+
+      <section aria-label="Connections" className="space-y-3">
+        <h2 className="text-sm font-semibold text-[var(--color-foreground)]">
+          Connected clients
+        </h2>
+        <ConnectionsList
+          state={LIST_UNAVAILABLE}
+          connectAction={
+            <Button asChild variant="outline" size="sm">
+              <Link to="/ai/connect">Connect an AI client</Link>
+            </Button>
+          }
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authed/ai/index.tsx
+++ b/apps/web/src/routes/_authed/ai/index.tsx
@@ -8,6 +8,7 @@ import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
 import {
   PROTOCOL_FLOOR_VERSION,
   PROTOCOL_TARGET_VERSION,
+  SELF_HOSTED_PROXY_REQUIREMENT,
 } from "@/features/ai-connections/client-table";
 import type { ConnectionsState } from "@/features/ai-connections/connection-model";
 
@@ -61,6 +62,11 @@ function AiConnectionsPage() {
           anything below {PROTOCOL_FLOOR_VERSION}.
         </p>
         <CopyableMono value={endpoint} label="Copy the MCP endpoint" />
+        {/* Derived from this origin, which does not prove anything forwards it.
+            See SELF_HOSTED_PROXY_REQUIREMENT for the two proxies that do not. */}
+        <p className="text-xs text-[var(--color-muted-foreground)]">
+          {SELF_HOSTED_PROXY_REQUIREMENT}
+        </p>
       </section>
 
       <section aria-label="Connections" className="space-y-3">

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,6 +4,12 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 
+// The forwarded-path list lives in src/ so a test can read it and check it
+// against the paths the Go server actually mounts. See
+// src/lib/dev-proxy-paths.test.ts -- an untested proxy list is what let
+// three root-mounted routes ship unreachable.
+import { DEV_PROXY_PATHS } from "./src/lib/dev-proxy-paths";
+
 // Build version is injected via the `BUILD_VERSION` env var at vite-build
 // time (set by Cloud Build). `apps/web/src/lib/build.ts` reads it as
 // `__BUILD_VERSION__`. Local `vite dev` and unsuffixed `vite build` runs fall
@@ -33,11 +39,13 @@ export default defineConfig({
   },
   server: {
     port: 5173,
-    // Proxy every backend surface to the API (mirrors the prod nginx routing).
-    // The client uses same-origin relative paths (baseUrl ""), so each real API
-    // prefix must be forwarded: /api/v1/*, /auth/*, /enroll, /agent/*, health.
+    // Proxy every backend surface to the API. The client uses same-origin
+    // relative paths (baseUrl ""), so a surface that is not forwarded here is
+    // answered by the SPA's index.html with a 200 and an HTML body -- which no
+    // client reports as an error. DEV_PROXY_PATHS carries the list and its
+    // test checks it against what the Go server mounts.
     proxy: Object.fromEntries(
-      ["/api", "/auth", "/enroll", "/agent", "/healthz", "/readyz"].map((p) => [
+      DEV_PROXY_PATHS.map((p) => [
         p,
         {
           target: process.env.VITE_API_BASE_URL ?? "http://localhost:8080",


### PR DESCRIPTION
## S16 — the AI connection wizard and client config table

The MCP flow has been live since `0.61.147` and nothing in the dashboard pointed at it. The reported complaint was *"I can't see in the ui what's the route for this all ai settings? it's not in the sidebar at all."*

**`/ai` is now a sidebar entry and the front door. `/ai/connect` is the wizard.**

### The exit gate

*Every published snippet is generated from the tested table, never hand-written.*

`features/ai-connections/client-table.ts` is data, not components — no React, no router, no design-system import, so moving it into a shared package for the marketing site is a file move rather than an untangling. Each row carries the wrapper key, the URL key, whether a `type` is emitted, the auth methods and a `verified_at` date. `snippet.ts` generates from it and refuses rather than approximating.

`snippet.test.ts` has three jobs: assert each recorded per-client difference by name; walk the **whole** table so a new row is covered on the day it is added; and scan the shipped UI sources so a hand-written config block fails the suite.

Per-client differences now pinned, each of which breaks a copied config silently rather than loudly:

| Client | Wrapper | URL key | Type |
|---|---|---|---|
| Claude Code | `mcpServers` | `url` | **required** `"type": "http"` — a URL with no type is read as a local process and skipped with an error |
| VS Code / Copilot | **`servers`** | `url` | `"type": "http"` |
| Cursor | `mcpServers` | `url` | **must not be emitted** |
| Gemini CLI | `mcpServers` | **`httpUrl`** | none — the key picks the transport; `url` would select the older event-stream transport we do not serve |
| Windsurf / Devin | `mcpServers` | `serverUrl` | none |
| Claude Desktop / ChatGPT | GUI, no file | — | OAuth only; no header field exists |

### Client first, method second

Picking a client computes which auth methods are possible and disables the rest **with that client's own reason on the disabled card**, never a generic "unavailable". VS Code's OAuth card reads *"not yet verified by us"* with the date we last checked, so a stale entry looks stale instead of permanent.

### Absence stays absence

- A snippet is **refused**, not approximated, where the shape is unsourced (Codex CLI's TOML table header). A config that parses and never connects is worse than no config.
- No Windows path is printed anywhere — every source documented POSIX only.
- The connections list separates **"we could not load this"**, **"you have none"** and **"the control plane cannot list these yet"** into three different sentences.
- An absent protocol header renders as *"No protocol header sent (treated as 2025-03-26)"*, never as a version the client never claimed.

### Mutation sweep

25 mutations across two passes. Every safety property was deleted in the source and the suite re-run. Three survived and are now pinned — see the second commit. The over-fire pass then caught the new sidebar guard blocking correct work (it froze the label copy); it now matches on the route.

### Dev proxy: `/mcp` and the discovery documents

The dev server forwarded `/api /auth /enroll /agent /healthz /readyz` and none of the four
paths the API mounts on the **root** engine, so a developer running `vite dev` and following
this wizard got the SPA's `index.html` — a 200, an HTML body, and nothing any AI client
reports as an error. `infra/urlmap.yaml:81` routes `/mcp` on hosted; nginx does not, and that
half is `devops-engineer`'s.

Read from the Go source, not assumed: `transport.go` mounts `POST /mcp`, `discovery.go`
mounts three `/.well-known/oauth-*` documents. `^/mcp$` is exact so a future `/mcp-something`
app route is not swallowed; `/.well-known` is a prefix.

The list moved to `src/lib/dev-proxy-paths.ts` so it is testable, and the test reads
`transport.go` and `discovery.go` and asserts every declared path is forwarded — the next
root-mounted route reddens on the commit that adds it. Three have shipped unreachable this
way and all three were caught by a human noticing.

### What is NOT in this PR

- **The nginx `/mcp` location.** `infra/` is `devops-engineer`'s; routed separately.
- **The site-scope escalation.** Real, confirmed, backend, fixed in #594.
- **No connections list data.** The control plane exposes `register`, `token`, `authorize` and `consent` (`apps/api/internal/mcp/handler.go:71` and `:89`) and no endpoint that lists or revokes a grant. The list component is built and tested; the page renders the gap rather than fetching a path that does not exist. **Listing / rotate / pause / revoke is a `backend-architect` job.**
- **Eight named clients, not eleven.** The design calls for eleven plus the generic entry; the source it was verified against enumerates eight. The shortfall is a declared constant asserted in the test rather than three padded product names with guessed config shapes.
- **No config file paths.** `configPath` is `null` on every row with the reason rendered on screen. Filling one is a one-row change once somebody verifies a path and records the date.

### Gates

| Gate | Exit |
|---|---|
| `pnpm -C apps/web typecheck` | `0` |
| `pnpm -C apps/web lint` | `0` (10 pre-existing warnings, 0 errors) |
| `pnpm -C apps/web test` | `0` — 162 files, 1951 tests |
| `pnpm -C apps/web build` | `0` — `routeTree.gen.ts` regenerated and committed |

`apps/web/node_modules/.bin/impeccable detect apps/web/src` exits `2` with one finding:
`sidebar.tsx:642 [side-tab] border-l-2`. **Pre-existing, not from this change** — at the merge base
`dd4d517a` the identical finding sits at `sidebar.tsx:632`; my 10-line nav addition shifted it down
ten lines. It is the sidebar's documented active-item treatment ("active = accent + 2px left ring
primary"), introduced in `ff3290b8`. Not touched here.

Draft. Do not merge.
