### PR TITLE
feat(db): m127 — MCP grant absolute expiry, idle expiry and capability set

### DIFF
--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -268,11 +268,29 @@ RETURNING *;
 -- either gets 23502 rather than a live organisation-wide grant (Decision 1).
 -- The caller passes status explicitly -- 'active' -- rather than relying on the
 -- schema to assume it.
+--
+-- m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+-- columns behave the same way: a caller that omits capabilities or expires_at
+-- gets 23502, NOT an unrestricted or never-expiring connection.
+--
+-- THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+-- CreateMCPGrantParams is a named-field struct literal at
+-- internal/mcp/service.go:570 and in three integration fixtures, so adding
+-- fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+-- which is NULL, which is refused at the INSERT. backend-architect must supply
+-- all three. A loud 23502 at creation is the correct failure and is strictly
+-- better than the alternative of a DEFAULT that quietly mints a credential
+-- nobody chose the terms of.
+--
+-- idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+-- meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+-- only safe one until TouchMCPGrantInTenantTx has a caller.
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, capabilities, expires_at,
+    idle_expire_after_days
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING *;
 
@@ -483,6 +501,21 @@ WHERE mcp_connection_tokens.token_hash = $1;
 -- The grant is joined on tenant_id as well as id: the token and its grant must
 -- belong to the same organisation, checked in the join rather than assumed
 -- from the foreign key.
+-- m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+-- a second read the caller might forget. A grant past its absolute expiry, or
+-- past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+-- Both are evaluated on the already-fetched grant row, so neither costs a round
+-- trip and neither needs an index.
+--
+-- The wireframe's "there is no silent read-only period" is a consequence of
+-- this shape: expiry flips one boolean to false outright and cannot degrade a
+-- connection to a reduced capability set, because there is one boolean here and
+-- not a tier.
+--
+-- g.capabilities is returned so the capability set is read from the SAME ROW
+-- and the SAME transaction as the verdict it was authorized under (S7's exit
+-- gate: discovery never grants what the registry does not hold, and it cannot
+-- hold what this row does not carry).
 SELECT
     g.id                          AS grant_id,
     g.name                        AS grant_name,
@@ -491,17 +524,47 @@ SELECT
     g.scope_tag_ids               AS scope_tag_ids,
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
+    g.capabilities                AS grant_capabilities,
+    g.expires_at                  AS grant_expires_at,
+    g.idle_expire_after_days      AS grant_idle_expire_after_days,
+    g.last_used_at                AS grant_last_used_at,
     t.id                          AS token_id,
     t.token_prefix                AS token_prefix,
     t.status                      AS token_status,
     t.expires_at                  AS token_expires_at,
+    -- The component reasons, so a refusal can be logged with its cause. Both
+    -- COALESCE to TRUE -- the FAIL-CLOSED direction for a negative flag, since
+    -- these say "expired". An absent value must never read as "still valid".
+    -- They are diagnostics; `authorized` below is the verdict.
+    COALESCE(g.expires_at <= now(), true)::boolean AS grant_absolute_expired,
+    COALESCE(g.idle_expire_after_days IS NOT NULL
+        AND COALESCE(g.last_used_at, g.created_at)
+            + make_interval(days => g.idle_expire_after_days) <= now(),
+        true)::boolean AS grant_idle_expired,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
     -- how a nil comes to be read as anything other than refusal.
     COALESCE(g.status = 'active'
         AND t.status = 'active'
-        AND (t.expires_at IS NULL OR t.expires_at > now()), false)::boolean AS authorized
+        AND (t.expires_at IS NULL OR t.expires_at > now())
+        -- ABSOLUTE EXPIRY. NO `IS NULL OR` BRANCH, and its absence is the
+        -- point: mcp_grants.expires_at is NOT NULL (m127 DECISION 2), so
+        -- unlike t.expires_at above there is no nullable case here for a
+        -- reader to get backwards.
+        AND g.expires_at > now()
+        -- IDLE EXPIRY. NULL means never idle-expire, which is a DIFFERENT fact
+        -- from the absolute expiry above and is why the NULL branch appears on
+        -- this line and not that one. coalesce(last_used_at, created_at):
+        -- a grant never used is idle since it was created.
+        --
+        -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
+        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
+        -- NULL and this collapses to created_at + N days for every row.
+        AND (g.idle_expire_after_days IS NULL
+             OR COALESCE(g.last_used_at, g.created_at)
+                + make_interval(days => g.idle_expire_after_days) > now()),
+        false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5641,6 +5641,37 @@ CREATE TABLE mcp_grants (
             AND cardinality(scope_site_ids) > 0
             AND cardinality(scope_tag_ids) = 0)
     ),
+    -- WHICH TOOLS this grant may reach (m127 DECISION 1). NOT NULL, NO
+    -- DEFAULT: a nullable capabilities column read as "no narrowing applied,
+    -- therefore everything" is the defect this surface exists to prevent. '{}'
+    -- is legal and means zero capabilities, which reaches no tool.
+    --
+    -- Deliberately the OPPOSITE of api_keys.capabilities, which is nullable --
+    -- that column had a `role` fallback and a live fleet to avoid stripping at
+    -- boot; this one has no second source of authority, so NULL would only
+    -- mean "unknown", and an unknown grant is refused.
+    capabilities text[] NOT NULL,
+    -- Shape, exactly as m120 checks api_keys.capabilities: one dimension (a
+    -- nested literal would be flattened by unnest() into capabilities nobody
+    -- granted), no NULL element, no empty string, and the 64 ceiling the
+    -- wireframe states as a property of the credential.
+    CONSTRAINT mcp_grants_capabilities_shape_check CHECK (
+        coalesce(array_ndims(capabilities), 1) = 1
+        AND cardinality(capabilities) <= 64
+        AND array_position(capabilities, NULL) IS NULL
+        AND NOT ('' = ANY (capabilities))
+    ),
+    -- CLOSED VOCABULARY, checked against the registry by name. This is S7's
+    -- exit gate -- discovery never grants what the registry does not hold --
+    -- pushed into the one place a call site cannot forget.
+    --
+    -- Keep in lockstep with capabilityVocabulary in internal/mcp/policy.go,
+    -- which holds exactly this one entry today. EXTENDING IT IS A MIGRATION,
+    -- and that coupling is the review gate m124 DECISION 1 asked for: a write
+    -- capability cannot reach this table until someone writes a migration
+    -- naming it. Adding a Capability to policy.go alone fails 23514 on INSERT.
+    CONSTRAINT mcp_grants_capabilities_vocabulary_check
+        CHECK (capabilities <@ ARRAY['mcp.sites.read']::text[]),
     -- The registered OAuth client, or NULL on the headless token path. No
     -- foreign key: neither ON DELETE action is right for a recorded fact.
     client_id text NULL,
