### PR TITLE
infra(nginx): route /mcp and the OAuth discovery paths on self-hosted

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -5,6 +5,7 @@
 #   - the agent endpoints (/enroll, /agent/*) -> proxied to api:8080 (root API paths)
 #   - RUM beacon ingest  (/rum/*)              -> proxied to api:8080 (root API path)
 #   - provider webhooks  (/webhooks/*)         -> proxied to api:8080 (root API path)
+#   - MCP + OAuth discovery (/mcp, /.well-known/oauth-*) -> proxied (root API paths)
 # The API's routes live under /api/v1, /enroll, /agent/v1, /rum and /webhooks — so we
 # must NOT strip the /api prefix, and we must explicitly proxy every other public
 # root-API path (otherwise a request to any of them falls through to the SPA
@@ -157,6 +158,46 @@ server {
     # server-to-server POST, public/unauthenticated at the edge (verified by
     # provider signature in the Go handler).
     location /webhooks/ {
+        proxy_pass http://$api_upstream;
+    }
+
+    # MCP endpoint (root-mounted by internal/mcp/transport.go's TransportPath).
+    # This is the URL the connect wizard tells an operator to paste into their
+    # AI client, so it is the one path where falling through to the SPA is
+    # invisible: index.html answers GET with 200 text/html, which reads as
+    # "something is there" while no MCP client can ever speak to it.
+    #
+    # Exact match: TransportPath is exactly /mcp with no sub-paths, and the Go
+    # handler answers every non-POST verb itself with a 405 that says the
+    # endpoint IS deployed. Proxying the whole verb set is what lets that
+    # message reach the operator instead of nginx's SPA fallback.
+    location = /mcp {
+        proxy_pass http://$api_upstream;
+    }
+
+    # OAuth discovery documents for the MCP endpoint, root-mounted by
+    # internal/mcp/discovery.go's Register. A GUI client fetches these BEFORE it
+    # holds any credential, to find the authorization endpoints; unproxied they
+    # return the SPA's index.html, which parses as neither RFC 8414 nor RFC 9728
+    # metadata and leaves the client with no way to start an OAuth flow.
+    #
+    # Three exact matches, one per constant, NOT a `location /.well-known/`
+    # prefix. Two reasons: /.well-known/ is a shared namespace, and a prefix
+    # here would hijack acme-challenge from any operator running certbot's
+    # HTTP-01 against this same server block; and an exact rule per constant is
+    # checkable against the Go source one-for-one.
+    #
+    # The last one is NOT covered by the one above it. RFC 9728 section 3.1
+    # inserts the resource's path component after the well-known segment, so an
+    # MCP endpoint at /mcp advertises at /.well-known/oauth-protected-resource
+    # /mcp, and MCP revision 2025-11-25 clients try that form FIRST.
+    location = /.well-known/oauth-authorization-server {
+        proxy_pass http://$api_upstream;
+    }
+    location = /.well-known/oauth-protected-resource {
+        proxy_pass http://$api_upstream;
+    }
+    location = /.well-known/oauth-protected-resource/mcp {
         proxy_pass http://$api_upstream;
     }
 

--- a/infra/nginx/routing_smoke_test.sh
+++ b/infra/nginx/routing_smoke_test.sh
@@ -56,17 +56,28 @@ echo "==> creating docker network $NET"
 docker network create "$NET" >/dev/null
 
 # ---- stub upstream ---------------------------------------------------------
-# Echoes "backend <METHOD> <URI>" with HTTP 200 for ANY method and ANY path.
-# nginx's `return` directive (unlike static-file serving / try_files) is not
-# method-restricted, so this responds identically to GET/POST/OPTIONS/etc.
-# A 200 from here proves the request actually reached the api upstream; a 405
-# proves nginx answered it itself (the SPA try_files catch-all).
+# Echoes "backend <METHOD> <URI> xff=<X-Forwarded-For as received>" with HTTP
+# 200 for ANY method and ANY path. nginx's `return` directive (unlike
+# static-file serving / try_files) is not method-restricted, so this responds
+# identically to GET/POST/OPTIONS/etc.
+#
+# WHY THE BODY AND NOT THE STATUS. A 405 proves nginx answered a POST itself
+# via the SPA try_files catch-all, but that tell only exists for verbs
+# try_files refuses. A GET that falls through to the SPA returns 200 text/html
+# — the SAME status as a proxied GET — so status alone cannot distinguish
+# "reached the API" from "got the dashboard's index.html". That is exactly how
+# the OAuth discovery documents could have shipped unreachable behind a green
+# check. The "backend " prefix below is the discriminator: only the upstream
+# can produce it.
+#
+# xff= echoes what nginx-under-test actually SENT upstream, which is what lets
+# this suite prove a caller-supplied X-Forwarded-For never survives.
 cat >"$TMPDIR/stub.conf" <<'EOF'
 server {
     listen 8080;
     location / {
         add_header Content-Type text/plain always;
-        return 200 "backend $request_method $request_uri\n";
+        return 200 "backend $request_method $request_uri xff=$http_x_forwarded_for\n";
     }
 }
 EOF
@@ -154,6 +165,113 @@ assert_proxied() {
   fi
 }
 
+# ---- content-based assertions ---------------------------------------------
+# Everything below judges the RESPONSE BODY, never the status. See the stub
+# comment above for why: a GET-shaped route that falls through to the SPA
+# returns 200 text/html and is indistinguishable from a proxied 200 by status.
+
+fetch_body() {
+  local method="$1" path="$2"
+  curl -s -X "$method" "${BASE}${path}"
+}
+
+fetch_ctype() {
+  local method="$1" path="$2"
+  curl -s -o /dev/null -w '%{content_type}' -X "$method" "${BASE}${path}"
+}
+
+# The request reached the api upstream: only the stub emits "backend ".
+assert_backend() {
+  local method="$1" path="$2" label="$3"
+  local out ct
+  out="$(fetch_body "$method" "$path")"
+  ct="$(fetch_ctype "$method" "$path")"
+  case "$out" in
+    "backend $method "*)
+      echo "ok   (reached api): $label -> $method $path : ct=$ct body=${out%$'\n'}"
+      ;;
+    *)
+      echo "FAIL (reached api): $label -> $method $path : ct=$ct body=$(printf '%.90s' "$out")"
+      echo "     expected a body beginning 'backend $method ' from the stub upstream;"
+      echo "     this response did not come from the API — nginx answered it itself."
+      FAILED=1
+      ;;
+  esac
+}
+
+# nginx answered from the SPA fallback: HTML, and NOT the stub's marker. This
+# is the negative control that keeps assert_backend meaningful.
+assert_spa() {
+  local method="$1" path="$2" label="$3"
+  local out ct
+  out="$(fetch_body "$method" "$path")"
+  ct="$(fetch_ctype "$method" "$path")"
+  case "$out" in
+    "backend "*)
+      echo "FAIL (SPA expected): $label -> $method $path reached the api upstream: $out"
+      FAILED=1
+      return
+      ;;
+  esac
+  case "$ct" in
+    text/html*)
+      echo "ok   (SPA expected): $label -> $method $path : ct=$ct (index.html, not proxied)"
+      ;;
+    *)
+      echo "FAIL (SPA expected): $label -> $method $path : ct=$ct (expected text/html)"
+      FAILED=1
+      ;;
+  esac
+}
+
+# A caller-supplied X-Forwarded-For must never reach the API. nginx SETS the
+# header from $remote_addr rather than appending to it, so the upstream sees
+# exactly ONE entry and it is the observed peer. Two failures are caught here:
+# the supplied value surviving at all, and a second entry appearing (which
+# would make WPMGR_AUTH_PROXY_HOPS=1 wrong and break sign-in).
+SPOOFED_XFF="203.0.113.7"
+assert_xff_not_spoofable() {
+  local method="$1" path="$2" label="$3"
+  local out seen
+  out="$(curl -s -H "X-Forwarded-For: ${SPOOFED_XFF}" -X "$method" "${BASE}${path}")"
+  case "$out" in
+    "backend "*) ;;
+    *)
+      echo "FAIL (xff): $label -> $method $path never reached the api upstream, so the"
+      echo "     header could not be checked: $(printf '%.90s' "$out")"
+      FAILED=1
+      return
+      ;;
+  esac
+  seen="${out##* xff=}"
+  seen="${seen%$'\n'}"
+  case "$seen" in
+    *"$SPOOFED_XFF"*)
+      echo "FAIL (xff): $label -> $method $path forwarded the caller-supplied value:"
+      echo "     upstream saw X-Forwarded-For: '$seen' (contains the spoofed $SPOOFED_XFF)"
+      FAILED=1
+      return
+      ;;
+  esac
+  case "$seen" in
+    *,*)
+      echo "FAIL (xff): $label -> $method $path forwarded MORE THAN ONE entry:"
+      echo "     upstream saw X-Forwarded-For: '$seen'. WPMGR_AUTH_PROXY_HOPS=1 counts"
+      echo "     exactly one entry from this nginx; more than one breaks sign-in."
+      FAILED=1
+      return
+      ;;
+  esac
+  if [ -z "$seen" ]; then
+    echo "FAIL (xff): $label -> $method $path forwarded an EMPTY X-Forwarded-For."
+    echo "     The API needs the observed peer; an empty header is not a pass."
+    FAILED=1
+    return
+  fi
+  echo "ok   (xff): $label -> $method $path : upstream saw exactly one entry '$seen';"
+  echo "     the caller-supplied $SPOOFED_XFF was discarded"
+}
+
 echo
 echo "---- regression guards: GH #175 class (must NOT be 405) ----"
 assert_not_405 POST    /rum/ingest                     "RUM beacon ingest"
