### PR TITLE
feat(web): wizard step 3, choose which sites a connection may touch

### DIFF
--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1,10 +1,57 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent, within } from "@testing-library/react";
 
 import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
 
 import { Route } from "@/routes/_authed/ai/connect";
 import { MCP_CLIENTS } from "./client-table";
+import { useSites, DEFAULT_SITES_LIMIT } from "@/features/sites/use-sites";
+import { useTags } from "@/features/tags/use-tags";
+import { snapshotFromPage } from "@/features/mcp-consent/site-scope";
+import { fleetTotal, scopeCountLabel } from "./site-step";
+import type { Site, SiteTag } from "@wpmgr/api";
+
+// Step 3 reads the fleet and the tag registry through the same two hooks the
+// consent screen uses, so they are mocked the same way (see
+// routes/_authed/-connect.ai.test.tsx). What matters on this screen is that a
+// FAILED read and an EMPTY one produce different screens, which is only
+// testable if the test can put the hook into each state deliberately.
+vi.mock("@/features/sites/use-sites", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/sites/use-sites")>();
+  return { ...actual, useSites: vi.fn() };
+});
+vi.mock("@/features/tags/use-tags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/tags/use-tags")>();
+  return { ...actual, useTags: vi.fn() };
+});
+
+const mockedSites = vi.mocked(useSites);
+const mockedTags = vi.mocked(useTags);
+
+function fakeSite(n: number, tags: string[] = []): Site {
+  return {
+    id: `s${n}`,
+    name: `site-${n}.example`,
+    url: `https://site-${n}.example`,
+    tags,
+  } as Site;
+}
+
+/** A loaded fleet of `count` sites, short of the page limit so it is complete. */
+function loadedFleet(count: number, tagsFor: (n: number) => string[] = () => []) {
+  mockedSites.mockReturnValue(
+    mockQueryResult<Site[]>({
+      data: Array.from({ length: count }, (_, i) => fakeSite(i, tagsFor(i))),
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadedFleet(0);
+  mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: [] }));
+});
 
 // The wizard, through the real route component, the real router and a real
 // QueryClient -- not by calling a hook or rendering a subcomponent in
