### PR TITLE
fix(web): consent screen approves an empty site allowlist

### DIFF
--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -138,16 +138,32 @@ describe("ConsentScreen — what it can do and what it cannot", () => {
   });
 });
 
-describe("ConsentScreen — an empty site scope is not everything", () => {
-  it("starts with nothing selected and cannot be approved", () => {
+describe("ConsentScreen — an empty site scope is a working state, not an error (2026-08-23 revision)", () => {
+  it("starts with nothing selected, states the consequence, and CAN be approved", () => {
+    // Superseded framing (pre-2026-08-23): this blocked approval. The current
+    // wireframe rules an empty allowlist mints a credential that reads and
+    // proposes nothing, decided later -- a working state, not an error.
     renderWithProviders(<ConsentScreen {...props()} />);
-    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
-      /No sites are selected yet/i,
-    );
-    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    const summary = screen.getByTestId("consent-scope-summary").textContent ?? "";
+    expect(summary).toMatch(/No sites are selected/i);
+    expect(summary).toMatch(/read nothing and propose nothing/i);
+    expect(summary).toMatch(/working state, not an error/i);
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
   });
 
-  it("a tag matching no site says so, never that it covers everything", () => {
+  it("submits an empty list-mode scope when approved with nothing selected", () => {
+    const onApprove = vi.fn();
+    renderWithProviders(<ConsentScreen {...props({ onApprove })} />);
+    fireEvent.submit(screen.getByTestId("consent-approve").closest("form")!);
+    expect(onApprove).toHaveBeenCalledWith({
+      name: "Claude Desktop",
+      siteScopeMode: "list",
+      scopeTagIds: [],
+      scopeSiteIds: [],
+    });
+  });
+
+  it("a tag matching no site says so, states the consequence, and CAN be approved", () => {
     renderWithProviders(
       <ConsentScreen
         {...props({ tags: [{ id: "t9", name: "archived" }], tagsBySiteId: { s1: [], s2: [] } })}
@@ -157,9 +173,10 @@ describe("ConsentScreen — an empty site scope is not everything", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /archived/i }));
     const summary = screen.getByTestId("consent-scope-summary");
     expect(summary.textContent).toMatch(/matches no sites/i);
-    expect(summary.textContent).toMatch(/read nothing/i);
+    expect(summary.textContent).toMatch(/read nothing and propose nothing/i);
+    expect(summary.textContent).toMatch(/working state, not an error/i);
     expect(screen.queryByTestId("consent-scope-sites")).toBeNull();
-    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
   });
 
   it("a failed site load blocks approval instead of resolving to zero or to all", () => {

--- a/apps/web/src/features/mcp-consent/site-scope.test.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.test.ts
@@ -72,9 +72,9 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
     expect(scope.kind).toBe("none");
   });
 
-  it("an empty resolution is not approvable", () => {
-    expect(isScopeApprovable(resolveSiteScope(input({ mode: "tags", selectedTagNames: ["gone"] })))).toBe(false);
-    expect(isScopeApprovable(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })))).toBe(false);
+  it("an empty resolution IS approvable -- reading nothing is a working state, not an error (2026-08-23 revision)", () => {
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "tags", selectedTagNames: ["gone"] })))).toBe(true);
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })))).toBe(true);
   });
 
   it("only mode 'all' ever produces kind 'all'", () => {
@@ -92,6 +92,24 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
     const scope = resolveSiteScope(input({ mode: "all", fleet: { sites: [], complete: true } }));
     expect(scope.kind).toBe("all");
     expect(describeSiteScope(scope)).toMatch(/added later/i);
+  });
+});
+
+describe("isScopeApprovable — an empty allowlist is approvable, an unread one never is", () => {
+  // The 2026-08-23 wireframe revision (line 3559) rules that a connection with
+  // an empty allowlist "can read nothing and propose nothing. That is a
+  // working state, not an error." This block pins BOTH halves of that with
+  // equal force: `none` (however it was reached) now passes, and `unresolved`
+  // (however it was reached) still fails. Weakening either half back to the
+  // pre-2026-08-23 shape must redden this block, not just the copy tests.
+  it("accepts a resolved-to-nothing scope, from no selection and from no matches alike", () => {
+    expect(isScopeApprovable({ kind: "none", because: "no-selection" })).toBe(true);
+    expect(isScopeApprovable({ kind: "none", because: "no-matches" })).toBe(true);
+  });
+
+  it("still refuses a scope nobody has read, whether pending or failed", () => {
+    expect(isScopeApprovable({ kind: "unresolved", because: "loading" })).toBe(false);
+    expect(isScopeApprovable({ kind: "unresolved", because: "failed" })).toBe(false);
   });
 });
 

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -240,9 +240,13 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
       return `${siteCount(scope.sites.length)} ${verb} these tags today, listed below. ${future}`;
     }
     case "none":
+      // 2026-08-23 revision (wireframes.html:3559): an empty allowlist "is a
+      // working state, not an error -- it is how you mint a credential now and
+      // decide its reach later." Both branches say that consequence plainly
+      // rather than treating the choice as incomplete.
       return scope.because === "no-selection"
