### PR TITLE
feat(mcp): supply m127's grant columns and wire the activity stamp (#605)

### DIFF
--- a/apps/api/cmd/dump-routes/routes.go
+++ b/apps/api/cmd/dump-routes/routes.go
@@ -286,7 +286,7 @@ func buildEngine() (engine *gin.Engine, omittedDepsFields []string, err error) {
 	// cmd/wpmgr/main.go wires it (mcp.NewService(mcp.NewRepo(pool)) etc.), so
 	// POST /mcp, the four OAuth paths and the three well-known discovery
 	// documents all mount.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, "dump-routes")
 	mcpOAuthH := mcp.NewHandler(mcpSvc)
 	mcpDiscoveryH := mcp.NewDiscoveryHandler("https://cp.example.test")

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -540,7 +540,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// would make POST /mcp answer 404, which is indistinguishable from a
 	// routing failure. Self-host reaches it too; the grant is what authorizes,
 	// and an installation with no grants simply has no valid bearer token.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, version)
 	// The OAuth half, wired unconditionally for the same reason. Without it the
 	// transport above is mounted and correct and refuses every request forever,

--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -268,11 +268,29 @@ RETURNING *;
 -- either gets 23502 rather than a live organisation-wide grant (Decision 1).
 -- The caller passes status explicitly -- 'active' -- rather than relying on the
 -- schema to assume it.
+--
+-- m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+-- columns behave the same way: a caller that omits capabilities or expires_at
+-- gets 23502, NOT an unrestricted or never-expiring connection.
+--
+-- THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+-- CreateMCPGrantParams is a named-field struct literal at
+-- internal/mcp/service.go:570 and in three integration fixtures, so adding
+-- fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+-- which is NULL, which is refused at the INSERT. backend-architect must supply
+-- all three. A loud 23502 at creation is the correct failure and is strictly
+-- better than the alternative of a DEFAULT that quietly mints a credential
+-- nobody chose the terms of.
+--
+-- idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+-- meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+-- only safe one until TouchMCPGrantInTenantTx has a caller.
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, capabilities, expires_at,
+    idle_expire_after_days
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING *;
 
@@ -483,6 +501,21 @@ WHERE mcp_connection_tokens.token_hash = $1;
 -- The grant is joined on tenant_id as well as id: the token and its grant must
 -- belong to the same organisation, checked in the join rather than assumed
 -- from the foreign key.
+-- m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+-- a second read the caller might forget. A grant past its absolute expiry, or
+-- past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+-- Both are evaluated on the already-fetched grant row, so neither costs a round
+-- trip and neither needs an index.
+--
+-- The wireframe's "there is no silent read-only period" is a consequence of
+-- this shape: expiry flips one boolean to false outright and cannot degrade a
+-- connection to a reduced capability set, because there is one boolean here and
+-- not a tier.
+--
+-- g.capabilities is returned so the capability set is read from the SAME ROW
+-- and the SAME transaction as the verdict it was authorized under (S7's exit
+-- gate: discovery never grants what the registry does not hold, and it cannot
+-- hold what this row does not carry).
 SELECT
     g.id                          AS grant_id,
     g.name                        AS grant_name,
@@ -491,17 +524,47 @@ SELECT
     g.scope_tag_ids               AS scope_tag_ids,
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
+    g.capabilities                AS grant_capabilities,
+    g.expires_at                  AS grant_expires_at,
+    g.idle_expire_after_days      AS grant_idle_expire_after_days,
+    g.last_used_at                AS grant_last_used_at,
     t.id                          AS token_id,
     t.token_prefix                AS token_prefix,
     t.status                      AS token_status,
     t.expires_at                  AS token_expires_at,
+    -- The component reasons, so a refusal can be logged with its cause. Both
+    -- COALESCE to TRUE -- the FAIL-CLOSED direction for a negative flag, since
+    -- these say "expired". An absent value must never read as "still valid".
+    -- They are diagnostics; `authorized` below is the verdict.
+    COALESCE(g.expires_at <= now(), true)::boolean AS grant_absolute_expired,
+    COALESCE(g.idle_expire_after_days IS NOT NULL
+        AND COALESCE(g.last_used_at, g.created_at)
+            + make_interval(days => g.idle_expire_after_days) <= now(),
+        true)::boolean AS grant_idle_expired,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
     -- how a nil comes to be read as anything other than refusal.
     COALESCE(g.status = 'active'
         AND t.status = 'active'
-        AND (t.expires_at IS NULL OR t.expires_at > now()), false)::boolean AS authorized
+        AND (t.expires_at IS NULL OR t.expires_at > now())
+        -- ABSOLUTE EXPIRY. NO `IS NULL OR` BRANCH, and its absence is the
+        -- point: mcp_grants.expires_at is NOT NULL (m127 DECISION 2), so
+        -- unlike t.expires_at above there is no nullable case here for a
+        -- reader to get backwards.
+        AND g.expires_at > now()
+        -- IDLE EXPIRY. NULL means never idle-expire, which is a DIFFERENT fact
+        -- from the absolute expiry above and is why the NULL branch appears on
+        -- this line and not that one. coalesce(last_used_at, created_at):
+        -- a grant never used is idle since it was created.
+        --
+        -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
+        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
+        -- NULL and this collapses to created_at + N days for every row.
+        AND (g.idle_expire_after_days IS NULL
+             OR COALESCE(g.last_used_at, g.created_at)
+                + make_interval(days => g.idle_expire_after_days) > now()),
+        false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5641,6 +5641,37 @@ CREATE TABLE mcp_grants (
             AND cardinality(scope_site_ids) > 0
             AND cardinality(scope_tag_ids) = 0)
     ),
+    -- WHICH TOOLS this grant may reach (m127 DECISION 1). NOT NULL, NO
+    -- DEFAULT: a nullable capabilities column read as "no narrowing applied,
+    -- therefore everything" is the defect this surface exists to prevent. '{}'
+    -- is legal and means zero capabilities, which reaches no tool.
+    --
+    -- Deliberately the OPPOSITE of api_keys.capabilities, which is nullable --
+    -- that column had a `role` fallback and a live fleet to avoid stripping at
+    -- boot; this one has no second source of authority, so NULL would only
+    -- mean "unknown", and an unknown grant is refused.
+    capabilities text[] NOT NULL,
+    -- Shape, exactly as m120 checks api_keys.capabilities: one dimension (a
+    -- nested literal would be flattened by unnest() into capabilities nobody
+    -- granted), no NULL element, no empty string, and the 64 ceiling the
+    -- wireframe states as a property of the credential.
+    CONSTRAINT mcp_grants_capabilities_shape_check CHECK (
+        coalesce(array_ndims(capabilities), 1) = 1
+        AND cardinality(capabilities) <= 64
+        AND array_position(capabilities, NULL) IS NULL
+        AND NOT ('' = ANY (capabilities))
+    ),
+    -- CLOSED VOCABULARY, checked against the registry by name. This is S7's
+    -- exit gate -- discovery never grants what the registry does not hold --
+    -- pushed into the one place a call site cannot forget.
+    --
+    -- Keep in lockstep with capabilityVocabulary in internal/mcp/policy.go,
+    -- which holds exactly this one entry today. EXTENDING IT IS A MIGRATION,
+    -- and that coupling is the review gate m124 DECISION 1 asked for: a write
+    -- capability cannot reach this table until someone writes a migration
+    -- naming it. Adding a Capability to policy.go alone fails 23514 on INSERT.
+    CONSTRAINT mcp_grants_capabilities_vocabulary_check
+        CHECK (capabilities <@ ARRAY['mcp.sites.read']::text[]),
     -- The registered OAuth client, or NULL on the headless token path. No
     -- foreign key: neither ON DELETE action is right for a recorded fact.
     client_id text NULL,
