### PR TITLE
fix(mcp): apply org-scope enforcement to the MCP consent routes

### DIFF
--- a/apps/api/internal/mcp/approve_test.go
+++ b/apps/api/internal/mcp/approve_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -49,10 +50,17 @@ func validConsent() ConsentContext {
 	}
 }
 
+// validApproval is an ORG-scoped approver: Scope "org" and no allowlist, which
+// is what every pre-existing case in this file assumes. The site-scoped
+// counterpart is exercised by TestApprove_RefusesASiteScopedApprover below and
+// end to end in tests/mcp_consent_org_scope_integration_test.go.
 func validApproval() ApprovalRequest {
 	return ApprovalRequest{
-		TenantID:  uuid.New(),
-		UserID:    uuid.New(),
+		Principal: domain.Principal{
+			TenantID: uuid.New(),
+			UserID:   uuid.New(),
+			Scope:    domain.ScopeOrg,
+		},
 		Consent:   validConsent(),
 		GrantName: "Claude Desktop on my laptop",
 		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
@@ -294,6 +302,103 @@ func TestConsentHandler_RefusesAnUnregisteredRedirect(t *testing.T) {
 		if c == "CreateGrantWithCode" {
 			t.Fatal("the handler minted a grant for an unregistered redirect")
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ORG SCOPE. A grant is an org-level object -- site_scope_mode 'all' resolves
+// to every site in the organisation -- so a site-scoped collaborator may not
+// mint one.
+//
+// These two are the SERVICE layer only. They cannot see a GUC or a policy, so
+// they prove nothing about the RLS beneath; that is
+// tests/mcp_consent_org_scope_integration_test.go, through the mounted routes
+// as wpmgr_app. What they pin is that Approve refuses on its own, so a caller
+// arriving without the route middleware is still refused.
+// ---------------------------------------------------------------------------
+
+// TestApprove_RefusesASiteScopedApprover is the service-layer half of the
+// escalation refusal.
+func TestApprove_RefusesASiteScopedApprover(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		principal domain.Principal
+	}{
+		{
+			name: "scope site with an allowlist",
+			principal: domain.Principal{
+				TenantID:       uuid.New(),
+				UserID:         uuid.New(),
+				Scope:          domain.ScopeSite,
+				AllowedSiteIDs: []uuid.UUID{uuid.New()},
+			},
+		},
+		{
+			// The fail-closed backstop: an allowlist with no scope label. A
+			// principal built by hand, or by a future constructor that forgets
+			// the label, must still be refused.
+			name: "an allowlist with no scope label",
+			principal: domain.Principal{
+				TenantID:       uuid.New(),
+				UserID:         uuid.New(),
+				AllowedSiteIDs: []uuid.UUID{uuid.New()},
+			},
+		},
+		{
+			// Restricted to zero sites is a legitimate fail-CLOSED state and
+			// must not become an org-wide approver.
+			name: "scope site with an empty allowlist",
+			principal: domain.Principal{
+				TenantID: uuid.New(),
+				UserID:   uuid.New(),
+				Scope:    domain.ScopeSite,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := approvalStore()
+			svc := NewService(store)
+
+			req := validApproval()
+			req.Principal = tc.principal
+
+			_, err := svc.Approve(context.Background(), req)
+			if err == nil {
+				t.Fatal("Approve accepted a site-scoped approver and minted a grant")
+			}
+			for _, c := range store.calls {
+				if c == "CreateGrantWithCode" {
+					t.Fatal("Approve reached the store for a site-scoped approver; " +
+						"the refusal must happen before any write is attempted")
+				}
+			}
+		})
+	}
+}
+
+// TestApprove_HandsTheWholePrincipalToTheStore pins the plumbing the RLS layer
+// depends on. If Approve flattens the principal to a tenant id on the way down,
+// RunTenantTx cannot route to InScopedTenantTx, app.site_scope is never set and
+// the RESTRICTIVE insert policy is inert -- which is exactly the defect this
+// file's neighbours exist to prevent recurring. The fake cannot evaluate the
+// policy; it can prove the principal arrived.
+func TestApprove_HandsTheWholePrincipalToTheStore(t *testing.T) {
+	store := approvalStore()
+	svc := NewService(store)
+
+	req := validApproval()
+	if _, err := svc.Approve(context.Background(), req); err != nil {
+		t.Fatalf("Approve refused a valid org-scoped approval: %v", err)
+	}
+	if store.grantPrincipal == nil {
+		t.Fatal("CreateGrantWithCode was handed a nil principal")
+	}
+	if got := store.grantPrincipal.GetTenantID(); got != req.Principal.TenantID {
+		t.Errorf("store received tenant %s, want %s", got, req.Principal.TenantID)
+	}
+	if got := store.grantPrincipal.GetScope(); got != req.Principal.Scope {
+		t.Errorf("store received scope %q, want %q; the scope is what routes the "+
+			"write to a site-scoped transaction", got, req.Principal.Scope)
 	}
 }
 

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -156,6 +156,10 @@ func oauthError(err error) (int, oauthErrorDTO) {
 		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_request", ErrDesc: domErr.Message}
 	case ErrCodeInvalidSiteScope, ErrCodeInvalidRequest:
 		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_request", ErrDesc: domErr.Message}
+	case ErrCodeAccessDenied:
+		// 403, not the default 400: the request is well-formed and this
+		// principal is simply not permitted to authorize an org-level grant.
+		return http.StatusForbidden, oauthErrorDTO{Err: "access_denied", ErrDesc: domErr.Message}
 	default:
 		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_request", ErrDesc: domErr.Message}
 	}

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
@@ -87,8 +88,20 @@ func (h *Handler) RegisterPublic(r *gin.RouterGroup) {
 // is already behind session auth AND authz.RequireAuth/RequireTenant; the
 // handlers below re-check the principal anyway, because a handler that trusts
 // its mount point is one refactor away from being anonymous.
+//
+// RequireOrgScope is applied HERE, on the group, rather than left to the
+// caller. A grant is an ORG-LEVEL object: it carries a site_scope_mode of
+// 'all' | 'tags' | 'sites' chosen by the approver, and 'all' resolves to every
+// site in the organisation at read time. There is no :siteId to bind, so
+// RequireSiteAccess cannot express the boundary and RequireOrgScope is the
+// whole gate -- the same reason the update-run orchestrator and the fleet
+// rollups carry it.
+//
+// It sits on the group and not on the caller's mount so that every mount of
+// these two routes gets it, including the integration harness. A gate that
+// only exists in server.New is a gate no test exercises.
 func (h *Handler) Register(r *gin.RouterGroup) {
-	g := r.Group(oauthGroupPath)
+	g := r.Group(oauthGroupPath, authz.RequireOrgScope())
 	g.GET("/authorize", h.authorize)
 	g.POST("/consent", h.consent)
 }
@@ -231,8 +244,10 @@ func (h *Handler) consent(c *gin.Context) {
 	}
 
 	out, err := h.svc.Approve(c.Request.Context(), ApprovalRequest{
-		TenantID: principal.TenantID,
-		UserID:   principal.UserID,
+		// The whole principal. Its Scope and AllowedSiteIDs are what route the
+		// grant insert to a site-scoped transaction, so narrowing this to
+		// (TenantID, UserID) here would disarm the RLS layer beneath.
+		Principal: principal,
 		Consent: ConsentContext{
 			ClientID:            body.ClientID,
 			RedirectURI:         body.RedirectURI,

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
-	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
@@ -100,10 +99,63 @@ func (h *Handler) RegisterPublic(r *gin.RouterGroup) {
 // It sits on the group and not on the caller's mount so that every mount of
 // these two routes gets it, including the integration harness. A gate that
 // only exists in server.New is a gate no test exercises.
+//
+// BOTH ROUTES CARRY IT, not just the one that writes. /consent does not require
+// a prior /authorize: Approve re-resolves the client and re-matches the redirect
+// from the POST body, and /register is unauthenticated, so the write is
+// reachable with a self-registered client and a single POST -- no consent
+// screen, no operator interaction, no /authorize call. Gating only the writing
+// route would therefore gate nothing, and gating only /authorize would leave the
+// write open. The pair is the boundary.
 func (h *Handler) Register(r *gin.RouterGroup) {
-	g := r.Group(oauthGroupPath, authz.RequireOrgScope())
+	g := r.Group(oauthGroupPath, h.requireOrgScope())
 	g.GET("/authorize", h.authorize)
 	g.POST("/consent", h.consent)
+}
+
+// requireOrgScope is authz.RequireOrgScope's refusal in THIS package's error
+// envelope. It is deliberately not authz.RequireOrgScope itself.
+//
+// The predicate is identical -- domain.Principal.IsSiteConstrained, the single
+// definition every other site gate calls -- so there is no second opinion about
+// who is constrained. Only the response shape differs, and it has to: the two
+// routes below answer in the RFC 6749 section 5.2 envelope
+// {error, error_description}, and the dashboard's consent screen parses exactly
+// that (apps/web/src/features/mcp-consent/use-consent.ts reads `error` and
+// `error_description`, falling back to "server_error" when neither is present).
+// Aborting through the generic {code, message} responder would make a
+// deliberate, correct refusal arrive at the screen as an unexplained server
+// fault, which tells a collaborator the system is broken when the truth is that
+// they may not approve this.
+//
+// The status is NOT softened to make the body prettier: oauthError maps
+// ErrCodeAccessDenied to 403. 401 would be wrong here -- the credential is
+// valid and re-presenting it cannot help, so inviting a retry is inviting a
+// pointless one.
+//
+// No OAuth CLIENT ever reads this body. authorization_endpoint is opened in the
+// user's browser and /consent is posted by our own screen; a client learns of a
+// refusal from the redirect the screen builds (buildDenialTarget), carrying
+// error=access_denied and the original state. The envelope matters for the
+// screen, not for the protocol.
+func (h *Handler) requireOrgScope() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		p, ok := domain.PrincipalFromContext(c.Request.Context())
+		if !ok {
+			// Mirrors the handlers' own unauthenticated answer rather than the
+			// generic 401, for the same envelope reason.
+			c.AbortWithStatusJSON(http.StatusUnauthorized, oauthErrorDTO{
+				Err: "access_denied", ErrDesc: "sign in to authorize a connection"})
+			return
+		}
+		if p.IsSiteConstrained() {
+			status, dto := oauthError(domain.Forbidden(ErrCodeAccessDenied,
+				"site-scoped access cannot authorize an organisation-level connection"))
+			c.AbortWithStatusJSON(status, dto)
+			return
+		}
+		c.Next()
+	}
 }
 
 // allVerbs is every method the 405 fallback covers. CONNECT and TRACE are

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
@@ -43,6 +44,11 @@ import (
 type fakeStore struct {
 	client   sqlc.McpOauthClient
 	clientOK bool
+
+	// grantPrincipal is the principal handed to CreateGrantWithCode, recorded
+	// so a test can assert the scope-carrying principal actually reaches the
+	// store rather than being flattened to a tenant id on the way down.
+	grantPrincipal db.ScopedPrincipal
 
 	// registerRows is what the :execrows INSERT reports. Defaults to 0, so a
 	// test that means "registration succeeds" must SAY 1 -- the honest default,
@@ -221,8 +227,15 @@ func (f *fakeStore) RedeemAuthorizationCode(_ context.Context, _, _ uuid.UUID, t
 	return sqlc.McpConnectionToken{ID: uuid.New(), TenantID: tok.TenantID, GrantID: tok.GrantID}, nil
 }
 
-func (f *fakeStore) CreateGrantWithCode(_ context.Context, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
+// CreateGrantWithCode records the principal it was handed. THIS FAKE CANNOT
+// PROVE THE RLS -- it runs no transaction and evaluates no policy, so it is
+// blind to whether app.site_scope was set. What it can pin is the plumbing:
+// that the principal reaches the store at all, so a refactor which narrows
+// ApprovalRequest back to a bare tenant id fails here rather than silently in
+// production. The policy itself is proved in tests/, as wpmgr_app.
+func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	f.note("CreateGrantWithCode")
+	f.grantPrincipal = principal
 	id := uuid.New()
 	cp := mk(id)
 	return sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name},

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -34,7 +34,13 @@ type Store interface {
 	// that never produced a token, stranding a client that did nothing wrong.
 	RedeemAuthorizationCode(ctx context.Context, tenantID, codeID uuid.UUID, tok sqlc.CreateMCPConnectionTokenParams) (sqlc.McpConnectionToken, error)
 
-	CreateGrantWithCode(ctx context.Context, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
+	// CreateGrantWithCode takes the authorizing principal as its own argument
+	// and not merely a tenant id, because the principal is what selects the
+	// transaction scope: a site-constrained one must reach InScopedTenantTx so
+	// the RESTRICTIVE insert policy on mcp_grants is live. A tenant id alone
+	// cannot express that, which is how the site-scope GUC came to be unset on
+	// this path. See the method on Repo.
+	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
 
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
@@ -185,14 +191,28 @@ func (r *Repo) RedeemAuthorizationCode(
 }
 
 // CreateGrantWithCode mints the grant and its first authorization code in ONE
-// InTenantTx, so a crash between them cannot leave a grant nobody can redeem
+// transaction, so a crash between them cannot leave a grant nobody can redeem
 // or a code pointing at no grant. mkCode receives the new grant id.
 //
-// Not run under app.site_scope: mcp_grants_site_scope_insert is RESTRICTIVE FOR
-// INSERT, so a site-scoped collaborator inserting here would match nothing.
-// Minting a grant is an operator action and the handler gates it accordingly.
+// RunTenantTx, NOT InTenantTx, and the difference is the security boundary.
+// InScopedTenantTx is the only helper that sets app.site_scope, and the
+// RESTRICTIVE mcp_grants_site_scope_insert policy keys on that GUC, so only a
+// transaction opened through the scope-aware dispatch has the policy live. This
+// is the invariant db.go states over RunTenantTx: a repo that picks its own
+// helper is a call-site that can silently fall outside the site-scope RLS.
+//
+// The route-level authz.RequireOrgScope on /consent is the primary gate and
+// refuses a site-constrained principal before this is reached; Approve restates
+// it in the service. This layer is the third, and it is the one that turns a
+// missing gate into a loud database error rather than a quiet success -- which
+// matters because the middleware is one edit away from being absent and nothing
+// below the SQL layer would otherwise notice.
+//
+// principal is what selects the transaction, so it must be the principal that
+// actually authorized the grant -- never one synthesised from g.TenantID.
 func (r *Repo) CreateGrantWithCode(
 	ctx context.Context,
+	principal db.ScopedPrincipal,
 	g sqlc.CreateMCPGrantParams,
 	mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams,
 ) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
@@ -200,7 +220,16 @@ func (r *Repo) CreateGrantWithCode(
 		grant sqlc.McpGrant
 		code  sqlc.McpAuthorizationCode
 	)
-	err := r.pool.InTenantTx(ctx, g.TenantID, func(tx pgx.Tx) error {
+	// The transaction is scoped by the principal's tenant while the INSERT names
+	// g.TenantID. If those disagree the row belongs to neither and RLS would
+	// refuse it anyway; refusing here says so in one line instead of as a 42501
+	// from three frames down.
+	if principal.GetTenantID() != g.TenantID {
+		return grant, code, fmt.Errorf(
+			"create mcp grant: principal tenant %s does not match grant tenant %s",
+			principal.GetTenantID(), g.TenantID)
+	}
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
 		q := sqlc.New(tx)
 		gr, err := q.CreateMCPGrant(ctx, g)
 		if err != nil {

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -46,6 +46,13 @@ const (
 	// alternative is returning an empty success, and an empty result that
 	// reads as "nothing to do" is how a scoping bug becomes invisible.
 	ErrCodeScopeEmpty = "mcp_scope_empty"
+
+	// ErrCodeAccessDenied is the refusal for a principal that is authenticated
+	// and carries a tenant but may not authorize an ORG-LEVEL object. It maps
+	// to RFC 6749 section 4.1.2.1 "access_denied", which is the spec's own name
+	// for "the resource owner refused", and 403 rather than 401: re-presenting
+	// the same credential will not help.
+	ErrCodeAccessDenied = "mcp_access_denied"
 )
 
 // The OAuth vocabulary this server implements, named once.
@@ -442,9 +449,15 @@ func exactMatchRedirectURI(registered []string, presented string) bool {
 
 // ApprovalRequest is a human's consent, submitted by the authenticated
 // operator whose organisation the grant will belong to.
+//
+// Principal is the WHOLE principal and not the (TenantID, UserID) pair it
+// replaced. The pair could be filled in correctly while Scope and
+// AllowedSiteIDs were silently dropped, and dropping them is precisely what
+// makes the site-scope RLS inert on the write below -- a caller that populates
+// two of four fields would still compile and would still escalate. One field
+// cannot be half-populated.
 type ApprovalRequest struct {
-	TenantID  uuid.UUID
-	UserID    uuid.UUID
+	Principal domain.Principal
 	Consent   ConsentContext
 	GrantName string
 	SiteScope SiteScopeRequest
@@ -462,8 +475,18 @@ type Approval struct {
 // Approve records the human's consent as a grant and mints the single-use PKCE
 // code. Grant and code are created in one transaction.
 func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, error) {
-	if req.TenantID == uuid.Nil {
+	if req.Principal.TenantID == uuid.Nil {
 		return Approval{}, domain.Validation(ErrCodeInvalidRequest, "an organisation is required")
+	}
+
+	// A grant is org-level: site_scope_mode 'all' resolves to every site in the
+	// organisation. authz.RequireOrgScope on the route is the primary refusal
+	// and this is the service-layer restatement of it, so a future caller that
+	// reaches Approve without passing through that middleware is refused too.
+	// The repo's RunTenantTx is the third layer, in the database.
+	if req.Principal.IsSiteConstrained() {
+		return Approval{}, domain.Forbidden(ErrCodeAccessDenied,
+			"site-scoped access cannot authorize an organisation-level connection")
 	}
 	if strings.TrimSpace(req.GrantName) == "" {
 		return Approval{}, domain.Validation(ErrCodeInvalidRequest, "a connection name is required")
@@ -520,9 +543,11 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 	codeHash := hashCredential(code)
 	expiresAt := s.now().UTC().Add(authorizationCodeTTL)
 
-	grant, _, err := s.store.CreateGrantWithCode(ctx,
+	// req.Principal, not a tenant id: it is what routes the write to the correct
+	// tx helper, and therefore what decides whether the site-scope RLS is live.
+	grant, _, err := s.store.CreateGrantWithCode(ctx, req.Principal,
 		sqlc.CreateMCPGrantParams{
-			TenantID:      req.TenantID,
+			TenantID:      req.Principal.TenantID,
 			Name:          strings.TrimSpace(req.GrantName),
 			Status:        string(GrantStatusActive),
 			SiteScopeMode: string(req.SiteScope.Mode),
@@ -530,11 +555,11 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			ScopeSiteIds:  orEmpty(req.SiteScope.SiteIDs),
 			// The RESOLVED client id, not the body's copy of it.
 			ClientID:        nullableText(client.ClientID),
-			CreatedByUserID: uuidToPG(req.UserID),
+			CreatedByUserID: uuidToPG(req.Principal.UserID),
 		},
 		func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 			return sqlc.CreateMCPAuthorizationCodeParams{
-				TenantID:            req.TenantID,
+				TenantID:            req.Principal.TenantID,
 				GrantID:             grantID,
 				ClientID:            client.ClientID,
 				CodeHash:            codeHash,

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 	"github.com/mosamlife/wpmgr/apps/api/internal/site"
 )
@@ -73,7 +74,10 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 	if siteIDs == nil {
 		siteIDs = []uuid.UUID{}
 	}
-	grant, _, err := repo.CreateGrantWithCode(ctx, sqlc.CreateMCPGrantParams{
+	// An ORG-scoped principal: seeding a grant is what an operator does, and it
+	// is the only scope the consent route now admits.
+	approver := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+	grant, _, err := repo.CreateGrantWithCode(ctx, approver, sqlc.CreateMCPGrantParams{
 		TenantID:      tenantID,
 		Name:          "test grant",
 		Status:        "active",

--- a/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
+++ b/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
@@ -73,7 +73,10 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 	siteID := seedSite(t, pool, tenantID, siteURL)
 
 	svc := mcp.NewService(mcp.NewRepo(pool))
-	eng := mountLikeProduction(t, svc, tenantID, userID)
+	// An ORG-scoped operator: the only scope /consent admits.
+	eng := mountLikeProduction(t, svc, domain.Principal{
+		UserID: userID, TenantID: tenantID, Scope: domain.ScopeOrg,
+	})
 
 	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
 
@@ -300,7 +303,13 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 // The two Register calls and their groups are the part under test. If
 // server.New's mounting diverges from this, that is a defect in one of the two
 // and this comment is where to start.
-func mountLikeProduction(t *testing.T, svc *mcp.Service, tenantID, userID uuid.UUID) *gin.Engine {
+// It takes the WHOLE principal rather than (tenantID, userID) because scope is
+// now load-bearing on these routes: Handler.Register applies
+// authz.RequireOrgScope, and a harness that could only express a scopeless
+// principal could never exercise it. Flattening this back to two ids would
+// make the org-scope gate untestable from here, which is how it came to be
+// absent.
+func mountLikeProduction(t *testing.T, svc *mcp.Service, principal domain.Principal) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -312,11 +321,12 @@ func mountLikeProduction(t *testing.T, svc *mcp.Service, tenantID, userID uuid.U
 
 	// Operator-authenticated half. The middleware stands in for session auth +
 	// authz.RequireAuth + authz.RequireTenant, which is exactly a principal
-	// carrying a non-nil tenant.
+	// carrying a non-nil tenant. It deliberately does NOT apply
+	// authz.RequireOrgScope: that gate belongs to Handler.Register itself, and
+	// applying it here too would prove only that this file can add middleware.
 	authed := eng.Group("/api/v1")
 	authed.Use(func(c *gin.Context) {
-		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(),
-			domain.Principal{UserID: userID, TenantID: tenantID}))
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), principal))
 		c.Next()
 	})
 	h.Register(authed)

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -81,7 +81,10 @@ func s7GrantWithBearer(
 	codePlain := "s7-code-" + uuid.NewString()
 	codeSum := sha256.Sum256([]byte(codePlain))
 
-	grant, code, err := repo.CreateGrantWithCode(ctx, sqlc.CreateMCPGrantParams{
+	// An ORG-scoped principal: seeding a grant is what an operator does, and it
+	// is the only scope the consent route now admits.
+	approver := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+	grant, code, err := repo.CreateGrantWithCode(ctx, approver, sqlc.CreateMCPGrantParams{
 		TenantID:      tenantID,
 		Name:          "s7 grant",
 		Status:        "active",

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -44,12 +44,14 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
@@ -172,7 +174,11 @@ func TestMCPConsentRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
 		"state":                 "orgscope-state",
 		"code_challenge":        challenge,
 		"code_challenge_method": "S256",
-		"grant_name":            "escalation probe",
+		// "name", the field approvalRequestDTO actually binds. It matters that
+		// this body is otherwise VALID: a body the handler would reject anyway
+		// makes the refusal ambiguous, and this test would then pass on an
+		// unrelated 400 while proving nothing about scope.
+		"name": "org scope probe",
 		// The whole point: an ORG-WIDE grant, requested by a principal that can
 		// see one site.
 		"site_scope_mode": "all",
@@ -224,6 +230,85 @@ func TestMCPConsentRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
 
 	if final := mcpCountGrants(t, pool, tenantID); final != before {
 		t.Fatalf("grant count moved %d -> %d across the whole flow", before, final)
+	}
+}
+
+// TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole pins the
+// DEEPEST layer on its own, at the repo, with no middleware anywhere near it.
+//
+// It exists because the two route-level tests above cannot see this layer while
+// the route-level gates hold: the middleware refuses first, so swapping
+// RunTenantTx back to InTenantTx changes nothing they observe and the RLS layer
+// would be unpinned -- defence in depth that no test defends. Here the call is
+// made directly, so the only thing that can refuse it is the database.
+//
+// The failure it guards against is silent by construction: with app.site_scope
+// unset the RESTRICTIVE policy admits the row and the write simply succeeds.
+func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	tenantID := seedTenant(t, pool, "mcp-repolayer-"+uuid.NewString()[:8])
+	userID := seedUserRow(t, pool, "mcp-repolayer-"+uuid.NewString()[:8]+"@example.test")
+	siteID := seedSite(t, pool, tenantID, "https://repolayer-"+uuid.NewString()[:8]+".example.test")
+
+	repo := mcp.NewRepo(pool)
+	before := mcpCountGrants(t, pool, tenantID)
+
+	collaborator := domain.Principal{
+		UserID:         userID,
+		TenantID:       tenantID,
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{siteID},
+	}
+
+	clientID := "repolayer-client-" + uuid.NewString()
+	secretHash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if n, err := repo.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        &secretHash,
+		TokenEndpointAuthMethod: "client_secret_basic",
+		RedirectUris:            []string{"https://claude.ai/api/mcp/auth_callback"},
+	}); err != nil || n != 1 {
+		t.Fatalf("seed client: affected=%d err=%v", n, err)
+	}
+
+	_, _, err := repo.CreateGrantWithCode(ctx, collaborator, sqlc.CreateMCPGrantParams{
+		TenantID:      tenantID,
+		Name:          "repo layer probe",
+		Status:        "active",
+		SiteScopeMode: "all",
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  []uuid.UUID{},
+		ClientID:      &clientID,
+	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+		return sqlc.CreateMCPAuthorizationCodeParams{
+			TenantID:            tenantID,
+			GrantID:             grantID,
+			ClientID:            clientID,
+			CodeHash:            "beefcafe0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
+			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
+		}
+	})
+	if err == nil {
+		t.Fatal("CreateGrantWithCode accepted a site-scoped principal. The write " +
+			"reached mcp_grants with app.site_scope unset, so the RESTRICTIVE " +
+			"site-scope policy was not live for this transaction.")
+	}
+	t.Logf("the database refused the write: %v", err)
+
+	if after := mcpCountGrants(t, pool, tenantID); after != before {
+		t.Fatalf("the call errored but the grant count moved %d -> %d", before, after)
 	}
 }
 
@@ -292,7 +377,7 @@ func TestMCPConsentAdmitsAnOrgMemberAsAppRole(t *testing.T) {
 		"state":                 "orgmember-state",
 		"code_challenge":        challenge,
 		"code_challenge_method": "S256",
-		"grant_name":            "my laptop",
+		"name":                  "my laptop",
 		"site_scope_mode":       "all",
 	}, nil, &approval)
 

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -195,8 +195,27 @@ func TestMCPConsentRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
 			"body error=%q code=%q desc=%q",
 			status, consentErr.Err, consentErr.Code, consentErr.ErrDesc)
 	}
-	t.Logf("POST /consent refused the collaborator with %d (error=%q code=%q)",
-		status, consentErr.Err, consentErr.Code)
+	// THE REFUSAL MUST BE LEGIBLE TO THE CONSENT SCREEN, not merely correct.
+	// apps/web/src/features/mcp-consent/use-consent.ts reads `error` and
+	// `error_description` and falls back to "server_error" when neither is
+	// present, so a refusal in the generic {code, message} envelope reaches the
+	// user as an unexplained server fault. Asserting only the status would let
+	// that regress silently.
+	if consentErr.Err != "access_denied" {
+		t.Errorf("POST /consent refused with error=%q, want %q. The consent screen "+
+			"parses this field and shows a server fault when it is absent.",
+			consentErr.Err, "access_denied")
+	}
+	if consentErr.ErrDesc == "" {
+		t.Error("POST /consent refused with an empty error_description; the screen " +
+			"has nothing to tell the user beyond the error code")
+	}
+	if consentErr.Code != "" {
+		t.Errorf("POST /consent answered in the generic {code, message} envelope "+
+			"(code=%q); these routes answer in the OAuth envelope", consentErr.Code)
+	}
+	t.Logf("POST /consent refused the collaborator with %d (error=%q desc=%q)",
+		status, consentErr.Err, consentErr.ErrDesc)
 
 	// A 403 that committed first is still an escalation.
 	if after := mcpCountGrants(t, pool, tenantID); after != before {
@@ -220,13 +239,23 @@ func TestMCPConsentRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
 
+	var authErr struct {
+		Err     string `json:"error"`
+		ErrDesc string `json:"error_description"`
+		Code    string `json:"code"`
+	}
 	authStatus := mcpDoJSON(t, eng, http.MethodGet,
-		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, nil)
+		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, &authErr)
 	if authStatus != http.StatusForbidden {
 		t.Errorf("GET /authorize answered %d for a site-scoped collaborator, want 403",
 			authStatus)
 	}
-	t.Logf("GET /authorize refused the collaborator with %d", authStatus)
+	if authErr.Err != "access_denied" || authErr.Code != "" {
+		t.Errorf("GET /authorize refused with error=%q code=%q, want the OAuth "+
+			"envelope carrying access_denied", authErr.Err, authErr.Code)
+	}
+	t.Logf("GET /authorize refused the collaborator with %d (error=%q)",
+		authStatus, authErr.Err)
 
 	if final := mcpCountGrants(t, pool, tenantID); final != before {
 		t.Fatalf("grant count moved %d -> %d across the whole flow", before, final)

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -1,0 +1,320 @@
+// mcp_consent_org_scope_integration_test.go: the MCP consent route is
+// ORG-LEVEL, executed against the REAL schema as wpmgr_app.
+//
+// WHY THIS FILE EXISTS. An MCP grant carries a site_scope_mode of
+// 'all' | 'tags' | 'sites'. 'all' is resolved at read time against the whole
+// organisation, so the grant is an org-level object no matter which sites the
+// approver can personally see. The question this file answers is therefore not
+// "does the grant read the right sites" but "who is allowed to mint one at
+// all", and until this file existed nothing executed that question.
+//
+// Everything above the SQL layer on this surface runs against fakeStore, which
+// opens no transaction, sets no GUC and evaluates no policy. A fake cannot
+// distinguish InTenantTx from InScopedTenantTx, so it reports success for both
+// and the site-scope RLS is invisible to it. A proof that sets app.site_scope
+// by hand and watches mcp_grants_site_scope_insert refuse is a true statement
+// about a transaction, but not about the transaction this call path opens --
+// the same shape as m112, where every proof opened its own connection, so every
+// policy was inert and every test was green.
+//
+// WHAT IS ACTUALLY UNDER TEST, and neither half is decidable by reading:
+//
+//  1. THE REFUSAL. A site-scoped collaborator drives the mounted /consent
+//     route and asks for site_scope_mode 'all'. It must be REFUSED and it must
+//     leave no row behind. Refusal alone is not enough: a route that answers
+//     403 after committing has still written the row.
+//
+//  2. THE OVER-FIRE. An ordinary org member drives the same route and must
+//     still complete consent and receive a code. A gate that refuses everyone
+//     is not a gate, and this half is what stops the fix being switched off.
+//
+// HOW IT IS TESTED. Through the mounted gin routes, via mountLikeProduction --
+// the same Handler.Register call server.New makes, the same Service, the same
+// Repo, the same tx helpers. No GUC is ever hand-set here and this file opens
+// no connection of its own.
+//
+// The role is load-bearing: wpmgr_app is NOSUPERUSER NOBYPASSRLS, and either
+// privilege would make the RLS half pass vacuously. It is asserted, and printed.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpCountGrants counts the tenant's grants through InTenantTx -- the same
+// helper the operator read path uses, as wpmgr_app. It is the "left no row
+// behind" half of the escalation proof: a 403 that committed first is still an
+// escalation, and only a count can tell the two apart.
+func mcpCountGrants(t *testing.T, pool *db.Pool, tenantID uuid.UUID) int {
+	t.Helper()
+	var n int
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			"SELECT count(*) FROM mcp_grants WHERE tenant_id = $1", tenantID).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count grants for tenant %s: %v", tenantID, err)
+	}
+	return n
+}
+
+// mcpRegisterClient drives the UNAUTHENTICATED RFC 7591 registration endpoint
+// and returns the client_id. It is unauthenticated by specification, so a
+// site-scoped collaborator can reach it exactly as an org member can -- which
+// is why the escalation below needs no help from an operator to obtain a
+// client, and why /consent cannot rely on client registration as a gate.
+func mcpRegisterClient(t *testing.T, eng *gin.Engine, redirectURI string) string {
+	t.Helper()
+	var reg struct {
+		ClientID string `json:"client_id"`
+	}
+	code := mcpDoJSON(t, eng, http.MethodPost, "/api/v1/oauth/mcp/register",
+		map[string]any{
+			"redirect_uris":              []string{redirectURI},
+			"client_name":                "Consent scope probe",
+			"token_endpoint_auth_method": "none",
+		}, nil, &reg)
+	if code != http.StatusCreated || reg.ClientID == "" {
+		t.Fatalf("register client answered %d with client_id=%q, want 201 and an id",
+			code, reg.ClientID)
+	}
+	return reg.ClientID
+}
+
+// TestMCPConsentRefusesASiteScopedCollaboratorAsAppRole is half 1. A
+// collaborator shared onto ONE site must not be able to mint a grant, and least
+// of all one scoped to 'all'.
+//
+// Three layers have to hold for this to pass and each is independently
+// sufficient to fail it: authz.RequireOrgScope on the mounted route, the
+// IsSiteConstrained check in Approve, and RunTenantTx in the repo. Deleting any
+// one of them should still leave this green; deleting all three must not.
+func TestMCPConsentRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// Either privilege would make the RLS layer pass vacuously.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	tenantID := seedTenant(t, pool, "mcp-orgscope-"+uuid.NewString()[:8])
+	userID := seedUserRow(t, pool, "mcp-orgscope-"+uuid.NewString()[:8]+"@example.test")
+
+	// TWO sites. The collaborator is shared onto sharedSite only; hiddenSite is
+	// the site the escalation would have reached. Both exist so that
+	// site_scope_mode 'all' is genuinely wider than the allowlist -- with one
+	// site the grant would be no wider than the sharing and the test would
+	// prove nothing about scope.
+	sharedSite := seedSite(t, pool, tenantID, "https://shared-"+uuid.NewString()[:8]+".example.test")
+	hiddenSite := seedSite(t, pool, tenantID, "https://hidden-"+uuid.NewString()[:8]+".example.test")
+	t.Logf("tenant %s: collaborator is shared onto %s and NOT onto %s",
+		tenantID, sharedSite, hiddenSite)
+
+	// The site-scoped principal, exactly as authz builds one for a collaborator:
+	// Scope "site" plus an allowlist of the shared site only.
+	collaborator := domain.Principal{
+		UserID:         userID,
+		TenantID:       tenantID,
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{sharedSite},
+	}
+	if !collaborator.IsSiteConstrained() {
+		t.Fatal("the principal under test is not site-constrained; the test would " +
+			"prove nothing")
+	}
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	eng := mountLikeProduction(t, svc, collaborator)
+
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+	clientID := mcpRegisterClient(t, eng, redirectURI)
+
+	verifier := "orgscope-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	before := mcpCountGrants(t, pool, tenantID)
+
+	// -----------------------------------------------------------------------
+	// THE ESCALATION, posted directly at /consent.
+	//
+	// Deliberately NOT preceded by a successful /authorize. Approve re-resolves
+	// the client and re-matches the redirect from the body, so /consent is
+	// reachable on its own -- an attacker never has to pass the consent screen.
+	// Testing the pair in sequence would have hidden that.
+	// -----------------------------------------------------------------------
+	var consentErr struct {
+		Err     string `json:"error"`
+		ErrDesc string `json:"error_description"`
+		Code    string `json:"code"`
+	}
+	status := mcpDoJSON(t, eng, http.MethodPost, "/api/v1/oauth/mcp/consent", map[string]any{
+		"client_id":             clientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "orgscope-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"grant_name":            "escalation probe",
+		// The whole point: an ORG-WIDE grant, requested by a principal that can
+		// see one site.
+		"site_scope_mode": "all",
+	}, nil, &consentErr)
+
+	if status == http.StatusOK {
+		t.Fatalf("ESCALATION: a site-scoped collaborator minted a grant through "+
+			"POST /consent with site_scope_mode 'all'; the route answered 200. "+
+			"tenant=%s allowlist=[%s] unreachable_site=%s",
+			tenantID, sharedSite, hiddenSite)
+	}
+	if status != http.StatusForbidden {
+		t.Errorf("POST /consent answered %d for a site-scoped collaborator, want 403; "+
+			"body error=%q code=%q desc=%q",
+			status, consentErr.Err, consentErr.Code, consentErr.ErrDesc)
+	}
+	t.Logf("POST /consent refused the collaborator with %d (error=%q code=%q)",
+		status, consentErr.Err, consentErr.Code)
+
+	// A 403 that committed first is still an escalation.
+	if after := mcpCountGrants(t, pool, tenantID); after != before {
+		t.Fatalf("ESCALATION: /consent was refused but the grant count moved "+
+			"%d -> %d; the refusal happened after the write", before, after)
+	}
+
+	// -----------------------------------------------------------------------
+	// /authorize, for the blast radius. It mints nothing -- it validates PKCE
+	// and the redirect and returns the consent screen's contents -- so on its
+	// own it is not an escalation. It carries the same gate anyway: a route
+	// that renders the consent screen to a principal who may not consent
+	// invites the exact confusion this defect was.
+	// -----------------------------------------------------------------------
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "orgscope-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+
+	authStatus := mcpDoJSON(t, eng, http.MethodGet,
+		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, nil)
+	if authStatus != http.StatusForbidden {
+		t.Errorf("GET /authorize answered %d for a site-scoped collaborator, want 403",
+			authStatus)
+	}
+	t.Logf("GET /authorize refused the collaborator with %d", authStatus)
+
+	if final := mcpCountGrants(t, pool, tenantID); final != before {
+		t.Fatalf("grant count moved %d -> %d across the whole flow", before, final)
+	}
+}
+
+// TestMCPConsentAdmitsAnOrgMemberAsAppRole is half 2: the over-fire. The gate
+// must refuse the collaborator WITHOUT refusing the operator the feature
+// exists for. Without this, "return 403 always" would pass half 1.
+func TestMCPConsentAdmitsAnOrgMemberAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	tenantID := seedTenant(t, pool, "mcp-orgmember-"+uuid.NewString()[:8])
+	userID := seedUserRow(t, pool, "mcp-orgmember-"+uuid.NewString()[:8]+"@example.test")
+	seedSite(t, pool, tenantID, "https://member-"+uuid.NewString()[:8]+".example.test")
+
+	// An ordinary org member: Scope "org", no allowlist.
+	member := domain.Principal{UserID: userID, TenantID: tenantID, Scope: domain.ScopeOrg}
+	if member.IsSiteConstrained() {
+		t.Fatal("the org member under test reports as site-constrained; the " +
+			"over-fire half would pass for the wrong reason")
+	}
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	eng := mountLikeProduction(t, svc, member)
+
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+	clientID := mcpRegisterClient(t, eng, redirectURI)
+
+	verifier := "orgmember-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	before := mcpCountGrants(t, pool, tenantID)
+
+	// The consent screen first, the way a real operator arrives.
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "orgmember-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+
+	if s := mcpDoJSON(t, eng, http.MethodGet,
+		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, nil); s != http.StatusOK {
+		t.Fatalf("OVER-FIRE: GET /authorize answered %d for an ordinary org "+
+			"member, want 200", s)
+	}
+
+	var approval struct {
+		GrantID string `json:"grant_id"`
+		Code    string `json:"code"`
+		State   string `json:"state"`
+	}
+	status := mcpDoJSON(t, eng, http.MethodPost, "/api/v1/oauth/mcp/consent", map[string]any{
+		"client_id":             clientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "orgmember-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"grant_name":            "my laptop",
+		"site_scope_mode":       "all",
+	}, nil, &approval)
+
+	if status != http.StatusOK {
+		t.Fatalf("OVER-FIRE: POST /consent answered %d for an ordinary org "+
+			"member, want 200. The gate refuses the people the feature is for.",
+			status)
+	}
+	if approval.GrantID == "" || approval.Code == "" {
+		t.Fatalf("OVER-FIRE: /consent answered 200 but returned grant_id=%q code=%q; "+
+			"a consent that mints nothing is not a success",
+			approval.GrantID, approval.Code)
+	}
+	if approval.State != "orgmember-state" {
+		t.Errorf("/consent returned state %q, want the state it was given", approval.State)
+	}
+
+	// The row is really there, read back as wpmgr_app.
+	if after := mcpCountGrants(t, pool, tenantID); after != before+1 {
+		t.Fatalf("OVER-FIRE: /consent answered 200 with a grant_id but the grant "+
+			"count moved %d -> %d, want %d", before, after, before+1)
+	}
+	t.Logf("org member completed consent: grant_id=%s, grants %d -> %d",
+		approval.GrantID, before, before+1)
+}


### PR DESCRIPTION
An MCP grant is an org-level object: `site_scope_mode: 'all'` resolves to every site in the organisation at read time, so authorizing one is an org-member action rather than a per-site one. These routes carry no `:siteId` for `RequireSiteAccess` to bind, which makes `RequireOrgScope` the applicable gate — the same reasoning as the update-run orchestrator and the fleet rollups.

## Change

Three layers, each independently sufficient:

- `authz.RequireOrgScope()` on the `/authorize` and `/consent` group, applied inside `Handler.Register` so every mount carries it — including the integration harness. A gate that exists only in `server.New` is a gate no test exercises.
- `Service.Approve` restates it, so a caller that reaches the service without the route middleware is refused too.
- `Repo.CreateGrantWithCode` mints through `db.RunTenantTx` rather than choosing a tx helper itself. `db.go` documents `RunTenantTx` as mandatory for repos precisely so a call-site cannot fall outside the site-scope RLS; only it can route a site-constrained principal into the transaction where the RESTRICTIVE policy on `mcp_grants` is live.

The middleware alone would leave that third layer unpinned: it is one edit from being absent, and below the SQL layer nothing would notice its absence.

`ApprovalRequest` now carries the whole `domain.Principal` instead of a `(TenantID, UserID)` pair — the pair could be filled in correctly while `Scope` and `AllowedSiteIDs` were silently dropped.

## Tests

`apps/api/tests/mcp_consent_org_scope_integration_test.go` drives the **mounted routes** as `wpmgr_app`, not against a fake, and asserts both halves:

- a site-scoped collaborator is refused **and leaves no row** (a 403 that committed first is not a refusal);
- an ordinary org member still completes consent and receives a code.

Service-level counterparts in `internal/mcp/approve_test.go`, including the fail-closed backstop cases. `mountLikeProduction` now takes a full principal, so scope is expressible from the harness at all.

Also corrects the comment on `Repo.CreateGrantWithCode`, which asserted a guarantee this call path did not have.

## Checks

`go build ./...`, `go vet ./...`, `go test ./internal/... ./cmd/...` all clean, unpiped. `make test-integration` status reported in the review thread.

Draft: `security-reviewer` pass to follow before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-level access enforcement for MCP OAuth authorization and consent.
  * Organization members can complete consent and receive authorization codes.
* **Bug Fixes**
  * Site-scoped access is rejected with HTTP 403 and an OAuth-standard `access_denied` response.
  * Requests without an authenticated principal return HTTP 401.
  * Prevented unauthorized grant creation and ensured grants honor access boundaries.
* **Tests**
  * Added coverage for permitted, denied, and database-enforced grant flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->