### PR TITLE
release: 0.61.148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.148] - 2026-08-30
+
+### Added
+
+- The AI connection surface is now usable end to end from the dashboard. `/ai` is a sidebar entry and the front door, and `/ai/connect` is a wizard that generates the configuration block for the client you pick. The per-client differences come from a tested table rather than hand-written snippets, so each published block is generated from a recorded entry carrying the date it was last verified, and a shape we have no source for is refused rather than approximated.
+- A connections list, showing which AI clients are connected, what each one negotiated, and when it was last used. "Never connected" and "connected but sent no protocol version" are kept distinct, and a list that failed to load is distinguishable from an organisation with no connections.
+- Revoke, from that list.
+- OAuth discovery documents (RFC 8414 and RFC 9728), so a GUI client with no field for an authorization endpoint can find one for itself. The issuer is derived from the configured public base URL rather than a constant, and an unset or unparseable value returns an error naming `WPMGR_PUBLIC_BASE_URL` instead of serving a document that names the wrong host.
+- The production load-balancer routing configuration now lives in this repository (`infra/urlmap.yaml`), with a CI check that proves every route the API actually mounts has a rule pointing at the API backend. The route list is dumped from the real engine, never hand-kept.
+
+### Changed
+
+- Revoking a connection now revokes its tokens in the same step, so the client stops working on its next request rather than continuing until its token expires.
+- The bundled nginx configuration and the development proxy now forward the MCP endpoint and the OAuth discovery paths. These are mounted at the root rather than under `/api/`, and were previously answered by the dashboard web app, so an operator who copied the endpoint out of the connection wizard got a page of HTML and no client could complete a handshake.
+- **Self-hosted action, if you run your own reverse proxy** rather than the bundled one. Forward these four paths to the control plane; all four are root-mounted, so a rule that only forwards `/api/` will miss every one of them:
+
+  ```
+  /mcp
+  /.well-known/oauth-authorization-server
+  /.well-known/oauth-protected-resource
+  /.well-known/oauth-protected-resource/mcp
+  ```
+
+  The last is not covered by the one above it: RFC 9728 inserts the resource path after the well-known segment, and current clients try that form first. Prefer exact-match rules over a `/.well-known/` prefix, so an ACME HTTP-01 challenge served from the same host keeps working. The bundled `infra/nginx/nginx.conf` already does all of this and needs no action. Without these rules the connection wizard will hand you an endpoint that returns your own dashboard.
+
+### Security
+
+- Organisation-scope enforcement is now applied to the AI connection authorization endpoints. Upgrading is recommended for every install that has the AI connection surface reachable.
+- **The `WPMGR_SESSION_SECRET` rotation guidance from 0.61.147 still stands and is not superseded by this release.** If you are upgrading from 0.61.146 or earlier you have not seen it yet: read the "Self-hosted upgrade action" note in the [0.61.147 entry](#061147---2026-08-30) below before rotating, because there is one prerequisite that has to come first or stored secrets become unreadable.
+
 ## [0.61.147] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.147**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.148**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.147
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.147
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.147
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.148
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.148
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.148
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.147   # omit to track :latest
+export WPMGR_VERSION=v0.61.148   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,42 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.148",
+    date: "2026-08-30",
+    summary:
+      "The AI connection surface is now usable end to end. There is a page for it in the dashboard, a wizard that writes the configuration block for the client you pick, a list of what is connected and when it was last used, and revoke. OAuth discovery documents let a client with no endpoint field find the authorization endpoints for itself, and the bundled proxy now routes the paths those clients need. Self-hosted operators running their own reverse proxy have one routing change to make; the changelog entry lists the exact paths.",
+    items: [
+      {
+        tag: "Added",
+        text: "A dashboard home for AI connections, with a connection wizard. Pick your client and the wizard generates the configuration block for it. The per-client differences come from a tested table rather than hand-written snippets, each entry carrying the date it was last verified, and a configuration shape we have no source for is refused rather than guessed at.",
+      },
+      {
+        tag: "Added",
+        text: "A connections list showing which clients are connected, what each negotiated, and when it was last used, plus revoke. A client that has never connected reads differently from one that connected without declaring a protocol version, and a list that failed to load is distinguishable from an organisation that has no connections yet.",
+      },
+      {
+        tag: "Added",
+        text: "OAuth discovery documents, so a client with no field in which to be told where to authorize can find the authorization endpoints for itself. The issuer is derived from the configured public address rather than a fixed value, so a self-hosted install advertises its own origin; an install with that value unset returns an error naming the setting rather than a document pointing somewhere real and wrong.",
+      },
+      {
+        tag: "Changed",
+        text: "Revoking a connection now revokes its tokens in the same step, so the client stops working on its next request rather than continuing until its token expires.",
+      },
+      {
+        tag: "Changed",
+        text: "The bundled reverse proxy and the development proxy now route the AI connection endpoint and the discovery documents. These sit at the root rather than under the API prefix and were previously answered by the dashboard itself, so an endpoint copied out of the wizard returned a web page. Self-hosted operators running their own proxy in place of the bundled one need to forward those paths; the install guide lists all four and explains why one of them is easy to miss.",
+      },
+      {
+        tag: "Added",
+        text: "The production routing configuration now lives in the repository, with a check on every change that proves each route the API actually serves has a rule pointing at it. The route list is read from the running engine rather than kept by hand, so a route that ships unreachable is caught before the deploy rather than after it.",
+      },
+      {
+        tag: "Security",
+        text: "Organisation-scope enforcement is now applied to the AI connection authorization endpoints. Upgrading is recommended for any install with that surface reachable. The session secret rotation guidance from 0.61.147 still stands and is not superseded; if you are coming from 0.61.146 or earlier, read that entry's upgrade note before rotating.",
+      },
+    ],
+  },
+  {
     version: "0.61.147",
     date: "2026-08-30",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -148,6 +148,52 @@ silently reconfigure a load-balanced deployment onto a single shared limiter
 key. The control plane logs the value it resolved, and names the variable in
 the error when it refuses one.
 
+### Reverse proxy: paths that must reach the API {#proxy-paths}
+
+**If you run the bundled `infra/nginx/` config, there is nothing to do here.**
+It already carries these rules. This section is for an operator fronting the
+stack with their own reverse proxy.
+
+Most of the control plane lives under `/api/`, so a single `/api/` rule covers
+it. Four paths do not: they are mounted at the **root**, and a proxy that
+forwards only `/api/` will send all four to the dashboard SPA instead.
+
+| Path | What it is |
+|------|------------|
+| `/mcp` | the AI connection endpoint, the URL the connect wizard tells you to paste into your client |
+| `/.well-known/oauth-authorization-server` | OAuth authorization server metadata (RFC 8414) |
+| `/.well-known/oauth-protected-resource` | protected resource metadata (RFC 9728) |
+| `/.well-known/oauth-protected-resource/mcp` | the same metadata at the resource-path form of the URL |
+
+The fourth is **not** covered by the third. RFC 9728 section 3.1 inserts the
+resource's path component after the well-known segment, and current AI clients
+try that form first.
+
+This failure is quiet, which is the reason it is called out here rather than
+left to be discovered. An unrouted path falls through to the dashboard, which
+answers `200` with `text/html` for anything. A health check or a status-code
+smoke test sees a `200` and reports success; the client sees a page of HTML
+where it expected metadata, and simply cannot start an authorization flow. If
+the connection wizard hands you an endpoint that returns your dashboard, this
+is why.
+
+Two things to get right in the rules themselves:
+
+- **Match `/.well-known/` exactly, per path, not as a prefix.** `/.well-known/`
+  is a shared namespace. A prefix rule captures `/.well-known/acme-challenge`
+  too, which breaks certificate issuance and renewal if you use an ACME client
+  (certbot and similar) against the same server block.
+- **Do not redefine `proxy_set_header` inside these locations.** Header
+  inheritance in nginx is per level: setting any one header in a location drops
+  every header inherited from the server block, including `X-Forwarded-For`.
+  Doing that on exactly the paths an AI client uses is worth avoiding. Inherit
+  them, and the entry count stays the same, so your
+  [`WPMGR_AUTH_PROXY_HOPS`](#proxy-hops) value is unaffected.
+
+`infra/nginx/nginx.conf` is the worked example, and
+`infra/nginx/routing_smoke_test.sh` is the test that proves the routing rather
+than just the status code.
+
 ### Postgres: two-DSN model and the `wpmgr_app` role
 
 WPMgr uses two Postgres connection strings:
@@ -259,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.147   # omit to track :latest
+export WPMGR_VERSION=v0.61.148   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 
@@ -377,7 +423,9 @@ Grafana then ships with the WPMgr dashboards pre-provisioned. See
   session secret, DB password, and S3 keys before any network-exposed deploy.
 - Put a TLS-terminating reverse proxy (the bundled `infra/nginx/` config, or
   your own) in front of the published API port (`WPMGR_API_PORT`, default
-  `:8081`) for production.
+  `:8081`) for production. If it is your own rather than the bundled config,
+  see [Reverse proxy: paths that must reach the API](#proxy-paths) for the four
+  root-mounted paths an `/api/`-only rule will miss.
 - **First-run ownership requires the provisioning claim.** The dashboard Sign
   Up form cannot create the first account. `POST /auth/register` only grants
   ownership when the request carries the `X-Wpmgr-Bootstrap-Claim` header set

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.147
+  version: 0.61.148
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Control-plane-only release cut. Does not merge itself, does not tag: merge, then deploy, then owner QA, then tag last.

## Version surfaces

Five files move. The agent version triple (plugin header, `WPMGR_AGENT_VERSION`, `readme.txt` Stable tag) and the marketing hero badge deliberately do **not**, because `apps/agent` has no change since 0.61.147 and the badge names the agent version.

```
git diff --name-only 0c55c5c7..HEAD -- apps/agent/   # empty
```

Both gates clean, self-test first, statuses read unpiped:

```
bash scripts/check-version-surfaces_test.sh   # exit 0, 76 passed, 0 failed
bash scripts/check-version-surfaces.sh        # exit 0
node apps/marketing/scripts/check-copy.mjs    # exit 0
```

The guard confirms both halves in one run: hero badge on agent 0.61.147 matching the plugin, install surfaces on 0.61.148.

## Contents

- The AI connection surface is usable end to end: `/ai` page and connection wizard generating a per-client configuration block from a tested table, sidebar entry, connections list, revoke.
- Revoke now cascades to tokens, so a revoked client stops on its next request rather than at expiry.
- OAuth discovery documents, so a GUI client can find the authorization endpoints itself.
- Bundled nginx and the dev proxy now forward the MCP endpoint and the discovery paths.
- The production load-balancer url-map is in the repo with a CI route-coverage check.

## Operator notes placed

1. The four root-mounted paths a self-hosted operator must forward through their **own** reverse proxy now have a linkable section in `docs/install.md` (`#proxy-paths`), next to the existing proxy material, with a pointer from the First-run notes reverse-proxy bullet. An operator configuring a proxy reads the install guide, not the changelog; the changelog carries the same list for upgraders.
2. 0.61.147's session-secret rotation guidance is **not** superseded. The Security section points at that entry by name, so an operator going from 0.61.146 straight to 0.61.148 who reads only the newest entry still sees it.

## Note on one Security line

One item is described as an improvement and not a mechanism. This entry is public before the deploy that carries it, so the detail waits for the deploy.