@@ -5656,7 +5687,40 @@ CREATE TABLE mcp_grants (
     last_used_at timestamptz NULL,
     revoked_at   timestamptz NULL,
     CONSTRAINT mcp_grants_revoked_at_matches_status_check
-        CHECK ((status = 'revoked') = (revoked_at IS NOT NULL))
+        CHECK ((status = 'revoked') = (revoked_at IS NOT NULL)),
+
+    -- ABSOLUTE EXPIRY (m127 DECISION 2). NOT NULL, NO DEFAULT. NULL IS
+    -- UNREPRESENTABLE -- not "NULL means never". Step 5 of the wireframe offers
+    -- 30 days / 90 days / 1 year / on a date and NO "never" option, so a
+    -- never-expiring connection is not a thing the product offers and not a
+    -- thing the schema can hold. The point of NOT NULL here is that the
+    -- read-time predicate has NO NULL BRANCH for a caller to get backwards.
+    expires_at timestamptz NOT NULL,
+    -- A grant cannot be born already expired. Immediate termination is
+    -- REVOCATION (status = 'revoked'), not a backdated expiry; keeping the two
+    -- mechanisms distinct is what keeps revoked_at honest.
+    CONSTRAINT mcp_grants_expires_at_after_created_check
+        CHECK (expires_at > created_at),
+
+    -- IDLE EXPIRY (m127 DECISION 2), a WINDOW LENGTH IN DAYS and not an
+    -- instant. NULL MEANS NEVER IDLE-EXPIRE, and only that -- Step 5's second
+    -- control does offer "Never" beside 30 and 90 days, so this axis has three
+    -- states and the third is representable. The deadline is computed at read
+    -- time from coalesce(last_used_at, created_at) so it moves whenever the
+    -- connection is used, which is what "expire it if unused for N days" means.
+    --
+    -- WARNING (m127 DECISION 4): mcp_grants.last_used_at IS NEVER WRITTEN
+    -- TODAY. TouchMCPGrantInTenantTx has zero Go callers, so
+    -- coalesce(last_used_at, created_at) collapses to created_at permanently.
+    -- A non-NULL value here would therefore kill every affected connection N
+    -- days after CREATION however active it is. NULL with no default is what
+    -- makes that unreachable. Wiring the activity stamp is a PREREQUISITE of
+    -- writing this column, not a follow-up.
+    idle_expire_after_days integer NULL,
+    CONSTRAINT mcp_grants_idle_expire_after_days_check CHECK (
+        idle_expire_after_days IS NULL
+        OR (idle_expire_after_days >= 1 AND idle_expire_after_days <= 3650)
+    )
 );
 
 -- "Is this grant live right now" in one indexed read.

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -28,6 +28,13 @@ const (
 	ActorUser   = "user"
 	ActorAPIKey = "api_key"
 	ActorSystem = "system"
+	// ActorAssistant is the model on the other end of an MCP connection --
+	// never a human and never the control plane itself. actor_type has no
+	// CHECK constraint (db/schema.sql), so this needed no migration.
+	// ActorID for this kind is the grant id (internal/mcp), NOT a user or key
+	// id: an MCP grant is the credential a model acts under, the way a user id
+	// or an api_key id is the credential a human or a script acts under.
+	ActorAssistant = "assistant"
 
 	ActionLoginSuccess = "auth.login.success"
 	ActionLoginFailure = "auth.login.failure"
@@ -352,6 +359,41 @@ const (
 	// ActionAdminBillingStateForced: metadata: reason, old_plan,
 	// old_plan_status, new_plan, new_plan_status.
 	ActionAdminBillingStateForced = "admin.billing.state.forced"
+
+	// The MCP connection surface (ADR-064). Approve, revoke, and every tool
+	// call are the three points where an MCP grant does something a human
+	// operator can be asked about afterward, and each needed a row here --
+	// before this the surface wrote zero.
+	//
+	// ActionMCPGrantCreated is recorded on the SAME transaction as the grant
+	// insert (internal/mcp.Service.Approve, via RecordInTx), so a rolled-back
+	// grant leaves no row claiming one was created. ActorType is ActorUser:
+	// the grant belongs to the organisation of the human who approved it, and
+	// ActorID is that user's id, not the grant's. Metadata: grant_name,
+	// site_scope_mode.
+	ActionMCPGrantCreated = "mcp.grant.created"
+	// ActionMCPGrantRevoked is recorded on the SAME transaction as the revoke
+	// (internal/mcp.Service.RevokeConnection, via RecordInTx). ActorType is
+	// ActorUser -- the operator who revoked, ActorID their user id. Metadata:
+	// grant_name, grants_revoked, tokens_revoked, already_revoked.
+	ActionMCPGrantRevoked = "mcp.grant.revoked"
+	// ActionMCPToolCalled is recorded per successful tool invocation on the
+	// transport path (internal/mcp.Service.RecordToolCall), BEST-EFFORT like
+	// most of this log (Record, not RecordInTx): there is no companion write
+	// to roll back alongside it, and a purely observational record must not
+	// take down the read path it observes. ActorType is ActorAssistant --
+	// this is the one action class in the whole log recorded as the MODEL's
+	// own act rather than the human who granted it access -- and ActorID is
+	// the mcp_grants id, not a user id. Metadata carries grant_name as the
+	// actor's display label: ListAuditEntries/ListAuditEntriesFiltered
+	// resolve ActorName by joining users/api_keys on actor_type, and neither
+	// join has an arm for "assistant" (that join lives in db/query/*.sql,
+	// database-engineer's surface, and a fourth JOIN did not land alongside
+	// this Go-only change) -- so the label travels in Metadata rather than in
+	// the ActorName column until that join exists. Also carries
+	// operator_permission (the dashboard authority the tool call mirrors) and
+	// tool.
+	ActionMCPToolCalled = "mcp.tool.called"
 )
 
 // Entry is one audit record.
@@ -372,6 +414,12 @@ type Entry struct {
 	// ActorType == ActorAPIKey. Nil for ActorSystem events and for any actor
 	// row that no longer exists (e.g. a deleted user). Only List and
 	// ListFiltered populate this field; Record's returned Entry does not.
+	//
+	// Also nil for ActorType == ActorAssistant: the join that would resolve it
+	// (mcp_grants.name, the same shape as the api_keys.name join above) does
+	// not exist in ListAuditEntries/ListAuditEntriesFiltered today. An
+	// ActionMCPToolCalled recorder carries the grant's name in Metadata
+	// instead, so the label is not lost, only not yet promoted to this column.
 	ActorName *string
 	// ActorEmail is the acting user's email when ActorType == ActorUser. Nil
 	// otherwise. Only List and ListFiltered populate this field.

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -188,22 +188,26 @@ const createMCPGrant = `-- name: CreateMCPGrant :one
 
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, capabilities, expires_at,
+    idle_expire_after_days
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days
 `
 
 type CreateMCPGrantParams struct {
-	TenantID        uuid.UUID   `json:"tenant_id"`
-	Name            string      `json:"name"`
-	Status          string      `json:"status"`
-	SiteScopeMode   string      `json:"site_scope_mode"`
-	ScopeTagIds     []uuid.UUID `json:"scope_tag_ids"`
-	ScopeSiteIds    []uuid.UUID `json:"scope_site_ids"`
-	ClientID        *string     `json:"client_id"`
-	CreatedByUserID pgtype.UUID `json:"created_by_user_id"`
+	TenantID            uuid.UUID   `json:"tenant_id"`
+	Name                string      `json:"name"`
+	Status              string      `json:"status"`
+	SiteScopeMode       string      `json:"site_scope_mode"`
+	ScopeTagIds         []uuid.UUID `json:"scope_tag_ids"`
+	ScopeSiteIds        []uuid.UUID `json:"scope_site_ids"`
+	ClientID            *string     `json:"client_id"`
+	CreatedByUserID     pgtype.UUID `json:"created_by_user_id"`
+	Capabilities        []string    `json:"capabilities"`
+	ExpiresAt           time.Time   `json:"expires_at"`
+	IdleExpireAfterDays *int32      `json:"idle_expire_after_days"`
 }
 
 // ===========================================================================
@@ -231,6 +235,23 @@ type CreateMCPGrantParams struct {
 // either gets 23502 rather than a live organisation-wide grant (Decision 1).
 // The caller passes status explicitly -- 'active' -- rather than relying on the
 // schema to assume it.
+//
+// m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+// columns behave the same way: a caller that omits capabilities or expires_at
+// gets 23502, NOT an unrestricted or never-expiring connection.
+//
+// THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+// CreateMCPGrantParams is a named-field struct literal at
+// internal/mcp/service.go:570 and in three integration fixtures, so adding
+// fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+// which is NULL, which is refused at the INSERT. backend-architect must supply
+// all three. A loud 23502 at creation is the correct failure and is strictly
+// better than the alternative of a DEFAULT that quietly mints a credential
+// nobody chose the terms of.
+//
+// idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+// only safe one until TouchMCPGrantInTenantTx has a caller.
 func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error) {
 	row := q.db.QueryRow(ctx, createMCPGrant,
 		arg.TenantID,
@@ -241,6 +262,9 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		arg.ScopeSiteIds,
 		arg.ClientID,
 		arg.CreatedByUserID,
+		arg.Capabilities,
+		arg.ExpiresAt,
+		arg.IdleExpireAfterDays,
 	)
 	var i McpGrant
 	err := row.Scan(
@@ -251,6 +275,7 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -260,6 +285,8 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }
@@ -413,7 +440,7 @@ func (q *Queries) GetMCPConnectionTokenByHashForLookup(ctx context.Context, toke
 }
 
 const getMCPGrant = `-- name: GetMCPGrant :one
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days FROM mcp_grants
 WHERE tenant_id = $1 AND id = $2
 `
 
@@ -436,6 +463,7 @@ func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGr
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -445,6 +473,8 @@ func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGr
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }
@@ -531,7 +561,7 @@ func (q *Queries) ListMCPConnectionTokensForGrant(ctx context.Context, arg ListM
 }
 
 const listMCPGrantsForOrg = `-- name: ListMCPGrantsForOrg :many
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days FROM mcp_grants
 WHERE tenant_id = $1
 ORDER BY created_at DESC, id DESC
 `
@@ -563,6 +593,7 @@ func (q *Queries) ListMCPGrantsForOrg(ctx context.Context, tenantID uuid.UUID) (
 			&i.SiteScopeMode,
 			&i.ScopeTagIds,
 			&i.ScopeSiteIds,
+			&i.Capabilities,
 			&i.ClientID,
 			&i.ClientName,
 			&i.ClientVersion,
@@ -572,6 +603,8 @@ func (q *Queries) ListMCPGrantsForOrg(ctx context.Context, tenantID uuid.UUID) (
 			&i.CreatedAt,
 			&i.LastUsedAt,
 			&i.RevokedAt,
+			&i.ExpiresAt,
+			&i.IdleExpireAfterDays,
 		); err != nil {
 			return nil, err
 		}
@@ -592,17 +625,47 @@ SELECT
     g.scope_tag_ids               AS scope_tag_ids,
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
+    g.capabilities                AS grant_capabilities,
+    g.expires_at                  AS grant_expires_at,
+    g.idle_expire_after_days      AS grant_idle_expire_after_days,
+    g.last_used_at                AS grant_last_used_at,
     t.id                          AS token_id,
     t.token_prefix                AS token_prefix,
     t.status                      AS token_status,
     t.expires_at                  AS token_expires_at,
+    -- The component reasons, so a refusal can be logged with its cause. Both
+    -- COALESCE to TRUE -- the FAIL-CLOSED direction for a negative flag, since
+    -- these say "expired". An absent value must never read as "still valid".
+    -- They are diagnostics; ` + "`" + `authorized` + "`" + ` below is the verdict.
+    COALESCE(g.expires_at <= now(), true)::boolean AS grant_absolute_expired,
+    COALESCE(g.idle_expire_after_days IS NOT NULL
+        AND COALESCE(g.last_used_at, g.created_at)
+            + make_interval(days => g.idle_expire_after_days) <= now(),
+        true)::boolean AS grant_idle_expired,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
     -- how a nil comes to be read as anything other than refusal.
     COALESCE(g.status = 'active'
         AND t.status = 'active'
-        AND (t.expires_at IS NULL OR t.expires_at > now()), false)::boolean AS authorized
+        AND (t.expires_at IS NULL OR t.expires_at > now())
+        -- ABSOLUTE EXPIRY. NO ` + "`" + `IS NULL OR` + "`" + ` BRANCH, and its absence is the
+        -- point: mcp_grants.expires_at is NOT NULL (m127 DECISION 2), so
+        -- unlike t.expires_at above there is no nullable case here for a
+        -- reader to get backwards.
+        AND g.expires_at > now()
+        -- IDLE EXPIRY. NULL means never idle-expire, which is a DIFFERENT fact
+        -- from the absolute expiry above and is why the NULL branch appears on
+        -- this line and not that one. coalesce(last_used_at, created_at):
+        -- a grant never used is idle since it was created.
+        --
+        -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
+        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
+        -- NULL and this collapses to created_at + N days for every row.
+        AND (g.idle_expire_after_days IS NULL
+             OR COALESCE(g.last_used_at, g.created_at)
+                + make_interval(days => g.idle_expire_after_days) > now()),
+        false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id
@@ -615,18 +678,24 @@ type ReCheckMCPRequestAuthorizationInTenantTxParams struct {
 }
 
 type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
-	GrantID        uuid.UUID          `json:"grant_id"`
-	GrantName      string             `json:"grant_name"`
-	GrantStatus    string             `json:"grant_status"`
-	SiteScopeMode  string             `json:"site_scope_mode"`
-	ScopeTagIds    []uuid.UUID        `json:"scope_tag_ids"`
-	ScopeSiteIds   []uuid.UUID        `json:"scope_site_ids"`
-	ClientID       *string            `json:"client_id"`
-	TokenID        uuid.UUID          `json:"token_id"`
-	TokenPrefix    string             `json:"token_prefix"`
-	TokenStatus    string             `json:"token_status"`
-	TokenExpiresAt pgtype.Timestamptz `json:"token_expires_at"`
-	Authorized     bool               `json:"authorized"`
+	GrantID                  uuid.UUID          `json:"grant_id"`
+	GrantName                string             `json:"grant_name"`
+	GrantStatus              string             `json:"grant_status"`
+	SiteScopeMode            string             `json:"site_scope_mode"`
+	ScopeTagIds              []uuid.UUID        `json:"scope_tag_ids"`
+	ScopeSiteIds             []uuid.UUID        `json:"scope_site_ids"`
+	ClientID                 *string            `json:"client_id"`
+	GrantCapabilities        []string           `json:"grant_capabilities"`
+	GrantExpiresAt           time.Time          `json:"grant_expires_at"`
+	GrantIdleExpireAfterDays *int32             `json:"grant_idle_expire_after_days"`
+	GrantLastUsedAt          pgtype.Timestamptz `json:"grant_last_used_at"`
+	TokenID                  uuid.UUID          `json:"token_id"`
+	TokenPrefix              string             `json:"token_prefix"`
+	TokenStatus              string             `json:"token_status"`
+	TokenExpiresAt           pgtype.Timestamptz `json:"token_expires_at"`
+	GrantAbsoluteExpired     bool               `json:"grant_absolute_expired"`
+	GrantIdleExpired         bool               `json:"grant_idle_expired"`
+	Authorized               bool               `json:"authorized"`
 }
 
 // Runs InTenantTx with the tenant the lookup above established. STEP 2 OF 2,
@@ -649,6 +718,21 @@ type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
 // The grant is joined on tenant_id as well as id: the token and its grant must
 // belong to the same organisation, checked in the join rather than assumed
 // from the foreign key.
+// m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+// a second read the caller might forget. A grant past its absolute expiry, or
+// past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+// Both are evaluated on the already-fetched grant row, so neither costs a round
+// trip and neither needs an index.
+//
+// The wireframe's "there is no silent read-only period" is a consequence of
+// this shape: expiry flips one boolean to false outright and cannot degrade a
+// connection to a reduced capability set, because there is one boolean here and
+// not a tier.
+//
+// g.capabilities is returned so the capability set is read from the SAME ROW
+// and the SAME transaction as the verdict it was authorized under (S7's exit
+// gate: discovery never grants what the registry does not hold, and it cannot
+// hold what this row does not carry).
 func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error) {
 	row := q.db.QueryRow(ctx, reCheckMCPRequestAuthorizationInTenantTx, arg.TenantID, arg.ID)
 	var i ReCheckMCPRequestAuthorizationInTenantTxRow
@@ -660,10 +744,16 @@ func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, 
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
 		&i.ClientID,
+		&i.GrantCapabilities,
+		&i.GrantExpiresAt,
+		&i.GrantIdleExpireAfterDays,
+		&i.GrantLastUsedAt,
 		&i.TokenID,
 		&i.TokenPrefix,
 		&i.TokenStatus,
 		&i.TokenExpiresAt,
+		&i.GrantAbsoluteExpired,
+		&i.GrantIdleExpired,
 		&i.Authorized,
 	)
 	return i, err
@@ -676,7 +766,7 @@ SET client_name                 = $3,
     protocol_version            = $5,
     client_identity_recorded_at = now()
 WHERE tenant_id = $1 AND id = $2
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days
 `
 
 type RecordMCPGrantClientIdentityInTenantTxParams struct {
@@ -714,6 +804,7 @@ func (q *Queries) RecordMCPGrantClientIdentityInTenantTx(ctx context.Context, ar
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -723,6 +814,8 @@ func (q *Queries) RecordMCPGrantClientIdentityInTenantTx(ctx context.Context, ar
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -486,6 +486,7 @@ type McpGrant struct {
 	SiteScopeMode            string             `json:"site_scope_mode"`
 	ScopeTagIds              []uuid.UUID        `json:"scope_tag_ids"`
 	ScopeSiteIds             []uuid.UUID        `json:"scope_site_ids"`
+	Capabilities             []string           `json:"capabilities"`
 	ClientID                 *string            `json:"client_id"`
 	ClientName               *string            `json:"client_name"`
 	ClientVersion            *string            `json:"client_version"`
@@ -495,6 +496,8 @@ type McpGrant struct {
 	CreatedAt                time.Time          `json:"created_at"`
 	LastUsedAt               pgtype.Timestamptz `json:"last_used_at"`
 	RevokedAt                pgtype.Timestamptz `json:"revoked_at"`
+	ExpiresAt                time.Time          `json:"expires_at"`
+	IdleExpireAfterDays      *int32             `json:"idle_expire_after_days"`
 }
 
 type McpOauthClient struct {

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -614,6 +614,23 @@ type Querier interface {
 	// either gets 23502 rather than a live organisation-wide grant (Decision 1).
 	// The caller passes status explicitly -- 'active' -- rather than relying on the
 	// schema to assume it.
+	//
+	// m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+	// columns behave the same way: a caller that omits capabilities or expires_at
+	// gets 23502, NOT an unrestricted or never-expiring connection.
+	//
+	// THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+	// CreateMCPGrantParams is a named-field struct literal at
+	// internal/mcp/service.go:570 and in three integration fixtures, so adding
+	// fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+	// which is NULL, which is refused at the INSERT. backend-architect must supply
+	// all three. A loud 23502 at creation is the correct failure and is strictly
+	// better than the alternative of a DEFAULT that quietly mints a credential
+	// nobody chose the terms of.
+	//
+	// idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+	// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+	// only safe one until TouchMCPGrantInTenantTx has a caller.
 	CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error)
 	// ---------------------------------------------------------------------------
 	// backup_manifest_entries
@@ -3066,6 +3083,21 @@ type Querier interface {
 	// The grant is joined on tenant_id as well as id: the token and its grant must
 	// belong to the same organisation, checked in the join rather than assumed
 	// from the foreign key.
+	// m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+	// a second read the caller might forget. A grant past its absolute expiry, or
+	// past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+	// Both are evaluated on the already-fetched grant row, so neither costs a round
+	// trip and neither needs an index.
+	//
+	// The wireframe's "there is no silent read-only period" is a consequence of
+	// this shape: expiry flips one boolean to false outright and cannot degrade a
+	// connection to a reduced capability set, because there is one boolean here and
+	// not a tier.
+	//
+	// g.capabilities is returned so the capability set is read from the SAME ROW
+	// and the SAME transaction as the verdict it was authorized under (S7's exit
+	// gate: discovery never grants what the registry does not hold, and it cannot
+	// hold what this row does not carry).
 	ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error)
 	RecolorTag(ctx context.Context, arg RecolorTagParams) (SiteTag, error)
 	// Runs InTenantTx. Decision 10: there are TWO distinguishable absences in the

--- a/apps/api/internal/mcp/model.go
+++ b/apps/api/internal/mcp/model.go
@@ -24,11 +24,19 @@ import (
 type Scope string
 
 // ScopeRead is the only scope this surface grants, and the surface is
-// read-only by construction rather than by configuration (m124 DECISION 1:
-// there is deliberately no capability column, because it would be the place a
-// write capability could later appear without a migration and without a
-// review). A write scope does not belong here; it belongs in its own migration
-// with its own review.
+// read-only by construction rather than by configuration.
+//
+// m127 DID MINT mcp_grants.capabilities, so the older statement here -- that
+// there is deliberately no capability column -- is no longer true and has been
+// removed rather than left to be believed. What it was protecting survives, and
+// survives in a stronger form: the column is NOT NULL with no default and
+// carries a CHECK closed over the same one-name vocabulary this package holds
+// (capabilityVocabulary), so a write capability STILL cannot appear in a row
+// without a migration and without a review. The column narrows what a
+// connection may do; it cannot widen it past what scopeCapabilities maps.
+//
+// A write scope does not belong here; it belongs in its own migration with its
+// own review.
 const ScopeRead Scope = "mcp:read"
 
 // SiteScopeMode says which sites a grant may read. It mirrors

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -258,13 +258,22 @@ func (f *fakeStore) RedeemAuthorizationCode(_ context.Context, _, _ uuid.UUID, t
 // that the principal reaches the store at all, so a refactor which narrows
 // ApprovalRequest back to a bare tenant id fails here rather than silently in
 // production. The policy itself is proved in tests/, as wpmgr_app.
-func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
+func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(pgx.Tx, sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	f.note("CreateGrantWithCode")
 	f.grantPrincipal = principal
 	id := uuid.New()
 	cp := mk(id)
-	return sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name},
-		sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
+	grant := sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name}
+	// No real tx to hand onCreated -- this fake runs no transaction at all.
+	// Service.Approve's callback checks s.audit == nil before touching tx, and
+	// no test in this package wires WithAudit, so nil here is never
+	// dereferenced.
+	if onCreated != nil {
+		if err := onCreated(nil, grant); err != nil {
+			return sqlc.McpGrant{}, sqlc.McpAuthorizationCode{}, err
+		}
+	}
+	return grant, sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
 }
 
 func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
@@ -349,6 +358,7 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	_ context.Context,
 	p domain.Principal,
 	_ uuid.UUID,
+	onRevoked func(pgx.Tx, sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	f.note("RevokeGrantWithTokens")
 	f.mu.Lock()
@@ -356,6 +366,13 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	f.mu.Unlock()
 	if f.revokeErr != nil {
 		return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, f.revokeErr
+	}
+	// No real tx, same reasoning as CreateGrantWithCode above: the callback
+	// checks s.audit == nil before touching it.
+	if onRevoked != nil {
+		if err := onRevoked(nil, f.revokeRow); err != nil {
+			return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, err
+		}
 	}
 	return f.revokeRow, nil
 }

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -100,6 +100,16 @@ type fakeStore struct {
 	// coerced into a string.
 	identityCalls []recordedIdentity
 
+	// touchErr forces the activity stamp to fail, which the transport must
+	// surface as a REFUSED request rather than serve the tool anyway: an
+	// unrecorded use is indistinguishable from no use at all once
+	// idle_expire_after_days starts reading last_used_at.
+	touchErr error
+	// touchCalls records every TouchActivity argument set, so a test can assert
+	// the stamp happened, happened on the right ids, and did NOT happen on the
+	// methods that must not refresh an idle deadline.
+	touchCalls []touchedActivity
+
 	// sites is what ListSitesForRead returns; sitesMore is its page-bound
 	// overflow flag; sitesErr forces the read to fail.
 	sites     []sqlc.ListSitesRow
@@ -314,6 +324,30 @@ func (f *fakeStore) RecordClientIdentity(
 		Name: name, Version: version, ProtocolVersion: protocolVersion,
 	})
 	return f.identityErr
+}
+
+// touchedActivity is one TouchActivity call, recorded with all three ids so a
+// test can assert the stamp reached the grant AND the token, and reached them
+// under the tenant the request resolved to.
+type touchedActivity struct {
+	TenantID uuid.UUID
+	GrantID  uuid.UUID
+	TokenID  uuid.UUID
+}
+
+func (f *fakeStore) TouchActivity(
+	_ context.Context, tenantID, grantID, tokenID uuid.UUID,
+) (time.Time, error) {
+	f.note("TouchActivity")
+	f.touchCalls = append(f.touchCalls, touchedActivity{
+		TenantID: tenantID, GrantID: grantID, TokenID: tokenID,
+	})
+	if f.touchErr != nil {
+		// The zero time.Time goes back WITH the error, so a caller that ignores
+		// the error and uses the stamp gets year 1 rather than a plausible one.
+		return time.Time{}, f.touchErr
+	}
+	return time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC), nil
 }
 
 func (f *fakeStore) ListSitesForRead(_ context.Context, _ uuid.UUID, limit int32) ([]sqlc.ListSitesRow, bool, error) {
@@ -761,8 +795,10 @@ func TestAuthenticate_RevocationBitesOnTheNextRequest(t *testing.T) {
 		recheck: sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
 			GrantID: tok.GrantID, GrantStatus: "active",
 			SiteScopeMode: "all", TokenID: tok.ID, TokenStatus: "active",
-			TokenExpiresAt: tok.ExpiresAt,
-			Authorized:     true,
+			TokenExpiresAt:    tok.ExpiresAt,
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
+			Authorized:        true,
 		},
 		scopeSites: []uuid.UUID{siteID},
 	}
@@ -841,7 +877,10 @@ func TestAuthenticate_EmptyResolvedScopeGrantsNoSites(t *testing.T) {
 			GrantID: tok.GrantID, GrantStatus: "active",
 			SiteScopeMode: "tags", ScopeTagIds: []uuid.UUID{uuid.New()},
 			TokenID: tok.ID, TokenStatus: "active",
-			TokenExpiresAt: tok.ExpiresAt, Authorized: true,
+			TokenExpiresAt:    tok.ExpiresAt,
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
+			Authorized:        true,
 		},
 		scopeSites: nil, // the tag matched no site
 	}

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -110,6 +110,52 @@ func grantScopes() []Scope {
 	return []Scope{ScopeRead}
 }
 
+// DefaultGrantCapabilities is the capability set stamped onto mcp_grants.
+// capabilities when a NEW grant is created and the consent screen offered no
+// narrowing control.
+//
+// It is the vocabulary, which is also the org default while exactly one scope
+// is recognised. It is a FUNCTION and not a constant slice because a package
+// variable would be shared, mutable, and one append away from widening every
+// grant this surface has ever minted.
+//
+// This is where a chosen value replaces a defaulted one when Step 5's
+// capability control ships: the operator's selection arrives on
+// ApprovalRequest and is passed instead. It is deliberately NOT a database
+// DEFAULT -- see the column's NOT NULL and m127's reasoning about a credential
+// nobody chose the terms of.
+func DefaultGrantCapabilities() []Capability { return AllCapabilities() }
+
+// capabilityNames renders capabilities for the text[] column.
+func capabilityNames(caps []Capability) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, string(c))
+	}
+	return out
+}
+
+// capabilitiesFromColumn reads mcp_grants.capabilities back into the domain
+// type.
+//
+// IT DOES NOT FILTER, and that omission is deliberate. Dropping an unknown name
+// here would hand NarrowTo a set that had already been quietly reduced, so a
+// row carrying a capability outside this build's vocabulary would authenticate
+// as though it carried only the known ones. The refusal belongs at NarrowTo,
+// where an unheld capability rejects the whole set instead of being trimmed out
+// of it -- the same reasoning ParseRequestedScopes gives for refusing an
+// unrecognised scope rather than ignoring it.
+//
+// A nil or empty column yields an empty slice, which the caller must treat as
+// "no capability" and never as "unrestricted".
+func capabilitiesFromColumn(names []string) []Capability {
+	out := make([]Capability, 0, len(names))
+	for _, n := range names {
+		out = append(out, Capability(n))
+	}
+	return out
+}
+
 // CapabilitySet is a RESOLVED set of capabilities.
 //
 // It is a struct and not a []Capability on purpose, and the reasoning is
@@ -169,13 +215,17 @@ func (s CapabilitySet) Sorted() []Capability {
 // OrgDefaultCapabilities is the WIDEST capability set any connection in this
 // organisation may hold, derived from the scopes the surface granted it.
 //
-// There is no capabilities column on mcp_grants and that is m124 DECISION 1:
-// minting one would create the place a write capability could appear without a
-// migration and without a review. So the org default is DERIVED from the closed
-// scope registry rather than stored, and it cannot exceed what
-// scopeCapabilities maps. When a differentiated-read column does arrive it
-// arrives NOT NULL with no default and a closed CHECK, and it narrows this --
-// it never replaces it as the ceiling.
+// IT IS THE CEILING, NOT THE ANSWER. m127 added mcp_grants.capabilities -- NOT
+// NULL, no default, closed CHECK, exactly as m124 DECISION 1 required of any
+// such column -- so a live connection's capability set is now READ FROM THAT
+// ROW and then narrowed against this ceiling (Service.Authenticate). This
+// function is no longer what a request path may use on its own: doing so
+// answers from the scope registry rather than from the grant, which agrees with
+// the row only while the vocabulary holds one name.
+//
+// It stays derived rather than stored because a ceiling that could be raised by
+// writing a row is not a ceiling. scopeCapabilities is the only thing that can
+// widen it, and widening that map is a code change under review.
 //
 // An empty or nil scope list yields an EMPTY set and an error, never a
 // permissive one. Absence is refusal here exactly as it is in

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -58,6 +59,23 @@ type Store interface {
 	// identity on the grant. protocolVersion is a *string and NOT a string so
 	// that "sent no header" survives as NULL -- see the method on Repo.
 	RecordClientIdentity(ctx context.Context, tenantID, grantID uuid.UUID, name, version string, protocolVersion *string) error
+
+	// TouchActivity stamps last_used_at on the grant AND on the token that
+	// carried the request, in ONE transaction.
+	//
+	// IT TAKES BOTH IDS AND WRITES BOTH ROWS BECAUSE THEY ANSWER DIFFERENT
+	// QUESTIONS AND MUST NOT DISAGREE. mcp_grants.last_used_at is what the
+	// connections list renders and what the idle-expiry predicate reads;
+	// mcp_connection_tokens.last_used_at is what tells an operator mid-rotation
+	// which of two live tokens is still in use. A grant stamped without its
+	// token would make the rotation UI claim a token nobody has retired is
+	// dead.
+	//
+	// It returns the stamped instant rather than nothing, so a caller can
+	// assert the write happened instead of trusting a nil error over a query
+	// that matched no row -- both underlying statements are :one for that
+	// reason, and pgx.ErrNoRows here means the row was not visible.
+	TouchActivity(ctx context.Context, tenantID, grantID, tokenID uuid.UUID) (time.Time, error)
 
 	// ListSitesForRead reads one bounded page of the tenant's sites for the
 	// list_sites tool. It returns the rows AND whether the bound was reached
@@ -404,6 +422,52 @@ func (r *Repo) RecordClientIdentity(
 		}
 		return nil
 	})
+}
+
+// TouchActivity stamps last_used_at on the grant and on its token.
+//
+// IT RUNS InTenantTx, NEVER THE TOKEN-LOOKUP TRANSACTION THAT JUST RESOLVED
+// THIS TOKEN. mcp_connection_tokens_lookup is FOR SELECT, so an UPDATE inside
+// that scope matches zero rows and reports success -- the same silent zero-row
+// write both queries' own comments warn about. That is also why both are :one:
+// a stamp that hit nothing is pgx.ErrNoRows here rather than a nil error over a
+// column that never moved.
+//
+// BOTH WRITES ARE IN ONE TRANSACTION so the two stamps cannot disagree about
+// whether this request happened.
+//
+// The returned instant comes from the GRANT's RETURNING clause, not from the Go
+// clock: now() is evaluated by the database, and reading it back is what makes
+// "the row moved" provable rather than assumed. LastUsedAt is checked for
+// validity because a NULL returned by an UPDATE that sets the column to now()
+// would mean the write did not land, and reporting that as a zero time.Time
+// would hand the caller a stamp from year 1 that reads as success.
+func (r *Repo) TouchActivity(ctx context.Context, tenantID, grantID, tokenID uuid.UUID) (time.Time, error) {
+	var stamped time.Time
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		q := sqlc.New(tx)
+
+		grantRow, err := q.TouchMCPGrantInTenantTx(ctx,
+			sqlc.TouchMCPGrantInTenantTxParams{TenantID: tenantID, ID: grantID})
+		if err != nil {
+			return fmt.Errorf("touch mcp grant: %w", err)
+		}
+		if !grantRow.LastUsedAt.Valid {
+			return fmt.Errorf("touch mcp grant: last_used_at came back NULL from an UPDATE that sets it to now()")
+		}
+
+		if _, err := q.TouchMCPConnectionTokenInTenantTx(ctx,
+			sqlc.TouchMCPConnectionTokenInTenantTxParams{TenantID: tenantID, ID: tokenID}); err != nil {
+			return fmt.Errorf("touch mcp connection token: %w", err)
+		}
+
+		stamped = grantRow.LastUsedAt.Time
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	return stamped, nil
 }
 
 // ListSitesForRead reads one bounded page of the tenant's sites inside

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -41,7 +41,14 @@ type Store interface {
 	// the RESTRICTIVE insert policy on mcp_grants is live. A tenant id alone
 	// cannot express that, which is how the site-scope GUC came to be unset on
 	// this path. See the method on Repo.
-	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
+	//
+	// onCreated runs INSIDE the same transaction as both inserts, after both
+	// succeed, so the caller (Service.Approve) can append the
+	// ActionMCPGrantCreated audit row via audit.Recorder.RecordInTx over the
+	// SAME tx -- a rolled-back grant then leaves no audit row claiming one
+	// exists, because an error from onCreated rolls the whole transaction back
+	// exactly as an error from either insert would. May be nil.
+	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
 
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
@@ -79,7 +86,14 @@ type Store interface {
 	// organisation's, or refused by RLS. It is the ONLY outcome meaning "not
 	// there"; a returned row of two zeroes is an idempotent success. See the
 	// query's four-outcome comment.
-	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
+	//
+	// onRevoked runs INSIDE the same transaction as the revoke statement,
+	// after it succeeds (any of the three non-error outcomes), so the caller
+	// (Service.RevokeConnection) can append the ActionMCPGrantRevoked audit
+	// row via audit.Recorder.RecordInTx over the SAME tx. It does NOT run on
+	// pgx.ErrNoRows -- nothing was written, so nothing should be attributed.
+	// May be nil.
+	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID, onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
 }
 
 // Repo is the live Store. Every method names the tx helper it runs under, and
@@ -239,6 +253,7 @@ func (r *Repo) CreateGrantWithCode(
 	principal db.ScopedPrincipal,
 	g sqlc.CreateMCPGrantParams,
 	mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams,
+	onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error,
 ) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	var (
 		grant sqlc.McpGrant
@@ -262,6 +277,13 @@ func (r *Repo) CreateGrantWithCode(
 		cd, err := q.CreateMCPAuthorizationCode(ctx, mkCode(gr.ID))
 		if err != nil {
 			return fmt.Errorf("create mcp authorization code: %w", err)
+		}
+		// Inside the same tx, after both inserts. An error here rolls both of
+		// them back with it -- see the interface doc on onCreated.
+		if onCreated != nil {
+			if err := onCreated(tx, gr); err != nil {
+				return err
+			}
 		}
 		grant, code = gr, cd
 		return nil
@@ -481,6 +503,7 @@ func (r *Repo) RevokeGrantWithTokens(
 	ctx context.Context,
 	principal domain.Principal,
 	grantID uuid.UUID,
+	onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	var out sqlc.RevokeMCPGrantWithTokensInTenantTxRow
 	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
@@ -492,10 +515,16 @@ func (r *Repo) RevokeGrantWithTokens(
 		if err != nil {
 			// pgx.ErrNoRows is meaningful to the caller and is NOT wrapped in a
 			// message that would make errors.Is harder to reach for. Every
-			// other error is an infra failure.
+			// other error is an infra failure. Neither reaches onRevoked --
+			// nothing was written, so nothing should be attributed.
 			return err
 		}
 		out = row
+		if onRevoked != nil {
+			if err := onRevoked(tx, row); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -29,6 +29,22 @@ const (
 	authorizationCodeTTL = 5 * time.Minute
 	connectionTokenTTL   = 90 * 24 * time.Hour
 	tokenPrefixLen       = 12
+
+	// grantAbsoluteTTL is the absolute lifetime stamped onto a new grant's
+	// mcp_grants.expires_at.
+	//
+	// IT IS A GO CONSTANT AND NOT A COLUMN DEFAULT, AND THE DIFFERENCE IS THE
+	// WHOLE OF m127 DECISION 2. The column is NOT NULL with no default, so this
+	// call site cannot omit the term and get one silently -- it gets 23502. The
+	// value is chosen here, once, where it is reviewable, rather than in the
+	// schema where it would apply to every future writer including one that
+	// meant to ask the operator.
+	//
+	// 90 days matches the consent wireframe's pre-selected option and the value
+	// m127 backfilled existing rows with. When Step 5's control ships, the
+	// operator's choice arrives on ApprovalRequest and REPLACES this default at
+	// this line; it does not become a second default anywhere else.
+	grantAbsoluteTTL = 90 * 24 * time.Hour
 )
 
 // Error codes. These are domain codes; the OAuth wire errors are mapped from
@@ -600,6 +616,39 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			// The RESOLVED client id, not the body's copy of it.
 			ClientID:        nullableText(client.ClientID),
 			CreatedByUserID: uuidToPG(req.Principal.UserID),
+
+			// m127's three columns, ALL SUPPLIED EXPLICITLY. Two of them are
+			// NOT NULL with no default precisely so that this literal cannot
+			// forget one: a missing field is the zero value, which is
+			// nil/invalid, which is NULL, which is 23502 at the INSERT rather
+			// than an unrestricted or never-expiring connection.
+			//
+			// Capabilities is the STORED per-connection capability set, and
+			// from here on it is the authority Authenticate reads -- not a
+			// value recomputed from the scope registry at request time. It is
+			// written as the org default because Phase 1's consent screen
+			// offers no narrowing control; the moment it does, the operator's
+			// choice arrives here and NarrowTo is what applies it.
+			Capabilities: capabilityNames(DefaultGrantCapabilities()),
+			ExpiresAt:    s.now().UTC().Add(grantAbsoluteTTL),
+
+			// IDLE EXPIRY IS WRITTEN NULL, AND NULL IS THE ANSWER, NOT A
+			// PLACEHOLDER. NULL means "never idle-expire" (m127 DECISION 4).
+			//
+			// A non-NULL value here is only safe once mcp_grants.last_used_at
+			// is actually written, because the deadline is
+			// coalesce(last_used_at, created_at) + N days: with the stamp
+			// unwired that collapses to created_at + N and every connection
+			// dies N days after creation however heavily it is used. The stamp
+			// IS wired now (RecordActivity, called from the transport's
+			// tools/list and tools/call arms), so a non-NULL window has become
+			// REPRESENTABLE -- but nothing yet asks the operator for one, and
+			// inventing a window nobody chose is exactly the "credential nobody
+			// chose the terms of" this column refuses to default.
+			//
+			// So: NULL until Step 5's second control ships and supplies a
+			// chosen value. The prerequisite is now met; the input is not.
+			IdleExpireAfterDays: nil,
 		},
 		func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 			return sqlc.CreateMCPAuthorizationCodeParams{
@@ -963,44 +1012,70 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	// they are independent: the site axis above says WHICH SITES, this one says
 	// WHICH TOOLS.
 	//
-	// THE ORG DEFAULT IS DERIVED, NOT STORED, AND THAT IS m124 DECISION 1. There
-	// is deliberately no capabilities column on mcp_grants, because minting one
-	// would create the place a write capability could appear without a
-	// migration and without a review. So the ceiling is computed from the closed
-	// scope registry, and every live grant on this surface holds ScopeRead by
-	// construction -- ParseRequestedScopes refuses anything else and
-	// recognisedScopes holds exactly that one entry.
+	// THE STORED COLUMN IS THE AUTHORITY, AND THAT IS WHAT m127 CHANGED.
+	// mcp_grants.capabilities now exists -- NOT NULL, no default, CHECKed
+	// against the same closed vocabulary this package holds -- and it is read
+	// off chk.GrantCapabilities, THE SAME ROW AND THE SAME TRANSACTION as the
+	// `authorized` verdict this request was admitted under.
 	//
-	// WHAT IS NOT WIRED YET, SAID PLAINLY RATHER THAN IMPLIED. Two gaps, and
-	// the second is a LATENT WIDENING rather than a missing narrowing:
+	// Recomputing the set from the scope registry instead, as this line did
+	// before m127, is a GUESS: it agrees with the row today only because the
+	// vocabulary holds one name, and it diverges the instant a grant is created
+	// holding anything else. It also answers "full capabilities" for a grant
+	// whose stored set is EMPTY, which is the case where the two disagree by
+	// everything.
 	//
-	//  1. There is no stored per-connection capability narrowing, so this value
-	//     IS the org default. CapabilitySet.NarrowTo is the mechanism that
-	//     applies one, and it refuses a request wider than the default rather
-	//     than granting it; the COLUMN it would read from arrives with its own
-	//     migration, NOT NULL, no default, closed CHECK, as DECISION 1
-	//     requires.
+	// THE ORG DEFAULT REMAINS THE CEILING; the stored value NARROWS it and
+	// never replaces it. That ordering is the only thing standing between a row
+	// and a capability the organisation's scopes do not confer, so a capability
+	// in the column that the default does not hold is REFUSED here -- not
+	// honoured, and not quietly dropped. Dropping would be fail-closed and
+	// still wrong, for the reason written on NarrowTo.
 	//
-	//  2. THE SCOPE LIST BELOW IS A CONSTANT, NOT THE GRANT'S OWN SCOPES.
-	//     mcp_grants has no scopes column, so there is nothing per-grant to
-	//     read; grantScopes() returns the one scope every live grant holds by
-	//     construction. That is exact TODAY and only because recognisedScopes
-	//     holds exactly one entry. The day a second scope joins it, a
-	//     connection granted ONLY that scope would still be handed ScopeRead's
-	//     capabilities here -- a widening, and one no existing test catches,
-	//     because TestEveryRecognisedScopeHasACapabilityMapping pins the map's
-	//     totality and not this function's input.
+	// ONE GAP SURVIVES m127, AND IT IS A LATENT WIDENING RATHER THAN A MISSING
+	// NARROWING: the scope list below is a CONSTANT, not the grant's own
+	// scopes. mcp_grants still has no scopes column, so there is nothing
+	// per-grant to read; grantScopes() returns the one scope every live grant
+	// holds by construction. That is exact TODAY and only because
+	// recognisedScopes holds exactly one entry. The day a second scope joins
+	// it, a connection granted ONLY that scope would still be handed
+	// ScopeRead's capabilities as its CEILING here -- a widening, and one no
+	// existing test catches, because
+	// TestEveryRecognisedScopeHasACapabilityMapping pins the map's totality and
+	// not this function's input.
 	//
-	//     TestGrantScopesIsExactOnlyWhileOneScopeExists goes red the moment
-	//     recognisedScopes grows, so whoever adds the second scope is forced to
-	//     come here and read a grant's scopes instead of a constant.
-	caps, err := OrgDefaultCapabilities(grantScopes())
+	// TestGrantScopesIsExactOnlyWhileOneScopeExists goes red the moment
+	// recognisedScopes grows, so whoever adds the second scope is forced to
+	// come here and read a grant's scopes instead of a constant.
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
 	if err != nil {
 		// A capability set that cannot be resolved is a REFUSAL, never an
 		// empty-but-proceeding one. An AuthorizedRequest with a zero-value
 		// CapabilitySet reaches no tool, so proceeding would produce a
 		// connection that authenticates and then refuses everything with no
 		// explanation anywhere.
+		return AuthorizedRequest{}, fmt.Errorf("resolve grant capabilities: %w", err)
+	}
+
+	// AN EMPTY STORED SET IS REFUSED BY NAME, not carried forward as an empty
+	// CapabilitySet. The column's shape CHECK admits '{}' -- the restrictive
+	// value passes the vocabulary containment test -- so the state is
+	// representable in the database even though no write path in this package
+	// mints it. Carrying it forward would authenticate a connection that then
+	// answers every tools/call with "not available" and every tools/list with
+	// nothing, which is precisely the half-working connection m127 DECISION 3
+	// says this boundary must not be able to produce.
+	stored := capabilitiesFromColumn(chk.GrantCapabilities)
+	if len(stored) == 0 {
+		return AuthorizedRequest{}, domain.Unauthorized(ErrCodeCapabilityUnmapped,
+			"this connection holds no capability, so it can reach no tool")
+	}
+
+	caps, err := ceiling.NarrowTo(stored)
+	if err != nil {
+		// Same refusal, same reason: a stored set that cannot be reconciled
+		// with the organisation's ceiling is not silently reduced to the
+		// intersection. See NarrowTo.
 		return AuthorizedRequest{}, fmt.Errorf("resolve grant capabilities: %w", err)
 	}
 
@@ -1034,6 +1109,55 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 func (s *Service) RecordConnect(ctx context.Context, auth AuthorizedRequest, name, version string, protocolHeader *string) error {
 	if err := s.store.RecordClientIdentity(ctx, auth.TenantID, auth.GrantID, name, version, protocolHeader); err != nil {
 		return fmt.Errorf("record mcp connect: %w", err)
+	}
+	return nil
+}
+
+// RecordActivity stamps mcp_grants.last_used_at (and the token's) for one
+// request that used this connection. GH #605.
+//
+// ============================================================================
+// WHAT COUNTS AS "USED", DECIDED EXPLICITLY: EVERY TOOL CALL, NOT CONNECT.
+// ============================================================================
+//
+// The caller is TransportHandler.dispatch, from the tools/list and tools/call
+// arms only. initialize, ping and notifications/initialized do NOT stamp.
+//
+// STAMPING ONCE PER SESSION AT CONNECT WAS THE ALTERNATIVE AND IT IS REJECTED,
+// for two reasons and not one:
+//
+//  1. IT WOULD MAKE THE COLUMN MEAN "last connected", which is a weaker claim
+//     than its name and than the connections list's "Last used" label. Renaming
+//     either to match would then be part of the change.
+//
+//  2. MORE IMPORTANTLY IT WOULD NOT BE SAFE TO IDLE-EXPIRE AGAINST. Streamable
+//     HTTP sessions are long-lived and initialize happens once at the start of
+//     one. A client that initialized in January and has called tools every day
+//     since would carry a January stamp, so a 30-day idle window would kill a
+//     demonstrably active connection in February. That is a smaller, quieter
+//     version of exactly the fleet outage m127 DECISION 4 describes, and the
+//     whole point of wiring this stamp is to make that outage impossible rather
+//     than rare.
+//
+// ping and notifications/initialized are excluded for the opposite reason: they
+// are transport keepalives that a stuck background process emits forever
+// without anyone using anything. Letting them refresh the deadline would make
+// "unused for 30 days" unfalsifiable and the feature decorative. Connecting is
+// still recorded -- RecordConnect stamps client_identity_recorded_at, which is
+// the separate fact "this client has connected at least once".
+//
+// THE ERROR IS RETURNED AND THE CALLER REFUSES THE REQUEST, deliberately unlike
+// RecordToolCall's best-effort audit append one function below. last_used_at is
+// an INPUT TO AN AUTHORIZATION DEADLINE, not an observation of one: a stamp
+// that silently fails leaves the connection's idle clock running while it is
+// being used, and the cost lands N days later as an expiry nobody can explain.
+// Refusing is loud, immediate, and local to the request that could not be
+// recorded -- and it costs nothing in practice, because a database that cannot
+// take this write also could not have served the two reads Authenticate just
+// made.
+func (s *Service) RecordActivity(ctx context.Context, auth AuthorizedRequest) error {
+	if _, err := s.store.TouchActivity(ctx, auth.TenantID, auth.GrantID, auth.TokenID); err != nil {
+		return fmt.Errorf("record mcp activity: %w", err)
 	}
 	return nil
 }

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
@@ -177,6 +178,16 @@ type Clock func() time.Time
 type Service struct {
 	store Store
 	now   Clock
+	// audit is nil unless WithAudit is called. Every audit write in this
+	// package guards on it being nil first -- see Approve, RevokeConnection,
+	// and RecordToolCall -- so a Service built by the many unit tests in this
+	// package (fakeStore, no real Postgres pool to back an audit.Recorder)
+	// keeps working unaudited. Production wiring (cmd/wpmgr/main.go) always
+	// calls WithAudit; a Service that reaches a request path without it is a
+	// wiring bug, not a supported configuration, and the finding to raise if
+	// one is ever found is "this deploy path is unattributable", not "make the
+	// nil check quieter".
+	audit *audit.Recorder
 }
 
 func NewService(store Store) *Service {
@@ -187,6 +198,18 @@ func NewService(store Store) *Service {
 func (s *Service) WithClock(c Clock) *Service {
 	cp := *s
 	cp.now = c
+	return &cp
+}
+
+// WithAudit returns a copy that appends ActionMCPGrantCreated,
+// ActionMCPGrantRevoked and ActionMCPToolCalled through rec. Mirrors
+// WithClock's copy-and-return shape. cmd/wpmgr/main.go calls this on the one
+// Service the process constructs; a Service left without it (as most of this
+// package's unit tests are, deliberately, since they drive a fakeStore with no
+// backing Postgres pool) simply does not audit -- see the field doc on audit.
+func (s *Service) WithAudit(rec *audit.Recorder) *Service {
+	cp := *s
+	cp.audit = rec
 	return &cp
 }
 
@@ -589,6 +612,29 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 				RedirectUri:         req.Consent.RedirectURI,
 				ExpiresAt:           expiresAt,
 			}
+		},
+		// ActionMCPGrantCreated, in the SAME transaction as both inserts above.
+		// This is "the row written to the audit log" the operator-facing
+		// consent flow promises: if the grant or the code fails to insert, or
+		// this append fails, the whole approval rolls back and there is no
+		// mcp.grant.created row for a grant that does not exist.
+		func(tx pgx.Tx, gr sqlc.McpGrant) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   req.Principal.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    req.Principal.UserID.String(),
+				Action:     audit.ActionMCPGrantCreated,
+				TargetType: "mcp_grant",
+				TargetID:   gr.ID.String(),
+				Metadata: map[string]any{
+					"grant_name":      gr.Name,
+					"site_scope_mode": gr.SiteScopeMode,
+				},
+			})
+			return aerr
 		})
 	if err != nil {
 		return Approval{}, fmt.Errorf("create grant and code: %w", err)
@@ -848,6 +894,14 @@ type AuthorizedRequest struct {
 	TenantID uuid.UUID
 	GrantID  uuid.UUID
 	TokenID  uuid.UUID
+	// GrantName is the grant's operator-assigned name (mcp_grants.name), read
+	// at the same ReCheckAuthorization call that resolves GrantID -- no extra
+	// query. It exists so RecordToolCall can stamp a human-readable label onto
+	// an ActionMCPToolCalled event without a database join: ActorName
+	// resolution (ListAuditEntries) has no arm for ActorAssistant today, so
+	// this is how the label travels until it does. Never used for
+	// authorization, only for display.
+	GrantName string
 
 	// Sites is the resolved site scope: the PER-CONNECTION narrowing on the
 	// site axis. Zero value allows nothing.
@@ -955,6 +1009,7 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	return AuthorizedRequest{
 		TenantID:     tok.TenantID,
 		GrantID:      chk.GrantID,
+		GrantName:    chk.GrantName,
 		TokenID:      chk.TokenID,
 		Sites:        NewSiteSet(ids),
 		Capabilities: caps,
@@ -981,6 +1036,48 @@ func (s *Service) RecordConnect(ctx context.Context, auth AuthorizedRequest, nam
 		return fmt.Errorf("record mcp connect: %w", err)
 	}
 	return nil
+}
+
+// RecordToolCall appends the ActionMCPToolCalled audit row for one
+// successfully executed tool call. The caller (TransportHandler.callTool)
+// invokes this AFTER entry.invoke returns without error -- a refused call
+// never reaches a tenant's data, and is already visible in the operator log
+// TransportHandler writes at refusal time (h.log.WarnContext), so it earns no
+// row here.
+//
+// ActorType is ActorAssistant, the one actor kind in this whole log that
+// attributes the row to the MODEL rather than to the human who granted it
+// access: auth.GrantID identifies WHICH connection acted, which is the fact an
+// operator reviewing "what did this MCP client touch" actually wants, and it
+// is a fact ActorUser (the approving human, possibly long gone from the
+// account) cannot carry. operatorPermission and toolName both come from the
+// registry entry AuthorizeTool already resolved -- see the OperatorPermission
+// doc on ToolPolicy for why that field lands here.
+//
+// BEST-EFFORT, deliberately unlike Approve/RevokeConnection's RecordInTx:
+// there is no companion write in the same transaction to roll back alongside a
+// failed append (a tool call in this phase is a read), so failing the whole
+// tool call because its own audit trail could not be appended would let a
+// purely observational feature take down the read path it exists to observe.
+// The error is returned so the caller can log it, never to be treated as a
+// reason to withhold the tool's answer.
+func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, toolName string, operatorPermission string) error {
+	if s.audit == nil {
+		return nil
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:   auth.TenantID,
+		ActorType:  audit.ActorAssistant,
+		ActorID:    auth.GrantID.String(),
+		Action:     audit.ActionMCPToolCalled,
+		TargetType: "mcp_tool",
+		TargetID:   toolName,
+		Metadata: map[string]any{
+			"grant_name":          auth.GrantName,
+			"operator_permission": operatorPermission,
+		},
+	})
+	return err
 }
 
 // ListSitesForModel is the one Phase 1 read tool. It returns the rendered tool
@@ -1196,7 +1293,32 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 			"a connection id is required")
 	}
 
-	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID)
+	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID,
+		// ActionMCPGrantRevoked, in the SAME transaction as the revoke
+		// statement. Runs on all three non-error outcomes (freshly revoked,
+		// half-revoked repair, idempotent no-op): the operator explicitly
+		// asked for this credential to be revoked and the request is what is
+		// being attributed, not merely a state transition. It never runs
+		// alongside pgx.ErrNoRows -- see onRevoked's doc on the interface.
+		func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   p.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    p.UserID.String(),
+				Action:     audit.ActionMCPGrantRevoked,
+				TargetType: "mcp_grant",
+				TargetID:   grantID.String(),
+				Metadata: map[string]any{
+					"grants_revoked":  row.GrantsRevoked,
+					"tokens_revoked":  row.TokensRevoked,
+					"already_revoked": row.GrantsRevoked == 0,
+				},
+			})
+			return aerr
+		})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return RevokeOutcome{}, domain.NotFound(ErrCodeConnectionNotFound,

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -423,10 +423,15 @@ func (h *TransportHandler) initialize(
 	}
 	if err := h.svc.RecordConnect(c.Request.Context(), auth,
 		p.ClientInfo.Name, p.ClientInfo.Version, headerValue); err != nil {
-		// A failed audit write is NOT swallowed. The connect record is how an
+		// NOT an audit write -- RecordConnect updates mcp_grants (client name,
+		// version, protocol header) via Store.RecordClientIdentity, and that
+		// update is NOT swallowed on failure. The connect record is how an
 		// operator sees what is attached to their organisation, and a session
 		// that proceeded after failing to record itself would be an
-		// unattributable connection.
+		// unattributable connection. (The actual audit_events row for this
+		// surface is ActionMCPToolCalled, written per tool call by
+		// Service.RecordToolCall -- initialize itself is not a tool call and
+		// writes no audit row.)
 		h.log.ErrorContext(c.Request.Context(), "mcp connect record failed",
 			slog.String("tenant_id", auth.TenantID.String()),
 			slog.String("grant_id", auth.GrantID.String()),
@@ -540,6 +545,23 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 	if err != nil {
 		return h.toolError(req.ID, err)
 	}
+
+	// The operator-facing audit row (ActionMCPToolCalled), for this call and
+	// no other outcome: a refusal above never reached a tenant's data and is
+	// already covered by the WarnContext log at the refusal site. BEST-EFFORT
+	// like RecordConnect's client-identity write is not -- a failure here is
+	// logged, never returned to the caller, because withholding a successful
+	// read's answer over a failure to record having answered it would make an
+	// observational feature take down the read path it observes.
+	if err := h.svc.RecordToolCall(ctx, auth, entry.Name, string(entry.OperatorPermission)); err != nil {
+		h.log.ErrorContext(ctx, "mcp tool call audit write failed",
+			slog.String("tenant_id", auth.TenantID.String()),
+			slog.String("grant_id", auth.GrantID.String()),
+			slog.String("tool", entry.Name),
+			slog.String("error", err.Error()),
+		)
+	}
+
 	return newResponse(req.ID, map[string]any{
 		"content": []map[string]any{{"type": "text", "text": text}},
 	})

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -343,6 +343,11 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{}), http.StatusOK, true
 
 	case "tools/list":
+		// THE ACTIVITY STAMP IS BEFORE THE ANSWER, NOT AFTER IT. See
+		// stampActivity.
+		if resp, refused := h.stampActivity(ctx, auth, req); refused {
+			return resp, http.StatusOK, true
+		}
 		// VisibleTools, NOT Tools. Tools() is the whole registry and is not a
 		// request-path value; VisibleTools filters by this connection's
 		// capability set and site scope through the SAME predicate tools/call
@@ -351,6 +356,9 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{"tools": VisibleTools(auth)}), http.StatusOK, true
 
 	case "tools/call":
+		if resp, refused := h.stampActivity(ctx, auth, req); refused {
+			return resp, http.StatusOK, true
+		}
 		return h.callTool(ctx, auth, req), http.StatusOK, true
 
 	// Resources and prompts are OUT OF SCOPE for Phase 1 and are refused by
@@ -458,6 +466,39 @@ func (h *TransportHandler) initialize(
 type toolCallParams struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments"`
+}
+
+// stampActivity records that this connection was used, and reports whether the
+// request must be refused because the record could not be written. GH #605.
+//
+// IT RUNS BEFORE THE TOOL, AND THE ORDERING IS THE POINT. Stamping after a
+// successful call would leave every refused or failed call unrecorded, so a
+// connection whose calls are all being refused would look idle and would
+// eventually idle-expire -- silently converting a permissions problem into an
+// expired credential. What this column answers is "did anyone drive this
+// connection", and driving it is what the request already is by the time this
+// runs: Authenticate has passed, so the caller holds a live token on a live,
+// unexpired grant.
+//
+// A FAILED STAMP REFUSES THE REQUEST rather than being logged and dropped. See
+// Service.RecordActivity for why this one is not best-effort like the audit
+// append in callTool. The refusal is the INTERNAL code, never an auth or a
+// tool-availability code: nothing is wrong with the caller's token or its
+// capability set, and telling it otherwise would send an operator rotating a
+// credential that was never the problem.
+func (h *TransportHandler) stampActivity(ctx context.Context, auth AuthorizedRequest, req jsonrpcRequest) (jsonrpcResponse, bool) {
+	if err := h.svc.RecordActivity(ctx, auth); err != nil {
+		h.log.ErrorContext(ctx, "mcp activity stamp failed",
+			slog.String("tenant_id", auth.TenantID.String()),
+			slog.String("grant_id", auth.GrantID.String()),
+			slog.String("token_id", auth.TokenID.String()),
+			slog.String("method", req.Method),
+			slog.String("error", err.Error()),
+		)
+		return newErrorResponse(req.ID, codeInternalError,
+			"this request could not be recorded against the connection, so it was not served", nil), true
+	}
+	return jsonrpcResponse{}, false
 }
 
 // callTool is S7's EXIT GATE, and the gate is the absence of a `default` arm.

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -54,6 +54,14 @@ func liveGrantStore(siteIDs ...uuid.UUID) *fakeStore {
 			Authorized: true,
 			GrantID:    uuid.New(),
 			TokenID:    uuid.New(),
+			// m127: the capability set is READ FROM THIS ROW, so a fixture that
+			// omits it models a grant holding NO capability and every request
+			// against it is refused. That is the honest default -- leaving the
+			// field zero here and having the transport work anyway would mean
+			// the service was still computing capabilities instead of reading
+			// them.
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
 		},
 		scopeSites: siteIDs,
 	}

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -941,6 +942,113 @@ func TestNotification_ToolsCallWithNoIdDoesNotExecuteTheTool(t *testing.T) {
 	}
 	if !executed {
 		t.Fatal("the id-carrying control did not execute the tool either; the fixture is broken")
+	}
+}
+
+// TestActivityStamp_OnEveryToolCallAndNotOnKeepalives pins the decision GH #605
+// turns on: WHICH methods count as "used".
+//
+// The stamp is what makes mcp_grants.last_used_at real, and last_used_at is the
+// input to the idle-expiry deadline. Both directions are asserted because each
+// alone is a different bug:
+//
+//   - tools/list and tools/call MUST stamp. If they do not, an actively used
+//     connection reads as never used and idle-expires -- the fleet outage m127
+//     DECISION 4 describes.
+//   - ping and notifications/initialized MUST NOT. They are keepalives a stuck
+//     background process emits forever; letting them refresh the deadline makes
+//     "unused for 30 days" unfalsifiable and the feature decorative.
+//
+// initialize does not stamp either: RecordConnect already records that a client
+// connected (client_identity_recorded_at), which is the separate fact.
+func TestActivityStamp_OnEveryToolCallAndNotOnKeepalives(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantStamp bool
+	}{
+		{"tools/list stamps", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, true},
+		{"tools/call stamps",
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, true},
+		{"ping does not stamp", `{"jsonrpc":"2.0","id":1,"method":"ping"}`, false},
+		{"initialize does not stamp",
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"c","version":"1"}}}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := liveGrantStore(uuid.New())
+			r := newTransportRouter(t, store)
+
+			w := post(t, r, tc.body, nil)
+			if w.Code != http.StatusOK {
+				t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+			}
+
+			got := len(store.touchCalls) > 0
+			if got != tc.wantStamp {
+				t.Fatalf("%s: stamped=%v want %v (%d TouchActivity calls)",
+					tc.name, got, tc.wantStamp, len(store.touchCalls))
+			}
+			if !tc.wantStamp {
+				return
+			}
+			// The ids matter as much as the count: a stamp on the wrong grant
+			// keeps the wrong connection alive.
+			c := store.touchCalls[0]
+			if c.TenantID != store.token.TenantID {
+				t.Errorf("stamped tenant %s, want %s", c.TenantID, store.token.TenantID)
+			}
+			if c.GrantID != store.recheck.GrantID {
+				t.Errorf("stamped grant %s, want %s", c.GrantID, store.recheck.GrantID)
+			}
+			if c.TokenID != store.recheck.TokenID {
+				t.Errorf("stamped token %s, want %s", c.TokenID, store.recheck.TokenID)
+			}
+		})
+	}
+}
+
+// TestActivityStamp_FailureRefusesTheRequestAndDoesNotRunTheTool is the other
+// half of the decision: the stamp is NOT best-effort.
+//
+// A stamp that fails silently leaves the connection's idle clock running while
+// it is being used, and the cost lands N days later as an expiry nobody can
+// explain. So the request is refused -- with the INTERNAL code, never an auth
+// or tool-availability code, because nothing is wrong with the caller's token
+// or its capability set and telling it otherwise sends an operator rotating a
+// credential that was never the problem.
+func TestActivityStamp_FailureRefusesTheRequestAndDoesNotRunTheTool(t *testing.T) {
+	store := liveGrantStore(uuid.New())
+	store.touchErr = errors.New("simulated: the stamp could not be written")
+	r := newTransportRouter(t, store)
+
+	w := post(t, r,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+
+	var resp struct {
+		Error struct {
+			Code int `json:"code"`
+		} `json:"error"`
+		Result any `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (%s)", err, w.Body.String())
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d (internal): %s",
+			resp.Error.Code, codeInternalError, w.Body.String())
+	}
+	if resp.Result != nil {
+		t.Fatalf("a refused request still carried a result: %s", w.Body.String())
+	}
+
+	// AND THE TOOL DID NOT RUN. Serving the read anyway would mean the caller
+	// got its answer while the record that it asked says otherwise -- the stamp
+	// runs before the tool precisely so an unrecordable request is not served.
+	for _, c := range store.callLog() {
+		if c == "ListSitesForRead" {
+			t.Fatal("the tool executed despite the activity stamp failing")
+		}
 	}
 }
 

--- a/apps/api/migrations/20260829000000_m127_mcp_grant_expiry_capabilities.sql
+++ b/apps/api/migrations/20260829000000_m127_mcp_grant_expiry_capabilities.sql
@@ -1,0 +1,439 @@
+-- m127 - ADR-064 S4/S5: give an MCP grant an ABSOLUTE EXPIRY, an IDLE EXPIRY
+-- and an EXPLICIT PER-CONNECTION CAPABILITY SET.
+--
+-- This migration CORRECTS NOTHING. It edits no applied migration, it re-runs no
+-- earlier backfill, and no database in any state needs converging onto it
+-- beyond the one-time backfill in step (0) below, which is described in
+-- DECISION 9. There is no m114/m115-shaped follow-up owed.
+--
+-- WHY IT EXISTS. The connection wizard shipped with 3 of the 10 steps the
+-- wireframes specify. Steps 4 (choose what it may do) and 5 (expiry and
+-- security) cannot be built at all, because mcp_grants has nowhere to put their
+-- data: no expiry of either kind, and no capability set. m124 DECISION 1
+-- declined to mint a capabilities column and said why; internal/mcp/service.go
+-- names the exact column this migration must add, in the comment at the
+-- OrgDefaultCapabilities call site:
+--
+--     "the COLUMN it would read from arrives with its own migration, NOT NULL,
+--      no default, closed CHECK, as DECISION 1 requires."
+--
+-- That is the specification for DECISION 1 below, written by the code that will
+-- read the column. This file implements it literally.
+--
+-- ===========================================================================
+-- DECISION 1: THE CAPABILITY SET IS NOT NULL, HAS NO DEFAULT, AND ITS
+--             VOCABULARY IS CLOSED BY CHECK
+-- ===========================================================================
+--
+-- m124 DECISION 1 established the rule for the site axis: absence must be
+-- UNREPRESENTABLE or must mean REFUSED, never permitted. The capability axis
+-- gets the same treatment, by three separate mechanisms, because a single
+-- NOT NULL is not enough.
+--
+--   a. NOT NULL WITH NO DEFAULT. A nullable capabilities column that Go reads
+--      as "no narrowing applied, therefore every capability" is the precise
+--      defect this whole surface has been fighting, and it is the one shape
+--      CapabilitySet's zero value was designed to make impossible in Go. The
+--      column now makes it impossible in the database too: a caller that omits
+--      capabilities gets 23502, not an unrestricted connection.
+--
+--      THIS IS DELIBERATELY THE OPPOSITE OF api_keys.capabilities AT m120,
+--      which is NULLABLE with no default. m120's reasoning does not transfer
+--      and m124 DECISION 1(c) already said why: api_keys had a live fleet of
+--      pre-existing rows whose authority came from a `role` column, so '{}'
+--      would have stripped every key in the fleet at boot and NULL had to mean
+--      "this key has no capability set at all". mcp_grants has no second
+--      source of authority to fall back to. There is nothing for NULL to mean
+--      here except "unknown", and an unknown grant is refused, so the value is
+--      not worth being able to store.
+--
+--   b. AN EMPTY ARRAY IS PERMITTED AND MEANS EXACTLY ZERO CAPABILITIES. It is
+--      the restrictive direction: a connection holding '{}' reaches no tool.
+--      CapabilitySet in internal/mcp/policy.go has the same property and no
+--      method answering "does this mean everything", so the two agree.
+--
+--   c. THE VOCABULARY IS CLOSED BY CHECK, against the registry, BY NAME. This
+--      is the mechanism S7's exit gate asks for -- discovery never grants what
+--      the registry does not hold -- pushed down to the one place that cannot
+--      be forgotten at a call site.
+--
+--      THE VOCABULARY IS `mcp.sites.read`, AND THAT IS THE WHOLE LIST TODAY.
+--      internal/mcp/policy.go declares capabilityVocabulary as a closed map
+--      with exactly that one entry, and CapSitesRead is commented "the only
+--      capability the Phase 1 surface has". The CHECK below admits that one
+--      string and nothing else.
+--
+--      THE WIREFRAMES NAME THREE GROUPS AND THIS CHECK ADMITS ONE, ON PURPOSE.
+--      Step 4 draws site.content.read, site.inventory.read and
+--      site.content.propose. None of those exist in the registry. Admitting a
+--      name the registry does not hold would store a capability that resolves
+--      to no tool -- a grant the operator believes they made and the surface
+--      silently does not honour, which is the same shape as the dropped scope
+--      token scope.go already refuses. So Step 4 can be built now and will
+--      honestly offer one group until each further group arrives WITH ITS OWN
+--      MIGRATION EXTENDING THIS CHECK.
+--
+--      THAT COUPLING IS THE POINT, NOT AN INCONVENIENCE. m124 DECISION 1
+--      declined a capabilities column specifically because it "would create the
+--      place a write capability could appear without a migration and without a
+--      review". The closed CHECK is what buys the column back without buying
+--      that hazard: a write capability cannot reach this table until someone
+--      writes a migration naming it, which is a reviewed artefact. Adding a
+--      Capability to policy.go alone is NOT sufficient and will fail 23514 at
+--      the INSERT.
+--
+--   d. THE CEILING IS 64, AND IT IS A PROPERTY OF THE CREDENTIAL. The wireframe
+--      says so in those words ("A connection holds at most 64", "The ceiling is
+--      a property of the credential, not a licence tier"), and it is the same
+--      figure m120 chose for api_keys.capabilities. Shape is otherwise checked
+--      exactly as m120 checks it -- one dimension, no NULL element, no empty
+--      string -- using only IMMUTABLE expressions so the constraint is valid in
+--      a CHECK.
+--
+--      NOT CHECKED: element uniqueness. Deduplication needs a subquery
+--      (cardinality vs. a DISTINCT unnest) and CHECK forbids one. A duplicate
+--      is harmless to a set-membership read and merely consumes ceiling; the
+--      API layer should dedupe before insert.
+--
+-- ===========================================================================
+-- DECISION 2: TWO EXPIRIES, AND NULL MEANS A DIFFERENT THING IN EACH
+-- ===========================================================================
+--
+-- Absolute expiry and idle expiry are DIFFERENT FACTS. The brief requires that
+-- a NULL in either must not read as the other, nor as "never expires" when the
+-- operator chose a date. They are stated separately here because they are
+-- stored differently, and the difference is taken straight from the wireframe.
+--
+--   expires_at timestamptz NOT NULL, NO DEFAULT.
+--     NULL IS UNREPRESENTABLE. Not "NULL means never" -- there is no NULL.
+--     Step 5 offers four choices: 30 days, 90 days, 1 year, On a date. THERE IS
+--     NO "NEVER" OPTION ON THIS CONTROL. A never-expiring connection is not a
+--     thing the product offers, so it is not a thing the schema can hold, and
+--     the read-time predicate in DECISION 3 therefore has NO NULL BRANCH FOR A
+--     CALLER TO GET BACKWARDS. That is the entire reason this column is NOT
+--     NULL rather than nullable-with-a-convention.
+--
+--   idle_expire_after_days integer NULL, NO DEFAULT.
+--     NULL MEANS NEVER IDLE-EXPIRE, and it means only that. Step 5's second
+--     control does offer "Never" alongside 30 days and 90 days, so this axis
+--     genuinely has three states and the third is representable. It is an
+--     INTERVAL LENGTH, not an instant: the deadline is computed at read time
+--     from the activity stamp, so it moves whenever the connection is used,
+--     which is what "expire it if unused for 30 days" means. Storing a
+--     precomputed idle deadline would require rewriting the row on every
+--     request and would be wrong the moment a request was not recorded.
+--
+--     Stored as a day count rather than an interval because the control offers
+--     whole days, an integer needs no pgtype.Interval at the Go boundary, and a
+--     day count cannot smuggle a month or a microsecond into a security
+--     deadline.
+--
+--   THE TWO ARE INDEPENDENT AND BOTH BIND. A grant is refused if it is past its
+--   absolute expiry OR past its idle deadline. Neither can rescue the other.
+--
+-- ===========================================================================
+-- DECISION 3: EXPIRY IS PART OF THE `authorized` VERDICT, NOT A SECOND READ
+-- ===========================================================================
+--
+-- ReCheckMCPRequestAuthorizationInTenantTx already runs on EVERY REQUEST and
+-- already returns `authorized` as the whole verdict in one column, "computed
+-- here so that no caller reassembles it". Both expiries join that predicate in
+-- this migration's companion change to db/query/mcp_connections.sql.
+--
+-- A GRANT PAST EITHER EXPIRY NOW FAILS THE SAME PREDICATE A REVOKED GRANT
+-- FAILS. It is one boolean, one index probe on a primary key, no extra round
+-- trip, and no opportunity for a caller to forget the check -- which is the
+-- brief's requirement that expiry be enforceable at the point of use, cheaply.
+--
+-- THE WIREFRAME'S "no silent read-only period" IS A CONSEQUENCE OF THIS SHAPE.
+-- Expiry flips `authorized` to false outright; it does not degrade the
+-- connection to a reduced capability set. There is no code path here that could
+-- produce a half-working connection, because there is one boolean and not a
+-- tier.
+--
+-- NO SWEEP JOB IS REQUIRED FOR ENFORCEMENT. Expiry is evaluated at read time
+-- against now(), so a grant stops working at the instant it expires whether or
+-- not any background worker ran. A sweep is needed only for the wireframe's
+-- courtesy email ("14 days and 1 day before") and, optionally, for flipping
+-- status to a terminal value for display. Neither is an enforcement dependency,
+-- and a sweep that fails to run must never be able to extend a credential.
+--
+-- NO NEW INDEX. The hot path reaches the grant by primary key through the join
+-- on t.grant_id, so both expiry predicates are evaluated on an already-fetched
+-- row and index nothing. mcp_grants_live_idx (partial on status = 'active')
+-- already serves the notification sweep's candidate scan. Adding an index on
+-- expires_at would earn nothing on either path.
+--
+-- ===========================================================================
+-- DECISION 4: IDLE EXPIRY READS coalesce(last_used_at, created_at), AND IT IS
+--             INERT BY CONSTRUCTION UNTIL THE ACTIVITY STAMP IS WIRED
+-- ===========================================================================
+--
+-- THIS IS THE MOST DANGEROUS THING IN THIS MIGRATION AND IT IS WRITTEN DOWN
+-- RATHER THAN LEFT TO BE DISCOVERED.
+--
+-- mcp_grants.last_used_at IS NEVER WRITTEN TODAY. TouchMCPGrantInTenantTx
+-- exists in db/query/mcp_connections.sql, generates cleanly, and HAS ZERO GO
+-- CALLERS:
+--
+--   grep -rn "TouchMCPGrant" apps/api --include="*.go" | grep -v "internal/db/sqlc/"
+--     -> 0 matches
+--
+-- TouchMCPConnectionTokenInTenantTx is in the same state, also 0 callers. So
+-- every mcp_grants row in existence has last_used_at IS NULL regardless of how
+-- heavily its connection is used.
+--
+-- CONSEQUENCE, STATED PLAINLY: if a non-NULL idle_expire_after_days is ever
+-- written while the stamp is still unwired, coalesce(last_used_at, created_at)
+-- collapses to created_at permanently, and EVERY AFFECTED CONNECTION DIES
+-- idle_expire_after_days AFTER IT WAS CREATED NO MATTER HOW ACTIVE IT IS. With
+-- the wireframe's pre-selected 30 days that is a fleet-wide outage of every AI
+-- connection, thirty days after this ships, with no operator action and nothing
+-- in any log naming the cause.
+--
+-- THE SCHEMA IS SAFE BY CONSTRUCTION AGAINST THAT, AND ONLY BY CONSTRUCTION:
+-- idle_expire_after_days is NULL with NO DEFAULT, and NULL means never
+-- idle-expire, so no existing row and no row inserted by a caller that does not
+-- mention the column can idle-expire. The hazard is unreachable until Go
+-- deliberately writes a value into it.
+--
+-- THE ORDERING CONSTRAINT THIS PLACES ON backend-architect IS HARD:
+-- TouchMCPGrantInTenantTx must be called on the request path BEFORE the API is
+-- allowed to persist any non-NULL idle_expire_after_days. Wiring the stamp is a
+-- prerequisite of Step 5's second control, not a follow-up to it.
+--
+-- coalesce(last_used_at, created_at) is the right expression once the stamp is
+-- live -- a grant that has never been used is idle since it was created, which
+-- is precisely the credential the wireframe is aimed at ("a connection nobody
+-- has used in a month is a credential nobody is watching") -- and it is also
+-- what makes the unwired state degrade to "expires at created_at + N" rather
+-- than to something unbounded. It fails CLOSED, which is why the outage above
+-- is an outage and not a silent extension of every credential. That is the
+-- correct direction and it is still an outage.
+--
+-- ===========================================================================
+-- DECISION 5: RLS IS INHERITED, NOT ADDED, AND WHICH DISPATCH HELPER BINDS IT
+-- ===========================================================================
+--
+-- THIS MIGRATION CREATES NO TABLE AND NO POLICY. It adds three columns to
+-- mcp_grants, which m124 already put under ENABLE plus FORCE ROW LEVEL
+-- SECURITY with five policies: the permissive mcp_grants_tenant_isolation and
+-- the four RESTRICTIVE mcp_grants_site_scope_{select,insert,update,delete}.
+-- RLS filters ROWS, not columns, so a new column on a protected table is
+-- protected by the existing policies with no further statement. Adding a
+-- redundant policy here would be a second thing to keep in sync.
+--
+-- NO ROW IS OWED IN db/rls-cross-tenant-policies.txt. That ledger records
+-- policies that grant access ACROSS tenants. Every policy on mcp_grants is
+-- tenant-isolated, none of them is cross-tenant, and this migration adds no
+-- policy of any kind. The ledger is unchanged and check-rls-cross-tenant.sh
+-- must stay green without an edit.
+--
+-- WHICH DISPATCH HELPER A CALLER MUST USE: db.RunTenantTx, ALWAYS, AND THAT IS
+-- A CORRECTNESS REQUIREMENT AND NOT A CONVENTION. The four site_scope policies
+-- are RESTRICTIVE and each tests
+-- coalesce(current_setting('app.site_scope', true), '') <> 'on'. RunTenantTx
+-- (internal/db/db.go:772, dispatching through dispatchTenantTx at :755-763) is
+-- THE ONLY THING THAT SETS THAT GUC. A call site that picks InTenantTx,
+-- InTenantTxAsUser or InScopedTenantTx itself leaves it unset, the coalesced
+-- empty string is not equal to 'on', THE RESTRICTIVE CHECK PASSES, and the
+-- statement proceeds with no error raised anywhere.
+--
+-- A live privilege escalation of exactly that shape was fixed in this area on
+-- 2026-08-30: a call site used InTenantTx directly, app.site_scope was never
+-- set, and the policy admitted the write. A POLICY THAT TESTS A GUC IS INERT ON
+-- ANY PATH THAT DOES NOT SET IT. Capabilities and expiry are now part of what a
+-- site-scoped collaborator must not be able to widen, so every write to these
+-- three columns inherits that requirement.
+--
+-- ===========================================================================
+-- DECISION 6: THE BACKFILL PRESERVES TODAY'S EFFECTIVE AUTHORITY EXACTLY, AND
+--             IS NOT A PERMISSIVE DEFAULT
+-- ===========================================================================
+--
+-- Two of the three columns are NOT NULL, and mcp_grants is no longer guaranteed
+-- empty -- m124 applied on 2026-08-26 and this file lands on 2026-08-29, so a
+-- production row may exist. m124 DECISION 1(c) explicitly rested on "these
+-- tables start empty, so no such backfill hazard exists"; THAT SENTENCE HAS
+-- EXPIRED and this migration must handle rows.
+--
+-- A DEFAULT CLAUSE AND A ONE-TIME BACKFILL ARE NOT THE SAME THING. No column
+-- below carries a DEFAULT. Step (0) sets a value on rows that already exist and
+-- then the NOT NULL is armed, so every FUTURE insert must still say. The
+-- distinction is the whole of constraint 1 in the brief.
+--
+--   capabilities -> ARRAY['mcp.sites.read'].
+--     THIS GRANTS NOTHING NEW AND IT IS NOT A WILDCARD. It is the exact,
+--     complete set every existing grant already holds, read off the code rather
+--     than chosen: internal/mcp/service.go resolves the capability set as
+--     OrgDefaultCapabilities(grantScopes()), grantScopes() returns exactly
+--     {ScopeRead} for every live grant by construction, and scopeCapabilities
+--     maps ScopeRead to exactly {CapSitesRead}. So the backfill writes down what
+--     the running system already computes. Any existing connection keeps working
+--     with precisely the authority it has today, and gains none.
+--
+--     '{}' WAS CONSIDERED AND REJECTED. It is the more restrictive value, but it
+--     would silently strip every existing connection to zero capabilities the
+--     moment backend-architect wires the read, which is an outage caused by a
+--     migration rather than by an operator decision -- and it would be an
+--     outage justified as safety while the safe-and-correct value was known and
+--     derivable. Fail-closed is the right default when the answer is unknown.
+--     Here it is known.
+--
+--   expires_at -> now() + interval '90 days'.
+--     90 days is the wireframe's pre-selected choice. now() AND NOT
+--     created_at + 90 days, deliberately: keying off created_at would make any
+--     grant older than 90 days expire the instant this migration applies,
+--     inside main() at boot, on every install at once. now() + 90 days cannot
+--     be in the past for any row, so no existing connection is killed by
+--     applying this file, and every operator gets a full 90 days of notice to
+--     choose a real expiry. This is the m110/m111 lesson: a backfill that can
+--     land a row in an invalid or hostile state is the thing that needs the
+--     repair migration.
+--
+--   idle_expire_after_days -> left NULL.
+--     Nothing to backfill. NULL is a legal, meaningful value on this column
+--     (never idle-expire) and it is the only safe one while DECISION 4's stamp
+--     is unwired.
+--
+-- EVERY STATEMENT BELOW IS IDEMPOTENT AND THE FILE IS RE-RUNNABLE. The backfill
+-- is guarded by IS NULL so a second application updates zero rows and cannot
+-- push an operator-chosen expiry 90 days into the future.
+
+-- ---------------------------------------------------------------------------
+-- (0) Columns, added nullable so existing rows survive the ALTER.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "capabilities" text[];
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "expires_at" timestamptz;
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "idle_expire_after_days" integer;
+
+-- ---------------------------------------------------------------------------
+-- (1) Backfill. WHERE ... IS NULL makes this a no-op on a second run and
+--     protects a value an operator has already chosen. See DECISION 6.
+-- ---------------------------------------------------------------------------
+
+UPDATE "public"."mcp_grants"
+   SET "capabilities" = ARRAY['mcp.sites.read']::text[]
+ WHERE "capabilities" IS NULL;
+
+UPDATE "public"."mcp_grants"
+   SET "expires_at" = now() + interval '90 days'
+ WHERE "expires_at" IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- (2) Arm NOT NULL, now that no row violates it. SET NOT NULL is a no-op when
+--     the column is already NOT NULL, so this is safe to re-run.
+--     idle_expire_after_days stays NULLABLE -- NULL is a real value there.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."mcp_grants"
+    ALTER COLUMN "capabilities" SET NOT NULL;
+
+ALTER TABLE "public"."mcp_grants"
+    ALTER COLUMN "expires_at" SET NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- (3) Constraints. Each guarded by a pg_constraint probe so the file re-runs.
+-- ---------------------------------------------------------------------------
+
+-- Shape of the capability set. m120's constraint verbatim in intent: one
+-- dimension (a literal like '{{a},{b}}' would otherwise be flattened by
+-- unnest() into capabilities nobody granted), no NULL element, no empty string,
+-- and the 64 ceiling the wireframe states. IMMUTABLE expressions only.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_capabilities_shape_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_capabilities_shape_check"
+            CHECK (
+                coalesce(array_ndims("capabilities"), 1) = 1
+                AND cardinality("capabilities") <= 64
+                AND array_position("capabilities", NULL) IS NULL
+                AND NOT ('' = ANY ("capabilities"))
+            );
+    END IF;
+END;
+$$;
+
+-- Closed vocabulary. See DECISION 1(c). `<@` is array containment and is
+-- IMMUTABLE; the empty array is contained by every array, so '{}' -- zero
+-- capabilities, the restrictive value -- passes, which is intended.
+--
+-- EXTENDING THIS LIST IS A MIGRATION, and that is the review gate m124
+-- DECISION 1 asked for. Keep it in lockstep with capabilityVocabulary in
+-- apps/api/internal/mcp/policy.go.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_capabilities_vocabulary_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_capabilities_vocabulary_check"
+            CHECK ("capabilities" <@ ARRAY['mcp.sites.read']::text[]);
+    END IF;
+END;
+$$;
+
+-- A grant cannot be born already expired. Nonsense rather than danger -- an
+-- already-expired grant fails the DECISION 3 predicate and is refused -- but it
+-- is unrepresentable rather than merely harmless, which is the house standard.
+-- Immediate termination is REVOCATION (status = 'revoked'), not a backdated
+-- expiry, and keeping the two mechanisms distinct keeps revoked_at honest.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_expires_at_after_created_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_expires_at_after_created_check"
+            CHECK ("expires_at" > "created_at");
+    END IF;
+END;
+$$;
+
+-- The idle window is a positive number of days, or NULL for "never". Zero is
+-- refused because "expire it if unused for 0 days" has no meaning and would
+-- read as an immediate kill dressed up as a policy; ten years is the ceiling
+-- so a fat-fingered value cannot become an effectively-absent control.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_idle_expire_after_days_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_idle_expire_after_days_check"
+            CHECK (
+                "idle_expire_after_days" IS NULL
+                OR ("idle_expire_after_days" >= 1
+                    AND "idle_expire_after_days" <= 3650)
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- (4) Grants.
+--
+-- Nothing to add. m1's ALTER DEFAULT PRIVILEGES and m124's explicit
+-- GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_grants TO wpmgr_app are
+-- table-level and cover columns added later; PostgreSQL has no per-column
+-- grant in force on this table that a new column could fall outside of. Stated
+-- rather than left silent, because "the new column is invisible to wpmgr_app"
+-- is the kind of failure that looks like an RLS bug for a day.
+-- ---------------------------------------------------------------------------

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -96,7 +96,7 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("seed grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -85,6 +85,13 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  siteIDs,
 		ClientID:      &clientID,
+		// m127's three columns. capabilities and expires_at are NOT NULL with
+		// no default, so omitting either is a 23502 and not a permissive
+		// fixture. idle_expire_after_days is left NULL -- "never idle-expire" --
+		// which is what Service.Approve writes.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		return sqlc.CreateMCPAuthorizationCodeParams{
 			TenantID:            tenantID,

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -92,6 +92,10 @@ func s7GrantWithBearer(
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  siteIDs,
 		ClientID:      &clientID,
+		// m127: both NOT NULL with no default. See the s6b2 fixture.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		return sqlc.CreateMCPAuthorizationCodeParams{
 			TenantID:            tenantID,

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -103,7 +103,7 @@ func s7GrantWithBearer(
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("create grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -1,0 +1,371 @@
+// mcp_audit_events_integration_test.go: the three audit_events writes added to
+// the MCP connection surface -- ActionMCPGrantCreated, ActionMCPGrantRevoked,
+// ActionMCPToolCalled -- proven against the REAL schema, RLS and application
+// role, through the SAME code path production uses.
+//
+// WHY THIS FILE EXISTS. internal/mcp wrote ZERO rows to audit_log before this
+// slice: `grep -rn '\.Record(\|RecordInTx(' internal/mcp/*.go` matched nothing
+// outside _test.go's httptest.NewRecorder. An approve, a revoke or a tool call
+// that reaches a tenant's data left no attributable row. A unit test against
+// fakeStore cannot prove any of the three things that actually matter here:
+//
+//  1. mcp.grant.created lands in the SAME transaction as the grant insert
+//     (RecordInTx, not Record), so a rolled-back grant leaves no row claiming
+//     one exists -- see the rollback proof below.
+//  2. The row is readable back only through db.Pool as wpmgr_app -- NOSUPERUSER,
+//     NOBYPASSRLS -- which mcpAssertAndReportRole asserts and prints. A test
+//     that opened its own connection would leave every RLS policy inert and
+//     pass regardless; that is exactly how m112's proofs passed while the email
+//     domain was cross-site readable.
+//  3. A second tenant's InTenantTx cannot see the first tenant's assistant row,
+//     even though both share one physical audit_log table.
+//
+// So: every write and every read below goes through the same Service, the same
+// Handler, the same TransportHandler and the same tx helpers server.New wires,
+// with the app-role pool. No GUC is hand-set anywhere in this file.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpAuditRow is the slice of audit_log columns these proofs care about.
+type mcpAuditRow struct {
+	actorType string
+	actorID   string
+	targetID  string
+	metadata  map[string]any
+}
+
+// queryMCPAuditRowsAsAppRole reads audit_log for one tenant and action THROUGH
+// db.Pool.InTenantTx -- the same tx helper Recorder.List uses -- so RLS is live
+// for this read exactly as it is for the write under test.
+func queryMCPAuditRowsAsAppRole(t *testing.T, pool *db.Pool, tenantID uuid.UUID, action string) []mcpAuditRow {
+	t.Helper()
+	var out []mcpAuditRow
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(context.Background(),
+			`SELECT actor_type, actor_id, target_id, metadata FROM audit_log
+			  WHERE tenant_id = $1 AND action = $2`, tenantID, action)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var r mcpAuditRow
+			var metaRaw []byte
+			if err := rows.Scan(&r.actorType, &r.actorID, &r.targetID, &metaRaw); err != nil {
+				return err
+			}
+			if len(metaRaw) > 0 {
+				if err := json.Unmarshal(metaRaw, &r.metadata); err != nil {
+					return err
+				}
+			}
+			out = append(out, r)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		t.Fatalf("query audit_log action=%s for tenant %s: %v", action, tenantID, err)
+	}
+	return out
+}
+
+// TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole drives the
+// WHOLE MCP surface -- register, authorize, consent, exchange, a real tools/call
+// over the mounted transport, then revoke -- and asserts each of the three new
+// audit rows lands with the right actor, target and metadata. It also proves
+// tenant isolation: a second tenant's InTenantTx read sees none of it.
+func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion below.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-audit-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-audit-"+suffix+"@example.test")
+	siteURL := "https://" + suffix + ".example.test"
+	seedSite(t, pool, tenantID, siteURL)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	// An org-scoped admin: the role RegisterConnections' PermAPIKeyManage
+	// requires for revoke, and the only scope /consent admits.
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	eng := mountLikeProduction(t, svc, admin)
+
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+	const grantName = "mcp audit events test connection"
+
+	// ------------------------------------------------------------------
+	// register -> authorize -> consent -> exchange, exactly as
+	// adr064_s6b3_mcp_oauth_end_to_end_test.go proves the flow composes.
+	// ------------------------------------------------------------------
+	var reg struct {
+		ClientID string `json:"client_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.RegisterPath, map[string]any{
+		"redirect_uris":              []string{redirectURI},
+		"client_name":                "Claude Desktop",
+		"client_uri":                 "https://claude.ai",
+		"token_endpoint_auth_method": "none",
+	}, nil, &reg); code != http.StatusCreated {
+		t.Fatalf("register answered %d, want 201", code)
+	}
+
+	verifier := "audit-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", reg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "audit-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	if code := mcpDoJSON(t, eng, http.MethodGet, mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		t.Fatalf("authorize answered %d, want 200", code)
+	}
+
+	var approval struct {
+		GrantID string `json:"grant_id"`
+		Code    string `json:"code"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConsentPath, map[string]any{
+		"client_id":             reg.ClientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "audit-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"name":                  grantName,
+		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+	}, nil, &approval); code != http.StatusOK {
+		t.Fatalf("consent answered %d, want 200", code)
+	}
+	grantID := approval.GrantID
+
+	// ------------------------------------------------------------------
+	// PROOF 1: mcp.grant.created landed, actor = the approving USER.
+	// ------------------------------------------------------------------
+	created := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	if len(created) != 1 {
+		t.Fatalf("mcp.grant.created rows = %d, want exactly 1", len(created))
+	}
+	if created[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.created actor_type = %q, want %q", created[0].actorType, audit.ActorUser)
+	}
+	if created[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.created actor_id = %q, want the approving user %q", created[0].actorID, userID)
+	}
+	if created[0].targetID != grantID {
+		t.Errorf("mcp.grant.created target_id = %q, want the grant id %q", created[0].targetID, grantID)
+	}
+	if got, _ := created[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.grant.created metadata.grant_name = %q, want %q", got, grantName)
+	}
+	t.Logf("PROOF 1 ok: mcp.grant.created attributed to user %s for grant %s", userID, grantID)
+
+	// ------------------------------------------------------------------
+	// Exchange the code, then call tools/call over the real transport.
+	// ------------------------------------------------------------------
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", approval.Code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", reg.ClientID)
+	form.Set("code_verifier", verifier)
+
+	tokReq := httptest.NewRequest(http.MethodPost, mcp.TokenPath, strings.NewReader(form.Encode()))
+	tokReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokReq.RemoteAddr = "203.0.113.7:5555"
+	tokW := httptest.NewRecorder()
+	eng.ServeHTTP(tokW, tokReq)
+	if tokW.Code != http.StatusOK {
+		t.Fatalf("token exchange answered %d, want 200: %s", tokW.Code, tokW.Body.String())
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(tokW.Body.Bytes(), &tok); err != nil {
+		t.Fatalf("token response is not JSON: %v", err)
+	}
+	if tok.AccessToken == "" {
+		t.Fatal("token exchange returned no access_token")
+	}
+
+	got := mcpRPC(t, eng, tok.AccessToken, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("tools/call %s answered %d, want 200: %s", mcp.ToolListSites, got.status, got.body)
+	}
+
+	// ------------------------------------------------------------------
+	// PROOF 2: mcp.tool.called landed, actor = the ASSISTANT (the grant),
+	// never the approving user.
+	// ------------------------------------------------------------------
+	called := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("mcp.tool.called rows = %d, want exactly 1", len(called))
+	}
+	if called[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.tool.called actor_type = %q, want %q", called[0].actorType, audit.ActorAssistant)
+	}
+	if called[0].actorID != grantID {
+		t.Errorf("mcp.tool.called actor_id = %q, want the grant id %q (NOT the user)", called[0].actorID, grantID)
+	}
+	if called[0].targetID != mcp.ToolListSites {
+		t.Errorf("mcp.tool.called target_id = %q, want the tool name %q", called[0].targetID, mcp.ToolListSites)
+	}
+	if got, _ := called[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.tool.called metadata.grant_name = %q, want %q (the actor label)", got, grantName)
+	}
+	if got, _ := called[0].metadata["operator_permission"].(string); got != string(authz.PermSiteRead) {
+		t.Errorf("mcp.tool.called metadata.operator_permission = %q, want %q", got, authz.PermSiteRead)
+	}
+	t.Logf("PROOF 2 ok: mcp.tool.called attributed to assistant/grant %s, not to user %s", grantID, userID)
+
+	// ------------------------------------------------------------------
+	// PROOF 3 (tenant isolation): a SECOND tenant's InTenantTx read sees
+	// NONE of tenant 1's assistant row, even though both live in the same
+	// physical audit_log table.
+	// ------------------------------------------------------------------
+	otherTenant := seedTenant(t, pool, "mcp-audit-other-"+suffix)
+	cross := queryMCPAuditRowsAsAppRole(t, pool, otherTenant, audit.ActionMCPToolCalled)
+	if len(cross) != 0 {
+		t.Fatalf("PROOF 3: tenant %s's InTenantTx read %d mcp.tool.called row(s) belonging to "+
+			"tenant %s; RLS did not isolate the assistant actor's row across tenants",
+			otherTenant, len(cross), tenantID)
+	}
+	t.Logf("PROOF 3 ok: tenant %s cannot see tenant %s's assistant audit row", otherTenant, tenantID)
+
+	// ------------------------------------------------------------------
+	// PROOF 4: mcp.grant.revoked landed, actor = the revoking USER.
+	// ------------------------------------------------------------------
+	connEng := mountConnectionsLikeProduction(t, svc, admin)
+	var revoked struct {
+		GrantsRevoked int64 `json:"grants_revoked"`
+	}
+	if code := mcpDoJSON(t, connEng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(grantID), nil, nil, &revoked); code != http.StatusOK {
+		t.Fatalf("revoke answered %d, want 200", code)
+	}
+	if revoked.GrantsRevoked != 1 {
+		t.Fatalf("revoke grants_revoked = %d, want 1 for a first revoke", revoked.GrantsRevoked)
+	}
+
+	revokedRows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantRevoked)
+	if len(revokedRows) != 1 {
+		t.Fatalf("mcp.grant.revoked rows = %d, want exactly 1", len(revokedRows))
+	}
+	if revokedRows[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.revoked actor_type = %q, want %q", revokedRows[0].actorType, audit.ActorUser)
+	}
+	if revokedRows[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.revoked actor_id = %q, want the revoking user %q", revokedRows[0].actorID, userID)
+	}
+	if revokedRows[0].targetID != grantID {
+		t.Errorf("mcp.grant.revoked target_id = %q, want the grant id %q", revokedRows[0].targetID, grantID)
+	}
+	t.Logf("PROOF 4 ok: mcp.grant.revoked attributed to user %s for grant %s", userID, grantID)
+}
+
+// TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole is the
+// fail-closed half: Service.Approve wires the ActionMCPGrantCreated append
+// through Repo.CreateGrantWithCode's onCreated hook, which runs INSIDE the same
+// transaction as both inserts. This simulates an onCreated-shaped failure (the
+// exact hook the audit append uses) and asserts the whole write rolls back --
+// no mcp_grants row AND no audit_log row for the grant id that never committed.
+func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenantID := seedTenant(t, pool, "mcp-audit-rb-"+uuid.NewString()[:8])
+	repo := mcp.NewRepo(pool)
+	principal := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+
+	simulated := errors.New("simulated: mcp.grant.created append failed")
+	var capturedGrantID uuid.UUID
+	_, _, err := repo.CreateGrantWithCode(ctx, principal, sqlc.CreateMCPGrantParams{
+		TenantID:      tenantID,
+		Name:          "should not survive",
+		Status:        "active",
+		SiteScopeMode: "all",
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  []uuid.UUID{},
+	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+		capturedGrantID = grantID
+		return sqlc.CreateMCPAuthorizationCodeParams{
+			TenantID:            tenantID,
+			GrantID:             grantID,
+			ClientID:            "rollback-probe-client",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
+			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
+		}
+	}, func(tx pgx.Tx, gr sqlc.McpGrant) error {
+		return simulated
+	})
+
+	if err == nil {
+		t.Fatal("CreateGrantWithCode succeeded despite the onCreated hook failing, want an error")
+	}
+	if !errors.Is(err, simulated) {
+		t.Errorf("error = %v, want it to wrap the simulated failure", err)
+	}
+	if capturedGrantID == uuid.Nil {
+		t.Fatal("the grant id was never captured; the insert must run before onCreated for this proof to mean anything")
+	}
+
+	var grantCount int
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM mcp_grants WHERE id = $1`, capturedGrantID).Scan(&grantCount)
+	}); err != nil {
+		t.Fatalf("count mcp_grants: %v", err)
+	}
+	if grantCount != 0 {
+		t.Errorf("mcp_grants row for %s committed despite the audit hook failing, want 0 rows", capturedGrantID)
+	}
+
+	rows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	for _, r := range rows {
+		if r.targetID == capturedGrantID.String() {
+			t.Fatalf("found an mcp.grant.created row for grant %s, which never committed", capturedGrantID)
+		}
+	}
+	t.Logf("rollback proof ok: neither mcp_grants nor audit_log carries a row for %s", capturedGrantID)
+}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -325,6 +325,13 @@ func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *tes
 		SiteScopeMode: "all",
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  []uuid.UUID{},
+		// m127: both NOT NULL with no default. Supplied so the rollback this
+		// test asserts is the SIMULATED audit failure and not a 23502 that
+		// would roll the same transaction back for the wrong reason -- which
+		// would make the assertion pass while proving nothing.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		capturedGrantID = grantID
 		return sqlc.CreateMCPAuthorizationCodeParams{

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -331,7 +331,7 @@ func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *tes
 			TenantID:            tenantID,
 			GrantID:             grantID,
 			ClientID:            "rollback-probe-client",
-			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 			CodeChallengeMethod: "S256",
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -328,7 +328,7 @@ func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err == nil {
 		t.Fatal("CreateGrantWithCode accepted a site-scoped principal. The write " +
 			"reached mcp_grants with app.site_scope unset, so the RESTRICTIVE " +

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -317,6 +317,11 @@ func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  []uuid.UUID{},
 		ClientID:      &clientID,
+		// m127: both NOT NULL with no default. Supplied so this proof fails on
+		// the RLS refusal it is actually about, not on a 23502.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		return sqlc.CreateMCPAuthorizationCodeParams{
 			TenantID:            tenantID,

--- a/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
+++ b/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
@@ -1,0 +1,516 @@
+// mcp_grant_expiry_activity_integration_test.go: m127's three grant columns
+// and GH #605's activity stamp, executed against the REAL schema as wpmgr_app.
+//
+// WHY THIS FILE EXISTS. m127 wrote its own hazard down rather than leaving it
+// to be discovered, and the hazard is not decidable by reading Go:
+//
+//	"if a non-NULL idle_expire_after_days is ever written while the stamp is
+//	 still unwired, coalesce(last_used_at, created_at) collapses to created_at
+//	 permanently, and EVERY AFFECTED CONNECTION DIES idle_expire_after_days
+//	 AFTER IT WAS CREATED NO MATTER HOW ACTIVE IT IS."
+//
+// The Go change that closes it is one call to Repo.TouchActivity. Whether that
+// call actually MOVES THE COLUMN THE PREDICATE READS is a property of the
+// query, the tx helper, the RLS policies and the role together -- exactly the
+// combination m112's proofs got wrong by opening their own connections, so
+// every policy was inert and every test was green.
+//
+// FOUR THINGS ARE IN QUESTION HERE, and each is executed rather than argued:
+//
+//  1. Service.Approve supplies all three of m127's columns. capabilities and
+//     expires_at are NOT NULL with no default, so an omission is 23502; and
+//     idle_expire_after_days must come back NULL, because NULL is the answer
+//     ("never idle-expire"), not a placeholder.
+//
+//  2. The stamp lands. last_used_at is NULL on a fresh grant and non-NULL after
+//     one RecordActivity, read back through the same verdict query the request
+//     path reads.
+//
+//  3. THE FLEET-OUTAGE CASE, BOTH DIRECTIONS. A grant older than its idle
+//     window is refused when it has never been used, and the SAME grant is
+//     authorized once the stamp has run. Without direction two this is just a
+//     test that expiry works; without direction one it is a test that proves
+//     nothing about expiry at all.
+//
+//  4. Absolute expiry still bites, and ACTIVITY CANNOT RESCUE IT. The two
+//     expiries are independent facts (m127 DECISION 2) and a stamp that
+//     extended the absolute one would silently make every connection immortal.
+//
+// HOW IT IS TESTED. Through mcp.Repo and mcp.Service -- the same methods the
+// transport calls, the same generated queries, the same tx helpers. GUCs are
+// never hand-set and no connection is opened by this file. The role is
+// load-bearing and is asserted inside the transaction under test: wpmgr_app is
+// NOSUPERUSER NOBYPASSRLS, and either privilege would make all of this pass
+// vacuously.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// mcpAgeGrant rewrites created_at and idle_expire_after_days on one grant, so a
+// test can construct "this connection is older than its idle window" without
+// waiting days for it.
+//
+// IT GOES THROUGH pool.InTenantTx, NOT ITS OWN CONNECTION. A raw connection
+// here would set no GUC, so the UPDATE would run with the policies inert -- and
+// then the test would be constructing its fixture through a path the request
+// path does not have, which is the failure mode this whole file exists to
+// avoid. Under InTenantTx as wpmgr_app the write only lands if the tenant
+// policy actually admits it.
+func mcpAgeGrant(t *testing.T, pool interface {
+	InTenantTx(context.Context, uuid.UUID, func(pgx.Tx) error) error
+}, tenantID, grantID uuid.UUID, createdAgo time.Duration, idleDays *int32) {
+	t.Helper()
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(context.Background(),
+			`UPDATE mcp_grants
+			    SET created_at = now() - $3::interval,
+			        idle_expire_after_days = $4
+			  WHERE tenant_id = $1 AND id = $2`,
+			tenantID, grantID, createdAgo.String(), idleDays)
+		if err != nil {
+			return err
+		}
+		// A zero-row UPDATE that reports success is the exact silent failure
+		// m124 obligation 1 names. If the fixture did not land, every
+		// assertion below would be measuring an untouched grant.
+		if tag.RowsAffected() != 1 {
+			t.Fatalf("aging fixture updated %d rows, want 1 -- the fixture did not land, "+
+				"so nothing below is testing what it claims", tag.RowsAffected())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("age grant %s: %v", grantID, err)
+	}
+}
+
+// mcpReadGrantColumns reads the three m127 columns plus last_used_at straight
+// off the row, under InTenantTx as wpmgr_app.
+func mcpReadGrantColumns(t *testing.T, pool interface {
+	InTenantTx(context.Context, uuid.UUID, func(pgx.Tx) error) error
+}, tenantID, grantID uuid.UUID) (caps []string, expiresAt time.Time, idleDays *int32, lastUsed *time.Time) {
+	t.Helper()
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT capabilities, expires_at, idle_expire_after_days, last_used_at
+			   FROM mcp_grants WHERE tenant_id = $1 AND id = $2`,
+			tenantID, grantID).Scan(&caps, &expiresAt, &idleDays, &lastUsed)
+	})
+	if err != nil {
+		t.Fatalf("read grant columns for %s: %v", grantID, err)
+	}
+	return caps, expiresAt, idleDays, lastUsed
+}
+
+// TestMCPApproveSuppliesM127ColumnsAsAppRole is question 1: the consent flow's
+// own minting path, end to end, against the real NOT NULL columns.
+//
+// THE 23502 IS THE DESIGNED FAILURE AND THIS TEST IS WHAT MAKES IT VISIBLE. A
+// CreateMCPGrantParams literal that omits either NOT NULL field still COMPILES
+// -- the field is simply left zero, which is nil/invalid, which is NULL -- so
+// the build says nothing and only an executed INSERT can. That is why this
+// proof drives Service.Approve rather than asserting on the struct.
+func TestMCPApproveSuppliesM127ColumnsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-m127-approve-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (Approve read-back path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	clientID := "m127-client-" + uuid.NewString()
+	secretHash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if n, err := repo.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        &secretHash,
+		TokenEndpointAuthMethod: "client_secret_basic",
+		RedirectUris:            []string{"https://claude.ai/api/mcp/auth_callback"},
+	}); err != nil || n != 1 {
+		t.Fatalf("seed client: affected=%d err=%v", n, err)
+	}
+
+	before := time.Now().UTC()
+	approval, err := svc.Approve(ctx, mcp.ApprovalRequest{
+		Principal: domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg},
+		GrantName: "m127 column proof",
+		SiteScope: mcp.SiteScopeRequest{Mode: mcp.SiteScopeModeAll},
+		Consent: mcp.ConsentContext{
+			ClientID:            clientID,
+			RedirectURI:         "https://claude.ai/api/mcp/auth_callback",
+			Scopes:              []mcp.Scope{mcp.ScopeRead},
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+		},
+	})
+	if err != nil {
+		// A 23502 lands HERE, and it is the failure this whole change exists to
+		// remove. Naming it in the message means the next reader does not have
+		// to decode the SQLSTATE.
+		t.Fatalf("Approve failed -- if this is SQLSTATE 23502 then a NOT NULL m127 "+
+			"column is not being supplied at internal/mcp/service.go's "+
+			"CreateMCPGrantParams literal: %v", err)
+	}
+	after := time.Now().UTC()
+
+	caps, expiresAt, idleDays, lastUsed := mcpReadGrantColumns(t, pool, tenant, approval.GrantID)
+
+	// capabilities: the stored set, not an empty array and not a guess.
+	if len(caps) != 1 || caps[0] != string(mcp.CapSitesRead) {
+		t.Fatalf("capabilities = %v, want exactly [%q]", caps, mcp.CapSitesRead)
+	}
+
+	// expires_at: NOT NULL, in the future, and roughly the 90-day term. The
+	// window is deliberately loose on the low side and tight on the high side:
+	// the assertion that matters is that SOMETHING chose a bounded term, not
+	// that a clock agreed to the second.
+	if !expiresAt.After(after) {
+		t.Fatalf("expires_at = %s is not in the future (now ~%s)", expiresAt, after)
+	}
+	wantLo := before.Add(89 * 24 * time.Hour)
+	wantHi := after.Add(91 * 24 * time.Hour)
+	if expiresAt.Before(wantLo) || expiresAt.After(wantHi) {
+		t.Fatalf("expires_at = %s, want between %s and %s (the 90-day term)",
+			expiresAt, wantLo, wantHi)
+	}
+
+	// idle_expire_after_days: NULL, and NULL is the answer.
+	//
+	// A NON-NULL VALUE HERE WOULD BE THE FLEET OUTAGE, not a stricter default:
+	// m127 DECISION 4 is that a window may only be persisted once the stamp is
+	// wired AND an operator has chosen one. The stamp is wired now; no control
+	// asks for a window yet, so writing one would be inventing a deadline
+	// nobody chose.
+	if idleDays != nil {
+		t.Fatalf("idle_expire_after_days = %d, want NULL -- a window nobody chose "+
+			"would expire this connection %d days after creation", *idleDays, *idleDays)
+	}
+
+	// last_used_at: NULL on a grant that has never served a request. This is
+	// the baseline the stamp test moves.
+	if lastUsed != nil {
+		t.Fatalf("last_used_at = %s on a brand new grant, want NULL", *lastUsed)
+	}
+
+	t.Logf("Approve wrote capabilities=%v expires_at=%s idle_expire_after_days=NULL last_used_at=NULL",
+		caps, expiresAt.Format(time.RFC3339))
+}
+
+// TestMCPActivityStampLandsAsAppRole is question 2, and it is GH #605 itself:
+// mcp_grants.last_used_at was never written, so the connections list reported
+// every connection as "Never used" including one actively reading the fleet.
+//
+// The read-back is through ReCheckAuthorization -- THE SAME QUERY THE REQUEST
+// PATH READS THE VERDICT FROM -- rather than a bespoke SELECT, so this also
+// establishes that the column the idle predicate consults is the column the
+// stamp moved.
+func TestMCPActivityStampLandsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-605-stamp-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (TouchActivity path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://stamp.example.com", Name: "stamp-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	// BASELINE: never used. If this were already non-NULL the assertion below
+	// would pass without the stamp doing anything.
+	if _, _, _, lastUsed := mcpReadGrantColumns(t, pool, tenant, grant.ID); lastUsed != nil {
+		t.Fatalf("last_used_at = %s before any request, want NULL", *lastUsed)
+	}
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate with a live bearer: %v", err)
+	}
+
+	// THE STAMP, through the method the transport's tools/list and tools/call
+	// arms call.
+	if err := svc.RecordActivity(ctx, auth); err != nil {
+		t.Fatalf("RecordActivity: %v", err)
+	}
+
+	// Read it back through the VERDICT QUERY, under the same tenant.
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, auth.TokenID)
+	if err != nil {
+		t.Fatalf("re-check after stamp: %v", err)
+	}
+	if !chk.GrantLastUsedAt.Valid {
+		t.Fatal("last_used_at is still NULL after RecordActivity -- the stamp did not " +
+			"land, and every connection will still read as \"Never used\" (GH #605)")
+	}
+	if chk.GrantLastUsedAt.Time.Before(grant.CreatedAt.Add(-time.Second)) {
+		t.Fatalf("last_used_at = %s is before the grant's own created_at %s",
+			chk.GrantLastUsedAt.Time, grant.CreatedAt)
+	}
+	t.Logf("grant.last_used_at stamped to %s and read back through the verdict query",
+		chk.GrantLastUsedAt.Time.Format(time.RFC3339))
+
+	// THE TOKEN HALF. The rotation UI tells two live tokens apart by
+	// last_used_at, so a grant stamped without its token would make it claim a
+	// token nobody has retired is dead.
+	var tokenLastUsed *time.Time
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT last_used_at FROM mcp_connection_tokens WHERE tenant_id = $1 AND id = $2`,
+			tenant, auth.TokenID).Scan(&tokenLastUsed)
+	}); err != nil {
+		t.Fatalf("read token last_used_at: %v", err)
+	}
+	if tokenLastUsed == nil {
+		t.Fatal("mcp_connection_tokens.last_used_at is still NULL after RecordActivity -- " +
+			"TouchMCPConnectionTokenInTenantTx is still unwired")
+	}
+	t.Logf("token.last_used_at stamped to %s in the same transaction",
+		tokenLastUsed.Format(time.RFC3339))
+}
+
+// TestMCPActiveConnectionDoesNotIdleExpireAsAppRole is question 3, and it is
+// the fleet outage m127 DECISION 4 describes, constructed and executed in both
+// directions on ONE grant.
+//
+// The grant is aged 10 days with a 1-day idle window. Direction one is the
+// outage as it would have shipped: last_used_at NULL, so
+// coalesce(last_used_at, created_at) is created_at, so the connection is
+// refused despite nothing being wrong with it. Direction two is the fix: one
+// RecordActivity, and the same grant with the same window is authorized.
+//
+// BOTH HALVES ARE REQUIRED. Direction one alone is a test that idle expiry
+// works. Direction two alone is a test that could pass with idle expiry
+// disabled entirely. Only together do they say "the deadline moves with use".
+func TestMCPActiveConnectionDoesNotIdleExpireAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-127-idle-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (idle expiry path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://idle.example.com", Name: "idle-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	oneDay := int32(1)
+	mcpAgeGrant(t, pool, tenant, grant.ID, 10*24*time.Hour, &oneDay)
+
+	// ---- DIRECTION ONE: never used, and therefore idle-expired. ----
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, mcpTokenIDFor(t, repo, ctx, bearer))
+	if err != nil {
+		t.Fatalf("re-check before stamp: %v", err)
+	}
+	if chk.GrantLastUsedAt.Valid {
+		t.Fatalf("fixture is wrong: last_used_at = %s, want NULL for the never-used case",
+			chk.GrantLastUsedAt.Time)
+	}
+	if !chk.GrantIdleExpired {
+		t.Fatal("a grant created 10 days ago with a 1-day idle window and no recorded " +
+			"use is not reported idle-expired; the idle predicate is not binding")
+	}
+	if chk.Authorized {
+		t.Fatal("an idle-expired grant came back authorized -- idle expiry is not part " +
+			"of the verdict")
+	}
+	if _, err := svc.Authenticate(ctx, bearer); err == nil {
+		t.Fatal("Authenticate admitted a grant past its idle window")
+	}
+	t.Log("direction one: never-used grant older than its idle window is REFUSED")
+
+	// ---- DIRECTION TWO: the same grant, actively used. ----
+	//
+	// The stamp has to be issued outside Authenticate, because Authenticate now
+	// refuses this grant -- which is exactly the state a real connection is
+	// never in, since a real connection is stamped on every tool call from its
+	// first one. Constructing the stamp directly is what lets ONE grant carry
+	// both directions and makes the comparison exact.
+	if err := repoTouch(ctx, repo, tenant, grant.ID, chk.TokenID); err != nil {
+		t.Fatalf("stamp activity: %v", err)
+	}
+
+	chk2, err := repo.ReCheckAuthorization(ctx, tenant, chk.TokenID)
+	if err != nil {
+		t.Fatalf("re-check after stamp: %v", err)
+	}
+	if chk2.GrantIdleExpired {
+		t.Fatal("THE FLEET OUTAGE: a connection used seconds ago is still reported " +
+			"idle-expired. coalesce(last_used_at, created_at) is still collapsing to " +
+			"created_at, so every connection dies N days after creation however " +
+			"active it is (m127 DECISION 4)")
+	}
+	if !chk2.Authorized {
+		t.Fatalf("an actively used grant is not authorized: grant_status=%q token_status=%q "+
+			"absolute_expired=%v idle_expired=%v",
+			chk2.GrantStatus, chk2.TokenStatus, chk2.GrantAbsoluteExpired, chk2.GrantIdleExpired)
+	}
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate refused an actively used connection: %v", err)
+	}
+	if !auth.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatal("an actively used connection resolved to no capability")
+	}
+	t.Logf("direction two: the SAME grant, stamped, is AUTHORIZED with %d capability and %d site",
+		auth.Capabilities.Len(), auth.Sites.Len())
+}
+
+// TestMCPAbsoluteExpiryRefusesAndActivityCannotRescueItAsAppRole is question 4.
+//
+// The two expiries are independent facts and neither can rescue the other
+// (m127 DECISION 2). The direction that matters is this one: if the activity
+// stamp extended the ABSOLUTE expiry as well as the idle one, every connection
+// that is used at all would be immortal and the 90-day term would be
+// decorative -- a silent extension of every credential, which is the failure
+// direction m127 says the schema must never take.
+func TestMCPAbsoluteExpiryRefusesAndActivityCannotRescueItAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-127-abs-"+uuid.NewString()[:8])
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://abs.example.com", Name: "abs-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	// It authenticates first, so the refusal below is attributable to the
+	// expiry and not to a broken fixture.
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate before expiry: %v", err)
+	}
+	tokenID := auth.TokenID
+
+	// Push expires_at into the past. created_at moves with it because
+	// mcp_grants_expires_at_after_created_check requires expires_at >
+	// created_at, and a fixture that violates a CHECK would fail for a reason
+	// this test is not about.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE mcp_grants
+			    SET created_at = now() - interval '100 days',
+			        expires_at = now() - interval '1 hour'
+			  WHERE tenant_id = $1 AND id = $2`,
+			tenant, grant.ID)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			t.Fatalf("expiry fixture updated %d rows, want 1", tag.RowsAffected())
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("expire grant: %v", err)
+	}
+
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, tokenID)
+	if err != nil {
+		t.Fatalf("re-check after expiry: %v", err)
+	}
+	if !chk.GrantAbsoluteExpired {
+		t.Fatal("a grant whose expires_at is in the past is not reported absolute-expired")
+	}
+	if chk.Authorized {
+		t.Fatal("an expired grant came back authorized -- absolute expiry is not part of " +
+			"the verdict")
+	}
+	if _, err := svc.Authenticate(ctx, bearer); err == nil {
+		t.Fatal("Authenticate admitted a grant past its absolute expiry")
+	}
+	t.Log("a grant past expires_at is REFUSED")
+
+	// THE RESCUE ATTEMPT. Stamp it, hard, and confirm the verdict does not
+	// move.
+	if err := repoTouch(ctx, repo, tenant, grant.ID, tokenID); err != nil {
+		t.Fatalf("stamp activity on an expired grant: %v", err)
+	}
+	chk2, err := repo.ReCheckAuthorization(ctx, tenant, tokenID)
+	if err != nil {
+		t.Fatalf("re-check after stamping an expired grant: %v", err)
+	}
+	if !chk2.GrantLastUsedAt.Valid {
+		t.Fatal("fixture is wrong: the stamp did not land, so the rescue is untested")
+	}
+	if chk2.Authorized || !chk2.GrantAbsoluteExpired {
+		t.Fatal("USE EXTENDED AN ABSOLUTE EXPIRY: a stamped grant past expires_at came " +
+			"back authorized. The two expiries are independent and activity must move " +
+			"only the idle one")
+	}
+	t.Log("the same grant, freshly stamped, is STILL refused: activity moves the idle " +
+		"deadline and never the absolute one")
+}
+
+// repoTouch issues the activity stamp through the Store interface the service
+// uses, so this file never reimplements the UPDATE it is testing.
+func repoTouch(ctx context.Context, repo *mcp.Repo, tenantID, grantID, tokenID uuid.UUID) error {
+	_, err := repo.TouchActivity(ctx, tenantID, grantID, tokenID)
+	return err
+}
+
+// mcpTokenIDFor resolves the token id for a bearer WITHOUT going through
+// Authenticate, which refuses an expired grant and therefore cannot be used to
+// learn the id of the token whose expiry is under test.
+//
+// It uses Repo.LookupConnectionToken -- step 1 of the real two-query
+// authentication, under InMCPTokenLookupTx -- so even the fixture reaches the
+// row the way production does.
+func mcpTokenIDFor(t *testing.T, repo *mcp.Repo, ctx context.Context, bearer string) uuid.UUID {
+	t.Helper()
+	sum := sha256.Sum256([]byte(bearer))
+	row, err := repo.LookupConnectionToken(ctx, hex.EncodeToString(sum[:]))
+	if err != nil {
+		t.Fatalf("resolve token id: %v", err)
+	}
+	return row.ID
+}

--- a/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
+++ b/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
@@ -491,6 +491,87 @@ func TestMCPAbsoluteExpiryRefusesAndActivityCannotRescueItAsAppRole(t *testing.T
 		"deadline and never the absolute one")
 }
 
+// TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole is the proof that
+// Authenticate READS the capability column rather than recomputing it.
+//
+// IT IS THE ONLY CONSTRUCTION IN WHICH THE TWO ANSWERS DIFFER TODAY. The
+// vocabulary holds exactly one name, so for any grant carrying
+// [mcp.sites.read] the stored set and the set computed from grantScopes() are
+// identical and no test can tell them apart. An EMPTY stored set is the
+// discriminator: the column's shape CHECK admits '{}' (the restrictive value
+// passes the vocabulary containment test), the computed answer is still
+// [mcp.sites.read], and only a path that reads the row refuses.
+//
+// Deleting the verdict-row read and restoring OrgDefaultCapabilities(
+// grantScopes()) makes this test, and only this test, go red.
+func TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-127-caps-"+uuid.NewString()[:8])
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://caps.example.com", Name: "caps-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	// It authenticates with the seeded capability, so the refusal below is
+	// attributable to the emptied column and not to a broken fixture.
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate before emptying capabilities: %v", err)
+	}
+	if !auth.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatal("the seeded grant did not resolve to its own capability")
+	}
+
+	// Empty the column. The grant stays 'active' and unexpired -- ONLY the
+	// capability set changes, so nothing else can explain the refusal.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE mcp_grants SET capabilities = '{}'::text[]
+			  WHERE tenant_id = $1 AND id = $2`, tenant, grant.ID)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			t.Fatalf("capability fixture updated %d rows, want 1", tag.RowsAffected())
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("empty capabilities: %v", err)
+	}
+
+	// The verdict itself is unchanged: an empty capability set is not an
+	// expiry and not a revocation, so `authorized` stays true. That is what
+	// makes this a test of the Go read and not of the SQL predicate.
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, auth.TokenID)
+	if err != nil {
+		t.Fatalf("re-check after emptying capabilities: %v", err)
+	}
+	if !chk.Authorized {
+		t.Fatalf("emptying capabilities changed the SQL verdict; this test can no longer "+
+			"isolate the Go read (grant_status=%q)", chk.GrantStatus)
+	}
+	if len(chk.GrantCapabilities) != 0 {
+		t.Fatalf("grant_capabilities = %v after emptying, want []", chk.GrantCapabilities)
+	}
+
+	if _, err := svc.Authenticate(ctx, bearer); err == nil {
+		t.Fatal("Authenticate ADMITTED a grant whose stored capability set is empty. " +
+			"The capability set is being computed from the scope registry instead of " +
+			"read from the grant, so the column is decorative and a narrowed connection " +
+			"would hold the org default regardless of what was stored.")
+	}
+	t.Log("a grant with capabilities = '{}' is REFUSED: the stored column is the authority")
+}
+
 // repoTouch issues the activity stamp through the Store interface the service
 // uses, so this file never reimplements the UPDATE it is testing.
 func repoTouch(ctx context.Context, repo *mcp.Repo, tenantID, grantID, tokenID uuid.UUID) error {


### PR DESCRIPTION
Makes m127's three new `mcp_grants` columns real in Go, and wires the activity
stamp that must exist before any idle window can safely be persisted.

Stacked on two branches that are merged into this one and must land first:
`worktree-agent-a354e37ca74442255` (m127) and
`worktree-agent-a166a9bf4132d224d` (MCP audit events).

## What changed

**1. `Service.Approve` supplies all three columns.** `capabilities` and
`expires_at` are `NOT NULL` with no default, so the previous literal was a
23502 on every grant creation. Both come from a Go constant at the call site,
never a column `DEFAULT` — an omitted term must be a loud refusal, not a
credential nobody chose the terms of. `idle_expire_after_days` is written
`NULL`, which means "never idle-expire" and is the answer, not a placeholder.

**2. `Authenticate` reads capabilities off the verdict row.** The request path
computed them from the scope registry; it now reads `chk.GrantCapabilities` —
same row, same transaction as the `authorized` verdict. The org default stays
the ceiling and the stored value narrows it through `CapabilitySet.NarrowTo`,
so a stored capability the org's scopes do not confer is refused rather than
honoured or silently dropped. An empty stored set is refused by name.

**3. `TouchMCPGrantInTenantTx` and `TouchMCPConnectionTokenInTenantTx` gain
their first callers (#605).** `Repo.TouchActivity` stamps both in one
`InTenantTx`. The transport calls it from the `tools/list` and `tools/call`
arms, before the tool runs, and refuses the request if the stamp fails —
`last_used_at` is an input to an authorization deadline, not an observation of
one.

**Stamp on every tool call, not once at connect.** A Streamable HTTP session is
long-lived and `initialize` happens once at the start of one, so a connect-only
stamp would make a connection used daily since January carry a January stamp
and idle-expire in February. `ping` and `notifications/initialized` are
excluded on purpose: they are keepalives a stuck process emits forever, and
letting them refresh the deadline would make "unused for 30 days"
unfalsifiable.

**4. Stale comments corrected** in `model.go`, `policy.go` and `service.go`,
which all asserted `mcp_grants` has no capabilities column.

## Proofs

`apps/api/tests/mcp_grant_expiry_activity_integration_test.go`, all through
`mcp.Repo`/`mcp.Service` as `wpmgr_app` with the role asserted inside the
transaction under test:

- `Approve` writes `capabilities=[mcp.sites.read]`, `expires_at` in the 90-day
  term, `idle_expire_after_days` NULL.
- The stamp lands on grant and token, read back through the verdict query.
- The fleet outage, both directions on one grant: never-used past its idle
  window is REFUSED; the same grant stamped is AUTHORIZED.
- A grant past `expires_at` is refused, and stamping it leaves it refused.

## For the other layers

- `apps/api/db/query/mcp_connections.sql` still carries two comments saying
  `TouchMCPGrantInTenantTx` has no Go caller and that `last_used_at` is always
  NULL. Both are now false. That file is `database-engineer`'s.
- `apps/web` can render `last_used_at` as a real value; "Never used" now means
  never used.
