### PR TITLE
S16: AI connections list and revoke, with the token cascade

### DIFF
--- a/apps/api/internal/mcp/connections_test.go
+++ b/apps/api/internal/mcp/connections_test.go
@@ -1,0 +1,672 @@
+// connections_test.go: the unit half of the S16 list-and-revoke slice.
+//
+// WHAT THIS FILE CAN AND CANNOT PROVE, said up front because the gap is the
+// interesting part. Everything here runs against fakeStore, so it proves the Go
+// BRANCH STRUCTURE: which outcome maps to which status, which absence stays an
+// absence, which principal is refused before the database is reached. It proves
+// NOTHING about RLS, because a fake has no policies -- the site-scope policy and
+// the revoke cascade are proven in
+// apps/api/tests/adr064_s16_mcp_connections_integration_test.go, against the
+// real schema as wpmgr_app. Every proof above the SQL layer on this stack runs
+// against fakeStore and that gap is what let a P1 reach review, so the split is
+// stated rather than assumed.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+func ptrStr(s string) *string { return &s }
+
+func tsAt(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t, Valid: true}
+}
+
+// orgPrincipal is a full organisation member: not site constrained.
+func orgPrincipal(tenantID uuid.UUID) domain.Principal {
+	return domain.Principal{
+		Type:     domain.PrincipalUser,
+		UserID:   uuid.New(),
+		TenantID: tenantID,
+		Role:     "admin",
+		Scope:    "org",
+	}
+}
+
+// siteScopedPrincipal is an outside collaborator shared onto ONE site. This is
+// the principal mcp_grants_site_scope_select exists to refuse.
+func siteScopedPrincipal(tenantID uuid.UUID) domain.Principal {
+	return domain.Principal{
+		Type:           domain.PrincipalUser,
+		UserID:         uuid.New(),
+		TenantID:       tenantID,
+		Role:           "admin", // admin ON THAT SITE, and still refused
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{uuid.New()},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- A FAILED LIST IS NOT AN EMPTY LIST.
+//
+// The single most repeated defect on this project (26+ instances). The service
+// must return (nil, err) and the handler must answer non-2xx; neither may
+// produce a body that decodes into a zero-length list.
+// ---------------------------------------------------------------------------
+
+func TestListConnectionsFailureIsNeverAnEmptyList(t *testing.T) {
+	tenantID := uuid.New()
+	boom := errors.New("connection refused: the database is down")
+	store := &fakeStore{grantsErr: boom}
+	svc := NewService(store)
+
+	got, err := svc.ListConnections(context.Background(), orgPrincipal(tenantID))
+	if err == nil {
+		t.Fatal("a failed read returned no error; the caller cannot tell it failed")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("the underlying failure was not wrapped through: got %v", err)
+	}
+	// The assertion that matters. A non-nil empty slice here is what becomes
+	// "you have no connections" on screen.
+	if got != nil {
+		t.Fatalf("a failed read returned a non-nil slice of len %d. An empty list "+
+			"is a CLAIM that the organisation has no connections, and this read "+
+			"never happened", len(got))
+	}
+}
+
+func TestListConnectionsHandlerAnswersNon2xxOnFailureWithNoConnectionsKey(t *testing.T) {
+	tenantID := uuid.New()
+	store := &fakeStore{grantsErr: errors.New("database is down")}
+	eng := newConnectionsRouter(t, store, orgPrincipal(tenantID))
+
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, httptest.NewRequest(http.MethodGet, ConnectionsPath, nil))
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("a failed list answered 200. body: %s", w.Body.String())
+	}
+
+	// The envelope check is the second half and it is not redundant: a client
+	// that ignores the status must still be unable to decode this body into a
+	// list. The house error envelope has no `connections` key at all.
+	var probe connectionListDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &probe); err == nil && probe.Connections != nil {
+		t.Fatalf("the error body decoded into a connections list of len %d; a "+
+			"client ignoring the status would render an empty fleet. body: %s",
+			len(probe.Connections), w.Body.String())
+	}
+}
+
+// The other half of the pair: a genuinely empty organisation MUST be
+// distinguishable, and must serialise as [] rather than null. Without this the
+// test above is satisfiable by refusing everything.
+func TestListConnectionsEmptyOrgIsAnEmptyArrayNotNull(t *testing.T) {
+	tenantID := uuid.New()
+	store := &fakeStore{grants: nil} // no error, no rows
+	eng := newConnectionsRouter(t, store, orgPrincipal(tenantID))
+
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, httptest.NewRequest(http.MethodGet, ConnectionsPath, nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("an empty organisation answered %d, want 200. body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"connections":[]`) {
+		t.Errorf("an empty list did not serialise as []; a null would force every "+
+			"consumer to special-case a third state. body: %s", w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- THE SITE-SCOPE GATE REFUSES OUT LOUD RATHER THAN RETURNING [].
+//
+// Constraint 2 of the brief. RLS refuses by returning zero rows with no error,
+// which on this path is indistinguishable from an empty organisation -- so the
+// service must refuse BEFORE the store is reached, and must SAY so.
+// ---------------------------------------------------------------------------
+
+func TestSiteScopedPrincipalIsRefusedAndNeverReachesTheStore(t *testing.T) {
+	tenantID := uuid.New()
+
+	t.Run("list", func(t *testing.T) {
+		store := &fakeStore{}
+		svc := NewService(store)
+
+		got, err := svc.ListConnections(context.Background(), siteScopedPrincipal(tenantID))
+		if err == nil {
+			t.Fatalf("a site-scoped collaborator listed %d connections without "+
+				"being refused", len(got))
+		}
+		if got != nil {
+			t.Errorf("the refusal came with a non-nil slice of len %d", len(got))
+		}
+		var de *domain.Error
+		if !errors.As(err, &de) || de.Code != ErrCodeOrgScopeRequired {
+			t.Fatalf("want a %s domain error, got %v", ErrCodeOrgScopeRequired, err)
+		}
+		if de.Kind != domain.KindForbidden {
+			t.Errorf("the refusal is Kind %v, want Forbidden", de.Kind)
+		}
+		// The store must not have been consulted at all. If it had, an RLS
+		// refusal downstream would have come back as zero rows and this
+		// service would have reported an empty list.
+		if log := store.callLog(); len(log) != 0 {
+			t.Errorf("the store was called %v despite the principal being refused; "+
+				"the refusal must precede the read", log)
+		}
+	})
+
+	t.Run("revoke", func(t *testing.T) {
+		store := &fakeStore{}
+		svc := NewService(store)
+
+		_, err := svc.RevokeConnection(context.Background(),
+			siteScopedPrincipal(tenantID), uuid.New())
+		if err == nil {
+			t.Fatal("a site-scoped collaborator revoked an organisation-wide credential")
+		}
+		var de *domain.Error
+		if !errors.As(err, &de) || de.Code != ErrCodeOrgScopeRequired {
+			t.Fatalf("want a %s domain error, got %v", ErrCodeOrgScopeRequired, err)
+		}
+		if log := store.callLog(); len(log) != 0 {
+			t.Errorf("the store was called %v despite the principal being refused", log)
+		}
+	})
+}
+
+// The service hands the PRINCIPAL to the store, not a bare tenant id. That is
+// what routes the query through db.RunTenantTx's site-scope dispatch; a
+// signature taking a tenantID could only reach InTenantTx, leaving the
+// RESTRICTIVE policies inert.
+func TestStoreReceivesThePrincipalSoRunTenantTxCanDispatch(t *testing.T) {
+	tenantID := uuid.New()
+	p := orgPrincipal(tenantID)
+	store := &fakeStore{}
+	svc := NewService(store)
+
+	if _, err := svc.ListConnections(context.Background(), p); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if _, err := svc.RevokeConnection(context.Background(), p, uuid.New()); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	if len(store.listPrincipals) != 1 || store.listPrincipals[0].UserID != p.UserID {
+		t.Errorf("ListGrants did not receive the calling principal: %+v", store.listPrincipals)
+	}
+	if len(store.revokePrincipals) != 1 || store.revokePrincipals[0].UserID != p.UserID {
+		t.Errorf("RevokeGrantWithTokens did not receive the calling principal: %+v",
+			store.revokePrincipals)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- REVOKE'S FOUR OUTCOMES, AND ONLY ONE IS A FAILURE.
+//
+// Constraint 4: "a revoke that matched zero rows must not return success". The
+// discriminator is whether a ROW CAME BACK, never what the counts say -- a row
+// of two zeroes is an idempotent success, and mapping it to 404 would report a
+// correctly revoked credential as still live.
+// ---------------------------------------------------------------------------
+
+func TestRevokeOutcomeMapping(t *testing.T) {
+	tenantID := uuid.New()
+
+	cases := []struct {
+		name       string
+		row        sqlc.RevokeMCPGrantWithTokensInTenantTxRow
+		storeErr   error
+		wantStatus int
+		wantCode   string
+		// wantAlready is only read on a 200.
+		wantAlready bool
+		wantTokens  int64
+	}{
+		{
+			name:       "no row at all means the grant is not visible: 404",
+			storeErr:   pgx.ErrNoRows,
+			wantStatus: http.StatusNotFound,
+			wantCode:   ErrCodeConnectionNotFound,
+		},
+		{
+			name:       "first revoke flips the grant and kills two tokens: 200",
+			row:        sqlc.RevokeMCPGrantWithTokensInTenantTxRow{GrantsRevoked: 1, TokensRevoked: 2},
+			wantStatus: http.StatusOK,
+			wantTokens: 2,
+		},
+		{
+			name: "half-revoked repair: grant already revoked, tokens were still live: 200",
+			row:  sqlc.RevokeMCPGrantWithTokensInTenantTxRow{GrantsRevoked: 0, TokensRevoked: 3},
+			// This is the state a security review actually observed in this
+			// database. Re-running IS the repair, and it is a success.
+			wantStatus:  http.StatusOK,
+			wantAlready: true,
+			wantTokens:  3,
+		},
+		{
+			name: "already fully revoked: two zeroes is an IDEMPOTENT SUCCESS, not a 404",
+			row:  sqlc.RevokeMCPGrantWithTokensInTenantTxRow{GrantsRevoked: 0, TokensRevoked: 0},
+			// The trap. Two zeroes look like "nothing happened, therefore
+			// something went wrong"; the row came back, which is what says the
+			// grant is visible and the requested end state holds.
+			wantStatus:  http.StatusOK,
+			wantAlready: true,
+			wantTokens:  0,
+		},
+		{
+			name:       "an infra error is a 500 and never a quiet success",
+			storeErr:   errors.New("connection reset by peer"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeStore{revokeRow: tc.row, revokeErr: tc.storeErr}
+			eng := newConnectionsRouter(t, store, orgPrincipal(tenantID))
+
+			w := httptest.NewRecorder()
+			eng.ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+				ConnectionRevokePathFor(uuid.NewString()), nil))
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("answered %d, want %d. body: %s", w.Code, tc.wantStatus, w.Body.String())
+			}
+
+			if tc.wantStatus != http.StatusOK {
+				if tc.wantCode != "" {
+					var env struct {
+						Code string `json:"code"`
+					}
+					if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+						t.Fatalf("error body is not JSON: %v", err)
+					}
+					if env.Code != tc.wantCode {
+						t.Errorf("code %q, want %q", env.Code, tc.wantCode)
+					}
+				}
+				return
+			}
+
+			var got revokeResponseDTO
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("success body is not JSON: %v", err)
+			}
+			if got.Status != string(GrantStatusRevoked) {
+				t.Errorf("status %q, want %q", got.Status, GrantStatusRevoked)
+			}
+			if got.AlreadyRevoked != tc.wantAlready {
+				t.Errorf("already_revoked %v, want %v", got.AlreadyRevoked, tc.wantAlready)
+			}
+			// The token count is on the wire because "revoked, 0 tokens killed"
+			// and "revoked, 3 tokens killed" are different facts to an operator.
+			if got.TokensRevoked != tc.wantTokens {
+				t.Errorf("tokens_revoked %d, want %d", got.TokensRevoked, tc.wantTokens)
+			}
+		})
+	}
+}
+
+// A malformed id answers 404, identically to an id from another organisation and
+// to one that never existed. Any other status here is an existence oracle.
+func TestRevokeMalformedIDIs404NotAnOracle(t *testing.T) {
+	store := &fakeStore{revokeErr: pgx.ErrNoRows}
+	eng := newConnectionsRouter(t, store, orgPrincipal(uuid.New()))
+
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		ConnectionsPath+"/not-a-uuid/revoke", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("a malformed connection id answered %d, want 404; a different "+
+			"status for a malformed id than for an unknown one tells a caller "+
+			"which ids are well-formed. body: %s", w.Code, w.Body.String())
+	}
+	// And it must not have reached the database at all.
+	if log := store.callLog(); len(log) != 0 {
+		t.Errorf("a malformed id reached the store: %v", log)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 4 -- THE FOUR PROTOCOL STATES STAY FOUR.
+//
+// Constraint 3: protocol_version NULL means "this client sent no protocol
+// header", NOT "unknown version". And the DTO's zero value must never read as a
+// version.
+// ---------------------------------------------------------------------------
+
+func TestClassifyStoredProtocolKeepsFourStatesApart(t *testing.T) {
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		recordedAt  *time.Time
+		stored      *string
+		wantState   ClientProtocolState
+		wantVersion string
+	}{
+		{
+			name:      "never connected: recorded_at NULL",
+			wantState: ClientProtocolNeverConnected,
+		},
+		{
+			name:       "connected, sent no header: recorded_at set, version NULL",
+			recordedAt: &now,
+			wantState:  ClientProtocolAbsent,
+		},
+		{
+			name:        "sent a revision we speak",
+			recordedAt:  &now,
+			stored:      ptrStr("2025-06-18"),
+			wantState:   ClientProtocolRecognised,
+			wantVersion: "2025-06-18",
+		},
+		{
+			name:        "sent the floor, which we speak",
+			recordedAt:  &now,
+			stored:      ptrStr(ProtocolFloor),
+			wantState:   ClientProtocolRecognised,
+			wantVersion: ProtocolFloor,
+		},
+		{
+			name:        "sent a revision below the floor",
+			recordedAt:  &now,
+			stored:      ptrStr("2024-11-05"),
+			wantState:   ClientProtocolUnrecognised,
+			wantVersion: "2024-11-05",
+		},
+		{
+			name:        "sent an unknown future revision: refused, never assumed compatible",
+			recordedAt:  &now,
+			stored:      ptrStr("2099-01-01"),
+			wantState:   ClientProtocolUnrecognised,
+			wantVersion: "2099-01-01",
+		},
+		{
+			name:        "sent garbage",
+			recordedAt:  &now,
+			stored:      ptrStr("banana"),
+			wantState:   ClientProtocolUnrecognised,
+			wantVersion: "banana",
+		},
+		{
+			// The anomaly guard. NegotiateProtocol("") returns AssumedFloor with
+			// Version=ProtocolFloor, so an unguarded pass-through would print
+			// "2025-03-26" against a column that holds "". A stored empty string
+			// is not an absent header -- absence is NULL.
+			name:       "a non-NULL empty string is an anomaly, never the floor",
+			recordedAt: &now,
+			stored:     ptrStr(""),
+			wantState:  ClientProtocolUnrecognised,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyStoredProtocol(tc.recordedAt, tc.stored)
+			if got.State != tc.wantState {
+				t.Fatalf("state %q, want %q", got.State, tc.wantState)
+			}
+			if got.Version != tc.wantVersion {
+				t.Errorf("version %q, want %q", got.Version, tc.wantVersion)
+			}
+			// The load-bearing negative: neither absence state may carry a
+			// version. This is the assertion that catches a future "helpful"
+			// default of the floor onto an absent header.
+			if tc.wantState == ClientProtocolAbsent || tc.wantState == ClientProtocolNeverConnected {
+				if got.Version != "" {
+					t.Errorf("state %q carries version %q; absence must carry no "+
+						"version at all -- NULL means the client sent no header, "+
+						"not that we do not know which one", got.State, got.Version)
+				}
+			}
+		})
+	}
+}
+
+// A recorded-at of NULL wins over a set version. The branch order is the
+// contract: this is what stops a never-connected grant reading as "sent no
+// header".
+func TestNeverConnectedWinsOverAStoredVersion(t *testing.T) {
+	got := ClassifyStoredProtocol(nil, ptrStr("2025-06-18"))
+	if got.State != ClientProtocolNeverConnected {
+		t.Fatalf("state %q, want %q", got.State, ClientProtocolNeverConnected)
+	}
+}
+
+// The DTO must not let the absence states carry a version key with a value.
+func TestProtocolDTOEmitsNullVersionForBothAbsenceStates(t *testing.T) {
+	for _, state := range []ClientProtocolState{ClientProtocolNeverConnected, ClientProtocolAbsent} {
+		dto := toConnectionDTO(Connection{Protocol: ClientProtocol{State: state}})
+		if dto.Protocol.Version != nil {
+			t.Errorf("state %q serialised version %q; want null", state, *dto.Protocol.Version)
+		}
+		if dto.Protocol.State != string(state) {
+			t.Errorf("state serialised as %q, want %q", dto.Protocol.State, state)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 5 -- NULL last_used_at IS NOT A DATE.
+//
+// Constraint 4 again. The trap is a time.Time zero value, which serialises as
+// 0001-01-01T00:00:00Z and renders as a real date in the year 1.
+// ---------------------------------------------------------------------------
+
+func TestNullTimestampsSerialiseAsNullAndNeverAsTheZeroYear(t *testing.T) {
+	grant := sqlc.McpGrant{
+		ID:            uuid.New(),
+		Name:          "Claude Desktop",
+		Status:        string(GrantStatusActive),
+		SiteScopeMode: string(SiteScopeModeAll),
+		CreatedAt:     time.Date(2026, 8, 30, 9, 0, 0, 0, time.UTC),
+		// LastUsedAt, RevokedAt and ClientIdentityRecordedAt all left invalid:
+		// a fresh grant nothing has connected to yet.
+	}
+
+	dto := toConnectionDTO(connectionFromGrant(grant))
+	raw, err := json.Marshal(dto)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+
+	if !strings.Contains(body, `"last_used_at":null`) {
+		t.Errorf("a never-used connection did not serialise last_used_at as null. body: %s", body)
+	}
+	if !strings.Contains(body, `"revoked_at":null`) {
+		t.Errorf("a live connection did not serialise revoked_at as null. body: %s", body)
+	}
+	// The specific trap, named so a failure explains itself.
+	if strings.Contains(body, "0001-01-01") {
+		t.Errorf("a NULL timestamp serialised as the Go zero time, which renders "+
+			"as a real date in the year 1. body: %s", body)
+	}
+	// And the keys must be PRESENT, not omitted: a missing key is a third state
+	// the consumer has to guess at.
+	for _, key := range []string{`"last_used_at"`, `"revoked_at"`,
+		`"reported_client_name"`, `"reported_client_version"`} {
+		if !strings.Contains(body, key) {
+			t.Errorf("key %s was omitted entirely; an explicit null says "+
+				"'none' out loud, an absent key says nothing. body: %s", key, body)
+		}
+	}
+}
+
+func TestPresentTimestampSurvivesAsADate(t *testing.T) {
+	used := time.Date(2026, 8, 29, 14, 30, 0, 0, time.UTC)
+	dto := toConnectionDTO(connectionFromGrant(sqlc.McpGrant{
+		ID:         uuid.New(),
+		Status:     string(GrantStatusActive),
+		CreatedAt:  used,
+		LastUsedAt: tsAt(used),
+	}))
+	if dto.LastUsedAt == nil {
+		t.Fatal("a used connection serialised last_used_at as null")
+	}
+	if !strings.HasPrefix(*dto.LastUsedAt, "2026-08-29T14:30:00") {
+		t.Errorf("last_used_at %q does not carry the stored instant", *dto.LastUsedAt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 6 -- REVOKED GRANTS ARE LISTED, AND STATUS IS READ NOT INFERRED.
+//
+// m124 Decision 2 keeps the revoked row so last_used_at and revoked_at stay
+// readable. Filtering them out here would hide exactly the record an operator
+// reviews after revoking.
+// ---------------------------------------------------------------------------
+
+func TestListIncludesRevokedGrantsAndReportsStoredStatus(t *testing.T) {
+	revokedAt := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	store := &fakeStore{grants: []sqlc.McpGrant{
+		{
+			ID: uuid.New(), Name: "live", Status: string(GrantStatusActive),
+			SiteScopeMode: string(SiteScopeModeAll), CreatedAt: revokedAt,
+		},
+		{
+			ID: uuid.New(), Name: "dead", Status: string(GrantStatusRevoked),
+			SiteScopeMode: string(SiteScopeModeAll), CreatedAt: revokedAt,
+			RevokedAt: tsAt(revokedAt), LastUsedAt: tsAt(revokedAt),
+		},
+	}}
+	svc := NewService(store)
+
+	got, err := svc.ListConnections(context.Background(), orgPrincipal(uuid.New()))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d connections, want 2; a revoked grant was filtered out and "+
+			"its last_used_at record went with it", len(got))
+	}
+	if got[1].Status != GrantStatusRevoked {
+		t.Errorf("the revoked grant reports status %q", got[1].Status)
+	}
+	if got[1].RevokedAt == nil {
+		t.Error("the revoked grant lost its revoked_at")
+	}
+	if got[0].Status != GrantStatusActive {
+		t.Errorf("the live grant reports status %q", got[0].Status)
+	}
+	// Status is READ, never inferred from RevokedAt being nil.
+	if got[0].RevokedAt != nil {
+		t.Error("the live grant carries a revoked_at")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 7 -- THE UNVERIFIED CLIENT CLAIM IS NEVER DEFAULTED TO THE OPERATOR'S.
+// ---------------------------------------------------------------------------
+
+func TestReportedClientIsNeverDefaultedToTheOperatorName(t *testing.T) {
+	c := connectionFromGrant(sqlc.McpGrant{
+		ID:     uuid.New(),
+		Name:   "Sohil's laptop", // the OPERATOR's name for the connection
+		Status: string(GrantStatusActive),
+		// ClientName left NULL: the client has reported nothing.
+	})
+	if c.ReportedClientName != nil {
+		t.Fatalf("a client that reported no name came back as %q; the operator's "+
+			"label and the client's claim are different assertions and must not "+
+			"be substituted for one another", *c.ReportedClientName)
+	}
+
+	c2 := connectionFromGrant(sqlc.McpGrant{
+		ID: uuid.New(), Name: "Sohil's laptop", Status: string(GrantStatusActive),
+		ClientName: ptrStr("Claude Desktop"), ClientVersion: ptrStr("1.2.3"),
+	})
+	if c2.ReportedClientName == nil || *c2.ReportedClientName != "Claude Desktop" {
+		t.Error("the client's reported name was lost")
+	}
+	if c2.Name != "Sohil's laptop" {
+		t.Error("the operator's name was overwritten by the client's claim")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 8 -- THE ROUTES ARE MOUNTED, AND A WRONG VERB IS 405 NOT 404.
+//
+// A 404 reads as "not deployed", which is exactly how the S6b-2 blocker
+// presented and cost a debugging session.
+// ---------------------------------------------------------------------------
+
+func TestConnectionRoutesAreMountedAndWrongVerbsAre405(t *testing.T) {
+	eng := newConnectionsRouter(t, &fakeStore{}, orgPrincipal(uuid.New()))
+	id := uuid.NewString()
+
+	cases := []struct {
+		method, path string
+		want         int
+	}{
+		{http.MethodGet, ConnectionsPath, http.StatusOK},
+		{http.MethodPost, ConnectionRevokePathFor(id), http.StatusOK},
+		{http.MethodDelete, ConnectionsPath, http.StatusMethodNotAllowed},
+		{http.MethodPut, ConnectionsPath, http.StatusMethodNotAllowed},
+		{http.MethodGet, ConnectionRevokePathFor(id), http.StatusMethodNotAllowed},
+		{http.MethodDelete, ConnectionRevokePathFor(id), http.StatusMethodNotAllowed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			eng.ServeHTTP(w, httptest.NewRequest(tc.method, tc.path, nil))
+			if w.Code != tc.want {
+				t.Fatalf("answered %d, want %d. body: %s", w.Code, tc.want, w.Body.String())
+			}
+			if tc.want == http.StatusMethodNotAllowed && w.Header().Get("Allow") == "" {
+				t.Error("a 405 carried no Allow header, so it does not say which verb to use")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Router fixture
+// ---------------------------------------------------------------------------
+
+// newConnectionsRouter mounts RegisterConnections the way server.New does:
+// on a group carrying a principal, which is what RequireAuth + RequireTenant
+// guarantee by the time the handler runs.
+//
+// THE PERMISSION MIDDLEWARE IS REAL HERE, not stubbed. RegisterConnections
+// installs authz.RequirePermission itself, so these tests exercise the actual
+// gate; the principal fixtures carry role "admin", which
+// authz.minRoleFor[PermAPIKeyRead] requires.
+func newConnectionsRouter(t *testing.T, store Store, p domain.Principal) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	eng := gin.New()
+	g := eng.Group(APIV1Prefix)
+	g.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), p))
+		c.Next()
+	})
+	NewHandler(NewService(store)).RegisterConnections(g)
+	return eng
+}

--- a/apps/api/internal/mcp/discovery.go
+++ b/apps/api/internal/mcp/discovery.go
@@ -32,6 +32,29 @@ const APIV1Prefix = "/api/v1"
 // never by rebuilding the path.
 const oauthGroupPath = "/oauth/mcp"
 
+// connectionsGroupPath is the group Handler.RegisterConnections opens under
+// APIV1Prefix, and connectionIDParam is the path parameter it binds.
+//
+// They live here beside the OAuth paths, and as CONSTANTS rather than literals,
+// for the reason the block above gives: a path that is written twice is a path
+// that drifts. infra/urlmap.yaml routes these under its `/api/*` rule, so no
+// new url-map path rule is required -- unlike the root-mounted /mcp and
+// /.well-known documents, which each needed one and were unreachable until they
+// got it.
+const (
+	connectionsGroupPath = "/mcp/connections"
+	connectionIDParam    = "connectionId"
+)
+
+// ConnectionsPath and ConnectionRevokePathFor are the absolute forms, exported
+// so a test asserts the mounted route rather than restating the string.
+const ConnectionsPath = APIV1Prefix + connectionsGroupPath
+
+// ConnectionRevokePathFor builds the revoke path for one connection id.
+func ConnectionRevokePathFor(id string) string {
+	return ConnectionsPath + "/" + id + "/revoke"
+}
+
 // The four OAuth paths, absolute, exactly as mounted.
 const (
 	RegisterPath  = APIV1Prefix + oauthGroupPath + "/register"

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
@@ -119,6 +120,149 @@ type tokenResponseDTO struct {
 	TokenType   string `json:"token_type"`
 	ExpiresIn   int    `json:"expires_in"`
 	Scope       string `json:"scope"`
+}
+
+// ---------------------------------------------------------------------------
+// The operator-facing connections surface (S16). These are HOUSE routes under
+// /api/v1 read by the dashboard, NOT OAuth endpoints, so they answer in the
+// house error envelope via httpx.Error rather than in oauthErrorDTO.
+// ---------------------------------------------------------------------------
+
+// protocolReportDTO carries the four-state classification onto the wire WITHOUT
+// flattening it into a nullable string.
+//
+// State is always present and is the field to switch on. Version is a *string
+// and is null for `never_connected` and for `absent` -- those two states have no
+// version because the client named none, and emitting the negotiated floor
+// there would put a claim in the client's mouth. A consumer that reads Version
+// and ignores State gets null, which is the fail-visible direction.
+type protocolReportDTO struct {
+	State   string  `json:"state"`
+	Version *string `json:"version"`
+}
+
+// connectionDTO is one row of the connections list.
+//
+// EVERY NULLABLE FIELD IS A POINTER AND CARRIES NO `omitempty`. That is
+// deliberate on both counts: `omitempty` would DROP the key entirely for a
+// never-used connection, and a missing key is a third state the consumer has to
+// guess at, whereas an explicit `"last_used_at": null` says "never" out loud.
+// The frontend model (apps/web/src/features/ai-connections/connection-model.ts)
+// maps null onto its own `{kind: "never"}` tag.
+type connectionDTO struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Status        string   `json:"status"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	Scopes        []string `json:"scopes"`
+	CreatedAt     string   `json:"created_at"`
+
+	// The client's OWN unverified claims. Never defaulted to Name: one is the
+	// client's assertion and the other is the operator's, and the `reported_`
+	// prefix is here so a template author cannot render the first as the second.
+	ReportedClientName    *string `json:"reported_client_name"`
+	ReportedClientVersion *string `json:"reported_client_version"`
+
+	Protocol protocolReportDTO `json:"protocol"`
+
+	// null means NEVER USED. It is not omitted and it is never a zero date.
+	LastUsedAt *string `json:"last_used_at"`
+	// null means not revoked.
+	RevokedAt *string `json:"revoked_at"`
+}
+
+// connectionListDTO wraps the list in an OBJECT rather than returning a bare
+// JSON array, and the wrapper is a safety property rather than a style
+// preference.
+//
+// A bare `[]` response body and an error body are both valid JSON, and a client
+// that forgets to check the status code can decode an error into a slice and
+// get length zero -- "you have no connections" rendered from a failure. The
+// house error envelope is `{"code":…,"message":…}`, which cannot decode into
+// this struct's `connections` array at all, so the two shapes are
+// distinguishable even by a caller that ignores the status.
+type connectionListDTO struct {
+	// Always non-nil on a 200. A nil slice would marshal as `null`, which a
+	// consumer would have to special-case into a third state.
+	Connections []connectionDTO `json:"connections"`
+}
+
+// revokeResponseDTO reports WHAT THE REVOKE DID, not merely that it returned.
+//
+// The counts are on the wire because three different successes are possible and
+// they are not interchangeable to a human: a first revoke that killed two live
+// tokens, an idempotent retry that had nothing left to do, and the repair of a
+// half-revoked grant whose tokens were still live. An operator reading
+// "revoked, 0 tokens" after a first revoke has learned something worth knowing.
+type revokeResponseDTO struct {
+	// Status is the END STATE, which is 'revoked' for every success here --
+	// including the idempotent retry, because the grant IS revoked.
+	Status string `json:"status"`
+	// GrantsRevoked is 1 when this call flipped the grant, 0 when it was
+	// already revoked.
+	GrantsRevoked int64 `json:"grants_revoked"`
+	// TokensRevoked is how many live bearer tokens this call killed.
+	TokensRevoked int64 `json:"tokens_revoked"`
+	// AlreadyRevoked is true when the grant was not active when the statement
+	// ran. The request still succeeded.
+	AlreadyRevoked bool `json:"already_revoked"`
+}
+
+// toConnectionDTO maps one domain Connection onto the wire.
+//
+// Timestamps become RFC 3339 STRINGS through a nil-preserving helper rather
+// than being handed to encoding/json as *time.Time. Both marshal identically
+// today; the string form is used so that the nil check is written once, here,
+// where it is visible, instead of relying on a marshaller detail to keep
+// "never" out of the year 1.
+func toConnectionDTO(c Connection) connectionDTO {
+	scopes := make([]string, 0, len(c.Scopes))
+	for _, s := range c.Scopes {
+		scopes = append(scopes, string(s))
+	}
+
+	proto := protocolReportDTO{State: string(c.Protocol.State)}
+	// Version travels ONLY for the two states that have one. Guarding on the
+	// state rather than on the string being non-empty is what stops a future
+	// classifier bug from leaking a version onto `absent`.
+	if c.Protocol.State == ClientProtocolRecognised || c.Protocol.State == ClientProtocolUnrecognised {
+		v := c.Protocol.Version
+		proto.Version = &v
+	}
+
+	return connectionDTO{
+		ID:                    c.ID.String(),
+		Name:                  c.Name,
+		Status:                string(c.Status),
+		SiteScopeMode:         string(c.SiteScopeMode),
+		Scopes:                scopes,
+		CreatedAt:             c.CreatedAt.UTC().Format(time.RFC3339Nano),
+		ReportedClientName:    c.ReportedClientName,
+		ReportedClientVersion: c.ReportedClientVersion,
+		Protocol:              proto,
+		LastUsedAt:            isoOrNil(c.LastUsedAt),
+		RevokedAt:             isoOrNil(c.RevokedAt),
+	}
+}
+
+// toConnectionListDTO maps the whole list, guaranteeing a non-nil slice so a
+// genuinely empty organisation serialises as `[]` and never as `null`.
+func toConnectionListDTO(cs []Connection) connectionListDTO {
+	out := make([]connectionDTO, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, toConnectionDTO(c))
+	}
+	return connectionListDTO{Connections: out}
+}
+
+// isoOrNil renders a time as RFC 3339, preserving nil as nil. It is the one
+// place "never" is kept out of the year 1.
+func isoOrNil(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.UTC().Format(time.RFC3339Nano)
+	return &s
 }
 
 // oauthErrorDTO is the RFC 6749 section 5.2 error envelope. The OAuth

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -9,7 +9,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
 )
 
 // Handler serves the OAuth surface for the read-only MCP endpoint.
@@ -91,6 +93,148 @@ func (h *Handler) Register(r *gin.RouterGroup) {
 	g := r.Group(oauthGroupPath)
 	g.GET("/authorize", h.authorize)
 	g.POST("/consent", h.consent)
+}
+
+// RegisterConnections mounts the OPERATOR-FACING connection management surface
+// (S16, design Step 10):
+//
+//	GET  /api/v1/mcp/connections
+//	POST /api/v1/mcp/connections/:connectionId/revoke
+//
+// It is a THIRD mount point, separate from Register and RegisterPublic, because
+// these are house API routes rather than OAuth endpoints: they answer in the
+// house error envelope, they are read by the dashboard, and they carry per-route
+// RBAC that the OAuth endpoints cannot (RFC 7591 registration is anonymous by
+// specification).
+//
+// THE PERMISSIONS ARE THE SITE-SCOPE GATE, AND THE CHOICE OF THESE TWO IS
+// DELIBERATE. There is no RequireSiteAccess here and there must not be: a grant
+// is an ORGANISATION-wide credential with no :siteId in its path, so a per-site
+// gate has nothing to key on. What closes the hole instead is that
+// PermAPIKeyRead and PermAPIKeyManage are both members of authz.orgLevelPerms,
+// which makes RequirePermission refuse ANY site-constrained principal outright,
+// regardless of the role it holds on the one site it can see. That is the
+// permission-layer half of what mcp_grants_site_scope_select does in the
+// database, and reusing the API-key permissions rather than minting new ones is
+// what guarantees the orgLevelPerms membership is not a step somebody has to
+// remember -- a fresh permission that was left out of that map would look
+// identical here and gate nothing.
+//
+// An MCP grant is the same class of object as an API key -- a long-lived,
+// organisation-scoped bearer credential -- so the trust tier matches too: admin+
+// to read, admin+ to revoke (authz.minRoleFor).
+//
+// POST /revoke AND NOT DELETE. Revocation is not a delete: m124 Decision 2 keeps
+// the row precisely so last_used_at and revoked_at stay readable afterwards.
+// Naming it DELETE would promise a removal this endpoint does not perform.
+func (h *Handler) RegisterConnections(r *gin.RouterGroup) {
+	g := r.Group(connectionsGroupPath)
+
+	g.GET("", authz.RequirePermission(authz.PermAPIKeyRead), h.listConnections)
+	g.POST("/:"+connectionIDParam+"/revoke",
+		authz.RequirePermission(authz.PermAPIKeyManage), h.revokeConnection)
+
+	// 405 rather than gin's bare 404 on a wrong verb, for the reason
+	// RegisterPublic gives: a 404 reads as "not deployed", which is exactly how
+	// the S6b-2 blocker presented and cost a debugging session. These carry NO
+	// permission middleware on purpose -- the verb is wrong regardless of who is
+	// asking, and answering 403 to a DELETE sends an operator to check a role
+	// when the fix is to send a POST.
+	houseMethodNotAllowedExcept(g, "", http.MethodGet)
+	houseMethodNotAllowedExcept(g, "/:"+connectionIDParam+"/revoke", http.MethodPost)
+}
+
+// listConnections answers GET /api/v1/mcp/connections.
+//
+// There is no branch here that can turn a failure into an empty list: every
+// error path goes to httpx.Error with a non-2xx, and the only 200 is built from
+// a slice the service returned alongside a nil error.
+func (h *Handler) listConnections(c *gin.Context) {
+	principal, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		// Unreachable behind RequireAuth; refusing anyway, because a handler
+		// that trusts its mount point is one refactor away from anonymous.
+		httpx.Error(c, domain.Unauthorized("unauthenticated", "authentication required"))
+		return
+	}
+
+	conns, err := h.svc.ListConnections(c.Request.Context(), principal)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toConnectionListDTO(conns))
+}
+
+// revokeConnection answers POST /api/v1/mcp/connections/:connectionId/revoke.
+//
+// It revokes the grant AND every live token under it. The service refuses to
+// express the half; see Service.RevokeConnection.
+func (h *Handler) revokeConnection(c *gin.Context) {
+	principal, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		httpx.Error(c, domain.Unauthorized("unauthenticated", "authentication required"))
+		return
+	}
+
+	grantID, err := uuid.Parse(c.Param(connectionIDParam))
+	if err != nil {
+		// 404 AND NOT 400, matching authz.RequireSiteAccess's stance on a
+		// malformed :siteId. A caller who cannot see this organisation's
+		// connections must get the same answer for a malformed id, an id from
+		// another organisation, and an id that never existed -- otherwise the
+		// status code is an existence oracle.
+		httpx.Error(c, domain.NotFound(ErrCodeConnectionNotFound, "no such connection"))
+		return
+	}
+
+	out, err := h.svc.RevokeConnection(c.Request.Context(), principal, grantID)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	// 200 for all three success shapes, including the idempotent retry that
+	// changed nothing. The counts say what happened; the status says the end
+	// state the caller asked for now holds. Answering 404 or 500 on a
+	// zero-count success would report a correctly revoked credential as a
+	// failure and invite the operator to believe it is still live.
+	c.JSON(http.StatusOK, revokeResponseDTO{
+		Status:         string(GrantStatusRevoked),
+		GrantsRevoked:  out.GrantsRevoked,
+		TokensRevoked:  out.TokensRevoked,
+		AlreadyRevoked: out.AlreadyRevoked,
+	})
+}
+
+// houseMethodNotAllowedExcept is methodNotAllowedExcept for house API routes.
+//
+// Same shape, different envelope, and the duplication is the point: the OAuth
+// version answers in oauthErrorDTO because an OAuth client library parses that
+// shape, while these routes are read by the dashboard and must answer in the
+// house envelope {"code","message"}.
+//
+// It writes that envelope DIRECTLY rather than going through httpx.Error,
+// because domain.Kind has no 405 member -- there is no domain error that maps
+// to StatusMethodNotAllowed, and inventing one would put a transport-level
+// concept into the domain vocabulary to serve one wrong-verb response. The
+// field names are kept identical to httpx's errorEnvelope so a client parses
+// one shape for every error on this surface.
+func houseMethodNotAllowedExcept(g *gin.RouterGroup, path string, supported ...string) {
+	allowed := strings.Join(supported, ", ")
+	for _, verb := range allVerbs {
+		if slices.Contains(supported, verb) {
+			continue
+		}
+		g.Handle(verb, path, func(c *gin.Context) {
+			c.Header("Allow", allowed)
+			c.AbortWithStatusJSON(http.StatusMethodNotAllowed, gin.H{
+				"code":    "method_not_allowed",
+				"message": "this endpoint accepts " + allowed + " only",
+			})
+		})
+	}
 }
 
 // allVerbs is every method the 405 fallback covers. CONNECT and TRACE are

--- a/apps/api/internal/mcp/model.go
+++ b/apps/api/internal/mcp/model.go
@@ -12,7 +12,12 @@
 // exchange and the site-scope resolution chokepoint live alongside it.
 package mcp
 
-import "github.com/google/uuid"
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // Scope is an OAuth scope this surface recognises. The registry in scope.go is
 // CLOSED: an unrecognised scope is refused, never ignored.
@@ -101,3 +106,140 @@ func (s SiteSet) Len() int { return len(s.ids) }
 // matches nothing, or a list whose every id was dropped by RLS. The caller
 // must handle it as "reads nothing", and must never widen it.
 func (s SiteSet) IsEmpty() bool { return len(s.ids) == 0 }
+
+// ---------------------------------------------------------------------------
+// The operator-facing view of a grant: what the connections list renders and
+// what the revoke button acts on (S16, design Step 10).
+// ---------------------------------------------------------------------------
+
+// ClientProtocolState is which of FOUR distinguishable facts a grant's stored
+// client identity represents. Four, not three, and not one nullable string.
+//
+// m124 Decision 10 stores two independent columns, and the pair carries more
+// information than either alone:
+//
+//	client_identity_recorded_at IS NULL      -> the client has NEVER CONNECTED.
+//	                                            It completed the OAuth dance and
+//	                                            has not yet opened a session, so
+//	                                            it has told us nothing at all.
+//	recorded_at set, protocol_version NULL   -> it connected AND SENT NO HEADER.
+//	                                            Most clients do exactly this;
+//	                                            NegotiateProtocol treats absence
+//	                                            as the floor and does not refuse.
+//	recorded_at set, protocol_version set    -> it sent a revision string, which
+//	                                            is either one we speak or one we
+//	                                            do not.
+//
+// The first two are the pair this type exists to keep apart. Collapsing them
+// gives an operator "no protocol version" for a connection that has never been
+// used, which reads as a compatibility problem when the truth is that nothing
+// has happened yet. The last two split because "2025-06-18" and "banana" are
+// not the same answer either.
+type ClientProtocolState string
+
+const (
+	// ClientProtocolNeverConnected: client_identity_recorded_at IS NULL.
+	ClientProtocolNeverConnected ClientProtocolState = "never_connected"
+	// ClientProtocolAbsent: connected, sent no MCP-Protocol-Version header.
+	ClientProtocolAbsent ClientProtocolState = "absent"
+	// ClientProtocolRecognised: sent a revision in SupportedRevisions().
+	ClientProtocolRecognised ClientProtocolState = "recognised"
+	// ClientProtocolUnrecognised: sent something this server does not speak.
+	ClientProtocolUnrecognised ClientProtocolState = "unrecognised"
+)
+
+// ClientProtocol is a stored protocol_version classified into one of the four
+// states above.
+//
+// Version is set ONLY for Recognised and Unrecognised, and it is the string the
+// CLIENT SENT rather than anything this server assumed. It is deliberately
+// empty for NeverConnected and for Absent: NULL means "this client sent no
+// protocol header", NOT "unknown version", and rendering the negotiated floor
+// here would be this package asserting a claim the client never made.
+type ClientProtocol struct {
+	State   ClientProtocolState
+	Version string
+}
+
+// ClassifyStoredProtocol turns the two stored columns into the four-state
+// answer. It is the ONE place that mapping is made, so a caller cannot invent a
+// fifth reading or flatten two states into one.
+//
+// THE ORDER OF THE BRANCHES IS THE CONTRACT. recordedAt is tested FIRST and
+// alone, because it is the column that separates "never connected" from
+// everything else; testing the version first would report a never-connected
+// grant as "sent no header", which is the exact conflation Decision 10 stores
+// two columns to prevent.
+//
+// The empty-string case is deliberately NOT routed through NegotiateProtocol's
+// absent branch. A non-NULL column holding "" is a data anomaly rather than an
+// absent header, and NegotiateProtocol answers "" with NegotiationAssumedFloor
+// carrying Version = ProtocolFloor -- so passing it through unguarded would
+// print "2025-03-26" against a connection that sent no such thing. It is
+// classified Unrecognised with the verbatim value instead, which is honest
+// about both the anomaly and about our not speaking it.
+func ClassifyStoredProtocol(recordedAt *time.Time, stored *string) ClientProtocol {
+	if recordedAt == nil {
+		return ClientProtocol{State: ClientProtocolNeverConnected}
+	}
+	if stored == nil {
+		return ClientProtocol{State: ClientProtocolAbsent}
+	}
+	raw := *stored
+	if strings.TrimSpace(raw) == "" {
+		return ClientProtocol{State: ClientProtocolUnrecognised, Version: raw}
+	}
+	if n := NegotiateProtocol(raw); n.Outcome == NegotiationAccepted {
+		return ClientProtocol{State: ClientProtocolRecognised, Version: n.Version}
+	}
+	// Below the floor, above the floor but outside the window, or unparseable.
+	// All three are "not a revision we speak", and the caller renders the raw
+	// value so an operator can see what was actually sent.
+	return ClientProtocol{State: ClientProtocolUnrecognised, Version: raw}
+}
+
+// Connection is one AI connection as an OPERATOR sees it: the row from
+// mcp_grants, with every nullable column kept nullable.
+//
+// EVERY POINTER HERE IS LOAD-BEARING AND NONE OF THEM MAY BECOME A VALUE.
+// LastUsedAt nil is "never used" and must stay distinguishable from a date; a
+// time.Time would carry the Go zero value 0001-01-01, which serialises as a
+// real timestamp and reads as "used, in the year 1". The same argument holds
+// for the two reported client strings, where "" would read as a client that
+// reported an empty name rather than one that reported none.
+//
+// WHAT IS DELIBERATELY ABSENT: ScopeSiteIds and ScopeTagIds. They are the
+// columns mcp_grants_site_scope_select exists to protect (PR #569 finding F1 --
+// scope_site_ids enumerates every site the organisation has granted MCP access
+// to), and no consumer of this slice renders them. Adding them later is a
+// deliberate act with its own review, not a field that arrives by copying the
+// row.
+type Connection struct {
+	ID   uuid.UUID
+	Name string
+	// Status is the stored liveness column, never inferred from RevokedAt.
+	Status GrantStatus
+	// SiteScopeMode says WHICH KIND of site scope this grant carries. The
+	// resolved site ids are not exposed; see the type comment.
+	SiteScopeMode SiteScopeMode
+	// Scopes is the OAuth scope set. See Service.ListConnections for why this
+	// is currently derived rather than read from the row.
+	Scopes    []Scope
+	CreatedAt time.Time
+
+	// ReportedClientName and ReportedClientVersion are the client's OWN claims,
+	// recorded at connect. They are UNVERIFIED -- registration is
+	// unauthenticated (m124 obligation 7) -- and are never defaulted to Name,
+	// which is the operator's claim. The two can disagree and that disagreement
+	// is worth seeing.
+	ReportedClientName    *string
+	ReportedClientVersion *string
+
+	// Protocol is the four-state classification of the stored header.
+	Protocol ClientProtocol
+
+	// LastUsedAt is nil when the connection has never been used.
+	LastUsedAt *time.Time
+	// RevokedAt is nil for a live connection.
+	RevokedAt *time.Time
+}

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -100,6 +100,31 @@ type fakeStore struct {
 	sitesMore bool
 	sitesErr  error
 
+	// S16 connections surface.
+	//
+	// grants is what ListGrants returns and grantsErr forces the read to fail.
+	// The two are independent so a test can drive "the read failed" separately
+	// from "the read returned nothing", which is the pair this whole slice
+	// exists to keep apart.
+	grants    []sqlc.McpGrant
+	grantsErr error
+
+	// revokeRow is what RevokeGrantWithTokens returns and revokeErr is the
+	// error it returns instead. revokeErr set to pgx.ErrNoRows models THE
+	// GRANT NOT BEING VISIBLE -- the only outcome that means "not there" --
+	// while a revokeRow of two zeroes models an already-fully-revoked grant,
+	// which is a SUCCESS. A fake that could not express both would let a
+	// handler map them to the same status and still pass.
+	revokeRow sqlc.RevokeMCPGrantWithTokensInTenantTxRow
+	revokeErr error
+
+	// revokePrincipals records the principal every revoke was issued with, so a
+	// test can assert the repo is handed the principal (and therefore reaches
+	// RunTenantTx's site-scope dispatch) rather than a bare tenant id.
+	revokePrincipals []domain.Principal
+	// listPrincipals does the same for the list path.
+	listPrincipals []domain.Principal
+
 	// call log. mu guards all four -- see note().
 	mu           sync.Mutex
 	consumeCalls int
@@ -280,6 +305,46 @@ func (f *fakeStore) ListSitesForRead(_ context.Context, _ uuid.UUID, limit int32
 		return f.sites[:limit], true, nil
 	}
 	return f.sites, f.sitesMore, nil
+}
+
+// ListGrants models Repo.ListGrants, INCLUDING its nil-on-error contract.
+//
+// It returns (nil, err) and never ([]T{}, err). Handing back an empty slice
+// beside an error is the fixture-level version of the defect this whole slice
+// guards against, and a fake that did it would let a service which ignores the
+// error still look correct.
+func (f *fakeStore) ListGrants(_ context.Context, p domain.Principal) ([]sqlc.McpGrant, error) {
+	f.note("ListGrants")
+	f.mu.Lock()
+	f.listPrincipals = append(f.listPrincipals, p)
+	f.mu.Unlock()
+	if f.grantsErr != nil {
+		return nil, f.grantsErr
+	}
+	return f.grants, nil
+}
+
+// RevokeGrantWithTokens models the four-outcome contract of
+// RevokeMCPGrantWithTokensInTenantTx.
+//
+// revokeErr is returned VERBATIM so a test can set pgx.ErrNoRows and drive the
+// "grant not visible" branch through errors.Is, exactly as the real repo does.
+// Otherwise revokeRow comes back -- including a row of two zeroes, which is the
+// idempotent-retry SUCCESS and is the outcome most easily mistaken for a
+// failure.
+func (f *fakeStore) RevokeGrantWithTokens(
+	_ context.Context,
+	p domain.Principal,
+	_ uuid.UUID,
+) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
+	f.note("RevokeGrantWithTokens")
+	f.mu.Lock()
+	f.revokePrincipals = append(f.revokePrincipals, p)
+	f.mu.Unlock()
+	if f.revokeErr != nil {
+		return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, f.revokeErr
+	}
+	return f.revokeRow, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // Store is the database surface the service depends on. It exists as an
@@ -50,6 +51,29 @@ type Store interface {
 	// with rows still unread, because a page-bounded list that reports itself
 	// as complete is a lie about the fleet.
 	ListSitesForRead(ctx context.Context, tenantID uuid.UUID, limit int32) ([]sqlc.ListSitesRow, bool, error)
+
+	// ListGrants and RevokeGrantWithTokens are the operator-facing pair (S16).
+	//
+	// BOTH TAKE THE PRINCIPAL AND NOT A BARE tenantID, and that is the whole
+	// reason the signature differs from every other method on this interface.
+	// mcp_grants carries RESTRICTIVE _site_scope policies that key on the
+	// app.site_scope GUC, and only db.Pool.RunTenantTx sets that GUC -- so a
+	// method taking a tenantID could only reach InTenantTx, which leaves those
+	// policies INERT. Passing the principal is what puts the dispatch in
+	// db.dispatchTenantTx's hands instead of this package's memory.
+	ListGrants(ctx context.Context, principal domain.Principal) ([]sqlc.McpGrant, error)
+
+	// RevokeGrantWithTokens flips the grant AND every active token in ONE
+	// statement. There is deliberately no grant-only revoke on this interface:
+	// a security review of this stack observed `grant_status revoked /
+	// token_status active`, and the only structural fix is that no caller can
+	// express the half.
+	//
+	// pgx.ErrNoRows means the grant is NOT VISIBLE -- absent, another
+	// organisation's, or refused by RLS. It is the ONLY outcome meaning "not
+	// there"; a returned row of two zeroes is an idempotent success. See the
+	// query's four-outcome comment.
+	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
 }
 
 // Repo is the live Store. Every method names the tx helper it runs under, and
@@ -364,6 +388,91 @@ func (r *Repo) ListSitesForRead(ctx context.Context, tenantID uuid.UUID, limit i
 		return rows[:limit], true, nil
 	}
 	return rows, false, nil
+}
+
+// ListGrants reads the organisation's grants NEWEST FIRST, through
+// db.Pool.RunTenantTx.
+//
+// RunTenantTx AND NOT InTenantTx, AND THAT IS THE SECURITY BOUNDARY OF THIS
+// METHOD. m124 carries mcp_grants_site_scope_select as a RESTRICTIVE FOR SELECT
+// policy whose predicate is `app.site_scope <> 'on'`, and app.site_scope is set
+// by exactly one helper: InScopedTenantTx, which RunTenantTx dispatches to for
+// a site-constrained principal. Calling InTenantTx here would leave that policy
+// permanently inert -- the query would succeed, return the whole organisation's
+// grant list including scope_site_ids, and every test would pass. That is the
+// documented shape of the m112 failure and it is why this method takes a
+// principal it does not otherwise use.
+//
+// WHAT THIS METHOD CANNOT DO, said here because the caller must: when RLS
+// refuses, PostgreSQL returns ZERO ROWS AND NO ERROR. This method therefore
+// cannot distinguish "your organisation has no connections" from "you were
+// refused", and it must not try -- an empty slice is a truthful report of what
+// the transaction could see. Service.ListConnections refuses a site-constrained
+// principal BEFORE reaching here precisely so that the empty result never has
+// to carry that ambiguity.
+//
+// No pagination. A grant is minted by a human clicking consent, so the row
+// count per organisation is bounded by human effort rather than by machines;
+// the ordering matches the house keyset convention (created_at DESC, id DESC)
+// so a cursor can be added later without the order changing under anyone.
+func (r *Repo) ListGrants(ctx context.Context, principal domain.Principal) ([]sqlc.McpGrant, error) {
+	var out []sqlc.McpGrant
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		rows, err := sqlc.New(tx).ListMCPGrantsForOrg(ctx, principal.TenantID)
+		if err != nil {
+			return fmt.Errorf("list mcp grants: %w", err)
+		}
+		out = rows
+		return nil
+	})
+	if err != nil {
+		// nil, NOT an empty slice. A failed read must never reach a caller
+		// looking like a successful empty one -- that is this project's
+		// signature defect, and returning `[]T{}` alongside an error is how it
+		// gets made at the layer that is supposed to prevent it.
+		return nil, err
+	}
+	return out, nil
+}
+
+// RevokeGrantWithTokens revokes the grant and every active token under it, in
+// the ONE CTE statement that cannot leave the half-revoked state.
+//
+// The four outcomes are the query's, restated here only where Go changes them:
+// pgx.ErrNoRows is returned VERBATIM so the caller can 404 on it, because it is
+// the only outcome that means the grant is not visible to this principal. Every
+// other outcome comes back as a row of counts and is a success of some kind.
+//
+// RunTenantTx for the same reason ListGrants uses it: mcp_grants carries a
+// RESTRICTIVE _site_scope UPDATE gate as well as the SELECT one, and running
+// this under InTenantTx would leave it inert. Note what that would look like --
+// a site-constrained principal successfully revoking an organisation-wide
+// credential, with a 200 and no trace.
+func (r *Repo) RevokeGrantWithTokens(
+	ctx context.Context,
+	principal domain.Principal,
+	grantID uuid.UUID,
+) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
+	var out sqlc.RevokeMCPGrantWithTokensInTenantTxRow
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).RevokeMCPGrantWithTokensInTenantTx(ctx,
+			sqlc.RevokeMCPGrantWithTokensInTenantTxParams{
+				TenantID: principal.TenantID,
+				ID:       grantID,
+			})
+		if err != nil {
+			// pgx.ErrNoRows is meaningful to the caller and is NOT wrapped in a
+			// message that would make errors.Is harder to reach for. Every
+			// other error is an infra failure.
+			return err
+		}
+		out = row
+		return nil
+	})
+	if err != nil {
+		return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, err
+	}
+	return out, nil
 }
 
 // nullableText is the pgtype-free helper for the *string columns sqlc emits.

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -46,6 +46,19 @@ const (
 	// alternative is returning an empty success, and an empty result that
 	// reads as "nothing to do" is how a scoping bug becomes invisible.
 	ErrCodeScopeEmpty = "mcp_scope_empty"
+
+	// ErrCodeConnectionNotFound is the answer for a grant id this principal
+	// cannot see. It carries NO information about whether the id exists
+	// elsewhere: an id from another organisation and an id that never existed
+	// produce the identical response, which is the same non-oracle stance
+	// authz.RequireSiteAccess takes when it 404s instead of 403ing.
+	ErrCodeConnectionNotFound = "mcp_connection_not_found"
+
+	// ErrCodeOrgScopeRequired refuses a site-constrained principal at the
+	// connections surface. It mirrors the authz middleware's own
+	// "org_scope_required" and exists as a SECOND, independent refusal -- see
+	// requireOrgScopedPrincipal for why one is not enough.
+	ErrCodeOrgScopeRequired = "mcp_org_scope_required"
 )
 
 // The OAuth vocabulary this server implements, named once.