@@ -5656,7 +5687,40 @@ CREATE TABLE mcp_grants (
     last_used_at timestamptz NULL,
     revoked_at   timestamptz NULL,
     CONSTRAINT mcp_grants_revoked_at_matches_status_check
-        CHECK ((status = 'revoked') = (revoked_at IS NOT NULL))
+        CHECK ((status = 'revoked') = (revoked_at IS NOT NULL)),
+
+    -- ABSOLUTE EXPIRY (m127 DECISION 2). NOT NULL, NO DEFAULT. NULL IS
+    -- UNREPRESENTABLE -- not "NULL means never". Step 5 of the wireframe offers
+    -- 30 days / 90 days / 1 year / on a date and NO "never" option, so a
+    -- never-expiring connection is not a thing the product offers and not a
+    -- thing the schema can hold. The point of NOT NULL here is that the
+    -- read-time predicate has NO NULL BRANCH for a caller to get backwards.
+    expires_at timestamptz NOT NULL,
+    -- A grant cannot be born already expired. Immediate termination is
+    -- REVOCATION (status = 'revoked'), not a backdated expiry; keeping the two
+    -- mechanisms distinct is what keeps revoked_at honest.
+    CONSTRAINT mcp_grants_expires_at_after_created_check
+        CHECK (expires_at > created_at),
+
+    -- IDLE EXPIRY (m127 DECISION 2), a WINDOW LENGTH IN DAYS and not an
+    -- instant. NULL MEANS NEVER IDLE-EXPIRE, and only that -- Step 5's second
+    -- control does offer "Never" beside 30 and 90 days, so this axis has three
+    -- states and the third is representable. The deadline is computed at read
+    -- time from coalesce(last_used_at, created_at) so it moves whenever the
+    -- connection is used, which is what "expire it if unused for N days" means.
+    --
+    -- WARNING (m127 DECISION 4): mcp_grants.last_used_at IS NEVER WRITTEN
+    -- TODAY. TouchMCPGrantInTenantTx has zero Go callers, so
+    -- coalesce(last_used_at, created_at) collapses to created_at permanently.
+    -- A non-NULL value here would therefore kill every affected connection N
+    -- days after CREATION however active it is. NULL with no default is what
+    -- makes that unreachable. Wiring the activity stamp is a PREREQUISITE of
+    -- writing this column, not a follow-up.
+    idle_expire_after_days integer NULL,
+    CONSTRAINT mcp_grants_idle_expire_after_days_check CHECK (
+        idle_expire_after_days IS NULL
+        OR (idle_expire_after_days >= 1 AND idle_expire_after_days <= 3650)
+    )
 );
 
 -- "Is this grant live right now" in one indexed read.

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -188,22 +188,26 @@ const createMCPGrant = `-- name: CreateMCPGrant :one
 
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, capabilities, expires_at,
+    idle_expire_after_days
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days
 `
 
 type CreateMCPGrantParams struct {
-	TenantID        uuid.UUID   `json:"tenant_id"`
-	Name            string      `json:"name"`
-	Status          string      `json:"status"`
-	SiteScopeMode   string      `json:"site_scope_mode"`
-	ScopeTagIds     []uuid.UUID `json:"scope_tag_ids"`
-	ScopeSiteIds    []uuid.UUID `json:"scope_site_ids"`
-	ClientID        *string     `json:"client_id"`
-	CreatedByUserID pgtype.UUID `json:"created_by_user_id"`
+	TenantID            uuid.UUID   `json:"tenant_id"`
+	Name                string      `json:"name"`
+	Status              string      `json:"status"`
+	SiteScopeMode       string      `json:"site_scope_mode"`
+	ScopeTagIds         []uuid.UUID `json:"scope_tag_ids"`
+	ScopeSiteIds        []uuid.UUID `json:"scope_site_ids"`
+	ClientID            *string     `json:"client_id"`
+	CreatedByUserID     pgtype.UUID `json:"created_by_user_id"`
+	Capabilities        []string    `json:"capabilities"`
+	ExpiresAt           time.Time   `json:"expires_at"`
+	IdleExpireAfterDays *int32      `json:"idle_expire_after_days"`
 }
 
 // ===========================================================================
@@ -231,6 +235,23 @@ type CreateMCPGrantParams struct {
 // either gets 23502 rather than a live organisation-wide grant (Decision 1).
 // The caller passes status explicitly -- 'active' -- rather than relying on the
 // schema to assume it.
+//
+// m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+// columns behave the same way: a caller that omits capabilities or expires_at
+// gets 23502, NOT an unrestricted or never-expiring connection.
+//
+// THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+// CreateMCPGrantParams is a named-field struct literal at
+// internal/mcp/service.go:570 and in three integration fixtures, so adding
+// fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+// which is NULL, which is refused at the INSERT. backend-architect must supply
+// all three. A loud 23502 at creation is the correct failure and is strictly
+// better than the alternative of a DEFAULT that quietly mints a credential
+// nobody chose the terms of.
+//
+// idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+// only safe one until TouchMCPGrantInTenantTx has a caller.
 func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error) {
 	row := q.db.QueryRow(ctx, createMCPGrant,
 		arg.TenantID,
@@ -241,6 +262,9 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		arg.ScopeSiteIds,
 		arg.ClientID,
 		arg.CreatedByUserID,
+		arg.Capabilities,
+		arg.ExpiresAt,
+		arg.IdleExpireAfterDays,
 	)
 	var i McpGrant
 	err := row.Scan(
@@ -251,6 +275,7 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -260,6 +285,8 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }
@@ -413,7 +440,7 @@ func (q *Queries) GetMCPConnectionTokenByHashForLookup(ctx context.Context, toke
 }
 
 const getMCPGrant = `-- name: GetMCPGrant :one
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days FROM mcp_grants
 WHERE tenant_id = $1 AND id = $2
 `
 
@@ -436,6 +463,7 @@ func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGr
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -445,6 +473,8 @@ func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGr
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }
@@ -531,7 +561,7 @@ func (q *Queries) ListMCPConnectionTokensForGrant(ctx context.Context, arg ListM
 }
 
 const listMCPGrantsForOrg = `-- name: ListMCPGrantsForOrg :many
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days FROM mcp_grants
 WHERE tenant_id = $1
 ORDER BY created_at DESC, id DESC
 `