@@ -175,6 +293,48 @@ assert_proxied GET  /readyz                        "readyz"
 assert_proxied POST /rum/ingest                    "RUM beacon ingest (proxied)"
 assert_proxied POST /webhooks/email/postmark/tok   "email webhook (proxied)"
 assert_proxied POST /webhooks/billing/stripe       "billing webhook (proxied)"
+
+echo
+echo "---- MCP + OAuth discovery: judged by BODY, because status cannot tell ----"
+# GH #589 class. POST /mcp is the URL the connect wizard publishes; the three
+# well-known documents are what a GUI client fetches before it holds any
+# credential. Unproxied, every one of them returns the dashboard's index.html
+# — and for the three GETs that is a 200, so the not-405 idiom above is blind
+# to them. These four assertions are the reason this suite grew a body check.
+assert_backend POST /mcp                                        "MCP endpoint (published to operators)"
+assert_backend GET  /.well-known/oauth-authorization-server     "RFC 8414 authorization server metadata"
+assert_backend GET  /.well-known/oauth-protected-resource       "RFC 9728 protected resource metadata"
+assert_backend GET  /.well-known/oauth-protected-resource/mcp   "RFC 9728 path-inserted form (MCP 2025-11-25 tries this FIRST)"
+# Non-POST verbs on /mcp must reach the Go handler too: it answers them with a
+# 405 that says the endpoint IS deployed, and that message only arrives if
+# nginx proxied the verb instead of serving index.html.
+assert_backend GET  /mcp                                        "MCP endpoint, GET (Go answers 405 'is deployed')"
+assert_backend OPTIONS /.well-known/oauth-protected-resource    "discovery CORS preflight"
+
+echo
+echo "---- forwarded-header handling: a caller-supplied X-Forwarded-For must not survive ----"
+# Unchanged on the paths that already existed...
+assert_xff_not_spoofable POST /auth/login                        "session auth (existing)"
+assert_xff_not_spoofable GET  /api/v1/x                          "dashboard API (existing)"
+assert_xff_not_spoofable POST /enroll                            "agent enrollment (existing)"
+assert_xff_not_spoofable POST /rum/ingest                        "RUM ingest (existing)"
+# ...and correct on the ones added for MCP. A new location that redefined any
+# proxy_set_header would drop ALL inherited ones (nginx inheritance is
+# per-level, not per-directive) and silently reintroduce the bypass here.
+assert_xff_not_spoofable POST /mcp                               "MCP endpoint (new)"
+assert_xff_not_spoofable GET  /.well-known/oauth-authorization-server  "RFC 8414 metadata (new)"
+assert_xff_not_spoofable GET  /.well-known/oauth-protected-resource    "RFC 9728 metadata (new)"
+assert_xff_not_spoofable GET  /.well-known/oauth-protected-resource/mcp "RFC 9728 path-inserted (new)"
+
+echo
+echo "---- negative controls: the body check can still say NO ----"
+# If these came back "backend ..." the assertions above would be vacuous.
+# /.well-known/ is deliberately NOT proxied as a prefix: an operator running
+# certbot HTTP-01 against this server block needs acme-challenge served from
+# disk, and a prefix location would hijack it.
+assert_spa GET /.well-known/acme-challenge/token123  "ACME HTTP-01 challenge stays local (not hijacked)"
+assert_spa GET /.well-known/oauth-not-a-real-doc     "unmounted well-known path still falls to the SPA"
+assert_spa GET /mcp-not-the-endpoint                 "exact match: /mcp does not swallow neighbours"
 
 echo
 echo "---- class invariant: SPA fallback intact, and a truly-unrouted public POST still 405 ----"