@@ -1025,4 +1038,199 @@ func orEmpty(ids []uuid.UUID) []uuid.UUID {
 		return []uuid.UUID{}
 	}
 	return ids
+}
+
+// ---------------------------------------------------------------------------
+// Operator-facing connection management (S16 -- design Step 10, list + revoke)
+// ---------------------------------------------------------------------------
+
+// requireOrgScopedPrincipal is the site-scope refusal, and it is the SECOND of
+// three independent layers rather than the only one.
+//
+// The three, outermost first:
+//
+//  1. authz.RequirePermission(PermAPIKeyRead / PermAPIKeyManage) in the route.
+//     Both are members of authz.orgLevelPerms, so a site-constrained principal
+//     is refused 403 there and never reaches this service.
+//  2. THIS FUNCTION.
+//  3. mcp_grants_site_scope_select / _update, RESTRICTIVE policies keyed on the
+//     app.site_scope GUC that Repo's RunTenantTx sets.
+//
+// LAYER 2 IS NOT REDUNDANT WITH LAYER 3, AND THAT IS THE ENTIRE POINT. Layer 3
+// refuses by returning ZERO ROWS WITH NO ERROR. On the list path that is
+// indistinguishable at the Go layer from an organisation that has minted no
+// connections, so a service relying on RLS alone would answer a refused
+// collaborator with `{"connections": []}` and the UI would render "you have no
+// connections" -- a false statement produced by a security control working
+// correctly. Refusing here is what makes the refusal SAYABLE.
+//
+// It is not redundant with layer 1 either: layer 1 lives in the route
+// registration, and a route mounted without its middleware is a wiring mistake
+// that presents as a working endpoint. This function is inside the call.
+func requireOrgScopedPrincipal(p domain.Principal) error {
+	if p.TenantID == uuid.Nil {
+		return domain.Validation(ErrCodeInvalidRequest, "an organisation is required")
+	}
+	if p.IsSiteConstrained() {
+		return domain.Forbidden(ErrCodeOrgScopeRequired,
+			"an AI connection is an organisation-wide credential, so listing or revoking one "+
+				"requires full organisation membership. This is a refusal, not an empty list.")
+	}
+	return nil
+}
+
+// ListConnections returns every grant in the principal's organisation, revoked
+// ones included.
+//
+// REVOKED GRANTS ARE RETURNED ON PURPOSE (m124 Decision 2). The row is kept
+// after revocation precisely so last_used_at and revoked_at stay readable: what
+// the credential did while it was live is the thing an operator reviews after
+// revoking it. The caller renders the status column and must never infer
+// liveness from presence in this list.
+//
+// The returned slice is nil on error and non-nil on success, including for a
+// genuinely empty organisation. That asymmetry is deliberate and is what lets
+// the layer above tell "we did not read the list" from "the list is empty".
+func (s *Service) ListConnections(ctx context.Context, p domain.Principal) ([]Connection, error) {
+	if err := requireOrgScopedPrincipal(p); err != nil {
+		return nil, err
+	}
+
+	rows, err := s.store.ListGrants(ctx, p)
+	if err != nil {
+		return nil, fmt.Errorf("list mcp connections: %w", err)
+	}
+
+	out := make([]Connection, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, connectionFromGrant(r))
+	}
+	return out, nil
+}
+
+// RevokeOutcome is what a revoke actually did. It is a struct of counts rather
+// than a bool because the query distinguishes four outcomes and three of them
+// are successes that differ in what was left to do -- see the query comment on
+// RevokeMCPGrantWithTokensInTenantTx.
+type RevokeOutcome struct {
+	// GrantsRevoked is 1 when this call flipped the grant, 0 when it was
+	// already revoked.
+	GrantsRevoked int64
+	// TokensRevoked is how many live bearer tokens this call killed. It can be
+	// non-zero while GrantsRevoked is 0: that is the REPAIR of a half-revoked
+	// grant, and it is the state a security review of this stack actually
+	// observed in the database.
+	TokensRevoked int64
+	// AlreadyRevoked reports that the grant was not active when this call ran.
+	// The request still succeeded -- the end state the caller asked for holds.
+	AlreadyRevoked bool
+}
+
+// RevokeConnection revokes a grant AND every live token beneath it.
+//
+// THE CASCADE IS THE POINT OF THIS METHOD. A revoke that flips only the grant
+// leaves a live bearer token in a client's config file, and this stack has
+// already been observed in exactly that state (`grant_status revoked /
+// token_status active`). The Store interface deliberately offers no grant-only
+// revoke, so there is no way to express the half here.
+//
+// FOUR OUTCOMES, AND ONLY ONE OF THEM IS A FAILURE:
+//
+//	pgx.ErrNoRows       the grant is not visible to this principal -- absent,
+//	                    another organisation's, or refused by RLS. 404. NOTHING
+//	                    WAS WRITTEN, and this is the ONLY reading of "matched no
+//	                    rows" that means failure.
+//	grants=1            flipped now, with TokensRevoked tokens killed.
+//	grants=0, tokens>0  the grant was already revoked and its tokens were not.
+//	                    This call CONVERGED that half-revoked state. Success.
+//	grants=0, tokens=0  already fully revoked. The requested end state holds, so
+//	                    this is an idempotent retry and it SUCCEEDED.
+//
+// THE LAST ONE IS THE TRAP AND IT IS WHY THIS COMMENT IS LONG. Two zeroes look
+// like "nothing happened, therefore something went wrong". Mapping them to 404
+// or 500 would report a correctly revoked credential as a failure, which invites
+// an operator to retry or -- much worse -- to believe the credential is still
+// live and go hunting for it. What separates the two cases is whether a ROW CAME
+// BACK AT ALL, never what the counts say.
+func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, grantID uuid.UUID) (RevokeOutcome, error) {
+	if err := requireOrgScopedPrincipal(p); err != nil {
+		return RevokeOutcome{}, err
+	}
+	if grantID == uuid.Nil {
+		// uuid.Nil is what a failed parse decays to. Refusing it by name stops
+		// a malformed id being sent to the database as a real-looking key.
+		return RevokeOutcome{}, domain.Validation(ErrCodeInvalidRequest,
+			"a connection id is required")
+	}
+
+	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RevokeOutcome{}, domain.NotFound(ErrCodeConnectionNotFound,
+				"no such connection")
+		}
+		return RevokeOutcome{}, fmt.Errorf("revoke mcp connection: %w", err)
+	}
+
+	return RevokeOutcome{
+		GrantsRevoked: row.GrantsRevoked,
+		TokensRevoked: row.TokensRevoked,
+		// Derived from the count and NOT from a second read: "the grant was not
+		// active when this statement ran" is exactly grants_revoked = 0, and
+		// asking the database again would be asking a different moment.
+		AlreadyRevoked: row.GrantsRevoked == 0,
+	}, nil
+}
+
+// connectionFromGrant maps one stored row onto the operator-facing shape.
+//
+// EVERY NULLABLE COLUMN STAYS NULLABLE. pgtype's Valid flag is consulted for
+// each timestamp rather than reading .Time unconditionally: an invalid
+// pgtype.Timestamptz carries the Go zero time, which serialises as a real
+// date in the year 1 and would render as "last used 1 Jan 0001" for a
+// connection that has never been used.
+//
+// Scopes is DERIVED, not read. mcp_grants has no scopes column (m124 Decision
+// 1 declines to add one, so that a write capability cannot appear without a
+// migration), and grantScopes() returns the one scope every live grant holds by
+// construction. That is exact only while recognisedScopes has one entry, which
+// is what TestGrantScopesIsExactOnlyWhileOneScopeExists pins -- when a second
+// scope is added, that test goes red and this line has to start reading the
+// grant instead of a constant.
+func connectionFromGrant(g sqlc.McpGrant) Connection {
+	return Connection{
+		ID:                    g.ID,
+		Name:                  g.Name,
+		Status:                GrantStatus(g.Status),
+		SiteScopeMode:         SiteScopeMode(g.SiteScopeMode),
+		Scopes:                grantScopes(),
+		CreatedAt:             g.CreatedAt,
+		ReportedClientName:    g.ClientName,
+		ReportedClientVersion: g.ClientVersion,
+		Protocol: ClassifyStoredProtocol(
+			timestamptzTimeOrNil(g.ClientIdentityRecordedAt), g.ProtocolVersion),
+		LastUsedAt: timestamptzTimeOrNil(g.LastUsedAt),
+		RevokedAt:  timestamptzTimeOrNil(g.RevokedAt),
+	}
+}
+
+// timestamptzTimeOrNil converts a pgtype.Timestamptz to *time.Time, mapping SQL
+// NULL to nil rather than to the Go zero time.
+//
+// It is the single line that keeps "never" distinguishable from "at
+// 0001-01-01", so it exists once and is called everywhere rather than being
+// restated per field.
+//
+// Distinct from tools.go's timestampOrNil, which renders straight to *string for
+// the model-facing tool output. This one stays in the time domain because the
+// DOMAIN type holds *time.Time; the string rendering happens later, in dto.go,
+// where the wire shape is decided. Two functions, because the two layers answer
+// to different consumers and collapsing them would make one of them render at
+// the wrong layer.
+func timestamptzTimeOrNil(ts pgtype.Timestamptz) *time.Time {
+	if !ts.Valid {
+		return nil
+	}
+	t := ts.Time
+	return &t
 }