@@ -563,6 +593,7 @@ func (q *Queries) ListMCPGrantsForOrg(ctx context.Context, tenantID uuid.UUID) (
 			&i.SiteScopeMode,
 			&i.ScopeTagIds,
 			&i.ScopeSiteIds,
+			&i.Capabilities,
 			&i.ClientID,
 			&i.ClientName,
 			&i.ClientVersion,
@@ -572,6 +603,8 @@ func (q *Queries) ListMCPGrantsForOrg(ctx context.Context, tenantID uuid.UUID) (
 			&i.CreatedAt,
 			&i.LastUsedAt,
 			&i.RevokedAt,
+			&i.ExpiresAt,
+			&i.IdleExpireAfterDays,
 		); err != nil {
 			return nil, err
 		}
@@ -592,17 +625,47 @@ SELECT
     g.scope_tag_ids               AS scope_tag_ids,
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
+    g.capabilities                AS grant_capabilities,
+    g.expires_at                  AS grant_expires_at,
+    g.idle_expire_after_days      AS grant_idle_expire_after_days,
+    g.last_used_at                AS grant_last_used_at,
     t.id                          AS token_id,
     t.token_prefix                AS token_prefix,
     t.status                      AS token_status,
     t.expires_at                  AS token_expires_at,
+    -- The component reasons, so a refusal can be logged with its cause. Both
+    -- COALESCE to TRUE -- the FAIL-CLOSED direction for a negative flag, since
+    -- these say "expired". An absent value must never read as "still valid".
+    -- They are diagnostics; ` + "`" + `authorized` + "`" + ` below is the verdict.
+    COALESCE(g.expires_at <= now(), true)::boolean AS grant_absolute_expired,
+    COALESCE(g.idle_expire_after_days IS NOT NULL
+        AND COALESCE(g.last_used_at, g.created_at)
+            + make_interval(days => g.idle_expire_after_days) <= now(),
+        true)::boolean AS grant_idle_expired,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
     -- how a nil comes to be read as anything other than refusal.
     COALESCE(g.status = 'active'
         AND t.status = 'active'
-        AND (t.expires_at IS NULL OR t.expires_at > now()), false)::boolean AS authorized
+        AND (t.expires_at IS NULL OR t.expires_at > now())
+        -- ABSOLUTE EXPIRY. NO ` + "`" + `IS NULL OR` + "`" + ` BRANCH, and its absence is the
+        -- point: mcp_grants.expires_at is NOT NULL (m127 DECISION 2), so
+        -- unlike t.expires_at above there is no nullable case here for a
+        -- reader to get backwards.
+        AND g.expires_at > now()
+        -- IDLE EXPIRY. NULL means never idle-expire, which is a DIFFERENT fact
+        -- from the absolute expiry above and is why the NULL branch appears on
+        -- this line and not that one. coalesce(last_used_at, created_at):
+        -- a grant never used is idle since it was created.
+        --
+        -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
+        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
+        -- NULL and this collapses to created_at + N days for every row.
+        AND (g.idle_expire_after_days IS NULL
+             OR COALESCE(g.last_used_at, g.created_at)
+                + make_interval(days => g.idle_expire_after_days) > now()),
+        false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id
@@ -615,18 +678,24 @@ type ReCheckMCPRequestAuthorizationInTenantTxParams struct {
 }
 
 type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
-	GrantID        uuid.UUID          `json:"grant_id"`
-	GrantName      string             `json:"grant_name"`
-	GrantStatus    string             `json:"grant_status"`
-	SiteScopeMode  string             `json:"site_scope_mode"`
-	ScopeTagIds    []uuid.UUID        `json:"scope_tag_ids"`
-	ScopeSiteIds   []uuid.UUID        `json:"scope_site_ids"`
-	ClientID       *string            `json:"client_id"`
-	TokenID        uuid.UUID          `json:"token_id"`
-	TokenPrefix    string             `json:"token_prefix"`
-	TokenStatus    string             `json:"token_status"`
-	TokenExpiresAt pgtype.Timestamptz `json:"token_expires_at"`
-	Authorized     bool               `json:"authorized"`
+	GrantID                  uuid.UUID          `json:"grant_id"`
+	GrantName                string             `json:"grant_name"`
+	GrantStatus              string             `json:"grant_status"`
+	SiteScopeMode            string             `json:"site_scope_mode"`
+	ScopeTagIds              []uuid.UUID        `json:"scope_tag_ids"`
+	ScopeSiteIds             []uuid.UUID        `json:"scope_site_ids"`
+	ClientID                 *string            `json:"client_id"`
+	GrantCapabilities        []string           `json:"grant_capabilities"`
+	GrantExpiresAt           time.Time          `json:"grant_expires_at"`
+	GrantIdleExpireAfterDays *int32             `json:"grant_idle_expire_after_days"`
+	GrantLastUsedAt          pgtype.Timestamptz `json:"grant_last_used_at"`
+	TokenID                  uuid.UUID          `json:"token_id"`
+	TokenPrefix              string             `json:"token_prefix"`
+	TokenStatus              string             `json:"token_status"`
+	TokenExpiresAt           pgtype.Timestamptz `json:"token_expires_at"`
+	GrantAbsoluteExpired     bool               `json:"grant_absolute_expired"`
+	GrantIdleExpired         bool               `json:"grant_idle_expired"`
+	Authorized               bool               `json:"authorized"`
 }
 
 // Runs InTenantTx with the tenant the lookup above established. STEP 2 OF 2,
@@ -649,6 +718,21 @@ type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
 // The grant is joined on tenant_id as well as id: the token and its grant must
 // belong to the same organisation, checked in the join rather than assumed
 // from the foreign key.
+// m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+// a second read the caller might forget. A grant past its absolute expiry, or
+// past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+// Both are evaluated on the already-fetched grant row, so neither costs a round
+// trip and neither needs an index.
+//
+// The wireframe's "there is no silent read-only period" is a consequence of
+// this shape: expiry flips one boolean to false outright and cannot degrade a
+// connection to a reduced capability set, because there is one boolean here and
+// not a tier.
+//
+// g.capabilities is returned so the capability set is read from the SAME ROW
+// and the SAME transaction as the verdict it was authorized under (S7's exit
+// gate: discovery never grants what the registry does not hold, and it cannot
+// hold what this row does not carry).
 func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error) {
 	row := q.db.QueryRow(ctx, reCheckMCPRequestAuthorizationInTenantTx, arg.TenantID, arg.ID)
 	var i ReCheckMCPRequestAuthorizationInTenantTxRow
@@ -660,10 +744,16 @@ func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, 
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
 		&i.ClientID,
+		&i.GrantCapabilities,
+		&i.GrantExpiresAt,
+		&i.GrantIdleExpireAfterDays,
+		&i.GrantLastUsedAt,
 		&i.TokenID,
 		&i.TokenPrefix,
 		&i.TokenStatus,
 		&i.TokenExpiresAt,
+		&i.GrantAbsoluteExpired,
+		&i.GrantIdleExpired,
 		&i.Authorized,
 	)
 	return i, err