### PR DESCRIPTION
## What

The bundled nginx (`infra/nginx/nginx.conf`) proxies `/api/`, `/auth/`, `/enroll`, `/agent/`, `/rum/` and `/webhooks/`, but had no location for the four paths `internal/mcp` mounts on the **root** Gin engine. On a self-hosted install:

- `POST /mcp` — the endpoint the connect wizard tells an operator to paste — returned the dashboard SPA
- the three OAuth discovery documents returned the SPA too, so a GUI client could never find the authorization endpoints

This is the same gap that made `POST /mcp` unreachable in production behind the load balancer. Hosted was fixed by `infra/urlmap.yaml`; self-hosted was not.

## Change

Four exact-match locations, one per constant in `apps/api/internal/mcp`:

| Path | Source |
|---|---|
| `/mcp` | `transport.go` `TransportPath` |
| `/.well-known/oauth-authorization-server` | `discovery.go`, RFC 8414 |
| `/.well-known/oauth-protected-resource` | `discovery.go`, RFC 9728 |
| `/.well-known/oauth-protected-resource/mcp` | `discovery.go`, RFC 9728 §3.1 |

The fourth is **not** covered by the third. RFC 9728 §3.1 inserts the resource's path component after the well-known segment, and MCP revision 2025-11-25 clients try that form first.