--- a/apps/api/internal/server/server.go
+++ b/apps/api/internal/server/server.go
@@ -598,6 +598,19 @@ func New(deps Deps) *Server {
 	// Refusing at the gate is what stops uuid.Nil being treated as a tenant.
 	if deps.MCPOAuthH != nil {
 		deps.MCPOAuthH.Register(v1)
+		// S16 — the operator-facing connection management surface:
+		// GET /api/v1/mcp/connections and
+		// POST /api/v1/mcp/connections/:connectionId/revoke.
+		//
+		// Mounted from the SAME nil check as Register above, deliberately. The
+		// connections list and the consent flow are two halves of one feature:
+		// an installation that can mint a grant and cannot show or revoke it is
+		// the exact gap this slice closes, so there is no assembly order in
+		// which one is mounted without the other.
+		//
+		// On v1, so RequireAuth and RequireTenant both apply before the
+		// per-route RequirePermission inside RegisterConnections.
+		deps.MCPOAuthH.RegisterConnections(v1)
 	}
 	deps.TenantH.Register(v1)
 	deps.SiteH.Register(v1)

--- a/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
+++ b/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
@@ -335,8 +335,14 @@ func TestMCPConnectionsListThroughMountedRouteAsAppRole(t *testing.T) {
 		t.Errorf("protocol.version = %q after a header-less connect; the client "+
 			"sent nothing and the negotiated floor is not its claim", *after.Protocol.Version)
 	}
+	// t.Fatal AND NOT t.Error, because the t.Logf at the end of this function
+	// dereferences after.ReportedName. On t.Error execution continues, the
+	// deref panics, and the panic is what gets reported -- so the one thing the
+	// reader needs, WHICH assertion failed, is the one thing buried. Fail here
+	// or the failure lies about itself.
 	if after.ReportedName == nil || *after.ReportedName != "Claude Desktop" {
-		t.Error("the client's self-reported name did not survive to the list")
+		t.Fatalf("the client's self-reported name did not survive to the list: %v",
+			after.ReportedName)
 	}
 	// The operator's name is a different assertion and must not have been
 	// overwritten by the client's.

--- a/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
+++ b/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
@@ -1,0 +1,698 @@
+// adr064_s16_mcp_connections_integration_test.go: the list-and-revoke slice
+// proven against the REAL SCHEMA, through the MOUNTED ROUTES, as wpmgr_app.
+//
+// WHY THIS FILE AND NOT ANOTHER UNIT TEST. internal/mcp/connections_test.go
+// proves the Go branch structure against fakeStore, and a fake has no RLS
+// policies -- so it cannot prove either of the two things that actually matter
+// here:
+//
+//  1. THE REVOKE CASCADE. The grant and every token beneath it must die in one
+//     statement. A fake returns whatever counts the test set.
+//  2. THE SITE-SCOPE POLICY. mcp_grants_site_scope_select is RESTRICTIVE and
+//     keys on the app.site_scope GUC, which only db.Pool.InScopedTenantTx sets.
+//     A test that opens its own connection, or that reaches the table through
+//     InTenantTx, leaves the policy INERT and passes regardless. That is
+//     precisely how m112's proofs passed while the email domain was
+//     cross-site readable.
+//
+// So: no connection is opened here that the request path does not open. Every
+// read and write lands through db.Pool as wpmgr_app -- NOSUPERUSER, NOBYPASSRLS
+// -- which mcpAssertAndReportRole asserts and prints inside the transactions
+// actually used.
+//
+// ONE HONEST LIMIT, STATED RATHER THAN GLOSSED. Service.Authenticate cannot on
+// its own distinguish a cascading revoke from a grant-only one: the
+// ReCheckMCPRequestAuthorizationInTenantTx predicate is
+// `g.status='active' AND t.status='active' AND ...`, so a revoked GRANT already
+// refuses even with a live token. Driving Authenticate is therefore necessary
+// (it proves revocation lands on the NEXT REQUEST) but not sufficient. The
+// cascade itself is proven by reading mcp_connection_tokens back and asserting
+// no active token survives -- see TestMCPRevokeCascadesToTokensAsAppRole's
+// STEP 5. A proof that stopped at Authenticate would go green against a
+// grant-only revoke, which is the exact half-revoked state a security review
+// already observed on this stack.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// connectedGrant is everything the OAuth flow produced, so the tests below can
+// act on a REAL grant with a REAL token rather than on rows inserted by hand.
+// Hand-inserted rows would skip the constraints and the RLS that the flow
+// actually crosses.
+type connectedGrant struct {
+	grantID     uuid.UUID
+	bearerToken string
+	tenantID    uuid.UUID
+	userID      uuid.UUID
+	siteURL     string
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- REVOKE CASCADES TO TOKENS, AND REVOCATION LANDS ON THE NEXT
+// REQUEST.
+//
+// The most important requirement in the slice: "a revoke that leaves live
+// tokens is a UI button that lies."
+// ---------------------------------------------------------------------------
+
+func TestMCPRevokeCascadesToTokensAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing: either privilege makes every assertion below
+	// vacuous. Asserted inside a transaction the path actually uses.
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open token lookup tx: %v", err)
+	}
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	g := connectRealGrant(t, pool, svc)
+	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(g.tenantID, g.userID))
+
+	// -----------------------------------------------------------------------
+	// STEP 1: THE POSITIVE CONTROL. The token must work BEFORE the revoke.
+	//
+	// Without this the refusal in STEP 4 proves nothing: a token that never
+	// worked is also refused after a revoke, and the test would go green
+	// against a revoke that does absolutely nothing.
+	// -----------------------------------------------------------------------
+	auth, err := svc.Authenticate(ctx, g.bearerToken)
+	if err != nil {
+		t.Fatalf("STEP 1 control: the freshly minted token does NOT authenticate, "+
+			"so nothing below can prove a revoke did anything: %v", err)
+	}
+	if auth.GrantID != g.grantID {
+		t.Fatalf("STEP 1 control: token resolved to grant %s, want %s", auth.GrantID, g.grantID)
+	}
+	t.Logf("STEP 1 control ok: the token authenticates and resolves to grant %s", g.grantID)
+
+	// -----------------------------------------------------------------------
+	// STEP 2: and there IS a live token in the database to cascade to. Another
+	// control -- if the flow had minted none, STEP 5 would pass vacuously.
+	// -----------------------------------------------------------------------
+	activeBefore := countTokens(t, pool, g.tenantID, g.grantID, "active")
+	if activeBefore == 0 {
+		t.Fatal("STEP 2 control: the OAuth flow left NO active token, so the " +
+			"cascade assertion in STEP 5 would pass without testing anything")
+	}
+	t.Logf("STEP 2 control ok: %d active token(s) exist under the grant", activeBefore)
+
+	// -----------------------------------------------------------------------
+	// STEP 3: revoke, THROUGH THE MOUNTED ROUTE.
+	// -----------------------------------------------------------------------
+	var revoked struct {
+		Status         string `json:"status"`
+		GrantsRevoked  int64  `json:"grants_revoked"`
+		TokensRevoked  int64  `json:"tokens_revoked"`
+		AlreadyRevoked bool   `json:"already_revoked"`
+	}
+	code := mcpDoJSON(t, eng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(g.grantID.String()), nil, nil, &revoked)
+	if code != http.StatusOK {
+		t.Fatalf("STEP 3 revoke answered %d, want 200", code)
+	}
+	if revoked.GrantsRevoked != 1 {
+		t.Errorf("STEP 3 grants_revoked = %d, want 1 for a first revoke of a live grant",
+			revoked.GrantsRevoked)
+	}
+	if revoked.TokensRevoked != activeBefore {
+		t.Errorf("STEP 3 tokens_revoked = %d but %d were active; the response "+
+			"under-reports what it killed", revoked.TokensRevoked, activeBefore)
+	}
+	if revoked.AlreadyRevoked {
+		t.Error("STEP 3 reported already_revoked=true for a first revoke")
+	}
+	t.Logf("STEP 3 ok: revoke flipped %d grant and %d token(s)",
+		revoked.GrantsRevoked, revoked.TokensRevoked)
+
+	// -----------------------------------------------------------------------
+	// STEP 4: REVOCATION LANDS ON THE NEXT REQUEST. Driven through
+	// Service.Authenticate -- the real credential path, not a fake.
+	// -----------------------------------------------------------------------
+	if _, err := svc.Authenticate(ctx, g.bearerToken); err == nil {
+		t.Fatal("STEP 4: the revoked connection's token STILL AUTHENTICATES. " +
+			"The revoke button lies.")
+	} else {
+		t.Logf("STEP 4 ok: the token is now refused: %v", err)
+	}
+
+	// -----------------------------------------------------------------------
+	// STEP 5: THE CASCADE ITSELF. This is the assertion STEP 4 cannot make.
+	//
+	// The recheck predicate ANDs the grant status and the token status, so a
+	// grant-only revoke also fails STEP 4. What separates the two is whether
+	// the TOKEN ROW died. A live token on a revoked grant is the exact state a
+	// security review observed here (grant_status revoked / token_status
+	// active), and it matters because the token is a bearer credential sitting
+	// in a client's config file: anything that ever checks it without joining
+	// the grant hands back a working session.
+	// -----------------------------------------------------------------------
+	if stillActive := countTokens(t, pool, g.tenantID, g.grantID, "active"); stillActive != 0 {
+		t.Fatalf("STEP 5 CASCADE FAILED: %d token(s) are still status='active' "+
+			"under a revoked grant. The revoke did not cascade.", stillActive)
+	}
+	revokedTokens := countTokens(t, pool, g.tenantID, g.grantID, "revoked")
+	if revokedTokens != activeBefore {
+		t.Fatalf("STEP 5 CASCADE FAILED: %d token(s) are status='revoked' but %d "+
+			"were active before; some token is in neither state",
+			revokedTokens, activeBefore)
+	}
+	// revoked_at must be stamped with the status. The schema's
+	// mcp_connection_tokens_revoked_at_matches_status_check requires it, so a
+	// row with one and not the other cannot exist -- asserting it here proves
+	// the constraint is actually on this table rather than assumed.
+	if missing := countRevokedTokensWithoutTimestamp(t, pool, g.tenantID, g.grantID); missing != 0 {
+		t.Errorf("STEP 5: %d revoked token(s) carry no revoked_at, so nothing "+
+			"records WHEN the credential died", missing)
+	}
+	t.Logf("STEP 5 ok: all %d token(s) are revoked with a revoked_at stamp", revokedTokens)
+
+	// -----------------------------------------------------------------------
+	// STEP 6: the idempotent retry. Two zeroes is a SUCCESS, not a 404.
+	//
+	// A handler that mapped this to 404 or 500 would tell an operator their
+	// correctly revoked credential failed to revoke -- inviting them to believe
+	// it is still live.
+	// -----------------------------------------------------------------------
+	var retry struct {
+		Status         string `json:"status"`
+		GrantsRevoked  int64  `json:"grants_revoked"`
+		TokensRevoked  int64  `json:"tokens_revoked"`
+		AlreadyRevoked bool   `json:"already_revoked"`
+	}
+	code = mcpDoJSON(t, eng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(g.grantID.String()), nil, nil, &retry)
+	if code != http.StatusOK {
+		t.Fatalf("STEP 6 re-revoking an already-revoked grant answered %d, want 200. "+
+			"The requested end state holds, so this is an idempotent success.", code)
+	}
+	if retry.GrantsRevoked != 0 || retry.TokensRevoked != 0 {
+		t.Errorf("STEP 6 re-revoke reported (%d, %d), want (0, 0)",
+			retry.GrantsRevoked, retry.TokensRevoked)
+	}
+	if !retry.AlreadyRevoked {
+		t.Error("STEP 6 re-revoke did not report already_revoked=true")
+	}
+	t.Log("STEP 6 ok: the idempotent retry succeeded and reported it changed nothing")
+
+	// -----------------------------------------------------------------------
+	// STEP 7: a grant id that does not exist is a 404, and NOTHING was written.
+	// This is what makes "matched zero rows" a failure in the one reading where
+	// it IS one.
+	// -----------------------------------------------------------------------
+	code = mcpDoJSON(t, eng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(uuid.NewString()), nil, nil, nil)
+	if code != http.StatusNotFound {
+		t.Fatalf("STEP 7 revoking an unknown grant answered %d, want 404", code)
+	}
+	t.Log("STEP 7 ok: an unknown grant id is 404, distinguished from an idempotent retry")
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- THE LIST IS REAL, AND THE THREE-WAY FACTS SURVIVE THE ROUND TRIP.
+// ---------------------------------------------------------------------------
+
+func TestMCPConnectionsListThroughMountedRouteAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InTenantTx(ctx, uuid.New(), func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	g := connectRealGrant(t, pool, svc)
+	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(g.tenantID, g.userID))
+
+	var list struct {
+		Connections []struct {
+			ID            string  `json:"id"`
+			Name          string  `json:"name"`
+			Status        string  `json:"status"`
+			SiteScopeMode string  `json:"site_scope_mode"`
+			LastUsedAt    *string `json:"last_used_at"`
+			RevokedAt     *string `json:"revoked_at"`
+			ReportedName  *string `json:"reported_client_name"`
+			Protocol      struct {
+				State   string  `json:"state"`
+				Version *string `json:"version"`
+			} `json:"protocol"`
+		} `json:"connections"`
+	}
+	code := mcpDoJSON(t, eng, http.MethodGet, mcp.ConnectionsPath, nil, nil, &list)
+	if code != http.StatusOK {
+		t.Fatalf("list answered %d, want 200", code)
+	}
+	if len(list.Connections) != 1 {
+		t.Fatalf("list returned %d connections, want the 1 the OAuth flow just "+
+			"minted. An empty list here is the whole defect this slice fixes.",
+			len(list.Connections))
+	}
+
+	got := list.Connections[0]
+	if got.ID != g.grantID.String() {
+		t.Errorf("listed connection id %q, want %q", got.ID, g.grantID)
+	}
+	if got.Status != string(mcp.GrantStatusActive) {
+		t.Errorf("a freshly consented grant lists as %q", got.Status)
+	}
+	// The grant was consented but never CONNECTED: no client has opened a
+	// session, so client_identity_recorded_at is NULL. That is
+	// "never_connected", NOT "absent" -- absence of a header is something only a
+	// client that actually connected can express.
+	if got.Protocol.State != string(mcp.ClientProtocolNeverConnected) {
+		t.Errorf("protocol.state = %q for a grant nothing has connected to; want %q",
+			got.Protocol.State, mcp.ClientProtocolNeverConnected)
+	}
+	if got.Protocol.Version != nil {
+		t.Errorf("protocol.version = %q for a never-connected grant; NULL means the "+
+			"client sent no protocol header, and rendering a version here puts a "+
+			"claim in its mouth", *got.Protocol.Version)
+	}
+	if got.LastUsedAt != nil {
+		t.Errorf("last_used_at = %q for a connection that has never been used; "+
+			"want null", *got.LastUsedAt)
+	}
+	if got.RevokedAt != nil {
+		t.Errorf("revoked_at = %q for a live connection", *got.RevokedAt)
+	}
+	if got.ReportedName != nil {
+		t.Errorf("reported_client_name = %q before any client reported one", *got.ReportedName)
+	}
+	t.Logf("list ok: grant %s, status=%s, protocol.state=%s, last_used_at=null",
+		got.ID, got.Status, got.Protocol.State)
+
+	// -----------------------------------------------------------------------
+	// Now record a connect with NO protocol header -- the case most real
+	// clients produce -- and prove the list moves from never_connected to
+	// absent WITHOUT inventing a version.
+	// -----------------------------------------------------------------------
+	auth, err := svc.Authenticate(ctx, g.bearerToken)
+	if err != nil {
+		t.Fatalf("authenticate before recording connect: %v", err)
+	}
+	// nil protocol header: the client sent none.
+	if err := svc.RecordConnect(ctx, auth, "Claude Desktop", "1.4.0", nil); err != nil {
+		t.Fatalf("record connect: %v", err)
+	}
+
+	code = mcpDoJSON(t, eng, http.MethodGet, mcp.ConnectionsPath, nil, nil, &list)
+	if code != http.StatusOK {
+		t.Fatalf("second list answered %d", code)
+	}
+	after := list.Connections[0]
+	if after.Protocol.State != string(mcp.ClientProtocolAbsent) {
+		t.Errorf("after a header-less connect, protocol.state = %q; want %q. "+
+			"'connected and sent no header' and 'has never connected' are "+
+			"different facts and m124 stores two columns to keep them apart",
+			after.Protocol.State, mcp.ClientProtocolAbsent)
+	}
+	if after.Protocol.Version != nil {
+		t.Errorf("protocol.version = %q after a header-less connect; the client "+
+			"sent nothing and the negotiated floor is not its claim", *after.Protocol.Version)
+	}
+	if after.ReportedName == nil || *after.ReportedName != "Claude Desktop" {
+		t.Error("the client's self-reported name did not survive to the list")
+	}
+	// The operator's name is a different assertion and must not have been
+	// overwritten by the client's.
+	if after.Name == "Claude Desktop" {
+		t.Error("the operator's connection name was replaced by the client's " +
+			"self-reported name; those are two different claims")
+	}
+	t.Logf("list ok after connect: protocol.state=%s, version=null, reported_client_name=%q",
+		after.Protocol.State, *after.ReportedName)
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- THE SITE-SCOPE GATE, AT BOTH LAYERS.
+//
+// Constraint 2. mcp_grants_site_scope_select is RESTRICTIVE and refuses by
+// returning ZERO ROWS WITH NO ERROR, which on a list path is indistinguishable
+// from an empty organisation. So both halves are proven: the policy is LIVE
+// (the repo really does see nothing), and the service REFUSES OUT LOUD rather
+// than reporting that nothing as an empty list.
+// ---------------------------------------------------------------------------
+
+func TestMCPGrantsSiteScopePolicyIsLiveAndTheServiceRefusesOutLoud(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	repo := mcp.NewRepo(pool)
+	g := connectRealGrant(t, pool, svc)
+
+	orgP := adminPrincipal(g.tenantID, g.userID)
+
+	// -----------------------------------------------------------------------
+	// CONTROL: the org member DOES see the grant through the very same repo
+	// method. Without this, "the collaborator sees nothing" could equally mean
+	// the query is broken for everyone.
+	// -----------------------------------------------------------------------
+	orgRows, err := repo.ListGrants(ctx, orgP)
+	if err != nil {
+		t.Fatalf("CONTROL: the org member's list failed: %v", err)
+	}
+	if len(orgRows) != 1 {
+		t.Fatalf("CONTROL: the org member sees %d grants, want 1. The refusal "+
+			"below would prove nothing against a query that returns nothing to "+
+			"anybody.", len(orgRows))
+	}
+	t.Logf("CONTROL ok: the org member reads %d grant through repo.ListGrants", len(orgRows))
+
+	// -----------------------------------------------------------------------
+	// THE POLICY. A site-scoped collaborator reaching the repo directly --
+	// which is what would happen if the handler's permission gate were ever
+	// removed -- must see NOTHING. This runs through RunTenantTx, so
+	// InScopedTenantTx sets app.site_scope='on' and the RESTRICTIVE policy is
+	// genuinely evaluated. Reaching the table through InTenantTx instead would
+	// leave it inert and this assertion would fail.
+	// -----------------------------------------------------------------------
+	scopedP := domain.Principal{
+		Type:     domain.PrincipalUser,
+		UserID:   g.userID,
+		TenantID: g.tenantID,
+		Role:     "admin", // admin on the one site it can see, and still refused
+		Scope:    domain.ScopeSite,
+		// A real site in this very tenant: the collaborator is legitimately
+		// shared onto it, and must still not read the org's grant list.
+		AllowedSiteIDs: []uuid.UUID{siteIDForURL(t, pool, g.tenantID, g.siteURL)},
+	}
+
+	scopedRows, err := repo.ListGrants(ctx, scopedP)
+	if err != nil {
+		t.Fatalf("the site-scoped read errored rather than being filtered: %v", err)
+	}
+	if len(scopedRows) != 0 {
+		t.Fatalf("mcp_grants_site_scope_select IS INERT: a site-scoped principal "+
+			"read %d grant(s), including scope_site_ids, which enumerates every "+
+			"site the organisation has granted MCP access to (PR #569 finding F1)",
+			len(scopedRows))
+	}
+	t.Log("POLICY ok: the RESTRICTIVE site-scope policy refused the read (0 rows)")
+
+	// -----------------------------------------------------------------------
+	// AND THE SERVICE MUST NOT REPORT THAT ZERO AS AN EMPTY LIST. This is the
+	// half RLS structurally cannot do: it refuses silently, so the Go layer has
+	// to be the one that SAYS "refused".
+	// -----------------------------------------------------------------------
+	conns, err := svc.ListConnections(ctx, scopedP)
+	if err == nil {
+		t.Fatalf("the service returned %d connections and no error for a "+
+			"site-scoped principal. RLS gave it zero rows and it reported that "+
+			"as 'you have no connections' -- a false statement produced by a "+
+			"security control working correctly.", len(conns))
+	}
+	if conns != nil {
+		t.Errorf("the refusal came with a non-nil slice of len %d", len(conns))
+	}
+	// The refusal must be a NAMED domain error, not a generic failure. An
+	// operator who sees "something went wrong" retries; one who sees
+	// "requires full organisation membership" understands and stops.
+	if de, ok := domain.AsDomain(err); !ok || de.Code != mcp.ErrCodeOrgScopeRequired {
+		t.Fatalf("want a %s domain error, got %v", mcp.ErrCodeOrgScopeRequired, err)
+	}
+	t.Logf("SERVICE ok: the site-scoped principal is refused by name: %v", err)
+
+	// -----------------------------------------------------------------------
+	// The same principal must not be able to REVOKE either. The insert/update
+	// gates exist for the same reason as the select one.
+	// -----------------------------------------------------------------------
+	if _, err := svc.RevokeConnection(ctx, scopedP, g.grantID); err == nil {
+		t.Fatal("a site-scoped collaborator revoked an organisation-wide credential")
+	}
+	// And the grant must still be live: the refusal must have written nothing.
+	stillActive := countGrants(t, pool, g.tenantID, g.grantID, "active")
+	if stillActive != 1 {
+		t.Fatalf("after a refused revoke the grant's active count is %d, want 1; "+
+			"the refusal wrote something", stillActive)
+	}
+	t.Log("REVOKE ok: the site-scoped principal is refused and the grant is untouched")
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// adminPrincipal is a full organisation member at the role
+// authz.minRoleFor[PermAPIKeyRead] requires.
+func adminPrincipal(tenantID, userID uuid.UUID) domain.Principal {
+	return domain.Principal{
+		Type:     domain.PrincipalUser,
+		UserID:   userID,
+		TenantID: tenantID,
+		Role:     "admin",
+		Scope:    "org",
+	}
+}
+
+// connectRealGrant drives the WHOLE OAuth flow through the mounted routes and
+// returns the grant and bearer token it produced.
+//
+// It goes through the flow rather than inserting rows because a hand-inserted
+// grant skips every CHECK, every RLS policy and every service invariant the
+// real path crosses -- and the thing under test here is what happens to a real
+// credential.
+func connectRealGrant(t *testing.T, pool *db.Pool, svc *mcp.Service) connectedGrant {
+	t.Helper()
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-s16-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-s16-"+suffix+"@example.test")
+	siteURL := "https://" + uuid.NewString()[:8] + ".example.test"
+	seedSite(t, pool, tenantID, siteURL)
+
+	eng := mountOAuthLikeProduction(t, svc, tenantID, userID)
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+
+	var reg struct {
+		ClientID string `json:"client_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.RegisterPath, map[string]any{
+		"redirect_uris":              []string{redirectURI},
+		"client_name":                "Claude Desktop",
+		"client_uri":                 "https://claude.ai",
+		"token_endpoint_auth_method": "none",
+	}, nil, &reg); code != http.StatusCreated {
+		t.Fatalf("fixture: registration answered %d, want 201", code)
+	}
+
+	verifier := "s16-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", reg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "s16-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	if code := mcpDoJSON(t, eng, http.MethodGet,
+		mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		t.Fatalf("fixture: authorize answered %d, want 200", code)
+	}
+
+	var approval struct {
+		GrantID string `json:"grant_id"`
+		Code    string `json:"code"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConsentPath, map[string]any{
+		"client_id":             reg.ClientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "s16-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"name":                  "s16 connection under test",
+		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+	}, nil, &approval); code != http.StatusOK {
+		t.Fatalf("fixture: consent answered %d, want 200", code)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", approval.Code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", reg.ClientID)
+	form.Set("code_verifier", verifier)
+
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	if code := mcpPostForm(t, eng, mcp.TokenPath, form, &tok); code != http.StatusOK {
+		t.Fatalf("fixture: token exchange answered %d, want 200", code)
+	}
+	if tok.AccessToken == "" {
+		t.Fatal("fixture: token exchange returned no access_token")
+	}
+
+	grantID, err := uuid.Parse(approval.GrantID)
+	if err != nil {
+		t.Fatalf("fixture: grant id %q is not a uuid: %v", approval.GrantID, err)
+	}
+
+	return connectedGrant{
+		grantID:     grantID,
+		bearerToken: tok.AccessToken,
+		tenantID:    tenantID,
+		userID:      userID,
+		siteURL:     siteURL,
+	}
+}
+
+// mountOAuthLikeProduction mounts the four OAuth endpoints the way server.New
+// does, with a principal standing in for RequireAuth + RequireTenant.
+func mountOAuthLikeProduction(t *testing.T, svc *mcp.Service, tenantID, userID uuid.UUID) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	eng := gin.New()
+	h := mcp.NewHandler(svc)
+	h.RegisterPublic(eng.Group(mcp.APIV1Prefix))
+
+	authed := eng.Group(mcp.APIV1Prefix)
+	authed.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(),
+			domain.Principal{UserID: userID, TenantID: tenantID}))
+		c.Next()
+	})
+	h.Register(authed)
+	return eng
+}
+
+// mountConnectionsLikeProduction mounts the connections surface the way
+// server.New does: on the /api/v1 group, behind a principal, with
+// RegisterConnections installing its OWN authz.RequirePermission middleware.
+//
+// The permission gate is NOT stubbed. It is the site-scope gate at the
+// permission layer (PermAPIKeyRead and PermAPIKeyManage are both members of
+// authz.orgLevelPerms), so stubbing it out would remove one of the three layers
+// under test.
+func mountConnectionsLikeProduction(t *testing.T, svc *mcp.Service, p domain.Principal) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	eng := gin.New()
+	g := eng.Group(mcp.APIV1Prefix)
+	g.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), p))
+		c.Next()
+	})
+	mcp.NewHandler(svc).RegisterConnections(g)
+	return eng
+}
+
+// countTokens counts this grant's tokens in a given status, THROUGH THE POOL as
+// wpmgr_app and inside InTenantTx -- the same transaction shape the request
+// path uses. A raw connection here would read past RLS and could report rows
+// the application can never see.
+func countTokens(t *testing.T, pool *db.Pool, tenantID, grantID uuid.UUID, status string) int64 {
+	t.Helper()
+	var n int64
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM mcp_connection_tokens
+			  WHERE tenant_id = $1 AND grant_id = $2 AND status = $3`,
+			tenantID, grantID, status).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count %s tokens: %v", status, err)
+	}
+	return n
+}
+
+// countRevokedTokensWithoutTimestamp finds revoked tokens carrying no
+// revoked_at -- the half-state the schema CHECK is supposed to make impossible.
+func countRevokedTokensWithoutTimestamp(t *testing.T, pool *db.Pool, tenantID, grantID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM mcp_connection_tokens
+			  WHERE tenant_id = $1 AND grant_id = $2
+			    AND status = 'revoked' AND revoked_at IS NULL`,
+			tenantID, grantID).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count revoked tokens without a timestamp: %v", err)
+	}
+	return n
+}
+
+// countGrants counts a grant in a given status, same transaction shape.
+func countGrants(t *testing.T, pool *db.Pool, tenantID, grantID uuid.UUID, status string) int64 {
+	t.Helper()
+	var n int64
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM mcp_grants
+			  WHERE tenant_id = $1 AND id = $2 AND status = $3`,
+			tenantID, grantID, status).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count %s grants: %v", status, err)
+	}
+	return n
+}
+
+// siteIDForURL resolves the seeded site's id through the pool as wpmgr_app.
+func siteIDForURL(t *testing.T, pool *db.Pool, tenantID uuid.UUID, siteURL string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT id FROM sites WHERE tenant_id = $1 AND url = $2`,
+			tenantID, siteURL).Scan(&id)
+	})
+	if err != nil {
+		t.Fatalf("resolve site id for %s: %v", siteURL, err)
+	}
+	return id
+}
+
+// mcpPostForm posts an application/x-www-form-urlencoded body, which is what
+// RFC 6749 specifies for the token endpoint and what every client library
+// sends. A non-2xx is returned to the caller rather than swallowed here.
+func mcpPostForm(t *testing.T, eng *gin.Engine, path string, form url.Values, out any) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "203.0.113.7:5555"
+
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+
+	if out != nil && w.Body.Len() > 0 {
+		if err := json.Unmarshal(w.Body.Bytes(), out); err != nil {
+			t.Fatalf("POST %s returned %d with a body that is not JSON: %v\nbody: %s",
+				path, w.Code, err, w.Body.String())
+		}
+	}
+	return w.Code
+}