@@ -676,7 +766,7 @@ SET client_name                 = $3,
     protocol_version            = $5,
     client_identity_recorded_at = now()
 WHERE tenant_id = $1 AND id = $2
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days
 `
 
 type RecordMCPGrantClientIdentityInTenantTxParams struct {
@@ -714,6 +804,7 @@ func (q *Queries) RecordMCPGrantClientIdentityInTenantTx(ctx context.Context, ar
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -723,6 +814,8 @@ func (q *Queries) RecordMCPGrantClientIdentityInTenantTx(ctx context.Context, ar
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -486,6 +486,7 @@ type McpGrant struct {
 	SiteScopeMode            string             `json:"site_scope_mode"`
 	ScopeTagIds              []uuid.UUID        `json:"scope_tag_ids"`
 	ScopeSiteIds             []uuid.UUID        `json:"scope_site_ids"`
+	Capabilities             []string           `json:"capabilities"`
 	ClientID                 *string            `json:"client_id"`
 	ClientName               *string            `json:"client_name"`
 	ClientVersion            *string            `json:"client_version"`
@@ -495,6 +496,8 @@ type McpGrant struct {
 	CreatedAt                time.Time          `json:"created_at"`
 	LastUsedAt               pgtype.Timestamptz `json:"last_used_at"`
 	RevokedAt                pgtype.Timestamptz `json:"revoked_at"`
+	ExpiresAt                time.Time          `json:"expires_at"`
+	IdleExpireAfterDays      *int32             `json:"idle_expire_after_days"`
 }
 
 type McpOauthClient struct {

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -614,6 +614,23 @@ type Querier interface {
 	// either gets 23502 rather than a live organisation-wide grant (Decision 1).
 	// The caller passes status explicitly -- 'active' -- rather than relying on the
 	// schema to assume it.
+	//
+	// m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+	// columns behave the same way: a caller that omits capabilities or expires_at
+	// gets 23502, NOT an unrestricted or never-expiring connection.
+	//
+	// THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+	// CreateMCPGrantParams is a named-field struct literal at
+	// internal/mcp/service.go:570 and in three integration fixtures, so adding
+	// fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+	// which is NULL, which is refused at the INSERT. backend-architect must supply
+	// all three. A loud 23502 at creation is the correct failure and is strictly
+	// better than the alternative of a DEFAULT that quietly mints a credential
+	// nobody chose the terms of.
+	//
+	// idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+	// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+	// only safe one until TouchMCPGrantInTenantTx has a caller.
 	CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error)
 	// ---------------------------------------------------------------------------
 	// backup_manifest_entries
@@ -3066,6 +3083,21 @@ type Querier interface {
 	// The grant is joined on tenant_id as well as id: the token and its grant must
 	// belong to the same organisation, checked in the join rather than assumed
 	// from the foreign key.
+	// m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+	// a second read the caller might forget. A grant past its absolute expiry, or
+	// past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+	// Both are evaluated on the already-fetched grant row, so neither costs a round
+	// trip and neither needs an index.
+	//
+	// The wireframe's "there is no silent read-only period" is a consequence of
+	// this shape: expiry flips one boolean to false outright and cannot degrade a
+	// connection to a reduced capability set, because there is one boolean here and
+	// not a tier.
+	//
+	// g.capabilities is returned so the capability set is read from the SAME ROW
+	// and the SAME transaction as the verdict it was authorized under (S7's exit
+	// gate: discovery never grants what the registry does not hold, and it cannot
+	// hold what this row does not carry).
 	ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error)
 	RecolorTag(ctx context.Context, arg RecolorTagParams) (SiteTag, error)
 	// Runs InTenantTx. Decision 10: there are TWO distinguishable absences in the

--- a/apps/api/migrations/20260829000000_m127_mcp_grant_expiry_capabilities.sql
+++ b/apps/api/migrations/20260829000000_m127_mcp_grant_expiry_capabilities.sql
@@ -1,0 +1,439 @@
+-- m127 - ADR-064 S4/S5: give an MCP grant an ABSOLUTE EXPIRY, an IDLE EXPIRY
+-- and an EXPLICIT PER-CONNECTION CAPABILITY SET.
+--
+-- This migration CORRECTS NOTHING. It edits no applied migration, it re-runs no
+-- earlier backfill, and no database in any state needs converging onto it
+-- beyond the one-time backfill in step (0) below, which is described in
+-- DECISION 9. There is no m114/m115-shaped follow-up owed.
+--
+-- WHY IT EXISTS. The connection wizard shipped with 3 of the 10 steps the
+-- wireframes specify. Steps 4 (choose what it may do) and 5 (expiry and
+-- security) cannot be built at all, because mcp_grants has nowhere to put their
+-- data: no expiry of either kind, and no capability set. m124 DECISION 1
+-- declined to mint a capabilities column and said why; internal/mcp/service.go
+-- names the exact column this migration must add, in the comment at the
+-- OrgDefaultCapabilities call site:
+--
+--     "the COLUMN it would read from arrives with its own migration, NOT NULL,
+--      no default, closed CHECK, as DECISION 1 requires."
+--
+-- That is the specification for DECISION 1 below, written by the code that will
+-- read the column. This file implements it literally.
+--
+-- ===========================================================================
+-- DECISION 1: THE CAPABILITY SET IS NOT NULL, HAS NO DEFAULT, AND ITS
+--             VOCABULARY IS CLOSED BY CHECK
+-- ===========================================================================
+--
+-- m124 DECISION 1 established the rule for the site axis: absence must be
+-- UNREPRESENTABLE or must mean REFUSED, never permitted. The capability axis
+-- gets the same treatment, by three separate mechanisms, because a single
+-- NOT NULL is not enough.
+--
+--   a. NOT NULL WITH NO DEFAULT. A nullable capabilities column that Go reads
+--      as "no narrowing applied, therefore every capability" is the precise
+--      defect this whole surface has been fighting, and it is the one shape
+--      CapabilitySet's zero value was designed to make impossible in Go. The
+--      column now makes it impossible in the database too: a caller that omits
+--      capabilities gets 23502, not an unrestricted connection.
+--
+--      THIS IS DELIBERATELY THE OPPOSITE OF api_keys.capabilities AT m120,
+--      which is NULLABLE with no default. m120's reasoning does not transfer
+--      and m124 DECISION 1(c) already said why: api_keys had a live fleet of
+--      pre-existing rows whose authority came from a `role` column, so '{}'
+--      would have stripped every key in the fleet at boot and NULL had to mean
+--      "this key has no capability set at all". mcp_grants has no second
+--      source of authority to fall back to. There is nothing for NULL to mean
+--      here except "unknown", and an unknown grant is refused, so the value is
+--      not worth being able to store.
+--
+--   b. AN EMPTY ARRAY IS PERMITTED AND MEANS EXACTLY ZERO CAPABILITIES. It is
+--      the restrictive direction: a connection holding '{}' reaches no tool.
+--      CapabilitySet in internal/mcp/policy.go has the same property and no
+--      method answering "does this mean everything", so the two agree.
+--
+--   c. THE VOCABULARY IS CLOSED BY CHECK, against the registry, BY NAME. This
+--      is the mechanism S7's exit gate asks for -- discovery never grants what
+--      the registry does not hold -- pushed down to the one place that cannot
+--      be forgotten at a call site.
+--
+--      THE VOCABULARY IS `mcp.sites.read`, AND THAT IS THE WHOLE LIST TODAY.
+--      internal/mcp/policy.go declares capabilityVocabulary as a closed map
+--      with exactly that one entry, and CapSitesRead is commented "the only
+--      capability the Phase 1 surface has". The CHECK below admits that one
+--      string and nothing else.
+--
+--      THE WIREFRAMES NAME THREE GROUPS AND THIS CHECK ADMITS ONE, ON PURPOSE.
+--      Step 4 draws site.content.read, site.inventory.read and
+--      site.content.propose. None of those exist in the registry. Admitting a
+--      name the registry does not hold would store a capability that resolves
+--      to no tool -- a grant the operator believes they made and the surface
+--      silently does not honour, which is the same shape as the dropped scope
+--      token scope.go already refuses. So Step 4 can be built now and will
+--      honestly offer one group until each further group arrives WITH ITS OWN
+--      MIGRATION EXTENDING THIS CHECK.
+--
+--      THAT COUPLING IS THE POINT, NOT AN INCONVENIENCE. m124 DECISION 1
+--      declined a capabilities column specifically because it "would create the
+--      place a write capability could appear without a migration and without a
+--      review". The closed CHECK is what buys the column back without buying
+--      that hazard: a write capability cannot reach this table until someone
+--      writes a migration naming it, which is a reviewed artefact. Adding a
+--      Capability to policy.go alone is NOT sufficient and will fail 23514 at
+--      the INSERT.
+--
+--   d. THE CEILING IS 64, AND IT IS A PROPERTY OF THE CREDENTIAL. The wireframe
+--      says so in those words ("A connection holds at most 64", "The ceiling is
+--      a property of the credential, not a licence tier"), and it is the same
+--      figure m120 chose for api_keys.capabilities. Shape is otherwise checked
+--      exactly as m120 checks it -- one dimension, no NULL element, no empty
+--      string -- using only IMMUTABLE expressions so the constraint is valid in
+--      a CHECK.
+--
+--      NOT CHECKED: element uniqueness. Deduplication needs a subquery
+--      (cardinality vs. a DISTINCT unnest) and CHECK forbids one. A duplicate
+--      is harmless to a set-membership read and merely consumes ceiling; the
+--      API layer should dedupe before insert.
+--
+-- ===========================================================================
+-- DECISION 2: TWO EXPIRIES, AND NULL MEANS A DIFFERENT THING IN EACH
+-- ===========================================================================
+--
+-- Absolute expiry and idle expiry are DIFFERENT FACTS. The brief requires that
+-- a NULL in either must not read as the other, nor as "never expires" when the
+-- operator chose a date. They are stated separately here because they are
+-- stored differently, and the difference is taken straight from the wireframe.
+--
+--   expires_at timestamptz NOT NULL, NO DEFAULT.
+--     NULL IS UNREPRESENTABLE. Not "NULL means never" -- there is no NULL.
+--     Step 5 offers four choices: 30 days, 90 days, 1 year, On a date. THERE IS
+--     NO "NEVER" OPTION ON THIS CONTROL. A never-expiring connection is not a
+--     thing the product offers, so it is not a thing the schema can hold, and
+--     the read-time predicate in DECISION 3 therefore has NO NULL BRANCH FOR A
+--     CALLER TO GET BACKWARDS. That is the entire reason this column is NOT
+--     NULL rather than nullable-with-a-convention.
+--
+--   idle_expire_after_days integer NULL, NO DEFAULT.
+--     NULL MEANS NEVER IDLE-EXPIRE, and it means only that. Step 5's second
+--     control does offer "Never" alongside 30 days and 90 days, so this axis
+--     genuinely has three states and the third is representable. It is an
+--     INTERVAL LENGTH, not an instant: the deadline is computed at read time
+--     from the activity stamp, so it moves whenever the connection is used,
+--     which is what "expire it if unused for 30 days" means. Storing a
+--     precomputed idle deadline would require rewriting the row on every
+--     request and would be wrong the moment a request was not recorded.
+--
+--     Stored as a day count rather than an interval because the control offers
+--     whole days, an integer needs no pgtype.Interval at the Go boundary, and a
+--     day count cannot smuggle a month or a microsecond into a security
+--     deadline.
+--
+--   THE TWO ARE INDEPENDENT AND BOTH BIND. A grant is refused if it is past its
+--   absolute expiry OR past its idle deadline. Neither can rescue the other.
+--
+-- ===========================================================================
+-- DECISION 3: EXPIRY IS PART OF THE `authorized` VERDICT, NOT A SECOND READ
+-- ===========================================================================
+--
+-- ReCheckMCPRequestAuthorizationInTenantTx already runs on EVERY REQUEST and
+-- already returns `authorized` as the whole verdict in one column, "computed
+-- here so that no caller reassembles it". Both expiries join that predicate in
+-- this migration's companion change to db/query/mcp_connections.sql.
+--
+-- A GRANT PAST EITHER EXPIRY NOW FAILS THE SAME PREDICATE A REVOKED GRANT
+-- FAILS. It is one boolean, one index probe on a primary key, no extra round
+-- trip, and no opportunity for a caller to forget the check -- which is the
+-- brief's requirement that expiry be enforceable at the point of use, cheaply.
+--
+-- THE WIREFRAME'S "no silent read-only period" IS A CONSEQUENCE OF THIS SHAPE.
+-- Expiry flips `authorized` to false outright; it does not degrade the
+-- connection to a reduced capability set. There is no code path here that could
+-- produce a half-working connection, because there is one boolean and not a
+-- tier.
+--
+-- NO SWEEP JOB IS REQUIRED FOR ENFORCEMENT. Expiry is evaluated at read time
+-- against now(), so a grant stops working at the instant it expires whether or
+-- not any background worker ran. A sweep is needed only for the wireframe's
+-- courtesy email ("14 days and 1 day before") and, optionally, for flipping
+-- status to a terminal value for display. Neither is an enforcement dependency,
+-- and a sweep that fails to run must never be able to extend a credential.
+--
+-- NO NEW INDEX. The hot path reaches the grant by primary key through the join
+-- on t.grant_id, so both expiry predicates are evaluated on an already-fetched
+-- row and index nothing. mcp_grants_live_idx (partial on status = 'active')
+-- already serves the notification sweep's candidate scan. Adding an index on
+-- expires_at would earn nothing on either path.
+--
+-- ===========================================================================
+-- DECISION 4: IDLE EXPIRY READS coalesce(last_used_at, created_at), AND IT IS
+--             INERT BY CONSTRUCTION UNTIL THE ACTIVITY STAMP IS WIRED
+-- ===========================================================================
+--
+-- THIS IS THE MOST DANGEROUS THING IN THIS MIGRATION AND IT IS WRITTEN DOWN
+-- RATHER THAN LEFT TO BE DISCOVERED.
+--
+-- mcp_grants.last_used_at IS NEVER WRITTEN TODAY. TouchMCPGrantInTenantTx
+-- exists in db/query/mcp_connections.sql, generates cleanly, and HAS ZERO GO
+-- CALLERS:
+--
+--   grep -rn "TouchMCPGrant" apps/api --include="*.go" | grep -v "internal/db/sqlc/"
+--     -> 0 matches
+--
+-- TouchMCPConnectionTokenInTenantTx is in the same state, also 0 callers. So
+-- every mcp_grants row in existence has last_used_at IS NULL regardless of how
+-- heavily its connection is used.
+--
+-- CONSEQUENCE, STATED PLAINLY: if a non-NULL idle_expire_after_days is ever
+-- written while the stamp is still unwired, coalesce(last_used_at, created_at)
+-- collapses to created_at permanently, and EVERY AFFECTED CONNECTION DIES
+-- idle_expire_after_days AFTER IT WAS CREATED NO MATTER HOW ACTIVE IT IS. With
+-- the wireframe's pre-selected 30 days that is a fleet-wide outage of every AI
+-- connection, thirty days after this ships, with no operator action and nothing
+-- in any log naming the cause.
+--
+-- THE SCHEMA IS SAFE BY CONSTRUCTION AGAINST THAT, AND ONLY BY CONSTRUCTION:
+-- idle_expire_after_days is NULL with NO DEFAULT, and NULL means never
+-- idle-expire, so no existing row and no row inserted by a caller that does not
+-- mention the column can idle-expire. The hazard is unreachable until Go
+-- deliberately writes a value into it.
+--
+-- THE ORDERING CONSTRAINT THIS PLACES ON backend-architect IS HARD:
+-- TouchMCPGrantInTenantTx must be called on the request path BEFORE the API is
+-- allowed to persist any non-NULL idle_expire_after_days. Wiring the stamp is a
+-- prerequisite of Step 5's second control, not a follow-up to it.
+--
+-- coalesce(last_used_at, created_at) is the right expression once the stamp is
+-- live -- a grant that has never been used is idle since it was created, which
+-- is precisely the credential the wireframe is aimed at ("a connection nobody
+-- has used in a month is a credential nobody is watching") -- and it is also
+-- what makes the unwired state degrade to "expires at created_at + N" rather
+-- than to something unbounded. It fails CLOSED, which is why the outage above
+-- is an outage and not a silent extension of every credential. That is the
+-- correct direction and it is still an outage.
+--
+-- ===========================================================================
+-- DECISION 5: RLS IS INHERITED, NOT ADDED, AND WHICH DISPATCH HELPER BINDS IT
+-- ===========================================================================
+--
+-- THIS MIGRATION CREATES NO TABLE AND NO POLICY. It adds three columns to
+-- mcp_grants, which m124 already put under ENABLE plus FORCE ROW LEVEL
+-- SECURITY with five policies: the permissive mcp_grants_tenant_isolation and
+-- the four RESTRICTIVE mcp_grants_site_scope_{select,insert,update,delete}.
+-- RLS filters ROWS, not columns, so a new column on a protected table is
+-- protected by the existing policies with no further statement. Adding a
+-- redundant policy here would be a second thing to keep in sync.
+--
+-- NO ROW IS OWED IN db/rls-cross-tenant-policies.txt. That ledger records
+-- policies that grant access ACROSS tenants. Every policy on mcp_grants is
+-- tenant-isolated, none of them is cross-tenant, and this migration adds no
+-- policy of any kind. The ledger is unchanged and check-rls-cross-tenant.sh
+-- must stay green without an edit.
+--
+-- WHICH DISPATCH HELPER A CALLER MUST USE: db.RunTenantTx, ALWAYS, AND THAT IS
+-- A CORRECTNESS REQUIREMENT AND NOT A CONVENTION. The four site_scope policies
+-- are RESTRICTIVE and each tests
+-- coalesce(current_setting('app.site_scope', true), '') <> 'on'. RunTenantTx
+-- (internal/db/db.go:772, dispatching through dispatchTenantTx at :755-763) is
+-- THE ONLY THING THAT SETS THAT GUC. A call site that picks InTenantTx,
+-- InTenantTxAsUser or InScopedTenantTx itself leaves it unset, the coalesced
+-- empty string is not equal to 'on', THE RESTRICTIVE CHECK PASSES, and the
+-- statement proceeds with no error raised anywhere.
+--
+-- A live privilege escalation of exactly that shape was fixed in this area on
+-- 2026-08-30: a call site used InTenantTx directly, app.site_scope was never
+-- set, and the policy admitted the write. A POLICY THAT TESTS A GUC IS INERT ON
+-- ANY PATH THAT DOES NOT SET IT. Capabilities and expiry are now part of what a
+-- site-scoped collaborator must not be able to widen, so every write to these
+-- three columns inherits that requirement.
+--
+-- ===========================================================================
+-- DECISION 6: THE BACKFILL PRESERVES TODAY'S EFFECTIVE AUTHORITY EXACTLY, AND
+--             IS NOT A PERMISSIVE DEFAULT
+-- ===========================================================================
+--
+-- Two of the three columns are NOT NULL, and mcp_grants is no longer guaranteed
+-- empty -- m124 applied on 2026-08-26 and this file lands on 2026-08-29, so a
+-- production row may exist. m124 DECISION 1(c) explicitly rested on "these
+-- tables start empty, so no such backfill hazard exists"; THAT SENTENCE HAS
+-- EXPIRED and this migration must handle rows.
+--
+-- A DEFAULT CLAUSE AND A ONE-TIME BACKFILL ARE NOT THE SAME THING. No column
+-- below carries a DEFAULT. Step (0) sets a value on rows that already exist and
+-- then the NOT NULL is armed, so every FUTURE insert must still say. The
+-- distinction is the whole of constraint 1 in the brief.
+--
+--   capabilities -> ARRAY['mcp.sites.read'].
+--     THIS GRANTS NOTHING NEW AND IT IS NOT A WILDCARD. It is the exact,
+--     complete set every existing grant already holds, read off the code rather
+--     than chosen: internal/mcp/service.go resolves the capability set as
+--     OrgDefaultCapabilities(grantScopes()), grantScopes() returns exactly
+--     {ScopeRead} for every live grant by construction, and scopeCapabilities
+--     maps ScopeRead to exactly {CapSitesRead}. So the backfill writes down what
+--     the running system already computes. Any existing connection keeps working
+--     with precisely the authority it has today, and gains none.
+--
+--     '{}' WAS CONSIDERED AND REJECTED. It is the more restrictive value, but it
+--     would silently strip every existing connection to zero capabilities the
+--     moment backend-architect wires the read, which is an outage caused by a
+--     migration rather than by an operator decision -- and it would be an
+--     outage justified as safety while the safe-and-correct value was known and
+--     derivable. Fail-closed is the right default when the answer is unknown.
+--     Here it is known.
+--
+--   expires_at -> now() + interval '90 days'.
+--     90 days is the wireframe's pre-selected choice. now() AND NOT
+--     created_at + 90 days, deliberately: keying off created_at would make any
+--     grant older than 90 days expire the instant this migration applies,
+--     inside main() at boot, on every install at once. now() + 90 days cannot
+--     be in the past for any row, so no existing connection is killed by
+--     applying this file, and every operator gets a full 90 days of notice to
+--     choose a real expiry. This is the m110/m111 lesson: a backfill that can
+--     land a row in an invalid or hostile state is the thing that needs the
+--     repair migration.
+--
+--   idle_expire_after_days -> left NULL.
+--     Nothing to backfill. NULL is a legal, meaningful value on this column
+--     (never idle-expire) and it is the only safe one while DECISION 4's stamp
+--     is unwired.
+--
+-- EVERY STATEMENT BELOW IS IDEMPOTENT AND THE FILE IS RE-RUNNABLE. The backfill
+-- is guarded by IS NULL so a second application updates zero rows and cannot
+-- push an operator-chosen expiry 90 days into the future.
+
+-- ---------------------------------------------------------------------------
+-- (0) Columns, added nullable so existing rows survive the ALTER.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "capabilities" text[];
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "expires_at" timestamptz;
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "idle_expire_after_days" integer;
+
+-- ---------------------------------------------------------------------------
+-- (1) Backfill. WHERE ... IS NULL makes this a no-op on a second run and
+--     protects a value an operator has already chosen. See DECISION 6.
+-- ---------------------------------------------------------------------------
+
+UPDATE "public"."mcp_grants"
+   SET "capabilities" = ARRAY['mcp.sites.read']::text[]
+ WHERE "capabilities" IS NULL;
+
+UPDATE "public"."mcp_grants"
+   SET "expires_at" = now() + interval '90 days'
+ WHERE "expires_at" IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- (2) Arm NOT NULL, now that no row violates it. SET NOT NULL is a no-op when
+--     the column is already NOT NULL, so this is safe to re-run.
+--     idle_expire_after_days stays NULLABLE -- NULL is a real value there.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."mcp_grants"
+    ALTER COLUMN "capabilities" SET NOT NULL;
+
+ALTER TABLE "public"."mcp_grants"
+    ALTER COLUMN "expires_at" SET NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- (3) Constraints. Each guarded by a pg_constraint probe so the file re-runs.
+-- ---------------------------------------------------------------------------
+
+-- Shape of the capability set. m120's constraint verbatim in intent: one
+-- dimension (a literal like '{{a},{b}}' would otherwise be flattened by
+-- unnest() into capabilities nobody granted), no NULL element, no empty string,
+-- and the 64 ceiling the wireframe states. IMMUTABLE expressions only.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_capabilities_shape_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_capabilities_shape_check"
+            CHECK (
+                coalesce(array_ndims("capabilities"), 1) = 1
+                AND cardinality("capabilities") <= 64
+                AND array_position("capabilities", NULL) IS NULL
+                AND NOT ('' = ANY ("capabilities"))
+            );
+    END IF;
+END;
+$$;
+
+-- Closed vocabulary. See DECISION 1(c). `<@` is array containment and is
+-- IMMUTABLE; the empty array is contained by every array, so '{}' -- zero
+-- capabilities, the restrictive value -- passes, which is intended.
+--
+-- EXTENDING THIS LIST IS A MIGRATION, and that is the review gate m124
+-- DECISION 1 asked for. Keep it in lockstep with capabilityVocabulary in
+-- apps/api/internal/mcp/policy.go.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_capabilities_vocabulary_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_capabilities_vocabulary_check"
+            CHECK ("capabilities" <@ ARRAY['mcp.sites.read']::text[]);
+    END IF;
+END;
+$$;
+
+-- A grant cannot be born already expired. Nonsense rather than danger -- an
+-- already-expired grant fails the DECISION 3 predicate and is refused -- but it
+-- is unrepresentable rather than merely harmless, which is the house standard.
+-- Immediate termination is REVOCATION (status = 'revoked'), not a backdated
+-- expiry, and keeping the two mechanisms distinct keeps revoked_at honest.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_expires_at_after_created_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_expires_at_after_created_check"
+            CHECK ("expires_at" > "created_at");
+    END IF;
+END;
+$$;
+
+-- The idle window is a positive number of days, or NULL for "never". Zero is
+-- refused because "expire it if unused for 0 days" has no meaning and would
+-- read as an immediate kill dressed up as a policy; ten years is the ceiling
+-- so a fat-fingered value cannot become an effectively-absent control.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_idle_expire_after_days_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_idle_expire_after_days_check"
+            CHECK (
+                "idle_expire_after_days" IS NULL
+                OR ("idle_expire_after_days" >= 1
+                    AND "idle_expire_after_days" <= 3650)
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- (4) Grants.
+--
+-- Nothing to add. m1's ALTER DEFAULT PRIVILEGES and m124's explicit
+-- GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_grants TO wpmgr_app are
+-- table-level and cover columns added later; PostgreSQL has no per-column
+-- grant in force on this table that a new column could fall outside of. Stated
+-- rather than left silent, because "the new column is invisible to wpmgr_app"
+-- is the kind of failure that looks like an RLS bug for a day.
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds the storage ADR-064 Steps 4 and 5 need on `mcp_grants`. Schema only — no
handlers, no endpoints, no UI. `security-reviewer` follows; **do not merge.**

| column | null | meaning |
|---|---|---|
| `capabilities` | `NOT NULL`, no default, closed CHECK | which tools this connection may reach. `'{}'` is legal and means zero. |
| `expires_at` | `NOT NULL`, no default | absolute expiry. **NULL is unrepresentable** — Step 5 offers 30d / 90d / 1y / on a date and no "never". |
| `idle_expire_after_days` | `NULL` allowed, no default | a window length in days. **NULL means never idle-expire**, and only that — Step 5's second control does offer "Never". |

`internal/mcp/service.go` already specified this column at the
`OrgDefaultCapabilities` call site — *"the COLUMN it would read from arrives
with its own migration, NOT NULL, no default, closed CHECK, as DECISION 1
requires"* — and this implements it literally.

## Expiry is in the verdict, not a second read

Both expiries join `authorized` in `ReCheckMCPRequestAuthorizationInTenantTx`,
which already runs on every request. A grant past either expiry fails **the
same predicate a revoked grant fails**, on the already-fetched row, so no extra
round trip and no caller can forget it. `expires_at` deliberately has no
`IS NULL OR` branch — that absence is the point of `NOT NULL`.

The wireframe's *"no silent read-only period"* falls out of this: expiry flips
one boolean, and there is no tier here that could half-work.

**No sweep job is needed for enforcement.** A sweep is needed only for the
courtesy email (14 days / 1 day before). A sweep that fails to run must never
be able to extend a credential, and here it cannot.

## The vocabulary CHECK admits one name, on purpose

`capabilityVocabulary` in `internal/mcp/policy.go` holds exactly
`mcp.sites.read`. The CHECK admits that and nothing else. The wireframes draw
three groups (`site.content.read`, `site.inventory.read`,
`site.content.propose`); none exists in the registry, and admitting a name the
registry does not hold would store a grant the surface silently does not
honour — S7's exit gate. Each further group arrives with its own migration, and
that coupling is the review gate m124 DECISION 1 asked for when it declined to
mint this column at all.

## Backfill

`mcp_grants` is no longer guaranteed empty (m124 applied 2026-08-26), so
m124 DECISION 1(c)'s "these tables start empty" has expired.

- `capabilities` → `ARRAY['mcp.sites.read']`. **Not a wildcard**: it is exactly
  what the running system already computes for every grant via
  `OrgDefaultCapabilities(grantScopes())`, so nothing gains authority. `'{}'`
  was considered and rejected — it would strip every existing connection the
  moment the read is wired, an outage caused by a migration rather than an
  operator, while the correct value was known.
- `expires_at` → `now() + 90 days`, **not** `created_at + 90 days`: keying off
  `created_at` would expire any older grant the instant this applies, inside
  `main()` at boot, on every install at once.

No column carries a `DEFAULT`. A one-time backfill and a default clause are not
the same thing: every future insert must still say.

## RLS

Adds **no table and no policy**. `mcp_grants` is already `ENABLE` + `FORCE ROW
LEVEL SECURITY` with five policies, and RLS filters rows, not columns.
`db/rls-cross-tenant-policies.txt` is unchanged — it records cross-tenant
policies and none is added.

Callers must reach these columns through **`db.RunTenantTx`**, the only thing
that sets `app.site_scope`; the four RESTRICTIVE `mcp_grants_site_scope_*`
policies are inert on any path that does not.

## Proofs

Self-test before the guard:

```
scripts/check-rls-cross-tenant_test.sh   -> 54 passed, 0 failed
scripts/check-rls-cross-tenant.sh        -> 105 cross-tenant policies checked
                                            against 105 ledger rows, 0 errors
