### PR TITLE
feat(web): the site-allowlist honesty box (Screen 8)

### DIFF
--- a/apps/api/cmd/dump-routes/routes.go
+++ b/apps/api/cmd/dump-routes/routes.go
@@ -286,7 +286,7 @@ func buildEngine() (engine *gin.Engine, omittedDepsFields []string, err error) {
 	// cmd/wpmgr/main.go wires it (mcp.NewService(mcp.NewRepo(pool)) etc.), so
 	// POST /mcp, the four OAuth paths and the three well-known discovery
 	// documents all mount.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, "dump-routes")
 	mcpOAuthH := mcp.NewHandler(mcpSvc)
 	mcpDiscoveryH := mcp.NewDiscoveryHandler("https://cp.example.test")

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -540,7 +540,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// would make POST /mcp answer 404, which is indistinguishable from a
 	// routing failure. Self-host reaches it too; the grant is what authorizes,
 	// and an installation with no grants simply has no valid bearer token.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, version)
 	// The OAuth half, wired unconditionally for the same reason. Without it the
 	// transport above is mounted and correct and refuses every request forever,

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -28,6 +28,13 @@ const (
 	ActorUser   = "user"
 	ActorAPIKey = "api_key"
 	ActorSystem = "system"
+	// ActorAssistant is the model on the other end of an MCP connection --
+	// never a human and never the control plane itself. actor_type has no
+	// CHECK constraint (db/schema.sql), so this needed no migration.
+	// ActorID for this kind is the grant id (internal/mcp), NOT a user or key
+	// id: an MCP grant is the credential a model acts under, the way a user id
+	// or an api_key id is the credential a human or a script acts under.
+	ActorAssistant = "assistant"
 
 	ActionLoginSuccess = "auth.login.success"
 	ActionLoginFailure = "auth.login.failure"
@@ -352,6 +359,41 @@ const (
 	// ActionAdminBillingStateForced: metadata: reason, old_plan,
 	// old_plan_status, new_plan, new_plan_status.
 	ActionAdminBillingStateForced = "admin.billing.state.forced"
+
+	// The MCP connection surface (ADR-064). Approve, revoke, and every tool
+	// call are the three points where an MCP grant does something a human
+	// operator can be asked about afterward, and each needed a row here --
+	// before this the surface wrote zero.
+	//
+	// ActionMCPGrantCreated is recorded on the SAME transaction as the grant
+	// insert (internal/mcp.Service.Approve, via RecordInTx), so a rolled-back
+	// grant leaves no row claiming one was created. ActorType is ActorUser:
+	// the grant belongs to the organisation of the human who approved it, and
+	// ActorID is that user's id, not the grant's. Metadata: grant_name,
+	// site_scope_mode.
+	ActionMCPGrantCreated = "mcp.grant.created"
+	// ActionMCPGrantRevoked is recorded on the SAME transaction as the revoke
+	// (internal/mcp.Service.RevokeConnection, via RecordInTx). ActorType is
+	// ActorUser -- the operator who revoked, ActorID their user id. Metadata:
+	// grant_name, grants_revoked, tokens_revoked, already_revoked.
+	ActionMCPGrantRevoked = "mcp.grant.revoked"
+	// ActionMCPToolCalled is recorded per successful tool invocation on the
+	// transport path (internal/mcp.Service.RecordToolCall), BEST-EFFORT like
+	// most of this log (Record, not RecordInTx): there is no companion write
+	// to roll back alongside it, and a purely observational record must not
+	// take down the read path it observes. ActorType is ActorAssistant --
+	// this is the one action class in the whole log recorded as the MODEL's
+	// own act rather than the human who granted it access -- and ActorID is
+	// the mcp_grants id, not a user id. Metadata carries grant_name as the
+	// actor's display label: ListAuditEntries/ListAuditEntriesFiltered
+	// resolve ActorName by joining users/api_keys on actor_type, and neither
+	// join has an arm for "assistant" (that join lives in db/query/*.sql,
+	// database-engineer's surface, and a fourth JOIN did not land alongside
+	// this Go-only change) -- so the label travels in Metadata rather than in
+	// the ActorName column until that join exists. Also carries
+	// operator_permission (the dashboard authority the tool call mirrors) and
+	// tool.
+	ActionMCPToolCalled = "mcp.tool.called"
 )
 
 // Entry is one audit record.
@@ -372,6 +414,12 @@ type Entry struct {
 	// ActorType == ActorAPIKey. Nil for ActorSystem events and for any actor
 	// row that no longer exists (e.g. a deleted user). Only List and
 	// ListFiltered populate this field; Record's returned Entry does not.
+	//
+	// Also nil for ActorType == ActorAssistant: the join that would resolve it
+	// (mcp_grants.name, the same shape as the api_keys.name join above) does
+	// not exist in ListAuditEntries/ListAuditEntriesFiltered today. An
+	// ActionMCPToolCalled recorder carries the grant's name in Metadata
+	// instead, so the label is not lost, only not yet promoted to this column.
 	ActorName *string
 	// ActorEmail is the acting user's email when ActorType == ActorUser. Nil
 	// otherwise. Only List and ListFiltered populate this field.

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -258,13 +258,22 @@ func (f *fakeStore) RedeemAuthorizationCode(_ context.Context, _, _ uuid.UUID, t
 // that the principal reaches the store at all, so a refactor which narrows
 // ApprovalRequest back to a bare tenant id fails here rather than silently in
 // production. The policy itself is proved in tests/, as wpmgr_app.
-func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
+func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(pgx.Tx, sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	f.note("CreateGrantWithCode")
 	f.grantPrincipal = principal
 	id := uuid.New()
 	cp := mk(id)
-	return sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name},
-		sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
+	grant := sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name}
+	// No real tx to hand onCreated -- this fake runs no transaction at all.
+	// Service.Approve's callback checks s.audit == nil before touching tx, and
+	// no test in this package wires WithAudit, so nil here is never
+	// dereferenced.
+	if onCreated != nil {
+		if err := onCreated(nil, grant); err != nil {
+			return sqlc.McpGrant{}, sqlc.McpAuthorizationCode{}, err
+		}
+	}
+	return grant, sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
 }
 
 func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
@@ -349,6 +358,7 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	_ context.Context,
 	p domain.Principal,
 	_ uuid.UUID,
+	onRevoked func(pgx.Tx, sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	f.note("RevokeGrantWithTokens")
 	f.mu.Lock()
@@ -356,6 +366,13 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	f.mu.Unlock()
 	if f.revokeErr != nil {
 		return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, f.revokeErr
+	}
+	// No real tx, same reasoning as CreateGrantWithCode above: the callback
+	// checks s.audit == nil before touching it.
+	if onRevoked != nil {
+		if err := onRevoked(nil, f.revokeRow); err != nil {
+			return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, err
+		}
 	}
 	return f.revokeRow, nil
 }

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -41,7 +41,14 @@ type Store interface {
 	// the RESTRICTIVE insert policy on mcp_grants is live. A tenant id alone
 	// cannot express that, which is how the site-scope GUC came to be unset on
 	// this path. See the method on Repo.
-	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
+	//
+	// onCreated runs INSIDE the same transaction as both inserts, after both
+	// succeed, so the caller (Service.Approve) can append the
+	// ActionMCPGrantCreated audit row via audit.Recorder.RecordInTx over the
+	// SAME tx -- a rolled-back grant then leaves no audit row claiming one
+	// exists, because an error from onCreated rolls the whole transaction back
+	// exactly as an error from either insert would. May be nil.
+	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
 
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
@@ -79,7 +86,14 @@ type Store interface {
 	// organisation's, or refused by RLS. It is the ONLY outcome meaning "not
 	// there"; a returned row of two zeroes is an idempotent success. See the
 	// query's four-outcome comment.
-	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
+	//
+	// onRevoked runs INSIDE the same transaction as the revoke statement,
+	// after it succeeds (any of the three non-error outcomes), so the caller
+	// (Service.RevokeConnection) can append the ActionMCPGrantRevoked audit
+	// row via audit.Recorder.RecordInTx over the SAME tx. It does NOT run on
+	// pgx.ErrNoRows -- nothing was written, so nothing should be attributed.
+	// May be nil.
+	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID, onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
 }
 
 // Repo is the live Store. Every method names the tx helper it runs under, and
@@ -239,6 +253,7 @@ func (r *Repo) CreateGrantWithCode(
 	principal db.ScopedPrincipal,
 	g sqlc.CreateMCPGrantParams,
 	mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams,
+	onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error,
 ) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	var (
 		grant sqlc.McpGrant
@@ -262,6 +277,13 @@ func (r *Repo) CreateGrantWithCode(
 		cd, err := q.CreateMCPAuthorizationCode(ctx, mkCode(gr.ID))
 		if err != nil {
 			return fmt.Errorf("create mcp authorization code: %w", err)
+		}
+		// Inside the same tx, after both inserts. An error here rolls both of
+		// them back with it -- see the interface doc on onCreated.
+		if onCreated != nil {
+			if err := onCreated(tx, gr); err != nil {
+				return err
+			}
 		}
 		grant, code = gr, cd
 		return nil
@@ -481,6 +503,7 @@ func (r *Repo) RevokeGrantWithTokens(
 	ctx context.Context,
 	principal domain.Principal,
 	grantID uuid.UUID,
+	onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	var out sqlc.RevokeMCPGrantWithTokensInTenantTxRow
 	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
@@ -492,10 +515,16 @@ func (r *Repo) RevokeGrantWithTokens(
 		if err != nil {
 			// pgx.ErrNoRows is meaningful to the caller and is NOT wrapped in a
 			// message that would make errors.Is harder to reach for. Every
-			// other error is an infra failure.
+			// other error is an infra failure. Neither reaches onRevoked --
+			// nothing was written, so nothing should be attributed.
 			return err
 		}
 		out = row
+		if onRevoked != nil {
+			if err := onRevoked(tx, row); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
@@ -177,6 +178,16 @@ type Clock func() time.Time
 type Service struct {
 	store Store
 	now   Clock
+	// audit is nil unless WithAudit is called. Every audit write in this
+	// package guards on it being nil first -- see Approve, RevokeConnection,
+	// and RecordToolCall -- so a Service built by the many unit tests in this
+	// package (fakeStore, no real Postgres pool to back an audit.Recorder)
+	// keeps working unaudited. Production wiring (cmd/wpmgr/main.go) always
+	// calls WithAudit; a Service that reaches a request path without it is a
+	// wiring bug, not a supported configuration, and the finding to raise if
+	// one is ever found is "this deploy path is unattributable", not "make the
+	// nil check quieter".
+	audit *audit.Recorder
 }
 
 func NewService(store Store) *Service {
@@ -187,6 +198,18 @@ func NewService(store Store) *Service {
 func (s *Service) WithClock(c Clock) *Service {
 	cp := *s
 	cp.now = c
+	return &cp
+}
+
+// WithAudit returns a copy that appends ActionMCPGrantCreated,
+// ActionMCPGrantRevoked and ActionMCPToolCalled through rec. Mirrors
+// WithClock's copy-and-return shape. cmd/wpmgr/main.go calls this on the one
+// Service the process constructs; a Service left without it (as most of this
+// package's unit tests are, deliberately, since they drive a fakeStore with no
+// backing Postgres pool) simply does not audit -- see the field doc on audit.
+func (s *Service) WithAudit(rec *audit.Recorder) *Service {
+	cp := *s
+	cp.audit = rec
 	return &cp
 }
 
@@ -589,6 +612,29 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 				RedirectUri:         req.Consent.RedirectURI,
 				ExpiresAt:           expiresAt,
 			}
+		},
+		// ActionMCPGrantCreated, in the SAME transaction as both inserts above.
+		// This is "the row written to the audit log" the operator-facing
+		// consent flow promises: if the grant or the code fails to insert, or
+		// this append fails, the whole approval rolls back and there is no
+		// mcp.grant.created row for a grant that does not exist.
+		func(tx pgx.Tx, gr sqlc.McpGrant) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   req.Principal.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    req.Principal.UserID.String(),
+				Action:     audit.ActionMCPGrantCreated,
+				TargetType: "mcp_grant",
+				TargetID:   gr.ID.String(),
+				Metadata: map[string]any{
+					"grant_name":      gr.Name,
+					"site_scope_mode": gr.SiteScopeMode,
+				},
+			})
+			return aerr
 		})
 	if err != nil {
 		return Approval{}, fmt.Errorf("create grant and code: %w", err)
@@ -848,6 +894,14 @@ type AuthorizedRequest struct {
 	TenantID uuid.UUID
 	GrantID  uuid.UUID
 	TokenID  uuid.UUID
+	// GrantName is the grant's operator-assigned name (mcp_grants.name), read
+	// at the same ReCheckAuthorization call that resolves GrantID -- no extra
+	// query. It exists so RecordToolCall can stamp a human-readable label onto
+	// an ActionMCPToolCalled event without a database join: ActorName
+	// resolution (ListAuditEntries) has no arm for ActorAssistant today, so
+	// this is how the label travels until it does. Never used for
+	// authorization, only for display.
+	GrantName string
 
 	// Sites is the resolved site scope: the PER-CONNECTION narrowing on the
 	// site axis. Zero value allows nothing.
@@ -955,6 +1009,7 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	return AuthorizedRequest{
 		TenantID:     tok.TenantID,
 		GrantID:      chk.GrantID,
+		GrantName:    chk.GrantName,
 		TokenID:      chk.TokenID,
 		Sites:        NewSiteSet(ids),
 		Capabilities: caps,
@@ -981,6 +1036,48 @@ func (s *Service) RecordConnect(ctx context.Context, auth AuthorizedRequest, nam
 		return fmt.Errorf("record mcp connect: %w", err)
 	}
 	return nil
+}
+
+// RecordToolCall appends the ActionMCPToolCalled audit row for one
+// successfully executed tool call. The caller (TransportHandler.callTool)
+// invokes this AFTER entry.invoke returns without error -- a refused call
+// never reaches a tenant's data, and is already visible in the operator log
+// TransportHandler writes at refusal time (h.log.WarnContext), so it earns no
+// row here.
+//
+// ActorType is ActorAssistant, the one actor kind in this whole log that
+// attributes the row to the MODEL rather than to the human who granted it
+// access: auth.GrantID identifies WHICH connection acted, which is the fact an
+// operator reviewing "what did this MCP client touch" actually wants, and it
+// is a fact ActorUser (the approving human, possibly long gone from the
+// account) cannot carry. operatorPermission and toolName both come from the
+// registry entry AuthorizeTool already resolved -- see the OperatorPermission
+// doc on ToolPolicy for why that field lands here.
+//
+// BEST-EFFORT, deliberately unlike Approve/RevokeConnection's RecordInTx:
+// there is no companion write in the same transaction to roll back alongside a
+// failed append (a tool call in this phase is a read), so failing the whole
+// tool call because its own audit trail could not be appended would let a
+// purely observational feature take down the read path it exists to observe.
+// The error is returned so the caller can log it, never to be treated as a
+// reason to withhold the tool's answer.
+func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, toolName string, operatorPermission string) error {
+	if s.audit == nil {
+		return nil
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:   auth.TenantID,
+		ActorType:  audit.ActorAssistant,
+		ActorID:    auth.GrantID.String(),
+		Action:     audit.ActionMCPToolCalled,
+		TargetType: "mcp_tool",
+		TargetID:   toolName,
+		Metadata: map[string]any{
+			"grant_name":          auth.GrantName,
+			"operator_permission": operatorPermission,
+		},
+	})
+	return err
 }
 
 // ListSitesForModel is the one Phase 1 read tool. It returns the rendered tool
@@ -1196,7 +1293,32 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 			"a connection id is required")
 	}
 
-	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID)
+	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID,
+		// ActionMCPGrantRevoked, in the SAME transaction as the revoke
+		// statement. Runs on all three non-error outcomes (freshly revoked,
+		// half-revoked repair, idempotent no-op): the operator explicitly
+		// asked for this credential to be revoked and the request is what is
+		// being attributed, not merely a state transition. It never runs
+		// alongside pgx.ErrNoRows -- see onRevoked's doc on the interface.
+		func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   p.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    p.UserID.String(),
+				Action:     audit.ActionMCPGrantRevoked,
+				TargetType: "mcp_grant",
+				TargetID:   grantID.String(),
+				Metadata: map[string]any{
+					"grants_revoked":  row.GrantsRevoked,
+					"tokens_revoked":  row.TokensRevoked,
+					"already_revoked": row.GrantsRevoked == 0,
+				},
+			})
+			return aerr
+		})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return RevokeOutcome{}, domain.NotFound(ErrCodeConnectionNotFound,

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -423,10 +423,15 @@ func (h *TransportHandler) initialize(
 	}
 	if err := h.svc.RecordConnect(c.Request.Context(), auth,
 		p.ClientInfo.Name, p.ClientInfo.Version, headerValue); err != nil {
-		// A failed audit write is NOT swallowed. The connect record is how an
+		// NOT an audit write -- RecordConnect updates mcp_grants (client name,
+		// version, protocol header) via Store.RecordClientIdentity, and that
+		// update is NOT swallowed on failure. The connect record is how an
 		// operator sees what is attached to their organisation, and a session
 		// that proceeded after failing to record itself would be an
-		// unattributable connection.
+		// unattributable connection. (The actual audit_events row for this
+		// surface is ActionMCPToolCalled, written per tool call by
+		// Service.RecordToolCall -- initialize itself is not a tool call and
+		// writes no audit row.)
 		h.log.ErrorContext(c.Request.Context(), "mcp connect record failed",
 			slog.String("tenant_id", auth.TenantID.String()),
 			slog.String("grant_id", auth.GrantID.String()),
@@ -540,6 +545,23 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 	if err != nil {
 		return h.toolError(req.ID, err)
 	}
+
+	// The operator-facing audit row (ActionMCPToolCalled), for this call and
+	// no other outcome: a refusal above never reached a tenant's data and is
+	// already covered by the WarnContext log at the refusal site. BEST-EFFORT
+	// like RecordConnect's client-identity write is not -- a failure here is
+	// logged, never returned to the caller, because withholding a successful
+	// read's answer over a failure to record having answered it would make an
+	// observational feature take down the read path it observes.
+	if err := h.svc.RecordToolCall(ctx, auth, entry.Name, string(entry.OperatorPermission)); err != nil {
+		h.log.ErrorContext(ctx, "mcp tool call audit write failed",
+			slog.String("tenant_id", auth.TenantID.String()),
+			slog.String("grant_id", auth.GrantID.String()),
+			slog.String("tool", entry.Name),
+			slog.String("error", err.Error()),
+		)
+	}
+
 	return newResponse(req.ID, map[string]any{
 		"content": []map[string]any{{"type": "text", "text": text}},
 	})

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -96,7 +96,7 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("seed grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -103,7 +103,7 @@ func s7GrantWithBearer(
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("create grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -1,0 +1,371 @@
+// mcp_audit_events_integration_test.go: the three audit_events writes added to
+// the MCP connection surface -- ActionMCPGrantCreated, ActionMCPGrantRevoked,
+// ActionMCPToolCalled -- proven against the REAL schema, RLS and application
+// role, through the SAME code path production uses.
+//
+// WHY THIS FILE EXISTS. internal/mcp wrote ZERO rows to audit_log before this
+// slice: `grep -rn '\.Record(\|RecordInTx(' internal/mcp/*.go` matched nothing
+// outside _test.go's httptest.NewRecorder. An approve, a revoke or a tool call
+// that reaches a tenant's data left no attributable row. A unit test against
+// fakeStore cannot prove any of the three things that actually matter here:
+//
+//  1. mcp.grant.created lands in the SAME transaction as the grant insert
+//     (RecordInTx, not Record), so a rolled-back grant leaves no row claiming
+//     one exists -- see the rollback proof below.
+//  2. The row is readable back only through db.Pool as wpmgr_app -- NOSUPERUSER,
+//     NOBYPASSRLS -- which mcpAssertAndReportRole asserts and prints. A test
+//     that opened its own connection would leave every RLS policy inert and
+//     pass regardless; that is exactly how m112's proofs passed while the email
+//     domain was cross-site readable.
+//  3. A second tenant's InTenantTx cannot see the first tenant's assistant row,
+//     even though both share one physical audit_log table.
+//
+// So: every write and every read below goes through the same Service, the same
+// Handler, the same TransportHandler and the same tx helpers server.New wires,
+// with the app-role pool. No GUC is hand-set anywhere in this file.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpAuditRow is the slice of audit_log columns these proofs care about.
+type mcpAuditRow struct {
+	actorType string
+	actorID   string
+	targetID  string
+	metadata  map[string]any
+}
+
+// queryMCPAuditRowsAsAppRole reads audit_log for one tenant and action THROUGH
+// db.Pool.InTenantTx -- the same tx helper Recorder.List uses -- so RLS is live
+// for this read exactly as it is for the write under test.
+func queryMCPAuditRowsAsAppRole(t *testing.T, pool *db.Pool, tenantID uuid.UUID, action string) []mcpAuditRow {
+	t.Helper()
+	var out []mcpAuditRow
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(context.Background(),
+			`SELECT actor_type, actor_id, target_id, metadata FROM audit_log
+			  WHERE tenant_id = $1 AND action = $2`, tenantID, action)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var r mcpAuditRow
+			var metaRaw []byte
+			if err := rows.Scan(&r.actorType, &r.actorID, &r.targetID, &metaRaw); err != nil {
+				return err
+			}
+			if len(metaRaw) > 0 {
+				if err := json.Unmarshal(metaRaw, &r.metadata); err != nil {
+					return err
+				}
+			}
+			out = append(out, r)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		t.Fatalf("query audit_log action=%s for tenant %s: %v", action, tenantID, err)
+	}
+	return out
+}
+
+// TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole drives the
+// WHOLE MCP surface -- register, authorize, consent, exchange, a real tools/call
+// over the mounted transport, then revoke -- and asserts each of the three new
+// audit rows lands with the right actor, target and metadata. It also proves
+// tenant isolation: a second tenant's InTenantTx read sees none of it.
+func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion below.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-audit-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-audit-"+suffix+"@example.test")
+	siteURL := "https://" + suffix + ".example.test"
+	seedSite(t, pool, tenantID, siteURL)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	// An org-scoped admin: the role RegisterConnections' PermAPIKeyManage
+	// requires for revoke, and the only scope /consent admits.
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	eng := mountLikeProduction(t, svc, admin)
+
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+	const grantName = "mcp audit events test connection"
+
+	// ------------------------------------------------------------------
+	// register -> authorize -> consent -> exchange, exactly as
+	// adr064_s6b3_mcp_oauth_end_to_end_test.go proves the flow composes.
+	// ------------------------------------------------------------------
+	var reg struct {
+		ClientID string `json:"client_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.RegisterPath, map[string]any{
+		"redirect_uris":              []string{redirectURI},
+		"client_name":                "Claude Desktop",
+		"client_uri":                 "https://claude.ai",
+		"token_endpoint_auth_method": "none",
+	}, nil, &reg); code != http.StatusCreated {
+		t.Fatalf("register answered %d, want 201", code)
+	}
+
+	verifier := "audit-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", reg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "audit-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	if code := mcpDoJSON(t, eng, http.MethodGet, mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		t.Fatalf("authorize answered %d, want 200", code)
+	}
+
+	var approval struct {
+		GrantID string `json:"grant_id"`
+		Code    string `json:"code"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConsentPath, map[string]any{
+		"client_id":             reg.ClientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "audit-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"name":                  grantName,
+		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+	}, nil, &approval); code != http.StatusOK {
+		t.Fatalf("consent answered %d, want 200", code)
+	}
+	grantID := approval.GrantID
+
+	// ------------------------------------------------------------------
+	// PROOF 1: mcp.grant.created landed, actor = the approving USER.
+	// ------------------------------------------------------------------
+	created := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	if len(created) != 1 {
+		t.Fatalf("mcp.grant.created rows = %d, want exactly 1", len(created))
+	}
+	if created[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.created actor_type = %q, want %q", created[0].actorType, audit.ActorUser)
+	}
+	if created[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.created actor_id = %q, want the approving user %q", created[0].actorID, userID)
+	}
+	if created[0].targetID != grantID {
+		t.Errorf("mcp.grant.created target_id = %q, want the grant id %q", created[0].targetID, grantID)
+	}
+	if got, _ := created[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.grant.created metadata.grant_name = %q, want %q", got, grantName)
+	}
+	t.Logf("PROOF 1 ok: mcp.grant.created attributed to user %s for grant %s", userID, grantID)
+
+	// ------------------------------------------------------------------
+	// Exchange the code, then call tools/call over the real transport.
+	// ------------------------------------------------------------------
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", approval.Code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", reg.ClientID)
+	form.Set("code_verifier", verifier)
+
+	tokReq := httptest.NewRequest(http.MethodPost, mcp.TokenPath, strings.NewReader(form.Encode()))
+	tokReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokReq.RemoteAddr = "203.0.113.7:5555"
+	tokW := httptest.NewRecorder()
+	eng.ServeHTTP(tokW, tokReq)
+	if tokW.Code != http.StatusOK {
+		t.Fatalf("token exchange answered %d, want 200: %s", tokW.Code, tokW.Body.String())
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(tokW.Body.Bytes(), &tok); err != nil {
+		t.Fatalf("token response is not JSON: %v", err)
+	}
+	if tok.AccessToken == "" {
+		t.Fatal("token exchange returned no access_token")
+	}
+
+	got := mcpRPC(t, eng, tok.AccessToken, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("tools/call %s answered %d, want 200: %s", mcp.ToolListSites, got.status, got.body)
+	}
+
+	// ------------------------------------------------------------------
+	// PROOF 2: mcp.tool.called landed, actor = the ASSISTANT (the grant),
+	// never the approving user.
+	// ------------------------------------------------------------------
+	called := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("mcp.tool.called rows = %d, want exactly 1", len(called))
+	}
+	if called[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.tool.called actor_type = %q, want %q", called[0].actorType, audit.ActorAssistant)
+	}
+	if called[0].actorID != grantID {
+		t.Errorf("mcp.tool.called actor_id = %q, want the grant id %q (NOT the user)", called[0].actorID, grantID)
+	}
+	if called[0].targetID != mcp.ToolListSites {
+		t.Errorf("mcp.tool.called target_id = %q, want the tool name %q", called[0].targetID, mcp.ToolListSites)
+	}
+	if got, _ := called[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.tool.called metadata.grant_name = %q, want %q (the actor label)", got, grantName)
+	}
+	if got, _ := called[0].metadata["operator_permission"].(string); got != string(authz.PermSiteRead) {
+		t.Errorf("mcp.tool.called metadata.operator_permission = %q, want %q", got, authz.PermSiteRead)
+	}
+	t.Logf("PROOF 2 ok: mcp.tool.called attributed to assistant/grant %s, not to user %s", grantID, userID)
+
+	// ------------------------------------------------------------------
+	// PROOF 3 (tenant isolation): a SECOND tenant's InTenantTx read sees
+	// NONE of tenant 1's assistant row, even though both live in the same
+	// physical audit_log table.
+	// ------------------------------------------------------------------
+	otherTenant := seedTenant(t, pool, "mcp-audit-other-"+suffix)
+	cross := queryMCPAuditRowsAsAppRole(t, pool, otherTenant, audit.ActionMCPToolCalled)
+	if len(cross) != 0 {
+		t.Fatalf("PROOF 3: tenant %s's InTenantTx read %d mcp.tool.called row(s) belonging to "+
+			"tenant %s; RLS did not isolate the assistant actor's row across tenants",
+			otherTenant, len(cross), tenantID)
+	}
+	t.Logf("PROOF 3 ok: tenant %s cannot see tenant %s's assistant audit row", otherTenant, tenantID)
+
+	// ------------------------------------------------------------------
+	// PROOF 4: mcp.grant.revoked landed, actor = the revoking USER.
+	// ------------------------------------------------------------------
+	connEng := mountConnectionsLikeProduction(t, svc, admin)
+	var revoked struct {
+		GrantsRevoked int64 `json:"grants_revoked"`
+	}
+	if code := mcpDoJSON(t, connEng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(grantID), nil, nil, &revoked); code != http.StatusOK {
+		t.Fatalf("revoke answered %d, want 200", code)
+	}
+	if revoked.GrantsRevoked != 1 {
+		t.Fatalf("revoke grants_revoked = %d, want 1 for a first revoke", revoked.GrantsRevoked)
+	}
+
+	revokedRows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantRevoked)
+	if len(revokedRows) != 1 {
+		t.Fatalf("mcp.grant.revoked rows = %d, want exactly 1", len(revokedRows))
+	}
+	if revokedRows[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.revoked actor_type = %q, want %q", revokedRows[0].actorType, audit.ActorUser)
+	}
+	if revokedRows[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.revoked actor_id = %q, want the revoking user %q", revokedRows[0].actorID, userID)
+	}
+	if revokedRows[0].targetID != grantID {
+		t.Errorf("mcp.grant.revoked target_id = %q, want the grant id %q", revokedRows[0].targetID, grantID)
+	}
+	t.Logf("PROOF 4 ok: mcp.grant.revoked attributed to user %s for grant %s", userID, grantID)
+}
+
+// TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole is the
+// fail-closed half: Service.Approve wires the ActionMCPGrantCreated append
+// through Repo.CreateGrantWithCode's onCreated hook, which runs INSIDE the same
+// transaction as both inserts. This simulates an onCreated-shaped failure (the
+// exact hook the audit append uses) and asserts the whole write rolls back --
+// no mcp_grants row AND no audit_log row for the grant id that never committed.
+func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenantID := seedTenant(t, pool, "mcp-audit-rb-"+uuid.NewString()[:8])
+	repo := mcp.NewRepo(pool)
+	principal := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+
+	simulated := errors.New("simulated: mcp.grant.created append failed")
+	var capturedGrantID uuid.UUID
+	_, _, err := repo.CreateGrantWithCode(ctx, principal, sqlc.CreateMCPGrantParams{
+		TenantID:      tenantID,
+		Name:          "should not survive",
+		Status:        "active",
+		SiteScopeMode: "all",
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  []uuid.UUID{},
+	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+		capturedGrantID = grantID
+		return sqlc.CreateMCPAuthorizationCodeParams{
+			TenantID:            tenantID,
+			GrantID:             grantID,
+			ClientID:            "rollback-probe-client",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
+			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
+		}
+	}, func(tx pgx.Tx, gr sqlc.McpGrant) error {
+		return simulated
+	})
+
+	if err == nil {
+		t.Fatal("CreateGrantWithCode succeeded despite the onCreated hook failing, want an error")
+	}
+	if !errors.Is(err, simulated) {
+		t.Errorf("error = %v, want it to wrap the simulated failure", err)
+	}
+	if capturedGrantID == uuid.Nil {
+		t.Fatal("the grant id was never captured; the insert must run before onCreated for this proof to mean anything")
+	}
+
+	var grantCount int
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM mcp_grants WHERE id = $1`, capturedGrantID).Scan(&grantCount)
+	}); err != nil {
+		t.Fatalf("count mcp_grants: %v", err)
+	}
+	if grantCount != 0 {
+		t.Errorf("mcp_grants row for %s committed despite the audit hook failing, want 0 rows", capturedGrantID)
+	}
+
+	rows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	for _, r := range rows {
+		if r.targetID == capturedGrantID.String() {
+			t.Fatalf("found an mcp.grant.created row for grant %s, which never committed", capturedGrantID)
+		}
+	}
+	t.Logf("rollback proof ok: neither mcp_grants nor audit_log carries a row for %s", capturedGrantID)
+}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -331,7 +331,7 @@ func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *tes
 			TenantID:            tenantID,
 			GrantID:             grantID,
 			ClientID:            "rollback-probe-client",
-			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 			CodeChallengeMethod: "S256",
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -328,7 +328,7 @@ func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err == nil {
 		t.Fatal("CreateGrantWithCode accepted a site-scoped principal. The write " +
 			"reached mcp_grants with app.site_scope unset, so the RESTRICTIVE " +

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -138,16 +138,32 @@ describe("ConsentScreen — what it can do and what it cannot", () => {
   });
 });
 
-describe("ConsentScreen — an empty site scope is not everything", () => {
-  it("starts with nothing selected and cannot be approved", () => {
+describe("ConsentScreen — an empty site scope is a working state, not an error (2026-08-23 revision)", () => {
+  it("starts with nothing selected, states the consequence, and CAN be approved", () => {
+    // Superseded framing (pre-2026-08-23): this blocked approval. The current
+    // wireframe rules an empty allowlist mints a credential that reads and
+    // proposes nothing, decided later -- a working state, not an error.
     renderWithProviders(<ConsentScreen {...props()} />);
-    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
-      /No sites are selected yet/i,
-    );
-    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    const summary = screen.getByTestId("consent-scope-summary").textContent ?? "";
+    expect(summary).toMatch(/No sites are selected/i);
+    expect(summary).toMatch(/read nothing and propose nothing/i);
+    expect(summary).toMatch(/working state, not an error/i);
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
   });
 
-  it("a tag matching no site says so, never that it covers everything", () => {
+  it("submits an empty list-mode scope when approved with nothing selected", () => {
+    const onApprove = vi.fn();
+    renderWithProviders(<ConsentScreen {...props({ onApprove })} />);
+    fireEvent.submit(screen.getByTestId("consent-approve").closest("form")!);
+    expect(onApprove).toHaveBeenCalledWith({
+      name: "Claude Desktop",
+      siteScopeMode: "list",
+      scopeTagIds: [],
+      scopeSiteIds: [],
+    });
+  });
+
+  it("a tag matching no site says so, states the consequence, and CAN be approved", () => {
     renderWithProviders(
       <ConsentScreen
         {...props({ tags: [{ id: "t9", name: "archived" }], tagsBySiteId: { s1: [], s2: [] } })}
@@ -157,9 +173,10 @@ describe("ConsentScreen — an empty site scope is not everything", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /archived/i }));
     const summary = screen.getByTestId("consent-scope-summary");
     expect(summary.textContent).toMatch(/matches no sites/i);
-    expect(summary.textContent).toMatch(/read nothing/i);
+    expect(summary.textContent).toMatch(/read nothing and propose nothing/i);
+    expect(summary.textContent).toMatch(/working state, not an error/i);
     expect(screen.queryByTestId("consent-scope-sites")).toBeNull();
-    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
   });
 
   it("a failed site load blocks approval instead of resolving to zero or to all", () => {

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -25,6 +25,7 @@ import {
   type ScopedSite,
   type SiteScopeMode,
 } from "./site-scope";
+import { SiteEnforcementBox } from "./site-enforcement-box";
 
 // The consent screen (design Step 7).
 //
@@ -433,6 +434,12 @@ function SiteScopeBlock({
         Your organisation&apos;s records decide what this connection reads on each
         request, not this list. The list is what this dashboard could load just now.
       </p>
+
+      {/* Screen 8 (wireframes.html#s8) — the enforcement box. No `refusals`
+          prop: this connection does not exist yet (approval has not
+          happened), so there is no refusal history, tracked or otherwise, to
+          have an opinion about. See site-enforcement-box.tsx's module doc. */}
+      <SiteEnforcementBox scope={scope} />
     </section>
   );
 }

--- a/apps/web/src/features/mcp-consent/site-enforcement-box.test.tsx
+++ b/apps/web/src/features/mcp-consent/site-enforcement-box.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { SiteEnforcementBox } from "./site-enforcement-box";
+import { bannedWordHits } from "./site-enforcement";
+import type { ResolvedSiteScope, ScopedSite } from "./site-scope";
+
+const SITES: ScopedSite[] = [
+  { id: "s1", name: "Alpha", url: "https://alpha.example" },
+  { id: "s2", name: "Beta", url: "https://beta.example" },
+];
+
+const LIST_SCOPE: ResolvedSiteScope = {
+  kind: "sites",
+  sites: SITES,
+  basis: "list",
+  listComplete: true,
+};
+
+const TAG_SCOPE: ResolvedSiteScope = {
+  kind: "sites",
+  sites: SITES,
+  basis: "tags",
+  listComplete: true,
+};
+
+const ALL_SCOPE: ResolvedSiteScope = {
+  kind: "all",
+  shown: SITES,
+  listComplete: true,
+};
+
+describe("SiteEnforcementBox — named-sites mode", () => {
+  it("states the request-time check and that no other site is covered", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} />);
+    const box = screen.getByTestId("site-enforcement-box");
+    expect(box.textContent).toMatch(/checked against this list before WPMgr contacts any site/i);
+    expect(box.textContent).toMatch(/refused and recorded in the audit log/i);
+    expect(box.textContent).toMatch(/no other site is covered/i);
+    // The drift sentence belongs to tag mode only.
+    expect(box.textContent).not.toMatch(/included automatically/i);
+  });
+
+  it("omits the refusals line when no refusals summary is supplied", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} />);
+    expect(screen.queryByTestId("site-enforcement-refusals")).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — tag mode states the drift consequence", () => {
+  it("says sites added to the tag later are included automatically, without approval", () => {
+    renderWithProviders(<SiteEnforcementBox scope={TAG_SCOPE} />);
+    const box = screen.getByTestId("site-enforcement-box");
+    expect(box.textContent).toMatch(/included automatically/i);
+    expect(box.textContent).toMatch(/without anyone approving it/i);
+  });
+});
+
+describe("SiteEnforcementBox — every-site mode replaces the box rather than decorating it", () => {
+  it("says nothing is checked because there is no list", () => {
+    renderWithProviders(<SiteEnforcementBox scope={ALL_SCOPE} />);
+    const box = screen.getByTestId("site-enforcement-box");
+    expect(box.dataset.mode).toBe("all");
+    expect(box.textContent).toMatch(/nothing is checked against a list because there is no list/i);
+  });
+
+  it("has no 'how we check this' link — every-site mode has no list to explain", () => {
+    renderWithProviders(<SiteEnforcementBox scope={ALL_SCOPE} />);
+    expect(screen.queryByText(/how we check this/i)).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — 'none' and 'unresolved' render nothing", () => {
+  it("renders no box when nothing is selected", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={{ kind: "none", because: "no-selection" }} />,
+    );
+    expect(screen.queryByTestId("site-enforcement-box")).toBeNull();
+  });
+
+  it("renders no box while the scope is unresolved", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={{ kind: "unresolved", because: "loading" }} />,
+    );
+    expect(screen.queryByTestId("site-enforcement-box")).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — the refusals block, when supplied", () => {
+  it("renders an explicit not-tracked sentence rather than a zero or a dash", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} refusals={{ kind: "unavailable" }} />);
+    const line = screen.getByTestId("site-enforcement-refusals");
+    expect(line.textContent).toMatch(/do not yet track/i);
+    expect(line.textContent?.trim()).not.toBe("0");
+  });
+
+  it("renders a real zero as a stated fact", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={LIST_SCOPE} refusals={{ kind: "zero", windowDays: 7 }} />,
+    );
+    expect(screen.getByTestId("site-enforcement-refusals").textContent).toMatch(
+      /no requests have been refused/i,
+    );
+  });
+
+  it("renders a real count", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={LIST_SCOPE} refusals={{ kind: "count", count: 2, windowDays: 7 }} />,
+    );
+    expect(screen.getByTestId("site-enforcement-refusals").textContent).toMatch(
+      /refused 2 times in the last 7 days/i,
+    );
+  });
+});
+
+describe("SiteEnforcementBox — the 'How we check this' dialog", () => {
+  it("opens on click and says this is a check the application makes, not a database boundary", () => {
+    renderWithProviders(<SiteEnforcementBox scope={TAG_SCOPE} />);
+    fireEvent.click(screen.getByText(/how we check this/i));
+    expect(screen.getByText("How WPMgr checks site access")).toBeTruthy();
+    expect(screen.getByText(/is a check WPMgr makes when the assistant asks/i)).toBeTruthy();
+    expect(screen.getByText(/not a separate boundary inside the database/i)).toBeTruthy();
+  });
+
+  it("closes on the Close button", () => {
+    renderWithProviders(<SiteEnforcementBox scope={TAG_SCOPE} />);
+    fireEvent.click(screen.getByText(/how we check this/i));
+    fireEvent.click(screen.getByText("Close"));
+    expect(screen.queryByText("How WPMgr checks site access")).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — banned-word guard over the mounted screen", () => {
+  // Plant the guard against what actually renders, not against the source
+  // file: a component could import clean constants and still interpolate a
+  // banned word around them.
+  it("every mode's rendered text is free of the wireframe's banned words", () => {
+    for (const scope of [LIST_SCOPE, TAG_SCOPE, ALL_SCOPE]) {
+      const { unmount } = renderWithProviders(
+        <SiteEnforcementBox
+          scope={scope}
+          refusals={{ kind: "count", count: 2, windowDays: 7 }}
+        />,
+      );
+      const box = screen.getByTestId("site-enforcement-box");
+      expect(bannedWordHits(box.textContent ?? "")).toEqual([]);
+      unmount();
+    }
+  });
+
+  it("the 'How we check this' dialog is free of the wireframe's banned words", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} />);
+    fireEvent.click(screen.getByText(/how we check this/i));
+    const dialogText = screen.getByText("How WPMgr checks site access").closest("div")?.parentElement
+      ?.textContent;
+    expect(bannedWordHits(dialogText ?? "")).toEqual([]);
+  });
+});

--- a/apps/web/src/features/mcp-consent/site-enforcement-box.tsx
+++ b/apps/web/src/features/mcp-consent/site-enforcement-box.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import type { ResolvedSiteScope } from "./site-scope";
+import {
+  ENFORCEMENT_ALL_MODE_SENTENCE,
+  ENFORCEMENT_CHECK_SENTENCE,
+  ENFORCEMENT_LIST_MODE_SENTENCE,
+  ENFORCEMENT_TAG_DRIFT_SENTENCE,
+  HOW_WE_CHECK_AUDIT_PATH,
+  HOW_WE_CHECK_HEADING,
+  HOW_WE_CHECK_MECHANISM,
+  HOW_WE_CHECK_REMEDY,
+  HOW_WE_CHECK_SCOPE,
+  HOW_WE_CHECK_TITLE,
+  describeRefusals,
+  type RefusalsSummary,
+} from "./site-enforcement";
+
+// Screen 8 (wireframes.html#s8) — "How site access is enforced".
+//
+// THREE STATES, ONE STRING SET, per the wireframe's own framing. Named-sites
+// and tag-mode share the neutral box and its opening sentence; every-site
+// REPLACES the box with a warning-toned one rather than decorating the same
+// box, because "nothing is checked" is a materially different fact from "this
+// list is checked" and dressing one as the other would be the exact collapse
+// this screen exists to prevent.
+//
+// `refusals` IS OPTIONAL AND DELIBERATELY OMITTED BY EVERY CALLER TODAY. No
+// endpoint on the control plane counts refusals per connection
+// (use-ai-connections.ts's wire schema carries only `site_scope_mode`), and
+// the one caller wired so far (the consent screen) has no connection id yet
+// at all -- approval has not happened, so there is no history to have an
+// opinion about, "not tracked yet" included. Passing `refusals` renders the
+// explicit not-a-count sentence from site-enforcement.ts; omitting it leaves
+// the block out entirely. Both are honest; which one applies depends on
+// whether a connection exists to ask about.
+export interface SiteEnforcementBoxProps {
+  readonly scope: ResolvedSiteScope;
+  readonly refusals?: RefusalsSummary;
+}
+
+export function SiteEnforcementBox({ scope, refusals }: SiteEnforcementBoxProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // 'none' and 'unresolved' have no enforcement story of their own: the
+  // site-scope summary above this box already says there is nothing to
+  // check (no-selection/no-matches) or that the check cannot be described
+  // yet (loading/failed). Rendering this box for either would either repeat
+  // that sentence in different words or assert a mechanism over a scope we
+  // do not yet know.
+  if (scope.kind === "none" || scope.kind === "unresolved") return null;
+
+  const isEveryMode = scope.kind === "all";
+
+  return (
+    <div className="mt-4">
+      <div
+        data-testid="site-enforcement-box"
+        data-mode={isEveryMode ? "all" : scope.basis}
+        className={
+          isEveryMode
+            ? "rounded-md border border-[var(--color-warning)]/40 bg-warning-subtle p-3 text-sm text-warning-subtle-fg"
+            : "rounded-md border border-[var(--color-border)] p-3 text-sm text-[var(--color-foreground)]"
+        }
+      >
+        <p className="font-medium">
+          {isEveryMode ? (
+            <>
+              <AlertTriangle aria-hidden="true" className="mr-1.5 inline size-4 align-text-bottom" />
+              Every site in this organisation
+            </>
+          ) : (
+            "How site access is enforced"
+          )}
+        </p>
+
+        {isEveryMode ? (
+          <p className="mt-2">{ENFORCEMENT_ALL_MODE_SENTENCE}</p>
+        ) : (
+          <>
+            <p className="mt-2 text-[var(--color-muted-foreground)]">{ENFORCEMENT_CHECK_SENTENCE}</p>
+            <p className="mt-2 text-[var(--color-muted-foreground)]">
+              {scope.basis === "tags" ? ENFORCEMENT_TAG_DRIFT_SENTENCE : ENFORCEMENT_LIST_MODE_SENTENCE}
+            </p>
+          </>
+        )}
+
+        {refusals !== undefined && (
+          <p data-testid="site-enforcement-refusals" className="mt-2 text-[var(--color-muted-foreground)]">
+            {describeRefusals(refusals)}
+          </p>
+        )}
+
+        {!isEveryMode && (
+          <p className="mt-2 text-right">
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              className="h-auto p-0"
+              onClick={() => setDialogOpen(true)}
+            >
+              How we check this →
+            </Button>
+          </p>
+        )}
+      </div>
+
+      <HowWeCheckDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
+    </div>
+  );
+}
+
+/**
+ * The "How we check this" dialog (wireframes.html:2898-2922). Its job is to
+ * say plainly that scoping is a request-time check the application makes, not
+ * a boundary the database enforces, and to hand over the stronger lever
+ * (pausing the assistant, or removing the site from every list) rather than
+ * asking anyone to evaluate a threat model.
+ */
+export function HowWeCheckDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogContent ariaLabelledBy="how-we-check-title" className="max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle id="how-we-check-title">{HOW_WE_CHECK_TITLE}</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="text-sm text-[var(--color-muted-foreground)]">
+          <p>{HOW_WE_CHECK_MECHANISM}</p>
+          <p>{HOW_WE_CHECK_SCOPE}</p>
+          <p className="font-medium text-[var(--color-foreground)]">{HOW_WE_CHECK_HEADING}</p>
+          <p>{HOW_WE_CHECK_REMEDY}</p>
+          <p>
+            You can see every refusal:{" "}
+            <span className="font-mono text-[var(--color-foreground)]">{HOW_WE_CHECK_AUDIT_PATH}</span>
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/mcp-consent/site-enforcement.test.ts
+++ b/apps/web/src/features/mcp-consent/site-enforcement.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ENFORCEMENT_ALL_MODE_SENTENCE,
+  ENFORCEMENT_BANNED_WORDS,
+  ENFORCEMENT_CHECK_SENTENCE,
+  ENFORCEMENT_LIST_MODE_SENTENCE,
+  ENFORCEMENT_TAG_DRIFT_SENTENCE,
+  allEnforcementScreenStrings,
+  bannedWordHits,
+  describeRefusals,
+} from "./site-enforcement";
+
+// A guard nobody has seen fail is not known to guard anything. This file
+// proves the banned-word guard both fires on a real violation and does not
+// over-fire on the honest copy this screen actually ships.
+
+describe("bannedWordHits — fires on the wireframe's own banned words", () => {
+  it.each(ENFORCEMENT_BANNED_WORDS)("catches %s inside a sentence", (word) => {
+    const poisoned = `This connection is completely ${word} from every other request.`;
+    expect(bannedWordHits(poisoned)).toContain(word);
+  });
+
+  it("catches a multi-word phrase written with different surrounding case", () => {
+    expect(bannedWordHits("Nothing outside the Walled Off area can be reached.")).toContain(
+      "walled off",
+    );
+  });
+
+  it("does not fire on a word that merely shares a prefix with a banned word", () => {
+    // "safety" must not trip "safe": \bsafe\b requires a boundary right after
+    // "safe", and "safety" has no boundary there.
+    expect(bannedWordHits("Read our safety guidance before connecting an assistant.")).toEqual(
+      [],
+    );
+  });
+});
+
+describe("bannedWordHits — does not over-fire on the shipped copy", () => {
+  it("every string this screen renders is clean", () => {
+    for (const text of allEnforcementScreenStrings()) {
+      expect(bannedWordHits(text)).toEqual([]);
+    }
+  });
+
+  it.each([
+    ["the shared check sentence", ENFORCEMENT_CHECK_SENTENCE],
+    ["the named-list sentence", ENFORCEMENT_LIST_MODE_SENTENCE],
+    ["the tag-drift sentence", ENFORCEMENT_TAG_DRIFT_SENTENCE],
+    ["the every-site sentence", ENFORCEMENT_ALL_MODE_SENTENCE],
+  ] as const)("%s is clean", (_label, text) => {
+    expect(bannedWordHits(text)).toEqual([]);
+  });
+});
+
+describe("ENFORCEMENT_TAG_DRIFT_SENTENCE — the sharpest sentence on the screen", () => {
+  it("states the drift consequence in the wireframe's own terms", () => {
+    expect(ENFORCEMENT_TAG_DRIFT_SENTENCE).toMatch(/included automatically/i);
+    expect(ENFORCEMENT_TAG_DRIFT_SENTENCE).toMatch(/without anyone approving it/i);
+  });
+});
+
+describe("ENFORCEMENT_ALL_MODE_SENTENCE — every-site mode", () => {
+  it("says there is no list, in the wireframe's own words", () => {
+    expect(ENFORCEMENT_ALL_MODE_SENTENCE).toMatch(
+      /Nothing is checked against a list because there is no list\./,
+    );
+  });
+});
+
+describe("describeRefusals — three states, never collapsed", () => {
+  it("renders an explicit not-tracked sentence for 'unavailable', never a zero", () => {
+    const text = describeRefusals({ kind: "unavailable" });
+    expect(text).toMatch(/do not yet track/i);
+    expect(text).not.toMatch(/^0/);
+    expect(text).not.toBe("0");
+  });
+
+  it("renders a real zero as a stated fact, distinct from 'unavailable'", () => {
+    expect(describeRefusals({ kind: "zero", windowDays: 7 })).toBe(
+      "No requests have been refused.",
+    );
+  });
+
+  it("renders a count with its window and correct pluralisation", () => {
+    expect(describeRefusals({ kind: "count", count: 2, windowDays: 7 })).toBe(
+      "Refused 2 times in the last 7 days.",
+    );
+    expect(describeRefusals({ kind: "count", count: 1, windowDays: 7 })).toBe(
+      "Refused 1 time in the last 7 days.",
+    );
+  });
+
+  it("unavailable and zero never render the same sentence", () => {
+    expect(describeRefusals({ kind: "unavailable" })).not.toBe(
+      describeRefusals({ kind: "zero", windowDays: 7 }),
+    );
+  });
+});

--- a/apps/web/src/features/mcp-consent/site-enforcement.ts
+++ b/apps/web/src/features/mcp-consent/site-enforcement.ts
@@ -1,0 +1,161 @@
+// Screen 8 (wireframes.html#s8, "Revised 2026-08-24") — the site-allowlist
+// honesty surface. Pure copy and a banned-word guard, kept separate from the
+// rendering component so the guard test can run over plain strings.
+//
+// WHAT THIS SCREEN EXISTS TO STOP. Site scoping is a check WPMgr makes when an
+// assistant asks to do something. It is NOT a boundary inside the database:
+// there is no per-connection database role, no row-level policy keyed on a
+// grant, nothing that would stop a bug elsewhere in this codebase from
+// reaching a site outside the list. The check is real and it runs on every
+// request, but it is one gate in application code, not a wall. Copy on this
+// screen must say exactly that and nothing stronger.
+//
+// THE BANNED LIST IS THE WIREFRAME'S OWN (wireframes.html:2844-2846), not a
+// paraphrase of it: "isolated, isolation, sandboxed, walled off, cannot
+// reach, impossible, guaranteed, secure, safe, airtight, hard limit." Every
+// one of those words claims a boundary this feature does not have.
+export const ENFORCEMENT_BANNED_WORDS: readonly string[] = [
+  "isolated",
+  "isolation",
+  "sandboxed",
+  "walled off",
+  "cannot reach",
+  "impossible",
+  "guaranteed",
+  "secure",
+  "safe",
+  "airtight",
+  "hard limit",
+];
+
+function bannedWordPattern(word: string): RegExp {
+  // Multi-word phrases match as a literal substring. Single words match at a
+  // word boundary so "safe" fires on "Safe." and "unsafe" alike (both start a
+  // fresh word after a boundary) but not inside "safety", which shares no
+  // boundary with the "e" that would need to end the match.
+  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(word.includes(" ") ? escaped : `\\b${escaped}\\b`, "i");
+}
+
+/**
+ * Every banned word or phrase found in `text`, in list order. Empty means
+ * clean. Used both by the guard test (over the literal strings below) and by
+ * a render test (over the mounted screen's text content), because a guard
+ * that only ever reads its own source can be satisfied by a source that lies
+ * about what actually renders.
+ */
+export function bannedWordHits(text: string): string[] {
+  return ENFORCEMENT_BANNED_WORDS.filter((word) => bannedWordPattern(word).test(text));
+}
+
+/**
+ * The sentence every enforcement box opens with, for the two modes that carry
+ * an actual list (named sites, and sites-by-tag). It states the mechanism
+ * (checked per request, before any site is contacted) and the consequence of
+ * missing the list (refused, recorded), without saying WHERE the check lives
+ * relative to anything else.
+ */
+export const ENFORCEMENT_CHECK_SENTENCE =
+  "Every request from this assistant is checked against this list before WPMgr contacts any site. A request for a site that is not on the list is refused and recorded in the audit log.";
+
+/**
+ * Named-sites mode (basis 'list'). The set is fixed by construction — the
+ * operator picked it — so the only thing left to say is that nothing else is
+ * covered, including a site enrolled afterwards.
+ */
+export const ENFORCEMENT_LIST_MODE_SENTENCE =
+  "This is a fixed list. No other site is covered by this connection, including one added to the organisation later.";
+
+/**
+ * Tag mode's drift sentence (wireframes.html:2884-2885, and this screen's
+ * whole reason for existing per the build brief). NOT SOFTENED: it says
+ * "included automatically" and "without anyone approving it" in exactly
+ * those words, because that is the fact an operator choosing tag mode is
+ * agreeing to and the one this screen must not let them miss.
+ */
+export const ENFORCEMENT_TAG_DRIFT_SENTENCE =
+  "Sites added to these tags later will be included automatically, without anyone approving it.";
+
+/**
+ * Every-site mode. Quoted from wireframes.html:2890-2891 verbatim: there is
+ * no list to check against, so the sentence says that rather than describing
+ * an absent list as a boundary.
+ */
+export const ENFORCEMENT_ALL_MODE_SENTENCE =
+  "Nothing is checked against a list because there is no list. This connection can read any site in the organisation, including one added after you approved it.";
+
+/**
+ * What we know about how often this assistant has been refused a site.
+ *
+ * THREE STATES, NOT A NUMBER. `unavailable` is today's only real value: no
+ * endpoint on the control plane counts refusals per connection yet (grep
+ * confirms `/api/v1/mcp/connections` returns only `site_scope_mode`, not a
+ * count). `zero` and `count` exist so the box is ready the day that endpoint
+ * ships, and so a test can pin the difference between "none happened" and
+ * "we don't know" — the exact collapse this screen exists to prevent.
+ * Rendering `unavailable` as `zero` would fabricate a fact nobody measured;
+ * rendering it as a bare 0 or a dash would read as data.
+ */
+export type RefusalsSummary =
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "zero"; readonly windowDays: number }
+  | { readonly kind: "count"; readonly count: number; readonly windowDays: number };
+
+/**
+ * The sentence for a refusals summary, or null for `unavailable` when the
+ * caller has chosen to omit the block entirely rather than render an explicit
+ * placeholder (see `describeRefusalsExplicit` for the other choice).
+ */
+export function describeRefusals(summary: RefusalsSummary): string {
+  switch (summary.kind) {
+    case "unavailable":
+      return "We do not yet track how many requests have been refused for this connection.";
+    case "zero":
+      return "No requests have been refused.";
+    case "count":
+      return `Refused ${summary.count} time${summary.count === 1 ? "" : "s"} in the last ${summary.windowDays} days.`;
+  }
+}
+
+// "How we check this" dialog copy (wireframes.html:2904-2914), kept as named
+// constants so the render test and the banned-word guard both read the exact
+// strings that ship, not a re-typed approximation of them.
+export const HOW_WE_CHECK_TITLE = "How WPMgr checks site access";
+
+export const HOW_WE_CHECK_MECHANISM =
+  "When an assistant asks to do something, WPMgr resolves which sites the request covers, then checks each one against that assistant's list. Sites that are not on the list are dropped from the request and written to the audit log as refused. The assistant is told which sites were refused and why.";
+
+export const HOW_WE_CHECK_SCOPE =
+  "This check runs in one place, on every assistant request, and it runs before anything reaches a site.";
+
+export const HOW_WE_CHECK_HEADING = "What this does not do";
+
+export const HOW_WE_CHECK_REMEDY =
+  "It is a check WPMgr makes when the assistant asks. It is not a separate boundary inside the database. If a site must never be touched by any assistant, pause the assistant or take the site off every list, rather than relying on the check alone.";
+
+export const HOW_WE_CHECK_AUDIT_PATH = "Security → Audit → Denied";
+
+/**
+ * Every user-facing string this screen ships, gathered in one place so the
+ * banned-word guard can scan the whole surface without depending on a render.
+ * A NEW STRING ADDED TO THIS SCREEN AND NOT ADDED HERE IS NOT GUARDED — the
+ * render-level test in site-enforcement-box.test.tsx is the backstop for
+ * that gap.
+ */
+export function allEnforcementScreenStrings(): readonly string[] {
+  return [
+    ENFORCEMENT_CHECK_SENTENCE,
+    ENFORCEMENT_LIST_MODE_SENTENCE,
+    ENFORCEMENT_TAG_DRIFT_SENTENCE,
+    ENFORCEMENT_ALL_MODE_SENTENCE,
+    describeRefusals({ kind: "unavailable" }),
+    describeRefusals({ kind: "zero", windowDays: 7 }),
+    describeRefusals({ kind: "count", count: 2, windowDays: 7 }),
+    HOW_WE_CHECK_TITLE,
+    HOW_WE_CHECK_MECHANISM,
+    HOW_WE_CHECK_SCOPE,
+    HOW_WE_CHECK_HEADING,
+    HOW_WE_CHECK_REMEDY,
+    HOW_WE_CHECK_AUDIT_PATH,
+  ];
+}

--- a/apps/web/src/features/mcp-consent/site-scope.test.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.test.ts
@@ -72,9 +72,9 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
     expect(scope.kind).toBe("none");
   });
 
-  it("an empty resolution is not approvable", () => {
-    expect(isScopeApprovable(resolveSiteScope(input({ mode: "tags", selectedTagNames: ["gone"] })))).toBe(false);
-    expect(isScopeApprovable(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })))).toBe(false);
+  it("an empty resolution IS approvable -- reading nothing is a working state, not an error (2026-08-23 revision)", () => {
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "tags", selectedTagNames: ["gone"] })))).toBe(true);
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })))).toBe(true);
   });
 
   it("only mode 'all' ever produces kind 'all'", () => {
@@ -92,6 +92,24 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
     const scope = resolveSiteScope(input({ mode: "all", fleet: { sites: [], complete: true } }));
     expect(scope.kind).toBe("all");
     expect(describeSiteScope(scope)).toMatch(/added later/i);
+  });
+});
+
+describe("isScopeApprovable — an empty allowlist is approvable, an unread one never is", () => {
+  // The 2026-08-23 wireframe revision (line 3559) rules that a connection with
+  // an empty allowlist "can read nothing and propose nothing. That is a
+  // working state, not an error." This block pins BOTH halves of that with
+  // equal force: `none` (however it was reached) now passes, and `unresolved`
+  // (however it was reached) still fails. Weakening either half back to the
+  // pre-2026-08-23 shape must redden this block, not just the copy tests.
+  it("accepts a resolved-to-nothing scope, from no selection and from no matches alike", () => {
+    expect(isScopeApprovable({ kind: "none", because: "no-selection" })).toBe(true);
+    expect(isScopeApprovable({ kind: "none", because: "no-matches" })).toBe(true);
+  });
+
+  it("still refuses a scope nobody has read, whether pending or failed", () => {
+    expect(isScopeApprovable({ kind: "unresolved", because: "loading" })).toBe(false);
+    expect(isScopeApprovable({ kind: "unresolved", because: "failed" })).toBe(false);
   });
 });
 

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -240,9 +240,13 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
       return `${siteCount(scope.sites.length)} ${verb} these tags today, listed below. ${future}`;
     }
     case "none":
+      // 2026-08-23 revision (wireframes.html:3559): an empty allowlist "is a
+      // working state, not an error -- it is how you mint a credential now and
+      // decide its reach later." Both branches say that consequence plainly
+      // rather than treating the choice as incomplete.
       return scope.because === "no-selection"
-        ? "No sites are selected yet. Choose what this client may read before approving."
-        : "This selection matches no sites, so this connection would be able to read nothing. That is not the same as covering every site.";
+        ? "No sites are selected. That is a working state, not an error: this connection will read nothing and propose nothing until you give it sites to cover, now or later."
+        : "This selection matches no sites, so this connection will read nothing and propose nothing right now. That is a working state, not an error: you can widen its scope later.";
     case "unresolved":
       return scope.because === "loading"
         ? "Working out which sites this covers."
@@ -253,11 +257,19 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
 /**
  * Whether a scope may be approved.
  *
- * `none` is refusable rather than blocked-with-a-warning: server-side, an empty
- * payload is unstorable for mode 'list' and a tag matching nothing resolves to
- * an empty set, so approving it creates a grant that reads nothing. Better to
- * say that on this screen than to mint a credential that silently does nothing.
- * `unresolved` is blocked because consenting to an unread set is not consent.
+ * 2026-08-23 revision (wireframes.html:3559): "A connection with an empty
+ * allowlist can read nothing and propose nothing. That is a working state, not
+ * an error -- it is how you mint a credential now and decide its reach later."
+ * `none` is therefore approvable, on equal footing with `all` and `sites`.
+ * Narrowing to nothing is not refused here because it is enforced where it
+ * actually matters: by which tools are registered for the connection
+ * (wireframes.html:1743, "narrowing is applied by unregistering the tool, not
+ * by denying it at call time"), not by a client-side gate on this screen. The
+ * older rule that blocked an empty allowlist (wireframes.html:1293) is
+ * superseded.
+ *
+ * `unresolved` is the only kind that still blocks. Consenting to a scope
+ * nobody has read is not consent, whether the read is pending or failed.
  *
  * A TRUNCATED LIST DOES NOT BLOCK. It is disclosed instead. Blocking would
  * refuse every organisation past the page size, and the operator choosing "every
@@ -265,5 +277,5 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
  * is a false count or a list that poses as the whole fleet.
  */
 export function isScopeApprovable(scope: ResolvedSiteScope): boolean {
-  return scope.kind === "all" || scope.kind === "sites";
+  return scope.kind !== "unresolved";
 }


### PR DESCRIPTION
## Summary
- Adds Screen 8 from the wireframes ("site-allowlist honesty"): a request-time enforcement box shown on the AI-connection consent screen, in its three states — named sites, tag-scoped, and every-site — plus a "How we check this" dialog.
- States the tag-mode drift consequence explicitly, in the wireframe's own terms: sites added to a granted tag later are included automatically, without anyone approving it. The existing consent-screen summary sentence was adjacent to this but never said it.
- Every-site mode replaces the box rather than decorating it: "Nothing is checked against a list because there is no list."
- Ships a banned-word guard (`bannedWordHits`) over the wireframe's own list — isolated, isolation, sandboxed, walled off, cannot reach, impossible, guaranteed, secure, safe, airtight, hard limit — tested to fire on a planted violation and to pass clean on the shipped copy.
- No API change. The consent screen already resolves a full `ResolvedSiteScope` client-side (real site data, real tag matches), so the box is wired there with zero backend work.
- Refusals-count block: there is no refusals-count endpoint (`/api/v1/mcp/connections` returns only `site_scope_mode`). The component supports an optional `refusals` prop with three explicit states (`unavailable` / `zero` / `count`) so a real zero is never confused with "not tracked" — but no caller passes it today, since the consent screen has no connection id yet (approval hasn't happened) to have any refusal history to report. Omitting the prop omits the block entirely; passing `{kind: "unavailable"}` renders an explicit "we do not yet track this" sentence rather than a fabricated zero.
- Branches from `worktree-agent-a663b4924b65a4a06` (#606) per the task's base instruction, so this diff will shrink once #606 merges.

## Test plan
- [x] `pnpm -C apps/web typecheck` — exit 0
- [x] `pnpm -C apps/web lint` — exit 0 (10 pre-existing warnings elsewhere in the repo, none new)
- [x] `pnpm -C apps/web test -- --run` — 165 files / 2022 tests passed
- [x] `pnpm -C apps/web build` — exit 0, `routeTree.gen.ts` unchanged (no new route)
- [x] `apps/web/node_modules/.bin/impeccable detect apps/web/src/features/mcp-consent` — exit 0, no violations
- [x] Mutation sweep on the three mode sentences and the banned-word guard: each mutation reddened a test naming the exact property, then was reverted to green (see PR conversation / session report for the four before/after runs).
- [ ] Playwright e2e — not run; this PR does not touch login/enroll/restore.