### PR DESCRIPTION
Closes the gap PR #592 renders as an explicit `unavailable` state: the control plane could mint an MCP grant and had no way to show or revoke one.

## Endpoints

| Method | Path | Permission |
|---|---|---|
| `GET` | `/api/v1/mcp/connections` | `authz.PermAPIKeyRead` |
| `POST` | `/api/v1/mcp/connections/:connectionId/revoke` | `authz.PermAPIKeyManage` |

Both are under `/api/*`, which `infra/urlmap.yaml` already routes — no new path rule needed.

## The four established constraints

**1. Revoke cascades to tokens.** The `Store` interface deliberately offers *no* grant-only revoke, so the half-revoked state cannot be expressed in Go. `RevokeMCPGrantWithTokensInTenantTx` flips both tables in one CTE.

**2. The site-scope gate, in three layers.** `RequirePermission` (both permissions are already members of `authz.orgLevelPerms`, so a site-constrained principal is refused outright) → an explicit named refusal in the service → `mcp_grants_site_scope_select`. The middle layer is **not** redundant: RLS refuses by returning zero rows with no error, which on a list path is indistinguishable from an empty organisation. The repo reaches the table through `db.Pool.RunTenantTx`, which is what sets `app.site_scope` and keeps the policy live rather than inert.

