### PR TITLE
S16: wire /ai to the real connections endpoint (needs #593)

### DIFF
--- a/apps/web/src/features/ai-connections/connection-model.ts
+++ b/apps/web/src/features/ai-connections/connection-model.ts
@@ -17,6 +17,12 @@
  * version is a claim the client never made.
  */
 export type ProtocolHeader =
+  // FOUR states, matching apps/api/internal/mcp/model.go ClientProtocolState
+  // exactly. This type carried three until the endpoint existed; the server
+  // distinguishes "has never connected at all" from "connected and sent no
+  // header", and folding the first into the second would report a client that
+  // has never dialled in as one that dialled in badly.
+  | { readonly kind: "never_connected" }
   | { readonly kind: "absent" }
   | { readonly kind: "recognised"; readonly version: string }
   | { readonly kind: "unrecognised"; readonly version: string };
@@ -32,7 +38,11 @@ export type LastUsed =
   | { readonly kind: "never" }
   | { readonly kind: "at"; readonly iso: string };
 
-export type ConnectionStatus = "active" | "paused" | "revoked";
+// Exactly the two values mcp_grants_status_check permits (model.go
+// GrantStatus). "paused" was in this type before the endpoint existed and is
+// removed: the server cannot return it, there is no endpoint to produce it, and
+// a status the API cannot emit is a branch that renders for no reason.
+export type ConnectionStatus = "active" | "revoked";
 
 export interface AiConnection {
   readonly id: string;
@@ -50,6 +60,10 @@ export interface AiConnection {
   readonly scopes: readonly string[];
   readonly status: ConnectionStatus;
   readonly createdAt: string;
+  /** all | tags | sites - which sites the grant covers. */
+  readonly siteScopeMode: string;
+  /** null means not revoked. Never inferred from status, and never a zero date. */
+  readonly revokedAt: string | null;
 }
 
 /**
@@ -107,6 +121,10 @@ export function connectionsState(input: {
 /** Human label for a protocol header, keeping absence visible as absence. */
 export function protocolHeaderLabel(header: ProtocolHeader, floorVersion: string): string {
   switch (header.kind) {
+    case "never_connected":
+      // NOT "no header". This client has never opened a session at all, so it
+      // has never had the chance to send one.
+      return "Has not connected yet";
     case "absent":
       // Not "unknown", not blank, and not the floor version on its own: the
       // client sent nothing, and we treat that as the floor. Both halves are

--- a/apps/web/src/features/ai-connections/connection-model.ts
+++ b/apps/web/src/features/ai-connections/connection-model.ts
@@ -25,7 +25,18 @@ export type ProtocolHeader =
   | { readonly kind: "never_connected" }
   | { readonly kind: "absent" }
   | { readonly kind: "recognised"; readonly version: string }
-  | { readonly kind: "unrecognised"; readonly version: string };
+  | { readonly kind: "unrecognised"; readonly version: string }
+  // A FIFTH KIND THAT IS NOT A FIFTH WIRE STATE. The server never sends this;
+  // it is what WE say when the two fields it did send contradict each other --
+  // a `recognised` or `unrecognised` state carrying a null version.
+  //
+  // It exists because the first version of this mapping folded that
+  // contradiction into `absent`, and `absent` is a specific, confident claim
+  // ABOUT THE CLIENT: "it connected and sent no header". A malformed response
+  // is not that. It is us failing to understand the answer, which is a fact
+  // about us, and it belongs in the same family as the list's `unavailable`
+  // state rather than in the vocabulary of things the client did.
+  | { readonly kind: "unreadable" };
 
 /**
  * When a connection was last used.
@@ -121,6 +132,10 @@ export function connectionsState(input: {
 /** Human label for a protocol header, keeping absence visible as absence. */
 export function protocolHeaderLabel(header: ProtocolHeader, floorVersion: string): string {
   switch (header.kind) {
+    case "unreadable":
+      // Phrased as OUR failure, not the client's behaviour. Nothing here
+      // claims anything about what the client sent.
+      return "We could not read this client's protocol report";
     case "never_connected":
       // NOT "no header". This client has never opened a session at all, so it
       // has never had the chance to send one.

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -29,6 +29,8 @@ const CONNECTED: AiConnection = {
   scopes: ["mcp:read"],
   status: "active",
   createdAt: "2026-08-01T00:00:00.000Z",
+  siteScopeMode: "all",
+  revokedAt: null,
 };
 
 /** The copy that must never appear over a failure. */
@@ -143,6 +145,34 @@ describe("a field the client did not send is rendered as absent", () => {
     expect(screen.getByText(/treated as 2025-03-26/i)).toBeInTheDocument();
     // The number it would have been coerced into must not appear on its own.
     expect(screen.queryByText("2025-11-25")).not.toBeInTheDocument();
+  });
+
+  it("says a client has not connected yet, rather than that it sent no header", async () => {
+    // FOUR STATES, NOT THREE. This one was missing from the model until the
+    // endpoint existed. "Has never dialled in" and "dialled in and sent no
+    // header" are different facts about different things, and the server went
+    // out of its way not to flatten them into a nullable string.
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, protocolHeader: { kind: "never_connected" } }],
+    });
+    expect(await screen.findByText(/has not connected yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no protocol header sent/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("2025-11-25")).not.toBeInTheDocument();
+  });
+
+  it("gives all four protocol states four different sentences", () => {
+    const floor = "2025-03-26";
+    const labels = [
+      protocolHeaderLabel({ kind: "never_connected" }, floor),
+      protocolHeaderLabel({ kind: "absent" }, floor),
+      protocolHeaderLabel({ kind: "recognised", version: "2025-11-25" }, floor),
+      protocolHeaderLabel({ kind: "unrecognised", version: "2025-11-25" }, floor),
+    ];
+    // Same version string in the last two on purpose: if the label ever stopped
+    // marking the unrecognised one, these two would collide and this fails.
+    expect(new Set(labels).size).toBe(4);
+    for (const l of labels) expect(l.trim().length).toBeGreaterThan(0);
   });
 
   it("distinguishes an unrecognised version from a recognised one", () => {

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -172,18 +172,50 @@ describe("a field the client did not send is rendered as absent", () => {
     expect(screen.queryByText("2025-11-25")).not.toBeInTheDocument();
   });
 
-  it("gives all four protocol states four different sentences", () => {
+  it("gives all five protocol kinds five different sentences", () => {
     const floor = "2025-03-26";
     const labels = [
       protocolHeaderLabel({ kind: "never_connected" }, floor),
       protocolHeaderLabel({ kind: "absent" }, floor),
       protocolHeaderLabel({ kind: "recognised", version: "2025-11-25" }, floor),
       protocolHeaderLabel({ kind: "unrecognised", version: "2025-11-25" }, floor),
+      // Not a wire state: what we say when the response contradicts itself.
+      protocolHeaderLabel({ kind: "unreadable" }, floor),
     ];
-    // Same version string in the last two on purpose: if the label ever stopped
-    // marking the unrecognised one, these two would collide and this fails.
-    expect(new Set(labels).size).toBe(4);
+    // Same version string in the middle two on purpose: if the label ever
+    // stopped marking the unrecognised one, they would collide and this fails.
+    expect(new Set(labels).size).toBe(5);
     for (const l of labels) expect(l.trim().length).toBeGreaterThan(0);
+  });
+
+  it("phrases the unreadable label as our failure, not the client's behaviour", () => {
+    // The distinction the kind exists for. Asserted on the pronoun rather than
+    // the whole sentence, so rewording stays free.
+    const label = protocolHeaderLabel({ kind: "unreadable" }, "2025-03-26");
+    expect(label.toLowerCase()).toMatch(/\bwe\b|\bcould not\b|\bunreadable\b/);
+    // And it must not read as a claim about what the client sent.
+    expect(label.toLowerCase()).not.toContain("sent no");
+  });
+
+  it("renders an unreadable report as unreadable, not as 'sent no header'", async () => {
+    // Derived expectations, first time of asking. The property is that this
+    // kind renders as itself and not as a neighbour; the wording is free.
+    const floor = "2025-03-26";
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, protocolHeader: { kind: "unreadable" } }],
+    });
+    expect(
+      await screen.findByText(protocolHeaderLabel({ kind: "unreadable" }, floor)),
+    ).toBeInTheDocument();
+    // The specific wrong answer: a malformed response rendered as a confident
+    // fact about the client.
+    expect(
+      screen.queryByText(protocolHeaderLabel({ kind: "absent" }, floor)),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(protocolHeaderLabel({ kind: "never_connected" }, floor)),
+    ).not.toBeInTheDocument();
   });
 
   it("distinguishes an unrecognised version from a recognised one", () => {

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -140,9 +140,18 @@ describe("a field the client did not send is rendered as absent", () => {
       status: "ready",
       connections: [{ ...CONNECTED, protocolHeader: { kind: "absent" } }],
     });
-    // Both halves: the client sent nothing, AND we treat that as the floor.
-    expect(await screen.findByText(/no protocol header sent/i)).toBeInTheDocument();
-    expect(screen.getByText(/treated as 2025-03-26/i)).toBeInTheDocument();
+    // Derived, not frozen: the over-fire pass caught this pair of regexes
+    // reddening when the absent wording was reworded, which is correct work.
+    const floor = "2025-03-26";
+    expect(
+      await screen.findByText(protocolHeaderLabel({ kind: "absent" }, floor)),
+    ).toBeInTheDocument();
+    // Both halves still have to be SAID, which is a property of the label and
+    // is asserted on the label rather than on the rendered sentence: the client
+    // sent nothing, and we treat that as the floor.
+    const label = protocolHeaderLabel({ kind: "absent" }, floor);
+    expect(label).toContain(floor);
+    expect(label.length).toBeGreaterThan(floor.length);
     // The number it would have been coerced into must not appear on its own.
     expect(screen.queryByText("2025-11-25")).not.toBeInTheDocument();
   });

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -156,8 +156,19 @@ describe("a field the client did not send is rendered as absent", () => {
       status: "ready",
       connections: [{ ...CONNECTED, protocolHeader: { kind: "never_connected" } }],
     });
-    expect(await screen.findByText(/has not connected yet/i)).toBeInTheDocument();
-    expect(screen.queryByText(/no protocol header sent/i)).not.toBeInTheDocument();
+    // DERIVED, NOT HARDCODED. The over-fire pass caught an earlier version
+    // matching /has not connected yet/i: rewording that sentence is correct
+    // work and it reddened. Fourth instance of this trap in this slice. What
+    // must not regress is that this state renders as ITSELF and not as one of
+    // the other three, so the expected string comes from the same function the
+    // component uses.
+    const floor = "2025-03-26";
+    const expected = protocolHeaderLabel({ kind: "never_connected" }, floor);
+    expect(await screen.findByText(expected)).toBeInTheDocument();
+    // And not as either neighbouring state.
+    expect(
+      screen.queryByText(protocolHeaderLabel({ kind: "absent" }, floor)),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("2025-11-25")).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/features/ai-connections/connections-list.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.tsx
@@ -40,9 +40,13 @@ export interface ConnectionsListProps {
   isRetrying?: boolean;
   /** Rendered in the empty state so the operator has somewhere to go. */
   connectAction?: ReactNode;
-  onRotate?: (connection: AiConnection) => void;
-  onPause?: (connection: AiConnection) => void;
+  // ROTATE AND PAUSE ARE GONE, NOT DISABLED. #593 adds list and revoke and
+  // nothing else, so a rotate button could only ever fail. A control that
+  // cannot work is worse than an absent one: it advertises a capability and
+  // spends the operator's trust when it turns out not to exist.
   onRevoke?: (connection: AiConnection) => void;
+  /** Id currently being revoked, so its row can show the in-flight state. */
+  revokingId?: string | null;
 }
 
 function formatIso(iso: string): string {
@@ -58,9 +62,8 @@ export function ConnectionsList({
   onRetry,
   isRetrying,
   connectAction,
-  onRotate,
-  onPause,
   onRevoke,
+  revokingId,
 }: ConnectionsListProps) {
   if (state.status === "loading") {
     return (
@@ -151,13 +154,7 @@ export function ConnectionsList({
                 <span className="font-medium text-[var(--color-foreground)]">{c.name}</span>
                 <span className="ml-2">
                   <Badge
-                    variant={
-                      c.status === "active"
-                        ? "success"
-                        : c.status === "paused"
-                          ? "muted"
-                          : "destructive"
-                    }
+                    variant={c.status === "active" ? "success" : "destructive"}
                   >
                     {c.status}
                   </Badge>
@@ -231,32 +228,23 @@ export function ConnectionsList({
               </TableCell>
 
               <TableCell className="text-right">
-                <span className="inline-flex gap-1">
+                {/* An ALREADY-REVOKED grant gets no revoke button. The
+                    endpoint is idempotent, so pressing it would succeed and
+                    teach the operator nothing. */}
+                {c.status === "revoked" ? (
+                  <span className="text-xs text-[var(--color-muted-foreground)]">
+                    Revoked
+                  </span>
+                ) : (
                   <Button
                     variant="ghost"
                     size="sm"
-                    disabled={onRotate === undefined}
-                    onClick={() => onRotate?.(c)}
-                  >
-                    Rotate
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={onPause === undefined}
-                    onClick={() => onPause?.(c)}
-                  >
-                    {c.status === "paused" ? "Resume" : "Pause"}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={onRevoke === undefined}
+                    disabled={onRevoke === undefined || revokingId === c.id}
                     onClick={() => onRevoke?.(c)}
                   >
-                    Revoke
+                    {revokingId === c.id ? "Revoking..." : "Revoke"}
                   </Button>
-                </span>
+                )}
               </TableCell>
             </TableRow>
           ))}

--- a/apps/web/src/features/ai-connections/use-ai-connections.test.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.test.ts
@@ -94,11 +94,35 @@ describe("the four protocol states survive the wire", () => {
     ).toThrow();
   });
 
-  it("does not render a version the server contradicted its own state with", () => {
-    // recognised with a null version is a contradiction. Degrade to the one
-    // state that truthfully claims no version rather than printing "null".
-    const c = one(({ protocol: { state: "recognised", version: null } }));
-    expect(c.protocolHeader.kind).toBe("absent");
+  it("reports a contradicted pair as unreadable, NEVER as absent", () => {
+    // THE DEFECT THIS REPLACES. Both of these used to map to `absent`, which is
+    // a confident claim about the CLIENT -- "it connected and sent no header".
+    // A response that disagrees with itself supports no such claim. dto.go only
+    // populates Version for these two states, so a null here means we could not
+    // read the answer, which is a fact about us and not about anyone else.
+    for (const state of ["recognised", "unrecognised"]) {
+      const c = one({ protocol: { state, version: null } });
+      expect(c.protocolHeader.kind, `${state} with a null version`).toBe("unreadable");
+      // Named explicitly, so the wrong answer cannot come back by another route.
+      expect(c.protocolHeader.kind).not.toBe("absent");
+      expect(c.protocolHeader.kind).not.toBe("never_connected");
+    }
+  });
+
+  it("does not put a version on an unreadable report", () => {
+    const c = one({ protocol: { state: "recognised", version: null } });
+    expect("version" in c.protocolHeader).toBe(false);
+  });
+
+  it("still maps a well-formed absent, so the guard does not over-fire", () => {
+    // Routing every version-less state to `unreadable` would be the opposite
+    // defect: a genuine absent must still read as absent.
+    expect(one({ protocol: { state: "absent", version: null } }).protocolHeader.kind).toBe(
+      "absent",
+    );
+    expect(
+      one({ protocol: { state: "never_connected", version: null } }).protocolHeader.kind,
+    ).toBe("never_connected");
   });
 });
 

--- a/apps/web/src/features/ai-connections/use-ai-connections.test.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+
+import { parseConnectionList } from "./use-ai-connections";
+import type { AiConnection } from "./connection-model";
+
+// THE WIRE SHAPE IS THE BACKEND'S, AND THIS FILE IS WHERE THE TWO ARE COMPARED.
+//
+// Every fixture below is the shape apps/api/internal/mcp/dto.go actually
+// emits -- connectionListDTO wrapping connectionDTO, with protocolReportDTO's
+// {state, version} pair and pointers rendered as explicit nulls. The frontend
+// model was written BEFORE that endpoint existed and disagreed with it in three
+// places: it had three protocol states where the server has four, it carried a
+// "paused" status the server cannot emit, and it expected a bare array. Nothing
+// had ever compared them until this file.
+
+function row(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "Fleet manager",
+    status: "active",
+    site_scope_mode: "all",
+    scopes: ["mcp:read"],
+    created_at: "2026-08-01T00:00:00Z",
+    reported_client_name: "claude-code",
+    reported_client_version: "2.1.0",
+    protocol: { state: "recognised", version: "2025-11-25" },
+    last_used_at: "2026-08-29T10:00:00Z",
+    revoked_at: null,
+    ...over,
+  };
+}
+
+/** Parse a one-row payload the way the queryFn does, and return that row. */
+function one(over: Record<string, unknown> = {}): AiConnection {
+  const out = parseConnectionList({ connections: [row(over)] });
+  const first = out[0];
+  if (first === undefined) throw new Error("expected one connection");
+  return first;
+}
+
+describe("the wire shape parses into the model", () => {
+  it("reads the object wrapper, not a bare array", () => {
+    // dto.go wraps deliberately: a bare `[]` and an error body are both valid
+    // JSON, so a caller that ignores the status can decode a failure into a
+    // zero-length list.
+    const out = parseConnectionList({ connections: [row()] });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.name).toBe("Fleet manager");
+  });
+
+  it("refuses a bare array", () => {
+    expect(() => parseConnectionList([row()])).toThrow();
+  });
+
+  it("refuses the house error envelope rather than reading it as empty", () => {
+    // The exact confusion the wrapper exists to prevent.
+    expect(() =>
+      parseConnectionList({ code: "forbidden", message: "nope" }),
+    ).toThrow();
+  });
+
+  it("reads a genuinely empty organisation as an empty list", () => {
+    // The over-fire half: a real empty org must still parse.
+    expect(parseConnectionList({ connections: [] })).toEqual([]);
+  });
+});
+
+describe("the four protocol states survive the wire", () => {
+  it("maps never_connected without collapsing it into absent", () => {
+    const c = one(({ protocol: { state: "never_connected", version: null } }));
+    expect(c.protocolHeader.kind).toBe("never_connected");
+  });
+
+  it("maps absent without inventing a version", () => {
+    const c = one(({ protocol: { state: "absent", version: null } }));
+    expect(c.protocolHeader.kind).toBe("absent");
+    expect("version" in c.protocolHeader).toBe(false);
+  });
+
+  it("maps recognised and unrecognised with their versions", () => {
+    const rec = one(({ protocol: { state: "recognised", version: "2025-11-25" } }));
+    expect(rec.protocolHeader).toEqual({ kind: "recognised", version: "2025-11-25" });
+    const unr = one(({ protocol: { state: "unrecognised", version: "2024-11-05" } }),
+    );
+    expect(unr.protocolHeader).toEqual({ kind: "unrecognised", version: "2024-11-05" });
+  });
+
+  it("refuses an unknown fifth state rather than coercing it", () => {
+    // A closed enum. Coercing an unknown state into `absent` would be this
+    // codebase's signature defect, wearing the exact costume the server avoided
+    // by not flattening the state into a nullable string.
+    expect(() =>
+      parseConnectionList({ connections: [row({ protocol: { state: "weird", version: null } })] }),
+    ).toThrow();
+  });
+
+  it("does not render a version the server contradicted its own state with", () => {
+    // recognised with a null version is a contradiction. Degrade to the one
+    // state that truthfully claims no version rather than printing "null".
+    const c = one(({ protocol: { state: "recognised", version: null } }));
+    expect(c.protocolHeader.kind).toBe("absent");
+  });
+});
+
+describe("null is never coerced into a value", () => {
+  it("maps last_used_at null onto never, not a date", () => {
+    const c = one(({ last_used_at: null }));
+    expect(c.lastUsed).toEqual({ kind: "never" });
+  });
+
+  it("keeps a real last_used_at", () => {
+    const c = one(({ last_used_at: "2026-08-29T10:00:00Z" }));
+    expect(c.lastUsed).toEqual({ kind: "at", iso: "2026-08-29T10:00:00Z" });
+  });
+
+  it("keeps a null reported client name as null, never backfilled from name", () => {
+    const c = one(({ reported_client_name: null, reported_client_version: null }));
+    expect(c.reportedClientName).toBeNull();
+    // Never the operator's chosen name: one is the client's claim, the other is
+    // the operator's, and they can disagree.
+    expect(c.reportedClientName).not.toBe("Fleet manager");
+  });
+
+  it("keeps a version reported without a name", () => {
+    const c = one(({ reported_client_name: null, reported_client_version: "0.9" }));
+    expect(c.reportedClientVersion).toBe("0.9");
+  });
+
+  it("maps revoked_at null onto null, not a date", () => {
+    expect(one(({ revoked_at: null })).revokedAt).toBeNull();
+  });
+});
+
+describe("status matches what the server can actually emit", () => {
+  it("accepts the two values mcp_grants_status_check permits", () => {
+    expect(one(({ status: "active" })).status).toBe("active");
+    expect(
+      one(({ status: "revoked", revoked_at: "2026-08-29T11:00:00Z" })).status,
+    ).toBe("revoked");
+  });
+
+  it("refuses a status the server cannot return", () => {
+    // "paused" was in the model before the endpoint existed. There is no
+    // endpoint that produces it and no column that stores it.
+    expect(() =>
+      parseConnectionList({ connections: [row({ status: "paused" })] }),
+    ).toThrow();
+  });
+});

--- a/apps/web/src/features/ai-connections/use-ai-connections.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.ts
@@ -94,17 +94,24 @@ function toProtocolHeader(p: z.infer<typeof protocolSchema>): ProtocolHeader {
       return { kind: "never_connected" };
     case "absent":
       return { kind: "absent" };
+    // A CONTRADICTION IS NOT AN ABSENCE. Both branches below used to return
+    // `{kind: "absent"}` when the version was null, with a comment arguing
+    // that absent "truthfully claims no version". That was wrong, and it was
+    // the same defect this whole feature was built to avoid, one layer in:
+    // `absent` is a confident claim about the CLIENT -- it connected and sent
+    // no header -- so a malformed pair rendered as `absent` puts words in the
+    // client's mouth on the strength of a response we could not read.
+    //
+    // dto.go only populates Version for these two states, so a null here means
+    // the response disagrees with itself. That is our problem to report, not a
+    // fact to assert about anyone.
     case "recognised":
-      // A recognised state with no version is a contradiction. Report it as
-      // unrecognised-with-no-version rather than inventing one... except there
-      // is nothing honest to put in `version`, so it degrades to absent, which
-      // is the only state that truthfully claims no version.
       return p.version === null
-        ? { kind: "absent" }
+        ? { kind: "unreadable" }
         : { kind: "recognised", version: p.version };
     case "unrecognised":
       return p.version === null
-        ? { kind: "absent" }
+        ? { kind: "unreadable" }
         : { kind: "unrecognised", version: p.version };
   }
 }

--- a/apps/web/src/features/ai-connections/use-ai-connections.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.ts
@@ -1,0 +1,240 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { z } from "zod";
+
+import type { AiConnection, ProtocolHeader } from "./connection-model";
+
+// Reading the AI connections list, and revoking one.
+//
+// WHY RAW fetch AND NOT THE GENERATED CLIENT. These two routes are not in
+// packages/openapi/openapi.yaml -- #593 adds them to apps/api only, alongside
+// the OAuth endpoints, which internal/mcp/dto.go hand-shapes for its own
+// reasons. The same house pattern is already used by features/mcp-consent/
+// use-consent.ts, features/sharing/use-shares.ts and routes/accept.tsx: a
+// same-origin /api/v1 path with credentials included. Whether this surface
+// should join the OpenAPI document is a contract question for the API owner and
+// is flagged rather than decided here.
+//
+// THE ZOD PARSE IS NOT A SUBSTITUTE FOR GENERATED TYPES; IT IS THE THING
+// GENERATED TYPES WOULD NOT GIVE US. A generated type asserts a shape at
+// compile time and believes the server at runtime. Here the runtime check is
+// what keeps a malformed payload from rendering as a confident, wrong list --
+// in particular it is what stops an unknown protocol state being silently
+// dropped into a plausible one.
+
+export const CONNECTIONS_PATH = "/api/v1/mcp/connections";
+
+export const connectionKeys = {
+  all: ["ai-connections"] as const,
+  list: () => [...connectionKeys.all, "list"] as const,
+};
+
+/**
+ * The four protocol states, mirroring ClientProtocolState in
+ * apps/api/internal/mcp/model.go.
+ *
+ * A CLOSED ENUM, DELIBERATELY. An unknown fifth state fails the parse and
+ * surfaces as a failed load, rather than being coerced into `absent` -- which
+ * would be this codebase's signature defect wearing the exact costume the
+ * server went out of its way to prevent by not flattening the state into a
+ * nullable string.
+ */
+const protocolStateSchema = z.enum([
+  "never_connected",
+  "absent",
+  "recognised",
+  "unrecognised",
+]);
+
+const protocolSchema = z.object({
+  state: protocolStateSchema,
+  // null for never_connected and absent: those two have no version because the
+  // client named none. The server guards on state rather than emptiness.
+  version: z.string().nullable(),
+});
+
+const connectionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(["active", "revoked"]),
+  site_scope_mode: z.string(),
+  scopes: z.array(z.string()),
+  created_at: z.string(),
+  reported_client_name: z.string().nullable(),
+  reported_client_version: z.string().nullable(),
+  protocol: protocolSchema,
+  last_used_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+});
+
+// An OBJECT, not a bare array. dto.go says why: an error body and a bare `[]`
+// are both valid JSON, so a caller that ignores the status code can decode a
+// failure into a zero-length slice. The house error envelope cannot satisfy
+// this schema, so the two are distinguishable here even if that ever happened.
+const connectionListSchema = z.object({
+  connections: z.array(connectionSchema),
+});
+
+/**
+ * Turn the wire's `{state, version}` pair into the discriminated union.
+ *
+ * A VERSION IS ONLY READ FOR THE TWO STATES THAT HAVE ONE. If the server ever
+ * leaked a version onto `absent`, this drops it rather than rendering it,
+ * because `absent` means the client named no version and putting one there
+ * would be a claim the client never made.
+ */
+function toProtocolHeader(p: z.infer<typeof protocolSchema>): ProtocolHeader {
+  switch (p.state) {
+    case "never_connected":
+      return { kind: "never_connected" };
+    case "absent":
+      return { kind: "absent" };
+    case "recognised":
+      // A recognised state with no version is a contradiction. Report it as
+      // unrecognised-with-no-version rather than inventing one... except there
+      // is nothing honest to put in `version`, so it degrades to absent, which
+      // is the only state that truthfully claims no version.
+      return p.version === null
+        ? { kind: "absent" }
+        : { kind: "recognised", version: p.version };
+    case "unrecognised":
+      return p.version === null
+        ? { kind: "absent" }
+        : { kind: "unrecognised", version: p.version };
+  }
+}
+
+export function toAiConnection(raw: z.infer<typeof connectionSchema>): AiConnection {
+  return {
+    id: raw.id,
+    name: raw.name,
+    reportedClientName: raw.reported_client_name,
+    reportedClientVersion: raw.reported_client_version,
+    protocolHeader: toProtocolHeader(raw.protocol),
+    // null is NEVER USED. Not a zero date, not "unknown".
+    lastUsed:
+      raw.last_used_at === null ? { kind: "never" } : { kind: "at", iso: raw.last_used_at },
+    scopes: raw.scopes,
+    status: raw.status,
+    createdAt: raw.created_at,
+    siteScopeMode: raw.site_scope_mode,
+    revokedAt: raw.revoked_at,
+  };
+}
+
+/** Parse a list payload, throwing on anything that is not the promised shape. */
+export function parseConnectionList(body: unknown): AiConnection[] {
+  return connectionListSchema.parse(body).connections.map(toAiConnection);
+}
+
+/** An error the house envelope `{code, message}` carries. */
+export class ConnectionsRequestError extends Error {
+  readonly code: string;
+  readonly status: number;
+  constructor(code: string, message: string, status: number) {
+    super(message || code);
+    this.name = "ConnectionsRequestError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+async function readHouseError(res: Response): Promise<ConnectionsRequestError> {
+  // A NON-JSON OR UNPARSEABLE BODY IS STILL A FAILURE. The catch returns an
+  // error, never a success with empty fields.
+  let code = "server_error";
+  let message = "";
+  try {
+    const body: unknown = await res.json();
+    if (body && typeof body === "object") {
+      const rec = body as Record<string, unknown>;
+      if (typeof rec.code === "string" && rec.code.length > 0) code = rec.code;
+      if (typeof rec.message === "string") message = rec.message;
+    }
+  } catch {
+    // Defaults stand; `code` is already the pessimistic value.
+  }
+  if (message === "") {
+    // Branching on the status the server actually returns. The route carries
+    // RequirePermission(PermAPIKeyRead), which refuses any site-constrained
+    // principal outright, so 403 here is a real and expected answer.
+    message =
+      res.status === 403
+        ? "Your role cannot view AI connections. They are organisation-wide credentials, so this needs an admin."
+        : "The server did not answer with a list we could read.";
+  }
+  return new ConnectionsRequestError(code, message, res.status);
+}
+
+export function useAiConnections(): UseQueryResult<AiConnection[], Error> {
+  return useQuery({
+    queryKey: connectionKeys.list(),
+    queryFn: async (): Promise<AiConnection[]> => {
+      const res = await fetch(CONNECTIONS_PATH, {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) throw await readHouseError(res);
+      // A 200 whose body is not the promised shape throws. There is no path
+      // that resolves to a partial list, because a partial list renders as a
+      // complete one.
+      return parseConnectionList((await res.json()) as unknown);
+    },
+  });
+}
+
+export interface RevokeResult {
+  readonly status: string;
+  readonly grantsRevoked: number;
+  readonly tokensRevoked: number;
+  readonly alreadyRevoked: boolean;
+}
+
+const revokeSchema = z.object({
+  status: z.string(),
+  grants_revoked: z.number(),
+  tokens_revoked: z.number(),
+  already_revoked: z.boolean(),
+});
+
+/**
+ * Revoke a connection.
+ *
+ * INVALIDATES ON SUCCESS so the list cannot keep showing a revoked connection
+ * as active. The counts come back because three different successes are
+ * possible and they are not interchangeable to a human: a first revoke that
+ * killed live tokens, an idempotent retry, and the repair of a half-revoked
+ * grant.
+ */
+export function useRevokeConnection(): UseMutationResult<RevokeResult, Error, string> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (connectionId: string): Promise<RevokeResult> => {
+      const res = await fetch(
+        `${CONNECTIONS_PATH}/${encodeURIComponent(connectionId)}/revoke`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        },
+      );
+      if (!res.ok) throw await readHouseError(res);
+      const parsed = revokeSchema.parse((await res.json()) as unknown);
+      return {
+        status: parsed.status,
+        grantsRevoked: parsed.grants_revoked,
+        tokensRevoked: parsed.tokens_revoked,
+        alreadyRevoked: parsed.already_revoked,
+      };
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: connectionKeys.all });
+    },
+  });
+}

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -184,6 +184,40 @@ describe("revoke", () => {
     expect(screen.getByText(/next request/i)).toBeInTheDocument();
   });
 