```

The guard applies all 136 migration files in lexical order, so it also proves
m127 applies in sequence.

Red/green as `wpmgr_app` (`rolsuper=f`, `rolbypassrls=f`), **one command, four
grants**:

```
    grant_name    | grant_status | grant_absolute_expired | grant_idle_expired | authorized
------------------+--------------+------------------------+--------------------+------------
 absolute-expired | active       | t                      | f                  | f
 idle-expired     | active       | f                      | t                  | f
 live             | active       | f                      | f                  | t
 revoked          | revoked      | f                      | f                  | f
```

Mutation test — each constraint dropped one at a time: **all 6 reddened, each
naming its own constraint**, and each row was accepted once only that
constraint was dropped.

## What `backend-architect` must now do

1. **Wire `TouchMCPGrantInTenantTx` before persisting any non-NULL
   `idle_expire_after_days`.** It has **zero Go callers** today
   (`grep -rn "TouchMCPGrant" apps/api --include="*.go" | grep -v internal/db/sqlc/`
   → 0), so `last_used_at` is never written and
   `coalesce(last_used_at, created_at)` collapses to `created_at` permanently.
   With the wireframe's pre-selected 30 days that is a fleet-wide outage of
   every AI connection 30 days after ship. The schema is safe only because the
   column is NULL with no default.
2. **Supply all three fields in `CreateMCPGrantParams`** at
   `internal/mcp/service.go:570` and in the three integration fixtures. It is a
   named-field struct literal, so the build stays green and the omission
   surfaces as `23502` at INSERT — the designed failure, not a silent default.
3. **Read `GrantCapabilities` from the verdict row** instead of
   `OrgDefaultCapabilities(grantScopes())`, closing gap 1 named in the
   `service.go` comment.
4. Decide where the 14-day / 1-day notification sweep lives. It needs a query
   this PR deliberately does not add, because a cross-tenant sweep would need a
   ledger row and a policy decision of its own.

## Integration suite: 10 tests red, one cause, and it is the designed one

```
make test-integration > /tmp/m127_integration.log 2>&1; echo "STATUS=$?"
  -> STATUS=2
grep -c "^--- FAIL" /tmp/m127_integration.log   -> 10
```

All 10 are MCP grant-creation tests in five files
(`adr064_s16_mcp_connections_integration_test.go`,
`adr064_s6b2_mcp_transport_rls_test.go`,
`adr064_s6b3_mcp_oauth_end_to_end_test.go`,
`adr064_s7_mcp_tool_registry_rls_test.go`,
`mcp_consent_org_scope_integration_test.go`). Five report the failure directly:

```
create mcp grant: ERROR: null value in column "capabilities"
  of relation "mcp_grants" violates not-null constraint (SQLSTATE 23502)
```

The other five report `consent answered 500, want 200` — the HTTP surface over
the same `CreateGrantWithCode` call at `internal/mcp/service.go:570`. No
failure has any other root cause, and no non-MCP package regressed.

**This is the designed behaviour, not a defect to route around.** It is m124
DECISION 1 applied to the new columns: a caller that does not say what a
credential may do, or when it stops, gets `23502` rather than an unrestricted
or never-expiring connection. The fixtures and `service.go:570` are `.go` files
and therefore `backend-architect`'s to change — see item 2 above. **The suite
goes green when the caller supplies `capabilities` and `expires_at`, and it
must not be made green by giving either column a default.**