**3. `protocol_version` NULL is not a version.** Four states, not three: `never_connected` (`client_identity_recorded_at IS NULL`), `absent`, `recognised`, `unrecognised`. Neither absence state carries a version.

**4. Absence is not emptiness.** A failed list returns `nil` and a non-2xx in an envelope that cannot decode into a list; an empty org serialises as `[]`; `last_used_at` NULL stays `null`; a revoke that matched **no row** is 404 while a row of two zeroes is an idempotent **success**.

## One honest limit

`Service.Authenticate` alone **cannot** discriminate a cascading revoke from a grant-only one — the recheck predicate is `g.status='active' AND t.status='active'`, so a revoked grant already refuses. Driving `Authenticate` proves revocation lands on the next request; the cascade itself is proven by reading `mcp_connection_tokens` back and asserting no active token survives. Both assertions are in the integration test, and the limit is documented in its header.

## Not written

No SQL — every query already existed in `db/query/mcp_connections.sql`. No OpenAPI change — the MCP surface is absent from `openapi.yaml` and hand-shapes its DTOs, so neither generator moved.

## Left for a later slice

Rename, rotate, per-token listing/revocation, and per-site scope detail in the DTO (`scope_site_ids` is deliberately not exposed — it is the column finding F1 exists to protect).

## Review

**Do not merge** — a `security-reviewer` pass follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added operator-facing MCP connection management.
  - View active and revoked connections, including client details, protocol status, usage timestamps, and scopes.
  - Revoke connections and their active tokens from the API, with revocation counts reported.
  - Repeated revocation requests are safely handled as idempotent operations.
- **Access Control**
  - Limited connection management to organization-scoped operators with appropriate permissions.
  - Site-scoped access is rejected.
- **Error Handling**
  - Added clear responses for missing connections, invalid requests, unsupported methods, and server errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->