### PR TITLE
docs(db): correct the site-scope note on the grant-creation query

### DIFF
--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -246,10 +246,22 @@ RETURNING *;
 -- ===========================================================================
 
 -- name: CreateMCPGrant :one
--- Runs InTenantTx, and never under app.site_scope: mcp_grants_site_scope_insert
--- is RESTRICTIVE FOR INSERT, so a site-scoped collaborator inserting here
--- matches nothing (Decision 9 -- a per-site principal must not mint an
--- organisation-wide read credential).
+-- THE POLICY ON THIS INSERT ONLY BINDS IF THE CALLER SET THE GUC IT READS.
+-- mcp_grants_site_scope_insert is RESTRICTIVE FOR INSERT and its WITH CHECK
+-- coalesces current_setting('app.site_scope', true) to the empty string and
+-- compares it against 'on', so it refuses a site-scoped collaborator only
+-- inside a transaction where app.site_scope has actually been set to 'on'.
+-- Nothing else sets it: reach this query through db.RunTenantTx, which
+-- dispatches on the principal's scope and is the sole thing that does (its doc
+-- comment in internal/db/db.go states the rule for every table, not just this
+-- one). A call site that picks InTenantTx, InTenantTxAsUser or
+-- InScopedTenantTx itself leaves the setting unset, the coalesced empty string
+-- is not equal to 'on', the RESTRICTIVE check passes, and the row inserts with
+-- no error raised anywhere.
+--
+-- Decision 9 -- a per-site principal must not mint an organisation-wide read
+-- credential -- is therefore a property of the policy AND the dispatch
+-- together. The policy alone does not carry it.
 --
 -- No parameter defaults to a permissive value because no COLUMN does: status
 -- and site_scope_mode are NOT NULL with no default, so a caller that omits

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -209,10 +209,22 @@ type CreateMCPGrantParams struct {
 // ===========================================================================
 // mcp_grants -- the durable statement that a client may read some sites
 // ===========================================================================
-// Runs InTenantTx, and never under app.site_scope: mcp_grants_site_scope_insert
-// is RESTRICTIVE FOR INSERT, so a site-scoped collaborator inserting here
-// matches nothing (Decision 9 -- a per-site principal must not mint an
-// organisation-wide read credential).
+// THE POLICY ON THIS INSERT ONLY BINDS IF THE CALLER SET THE GUC IT READS.
+// mcp_grants_site_scope_insert is RESTRICTIVE FOR INSERT and its WITH CHECK
+// coalesces current_setting('app.site_scope', true) to the empty string and
+// compares it against 'on', so it refuses a site-scoped collaborator only
+// inside a transaction where app.site_scope has actually been set to 'on'.
+// Nothing else sets it: reach this query through db.RunTenantTx, which
+// dispatches on the principal's scope and is the sole thing that does (its doc
+// comment in internal/db/db.go states the rule for every table, not just this
+// one). A call site that picks InTenantTx, InTenantTxAsUser or
+// InScopedTenantTx itself leaves the setting unset, the coalesced empty string
+// is not equal to 'on', the RESTRICTIVE check passes, and the row inserts with
+// no error raised anywhere.
+//
+// Decision 9 -- a per-site principal must not mint an organisation-wide read
+// credential -- is therefore a property of the policy AND the dispatch
+// together. The policy alone does not carry it.
 //
 // No parameter defaults to a permissive value because no COLUMN does: status
 // and site_scope_mode are NOT NULL with no default, so a caller that omits

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -592,10 +592,22 @@ type Querier interface {
 	// ===========================================================================
 	// mcp_grants -- the durable statement that a client may read some sites
 	// ===========================================================================
-	// Runs InTenantTx, and never under app.site_scope: mcp_grants_site_scope_insert
-	// is RESTRICTIVE FOR INSERT, so a site-scoped collaborator inserting here
-	// matches nothing (Decision 9 -- a per-site principal must not mint an
-	// organisation-wide read credential).
+	// THE POLICY ON THIS INSERT ONLY BINDS IF THE CALLER SET THE GUC IT READS.
+	// mcp_grants_site_scope_insert is RESTRICTIVE FOR INSERT and its WITH CHECK
+	// coalesces current_setting('app.site_scope', true) to the empty string and
+	// compares it against 'on', so it refuses a site-scoped collaborator only
+	// inside a transaction where app.site_scope has actually been set to 'on'.
+	// Nothing else sets it: reach this query through db.RunTenantTx, which
+	// dispatches on the principal's scope and is the sole thing that does (its doc
+	// comment in internal/db/db.go states the rule for every table, not just this
+	// one). A call site that picks InTenantTx, InTenantTxAsUser or
+	// InScopedTenantTx itself leaves the setting unset, the coalesced empty string
+	// is not equal to 'on', the RESTRICTIVE check passes, and the row inserts with
+	// no error raised anywhere.
+	//
+	// Decision 9 -- a per-site principal must not mint an organisation-wide read
+	// credential -- is therefore a property of the policy AND the dispatch
+	// together. The policy alone does not carry it.
 	//
 	// No parameter defaults to a permissive value because no COLUMN does: status
 	// and site_scope_mode are NOT NULL with no default, so a caller that omits


### PR DESCRIPTION
The comment on `CreateMCPGrant` in `apps/api/db/query/mcp_connections.sql` described `mcp_grants_site_scope_insert` as refusing a site-scoped collaborator on its own. The policy is correct; what it depends on is the transaction wrapper the caller chose, since the RESTRICTIVE check reads a GUC that only the scope dispatch sets.

The replacement states that dependency as an invariant and points at `RunTenantTx` in `internal/db/db.go`, which already carries the general rule for every table.

## Scope

Comment only. No schema change, no migration, no policy change, no query text change — so no RLS guard run and no `make test-integration` is implicated by this diff.

Three copies, one source:

- `apps/api/db/query/mcp_connections.sql` — the source, hand-edited
- `apps/api/internal/db/sqlc/mcp_connections.sql.go` — regenerated
- `apps/api/internal/db/sqlc/querier.go` — regenerated

## Generator note

The first draft used a doubled single-quote for the empty string. The `.sql.go` emitter rewrites that pair into U+201D while `querier.go` keeps it verbatim, so the two generated copies disagreed and one of them misstated the SQL literal. The comment is phrased to avoid the token rather than to patch the output.

## Checks

```
sqlc v1.31.1 generate      -> git diff --quiet -- internal/db/sqlc/  exit 0
go build ./...             -> exit 0
go vet ./...               -> exit 0
grep -P '[\x{2018}\x{2019}\x{201c}\x{201d}]' over all three files -> no match (pattern verified against a positive control)
```