+  it("does not carry a failed revoke from one connection to the next", async () => {
+    // A's revoke fails; the operator closes and opens B. B must not be shown
+    // A's failure -- that tells them a revoke failed for something nobody
+    // tried to revoke. Same family as everything else on this page: state
+    // belonging to one subject presented as a fact about another.
+    const rowB = { ...ROW, id: "22222222-2222-2222-2222-222222222222", name: "CI reader" };
+    stubFetch((url) =>
+      url.includes("/revoke")
+        ? json({ code: "conflict", message: "REVOKE FAILED FOR FLEET MANAGER" }, 409)
+        : json({ connections: [ROW, rowB] }),
+    );
+    renderPage();
+    await screen.findByText("Fleet manager");
+
+    const [revokeA] = screen.getAllByRole("button", { name: /^revoke$/i });
+    fireEvent.click(revokeA!);
+    fireEvent.change(await screen.findByRole("textbox"), {
+      target: { value: "Fleet manager" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /revoke connection/i }));
+    expect(await screen.findByText(/REVOKE FAILED FOR FLEET MANAGER/i)).toBeInTheDocument();
+
+    // Close, then open the OTHER connection's dialog.
+    fireEvent.click(screen.getByRole("button", { name: /keep it connected/i }));
+    await waitFor(() =>
+      expect(screen.queryByText(/REVOKE FAILED FOR FLEET MANAGER/i)).not.toBeInTheDocument(),
+    );
+    const revokeB = screen.getAllByRole("button", { name: /^revoke$/i })[1];
+    fireEvent.click(revokeB!);
+    await screen.findByText(/next request/i);
+
+    expect(screen.queryByText(/REVOKE FAILED FOR FLEET MANAGER/i)).not.toBeInTheDocument();
+  });
+
   it("does not revoke anything merely by opening the dialog", async () => {
     const posts: string[] = [];
     stubFetch((url) => {

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -1,72 +1,200 @@
-import { describe, it, expect } from "vitest";
-import { screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
 
 import { renderWithProviders } from "@/test/render";
 
 import { Route } from "./index";
 import { MCP_TRANSPORT_PATH } from "@/features/ai-connections/client-table";
+import { CONNECTIONS_PATH } from "@/features/ai-connections/use-ai-connections";
 
 // FOUND BY THE MUTATION SWEEP. This route had no test at all, so the one
-// decision it makes -- pass `unavailable` to the list rather than `empty` --
-// was pinned by nothing. The sweep's "red" for that mutation was vitest
-// exiting 1 on "No test files found", which is a guard finding nothing and
-// being scored as a catch: the exact failure mode this project calls its
-// signature defect, reproduced inside the tool checking for it.
+// decision it makes was pinned by nothing. The sweep's "red" for that mutation
+// was vitest exiting 1 on "No test files found" -- a guard finding nothing and
+// being scored as a catch, which is this project's signature defect reproduced
+// inside the tool checking for it.
 //
-// The component-level states are covered in
-// features/ai-connections/connections-list.test.tsx. What is covered HERE is
-// the wiring: which state this page actually hands down.
+// Now that /ai does a REAL READ, the wiring is what this file covers: which
+// state the page hands down for each answer the endpoint can give. The states
+// themselves are covered in features/ai-connections/connections-list.test.tsx,
+// and the wire mapping in use-ai-connections.test.ts.
+//
+// The fetch is stubbed at the network boundary rather than the hook being
+// mocked, so the real queryFn, the real zod parse and the real state mapping
+// all run. A hook mock here would assert that the component renders whatever it
+// is handed, which is not the question.
 
 const AiPage = Route.options.component!;
+
+/**
+ * Resolve a fetch input to its URL.
+ *
+ * String(input) would stringify a Request object as "[object Object]" and the
+ * URL assertions below would then pass or fail for the wrong reason. Every
+ * branch is handled explicitly.
+ */
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function stubFetch(impl: (url: string) => Response | Promise<Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => Promise.resolve(impl(urlOf(input)))),
+  );
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 function renderPage() {
   return renderWithProviders(<AiPage />, { withRouter: true, initialPath: "/ai" });
 }
 
-describe("/ai", () => {
-  it("says we cannot list connections yet, and never that the operator has none", async () => {
-    renderPage();
-    expect(await screen.findByTestId("connections-unavailable")).toBeInTheDocument();
-    expect(screen.getByText(/cannot list your connections yet/i)).toBeInTheDocument();
+const ROW = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "Fleet manager",
+  status: "active",
+  site_scope_mode: "all",
+  scopes: ["mcp:read"],
+  created_at: "2026-08-01T00:00:00Z",
+  reported_client_name: "claude-code",
+  reported_client_version: "2.1.0",
+  protocol: { state: "recognised", version: "2025-11-25" },
+  last_used_at: "2026-08-29T10:00:00Z",
+  revoked_at: null,
+};
 
-    // The sentence that would be a claim about the operator's account made out
-    // of a gap in our own API.
-    expect(screen.queryByText(/no ai clients are connected/i)).not.toBeInTheDocument();
-    expect(screen.queryByTestId("connections-empty")).not.toBeInTheDocument();
-    // Nor a failure, which would send someone to retry something that cannot
-    // succeed.
-    expect(screen.queryByText(/could not load your ai connections/i)).not.toBeInTheDocument();
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.unstubAllGlobals());
+
+describe("/ai reads the real connections endpoint", () => {
+  it("asks the path the API actually mounts", async () => {
+    const seen: string[] = [];
+    stubFetch((url) => {
+      seen.push(url);
+      return json({ connections: [] });
+    });
+    renderPage();
+    await screen.findByTestId("connections-empty");
+    // apps/api/internal/mcp/discovery.go: ConnectionsPath = "/api/v1" +
+    // "/mcp/connections". A wrong path here would 404 and render as a failure,
+    // which is at least honest, but it would never show a connection.
+    expect(seen).toContain(CONNECTIONS_PATH);
+    expect(CONNECTIONS_PATH).toBe("/api/v1/mcp/connections");
   });
 
-  it("names the missing endpoint as the reason rather than staying vague", async () => {
+  it("renders the connections it was given", async () => {
+    stubFetch(() => json({ connections: [ROW] }));
     renderPage();
-    await screen.findByTestId("connections-unavailable");
-    expect(screen.getByText(/does not expose an endpoint/i)).toBeInTheDocument();
+    expect(await screen.findByText("Fleet manager")).toBeInTheDocument();
+    expect(screen.getByText(/claude-code 2\.1\.0/)).toBeInTheDocument();
+  });
+
+  it("renders a failed load as a failure, never as an empty list", async () => {
+    // The whole reason this page exists in the shape it does.
+    stubFetch(() => json({ code: "internal", message: "the server said 500" }, 500));
+    renderPage();
+    expect(await screen.findByText(/could not load your ai connections/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no ai clients are connected/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("connections-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders a 403 with the reason, not as an empty org", async () => {
+    // The route carries RequirePermission(PermAPIKeyRead), which refuses any
+    // site-constrained principal outright, so this is a real expected answer
+    // rather than a hypothetical.
+    stubFetch(() => json({ code: "forbidden", message: "" }, 403));
+    renderPage();
+    expect(await screen.findByText(/could not load your ai connections/i)).toBeInTheDocument();
+    expect(screen.getByText(/needs an admin/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("connections-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders a malformed 200 as a failure rather than a confident list", async () => {
+    // A 200 whose body is not the promised shape. Rendering it half-parsed
+    // would be a partial list shown as a complete one.
+    stubFetch(() => json({ connections: [{ id: "x" }] }));
+    renderPage();
+    expect(await screen.findByText(/could not load your ai connections/i)).toBeInTheDocument();
+  });
+
+  it("renders a genuinely empty organisation as empty", async () => {
+    // The over-fire half: correct empty work must still say "none".
+    stubFetch(() => json({ connections: [] }));
+    renderPage();
+    expect(await screen.findByTestId("connections-empty")).toBeInTheDocument();
+    expect(screen.queryByText(/could not load/i)).not.toBeInTheDocument();
+  });
+
+  it("no longer claims the feature does not exist", async () => {
+    // It was hardcoded to `unavailable` while there was no endpoint. Shipping
+    // that now would tell an operator the feature is missing while the endpoint
+    // sits there working.
+    stubFetch(() => json({ connections: [ROW] }));
+    renderPage();
+    await screen.findByText("Fleet manager");
+    expect(screen.queryByTestId("connections-unavailable")).not.toBeInTheDocument();
+  });
+});
+
+describe("/ai's static surfaces", () => {
+  beforeEach(() => stubFetch(() => json({ connections: [] })));
+
+  it("states the self-hosted proxy requirement beside the endpoint", async () => {
+    renderPage();
+    await screen.findByTestId("connections-empty");
+    expect(screen.getByText(/reverse proxy must forward \/mcp to the API/i)).toBeInTheDocument();
   });
 
   it("publishes this deployment's endpoint, not a hardcoded host", async () => {
     renderPage();
-    await screen.findByTestId("connections-unavailable");
-    const expected = `${window.location.origin}${MCP_TRANSPORT_PATH}`;
-    expect(screen.getByText(expected)).toBeInTheDocument();
-  });
-
-  it("states the self-hosted proxy requirement beside the endpoint", async () => {
-    renderPage();
-    await screen.findByTestId("connections-unavailable");
-    // Deriving /mcp from the origin does not prove anything forwards it.
-    // infra/urlmap.yaml routes it on hosted; infra/nginx/nginx.conf and
-    // apps/web/vite.config.ts do not.
-    expect(screen.getByText(/reverse proxy must forward \/mcp to the API/i)).toBeInTheDocument();
+    await screen.findByTestId("connections-empty");
+    expect(
+      screen.getByText(`${window.location.origin}${MCP_TRANSPORT_PATH}`),
+    ).toBeInTheDocument();
   });
 
   it("offers a route into the wizard, which is how that page is reached at all", async () => {
     renderPage();
-    // /ai/connect is deliberately absent from the sidebar, so this link is its
-    // only entry point. If it goes, the wizard becomes unreachable in exactly
-    // the way the whole slice exists to fix.
+    await screen.findByTestId("connections-empty");
     const links = await screen.findAllByRole("link", { name: /connect an ai client/i });
     expect(links.length).toBeGreaterThanOrEqual(1);
     expect(links[0]).toHaveAttribute("href", "/ai/connect");
+  });
+});
+
+describe("revoke", () => {
+  it("says what revoking actually does, on the client's next request", async () => {
+    stubFetch(() => json({ connections: [ROW] }));
+    renderPage();
+    await screen.findByText("Fleet manager");
+    fireEvent.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    // NOT "will no longer have access". The cascade kills the tokens and the
+    // grant is re-checked per request, so there is no expiry delay to imply.
+    await waitFor(() =>
+      expect(screen.getByText(/stops working on its/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/next request/i)).toBeInTheDocument();
+  });
+
+  it("does not revoke anything merely by opening the dialog", async () => {
+    const posts: string[] = [];
+    stubFetch((url) => {
+      if (url.includes("/revoke")) posts.push(url);
+      return json({ connections: [ROW] });
+    });
+    renderPage();
+    await screen.findByText("Fleet manager");
+    fireEvent.click(screen.getByRole("button", { name: /^revoke$/i }));
+    await screen.findByText(/next request/i);
+    // Opening a destructive dialog must not perform the destructive thing.
+    expect(posts).toEqual([]);
   });
 });

--- a/apps/web/src/routes/_authed/ai/index.tsx
+++ b/apps/web/src/routes/_authed/ai/index.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
 import { CopyableMono } from "@/components/shared/copyable-mono";
+import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
 import { ConnectionsList } from "@/features/ai-connections/connections-list";
 import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
 import {
@@ -10,38 +13,54 @@ import {
   PROTOCOL_TARGET_VERSION,
   SELF_HOSTED_PROXY_REQUIREMENT,
 } from "@/features/ai-connections/client-table";
-import type { ConnectionsState } from "@/features/ai-connections/connection-model";
+import {
+  useAiConnections,
+  useRevokeConnection,
+} from "@/features/ai-connections/use-ai-connections";
+import {
+  connectionsState,
+  type AiConnection,
+  type ConnectionsState,
+} from "@/features/ai-connections/connection-model";
 
-// /ai — the AI area's front door, and the answer to "what is the route for all
-// this AI stuff? it's not in the sidebar at all".
+// /ai — the AI area's front door, and the answer to "what is the route for this
+// all ai settings? it's not in the sidebar at all".
 //
 // ROUTE PLACEMENT. Under _authed/ because every connection here is
-// tenant-scoped; outside it this page would render for logged-out users and
-// 403 on every call. It IS in the sidebar, unlike /connect/ai next door, which
-// stays out because it is an OAuth redirect target rather than a destination.
+// tenant-scoped; outside it this page would render for logged-out users and 403
+// on every call. It IS in the sidebar, unlike /connect/ai next door, which stays
+// out because it is an OAuth redirect target rather than a destination.
 //
-// WHY THE LIST IS `unavailable` RATHER THAN EMPTY. The control plane exposes
-// four MCP OAuth endpoints -- register and token (unauthenticated), authorize
-// and consent (operator-authenticated) -- registered at
-// apps/api/internal/mcp/handler.go:71 and :89. There is no endpoint that lists
-// grants and none that revokes one. The honest render for that is a fifth
-// state that names the gap. Passing `{ status: "empty" }` here, or fetching an
-// endpoint that does not exist and letting the 404 fall through to an empty
-// array, would both put the sentence "no AI clients are connected" on screen as
-// a fact about the operator's account when it is a fact about our API surface.
+// THE LIST IS NOW A REAL READ. It was hardcoded to `unavailable` while the
+// control plane had no endpoint to ask; #593 adds GET /api/v1/mcp/connections
+// and POST /api/v1/mcp/connections/:id/revoke, so the honest render is the data.
+// The `unavailable` state stays in the model, unused here, because it is still
+// the right answer for any future surface whose API has not landed -- and
+// because deleting it would leave `empty` as the only place a gap could land.
 
 export const Route = createFileRoute("/_authed/ai/")({
   component: AiConnectionsPage,
 });
 
-const LIST_UNAVAILABLE: ConnectionsState = {
-  status: "unavailable",
-  reason:
-    "The control plane does not expose an endpoint for listing AI connections yet, so we have nothing to read. Until it does, we will not guess.",
-};
-
 function AiConnectionsPage() {
   const endpoint = mcpEndpointUrl();
+  const query = useAiConnections();
+  const revoke = useRevokeConnection();
+  const [pending, setPending] = useState<AiConnection | null>(null);
+
+  // The mapping that decides which sentence is shown, in one tested place.
+  // `connections ?? []` is precisely what this function exists to forbid: a
+  // failed load must not render as "you have no AI connections", which is a
+  // claim about the operator's account made out of a fact about our request.
+  const state: ConnectionsState = useMemo(
+    () =>
+      connectionsState({
+        isPending: query.isPending,
+        error: query.error,
+        connections: query.data,
+      }),
+    [query.isPending, query.error, query.data],
+  );
 
   return (
     <div className="space-y-6">
@@ -63,7 +82,7 @@ function AiConnectionsPage() {
         </p>
         <CopyableMono value={endpoint} label="Copy the MCP endpoint" />
         {/* Derived from this origin, which does not prove anything forwards it.
-            See SELF_HOSTED_PROXY_REQUIREMENT for the two proxies that do not. */}
+            See SELF_HOSTED_PROXY_REQUIREMENT for the proxies that do not. */}
         <p className="text-xs text-[var(--color-muted-foreground)]">
           {SELF_HOSTED_PROXY_REQUIREMENT}
         </p>
@@ -74,7 +93,11 @@ function AiConnectionsPage() {
           Connected clients
         </h2>
         <ConnectionsList
-          state={LIST_UNAVAILABLE}
+          state={state}
+          onRetry={() => void query.refetch()}
+          isRetrying={query.isFetching}
+          revokingId={revoke.isPending ? (pending?.id ?? null) : null}
+          onRevoke={(c) => setPending(c)}
           connectAction={
             <Button asChild variant="outline" size="sm">
               <Link to="/ai/connect">Connect an AI client</Link>
@@ -82,6 +105,55 @@ function AiConnectionsPage() {
           }
         />
       </section>
+
+      <DestructiveConfirm
+        open={pending !== null}
+        onClose={() => setPending(null)}
+        title="Revoke this connection"
+        resourceName={pending?.name ?? ""}
+        confirmLabel="Revoke connection"
+        cancelLabel="Keep it connected"
+        isPending={revoke.isPending}
+        errorMessage={
+          revoke.error instanceof Error ? revoke.error.message : null
+        }
+        // WHAT IT ACTUALLY DOES, not a generic warning. The revoke cascades to
+        // the grant's bearer tokens and the grant is re-checked on every
+        // request, so the client stops working on its NEXT request rather than
+        // at some token expiry. "Will no longer have access" would let an
+        // operator assume a delay that does not exist.
+        consequencesBody={
+          <>
+            <p>
+              The client stops working on its <strong>next request</strong>, not at some later
+              expiry. Its access tokens are killed at the same time.
+            </p>
+            <p>
+              The connection stays in this list afterwards so you can still see when it was last
+              used. Reconnecting means setting the client up again from scratch.
+            </p>
+          </>
+        }
+        onConfirm={() => {
+          const target = pending;
+          if (target === null) return;
+          revoke.mutate(target.id, {
+            onSuccess: (result) => {
+              setPending(null);
+              // The counts are reported because three different successes are
+              // possible and they are not interchangeable to a human.
+              toast.success(
+                result.alreadyRevoked
+                  ? `"${target.name}" was already revoked. ${result.tokensRevoked} live token(s) cleaned up.`
+                  : `"${target.name}" revoked. ${result.tokensRevoked} access token(s) stopped working.`,
+              );
+            },
+            // NO onError THAT CLOSES THE DIALOG. A failed revoke leaves the
+            // dialog open with errorMessage showing, and the list untouched, so
+            // a failure cannot read as a success.
+          });
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/routes/_authed/ai/index.tsx
+++ b/apps/web/src/routes/_authed/ai/index.tsx
@@ -108,7 +108,16 @@ function AiConnectionsPage() {
 
       <DestructiveConfirm
         open={pending !== null}
-        onClose={() => setPending(null)}
+        // RESET THE MUTATION, NOT JUST THE SUBJECT. Clearing `pending` alone
+        // left revoke.error set, so opening the dialog for connection B
+        // rendered connection A's failure -- telling the operator a revoke
+        // failed for something nobody tried to revoke. Same family as
+        // everything else here: state belonging to one subject presented as a
+        // fact about another.
+        onClose={() => {
+          setPending(null);
+          revoke.reset();
+        }}
         title="Revoke this connection"
         resourceName={pending?.name ?? ""}
         confirmLabel="Revoke connection"


### PR DESCRIPTION
Follows #592 (merged). Wires `/ai` to the endpoint #593 adds.

`/ai` was hardcoded to the `unavailable` state because the control plane had no endpoint to ask. #593 adds `GET /api/v1/mcp/connections` and `POST /api/v1/mcp/connections/:id/revoke`, so the honest render is now the data.

**#593 has merged**, so the endpoint this reads is on `main`. Rebased onto it.

## The model disagreed with the DTO in three places

It was written before the endpoint existed and nothing had ever compared them. Checked against `apps/api/internal/mcp/dto.go` on #593's branch rather than assumed:

| | Model had | DTO has |
|---|---|---|
| protocol | **three** states | **four** — `never_connected` was missing entirely |
| status | `active \| paused \| revoked` | `active \| revoked` — no column stores `paused` |
| payload | bare array | `{ connections: [...] }` |

`never_connected` mattered most. "Has never dialled in" and "dialled in and sent no header" are different facts, and `dto.go` goes out of its way not to flatten them into a nullable string — so neither does this. Four states now render four different sentences, asserted by comparing set size rather than by eyeballing.

`paused` is gone along with the **Pause and Rotate buttons**. #593 adds list and revoke and nothing else; a control that can only fail is worse than an absent one, because it advertises a capability and spends the operator's trust when it turns out not to exist.

## A contradicted protocol pair is unreadable, not absent

Review caught the four states collapsing one layer in from where I fixed them. A `recognised`/`unrecognised` state arriving with a **null version** was mapped to `absent`, so a malformed response rendered as *"No protocol header sent"* -- a confident claim about the client built on an answer we could not read. The comment I wrote beside it argued that `absent` "truthfully claims no version", which quietly redefines a claim about the client as a claim about a field.

`ProtocolHeader` now has an `unreadable` kind. **Not a fifth wire state**: the zod enum stays a closed four and the server never sends this. It is what we say when the two fields it did send disagree, phrased as our failure, in the same family as the list's `unavailable` state.

Also fixed: a failed revoke for connection A survived into connection B's dialog, because `onClose` cleared `pending` but not the mutation.

## Absence still stays absence

- The protocol state enum is **closed**: an unknown fifth state fails the zod parse and surfaces as a failed load, rather than being coerced into `absent` — which would be this codebase's signature defect wearing the exact costume the server avoided.
- A malformed 200 throws rather than rendering a partial list as a complete one.
- `last_used_at: null` is `{kind: "never"}`, never a zero date.
- A 403 (the route carries `RequirePermission(PermAPIKeyRead)`, which refuses any site-constrained principal) says the role needs an admin — not "you have no connections".
- The `unavailable` state stays in the model, now unused, because it is still right for a surface whose API has not landed, and deleting it would leave `empty` as the only place a gap could fall.

## Revoke says what it does

The cascade kills the grant's tokens and the grant is re-checked per request, so the confirm says the client stops on its **next request**, not at some expiry. A failed revoke leaves the dialog open with the reason and the list untouched, so it cannot read as a success. Success invalidates, so the list cannot keep showing a revoked connection as active.

## Tests

Fetch is stubbed at the **network boundary**, not the hook — so the real `queryFn`, the real zod parse and the real state mapping all run. A hook mock would only assert the component renders what it is handed, which is not the question.

## Gates

| Gate | Exit |
|---|---|
| `pnpm -C apps/web typecheck` | `0` |
| `pnpm -C apps/web lint` | `0` — 10 warnings, 0 errors, all pre-existing |
| `pnpm -C apps/web test` | `0` — 163 files, 1981 tests |

Threads at zero.
