### PR TITLE
mcp: write audit_events for grant create, revoke, and tool calls

### DIFF
--- a/apps/api/cmd/dump-routes/routes.go
+++ b/apps/api/cmd/dump-routes/routes.go
@@ -286,7 +286,7 @@ func buildEngine() (engine *gin.Engine, omittedDepsFields []string, err error) {
 	// cmd/wpmgr/main.go wires it (mcp.NewService(mcp.NewRepo(pool)) etc.), so
 	// POST /mcp, the four OAuth paths and the three well-known discovery
 	// documents all mount.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, "dump-routes")
 	mcpOAuthH := mcp.NewHandler(mcpSvc)
 	mcpDiscoveryH := mcp.NewDiscoveryHandler("https://cp.example.test")

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -540,7 +540,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// would make POST /mcp answer 404, which is indistinguishable from a
 	// routing failure. Self-host reaches it too; the grant is what authorizes,
 	// and an installation with no grants simply has no valid bearer token.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, version)
 	// The OAuth half, wired unconditionally for the same reason. Without it the
 	// transport above is mounted and correct and refuses every request forever,

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -28,6 +28,13 @@ const (
 	ActorUser   = "user"
 	ActorAPIKey = "api_key"
 	ActorSystem = "system"
+	// ActorAssistant is the model on the other end of an MCP connection --
+	// never a human and never the control plane itself. actor_type has no
+	// CHECK constraint (db/schema.sql), so this needed no migration.
+	// ActorID for this kind is the grant id (internal/mcp), NOT a user or key
+	// id: an MCP grant is the credential a model acts under, the way a user id
+	// or an api_key id is the credential a human or a script acts under.
+	ActorAssistant = "assistant"
 
 	ActionLoginSuccess = "auth.login.success"
 	ActionLoginFailure = "auth.login.failure"
@@ -352,6 +359,41 @@ const (
 	// ActionAdminBillingStateForced: metadata: reason, old_plan,
 	// old_plan_status, new_plan, new_plan_status.
 	ActionAdminBillingStateForced = "admin.billing.state.forced"
+
+	// The MCP connection surface (ADR-064). Approve, revoke, and every tool
+	// call are the three points where an MCP grant does something a human
+	// operator can be asked about afterward, and each needed a row here --
+	// before this the surface wrote zero.
+	//
+	// ActionMCPGrantCreated is recorded on the SAME transaction as the grant
+	// insert (internal/mcp.Service.Approve, via RecordInTx), so a rolled-back
+	// grant leaves no row claiming one was created. ActorType is ActorUser:
+	// the grant belongs to the organisation of the human who approved it, and
+	// ActorID is that user's id, not the grant's. Metadata: grant_name,
+	// site_scope_mode.
+	ActionMCPGrantCreated = "mcp.grant.created"
+	// ActionMCPGrantRevoked is recorded on the SAME transaction as the revoke
+	// (internal/mcp.Service.RevokeConnection, via RecordInTx). ActorType is
+	// ActorUser -- the operator who revoked, ActorID their user id. Metadata:
+	// grant_name, grants_revoked, tokens_revoked, already_revoked.
+	ActionMCPGrantRevoked = "mcp.grant.revoked"
+	// ActionMCPToolCalled is recorded per successful tool invocation on the
+	// transport path (internal/mcp.Service.RecordToolCall), BEST-EFFORT like
+	// most of this log (Record, not RecordInTx): there is no companion write
+	// to roll back alongside it, and a purely observational record must not
+	// take down the read path it observes. ActorType is ActorAssistant --
+	// this is the one action class in the whole log recorded as the MODEL's
+	// own act rather than the human who granted it access -- and ActorID is
+	// the mcp_grants id, not a user id. Metadata carries grant_name as the
+	// actor's display label: ListAuditEntries/ListAuditEntriesFiltered
+	// resolve ActorName by joining users/api_keys on actor_type, and neither
+	// join has an arm for "assistant" (that join lives in db/query/*.sql,
+	// database-engineer's surface, and a fourth JOIN did not land alongside
+	// this Go-only change) -- so the label travels in Metadata rather than in
+	// the ActorName column until that join exists. Also carries
+	// operator_permission (the dashboard authority the tool call mirrors) and
+	// tool.
+	ActionMCPToolCalled = "mcp.tool.called"
 )
 
 // Entry is one audit record.
@@ -372,6 +414,12 @@ type Entry struct {
 	// ActorType == ActorAPIKey. Nil for ActorSystem events and for any actor
 	// row that no longer exists (e.g. a deleted user). Only List and
 	// ListFiltered populate this field; Record's returned Entry does not.
+	//
+	// Also nil for ActorType == ActorAssistant: the join that would resolve it
+	// (mcp_grants.name, the same shape as the api_keys.name join above) does
+	// not exist in ListAuditEntries/ListAuditEntriesFiltered today. An
+	// ActionMCPToolCalled recorder carries the grant's name in Metadata
+	// instead, so the label is not lost, only not yet promoted to this column.
 	ActorName *string
 	// ActorEmail is the acting user's email when ActorType == ActorUser. Nil
 	// otherwise. Only List and ListFiltered populate this field.

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -258,13 +258,22 @@ func (f *fakeStore) RedeemAuthorizationCode(_ context.Context, _, _ uuid.UUID, t
 // that the principal reaches the store at all, so a refactor which narrows
 // ApprovalRequest back to a bare tenant id fails here rather than silently in
 // production. The policy itself is proved in tests/, as wpmgr_app.
-func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
+func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(pgx.Tx, sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	f.note("CreateGrantWithCode")
 	f.grantPrincipal = principal
 	id := uuid.New()
 	cp := mk(id)
-	return sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name},
-		sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
+	grant := sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name}
+	// No real tx to hand onCreated -- this fake runs no transaction at all.
+	// Service.Approve's callback checks s.audit == nil before touching tx, and
+	// no test in this package wires WithAudit, so nil here is never
+	// dereferenced.
+	if onCreated != nil {
+		if err := onCreated(nil, grant); err != nil {
+			return sqlc.McpGrant{}, sqlc.McpAuthorizationCode{}, err
+		}
+	}
+	return grant, sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
 }
 
 func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
@@ -349,6 +358,7 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	_ context.Context,
 	p domain.Principal,
 	_ uuid.UUID,
+	onRevoked func(pgx.Tx, sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	f.note("RevokeGrantWithTokens")
 	f.mu.Lock()
@@ -356,6 +366,13 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	f.mu.Unlock()
 	if f.revokeErr != nil {
 		return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, f.revokeErr
+	}
+	// No real tx, same reasoning as CreateGrantWithCode above: the callback
+	// checks s.audit == nil before touching it.
+	if onRevoked != nil {
+		if err := onRevoked(nil, f.revokeRow); err != nil {
+			return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, err
+		}
 	}
 	return f.revokeRow, nil
 }

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -41,7 +41,14 @@ type Store interface {
 	// the RESTRICTIVE insert policy on mcp_grants is live. A tenant id alone
 	// cannot express that, which is how the site-scope GUC came to be unset on
 	// this path. See the method on Repo.
-	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
+	//
+	// onCreated runs INSIDE the same transaction as both inserts, after both
+	// succeed, so the caller (Service.Approve) can append the
+	// ActionMCPGrantCreated audit row via audit.Recorder.RecordInTx over the
+	// SAME tx -- a rolled-back grant then leaves no audit row claiming one
+	// exists, because an error from onCreated rolls the whole transaction back
+	// exactly as an error from either insert would. May be nil.
+	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
 
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
@@ -79,7 +86,14 @@ type Store interface {
 	// organisation's, or refused by RLS. It is the ONLY outcome meaning "not
 	// there"; a returned row of two zeroes is an idempotent success. See the
 	// query's four-outcome comment.
-	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
+	//
+	// onRevoked runs INSIDE the same transaction as the revoke statement,
+	// after it succeeds (any of the three non-error outcomes), so the caller
+	// (Service.RevokeConnection) can append the ActionMCPGrantRevoked audit
+	// row via audit.Recorder.RecordInTx over the SAME tx. It does NOT run on
+	// pgx.ErrNoRows -- nothing was written, so nothing should be attributed.
+	// May be nil.
+	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID, onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
 }
 
 // Repo is the live Store. Every method names the tx helper it runs under, and
@@ -239,6 +253,7 @@ func (r *Repo) CreateGrantWithCode(
 	principal db.ScopedPrincipal,
 	g sqlc.CreateMCPGrantParams,
 	mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams,
+	onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error,
 ) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	var (
 		grant sqlc.McpGrant
@@ -262,6 +277,13 @@ func (r *Repo) CreateGrantWithCode(
 		cd, err := q.CreateMCPAuthorizationCode(ctx, mkCode(gr.ID))
 		if err != nil {
 			return fmt.Errorf("create mcp authorization code: %w", err)
+		}
+		// Inside the same tx, after both inserts. An error here rolls both of
+		// them back with it -- see the interface doc on onCreated.
+		if onCreated != nil {
+			if err := onCreated(tx, gr); err != nil {
+				return err
+			}
 		}
 		grant, code = gr, cd
 		return nil
@@ -481,6 +503,7 @@ func (r *Repo) RevokeGrantWithTokens(
 	ctx context.Context,
 	principal domain.Principal,
 	grantID uuid.UUID,
+	onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	var out sqlc.RevokeMCPGrantWithTokensInTenantTxRow
 	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
@@ -492,10 +515,16 @@ func (r *Repo) RevokeGrantWithTokens(
 		if err != nil {
 			// pgx.ErrNoRows is meaningful to the caller and is NOT wrapped in a
 			// message that would make errors.Is harder to reach for. Every
-			// other error is an infra failure.
+			// other error is an infra failure. Neither reaches onRevoked --
+			// nothing was written, so nothing should be attributed.
 			return err
 		}
 		out = row
+		if onRevoked != nil {
+			if err := onRevoked(tx, row); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
@@ -177,6 +178,16 @@ type Clock func() time.Time
 type Service struct {
 	store Store
 	now   Clock
+	// audit is nil unless WithAudit is called. Every audit write in this
+	// package guards on it being nil first -- see Approve, RevokeConnection,
+	// and RecordToolCall -- so a Service built by the many unit tests in this
+	// package (fakeStore, no real Postgres pool to back an audit.Recorder)
+	// keeps working unaudited. Production wiring (cmd/wpmgr/main.go) always
+	// calls WithAudit; a Service that reaches a request path without it is a
+	// wiring bug, not a supported configuration, and the finding to raise if
+	// one is ever found is "this deploy path is unattributable", not "make the
+	// nil check quieter".
+	audit *audit.Recorder
 }
 
 func NewService(store Store) *Service {
@@ -187,6 +198,18 @@ func NewService(store Store) *Service {
 func (s *Service) WithClock(c Clock) *Service {
 	cp := *s
 	cp.now = c
+	return &cp
+}
+
+// WithAudit returns a copy that appends ActionMCPGrantCreated,
+// ActionMCPGrantRevoked and ActionMCPToolCalled through rec. Mirrors
+// WithClock's copy-and-return shape. cmd/wpmgr/main.go calls this on the one
+// Service the process constructs; a Service left without it (as most of this
+// package's unit tests are, deliberately, since they drive a fakeStore with no
+// backing Postgres pool) simply does not audit -- see the field doc on audit.
+func (s *Service) WithAudit(rec *audit.Recorder) *Service {
+	cp := *s
+	cp.audit = rec
 	return &cp
 }
 
@@ -589,6 +612,29 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 				RedirectUri:         req.Consent.RedirectURI,
 				ExpiresAt:           expiresAt,
 			}
+		},
+		// ActionMCPGrantCreated, in the SAME transaction as both inserts above.
+		// This is "the row written to the audit log" the operator-facing
+		// consent flow promises: if the grant or the code fails to insert, or
+		// this append fails, the whole approval rolls back and there is no
+		// mcp.grant.created row for a grant that does not exist.
+		func(tx pgx.Tx, gr sqlc.McpGrant) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   req.Principal.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    req.Principal.UserID.String(),
+				Action:     audit.ActionMCPGrantCreated,
+				TargetType: "mcp_grant",
+				TargetID:   gr.ID.String(),
+				Metadata: map[string]any{
+					"grant_name":      gr.Name,
+					"site_scope_mode": gr.SiteScopeMode,
+				},
+			})
+			return aerr
 		})
 	if err != nil {
 		return Approval{}, fmt.Errorf("create grant and code: %w", err)
@@ -848,6 +894,14 @@ type AuthorizedRequest struct {
 	TenantID uuid.UUID
 	GrantID  uuid.UUID
 	TokenID  uuid.UUID
+	// GrantName is the grant's operator-assigned name (mcp_grants.name), read
+	// at the same ReCheckAuthorization call that resolves GrantID -- no extra
+	// query. It exists so RecordToolCall can stamp a human-readable label onto
+	// an ActionMCPToolCalled event without a database join: ActorName
+	// resolution (ListAuditEntries) has no arm for ActorAssistant today, so
+	// this is how the label travels until it does. Never used for
+	// authorization, only for display.
+	GrantName string
 
 	// Sites is the resolved site scope: the PER-CONNECTION narrowing on the
 	// site axis. Zero value allows nothing.
@@ -955,6 +1009,7 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	return AuthorizedRequest{
 		TenantID:     tok.TenantID,
 		GrantID:      chk.GrantID,
+		GrantName:    chk.GrantName,
 		TokenID:      chk.TokenID,
 		Sites:        NewSiteSet(ids),
 		Capabilities: caps,
@@ -981,6 +1036,48 @@ func (s *Service) RecordConnect(ctx context.Context, auth AuthorizedRequest, nam
 		return fmt.Errorf("record mcp connect: %w", err)
 	}
 	return nil
+}
+
+// RecordToolCall appends the ActionMCPToolCalled audit row for one
+// successfully executed tool call. The caller (TransportHandler.callTool)
+// invokes this AFTER entry.invoke returns without error -- a refused call
+// never reaches a tenant's data, and is already visible in the operator log
+// TransportHandler writes at refusal time (h.log.WarnContext), so it earns no
+// row here.
+//
+// ActorType is ActorAssistant, the one actor kind in this whole log that
+// attributes the row to the MODEL rather than to the human who granted it
+// access: auth.GrantID identifies WHICH connection acted, which is the fact an
+// operator reviewing "what did this MCP client touch" actually wants, and it
+// is a fact ActorUser (the approving human, possibly long gone from the
+// account) cannot carry. operatorPermission and toolName both come from the
+// registry entry AuthorizeTool already resolved -- see the OperatorPermission
+// doc on ToolPolicy for why that field lands here.
+//
+// BEST-EFFORT, deliberately unlike Approve/RevokeConnection's RecordInTx:
+// there is no companion write in the same transaction to roll back alongside a
+// failed append (a tool call in this phase is a read), so failing the whole
+// tool call because its own audit trail could not be appended would let a
+// purely observational feature take down the read path it exists to observe.
+// The error is returned so the caller can log it, never to be treated as a
+// reason to withhold the tool's answer.
+func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, toolName string, operatorPermission string) error {
+	if s.audit == nil {
+		return nil
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:   auth.TenantID,
+		ActorType:  audit.ActorAssistant,
+		ActorID:    auth.GrantID.String(),
+		Action:     audit.ActionMCPToolCalled,
+		TargetType: "mcp_tool",
+		TargetID:   toolName,
+		Metadata: map[string]any{
+			"grant_name":          auth.GrantName,
+			"operator_permission": operatorPermission,
+		},
+	})
+	return err
 }
 
 // ListSitesForModel is the one Phase 1 read tool. It returns the rendered tool
@@ -1196,7 +1293,32 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 			"a connection id is required")
 	}
 
-	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID)
+	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID,
+		// ActionMCPGrantRevoked, in the SAME transaction as the revoke
+		// statement. Runs on all three non-error outcomes (freshly revoked,
+		// half-revoked repair, idempotent no-op): the operator explicitly
+		// asked for this credential to be revoked and the request is what is
+		// being attributed, not merely a state transition. It never runs
+		// alongside pgx.ErrNoRows -- see onRevoked's doc on the interface.
+		func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   p.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    p.UserID.String(),
+				Action:     audit.ActionMCPGrantRevoked,
+				TargetType: "mcp_grant",
+				TargetID:   grantID.String(),
+				Metadata: map[string]any{
+					"grants_revoked":  row.GrantsRevoked,
+					"tokens_revoked":  row.TokensRevoked,
+					"already_revoked": row.GrantsRevoked == 0,
+				},
+			})
+			return aerr
+		})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return RevokeOutcome{}, domain.NotFound(ErrCodeConnectionNotFound,

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -423,10 +423,15 @@ func (h *TransportHandler) initialize(
 	}
 	if err := h.svc.RecordConnect(c.Request.Context(), auth,
 		p.ClientInfo.Name, p.ClientInfo.Version, headerValue); err != nil {
-		// A failed audit write is NOT swallowed. The connect record is how an
+		// NOT an audit write -- RecordConnect updates mcp_grants (client name,
+		// version, protocol header) via Store.RecordClientIdentity, and that
+		// update is NOT swallowed on failure. The connect record is how an
 		// operator sees what is attached to their organisation, and a session
 		// that proceeded after failing to record itself would be an
-		// unattributable connection.
+		// unattributable connection. (The actual audit_events row for this
+		// surface is ActionMCPToolCalled, written per tool call by
+		// Service.RecordToolCall -- initialize itself is not a tool call and
+		// writes no audit row.)
 		h.log.ErrorContext(c.Request.Context(), "mcp connect record failed",
 			slog.String("tenant_id", auth.TenantID.String()),
 			slog.String("grant_id", auth.GrantID.String()),
@@ -540,6 +545,23 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 	if err != nil {
 		return h.toolError(req.ID, err)
 	}
+
+	// The operator-facing audit row (ActionMCPToolCalled), for this call and
+	// no other outcome: a refusal above never reached a tenant's data and is
+	// already covered by the WarnContext log at the refusal site. BEST-EFFORT
+	// like RecordConnect's client-identity write is not -- a failure here is
+	// logged, never returned to the caller, because withholding a successful
+	// read's answer over a failure to record having answered it would make an
+	// observational feature take down the read path it observes.
+	if err := h.svc.RecordToolCall(ctx, auth, entry.Name, string(entry.OperatorPermission)); err != nil {
+		h.log.ErrorContext(ctx, "mcp tool call audit write failed",
+			slog.String("tenant_id", auth.TenantID.String()),
+			slog.String("grant_id", auth.GrantID.String()),
+			slog.String("tool", entry.Name),
+			slog.String("error", err.Error()),
+		)
+	}
+
 	return newResponse(req.ID, map[string]any{
 		"content": []map[string]any{{"type": "text", "text": text}},
 	})

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -96,7 +96,7 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("seed grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -103,7 +103,7 @@ func s7GrantWithBearer(
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("create grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -1,0 +1,371 @@
+// mcp_audit_events_integration_test.go: the three audit_events writes added to
+// the MCP connection surface -- ActionMCPGrantCreated, ActionMCPGrantRevoked,
+// ActionMCPToolCalled -- proven against the REAL schema, RLS and application
+// role, through the SAME code path production uses.
+//
+// WHY THIS FILE EXISTS. internal/mcp wrote ZERO rows to audit_log before this
+// slice: `grep -rn '\.Record(\|RecordInTx(' internal/mcp/*.go` matched nothing
+// outside _test.go's httptest.NewRecorder. An approve, a revoke or a tool call
+// that reaches a tenant's data left no attributable row. A unit test against
+// fakeStore cannot prove any of the three things that actually matter here:
+//
+//  1. mcp.grant.created lands in the SAME transaction as the grant insert
+//     (RecordInTx, not Record), so a rolled-back grant leaves no row claiming
+//     one exists -- see the rollback proof below.
+//  2. The row is readable back only through db.Pool as wpmgr_app -- NOSUPERUSER,
+//     NOBYPASSRLS -- which mcpAssertAndReportRole asserts and prints. A test
+//     that opened its own connection would leave every RLS policy inert and
+//     pass regardless; that is exactly how m112's proofs passed while the email
+//     domain was cross-site readable.
+//  3. A second tenant's InTenantTx cannot see the first tenant's assistant row,
+//     even though both share one physical audit_log table.
+//
+// So: every write and every read below goes through the same Service, the same
+// Handler, the same TransportHandler and the same tx helpers server.New wires,
+// with the app-role pool. No GUC is hand-set anywhere in this file.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpAuditRow is the slice of audit_log columns these proofs care about.
+type mcpAuditRow struct {
+	actorType string
+	actorID   string
+	targetID  string
+	metadata  map[string]any
+}
+
+// queryMCPAuditRowsAsAppRole reads audit_log for one tenant and action THROUGH
+// db.Pool.InTenantTx -- the same tx helper Recorder.List uses -- so RLS is live
+// for this read exactly as it is for the write under test.
+func queryMCPAuditRowsAsAppRole(t *testing.T, pool *db.Pool, tenantID uuid.UUID, action string) []mcpAuditRow {
+	t.Helper()
+	var out []mcpAuditRow
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(context.Background(),
+			`SELECT actor_type, actor_id, target_id, metadata FROM audit_log
+			  WHERE tenant_id = $1 AND action = $2`, tenantID, action)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var r mcpAuditRow
+			var metaRaw []byte
+			if err := rows.Scan(&r.actorType, &r.actorID, &r.targetID, &metaRaw); err != nil {
+				return err
+			}
+			if len(metaRaw) > 0 {
+				if err := json.Unmarshal(metaRaw, &r.metadata); err != nil {
+					return err
+				}
+			}
+			out = append(out, r)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		t.Fatalf("query audit_log action=%s for tenant %s: %v", action, tenantID, err)
+	}
+	return out
+}
+
+// TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole drives the
+// WHOLE MCP surface -- register, authorize, consent, exchange, a real tools/call
+// over the mounted transport, then revoke -- and asserts each of the three new
+// audit rows lands with the right actor, target and metadata. It also proves
+// tenant isolation: a second tenant's InTenantTx read sees none of it.
+func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion below.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-audit-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-audit-"+suffix+"@example.test")
+	siteURL := "https://" + suffix + ".example.test"
+	seedSite(t, pool, tenantID, siteURL)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	// An org-scoped admin: the role RegisterConnections' PermAPIKeyManage
+	// requires for revoke, and the only scope /consent admits.
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	eng := mountLikeProduction(t, svc, admin)
+
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+	const grantName = "mcp audit events test connection"
+
+	// ------------------------------------------------------------------
+	// register -> authorize -> consent -> exchange, exactly as
+	// adr064_s6b3_mcp_oauth_end_to_end_test.go proves the flow composes.
+	// ------------------------------------------------------------------
+	var reg struct {
+		ClientID string `json:"client_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.RegisterPath, map[string]any{
+		"redirect_uris":              []string{redirectURI},
+		"client_name":                "Claude Desktop",
+		"client_uri":                 "https://claude.ai",
+		"token_endpoint_auth_method": "none",
+	}, nil, &reg); code != http.StatusCreated {
+		t.Fatalf("register answered %d, want 201", code)
+	}
+
+	verifier := "audit-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", reg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "audit-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	if code := mcpDoJSON(t, eng, http.MethodGet, mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		t.Fatalf("authorize answered %d, want 200", code)
+	}
+
+	var approval struct {
+		GrantID string `json:"grant_id"`
+		Code    string `json:"code"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConsentPath, map[string]any{
+		"client_id":             reg.ClientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "audit-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"name":                  grantName,
+		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+	}, nil, &approval); code != http.StatusOK {
+		t.Fatalf("consent answered %d, want 200", code)
+	}
+	grantID := approval.GrantID
+
+	// ------------------------------------------------------------------
+	// PROOF 1: mcp.grant.created landed, actor = the approving USER.
+	// ------------------------------------------------------------------
+	created := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	if len(created) != 1 {
+		t.Fatalf("mcp.grant.created rows = %d, want exactly 1", len(created))
+	}
+	if created[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.created actor_type = %q, want %q", created[0].actorType, audit.ActorUser)
+	}
+	if created[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.created actor_id = %q, want the approving user %q", created[0].actorID, userID)
+	}
+	if created[0].targetID != grantID {
+		t.Errorf("mcp.grant.created target_id = %q, want the grant id %q", created[0].targetID, grantID)
+	}
+	if got, _ := created[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.grant.created metadata.grant_name = %q, want %q", got, grantName)
+	}
+	t.Logf("PROOF 1 ok: mcp.grant.created attributed to user %s for grant %s", userID, grantID)
+
+	// ------------------------------------------------------------------
+	// Exchange the code, then call tools/call over the real transport.
+	// ------------------------------------------------------------------
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", approval.Code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", reg.ClientID)
+	form.Set("code_verifier", verifier)
+
+	tokReq := httptest.NewRequest(http.MethodPost, mcp.TokenPath, strings.NewReader(form.Encode()))
+	tokReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokReq.RemoteAddr = "203.0.113.7:5555"
+	tokW := httptest.NewRecorder()
+	eng.ServeHTTP(tokW, tokReq)
+	if tokW.Code != http.StatusOK {
+		t.Fatalf("token exchange answered %d, want 200: %s", tokW.Code, tokW.Body.String())
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(tokW.Body.Bytes(), &tok); err != nil {
+		t.Fatalf("token response is not JSON: %v", err)
+	}
+	if tok.AccessToken == "" {
+		t.Fatal("token exchange returned no access_token")
+	}
+
+	got := mcpRPC(t, eng, tok.AccessToken, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("tools/call %s answered %d, want 200: %s", mcp.ToolListSites, got.status, got.body)
+	}
+
+	// ------------------------------------------------------------------
+	// PROOF 2: mcp.tool.called landed, actor = the ASSISTANT (the grant),
+	// never the approving user.
+	// ------------------------------------------------------------------
+	called := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("mcp.tool.called rows = %d, want exactly 1", len(called))
+	}
+	if called[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.tool.called actor_type = %q, want %q", called[0].actorType, audit.ActorAssistant)
+	}
+	if called[0].actorID != grantID {
+		t.Errorf("mcp.tool.called actor_id = %q, want the grant id %q (NOT the user)", called[0].actorID, grantID)
+	}
+	if called[0].targetID != mcp.ToolListSites {
+		t.Errorf("mcp.tool.called target_id = %q, want the tool name %q", called[0].targetID, mcp.ToolListSites)
+	}
+	if got, _ := called[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.tool.called metadata.grant_name = %q, want %q (the actor label)", got, grantName)
+	}
+	if got, _ := called[0].metadata["operator_permission"].(string); got != string(authz.PermSiteRead) {
+		t.Errorf("mcp.tool.called metadata.operator_permission = %q, want %q", got, authz.PermSiteRead)
+	}
+	t.Logf("PROOF 2 ok: mcp.tool.called attributed to assistant/grant %s, not to user %s", grantID, userID)
+
+	// ------------------------------------------------------------------
+	// PROOF 3 (tenant isolation): a SECOND tenant's InTenantTx read sees
+	// NONE of tenant 1's assistant row, even though both live in the same
+	// physical audit_log table.
+	// ------------------------------------------------------------------
+	otherTenant := seedTenant(t, pool, "mcp-audit-other-"+suffix)
+	cross := queryMCPAuditRowsAsAppRole(t, pool, otherTenant, audit.ActionMCPToolCalled)
+	if len(cross) != 0 {
+		t.Fatalf("PROOF 3: tenant %s's InTenantTx read %d mcp.tool.called row(s) belonging to "+
+			"tenant %s; RLS did not isolate the assistant actor's row across tenants",
+			otherTenant, len(cross), tenantID)
+	}
+	t.Logf("PROOF 3 ok: tenant %s cannot see tenant %s's assistant audit row", otherTenant, tenantID)
+
+	// ------------------------------------------------------------------
+	// PROOF 4: mcp.grant.revoked landed, actor = the revoking USER.
+	// ------------------------------------------------------------------
+	connEng := mountConnectionsLikeProduction(t, svc, admin)
+	var revoked struct {
+		GrantsRevoked int64 `json:"grants_revoked"`
+	}
+	if code := mcpDoJSON(t, connEng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(grantID), nil, nil, &revoked); code != http.StatusOK {
+		t.Fatalf("revoke answered %d, want 200", code)
+	}
+	if revoked.GrantsRevoked != 1 {
+		t.Fatalf("revoke grants_revoked = %d, want 1 for a first revoke", revoked.GrantsRevoked)
+	}
+
+	revokedRows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantRevoked)
+	if len(revokedRows) != 1 {
+		t.Fatalf("mcp.grant.revoked rows = %d, want exactly 1", len(revokedRows))
+	}
+	if revokedRows[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.revoked actor_type = %q, want %q", revokedRows[0].actorType, audit.ActorUser)
+	}
+	if revokedRows[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.revoked actor_id = %q, want the revoking user %q", revokedRows[0].actorID, userID)
+	}
+	if revokedRows[0].targetID != grantID {
+		t.Errorf("mcp.grant.revoked target_id = %q, want the grant id %q", revokedRows[0].targetID, grantID)
+	}
+	t.Logf("PROOF 4 ok: mcp.grant.revoked attributed to user %s for grant %s", userID, grantID)
+}
+
+// TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole is the
+// fail-closed half: Service.Approve wires the ActionMCPGrantCreated append
+// through Repo.CreateGrantWithCode's onCreated hook, which runs INSIDE the same
+// transaction as both inserts. This simulates an onCreated-shaped failure (the
+// exact hook the audit append uses) and asserts the whole write rolls back --
+// no mcp_grants row AND no audit_log row for the grant id that never committed.
+func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenantID := seedTenant(t, pool, "mcp-audit-rb-"+uuid.NewString()[:8])
+	repo := mcp.NewRepo(pool)
+	principal := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+
+	simulated := errors.New("simulated: mcp.grant.created append failed")
+	var capturedGrantID uuid.UUID
+	_, _, err := repo.CreateGrantWithCode(ctx, principal, sqlc.CreateMCPGrantParams{
+		TenantID:      tenantID,
+		Name:          "should not survive",
+		Status:        "active",
+		SiteScopeMode: "all",
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  []uuid.UUID{},
+	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+		capturedGrantID = grantID
+		return sqlc.CreateMCPAuthorizationCodeParams{
+			TenantID:            tenantID,
+			GrantID:             grantID,
+			ClientID:            "rollback-probe-client",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
+			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
+		}
+	}, func(tx pgx.Tx, gr sqlc.McpGrant) error {
+		return simulated
+	})
+
+	if err == nil {
+		t.Fatal("CreateGrantWithCode succeeded despite the onCreated hook failing, want an error")
+	}
+	if !errors.Is(err, simulated) {
+		t.Errorf("error = %v, want it to wrap the simulated failure", err)
+	}
+	if capturedGrantID == uuid.Nil {
+		t.Fatal("the grant id was never captured; the insert must run before onCreated for this proof to mean anything")
+	}
+
+	var grantCount int
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM mcp_grants WHERE id = $1`, capturedGrantID).Scan(&grantCount)
+	}); err != nil {
+		t.Fatalf("count mcp_grants: %v", err)
+	}
+	if grantCount != 0 {
+		t.Errorf("mcp_grants row for %s committed despite the audit hook failing, want 0 rows", capturedGrantID)
+	}
+
+	rows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	for _, r := range rows {
+		if r.targetID == capturedGrantID.String() {
+			t.Fatalf("found an mcp.grant.created row for grant %s, which never committed", capturedGrantID)
+		}
+	}
+	t.Logf("rollback proof ok: neither mcp_grants nor audit_log carries a row for %s", capturedGrantID)
+}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -331,7 +331,7 @@ func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *tes
 			TenantID:            tenantID,
 			GrantID:             grantID,
 			ClientID:            "rollback-probe-client",
-			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 			CodeChallengeMethod: "S256",
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -328,7 +328,7 @@ func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err == nil {
 		t.Fatal("CreateGrantWithCode accepted a site-scoped principal. The write " +
 			"reached mcp_grants with app.site_scope unset, so the RESTRICTIVE " +


### PR DESCRIPTION
## Summary
- internal/mcp wrote zero rows to audit_log. Adds three events: `mcp.grant.created` (consent approval), `mcp.grant.revoked` (revoke), `mcp.tool.called` (per successful tool call over the transport).
- Adds a fourth actor kind, `audit.ActorAssistant`, keyed on the grant id for tool calls. No migration: `actor_type` has no CHECK constraint.
- `mcp.grant.created` and `mcp.grant.revoked` use `audit.Recorder.RecordInTx` inside the SAME transaction as the underlying write (new `onCreated`/`onRevoked` hooks on `Repo.CreateGrantWithCode` / `RevokeGrantWithTokens`), so a rolled-back grant leaves no audit row. `mcp.tool.called` is best-effort (`Record`), matching the rest of the log, since a tool call in this phase is a read with no companion write to roll back against.
- `Service` gains `WithAudit(*audit.Recorder)`, mirroring `WithClock`, so the package's many fakeStore-backed unit tests are unaffected. Production wiring (`cmd/wpmgr/main.go`, `cmd/dump-routes/routes.go`) now passes the recorder through.
- Corrected a misleading comment in `transport.go` that called `RecordConnect`'s failure "a failed audit write NOT swallowed" — it updates `mcp_grants` (client identity), not an audit row.

## Known gap (reported, not fixed here — out of scope for a Go-only change)
`ListAuditEntries`/`ListAuditEntriesFiltered` (db/query/audit_log.sql) resolve `actor_name` via a `LEFT JOIN` keyed on `actor_type IN ('user','api_key')`. There is no arm for `'assistant'`, so a `mcp.tool.called` row's display name does not come back through `Entry.ActorName` yet — the grant's name travels in `Metadata.grant_name` instead. Closing this fully needs a database-engineer change to that query plus the frontend `ActorKind` union (`apps/web/src/features/audit/actor.ts`), both flagged as separate follow-up work, not done here.

## Test plan
- [x] `cd apps/api && go build ./... && go vet ./... && go test ./internal/... ./cmd/...` — green.
- [x] New integration test `apps/api/tests/mcp_audit_events_integration_test.go`, run through the real HTTP routes / transport / RLS as `wpmgr_app`:
  - `TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole` — proves all three events, actor kinds, target ids, metadata, and cross-tenant isolation of the assistant row.
  - `TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole` — proves a simulated `onCreated` failure leaves neither an `mcp_grants` row nor an `mcp.grant.created` row.
- [ ] `make test-integration` — not yet run in this session; needs a live Postgres (Docker) locally. Report will state plainly if it could not be run rather than treating a skip as a pass.