-        ? "No sites are selected yet. Choose what this client may read before approving."
-        : "This selection matches no sites, so this connection would be able to read nothing. That is not the same as covering every site.";
+        ? "No sites are selected. That is a working state, not an error: this connection will read nothing and propose nothing until you give it sites to cover, now or later."
+        : "This selection matches no sites, so this connection will read nothing and propose nothing right now. That is a working state, not an error: you can widen its scope later.";
     case "unresolved":
       return scope.because === "loading"
         ? "Working out which sites this covers."
@@ -253,11 +257,19 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
 /**
  * Whether a scope may be approved.
  *
- * `none` is refusable rather than blocked-with-a-warning: server-side, an empty
- * payload is unstorable for mode 'list' and a tag matching nothing resolves to
- * an empty set, so approving it creates a grant that reads nothing. Better to
- * say that on this screen than to mint a credential that silently does nothing.
- * `unresolved` is blocked because consenting to an unread set is not consent.
+ * 2026-08-23 revision (wireframes.html:3559): "A connection with an empty
+ * allowlist can read nothing and propose nothing. That is a working state, not
+ * an error -- it is how you mint a credential now and decide its reach later."
+ * `none` is therefore approvable, on equal footing with `all` and `sites`.
+ * Narrowing to nothing is not refused here because it is enforced where it
+ * actually matters: by which tools are registered for the connection
+ * (wireframes.html:1743, "narrowing is applied by unregistering the tool, not
+ * by denying it at call time"), not by a client-side gate on this screen. The
+ * older rule that blocked an empty allowlist (wireframes.html:1293) is
+ * superseded.
+ *
+ * `unresolved` is the only kind that still blocks. Consenting to a scope
+ * nobody has read is not consent, whether the read is pending or failed.
  *
  * A TRUNCATED LIST DOES NOT BLOCK. It is disclosed instead. Blocking would
  * refuse every organisation past the page size, and the operator choosing "every
@@ -265,5 +277,5 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
  * is a false count or a list that poses as the whole fleet.
  */
 export function isScopeApprovable(scope: ResolvedSiteScope): boolean {
-  return scope.kind === "all" || scope.kind === "sites";
+  return scope.kind !== "unresolved";
 }


### PR DESCRIPTION
## Summary
- Implements the owner's 2026-08-23 wireframe ruling (wireframes.html:3559, :1743): an empty site allowlist reads nothing and proposes nothing, and that is a working state, not an error - the older rule at wireframes.html:1293 is superseded.
- `isScopeApprovable` in `apps/web/src/features/mcp-consent/site-scope.ts` now refuses only `unresolved` scopes; `none` (whether from no selection or no matches) is approvable, matching the `canLeaveSiteStep` model.
- `describeSiteScope`'s empty-scope copy now states the consequence in the revision's own terms (no banned words: isolated, sandboxed, walled off, cannot reach, impossible, guaranteed, secure, safe).
- `consent-screen.tsx`'s `canApprove` already composed on top of `isScopeApprovable`, `scopesOk`, `tagPayload !== null`, and `!isApproving` - verified, no code change needed there.

## Finding for the reconciling sweep (not fixed here, per instructions)
`apps/web/src/features/ai-connections/site-step.ts` and its test, referenced in the brief as "already in the repo," do not exist on `main`. They exist only on the unmerged branch `feat/mcp-wizard-step3-sites` (commit `48459716`), which already implements `canLeaveSiteStep = scope.kind !== "unresolved"` (the exact model this PR follows) and a same-shaped tripwire test. When that branch merges, the same tripwire-rewrite applied here should be applied there, or the two should be reconciled directly - this branch could not touch that file because it is not reachable from here.

Also noted (separate sweep territory, not fixed): `apps/web/src/features/ai-connections/connection-model.ts`'s `AiConnection.siteScopeMode` field exists but is not yet rendered or editable anywhere in `connections-list.tsx` (the list/detail endpoint does not exist yet per that file's own header comment).

## Test plan
- [x] `pnpm -C apps/web typecheck` - exit 0
- [x] `pnpm -C apps/web lint` - exit 0 (pre-existing warnings only, none from this change)
- [x] `pnpm -C apps/web test` - 163 files / 1984 tests passed
- [x] `pnpm -C apps/web build` - exit 0, no routeTree churn
- [x] `apps/web/node_modules/.bin/impeccable detect apps/web/src/features/mcp-consent` - exit 0, clean
- [x] Mutation sweep on `isScopeApprovable` and the consequence copy (see table below) - each mutation reddened the test naming that property; suite green again after revert; `git diff --stat` matched the pre-sweep diff exactly (no residue)

| Mutation | Result |
|---|---|
| Drop `none` acceptance (revert to `all \|\| sites`) | 5 tests failed, all naming "approvable"/empty-scope |
| Drop `unresolved` refusal (`return true` unconditionally) | 5 tests failed, all naming "unresolved"/blocks-approval |
| Revert consequence copy to pre-2026-08-23 wording | 2 tests failed, naming "states the consequence" |
| Revert all three | 163/163 files green again, `git diff --stat` identical to pre-sweep |