Exact matches rather than a `location /.well-known/` prefix, so an operator running certbot HTTP-01 against this server block keeps `acme-challenge` served from disk. There is a negative-control assertion for exactly that.

## Forwarded headers

None of the four new locations defines `proxy_set_header`, so all six server-level headers are inherited unchanged — including `X-Forwarded-For $remote_addr`. nginx header inheritance is per-level, not per-directive: defining any one header inside a location drops all the others, which would have reintroduced the spoofing bypass on precisely the paths an AI client uses.

**`WPMGR_AUTH_PROXY_HOPS=1` is unaffected.** The number of `X-Forwarded-For` entries reaching the API is unchanged at one, proven per-path below.

## The smoke test could not have caught this

`infra/nginx/routing_smoke_test.sh` judged responses by **status**. A GET that falls through to the SPA returns `200 text/html` — the same status as a proxied GET. Only POST-shaped gaps produced the 405 tell, so the three discovery documents were invisible to it.

The stub upstream now echoes `backend <METHOD> <URI> xff=<received X-Forwarded-For>`, and the new assertions read the **body**:

- `assert_backend` — the response came from the API, not from `index.html`
- `assert_spa` — the negative control, so the above is not vacuous
- `assert_xff_not_spoofable` — a caller-supplied `X-Forwarded-For: 203.0.113.7` does not survive, exactly one entry arrives upstream, and an empty header fails rather than passes

## Executed red/green

Both runs are the real shipped config against a stub upstream.

**RED** (`nginx.conf` reverted to `origin/main`, new assertions in place) — `ROUTING SMOKE TEST: FAILED`:

```
FAIL (reached api): RFC 8414 authorization server metadata -> GET /.well-known/oauth-authorization-server : ct=text/html body=<!doctype html><html><body>wpmgr spa stub</body></html>
FAIL (reached api): RFC 9728 protected resource metadata -> GET /.well-known/oauth-protected-resource : ct=text/html body=<!doctype html><html><body>wpmgr spa stub</body></html>
FAIL (reached api): RFC 9728 path-inserted form (MCP 2025-11-25 tries this FIRST) -> GET /.well-known/oauth-protected-resource/mcp : ct=text/html body=<!doctype html><html><body>wpmgr spa stub</body></html>
FAIL (reached api): MCP endpoint (published to operators) -> POST /mcp : ct=text/html body=<html> <head><title>405 Not Allowed</title></head>
```