@@ -205,6 +252,233 @@ describe("the wizard does not promise things it cannot deliver", () => {
     // or in dev the copied URL reaches the SPA. Saying nothing would hand
     // someone a web page and let them debug their AI client.
     expect(screen.getByText(/reverse proxy must forward \/mcp to the API/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 -- "Choose which sites this connection may touch"
+// ---------------------------------------------------------------------------
+
+/** Get as far as step 3, which needs a client and a method behind it. */
+async function reachSiteStep() {
+  renderWizard();
+  await pickClient("Claude Code");
+  fireEvent.click(authCard("oauth"));
+  return await screen.findByTestId("site-step-count");
+}
+
+describe("step 3 exists at all, and sits before capabilities", () => {
+  it("renders a site step between the method and the setup artefact", async () => {
+    await reachSiteStep();
+    // The three modes the schema permits, on screen, as one radiogroup.
+    const modes = screen.getByRole("radiogroup", { name: /site scope/i });
+    for (const label of ["All sites", "By tag", "Named sites"]) {
+      expect(within(modes).getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("names the ordering as a decision rather than leaving it implied", async () => {
+    await reachSiteStep();
+    expect(screen.getByText(/chosen before capabilities, on purpose/i)).toBeInTheDocument();
+  });
+
+  it("numbers the setup artefact after it, so the rail and the page agree", async () => {
+    await reachSiteStep();
+    expect(screen.getByRole("heading", { name: /^4\. Set it up$/ })).toBeInTheDocument();
+    // And the rail no longer claims sites are chosen somewhere else.
+    expect(screen.queryByText(/4\. Choose sites and permissions/i)).not.toBeInTheDocument();
+  });
+
+  it("does not invent a numbered step for capabilities, which has no backend", async () => {
+    await reachSiteStep();
+    expect(screen.queryByRole("heading", { name: /what this connection may do/i })).toBeNull();
+    expect(screen.getByText(/permissions are chosen on the approval screen/i)).toBeInTheDocument();
+  });
+});
+
+describe("the count, and the fleet size it is entitled to claim", () => {
+  it("opens on the wireframe's empty ratio against a fleet it could read", async () => {
+    loadedFleet(60);
+    const count = await reachSiteStep();
+
+    // Derived from the same function the component calls, so a reworded
+    // sentence does not redden this and a wrong NUMBER does.
+    const expected = scopeCountLabel(
+      { kind: "none", because: "no-selection" },
+      fleetTotal(snapshotFromPage(Array.from({ length: 60 }, () => null as never), DEFAULT_SITES_LIMIT)),
+    );
+    expect(count).toHaveTextContent(expected);
+    expect(count.textContent?.startsWith("0 of 60")).toBe(true);
+  });
+
+  it("counts up as sites are picked, and back down as they are removed", async () => {
+    loadedFleet(60);
+    await reachSiteStep();
+
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    const picker = await screen.findByTestId("site-step-picker");
+    const boxes = within(picker).getAllByRole("checkbox");
+    fireEvent.click(boxes[0]!);
+    fireEvent.click(boxes[1]!);
+    expect(screen.getByTestId("site-step-count").textContent?.startsWith("2 of 60")).toBe(true);
+
+    // The token is the removal affordance, and removing must move the count.
+    fireEvent.click(screen.getAllByRole("button", { name: /^remove /i })[0]!);
+    expect(screen.getByTestId("site-step-count").textContent?.startsWith("1 of 60")).toBe(true);
+  });
+
+  it("refuses to state a fleet size when the page it read came back full", async () => {
+    // A full page is byte-identical to a full page with more behind it, so the
+    // denominator is a floor and the copy has to say so.
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    const count = await reachSiteStep();
+    expect(count.textContent).toMatch(/at least/i);
+  });
+
+  it("states the fleet size plainly when the page was short", async () => {
+    loadedFleet(7);
+    const count = await reachSiteStep();
+    expect(count.textContent).not.toMatch(/at least/i);
+    expect(count.textContent?.startsWith("0 of 7")).toBe(true);
+  });
+});
+
+describe("an empty scope is a working state, not an error", () => {
+  it("says so in as many words, and styles nothing as a failure", async () => {
+    loadedFleet(60);
+    await reachSiteStep();
+
+    const empty = screen.getByTestId("site-step-empty");
+    expect(empty).toHaveTextContent(/working state, not an error/i);
+    expect(empty).toHaveTextContent(/read nothing and propose nothing/i);
+    // Not an alert, because it is not one. An empty scope announced by a
+    // screen reader as an error is the same defect as rendering it in red.
+    expect(screen.queryByTestId("site-step-blocked")).toBeNull();
+    expect(empty.getAttribute("role")).toBeNull();
+  });
+
+  it("does not block the wizard on it", async () => {
+    loadedFleet(60);
+    await reachSiteStep();
+    // The setup artefact is reachable with nothing selected. An earlier
+    // revision of this surface disabled Continue here; that is the behaviour
+    // being corrected.
+    expect(screen.getByRole("heading", { name: /^4\. Set it up$/ })).toBeInTheDocument();
+    expect(await screen.findByText(/"mcpServers"/)).toBeInTheDocument();
+  });
+});
+
+describe("a failed load is not an empty fleet", () => {
+  it("holds the step and says the list did not load, rather than showing a zero", async () => {
+    mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined }));
+    await reachSiteStep();
+
+    expect(screen.getByTestId("site-step-blocked")).toHaveTextContent(/could not read/i);
+    // And no count is asserted over the top of it.
+    expect(screen.getByTestId("site-step-count").textContent).not.toMatch(/\d/);
+    // The empty-state sentence must NOT appear: "you have chosen nothing" and
+    // "we could not read the list" are different facts.
+    expect(screen.queryByTestId("site-step-empty")).toBeNull();
+  });
+
+  it("offers no site picker to choose from when the fleet is unknown", async () => {
+    mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined }));
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    expect(await screen.findByTestId("site-step-sites-failed")).toHaveTextContent(
+      /not the same as having no sites/i,
+    );
+    expect(screen.queryByTestId("site-step-picker")).toBeNull();
+  });
+
+  it("distinguishes a failed tag registry from an organisation with no tags", async () => {
+    loadedFleet(3);
+    mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: undefined }));
+    await reachSiteStep();
+
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("By tag"));
+    fireEvent.click(screen.getByRole("button", { name: /add tags/i }));
+    expect(await screen.findByTestId("site-step-tags-failed")).toBeInTheDocument();
+    expect(screen.queryByTestId("site-step-tags-empty")).toBeNull();
+  });
+});
+
+describe("a tag matching nothing in a partial page is not a zero", () => {
+  it("holds the step rather than claiming the tag reaches no site", async () => {
+    // A full page, and a tag that matches nothing in it. We have not seen every
+    // site, so "matches nothing" is a claim we cannot make.
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ data: [{ id: "t1", name: "seo-2026" } as SiteTag] }),
+    );
+    await reachSiteStep();
+
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("By tag"));
+    fireEvent.click(screen.getByRole("button", { name: /add tags/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+
+    expect(screen.getByTestId("site-step-blocked")).toBeInTheDocument();
+    expect(screen.getByTestId("site-step-count").textContent).not.toMatch(/\d/);
+  });
+
+  it("resolves the tag to a real set when the fleet is fully in hand", async () => {
+    loadedFleet(10, (n) => (n < 4 ? ["client-retainer"] : []));
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ data: [{ id: "t1", name: "client-retainer" } as SiteTag] }),
+    );
+    await reachSiteStep();
+
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("By tag"));
+    fireEvent.click(screen.getByRole("button", { name: /add tags/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+
+    expect(screen.getByTestId("site-step-count").textContent?.startsWith("4 of 10")).toBe(true);
+    expect(screen.queryByTestId("site-step-blocked")).toBeNull();
+    // A tag is re-resolved per request, and the screen says so rather than
+    // letting the operator read the list as frozen.
+    expect(screen.getByText(/resolved to a site list at every request/i)).toBeInTheDocument();
+    // The token carries the tag: prefix so it cannot be misread as a hostname.
+    // Scoped to the field, because the picker below renders the same label.
+    expect(
+      within(screen.getByTestId("site-step-tokenfield")).getByText("tag:client-retainer"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("the picker discloses what it could not offer", () => {
+  it("warns that the choices are not all of them when the page came back full", async () => {
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    expect(await screen.findByTestId("site-step-picker-truncated")).toHaveTextContent(
+      /not all of them/i,
+    );
+  });
+
+  it("says nothing of the sort when it listed the whole fleet", async () => {
+    loadedFleet(9);
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    await screen.findByTestId("site-step-picker");
+    expect(screen.queryByTestId("site-step-picker-truncated")).toBeNull();
+  });
+
+  it("does not offer a never-reach count it cannot compute", async () => {
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+    expect(screen.queryByTestId("site-step-excluded")).toBeNull();
+  });
+});
+
+describe("the wizard does not promise to carry the scope it collected", () => {
+  it("says plainly that the approval screen asks again", async () => {
+    loadedFleet(5);
+    await reachSiteStep();
+    expect(
+      screen.getByText(/nothing carries this selection to the approval screen/i),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -19,6 +19,8 @@ import {
   type McpClientRow,
 } from "./client-table";
 import { buildSnippet, type Snippet } from "./snippet";
+import { SiteScopeStep, type SiteScopeSelection } from "./site-scope-step";
+import type { FleetSnapshot } from "@/features/mcp-consent/site-scope";
 
 // The connection wizard (design §18). Client first, method second.
 //
@@ -28,18 +30,27 @@ import { buildSnippet, type Snippet } from "./snippet";
 // generic 'unavailable'. Asking a user to choose an auth method their client
 // cannot use is asking them to fail."
 //
-// WHAT THIS RENDERS AND WHAT IT DOES NOT. Steps 1, 2, 5 and 6 live here. Steps
-// 3 and 4 -- which sites, what capabilities -- are collected on the approval
-// screen at /connect/ai, because that is where the grant is actually created
-// (features/mcp-consent/consent-screen.tsx). Duplicating them here would build
-// a second, unwired copy of a consent decision, and a wizard that appears to
-// grant scope it cannot grant is worse than one that says where the choice
-// happens. The step rail below says so on screen.
+// WHAT THIS RENDERS AND WHAT IT DOES NOT. Steps 1, 2, 3 and the setup artefact
+// live here. STEP 3 IS NEW AND IS A REAL DECISION SURFACE: the wireframe puts
+// "which sites" before "what it may do" on purpose, and mcp_grants already
+// carries site_scope_mode, scope_tag_ids and scope_site_ids, so nothing about
+// the selection is blocked on the backend.
+//
+// WHAT STEP 3 STILL CANNOT DO, SAID ON SCREEN RATHER THAN HIDDEN. The grant is
+// created by the approval screen at /connect/ai, which the CLIENT redirects
+// into; this wizard never calls it and has no channel to hand it an answer.
+// So the choice made here is the operator arriving with the answer, not the
+// answer being written. The same is already true of the connection name two
+// sections down, and it is stated the same way rather than implied.
+//
+// Step 4 (capabilities) and the token artefact are NOT stubbed here. Their
+// schema and their endpoint do not exist yet, and a disabled control for a
+// feature with no backend is a promise this file cannot keep.
 //
 // NO SNIPPET IS WRITTEN IN THIS FILE. Every block comes from buildSnippet, and
 // snippet.test.ts fails the build if a config literal appears here.
 
-type Step = 1 | 2 | 3;
+type Step = 1 | 2 | 3 | 4;
 
 interface StepDef {
   readonly n: Step;
@@ -49,20 +60,48 @@ interface StepDef {
 const STEPS: readonly StepDef[] = [
   { n: 1, label: "Pick your client" },
   { n: 2, label: "How it signs in" },
-  { n: 3, label: "Set it up" },
+  { n: 3, label: "Sites it may reach" },
+  { n: 4, label: "Set it up" },
 ];
 
 export interface ConnectWizardProps {
   /** Absolute MCP endpoint for this deployment. Passed in, never assembled here. */
   endpointUrl: string;
+  /**
+   * What the route loaded of the fleet, or null when the load has not finished
+   * or failed. NULL IS NOT AN EMPTY SNAPSHOT, and a full page is NOT a whole
+   * fleet. Both facts travel inside FleetSnapshot rather than being re-derived
+   * on this screen.
+   */
+  fleet: FleetSnapshot | null;
+  /** The tag registry, or null when we could not read it. Null is not empty. */
+  tags: readonly { readonly id: string; readonly name: string }[] | null;
+  tagsBySiteId: Readonly<Record<string, readonly string[]>>;
+  sitesLoading: boolean;
   /** Where the approval flow lives, for the closing instructions. */
   className?: string;
 }
 
-export function ConnectWizard({ endpointUrl, className }: ConnectWizardProps) {
+export function ConnectWizard({
+  endpointUrl,
+  fleet,
+  tags,
+  tagsBySiteId,
+  sitesLoading,
+  className,
+}: ConnectWizardProps) {
   const [clientId, setClientId] = useState<string | null>(null);
   const [method, setMethod] = useState<AuthMethod | null>(null);
   const [name, setName] = useState("Fleet manager");
+  // NO DEFAULT 'all'. The consent screen refuses one for the same reason
+  // (m124 DECISION 1) and so does the schema: a scope nobody chose must not
+  // begin life as the widest one. 'list' holding nothing is the wireframe's
+  // opening state, and it is empty on purpose.
+  const [selection, setSelection] = useState<SiteScopeSelection>({
+    mode: "list",
+    tagNames: [],
+    siteIds: [],
+  });
 
   const client = useMemo(
     () => MCP_CLIENTS.find((c) => c.id === clientId) ?? null,
@@ -161,6 +200,33 @@ export function ConnectWizard({ endpointUrl, className }: ConnectWizardProps) {
       {client !== null && method !== null ? (
         <Section
           n={3}
+          title="Sites this connection may reach"
+          hint="Chosen before capabilities, on purpose. What a connection may do is only meaningful once you have fixed what it may do it to."
+        >
+          <SiteScopeStep
+            selection={selection}
+            onSelectionChange={setSelection}
+            fleet={fleet}
+            tags={tags}
+            tagsBySiteId={tagsBySiteId}
+            sitesLoading={sitesLoading}
+          />
+          {/* The same correction as the name field below, for the same reason.
+              The client opens the approval screen itself, so this page has no
+              channel into it and cannot hand it a scope. Deciding it here is
+              how you arrive with the answer; the approval screen is where it
+              is written, and it asks again. */}
+          <p className="mt-3 text-xs text-[var(--color-muted-foreground)]">
+            Nothing carries this selection to the approval screen. The client opens that
+            screen itself, so it asks for the scope again and that is where it is written.
+            Deciding it here is how you get there with the answer ready.
+          </p>
+        </Section>
+      ) : null}
+
+      {client !== null && method !== null ? (
+        <Section
+          n={4}
           title="Set it up"
           hint="Generated for this client. Every difference below is a real difference between clients."
         >
@@ -232,10 +298,11 @@ function StepRail({ current }: { current: Step }) {
       ))}
       <li className="flex items-center gap-2">
         <span aria-hidden="true">/</span>
-        {/* Named so the wizard does not look like it is hiding the consent
-            decision. It is made on the approval screen, which is where the
-            grant is created. */}
-        <span>4. Choose sites and permissions when you approve</span>
+        {/* Capabilities are NOT a numbered step in this rail. The grant columns
+            behind them do not exist yet, and a number for a screen that cannot
+            be built is a promise the rail has no way to keep. What it names
+            instead is where that decision is made today. */}
+        <span>Permissions are chosen on the approval screen</span>
       </li>
     </ol>
   );

--- a/apps/web/src/features/ai-connections/site-scope-step.tsx
+++ b/apps/web/src/features/ai-connections/site-scope-step.tsx
@@ -1,0 +1,405 @@
+import { useMemo, useState } from "react";
+import { X } from "lucide-react";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+import {
+  describeSiteScope,
+  resolveSiteScope,
+  type FleetSnapshot,
+  type ResolvedSiteScope,
+  type SiteScopeMode,
+} from "@/features/mcp-consent/site-scope";
+import {
+  SITE_STEP_MODES,
+  canLeaveSiteStep,
+  emptyTokenFieldLabel,
+  excludedSitesLabel,
+  fleetTotal,
+  scopeCountLabel,
+  scopeTokenLabel,
+  siteStepBlockedReason,
+} from "./site-step";
+
+// Step 3 of the connection wizard: which sites this connection may touch.
+//
+// WHY IT SITS BEFORE CAPABILITIES. The wireframe states the ordering as a
+// decision rather than a layout: "Chosen before capabilities, on purpose". A
+// capability list is meaningless until its blast radius is fixed, and asking
+// "what may it do" before "to what" produces a screen where every answer has to
+// be revised once the second question is answered.
+//
+// EVERY SENTENCE WITH A NUMBER IN IT COMES FROM site-step.ts OR site-scope.ts.
+// Nothing here computes a count inline, so there is exactly one place where a
+// partial page could be rendered as a whole fleet, and it is a pure function
+// with tests around it.
+
+export interface SiteScopeSelection {
+  readonly mode: SiteScopeMode;
+  readonly tagNames: readonly string[];
+  readonly siteIds: readonly string[];
+}
+
+export interface SiteScopeStepProps {
+  readonly selection: SiteScopeSelection;
+  readonly onSelectionChange: (next: SiteScopeSelection) => void;
+  /**
+   * What we loaded of the fleet, or null when the load has not finished or
+   * failed. NULL IS NOT AN EMPTY SNAPSHOT. See site-scope.ts.
+   */
+  readonly fleet: FleetSnapshot | null;
+  /**
+   * The tag registry, or null when we could not load it. Null is not an empty
+   * registry: one is a fact about the organisation, the other about our request.
+   */
+  readonly tags: readonly { readonly id: string; readonly name: string }[] | null;
+  readonly tagsBySiteId: Readonly<Record<string, readonly string[]>>;
+  readonly sitesLoading: boolean;
+}
+
+export function SiteScopeStep({
+  selection,
+  onSelectionChange,
+  fleet,
+  tags,
+  tagsBySiteId,
+  sitesLoading,
+}: SiteScopeStepProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { mode, tagNames, siteIds } = selection;
+
+  const scope: ResolvedSiteScope = useMemo(
+    () =>
+      resolveSiteScope({
+        mode,
+        selectedTagNames: tagNames,
+        selectedSiteIds: siteIds,
+        fleet,
+        tagsBySiteId,
+        sitesLoading,
+      }),
+    [mode, tagNames, siteIds, fleet, tagsBySiteId, sitesLoading],
+  );
+
+  const total = fleetTotal(fleet);
+  const blocked = siteStepBlockedReason(scope);
+  const excluded = excludedSitesLabel(scope, total);
+
+  function setMode(next: SiteScopeMode) {
+    // The selections are kept rather than cleared when the mode changes. They
+    // are separate fields on the wire (scope_tag_ids and scope_site_ids) and
+    // resolveSiteScope only ever reads the one belonging to the current mode,
+    // so a mode flipped by accident does not throw away the other answer.
+    onSelectionChange({ ...selection, mode: next });
+    setPickerOpen(false);
+  }
+
+  function toggleTag(name: string) {
+    onSelectionChange({
+      ...selection,
+      tagNames: tagNames.includes(name)
+        ? tagNames.filter((t) => t !== name)
+        : [...tagNames, name],
+    });
+  }
+
+  function toggleSite(id: string) {
+    onSelectionChange({
+      ...selection,
+      siteIds: siteIds.includes(id) ? siteIds.filter((s) => s !== id) : [...siteIds, id],
+    });
+  }
+
+  const tokens: readonly { key: string; label: string; remove: () => void }[] =
+    mode === "tags"
+      ? tagNames.map((name) => ({
+          key: name,
+          label: scopeTokenLabel("tags", name),
+          remove: () => toggleTag(name),
+        }))
+      : mode === "list"
+        ? siteIds.map((id) => ({
+            key: id,
+            label: scopeTokenLabel(
+              "list",
+              fleet?.sites.find((s) => s.id === id)?.name ?? id,
+            ),
+            remove: () => toggleSite(id),
+          }))
+        : [];
+
+  return (
+    <div className="space-y-3">
+      <SegmentedControl<SiteScopeMode>
+        aria-label="Site scope"
+        value={mode}
+        onChange={setMode}
+        options={SITE_STEP_MODES.map((m) => ({ value: m.value, label: m.label }))}
+      />
+
+      {/* The L state. A tag being resolved is a real wait, and the wireframe
+          gives it skeleton rows rather than a spinner, because what is arriving
+          is a list. */}
+      {scope.kind === "unresolved" && scope.because === "loading" ? (
+        <div data-testid="site-step-resolving" className="space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      ) : null}
+
+      {mode !== "all" ? (
+        <div>
+          <div
+            data-testid="site-step-tokenfield"
+            className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--color-border)] p-2"
+          >
+            {tokens.length === 0 ? (
+              <span className="px-1 text-xs text-[var(--color-muted-foreground)]">
+                {emptyTokenFieldLabel(mode)}
+              </span>
+            ) : (
+              tokens.map((t) => (
+                <span
+                  key={t.key}
+                  className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 px-2 py-0.5 text-xs text-[var(--color-foreground)]"
+                >
+                  <span className="font-mono">{t.label}</span>
+                  <button
+                    type="button"
+                    onClick={t.remove}
+                    aria-label={`Remove ${t.label}`}
+                    className="rounded-sm text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                  >
+                    <X aria-hidden="true" className="size-3" />
+                  </button>
+                </span>
+              ))
+            )}
+            <button
+              type="button"
+              onClick={() => setPickerOpen((open) => !open)}
+              aria-expanded={pickerOpen}
+              className="ml-auto rounded-md border border-[var(--color-border)] px-2 py-1 text-xs text-[var(--color-foreground)] hover:bg-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+            >
+              {/* Named for what the picker below actually lists. The wireframe
+                  writes "Add sites" on both modes; a control that opens a list
+                  of tags and calls them sites is the kind of small lie this
+                  screen exists to avoid. */}
+              {mode === "tags" ? "+ Add tags" : "+ Add sites"}
+            </button>
+          </div>
+
+          {pickerOpen ? (
+            <Picker
+              mode={mode}
+              fleet={fleet}
+              tags={tags}
+              tagNames={tagNames}
+              siteIds={siteIds}
+              onToggleTag={toggleTag}
+              onToggleSite={toggleSite}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      <p
+        data-testid="site-step-count"
+        className={cn(
+          "text-sm font-medium",
+          canLeaveSiteStep(scope)
+            ? "text-[var(--color-foreground)]"
+            : "text-[var(--color-destructive)]",
+        )}
+      >
+        {scopeCountLabel(scope, total)}
+      </p>
+
+      {/* THE EMPTY STATE, AND THE ONE SENTENCE THAT MAKES IT A STATE RATHER THAN
+          A FAILURE. Nothing here is styled as an error and nothing blocks on it:
+          an empty scope is a credential that reaches nothing yet, which is a
+          thing an operator is allowed to want. */}
+      {scope.kind === "none" && scope.because === "no-selection" ? (
+        <p
+          data-testid="site-step-empty"
+          className="text-sm text-[var(--color-muted-foreground)]"
+        >
+          A connection with an empty scope can read nothing and propose nothing. That is a
+          working state, not an error. It is how you mint a credential now and decide its
+          reach later.
+        </p>
+      ) : (
+        <p
+          data-testid="site-step-summary"
+          className="text-sm text-[var(--color-muted-foreground)]"
+        >
+          {describeSiteScope(scope)}
+        </p>
+      )}
+
+      {blocked !== null ? (
+        <p
+          role="alert"
+          data-testid="site-step-blocked"
+          className="rounded-md border border-[var(--color-destructive)]/30 p-3 text-sm text-[var(--color-destructive)]"
+        >
+          {blocked}
+        </p>
+      ) : null}
+
+      {excluded !== null ? (
+        <p data-testid="site-step-excluded" className="text-xs text-[var(--color-muted-foreground)]">
+          {excluded}
+        </p>
+      ) : null}
+
+      {mode === "tags" ? (
+        <p className="text-xs text-[var(--color-muted-foreground)]">
+          A tag is resolved to a site list at every request, not frozen here. Add a site to
+          the tag next month and this connection reaches it.
+        </p>
+      ) : null}
+
+      <p className="text-xs text-[var(--color-muted-foreground)]">
+        A site outside this scope is not greyed out with a reason when the model asks for
+        it. It is not listed at all. Telling a caller that a site exists but is off limits
+        is itself a disclosure.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The add panel.
+ *
+ * A FAILED REGISTRY AND AN EMPTY ONE GET DIFFERENT PANELS. `tags === null` is
+ * our request failing and says so; `tags === []` is a claim about the
+ * organisation and is only made when we actually read the registry. Same split
+ * for the fleet one branch down.
+ */
+function Picker({
+  mode,
+  fleet,
+  tags,
+  tagNames,
+  siteIds,
+  onToggleTag,
+  onToggleSite,
+}: {
+  mode: SiteScopeMode;
+  fleet: FleetSnapshot | null;
+  tags: readonly { readonly id: string; readonly name: string }[] | null;
+  tagNames: readonly string[];
+  siteIds: readonly string[];
+  onToggleTag: (name: string) => void;
+  onToggleSite: (id: string) => void;
+}) {
+  if (mode === "tags") {
+    if (tags === null) {
+      return (
+        <PickerNote testId="site-step-tags-failed" tone="error">
+          We could not load this organisation&apos;s tags, so there is nothing to pick
+          from. That is not the same as having no tags.
+        </PickerNote>
+      );
+    }
+    if (tags.length === 0) {
+      return (
+        <PickerNote testId="site-step-tags-empty" tone="muted">
+          This organisation has no tags yet. Create one on a site, or pick named sites
+          instead.
+        </PickerNote>
+      );
+    }
+    return (
+      <div data-testid="site-step-picker" className="mt-2 max-h-56 space-y-2 overflow-y-auto rounded-md border border-[var(--color-border)] p-2">
+        {tags.map((tag) => (
+          <label key={tag.id} className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={tagNames.includes(tag.name)}
+              onChange={() => onToggleTag(tag.name)}
+            />
+            <span className="font-mono text-xs">{scopeTokenLabel("tags", tag.name)}</span>
+          </label>
+        ))}
+      </div>
+    );
+  }
+
+  if (fleet === null) {
+    return (
+      <PickerNote testId="site-step-sites-failed" tone="error">
+        We could not load this organisation&apos;s sites, so there is nothing to pick from.
+        That is not the same as having no sites.
+      </PickerNote>
+    );
+  }
+
+  return (
+    <div data-testid="site-step-picker" className="mt-2 space-y-2">
+      {/* The picker is where truncation costs CHOICE rather than accuracy: the
+          grant is exactly what was ticked, but a site that never rendered
+          could not be ticked. Said here, beside the list it applies to. */}
+      {!fleet.complete ? (
+        <p
+          role="alert"
+          data-testid="site-step-picker-truncated"
+          className="rounded-md border border-[var(--color-destructive)]/30 p-2 text-xs text-[var(--color-destructive)]"
+        >
+          This organisation has more sites than we can list here, so the choices below are
+          not all of them. Anything you do not see is not covered.
+        </p>
+      ) : null}
+      {fleet.sites.length === 0 ? (
+        <PickerNote testId="site-step-sites-empty" tone="muted">
+          This organisation has no sites yet, so there is nothing to scope this connection
+          to.
+        </PickerNote>
+      ) : (
+        <div className="max-h-56 space-y-2 overflow-y-auto rounded-md border border-[var(--color-border)] p-2">
+          {fleet.sites.map((site) => (
+            <label key={site.id} className="flex items-start gap-2 text-sm">
+              <Checkbox
+                checked={siteIds.includes(site.id)}
+                onChange={() => onToggleSite(site.id)}
+              />
+              <span>
+                <span className="font-medium">{site.name}</span>{" "}
+                <span className="text-[var(--color-muted-foreground)]">{site.url}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PickerNote({
+  testId,
+  tone,
+  children,
+}: {
+  testId: string;
+  tone: "error" | "muted";
+  children: React.ReactNode;
+}) {
+  return (
+    <p
+      role={tone === "error" ? "alert" : undefined}
+      data-testid={testId}
+      className={cn(
+        "mt-2 rounded-md border p-2 text-xs",
+        tone === "error"
+          ? "border-[var(--color-destructive)]/30 text-[var(--color-destructive)]"
+          : "border-[var(--color-border)] text-[var(--color-muted-foreground)]",
+      )}
+    >
+      {children}
+    </p>
+  );
+}

--- a/apps/web/src/features/ai-connections/site-step.test.ts
+++ b/apps/web/src/features/ai-connections/site-step.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  isScopeApprovable,
+  resolveSiteScope,
+  snapshotFromPage,
+  type FleetSnapshot,
+  type ResolvedSiteScope,
+  type ScopedSite,
+} from "@/features/mcp-consent/site-scope";
+
+import {
+  SITE_STEP_MODES,
+  canLeaveSiteStep,
+  emptyTokenFieldLabel,
+  excludedSitesLabel,
+  fleetTotal,
+  scopeCountLabel,
+  scopeTokenLabel,
+  siteStepBlockedReason,
+  sitesInScope,
+} from "./site-step";
+
+// Step 3's arithmetic, which is the half of the screen that can lie with a
+// number rather than with a sentence.
+//
+// NO EXPECTED STRING IS FROZEN HERE. Every assertion is either a number, a
+// property of the string (contains this digit, contains no digit, does not
+// contain this word), or a string built from the same function under test with
+// different inputs. Freezing prose is how five separate tests on this surface
+// ended up asserting that the copy had not changed rather than that it was
+// true, and a reworded sentence should not redden a suite that is about
+// arithmetic.
+
+function site(n: number): ScopedSite {
+  return { id: `s${n}`, name: `site-${n}.example`, url: `https://site-${n}.example` };
+}
+
+function fleetOf(count: number, limit: number): FleetSnapshot {
+  return snapshotFromPage(
+    Array.from({ length: count }, (_, i) => site(i)),
+    limit,
+  );
+}
+
+const NO_TAGS: Readonly<Record<string, readonly string[]>> = {};
+
+function resolve(over: {
+  mode: "all" | "tags" | "list";
+  tagNames?: readonly string[];
+  siteIds?: readonly string[];
+  fleet: FleetSnapshot | null;
+  tagsBySiteId?: Readonly<Record<string, readonly string[]>>;
+  sitesLoading?: boolean;
+}): ResolvedSiteScope {
+  return resolveSiteScope({
+    mode: over.mode,
+    selectedTagNames: over.tagNames ?? [],
+    selectedSiteIds: over.siteIds ?? [],
+    fleet: over.fleet,
+    tagsBySiteId: over.tagsBySiteId ?? NO_TAGS,
+    sitesLoading: over.sitesLoading ?? false,
+  });
+}
+
+describe("the denominator never invents a fleet size", () => {
+  it("reports unknown, not zero, when the fleet did not load", () => {
+    // A failed load rendered as "0 of 0" is the failure-as-empty defect. The
+    // total must have no number in it at all.
+    expect(fleetTotal(null)).toEqual({ kind: "unknown" });
+  });
+
+  it("reports an exact total only when the page came back short", () => {
+    const total = fleetTotal(fleetOf(60, 200));
+    expect(total).toEqual({ kind: "exact", n: 60 });
+  });
+
+  it("reports a floor, not an exact total, when the page came back full", () => {
+    // 200 rows out of a 200-row request is indistinguishable from 200 out of
+    // 5000. Anything that reads this as a fleet size is claiming a row it does
+    // not hold.
+    const total = fleetTotal(fleetOf(200, 200));
+    expect(total.kind).toBe("floor");
+    expect(total).not.toEqual({ kind: "exact", n: 200 });
+  });
+});
+
+describe("the count line", () => {
+  it("prints the wireframe's ratio for an empty selection against a known fleet", () => {
+    const fleet = fleetOf(60, 200);
+    const scope = resolve({ mode: "list", fleet });
+    const label = scopeCountLabel(scope, fleetTotal(fleet));
+
+    // The shape the wireframe specifies, asserted as its parts rather than as
+    // a frozen sentence: zero in scope, sixty in the fleet, in that order.
+    expect(sitesInScope(scope)).toBe(0);
+    expect(label.startsWith("0 of 60")).toBe(true);
+    expect(label).not.toMatch(/at least/i);
+  });
+
+  it("degrades the denominator to a floor when the fleet page was full", () => {
+    const full = fleetOf(200, 200);
+    const short = fleetOf(200, 500);
+    const scope = (f: FleetSnapshot) => resolve({ mode: "list", fleet: f });
+
+    const floored = scopeCountLabel(scope(full), fleetTotal(full));
+    const exact = scopeCountLabel(scope(short), fleetTotal(short));
+
+    // Same numerator, same row count, different entitlement to claim it.
+    expect(floored).toMatch(/at least/i);
+    expect(exact).not.toMatch(/at least/i);
+    expect(floored).not.toBe(exact);
+  });
+
+  it("counts the selected sites, not the fleet, once something is picked", () => {
+    const fleet = fleetOf(60, 200);
+    const scope = resolve({ mode: "list", siteIds: ["s0", "s1", "s2"], fleet });
+    expect(sitesInScope(scope)).toBe(3);
+    expect(scopeCountLabel(scope, fleetTotal(fleet)).startsWith("3 of 60")).toBe(true);
+  });
+
+  it("prints NO number at all while the answer is still being worked out", () => {
+    // "Loading" must not render as a zero. A zero here is a confident answer,
+    // and the screen does not have one yet.
+    const scope = resolve({ mode: "tags", tagNames: ["a"], fleet: null, sitesLoading: true });
+    expect(scope.kind).toBe("unresolved");
+    expect(sitesInScope(scope)).toBeNull();
+    expect(scopeCountLabel(scope, fleetTotal(null))).not.toMatch(/\d/);
+  });
+
+  it("prints NO number at all when the fleet load failed", () => {
+    const scope = resolve({ mode: "list", siteIds: ["s0"], fleet: null, sitesLoading: false });
+    expect(scope.kind).toBe("unresolved");
+    expect(scopeCountLabel(scope, fleetTotal(null))).not.toMatch(/\d/);
+  });
+
+  it("distinguishes the pending answer from the failed one", () => {
+    const loading = resolve({ mode: "list", fleet: null, sitesLoading: true });
+    const failed = resolve({ mode: "list", fleet: null, sitesLoading: false });
+    expect(scopeCountLabel(loading, fleetTotal(null))).not.toBe(
+      scopeCountLabel(failed, fleetTotal(null)),
+    );
+    expect(siteStepBlockedReason(loading)).not.toBe(siteStepBlockedReason(failed));
+  });
+
+  it("says nothing is blocked when the scope resolved", () => {
+    const fleet = fleetOf(3, 200);
+    expect(siteStepBlockedReason(resolve({ mode: "list", fleet }))).toBeNull();
+    expect(siteStepBlockedReason(resolve({ mode: "all", fleet }))).toBeNull();
+  });
+});
+
+describe("an empty scope is a working state, and this is where that is decided", () => {
+  it("lets the operator leave step 3 with nothing selected", () => {
+    // The wireframe, verbatim on this point: an empty scope "is a working
+    // state, not an error". An earlier revision of this surface blocked the
+    // step here, and that is the behaviour being corrected.
+    const scope = resolve({ mode: "list", fleet: fleetOf(60, 200) });
+    expect(scope).toEqual({ kind: "none", because: "no-selection" });
+    expect(canLeaveSiteStep(scope)).toBe(true);
+  });
+
+  it("disagrees with the approval gate on exactly that input", () => {
+    // Two gates exist because they differ here and nowhere else. If these ever
+    // agree on every input, one of them is redundant and the empty state has
+    // silently become an error again.
+    const fleet = fleetOf(60, 200);
+    const empty = resolve({ mode: "list", fleet });
+    const picked = resolve({ mode: "list", siteIds: ["s1"], fleet });
+    const every = resolve({ mode: "all", fleet });
+    const unknown = resolve({ mode: "list", fleet: null });
+
+    expect([canLeaveSiteStep(empty), isScopeApprovable(empty)]).toEqual([true, false]);
+    // And they agree everywhere else.
+    for (const scope of [picked, every, unknown]) {
+      expect(canLeaveSiteStep(scope)).toBe(isScopeApprovable(scope));
+    }
+  });
+
+  it("still refuses to move on when nobody has read the fleet", () => {
+    const scope = resolve({ mode: "list", siteIds: ["s1"], fleet: null });
+    expect(canLeaveSiteStep(scope)).toBe(false);
+    expect(siteStepBlockedReason(scope)).not.toBeNull();
+  });
+
+  it("holds the step when a tag matches nothing in a page that is not the whole fleet", () => {
+    // "Matches nothing" is a claim that needs every site. Against a full page
+    // it is unresolved, not zero, and unresolved blocks.
+    const fleet = fleetOf(200, 200);
+    const scope = resolve({ mode: "tags", tagNames: ["nope"], fleet, tagsBySiteId: {} });
+    expect(scope.kind).toBe("unresolved");
+    expect(canLeaveSiteStep(scope)).toBe(false);
+  });
+
+  it("calls it a real zero once the page is known to be the whole fleet", () => {
+    const fleet = fleetOf(60, 200);
+    const scope = resolve({ mode: "tags", tagNames: ["nope"], fleet, tagsBySiteId: {} });
+    expect(scope).toEqual({ kind: "none", because: "no-matches" });
+    expect(canLeaveSiteStep(scope)).toBe(true);
+  });
+});
+
+describe("the sites this connection cannot reach", () => {
+  it("offers the excluded count only against an exact fleet", () => {
+    const exact = fleetOf(60, 200);
+    const floored = fleetOf(200, 200);
+    const pick = (f: FleetSnapshot) => resolve({ mode: "list", siteIds: ["s0", "s1"], fleet: f });
+
+    const label = excludedSitesLabel(pick(exact), fleetTotal(exact));
+    expect(label).not.toBeNull();
+    expect(label).toContain(String(60 - 2));
+
+    // A floor denominator makes the subtraction meaningless: the rows we never
+    // loaded are in neither half.
+    expect(excludedSitesLabel(pick(floored), fleetTotal(floored))).toBeNull();
+  });
+
+  it("says never only for a fixed list, because a tag is not fixed", () => {
+    const fleet = fleetOf(10, 200);
+    const byList = resolve({ mode: "list", siteIds: ["s0"], fleet });
+    const byTag = resolve({
+      mode: "tags",
+      tagNames: ["seo"],
+      fleet,
+      tagsBySiteId: { s0: ["seo"] },
+    });
+
+    expect(excludedSitesLabel(byList, fleetTotal(fleet))).toMatch(/never/i);
+    // A site given that tag next month IS reached, so "never" would be false.
+    expect(excludedSitesLabel(byTag, fleetTotal(fleet))).not.toMatch(/never/i);
+  });
+
+  it("offers nothing to see when the mode excludes nothing", () => {
+    const fleet = fleetOf(10, 200);
+    expect(excludedSitesLabel(resolve({ mode: "all", fleet }), fleetTotal(fleet))).toBeNull();
+  });
+
+  it("offers nothing while the scope is unresolved", () => {
+    const fleet = fleetOf(200, 200);
+    const scope = resolve({ mode: "tags", tagNames: ["x"], fleet, tagsBySiteId: {} });
+    expect(excludedSitesLabel(scope, fleetTotal(fleet))).toBeNull();
+  });
+});
+
+describe("the modes and their labels", () => {
+  it("offers exactly the three the schema permits, in the wireframe's order", () => {
+    expect(SITE_STEP_MODES.map((m) => m.value)).toEqual(["all", "tags", "list"]);
+  });
+
+  it("never puts a wire value on screen", () => {
+    // 'list' is the column value; "Named sites" is what a person reads.
+    for (const mode of SITE_STEP_MODES) {
+      expect(mode.label).not.toBe(mode.value);
+    }
+  });
+
+  it("prefixes a tag token and leaves a site token alone", () => {
+    expect(scopeTokenLabel("tags", "client-retainer")).toBe("tag:client-retainer");
+    expect(scopeTokenLabel("list", "acme.example")).toBe("acme.example");
+  });
+
+  it("names the thing the empty field is missing, per mode", () => {
+    expect(emptyTokenFieldLabel("tags")).not.toBe(emptyTokenFieldLabel("list"));
+  });
+});

--- a/apps/web/src/features/ai-connections/site-step.ts
+++ b/apps/web/src/features/ai-connections/site-step.ts
@@ -1,0 +1,202 @@
+// Wizard step 3 -- "Choose which sites this connection may touch".
+//
+// The RESOLUTION lives in features/mcp-consent/site-scope.ts and is not
+// duplicated here. That module already carries the two rules this screen must
+// obey (an empty resolved set means NO SITES, never every site; and the page we
+// hold is neither exhaustive nor fixed), and it was hardened on the consent
+// screen where the same mistakes cost consent. What lives HERE is only what
+// step 3 needs and the consent screen does not:
+//
+//   1. THE COUNT IN THE WIREFRAME'S SHAPE -- "0 of 60 sites." The consent
+//      screen deliberately never prints a fleet size, because it prints a
+//      sentence about coverage instead. Step 3 prints a ratio, and a ratio has
+//      a denominator, so the denominator is where the truncation trap lands on
+//      this screen. `FleetTotal` is that denominator made explicit: exact when
+//      the page came back short, a FLOOR when it came back full, and unknown
+//      when we could not read the fleet at all. No branch invents a total.
+//
+//   2. A DIFFERENT GATE. `isScopeApprovable` refuses `none`, because approving
+//      an empty grant mints a credential that reads nothing. Step 3 is not an
+//      approval and MUST NOT refuse `none`: the wireframe states in as many
+//      words that an empty scope "is a working state, not an error. It is how
+//      you mint a credential now and decide its reach later." The two gates
+//      disagree on exactly one input and that is the point of having two.
+//
+// Every string a caller renders comes from a function in this file, so the copy
+// for every branch is readable in one place and a test can derive its
+// expectation from the same function rather than freezing a sentence.
+
+import type {
+  FleetSnapshot,
+  ResolvedSiteScope,
+  SiteScopeMode,
+} from "@/features/mcp-consent/site-scope";
+
+/**
+ * The denominator of the count, and how much we are entitled to claim about it.
+ *
+ * `floor` is not a smaller `exact`. It means "we hold n rows and cannot see
+ * past them", which supports "at least n" and supports NO assertion that an
+ * n+1th site exists -- a fleet of exactly n satisfies it. `unknown` is not a
+ * zero: it is the failed or pending read, and it prints no number at all.
+ */
+export type FleetTotal =
+  | { readonly kind: "exact"; readonly n: number }
+  | { readonly kind: "floor"; readonly n: number }
+  | { readonly kind: "unknown" };
+
+/**
+ * Read the denominator off the snapshot.
+ *
+ * NULL IS `unknown`, NOT ZERO. A failed site load rendered as "0 of 0 sites" is
+ * the failure-as-empty defect this surface has already shipped three times.
+ */
+export function fleetTotal(fleet: FleetSnapshot | null): FleetTotal {
+  if (fleet === null) return { kind: "unknown" };
+  return fleet.complete
+    ? { kind: "exact", n: fleet.sites.length }
+    : { kind: "floor", n: fleet.sites.length };
+}
+
+/**
+ * How many sites the scope resolves to, or null when that is not knowable.
+ *
+ * `all` counts the rows we hold, which is a floor and is labelled as one by the
+ * denominator beside it. `unresolved` is null and never zero: "we do not know"
+ * and "none" are different answers and the count line renders them differently.
+ */
+export function sitesInScope(scope: ResolvedSiteScope): number | null {
+  switch (scope.kind) {
+    case "all":
+      return scope.shown.length;
+    case "sites":
+      return scope.sites.length;
+    case "none":
+      return 0;
+    case "unresolved":
+      return null;
+  }
+}
+
+function plural(n: number): string {
+  return n === 1 ? "site" : "sites";
+}
+
+/**
+ * The count line, in the wireframe's shape: "0 of 60 sites."
+ *
+ * The ratio is only printed when both halves are knowable. When the fleet page
+ * came back full the denominator becomes "at least 60", because a full page and
+ * a full page with more behind it are the same response; when the fleet did not
+ * load there is no ratio at all, and the line says so rather than printing a
+ * zero that reads as a confident answer.
+ */
+export function scopeCountLabel(scope: ResolvedSiteScope, total: FleetTotal): string {
+  const n = sitesInScope(scope);
+
+  if (n === null) {
+    return scope.kind === "unresolved" && scope.because === "loading"
+      ? "Working out how many sites this reaches."
+      : "We could not read this organisation's sites, so we cannot tell you how many this reaches.";
+  }
+
+  switch (total.kind) {
+    case "unknown":
+      // Unreachable while resolveSiteScope returns `unresolved` for a null
+      // fleet, and written out rather than thrown because the honest sentence
+      // costs one line and a crash costs the step.
+      return "We could not read this organisation's sites, so we cannot tell you how many this reaches.";
+    case "exact":
+      return `${n} of ${total.n} ${plural(total.n)}.`;
+    case "floor":
+      return `${n} of at least ${total.n} ${plural(total.n)}.`;
+  }
+}
+
+/**
+ * The sites this connection can NOT reach, when that is a number we may state.
+ *
+ * Null means "do not offer this", and it is null far more often than not:
+ *
+ *   - a FLOOR denominator makes the subtraction meaningless, because the sites
+ *     we never loaded are neither in the scope nor in the excluded count;
+ *   - mode `all` excludes nothing, so there is no set to show;
+ *   - an unresolved scope has no numerator to subtract.
+ *
+ * The WORD is chosen from the basis, because the wireframe's "can never reach"
+ * is true of a fixed list and false of a tag: a site given that tag next month
+ * is reached, and the tag branch says so instead.
+ */
+export function excludedSitesLabel(
+  scope: ResolvedSiteScope,
+  total: FleetTotal,
+): string | null {
+  if (total.kind !== "exact") return null;
+  if (scope.kind === "all" || scope.kind === "unresolved") return null;
+  const covered = scope.kind === "none" ? 0 : scope.sites.length;
+  const excluded = total.n - covered;
+  if (excluded <= 0) return null;
+  const basis = scope.kind === "sites" ? scope.basis : "list";
+  return basis === "list"
+    ? `See the ${excluded} this connection can never reach`
+    : `See the ${excluded} it does not reach today`;
+}
+
+/**
+ * Whether the wizard may move past step 3.
+ *
+ * THIS IS NOT `isScopeApprovable`, AND THE DIFFERENCE IS THE WHOLE POINT OF THE
+ * SCREEN. An empty scope passes here. The wireframe is explicit that it is "a
+ * working state, not an error", and an earlier revision of this surface that
+ * blocked the step on an empty allowlist is the behaviour being corrected.
+ *
+ * `unresolved` still blocks, for the reason it blocks everywhere else: carrying
+ * a selection whose meaning nobody has read is not a decision, and the count
+ * beside it would be a number we cannot stand behind.
+ */
+export function canLeaveSiteStep(scope: ResolvedSiteScope): boolean {
+  return scope.kind !== "unresolved";
+}
+
+/** Why the step is held, for the operator, or null when it is not held. */
+export function siteStepBlockedReason(scope: ResolvedSiteScope): string | null {
+  if (scope.kind !== "unresolved") return null;
+  return scope.because === "loading"
+    ? "Reading this organisation's sites."
+    : "We could not read this organisation's sites, so we cannot tell you what this selection covers. Nothing is wrong with your choice; the list did not load.";
+}
+
+export interface SiteScopeModeOption {
+  readonly value: SiteScopeMode;
+  readonly label: string;
+}
+
+/**
+ * The three modes, in the wireframe's order and wording.
+ *
+ * Order is load-bearing only in that the wireframe fixes it; the VALUES are the
+ * three the schema permits (mcp_grants.site_scope_mode) and the labels are the
+ * operator-facing names for them. `list` is "Named sites" on screen and `list`
+ * on the wire, and nothing renders the wire word.
+ */
+export const SITE_STEP_MODES: readonly SiteScopeModeOption[] = [
+  { value: "all", label: "All sites" },
+  { value: "tags", label: "By tag" },
+  { value: "list", label: "Named sites" },
+];
+
+/** The label on a token in the field. Tags carry the `tag:` prefix; sites do not. */
+export function scopeTokenLabel(mode: SiteScopeMode, value: string): string {
+  return mode === "tags" ? `tag:${value}` : value;
+}
+
+/**
+ * What the empty field says when nothing is picked.
+ *
+ * Mode `all` never reaches this: it has no tokens by construction and an empty
+ * token field there would read as "nothing selected" on the one mode that
+ * selects everything.
+ */
+export function emptyTokenFieldLabel(mode: SiteScopeMode): string {
+  return mode === "tags" ? "No tags selected" : "No sites selected";
+}

--- a/apps/web/src/routes/_authed/ai/connect.tsx
+++ b/apps/web/src/routes/_authed/ai/connect.tsx
@@ -1,8 +1,16 @@
+import { useMemo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { PageHeader } from "@/components/shared/page-header";
 import { ConnectWizard } from "@/features/ai-connections/connect-wizard";
 import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
+import {
+  snapshotFromPage,
+  type FleetSnapshot,
+  type ScopedSite,
+} from "@/features/mcp-consent/site-scope";
+import { DEFAULT_SITES_LIMIT, useSites } from "@/features/sites/use-sites";
+import { useTags } from "@/features/tags/use-tags";
 
 // /ai/connect — the connection wizard (design §18).
 //
@@ -20,6 +28,39 @@ export const Route = createFileRoute("/_authed/ai/connect")({
 });
 
 function ConnectAiClientPage() {
+  const sitesQuery = useSites({ view: "active" });
+  const tagsQuery = useTags();
+
+  // NULL, NOT [], WHEN WE CANNOT SEE THE FLEET, and a full page is NOT a whole
+  // fleet. Both readings are the consent route's (routes/_authed/connect.ai.tsx)
+  // and the reasoning is identical, so the assembly is identical rather than
+  // re-invented: an empty snapshot is a fleet with no sites, null is a fleet we
+  // did not read, and snapshotFromPage carries the "at least this many" fact
+  // that a paged listSites forces on anyone printing a count.
+  const fleet: FleetSnapshot | null = useMemo(() => {
+    if (sitesQuery.data === undefined) return null;
+    const sites: ScopedSite[] = sitesQuery.data.map((s) => ({
+      id: s.id,
+      name: s.name,
+      url: s.url,
+    }));
+    return snapshotFromPage(sites, DEFAULT_SITES_LIMIT);
+  }, [sitesQuery.data]);
+
+  const tagsBySiteId = useMemo(() => {
+    const out: Record<string, readonly string[]> = {};
+    for (const site of sitesQuery.data ?? []) out[site.id] = site.tags ?? [];
+    return out;
+  }, [sitesQuery.data]);
+
+  // NULL, NOT [], WHEN THE REGISTRY DID NOT LOAD. `?? []` here would turn a
+  // failed request into "this organisation has no tags yet", which is a claim
+  // about the organisation made out of a fact about our own request.
+  const tags = useMemo(() => {
+    if (tagsQuery.data === undefined) return null;
+    return tagsQuery.data.map((t) => ({ id: t.id, name: t.name }));
+  }, [tagsQuery.data]);
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -27,7 +68,13 @@ function ConnectAiClientPage() {
         subline="Pick your client first. Everything after that is computed from it, because the setup differs per client in ways that fail quietly."
         backTo={{ to: "/ai", label: "AI connections" }}
       />
-      <ConnectWizard endpointUrl={mcpEndpointUrl()} />
+      <ConnectWizard
+        endpointUrl={mcpEndpointUrl()}
+        fleet={fleet}
+        tags={tags}
+        tagsBySiteId={tagsBySiteId}
+        sitesLoading={sitesQuery.isPending}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What this is

Wizard **Step 3, "Choose which sites this connection may touch"**, built against the locked wireframe. The wizard shipped with `type Step = 1 | 2 | 3` (client, auth method, setup artefact); the wireframe puts site scope between the method and the artefact, before capabilities, and `mcp_grants` already carries `site_scope_mode`, `scope_tag_ids` and `scope_site_ids`, so the selection was never blocked on the backend.

Scope of this PR is Step 3 only. Steps 4, 5, 8, 9 and 10 are not stubbed.

## The screen

- Three modes as one radiogroup: **All sites / By tag / Named sites**, the three values `mcp_grants.site_scope_mode` permits.
- Token field with per-token removal, tags rendered `tag:name` so a tag cannot be misread as a hostname.
- An add panel over the fleet or the tag registry.
- The count in the wireframe's shape: `0 of 60 sites.`
- The empty state, with the wireframe's own claim: an empty scope "is a working state, not an error".

## Three things it refuses to do

**It does not present a page of sites as the whole fleet.** `listSites` is paged and `SiteList` carries no total, so a full page is byte-identical to a full page with more behind it. The denominator is explicit about which claim it can make: `exact` when the page came back short (`0 of 60 sites.`), a **floor** when it came back full (`0 of at least 200 sites.`), `unknown` when the fleet did not load. Resolution is reused from `features/mcp-consent/site-scope.ts` rather than reinvented.

**It does not read a failed load as an empty one.** An unresolved scope prints no number at all and holds the step. A tag matching nothing inside a partial page resolves to `unresolved`, not zero, because "matches nothing" is a claim that needs every site. A failed tag registry says so instead of rendering as an organisation with no tags.

**It does not treat an empty scope as an error.** `canLeaveSiteStep` diverges from `isScopeApprovable` on exactly one input, `none`, and a test asserts they agree on every other. An earlier revision of this surface blocked the step on an empty allowlist; that is the behaviour being corrected.

## What it says it cannot do

The grant is created by the approval screen at `/connect/ai`, which the client redirects into. This wizard has no channel into it, so the screen states plainly that nothing carries the selection there and that the approval screen asks again. Same correction, and the same wording pattern, as the connection-name field already on this page.

Capabilities are not given a numbered step in the rail. The grant columns behind them do not exist yet, and a number for a screen that cannot be built is a promise the rail cannot keep; it names where permissions are chosen today instead.

## Gates

| Command | Exit |
|---|---|
| `pnpm -C apps/web typecheck` | 0 |
| `pnpm -C apps/web lint` | 0 (10 pre-existing warnings, 0 errors) |
| `pnpm -C apps/web test` | 0, 164 files, 2023 tests passed |
| `pnpm -C apps/web build` | 0, no `routeTree.gen.ts` drift (no new route file) |
| `impeccable detect` on both touched dirs | no findings |

## Mutation table

Each property was deleted, the suite run, and the tree restored. 14 planted defects, **0 survivors**.

| # | Planted defect | Verdict | Named by |
|---|---|---|---|
| M1 | A full page treated as a known fleet size | RED | refuses to state a fleet size when the page it read came back full |
| M2 | A failed fleet load becomes a fleet of zero | RED | reports unknown, not zero, when the fleet did not load |
| M3 | The empty scope blocks the step | RED | lets the operator leave step 3 with nothing selected |
| M4 | An unresolved scope counts as zero sites | RED | prints NO number at all while the answer is still being worked out |
| M5 | The never-reach count offered against a floor | RED | offers the excluded count only against an exact fleet |
| M6 | A tag scope claims sites it can never reach | RED | says never only for a fixed list, because a tag is not fixed |
| M7 | The empty state described instead of stated | RED | says so in as many words, and styles nothing as a failure |
| M8 | A failed tag registry rendered as no tags | RED | distinguishes a failed tag registry from an organisation with no tags |
| M9 | A failed fleet load renders an empty picker | RED | offers no site picker to choose from when the fleet is unknown |
| M10 | The picker hides that it could not list every site | RED | warns that the choices are not all of them when the page came back full |
| M11 | Route reads a failed site load as an empty fleet | RED | holds the step and says the list did not load, rather than showing a zero |
| M12 | Route reads a failed tag load as an empty registry | RED | distinguishes a failed tag registry from an organisation with no tags |
| M13 | Step 3 removed from the wizard | RED | (whole file fails to compile, 12 tests) |
| M14 | The setup artefact numbered 3 again | RED | numbers the setup artefact after it, so the rail and the page agree |

The over-fire half: after the sweep the tree restored to a clean `git status` and the two files went green again, 58 tests.

No expected string is frozen. Every assertion is a number, a property of the string (contains this digit, contains no digit, does not contain "never"), or a string built by calling the same label function under different inputs.

## Two rulings wanted

1. **Should the rail show steps 4, 5, 8, 9 and 10 as forthcoming?** It currently does not.
2. **Should the wizard's Step 3 selection be carried into the approval screen?** Today nothing does, and the screen says so. Carrying it needs a mechanism that does not exist and would touch the separately-reviewed consent screen, so it was left out of this PR.