Every **pre-existing** assertion passed on that same broken config. That is the measure of how blind the status-only idiom was: the three discovery GETs came back `200 text/html`.

**GREEN** (this branch) — `ROUTING SMOKE TEST: PASSED`:

```
ok   (reached api): MCP endpoint (published to operators) -> POST /mcp : body=backend POST /mcp xff=192.168.65.1
ok   (reached api): RFC 8414 authorization server metadata -> GET /.well-known/oauth-authorization-server : body=backend GET /.well-known/oauth-authorization-server xff=192.168.65.1
ok   (reached api): RFC 9728 protected resource metadata -> GET /.well-known/oauth-protected-resource : body=backend GET /.well-known/oauth-protected-resource xff=192.168.65.1
ok   (reached api): RFC 9728 path-inserted form -> GET /.well-known/oauth-protected-resource/mcp : body=backend GET /.well-known/oauth-protected-resource/mcp xff=192.168.65.1

ok   (xff): session auth (existing) -> POST /auth/login : upstream saw exactly one entry '192.168.65.1'; the caller-supplied 203.0.113.7 was discarded
ok   (xff): dashboard API (existing) -> GET /api/v1/x : ... one entry ...; the caller-supplied 203.0.113.7 was discarded
ok   (xff): MCP endpoint (new) -> POST /mcp : ... one entry ...; the caller-supplied 203.0.113.7 was discarded
ok   (xff): RFC 8414 metadata (new) -> GET /.well-known/oauth-authorization-server : ... one entry ...; the caller-supplied 203.0.113.7 was discarded

ok   (SPA expected): ACME HTTP-01 challenge stays local (not hijacked) -> GET /.well-known/acme-challenge/token123 : ct=text/html
ok   (SPA expected): exact match: /mcp does not swallow neighbours -> GET /mcp-not-the-endpoint : ct=text/html
```

`nginx -t` on the patched config:

```
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

## Is there anything else missing? Swept, not eyeballed

`scripts/check-urlmap-routes.sh` proves this for the load balancer. There is no equivalent for the bundled nginx, so rather than reading the config I ran the whole route surface through it once, off to the side:

```
$ (cd apps/api && go run ./cmd/dump-routes) > /tmp/wpmgr-routes.tsv
$ awk -F'\t' '{n++} END{print n}' /tmp/wpmgr-routes.tsv
442
$ awk -F'\t' 'index($2,"/api/")==1{next} !s[$2]++{n++} END{print n}' /tmp/wpmgr-routes.tsv
73
```

Each of those 73 root-mounted paths was requested through the real bundled nginx against the stub upstream, `{param}` segments substituted, judged by body:

```
swept 73 distinct root-mounted paths; gaps: 0
SWEEP: every root-mounted route reaches the api upstream through the bundled nginx
```

So with this PR the bundled nginx is complete against the current route surface — the four MCP paths were the only gap.

## Not in this PR: the standing guard

Turning that sweep into a committed gate is the class fix, and it is **not** as expensive as it looks, because it needs no reimplementation of nginx location matching — the smoke test already runs a real nginx, so the sweep asks the actual matcher instead of simulating it. `apps/api/cmd/dump-routes` is the right route source and already has the output contract for it (`METHOD\tPATH` on stdout only, non-zero exit on an empty dump, and it populates the optional `server.Deps` so the nil-handler blind spot cannot hide a route).

What it would still take, and why it is a separate PR:

1. **CI's `nginx-routing` job has no Go.** It is checkout + docker only. Either add `actions/setup-go` to it, or commit the route dump with a drift check the way `scripts/check-urlmap-drift.sh` does for the url-map. That choice is the actual design decision here and deserves its own review.
2. **`{param}` substitution needs a rule**, not the `sed` one-liner I used off to the side.
3. **An allowlist with mandatory reasons**, matching `infra/urlmap-unrouted-routes.txt`'s two properties (no silent skips, no stale entries).
4. **Its own committed test suite**, per the repo's rule that build-gating logic is never a YAML block scalar.

Deliberately left out: scope creep on a routing change is its own risk, and this PR already carries the config fix plus the body-based assertions that make the next instance visible.
