### PR TITLE
feat(mcp): mint a connection token from the dashboard, the headless path

### DIFF
--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -187,6 +187,74 @@ type connectionListDTO struct {
 	Connections []connectionDTO `json:"connections"`
 }
 
+// mintConnectionRequestDTO is the wizard's headless-connection request.
+//
+// THE TAG FIELD IS `scope_tag_ids` AND IT CARRIES UUIDs, deliberately spelled
+// the same as approvalRequestDTO.ScopeTagIDs (above) so there is ONE wire
+// vocabulary for a tag across both mint paths. The consent screen already holds
+// the name->id map and refuses its own submit when the tag registry went null
+// mid-flight; the wizard reuses that map rather than introducing a name form
+// this endpoint would have to disambiguate on case and duplicates.
+//
+// Ids also survive a rename and names do not: a grant scoped by name would
+// silently change which sites it covers the day somebody renames a tag, and
+// nothing would say so. The server-side half of the bargain is that an id
+// naming no tag is REFUSED by id rather than dropped -- see
+// ErrCodeUnknownScopeTag.
+type mintConnectionRequestDTO struct {
+	Name          string   `json:"name"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	ScopeTagIDs   []string `json:"scope_tag_ids"`
+	ScopeSiteIDs  []string `json:"scope_site_ids"`
+
+	// Capabilities is OPTIONAL and an omitted list means the organisation
+	// default, never an empty set. See Service.resolveMintCapabilities: an
+	// empty stored capability set is a connection that authenticates and can
+	// then reach no tool at all.
+	Capabilities []string `json:"capabilities"`
+}
+
+// mintConnectionResponseDTO carries the plaintext EXACTLY ONCE.
+//
+// `token` has no `omitempty` and is not a pointer: it is always present on a
+// 201 and there is no success shape in which it is absent. If this struct is
+// ever reused for a read-back it must lose the field entirely rather than let
+// it marshal as empty -- an empty `token` key on a later response would read as
+// "the credential is blank" rather than "it was never stored", and the second
+// is the truth. Nothing can read it back, because nothing holds it: the row
+// carries token_prefix and a SHA-256 hash.
+type mintConnectionResponseDTO struct {
+	GrantID string `json:"grant_id"`
+
+	// The plaintext. Once, here, in the response body -- never logged, never in
+	// a URL or query string, never persisted.
+	Token string `json:"token"`
+
+	// The PUBLIC handle. The schema says it "carries no authentication weight",
+	// so it is safe to display and log, and it is how an operator matches a
+	// token in a config file to a row in the connections list.
+	TokenPrefix string `json:"token_prefix"`
+
+	ExpiresAt     string   `json:"expires_at"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	Capabilities  []string `json:"capabilities"`
+}
+
+func toMintConnectionResponse(m MintedConnection) mintConnectionResponseDTO {
+	return mintConnectionResponseDTO{
+		GrantID:       m.GrantID.String(),
+		Token:         m.Token,
+		TokenPrefix:   m.TokenPrefix,
+		ExpiresAt:     m.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		SiteScopeMode: string(m.SiteScopeMode),
+		// Non-nil even when empty, so the field serialises as [] rather than
+		// null. MintConnection cannot return an empty set today; the guarantee
+		// is written here so a consumer never has to treat null as a third
+		// state.
+		Capabilities: capabilityNames(m.Capabilities),
+	}
+}
+
 // revokeResponseDTO reports WHAT THE REVOKE DID, not merely that it returned.
 //
 // The counts are on the wire because three different successes are possible and

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -151,6 +151,26 @@ func (h *Handler) RegisterConnections(r *gin.RouterGroup) {
 	g := r.Group(connectionsGroupPath)
 
 	g.GET("", authz.RequirePermission(authz.PermAPIKeyRead), h.listConnections)
+
+	// POST "" mints a connection token: the DOCUMENTED HEADLESS PATH, because
+	// no client documents a device-code flow and Claude Code cannot run browser
+	// sign-in non-interactively. It is not a fallback for a failed OAuth dance.
+	//
+	// PermAPIKeyManage, THE SAME PERMISSION AS REVOKE, and that pairing is the
+	// org-scope gate rather than a convenience. Both PermAPIKeyRead and
+	// PermAPIKeyManage are members of authz.orgLevelPerms, so RequirePermission
+	// refuses ANY site-constrained principal outright -- which is what closes
+	// the hole here, since a grant is an organisation-wide credential with no
+	// :siteId for RequireSiteAccess to key on. Reusing the API-key permissions
+	// rather than minting a new one is what guarantees that membership is not a
+	// step somebody has to remember: a fresh permission left out of orgLevelPerms
+	// would look identical on this line and gate nothing.
+	//
+	// Minting is at least as sensitive as revoking -- revoke removes authority,
+	// mint creates a long-lived bearer credential -- so it takes the manage
+	// tier, never the read one.
+	g.POST("", authz.RequirePermission(authz.PermAPIKeyManage), h.mintConnection)
+
 	g.POST("/:"+connectionIDParam+"/revoke",
 		authz.RequirePermission(authz.PermAPIKeyManage), h.revokeConnection)
 
@@ -160,7 +180,7 @@ func (h *Handler) RegisterConnections(r *gin.RouterGroup) {
 	// permission middleware on purpose -- the verb is wrong regardless of who is
 	// asking, and answering 403 to a DELETE sends an operator to check a role
 	// when the fix is to send a POST.
-	houseMethodNotAllowedExcept(g, "", http.MethodGet)
+	houseMethodNotAllowedExcept(g, "", http.MethodGet, http.MethodPost)
 	houseMethodNotAllowedExcept(g, "/:"+connectionIDParam+"/revoke", http.MethodPost)
 }
 
@@ -185,6 +205,85 @@ func (h *Handler) listConnections(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, toConnectionListDTO(conns))
+}
+
+// mintConnection answers POST /api/v1/mcp/connections.
+//
+// It returns 201 with the plaintext token in the body, ONCE. The plaintext is
+// never put in a URL, a query string, a header or a log line -- a URL is
+// written to browser history, proxy logs and Referer headers, and this
+// credential outlives the session that asked for it by up to ninety days.
+//
+// THE HANDLER DOES NO AUTHORIZATION OF ITS OWN beyond re-reading the principal.
+// The org-scope decision belongs to the service (and to the route's
+// RequirePermission, and to the RLS beneath), so there is no fourth opinion
+// here that could drift from the other three.
+func (h *Handler) mintConnection(c *gin.Context) {
+	principal, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		// Unreachable behind RequireAuth; refusing anyway, because a handler
+		// that trusts its mount point is one refactor away from anonymous.
+		httpx.Error(c, domain.Unauthorized("unauthenticated", "authentication required"))
+		return
+	}
+
+	// Capped like the OAuth bodies. This one IS authenticated, so the cap is
+	// not admission control -- it bounds a decoder fed a streamed body by a
+	// caller who is already inside, which is cheap insurance rather than a
+	// security boundary.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxOAuthBodyBytes)
+
+	var body mintConnectionRequestDTO
+	if err := c.ShouldBindJSON(&body); err != nil {
+		httpx.Error(c, domain.Validation(ErrCodeInvalidRequest,
+			"the request body is not valid JSON"))
+		return
+	}
+
+	// parseUUIDs REFUSES a malformed id rather than dropping it, and that is
+	// the point on this path: uuid.Parse failure decays to uuid.Nil, and a
+	// dropped tag id silently NARROWS the scope the operator thought they were
+	// minting -- or empties it entirely, which then looks like a deliberate
+	// choice. The error names which field so the wizard can point at it.
+	tagIDs, err := parseUUIDs(body.ScopeTagIDs)
+	if err != nil {
+		httpx.Error(c, domain.Validation(ErrCodeInvalidSiteScope,
+			"scope_tag_ids contains a value that is not a UUID"))
+		return
+	}
+	siteIDs, err := parseUUIDs(body.ScopeSiteIDs)
+	if err != nil {
+		httpx.Error(c, domain.Validation(ErrCodeInvalidSiteScope,
+			"scope_site_ids contains a value that is not a UUID"))
+		return
+	}
+
+	caps := make([]Capability, 0, len(body.Capabilities))
+	for _, name := range body.Capabilities {
+		caps = append(caps, Capability(name))
+	}
+
+	out, err := h.svc.MintConnection(c.Request.Context(), MintConnectionRequest{
+		// The WHOLE principal. Its Scope and AllowedSiteIDs are what route the
+		// grant insert to a site-scoped transaction, so narrowing this to
+		// (TenantID, UserID) would disarm the RLS layer beneath while still
+		// compiling -- the same trap ApprovalRequest.Principal documents.
+		Principal:    principal,
+		Name:         body.Name,
+		SiteScope:    SiteScopeRequest{Mode: SiteScopeMode(body.SiteScopeMode), TagIDs: tagIDs, SiteIDs: siteIDs},
+		Capabilities: caps,
+	})
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	// Never cached, and never stored by an intermediary: the body holds a
+	// bearer credential. Same stance RFC 6749 5.1 takes on a token response,
+	// applied here because the payload is the same kind of thing.
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+	c.JSON(http.StatusCreated, toMintConnectionResponse(out))
 }
 
 // revokeConnection answers POST /api/v1/mcp/connections/:connectionId/revoke.

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -1,0 +1,494 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// THE CONNECTION-TOKEN MINT: the documented HEADLESS path, not a fallback.
+//
+// No MCP client documents a device-code flow and Claude Code cannot run browser
+// sign-in non-interactively, so headless, SSH and CI installs have no route
+// through /authorize + /consent at all. This endpoint is that route, and the
+// wireframes present it as the documented headless path rather than as
+// something an operator discovers after browser sign-in fails.
+//
+// WHAT IT SHARES WITH THE OAUTH PATH, AND WHY THAT IS THE WHOLE DESIGN. The
+// credential is built the same way (randomToken(32) -> hashCredential ->
+// token_prefix + token_hash), stored in the same table by the same generated
+// statement, expires on the same connectionTokenTTL, and hangs off a grant
+// created with the same m127 columns and the same mcp.grant.created audit
+// event. THE ONLY THING THAT DIFFERS IS HOW THE GRANT IS AUTHORISED INTO
+// BEING: consent authorises the OAuth grant, and an authenticated operator's
+// own request authorises this one. A parallel insert that reproduced the token
+// but skipped the grant path would produce a live credential that no audit row
+// explains, which is the state this file is written to make unrepresentable.
+// ---------------------------------------------------------------------------
+
+const (
+	// MintGlobalPerMin caps connection tokens this process mints per minute
+	// across ALL operators. Unspoofable and never evicted; this is the bound.
+	//
+	// MINTING CREDENTIALS UNTHROTTLED IS HOW ONE STOLEN SESSION BECOMES MANY.
+	// A session cookie that is replayed once buys one token; replayed in a loop
+	// against an unlimited mint it buys as many long-lived bearer credentials
+	// as the attacker cares to store, each surviving the session's own
+	// expiry and each needing its own revoke. The bound is what turns that from
+	// "unbounded" into "a handful, and the audit log names every one".
+	MintGlobalPerMin = 30
+
+	// MintPerUserPerMin caps tokens one operator may mint per minute.
+	//
+	// Sized to a human: setting up a headless connection is a deliberate act
+	// that produces one token, and an operator wiring several CI runners at
+	// once is still nowhere near this. It is deliberately far below
+	// MintGlobalPerMin so one compromised session cannot consume the process
+	// budget and lock every other operator out of the feature -- the same
+	// fairness reasoning register_limit.go gives for its per-peer layer.
+	MintPerUserPerMin = 5
+)
+
+// newMintLimiter builds the mint limiter, REUSING registrationLimiter rather
+// than restating its two-layer accounting.
+//
+// The type is named for its first caller, not for a property that excludes this
+// one: it is a global token bucket plus a capacity-bounded per-key bucket, it
+// charges nothing on a refused request, and a nil receiver refuses. All four
+// are exactly what this endpoint needs, and a second copy would be a second
+// place for the "reserve then release" bug register_limit.go documents having
+// already fixed once.
+//
+// THE KEY IS THE OPERATOR'S USER ID, NOT RemoteIP, AND THAT IS THE ONE REAL
+// DIFFERENCE. register_limit.go must key on the TCP peer because RFC 7591
+// registration is anonymous and every other identity on that request is
+// attacker-supplied. This endpoint is behind session auth, so the principal's
+// UserID is resolved by the session layer and cannot be set by a header --
+// it is a STRICTLY BETTER key than RemoteIP, and it is also the right one:
+// the harm being bounded is "one stolen session mints many credentials", and
+// that is a per-user quantity. Keying on RemoteIP here would instead collapse
+// every operator behind the load balancer into one bucket.
+func newMintLimiter() *registrationLimiter {
+	return newRegistrationLimiter(MintGlobalPerMin, MintPerUserPerMin)
+}
+
+// mintLimiterKey is the per-operator bucket key.
+//
+// A NIL user id gets a single shared reserved bucket rather than a fresh one,
+// for the reason registrationLimiter.allow gives the empty peer string: "we
+// could not identify who is asking" must be MORE restrictive than identifying
+// them, never less. RequireAuth makes uuid.Nil unreachable here in production;
+// this is what it costs to be wrong about that.
+func mintLimiterKey(userID uuid.UUID) string {
+	if userID == uuid.Nil {
+		return "\x00unattributed"
+	}
+	return userID.String()
+}
+
+// ErrCodeMintRateLimited is the refusal for an operator who has exhausted
+// either mint budget. It is a NAMED code rather than a bare 429 body so the
+// wizard can tell "slow down" from "you may not do this at all" -- the two need
+// different screens, and a client that cannot tell them apart shows the wrong
+// one.
+const ErrCodeMintRateLimited = "mcp_mint_rate_limited"
+
+// ErrCodeUnknownScopeTag is the LOUD refusal for a scope tag id that names no
+// tag in this organisation.
+//
+// IT EXISTS BECAUSE scope_tag_ids IS A uuid[] WITH NO FOREIGN KEY. PostgreSQL
+// has no referential integrity over array elements, so the column accepts any
+// UUID at all -- another organisation's tag, or a value that never named
+// anything. Such a grant stores cleanly, passes every CHECK, and then resolves
+// to zero sites forever at request time, where it is INDISTINGUISHABLE from a
+// deliberately narrow connection. That is scope silently narrowed to nothing
+// without anyone being told, which is the failure this endpoint is most likely
+// to produce and the one the operator has no way to diagnose.
+//
+// Refusing at mint time, naming the offending id, is the only moment the caller
+// still has the context to fix it.
+const ErrCodeUnknownScopeTag = "mcp_unknown_scope_tag"
+
+// ErrCodeUnknownScopeSite is the same refusal on the site axis. Same column
+// shape (uuid[], no foreign key), same silent-narrowing outcome, and it is
+// detected differently: a site id is verified by resolving it through the
+// audited chokepoint under tenant RLS, which drops every foreign id.
+const ErrCodeUnknownScopeSite = "mcp_unknown_scope_site"
+
+// MintConnectionRequest is an authenticated operator asking for a headless
+// connection token.
+//
+// Principal is the WHOLE principal for the reason ApprovalRequest's field doc
+// gives: its Scope and AllowedSiteIDs are what route the grant insert to a
+// site-scoped transaction, so narrowing this to (TenantID, UserID) would
+// disarm the RLS layer beneath while still compiling.
+type MintConnectionRequest struct {
+	Principal domain.Principal
+
+	// Name is the operator's own label for the connection. Required: an
+	// unnamed long-lived credential is one nobody can identify later in order
+	// to revoke it.
+	Name string
+
+	// SiteScope is the site axis, IN TAG AND SITE IDs.
+	//
+	// IDs AND NOT NAMES, AND THE CHOICE IS DELIBERATE. dto.go's
+	// approvalRequestDTO already puts `scope_tag_ids` on the wire as UUIDs, and
+	// the consent screen already holds the name->id map it needs to fill them
+	// in. Taking names here would create a SECOND wire vocabulary for the same
+	// concept and would reopen questions the id form has already closed --
+	// case-sensitivity, duplicate names, and what a rename does to a stored
+	// grant. A tag id is stable across a rename; a name is not, and a grant
+	// scoped by name would silently change meaning the day somebody renames a
+	// tag.
+	//
+	// The cost is that the caller must resolve names to ids, which the consent
+	// screen already does and refuses the submit when the registry is
+	// unavailable. What this endpoint adds, and what the consent path does not
+	// do, is VERIFY the ids server-side -- see ErrCodeUnknownScopeTag.
+	SiteScope SiteScopeRequest
+
+	// Capabilities is the tool axis. EMPTY MEANS "the organisation default",
+	// not "none": an empty stored capability set is a connection that
+	// authenticates and then reaches no tool, which Authenticate refuses by
+	// name, so writing one here would mint a credential that can never work.
+	// A non-empty list is NARROWED against the org ceiling, never widened past
+	// it -- CapabilitySet.NarrowTo refuses rather than intersects.
+	Capabilities []Capability
+}
+
+// MintedConnection is the response. Token is present exactly once, here.
+type MintedConnection struct {
+	GrantID uuid.UUID
+
+	// Token is the PLAINTEXT bearer credential. It exists in this struct, in
+	// the response body it is rendered into, and nowhere else: no column holds
+	// it, no log line prints it, and it is never put in a URL or a query
+	// string. Only TokenPrefix and the SHA-256 hash are persisted.
+	Token string
+
+	// TokenPrefix is the PUBLIC handle -- the schema says outright that it
+	// "carries no authentication weight". It is safe to log, display and store,
+	// and it is what lets an operator match a token in a config file against a
+	// row in the connections list without ever handling the secret.
+	TokenPrefix string
+
+	ExpiresAt     time.Time
+	SiteScopeMode SiteScopeMode
+	Capabilities  []Capability
+}
+
+// MintConnection creates a grant and its first connection token in ONE
+// transaction, and returns the plaintext once.
+//
+// THE ORDER OF THE REFUSALS IS THE SECURITY PROPERTY, and it mirrors Exchange:
+// everything that can refuse runs before anything is generated, the credential
+// is generated in memory only after the last refusal, and the write is a single
+// transaction that either lands whole or leaves no trace.
+func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest) (MintedConnection, error) {
+	// 1. THE ORG-SCOPE GUARD, restated in the service.
+	//
+	// A SITE-SCOPED COLLABORATOR MINTING AN ORG-WIDE GRANT WAS A LIVE
+	// PRODUCTION DEFECT on the sibling path: /register is unauthenticated, so
+	// one self-registered client and one POST to the writing route was the
+	// whole exploit -- no consent screen and no operator interaction. The fix
+	// there was to gate BOTH consent routes; the lesson here is that this path
+	// must carry the same gate or better, at every layer the other one does.
+	//
+	// It has three, outermost first, and requireOrgScopedPrincipal's own doc
+	// explains why none of them is redundant:
+	//   1. authz.RequirePermission(PermAPIKeyManage) on the route -- an
+	//      orgLevelPerms member, so RequirePermission refuses any
+	//      site-constrained principal outright.
+	//   2. THIS CALL.
+	//   3. mcp_grants_site_scope_insert, the RESTRICTIVE policy keyed on the
+	//      app.site_scope GUC that Repo's RunTenantTx sets.
+	// MUTATION M1 targets this line.
+	if err := requireOrgScopedPrincipal(req.Principal); err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 2. THE RATE LIMIT, charged before any work and keyed on the operator.
+	// Placed here rather than in the handler so that every mount of this
+	// service is limited, including a test harness -- a limiter that exists
+	// only in the route registration is one refactor away from being absent,
+	// which is the same reasoning Handler.Register gives for putting
+	// RequireOrgScope on the group. MUTATION M2 targets this block.
+	if ok, retryAfter := s.mintLimit.allow(mintLimiterKey(req.Principal.UserID)); !ok {
+		return MintedConnection{}, domain.RateLimited(ErrCodeMintRateLimited,
+			"too many connection tokens minted; retry shortly").
+			WithDetails(map[string]any{"retry_after_seconds": retryAfterSeconds(retryAfter)})
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return MintedConnection{}, domain.Validation(ErrCodeInvalidRequest,
+			"a connection name is required")
+	}
+
+	// 3. SITE SCOPE: the STRUCTURAL rules first, unchanged.
+	//
+	// ValidateSiteScopeRequest is the Go mirror of
+	// mcp_grants_site_scope_payload_check and it is reused verbatim: mode 'all'
+	// names nothing, mode 'tags' names at least one tag, mode 'list' names at
+	// least one site, and an absent mode is refused rather than read as 'all'.
+	// An empty allowlist is never a way to ask for every site.
+	if err := ValidateSiteScopeRequest(req.SiteScope); err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 4. SITE SCOPE: the REFERENTIAL check, which the structural one cannot do.
+	//
+	// This is where an id that names nothing is refused. See
+	// verifyScopeReferents -- and read its comment before adding any
+	// "resolves to no sites" refusal here, because that would be a defect
+	// rather than a hardening.
+	if err := s.verifyScopeReferents(ctx, req.Principal.TenantID, req.SiteScope); err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 5. CAPABILITIES: narrowed against the organisation's ceiling, never
+	// widened past it. NarrowTo REFUSES a capability the ceiling does not hold
+	// rather than dropping it, for the reason written on that method: a
+	// silently-dropped capability is a grant the operator did not ask for.
+	caps, err := s.resolveMintCapabilities(req.Capabilities)
+	if err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 6. THE CREDENTIAL. Generated only now, after the last refusal, and held
+	// in memory alone: the insert takes the PREFIX and the HASH, never this.
+	// MUTATION M3 targets the two fields below.
+	secret, err := randomToken(32)
+	if err != nil {
+		return MintedConnection{}, fmt.Errorf("generate connection token: %w", err)
+	}
+	now := s.now().UTC()
+	tokenExpiry := now.Add(connectionTokenTTL)
+
+	grant, tok, err := s.store.CreateGrantWithToken(ctx, req.Principal,
+		sqlc.CreateMCPGrantParams{
+			TenantID:      req.Principal.TenantID,
+			Name:          name,
+			Status:        string(GrantStatusActive),
+			SiteScopeMode: string(req.SiteScope.Mode),
+			ScopeTagIds:   orEmpty(req.SiteScope.TagIDs),
+			ScopeSiteIds:  orEmpty(req.SiteScope.SiteIDs),
+
+			// NO client_id. A connection token has no RFC 7591 client behind
+			// it -- nothing registered, nothing to resolve -- and the column is
+			// nullable precisely so this path can say so. Inventing a
+			// synthetic client id here would put a registration in the row that
+			// no client ever performed, and the connections list renders
+			// client identity as the CLIENT's own unverified claim; a
+			// fabricated one would be rendered with the same weight as a real
+			// one. NULL is the honest answer and it is also the one that makes
+			// this path identifiable in the data.
+			ClientID:        nil,
+			CreatedByUserID: uuidToPG(req.Principal.UserID),
+
+			// m127's columns, ALL SUPPLIED EXPLICITLY, exactly as Approve
+			// supplies them. Two are NOT NULL with no default so a forgotten
+			// field is 23502 at the INSERT rather than an unrestricted or
+			// never-expiring connection.
+			Capabilities: capabilityNames(caps.Sorted()),
+			ExpiresAt:    now.Add(grantAbsoluteTTL),
+
+			// NULL means "never idle-expire" (m127 DECISION 4), and NULL is the
+			// answer rather than a placeholder. Nothing asks the operator for a
+			// window yet, and inventing one nobody chose is the credential-terms
+			// defect that column refuses to default.
+			IdleExpireAfterDays: nil,
+		},
+		func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams {
+			return sqlc.CreateMCPConnectionTokenParams{
+				TenantID: req.Principal.TenantID,
+				GrantID:  grantID,
+				// The PUBLIC handle and the HASH. hashCredential is the one
+				// construction this package uses -- lower-case hex SHA-256,
+				// matching the '^[0-9a-f]{64}$' CHECK and internal/apikey --
+				// and there is deliberately no second one.
+				TokenPrefix: secret[:tokenPrefixLen],
+				TokenHash:   hashCredential(secret),
+				Status:      string(GrantStatusActive),
+				ExpiresAt:   timestamptzAt(tokenExpiry),
+			}
+		},
+		// ActionMCPGrantCreated, in the SAME transaction as both inserts. If
+		// either insert or this append fails, the whole mint rolls back and
+		// there is no audit row for a grant that does not exist -- and,
+		// equally, no grant without the row that explains it.
+		func(tx pgx.Tx, gr sqlc.McpGrant) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   req.Principal.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    req.Principal.UserID.String(),
+				Action:     audit.ActionMCPGrantCreated,
+				TargetType: "mcp_grant",
+				TargetID:   gr.ID.String(),
+				Metadata: map[string]any{
+					"grant_name":      gr.Name,
+					"site_scope_mode": gr.SiteScopeMode,
+					// HOW the grant came to exist. The OAuth path and this one
+					// produce the same row shape, so without this an auditor
+					// cannot tell a browser-consented connection from a
+					// headless-minted one -- and they are authorised by
+					// different things, which is exactly what an audit log is
+					// for.
+					"issuance": "connection_token",
+					// The PUBLIC handle only. It carries no authentication
+					// weight, and it is what lets an operator match this audit
+					// row to a token in a config file. The plaintext is not
+					// here and must never be.
+					"token_prefix": secret[:tokenPrefixLen],
+				},
+			})
+			return aerr
+		})
+	if err != nil {
+		return MintedConnection{}, fmt.Errorf("mint mcp connection: %w", err)
+	}
+
+	return MintedConnection{
+		GrantID:       grant.ID,
+		Token:         secret, // once, here, never again
+		TokenPrefix:   tok.TokenPrefix,
+		ExpiresAt:     tokenExpiry,
+		SiteScopeMode: req.SiteScope.Mode,
+		Capabilities:  caps.Sorted(),
+	}, nil
+}
+
+// resolveMintCapabilities turns the operator's requested capability list into
+// the set that will be stored.
+//
+// AN EMPTY REQUEST MEANS THE ORGANISATION DEFAULT, NOT AN EMPTY SET, and the
+// difference is the whole function. mcp_grants.capabilities admits '{}' -- the
+// shape CHECK passes it, because '{}' is the RESTRICTIVE value -- so an empty
+// set is perfectly storable, and Authenticate then refuses the connection by
+// name on every request ("this connection holds no capability, so it can reach
+// no tool"). Writing one would therefore mint a credential that authenticates
+// and can never do anything, which m127 DECISION 3 says this boundary must not
+// be able to produce. The operator asking for nothing on the tool axis is an
+// ABSENCE, and absence here means "you did not narrow", not "narrow to zero".
+//
+// Note the asymmetry with the SITE axis and that it is deliberate: an empty
+// site scope is a coherent connection (it reads no sites, and may read some
+// tomorrow), whereas an empty capability set is a connection that cannot
+// function at all. The two axes are not symmetric because their empty values
+// mean different things.
+func (s *Service) resolveMintCapabilities(requested []Capability) (CapabilitySet, error) {
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	if err != nil {
+		return CapabilitySet{}, fmt.Errorf("resolve organisation capabilities: %w", err)
+	}
+	if len(requested) == 0 {
+		return ceiling, nil
+	}
+	// NarrowTo REFUSES anything the ceiling does not hold rather than dropping
+	// it. Dropping would be fail-closed and still wrong: the operator would be
+	// told they minted a connection with capabilities it does not have.
+	return ceiling.NarrowTo(requested)
+}
+
+// verifyScopeReferents refuses a scope payload naming an id that resolves to no
+// row in THIS organisation.
+//
+// WHY IT IS NOT "REFUSE IF THE SCOPE RESOLVES TO NO SITES". Those are two
+// different questions and conflating them breaks a rule the owner ruled on
+// directly. A grant scoped to a real tag that currently carries zero sites is
+// LEGITIMATE: it reads nothing today, it reads whatever gets tagged tomorrow,
+// and it must be ACCEPTED AND STORED AS GIVEN -- never refused, and above all
+// never widened to mode 'all' on the grounds that empty "must have been a
+// mistake". An empty allowlist is never every site, in either direction.
+//
+// What is NOT legitimate is an id that names nothing at all, because
+// scope_tag_ids and scope_site_ids are uuid[] columns with no foreign key and
+// therefore accept any UUID. That grant stores cleanly and then resolves to
+// zero sites FOREVER, indistinguishable from the legitimate case above. So:
+//
+//	real tag, zero sites today  -> accepted, stored as given   (empty scope)
+//	id naming no tag at all     -> refused, loudly, by id      (typo/foreign id)
+//
+// Distinguishing them is what makes the empty-scope acceptance safe. Without
+// this check, "accept empty" would also silently accept a typo.
+//
+// MUTATION M4 targets the tag arm; MUTATION M5 targets the acceptance above.
+func (s *Service) verifyScopeReferents(ctx context.Context, tenantID uuid.UUID, req SiteScopeRequest) error {
+	switch req.Mode {
+	case SiteScopeModeTags:
+		// The tenant's tag registry, read under tenant RLS. Tags are a small,
+		// unpaginated per-tenant set by construction (see the query's own note),
+		// so reading the registry and comparing in Go costs one round trip and
+		// needs no new statement.
+		known, err := s.store.ListTagIDs(ctx, tenantID)
+		if err != nil {
+			// A FAILED READ IS NOT AN EMPTY REGISTRY. Proceeding on an error
+			// here would refuse every tag as unknown, or -- worse, if the
+			// comparison were ever inverted -- accept every tag unchecked.
+			// Neither is an answer, so this is an infra error and the mint
+			// stops.
+			return fmt.Errorf("read tag registry for scope verification: %w", err)
+		}
+		for _, want := range req.TagIDs {
+			if !slices.Contains(known, want) {
+				return domain.Validation(ErrCodeUnknownScopeTag,
+					fmt.Sprintf("scope tag %s does not exist in this organisation", want)).
+					WithDetails(map[string]any{"unknown_tag_id": want.String()})
+			}
+		}
+		return nil
+
+	case SiteScopeModeList:
+		// Site ids are verified through the AUDITED CHOKEPOINT rather than a
+		// second query: ResolveScopeSites runs InTenantTx and joins through
+		// `sites`, so tenant RLS drops every foreign or non-existent id. Under
+		// mode 'list' the resolution is exactly the subset of the requested ids
+		// that exist here, so anything missing from the result names nothing.
+		//
+		// This arm has no empty-scope ambiguity to preserve: a site either
+		// exists in this tenant or it does not.
+		resolved, err := s.store.ResolveScopeSites(ctx, tenantID,
+			string(SiteScopeModeList), nil, req.SiteIDs)
+		if err != nil {
+			return fmt.Errorf("resolve site scope for verification: %w", err)
+		}
+		for _, want := range req.SiteIDs {
+			if !slices.Contains(resolved, want) {
+				return domain.Validation(ErrCodeUnknownScopeSite,
+					fmt.Sprintf("scope site %s does not exist in this organisation", want)).
+					WithDetails(map[string]any{"unknown_site_id": want.String()})
+			}
+		}
+		return nil
+
+	default:
+		// Mode 'all' names no ids, so there is nothing to verify. Any other
+		// value never reaches here: ValidateSiteScopeRequest refused it above.
+		return nil
+	}
+}
+
+// retryAfterSeconds renders a limiter wait as whole seconds, never below one.
+// A "retry after 0 seconds" tells a client to retry immediately into the same
+// refusal, which is a busy loop wearing the shape of advice.
+func retryAfterSeconds(d time.Duration) int {
+	secs := int(d.Seconds())
+	if secs < 1 {
+		return 1
+	}
+	return secs
+}

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -213,7 +213,6 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	//   2. THIS CALL.
 	//   3. mcp_grants_site_scope_insert, the RESTRICTIVE policy keyed on the
 	//      app.site_scope GUC that Repo's RunTenantTx sets.
-	// MUTATION M1 targets this line.
 	if err := requireOrgScopedPrincipal(req.Principal); err != nil {
 		return MintedConnection{}, err
 	}
@@ -223,7 +222,7 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	// service is limited, including a test harness -- a limiter that exists
 	// only in the route registration is one refactor away from being absent,
 	// which is the same reasoning Handler.Register gives for putting
-	// RequireOrgScope on the group. MUTATION M2 targets this block.
+	// RequireOrgScope on the group.
 	if ok, retryAfter := s.mintLimit.allow(mintLimiterKey(req.Principal.UserID)); !ok {
 		return MintedConnection{}, domain.RateLimited(ErrCodeMintRateLimited,
 			"too many connection tokens minted; retry shortly").
@@ -268,7 +267,6 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 
 	// 6. THE CREDENTIAL. Generated only now, after the last refusal, and held
 	// in memory alone: the insert takes the PREFIX and the HASH, never this.
-	// MUTATION M3 targets the two fields below.
 	secret, err := randomToken(32)
 	if err != nil {
 		return MintedConnection{}, fmt.Errorf("generate connection token: %w", err)
@@ -426,7 +424,6 @@ func (s *Service) resolveMintCapabilities(requested []Capability) (CapabilitySet
 // Distinguishing them is what makes the empty-scope acceptance safe. Without
 // this check, "accept empty" would also silently accept a typo.
 //
-// MUTATION M4 targets the tag arm; MUTATION M5 targets the acceptance above.
 func (s *Service) verifyScopeReferents(ctx context.Context, tenantID uuid.UUID, req SiteScopeRequest) error {
 	switch req.Mode {
 	case SiteScopeModeTags:

--- a/apps/api/internal/mcp/mint_test.go
+++ b/apps/api/internal/mcp/mint_test.go
@@ -1,0 +1,547 @@
+package mcp
+
+// Unit proofs for the connection-token mint. Everything here runs against
+// fakeStore, so it proves the GO branch structure and the payload that reaches
+// the INSERT -- never the RLS, which no fake can evaluate. The RLS half is
+// proved in apps/api/tests as wpmgr_app.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// mintRouter mounts the connections group with its REAL middleware and injects
+// a principal, the same shape newConnectionsRouter uses.
+func mintRouter(t *testing.T, store Store, p domain.Principal) *http.Handler {
+	t.Helper()
+	eng := newConnectionsRouter(t, store, p)
+	var h http.Handler = eng
+	return &h
+}
+
+// postMint sends a mint request and returns status plus the decoded body.
+func postMint(t *testing.T, h http.Handler, body map[string]any) (int, map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, APIV1Prefix+connectionsGroupPath, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	out := map[string]any{}
+	if rec.Body.Len() > 0 {
+		// A body that will not decode is a finding, not something to skip:
+		// every response on this surface is JSON by contract.
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode response (status %d): %v\nbody: %s", rec.Code, err, rec.Body.String())
+		}
+	}
+	return rec.Code, out
+}
+
+func mintService(store Store) *Service { return NewService(store) }
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- A SITE-SCOPED COLLABORATOR IS REFUSED, AND THE REFUSAL IS SAYABLE.
+//
+// This is the live production defect's shape on the sibling path: one
+// self-registered client and one POST minted an organisation-wide grant for a
+// principal shared onto a single site. The gate must refuse, it must say so
+// (never an empty success), and NOTHING MAY BE WRITTEN.
+// ---------------------------------------------------------------------------
+
+func TestMintRefusesASiteScopedCollaborator(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: siteScopedPrincipal(tenant),
+		Name:      "ci-runner",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+	})
+	if err == nil {
+		t.Fatal("a site-scoped collaborator minted an organisation-wide connection token")
+	}
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) {
+		t.Fatalf("want a typed domain refusal, got %T: %v", err, err)
+	}
+	if domErr.Code != ErrCodeOrgScopeRequired {
+		t.Fatalf("want code %q, got %q (%s)", ErrCodeOrgScopeRequired, domErr.Code, domErr.Message)
+	}
+	if domain.HTTPStatus(domErr) != http.StatusForbidden {
+		t.Fatalf("want 403 for a refused collaborator, got %d", domain.HTTPStatus(domErr))
+	}
+
+	// NOTHING WAS WRITTEN. A refusal that still reached the store would mean
+	// the grant exists and only the response was refused.
+	for _, call := range store.callLog() {
+		if call == "CreateGrantWithToken" {
+			t.Fatal("the store was reached despite the refusal: a grant was written for a refused principal")
+		}
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants minted, got %d", len(store.minted))
+	}
+}
+
+// The same refusal through the MOUNTED ROUTE, so the permission middleware and
+// the service refusal are both exercised. A gate that holds in the service and
+// is bypassed by the handler guards nothing.
+func TestMintRefusesASiteScopedCollaboratorThroughTheMountedRoute(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	h := mintRouter(t, store, siteScopedPrincipal(tenant))
+
+	status, body := postMint(t, *h, map[string]any{
+		"name": "ci-runner", "site_scope_mode": "all",
+	})
+	if status != http.StatusForbidden {
+		t.Fatalf("want 403 through the mounted route, got %d (body %v)", status, body)
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants minted, got %d", len(store.minted))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- THE PLAINTEXT IS RETURNED ONCE AND IS NEVER STORED OR LOGGED.
+// ---------------------------------------------------------------------------
+
+func TestMintReturnsThePlaintextOnceAndStoresOnlyTheHash(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	out, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "  headless-ci  ", // trimmed by the service
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if out.Token == "" {
+		t.Fatal("no plaintext returned: the caller has no credential")
+	}
+	if len(store.minted) != 1 {
+		t.Fatalf("want exactly 1 mint, got %d", len(store.minted))
+	}
+	got := store.minted[0]
+
+	if got.Grant.Name != "headless-ci" {
+		t.Fatalf("name not trimmed: %q", got.Grant.Name)
+	}
+
+	// THE PLAINTEXT IS NOT IN THE ROW. Checked against every string field the
+	// INSERT carries, not merely against token_hash: a future field that
+	// captured it would be just as bad.
+	if got.Token.TokenHash == out.Token {
+		t.Fatal("the PLAINTEXT was stored in token_hash")
+	}
+	if got.Token.TokenHash != hashCredential(out.Token) {
+		t.Fatalf("token_hash is not the SHA-256 of the plaintext:\n got %q\nwant %q",
+			got.Token.TokenHash, hashCredential(out.Token))
+	}
+	if !isLowerHex64(got.Token.TokenHash) {
+		t.Fatalf("token_hash %q does not satisfy the column's '^[0-9a-f]{64}$' CHECK", got.Token.TokenHash)
+	}
+
+	// The PREFIX is the public handle and is a genuine prefix of the
+	// plaintext -- that is what makes it match a token in a config file. It is
+	// short enough to carry no authentication weight.
+	if got.Token.TokenPrefix != out.Token[:tokenPrefixLen] {
+		t.Fatalf("token_prefix %q is not the plaintext's first %d bytes",
+			got.Token.TokenPrefix, tokenPrefixLen)
+	}
+	if len(got.Token.TokenPrefix) >= len(out.Token) {
+		t.Fatal("token_prefix is the whole credential, so it is not a handle")
+	}
+	if got.Token.TokenPrefix != out.TokenPrefix {
+		t.Fatalf("returned prefix %q disagrees with the stored one %q", out.TokenPrefix, got.Token.TokenPrefix)
+	}
+	if !got.Token.ExpiresAt.Valid {
+		t.Fatal("expires_at was written NULL: this token would never expire")
+	}
+}
+
+// The plaintext must not reach a log. This drives the MOUNTED ROUTE with a
+// slog handler capturing everything at DEBUG and greps the captured bytes.
+func TestMintDoesNotEmitThePlaintextToLogsOrTheURL(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+
+	var logs bytes.Buffer
+	// Captures EVERYTHING, including debug: a leak that only appears at debug
+	// level is still a leak, and this is the level at which one would appear.
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	h := mintRouter(t, store, orgPrincipal(tenant))
+	status, body := postMint(t, *h, map[string]any{
+		"name": "headless-ci", "site_scope_mode": "all",
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("want 201, got %d (body %v)", status, body)
+	}
+
+	token, _ := body["token"].(string)
+	if token == "" {
+		t.Fatalf("no token in the response body: %v", body)
+	}
+
+	// ONCE IN THE BODY. The body is the only place it may appear.
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("re-marshal body: %v", err)
+	}
+	if n := strings.Count(string(raw), token); n != 1 {
+		t.Fatalf("the plaintext appears %d times in the response body, want exactly 1", n)
+	}
+
+	// NOWHERE IN THE LOGS.
+	if strings.Contains(logs.String(), token) {
+		t.Fatalf("THE PLAINTEXT WAS LOGGED:\n%s", logs.String())
+	}
+
+	// The guard must be able to fail. If the token were a substring of
+	// something universally present the assertion above would be vacuous, so
+	// prove the buffer search actually finds a planted needle.
+	logs.WriteString("planted-needle-" + token)
+	if !strings.Contains(logs.String(), token) {
+		t.Fatal("the log search cannot find a string that IS in the buffer; the previous assertion was vacuous")
+	}
+}
+
+// isLowerHex64 mirrors the '^[0-9a-f]{64}$' CHECK on every hash column.
+func isLowerHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- THE RATE LIMIT BITES, AND IT IS PER OPERATOR.
+// ---------------------------------------------------------------------------
+
+func TestMintIsRateLimitedPerOperator(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+	victim := orgPrincipal(tenant)
+
+	mint := func(p domain.Principal) error {
+		_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+			Principal: p, Name: "ci", SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+		})
+		return err
+	}
+
+	// The per-user budget, spent exactly.
+	for i := 0; i < MintPerUserPerMin; i++ {
+		if err := mint(victim); err != nil {
+			t.Fatalf("mint %d of the per-user budget failed: %v", i+1, err)
+		}
+	}
+	// One more must be refused. This is the assertion the whole limiter exists
+	// for: one stolen session must not become an unbounded number of long-lived
+	// bearer credentials.
+	err := mint(victim)
+	if err == nil {
+		t.Fatalf("the %dth mint succeeded: the per-user budget of %d is not enforced",
+			MintPerUserPerMin+1, MintPerUserPerMin)
+	}
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) || domErr.Code != ErrCodeMintRateLimited {
+		t.Fatalf("want %q, got %v", ErrCodeMintRateLimited, err)
+	}
+	if domain.HTTPStatus(domErr) != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d", domain.HTTPStatus(domErr))
+	}
+
+	// A REFUSED MINT WROTE NOTHING. The count must be exactly the budget.
+	if len(store.minted) != MintPerUserPerMin {
+		t.Fatalf("want %d grants written, got %d: a refused mint still wrote",
+			MintPerUserPerMin, len(store.minted))
+	}
+
+	// AND IT DOES NOT OVER-FIRE: a DIFFERENT operator in the same organisation
+	// is unaffected. A limiter that refuses honest work gets switched off.
+	other := orgPrincipal(tenant)
+	if err := mint(other); err != nil {
+		t.Fatalf("a different operator was refused by the first operator's budget: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 4 -- AN UNRESOLVABLE TAG IS REFUSED, LOUDLY AND BY ID.
+//
+// scope_tag_ids is a uuid[] with no foreign key, so the database accepts any
+// UUID at all. A tag id that names nothing therefore stores cleanly and then
+// resolves to zero sites forever -- silently narrowing the scope to nothing,
+// indistinguishable from a deliberately narrow connection.
+// ---------------------------------------------------------------------------
+
+func TestMintRefusesATagIDThatNamesNoTag(t *testing.T) {
+	tenant := uuid.New()
+	known := uuid.New()
+	ghost := uuid.New()
+	store := &fakeStore{tagIDs: []uuid.UUID{known}}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "ci",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{known, ghost}},
+	})
+	if err == nil {
+		t.Fatal("a tag id naming no tag was accepted: the grant's scope is silently narrowed to nothing")
+	}
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) || domErr.Code != ErrCodeUnknownScopeTag {
+		t.Fatalf("want %q, got %v", ErrCodeUnknownScopeTag, err)
+	}
+	// THE REFUSAL NAMES THE ID. A refusal that does not say which tag is
+	// unfixable by the operator who sent it.
+	if !strings.Contains(domErr.Message, ghost.String()) {
+		t.Fatalf("the refusal does not name the offending id %s: %q", ghost, domErr.Message)
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants written, got %d", len(store.minted))
+	}
+}
+
+// A FAILED REGISTRY READ IS NOT AN EMPTY REGISTRY. Proceeding on the error
+// would refuse every tag as unknown -- an infra failure wearing a 422, which
+// sends the operator to fix a tag that is fine.
+func TestMintTreatsAFailedTagRegistryReadAsInfraNotAsAnUnknownTag(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{tagIDsErr: errors.New("database is down")}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "ci",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{uuid.New()}},
+	})
+	if err == nil {
+		t.Fatal("a failed registry read produced a successful mint")
+	}
+	var domErr *domain.Error
+	if errors.As(err, &domErr) {
+		t.Fatalf("an infra failure was reported as the typed domain error %q: %v", domErr.Code, err)
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants written, got %d", len(store.minted))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 5 -- AN EMPTY SCOPE IS ACCEPTED AND STORED AS EMPTY, NEVER WIDENED.
+//
+// A real tag that carries zero sites today is a LEGITIMATE thing to mint: the
+// connection reads nothing now and reads whatever gets tagged later. The owner's
+// ruling on the 2026-08-24 wireframes is explicit that this must be accepted.
+// It must NOT be refused for resolving to nothing, and above all it must not be
+// widened to mode 'all' on the theory that empty "must have been a mistake".
+// ---------------------------------------------------------------------------
+
+func TestMintAcceptsATagThatResolvesToNoSitesAndStoresItAsGiven(t *testing.T) {
+	tenant := uuid.New()
+	emptyTag := uuid.New()
+	store := &fakeStore{
+		tagIDs: []uuid.UUID{emptyTag}, // the tag EXISTS
+		// ...and resolves to NO SITES. This is the state under test.
+		scopeSites: nil,
+	}
+	svc := mintService(store)
+
+	out, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "reads-nothing-yet",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{emptyTag}},
+	})
+	if err != nil {
+		t.Fatalf("a real tag carrying zero sites was refused: %v", err)
+	}
+	if out.Token == "" {
+		t.Fatal("no token returned")
+	}
+	if len(store.minted) != 1 {
+		t.Fatalf("want 1 mint, got %d", len(store.minted))
+	}
+	got := store.minted[0].Grant
+
+	// NEVER WIDENED. The mode and the payload are exactly what was asked for.
+	if got.SiteScopeMode != string(SiteScopeModeTags) {
+		t.Fatalf("the scope was WIDENED: stored mode %q, want %q", got.SiteScopeMode, SiteScopeModeTags)
+	}
+	if len(got.ScopeTagIds) != 1 || got.ScopeTagIds[0] != emptyTag {
+		t.Fatalf("the tag payload was not stored as given: %v", got.ScopeTagIds)
+	}
+	if len(got.ScopeSiteIds) != 0 {
+		t.Fatalf("sites appeared in a 'tags' grant: %v", got.ScopeSiteIds)
+	}
+	if out.SiteScopeMode != SiteScopeModeTags {
+		t.Fatalf("the response reports mode %q, want %q", out.SiteScopeMode, SiteScopeModeTags)
+	}
+}
+
+// The STRUCTURAL rules are unchanged: an empty allowlist is still not a way to
+// ask for every site, in either scoped mode. This is the guard against reading
+// the acceptance above too broadly.
+func TestMintKeepsTheStructuralEmptyAllowlistRefusals(t *testing.T) {
+	tenant := uuid.New()
+	for _, tc := range []struct {
+		name  string
+		scope SiteScopeRequest
+	}{
+		{"tags mode naming no tags", SiteScopeRequest{Mode: SiteScopeModeTags}},
+		{"list mode naming no sites", SiteScopeRequest{Mode: SiteScopeModeList}},
+		{"absent mode", SiteScopeRequest{}},
+		{"unrecognised mode", SiteScopeRequest{Mode: SiteScopeMode("everything")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeStore{}
+			svc := mintService(store)
+			_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+				Principal: orgPrincipal(tenant), Name: "ci", SiteScope: tc.scope,
+			})
+			if err == nil {
+				t.Fatal("accepted: an empty or absent site scope was read as a valid grant")
+			}
+			var domErr *domain.Error
+			if !errors.As(err, &domErr) || domErr.Code != ErrCodeInvalidSiteScope {
+				t.Fatalf("want %q, got %v", ErrCodeInvalidSiteScope, err)
+			}
+			if len(store.minted) != 0 {
+				t.Fatalf("want 0 grants written, got %d", len(store.minted))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 6 -- CAPABILITIES. An omitted list is the org default, never an empty
+// set; a capability wider than the ceiling is REFUSED rather than dropped.
+// ---------------------------------------------------------------------------
+
+func TestMintNeverStoresAnEmptyCapabilitySet(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	if _, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant), Name: "ci",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+		// No capabilities named at all.
+	}); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	got := store.minted[0].Grant
+	if len(got.Capabilities) == 0 {
+		t.Fatal("an EMPTY capability set was stored: this connection would authenticate and reach no tool")
+	}
+	want := capabilityNames(DefaultGrantCapabilities())
+	if len(got.Capabilities) != len(want) {
+		t.Fatalf("stored capabilities %v, want the org default %v", got.Capabilities, want)
+	}
+}
+
+func TestMintRefusesACapabilityWiderThanTheOrgDefault(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant), Name: "ci",
+		SiteScope:    SiteScopeRequest{Mode: SiteScopeModeAll},
+		Capabilities: []Capability{Capability("mcp.sites.write")},
+	})
+	if err == nil {
+		t.Fatal("a capability the organisation does not hold was accepted")
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants written, got %d", len(store.minted))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 7 -- THE WHOLE PRINCIPAL REACHES THE STORE.
+//
+// The store method takes a principal and not a tenant id precisely because
+// db.RunTenantTx dispatches on it: flattening it here would leave the
+// site-scope GUC unset and the RESTRICTIVE insert policy inert, and everything
+// would still compile and still pass.
+// ---------------------------------------------------------------------------
+
+func TestMintHandsTheWholePrincipalToTheStore(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+	p := orgPrincipal(tenant)
+
+	if _, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: p, Name: "ci", SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+	}); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if store.grantPrincipal == nil {
+		t.Fatal("no principal reached the store: the site-scope dispatch has nothing to key on")
+	}
+	if store.grantPrincipal.GetTenantID() != tenant {
+		t.Fatalf("store got tenant %s, want %s", store.grantPrincipal.GetTenantID(), tenant)
+	}
+	if store.grantPrincipal.GetUserID() != p.UserID {
+		t.Fatalf("store got user %s, want %s: app.user_id would be wrong for the audit hash chain",
+			store.grantPrincipal.GetUserID(), p.UserID)
+	}
+	// The created_by column must name the operator, not NULL.
+	if !store.minted[0].Grant.CreatedByUserID.Valid {
+		t.Fatal("created_by_user_id was written NULL: this credential is unattributable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 8 -- THE ROUTE EXISTS AND THE WRONG VERB SAYS SO.
+//
+// A 404 on this path reads as "not deployed", which is exactly how the S6b-2
+// blocker presented and cost a debugging session.
+// ---------------------------------------------------------------------------
+
+func TestMintRouteAnswers405AndNot404OnAWrongVerb(t *testing.T) {
+	h := mintRouter(t, &fakeStore{}, orgPrincipal(uuid.New()))
+	req := httptest.NewRequest(http.MethodDelete, APIV1Prefix+connectionsGroupPath, nil)
+	rec := httptest.NewRecorder()
+	(*h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405 on DELETE, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	if !strings.Contains(allow, http.MethodPost) || !strings.Contains(allow, http.MethodGet) {
+		t.Fatalf("Allow header %q does not name both supported verbs", allow)
+	}
+}

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -141,6 +141,23 @@ type fakeStore struct {
 	// listPrincipals does the same for the list path.
 	listPrincipals []domain.Principal
 
+	// The headless mint surface.
+	//
+	// minted captures every CreateGrantWithToken call WHOLE (principal, grant
+	// params, token params), because the properties this endpoint has to hold
+	// are properties of what reached the INSERT: that the token row carries a
+	// hash and a prefix and not the plaintext, that the scope arrays were
+	// stored as given rather than widened, and that the principal was not
+	// flattened on the way down. mintErr forces the write itself to fail.
+	minted  []mintedGrant
+	mintErr error
+
+	// tagIDs is the tenant's tag registry and tagIDsErr forces the read to
+	// fail. Independent, so "the registry is empty" and "the registry could not
+	// be read" are separately reachable.
+	tagIDs    []uuid.UUID
+	tagIDsErr error
+
 	// call log. mu guards all four -- see note().
 	mu           sync.Mutex
 	consumeCalls int
@@ -284,6 +301,77 @@ func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPr
 		}
 	}
 	return grant, sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
+}
+
+// mintedGrant is one captured CreateGrantWithToken call. The TOKEN PARAMS are
+// captured whole, so a test can assert what was actually sent to the INSERT --
+// which is the only way to prove the plaintext was not among it.
+type mintedGrant struct {
+	Principal db.ScopedPrincipal
+	Grant     sqlc.CreateMCPGrantParams
+	Token     sqlc.CreateMCPConnectionTokenParams
+}
+
+// CreateGrantWithToken records the principal and BOTH parameter sets.
+//
+// Like CreateGrantWithCode, THIS FAKE CANNOT PROVE THE RLS: it runs no
+// transaction and evaluates no policy. What it pins is the plumbing and the
+// PAYLOAD -- that the scope-carrying principal reaches the store rather than
+// being flattened to a tenant id, and that the token row carries a hash and a
+// prefix and never the plaintext. The policy itself is proved in tests/, as
+// wpmgr_app.
+func (f *fakeStore) CreateGrantWithToken(
+	_ context.Context,
+	principal db.ScopedPrincipal,
+	g sqlc.CreateMCPGrantParams,
+	mkToken func(uuid.UUID) sqlc.CreateMCPConnectionTokenParams,
+	onCreated func(pgx.Tx, sqlc.McpGrant) error,
+) (sqlc.McpGrant, sqlc.McpConnectionToken, error) {
+	f.note("CreateGrantWithToken")
+	if f.mintErr != nil {
+		return sqlc.McpGrant{}, sqlc.McpConnectionToken{}, f.mintErr
+	}
+	id := uuid.New()
+	tp := mkToken(id)
+
+	f.mu.Lock()
+	f.grantPrincipal = principal
+	f.minted = append(f.minted, mintedGrant{Principal: principal, Grant: g, Token: tp})
+	f.tokensMinted++
+	f.mu.Unlock()
+
+	grant := sqlc.McpGrant{
+		ID: id, TenantID: g.TenantID, Name: g.Name,
+		Status: g.Status, SiteScopeMode: g.SiteScopeMode,
+		ScopeTagIds: g.ScopeTagIds, ScopeSiteIds: g.ScopeSiteIds,
+		Capabilities: g.Capabilities,
+	}
+	// No real tx, same reasoning as CreateGrantWithCode: MintConnection's
+	// callback checks s.audit == nil before touching tx, and no test in this
+	// package wires WithAudit.
+	if onCreated != nil {
+		if err := onCreated(nil, grant); err != nil {
+			return sqlc.McpGrant{}, sqlc.McpConnectionToken{}, err
+		}
+	}
+	return grant, sqlc.McpConnectionToken{
+		ID: uuid.New(), TenantID: tp.TenantID, GrantID: tp.GrantID,
+		TokenPrefix: tp.TokenPrefix, TokenHash: tp.TokenHash, Status: tp.Status,
+	}, nil
+}
+
+// ListTagIDs models the tenant tag registry.
+//
+// tagIDsErr is separate from an empty tagIDs so a test can drive "the registry
+// read FAILED" apart from "this organisation has no tags" -- the pair this
+// package keeps apart everywhere else, and the pair that decides whether an
+// unknown-tag refusal is honest or is an infra failure wearing a 422.
+func (f *fakeStore) ListTagIDs(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	f.note("ListTagIDs")
+	if f.tagIDsErr != nil {
+		return nil, f.tagIDsErr
+	}
+	return f.tagIDs, nil
 }
 
 func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -51,6 +51,32 @@ type Store interface {
 	// exactly as an error from either insert would. May be nil.
 	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
 
+	// CreateGrantWithToken is CreateGrantWithCode's headless sibling: it mints
+	// the grant and its FIRST CONNECTION TOKEN in one transaction, for the
+	// non-OAuth path where no authorization code ever exists.
+	//
+	// It takes the principal for the identical reason, and the reason is the
+	// whole security boundary: only db.Pool.RunTenantTx sets app.site_scope,
+	// and mcp_grants_site_scope_insert is a RESTRICTIVE policy keyed on that
+	// GUC. A method taking a bare tenant id could only reach InTenantTx, which
+	// leaves the policy inert -- and this path writes a LONG-LIVED BEARER
+	// CREDENTIAL, so an inert insert policy here is strictly worse than on the
+	// consent path.
+	//
+	// onCreated runs INSIDE the same transaction, after both inserts, so
+	// Service.MintConnection can append ActionMCPGrantCreated over the SAME tx.
+	// An error from it rolls both inserts back, so there is never a live token
+	// whose grant has no audit row. May be nil.
+	CreateGrantWithToken(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkToken func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpConnectionToken, error)
+
+	// ListTagIDs returns every tag id in the tenant's registry.
+	//
+	// It exists so the mint path can REFUSE a scope tag id that names nothing,
+	// which no CHECK can do: scope_tag_ids is a uuid[] and PostgreSQL has no
+	// foreign key over array elements. See verifyScopeReferents for why this
+	// question is not the same as "does the scope resolve to any sites".
+	ListTagIDs(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error)
+
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
 	ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error)
@@ -307,6 +333,96 @@ func (r *Repo) CreateGrantWithCode(
 		return nil
 	})
 	return grant, code, err
+}
+
+// CreateGrantWithToken mints the grant and its first connection token in ONE
+// transaction, through RunTenantTx.
+//
+// RunTenantTx, NOT InTenantTx, for exactly the reason CreateGrantWithCode gives
+// above it: InScopedTenantTx is the only helper that sets app.site_scope, and
+// the RESTRICTIVE mcp_grants_site_scope_insert policy keys on that GUC. Picking
+// a helper here instead of dispatching on the principal is how a call site
+// silently falls outside the site-scope RLS -- and this one writes a bearer
+// credential that outlives the session that asked for it.
+//
+// THE TWO WRITES ARE ONE TRANSACTION and there is deliberately no way to
+// express half. A grant with no token is a connection an operator sees in the
+// list and can never use; a token with no grant is a credential
+// ReCheckAuthorization refuses on every request with nothing to explain it.
+// Both are states a two-commit version can leave behind after a crash, which is
+// the same argument RedeemAuthorizationCode makes for its own single
+// transaction.
+func (r *Repo) CreateGrantWithToken(
+	ctx context.Context,
+	principal db.ScopedPrincipal,
+	g sqlc.CreateMCPGrantParams,
+	mkToken func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams,
+	onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error,
+) (sqlc.McpGrant, sqlc.McpConnectionToken, error) {
+	var (
+		grant sqlc.McpGrant
+		token sqlc.McpConnectionToken
+	)
+	// Same guard as CreateGrantWithCode: a transaction scoped to one tenant
+	// while the INSERT names another is a row belonging to neither, and RLS
+	// would refuse it as a 42501 three frames down. Saying so here is one line.
+	if principal.GetTenantID() != g.TenantID {
+		return grant, token, fmt.Errorf(
+			"create mcp grant: principal tenant %s does not match grant tenant %s",
+			principal.GetTenantID(), g.TenantID)
+	}
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		q := sqlc.New(tx)
+		gr, err := q.CreateMCPGrant(ctx, g)
+		if err != nil {
+			return fmt.Errorf("create mcp grant: %w", err)
+		}
+		tk, err := q.CreateMCPConnectionToken(ctx, mkToken(gr.ID))
+		if err != nil {
+			// Rolls the grant insert back with it, so a failed mint leaves no
+			// half-built connection behind.
+			return fmt.Errorf("create mcp connection token: %w", err)
+		}
+		if onCreated != nil {
+			if err := onCreated(tx, gr); err != nil {
+				return err
+			}
+		}
+		grant, token = gr, tk
+		return nil
+	})
+	return grant, token, err
+}
+
+// ListTagIDs reads the tenant's tag registry inside InTenantTx, so `site_tags`
+// RLS scopes it to this organisation and a foreign tag can never appear in the
+// result a scope id is checked against.
+//
+// It returns ONLY the ids. The mint path asks one question of this registry --
+// "does this id name a tag here" -- and returning the whole row would invite a
+// caller to answer some other question from data it did not scope for.
+//
+// nil on error, never an empty slice: an empty registry and a failed read must
+// not be confusable, because the caller compares scope ids against this list
+// and an empty list would make every tag look unknown.
+func (r *Repo) ListTagIDs(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error) {
+	var out []uuid.UUID
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := sqlc.New(tx).ListTagsWithUsage(ctx, tenantID)
+		if err != nil {
+			return fmt.Errorf("list tag registry: %w", err)
+		}
+		ids := make([]uuid.UUID, 0, len(rows))
+		for _, row := range rows {
+			ids = append(ids, row.ID)
+		}
+		out = ids
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // LookupConnectionToken resolves a bearer token by hash under
@@ -603,6 +719,17 @@ func nullableText(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// timestamptzAt wraps a time as a VALID pgtype.Timestamptz.
+//
+// It exists so a mint cannot pass a zero-value Timestamptz by omission: that
+// value has Valid=false, which is SQL NULL, and expires_at is the column that
+// decides when a bearer credential dies. A NULL there is a never-expiring
+// token, so the conversion is written once, named, rather than open-coded at
+// each call site where the Valid flag can be forgotten.
+func timestamptzAt(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t, Valid: true}
 }
 
 // uuidToPG converts a uuid to the pgtype form CreateMCPGrantParams wants,

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -204,10 +204,30 @@ type Service struct {
 	// one is ever found is "this deploy path is unattributable", not "make the
 	// nil check quieter".
 	audit *audit.Recorder
+
+	// mintLimit bounds POST /api/v1/mcp/connections. It lives on the SERVICE
+	// and not on the Handler, unlike Handler.regLimit, and the placement is
+	// deliberate: /register is unauthenticated so its limiter can only key on
+	// the transport (RemoteIP), which only the handler can see, whereas this
+	// one keys on the authenticated operator and is therefore expressible at
+	// the service layer -- where every mount of MintConnection is covered,
+	// including a test harness that forgot the middleware.
+	//
+	// Never nil after NewService. registrationLimiter.allow refuses on a nil
+	// receiver anyway, so a Service built by a struct literal that skipped it
+	// mints NOTHING rather than minting unlimited.
+	mintLimit *registrationLimiter
 }
 
 func NewService(store Store) *Service {
-	return &Service{store: store, now: time.Now}
+	return &Service{
+		store: store,
+		now:   time.Now,
+		// Armed HERE rather than injected with a nil default, for the reason
+		// NewHandler gives about its own limiter: an unarmed limiter would be a
+		// wiring failure that presents as a working endpoint.
+		mintLimit: newMintLimiter(),
+	}
 }
 
 // WithClock returns a copy using the supplied clock. Test-only in practice.

--- a/apps/api/tests/mcp_connection_token_mint_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_integration_test.go
@@ -1,0 +1,476 @@
+package tests
+
+// Integration proofs for the connection-token mint: the DOCUMENTED HEADLESS
+// PATH (POST /api/v1/mcp/connections).
+//
+// EVERYTHING HERE RUNS AS wpmgr_app, THROUGH THE POOL, THROUGH THE MOUNTED
+// ROUTE. That is the whole reason this file exists alongside the package's unit
+// proofs: a fake store evaluates no policy and a test that opens its own
+// connection leaves every RLS policy inert while staying green, which is
+// exactly how m112's proofs passed over a cross-site-readable domain. The
+// credential minted here is authenticated back through mcp.Service.Authenticate
+// -- the same call the live transport makes on every request.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/sitetag"
+)
+
+// mintPath is the route under test, built from the package's own constants so
+// this file cannot drift from the mount.
+const mintPath = mcp.APIV1Prefix + "/mcp/connections"
+
+// mintResponse is the 201 body. `token` is decoded into a plain string rather
+// than skipped, because the point of every test below is what that string can
+// then do.
+type mintResponse struct {
+	GrantID       string   `json:"grant_id"`
+	Token         string   `json:"token"`
+	TokenPrefix   string   `json:"token_prefix"`
+	ExpiresAt     string   `json:"expires_at"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	Capabilities  []string `json:"capabilities"`
+}
+
+// TestMCPMintedTokenAuthenticatesAndIsTenantBoundAsAppRole is the end-to-end
+// proof: mint through the mounted route, authenticate the returned plaintext
+// through the production dispatch, and prove the credential reaches its own
+// organisation and nothing else.
+func TestMCPMintedTokenAuthenticatesAndIsTenantBoundAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// THE ROLE IS LOAD-BEARING FOR EVERY ASSERTION BELOW. Printed, not
+	// assumed: a proof running as superuser or BYPASSRLS would pass with every
+	// policy switched off.
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open token lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+
+	// TWO ORGANISATIONS. The second is not decoration: a token that
+	// authenticates is only interesting alongside proof that it authenticates
+	// NOTHING next door.
+	tenantA := seedTenant(t, pool, "mcp-mint-a-"+suffix)
+	tenantB := seedTenant(t, pool, "mcp-mint-b-"+suffix)
+	userA := seedUserRow(t, pool, "mint-a-"+suffix+"@example.test")
+	userB := seedUserRow(t, pool, "mint-b-"+suffix+"@example.test")
+
+	siteAURL := "https://a-" + suffix + ".example.test"
+	siteBURL := "https://b-" + suffix + ".example.test"
+	seedSite(t, pool, tenantA, siteAURL)
+	seedSite(t, pool, tenantB, siteBURL)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	adminA := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+	adminB := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userB, TenantID: tenantB,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+	engA := mountConnectionsLikeProduction(t, svc, adminA)
+	engB := mountConnectionsLikeProduction(t, svc, adminB)
+
+	// ------------------------------------------------------------------
+	// MINT, through the mounted route with its real RequirePermission.
+	// ------------------------------------------------------------------
+	var mintedA mintResponse
+	if code := mcpDoJSON(t, engA, http.MethodPost, mintPath, map[string]any{
+		"name":            "headless ci runner",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &mintedA); code != http.StatusCreated {
+		t.Fatalf("mint answered %d, want 201", code)
+	}
+	if mintedA.Token == "" {
+		t.Fatal("the mint returned no plaintext: there is no credential to use")
+	}
+	if mintedA.TokenPrefix == "" || !strings.HasPrefix(mintedA.Token, mintedA.TokenPrefix) {
+		t.Fatalf("token_prefix %q is not a prefix of the plaintext", mintedA.TokenPrefix)
+	}
+	if len(mintedA.Capabilities) == 0 {
+		t.Fatal("the grant was minted with NO capabilities: it would authenticate and reach no tool")
+	}
+
+	// ------------------------------------------------------------------
+	// THE CREDENTIAL WORKS, through the same call the transport makes.
+	// ------------------------------------------------------------------
+	authA, err := svc.Authenticate(ctx, mintedA.Token)
+	if err != nil {
+		t.Fatalf("the minted token does not authenticate: %v", err)
+	}
+	if authA.TenantID != tenantA {
+		t.Fatalf("token resolved to tenant %s, want %s", authA.TenantID, tenantA)
+	}
+	if authA.GrantID.String() != mintedA.GrantID {
+		t.Fatalf("token resolved to grant %s, want %s", authA.GrantID, mintedA.GrantID)
+	}
+	if authA.Sites.IsEmpty() {
+		t.Fatal("a site_scope_mode='all' grant resolved to no sites")
+	}
+
+	// ------------------------------------------------------------------
+	// ONLY THE HASH IS STORED. Read back as wpmgr_app inside InTenantTx --
+	// the same transaction shape the request path uses.
+	// ------------------------------------------------------------------
+	assertNoPlaintextStored(t, pool, tenantA, authA.GrantID, mintedA.Token, mintedA.TokenPrefix)
+
+	// ------------------------------------------------------------------
+	// CROSS-TENANT. Tenant B mints its own token; neither reaches the other.
+	// ------------------------------------------------------------------
+	var mintedB mintResponse
+	if code := mcpDoJSON(t, engB, http.MethodPost, mintPath, map[string]any{
+		"name":            "tenant b runner",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &mintedB); code != http.StatusCreated {
+		t.Fatalf("tenant B mint answered %d, want 201", code)
+	}
+	authB, err := svc.Authenticate(ctx, mintedB.Token)
+	if err != nil {
+		t.Fatalf("tenant B's token does not authenticate: %v", err)
+	}
+	if authB.TenantID != tenantB {
+		t.Fatalf("tenant B's token resolved to tenant %s, want %s", authB.TenantID, tenantB)
+	}
+
+	// The load-bearing half: A's credential must reach A's fleet and NOT B's.
+	// Asserted on the rendered tool output, which is what a model would
+	// actually receive.
+	readA, err := svc.ListSitesForModel(ctx, authA)
+	if err != nil {
+		t.Fatalf("list sites under tenant A's token: %v", err)
+	}
+	if !strings.Contains(readA, siteAURL) {
+		t.Fatalf("tenant A's token cannot see tenant A's own site %s:\n%s", siteAURL, readA)
+	}
+	if strings.Contains(readA, siteBURL) {
+		t.Fatalf("CROSS-TENANT READ: tenant A's token saw tenant B's site %s:\n%s", siteBURL, readA)
+	}
+
+	readB, err := svc.ListSitesForModel(ctx, authB)
+	if err != nil {
+		t.Fatalf("list sites under tenant B's token: %v", err)
+	}
+	if strings.Contains(readB, siteAURL) {
+		t.Fatalf("CROSS-TENANT READ: tenant B's token saw tenant A's site %s:\n%s", siteAURL, readB)
+	}
+
+	// Tenant B's grant is invisible to tenant A's connections list, and vice
+	// versa. This reads through the operator surface rather than the token
+	// surface, so both RLS paths are exercised.
+	assertGrantNotVisible(t, engA, mintedB.GrantID, "tenant A")
+	assertGrantNotVisible(t, engB, mintedA.GrantID, "tenant B")
+
+	// ------------------------------------------------------------------
+	// THE AUDIT ROW EXISTS, in tenant A and only in tenant A.
+	// ------------------------------------------------------------------
+	rows := queryMCPAuditRowsAsAppRole(t, pool, tenantA, audit.ActionMCPGrantCreated)
+	var found bool
+	for _, r := range rows {
+		if r.targetID != mintedA.GrantID {
+			continue
+		}
+		found = true
+		if r.actorType != audit.ActorUser {
+			t.Errorf("mcp.grant.created actor_type = %q, want %q", r.actorType, audit.ActorUser)
+		}
+		if r.actorID != userA.String() {
+			t.Errorf("mcp.grant.created actor_id = %q, want the minting operator %s", r.actorID, userA)
+		}
+		// The issuance discriminator is what separates a headless mint from a
+		// browser-consented grant in the log. Without it an auditor cannot
+		// tell which authorisation produced the credential.
+		if got, _ := r.metadata["issuance"].(string); got != "connection_token" {
+			t.Errorf("mcp.grant.created metadata.issuance = %q, want %q", got, "connection_token")
+		}
+		// The PUBLIC handle travels; the plaintext must not.
+		if got, _ := r.metadata["token_prefix"].(string); got != mintedA.TokenPrefix {
+			t.Errorf("metadata.token_prefix = %q, want %q", got, mintedA.TokenPrefix)
+		}
+		meta, mErr := json.Marshal(r.metadata)
+		if mErr != nil {
+			t.Fatalf("re-marshal audit metadata: %v", mErr)
+		}
+		if strings.Contains(string(meta), mintedA.Token) {
+			t.Fatalf("THE PLAINTEXT WAS WRITTEN TO THE AUDIT LOG: %s", meta)
+		}
+	}
+	if !found {
+		t.Fatalf("no %s audit row for grant %s: this credential is unexplained",
+			audit.ActionMCPGrantCreated, mintedA.GrantID)
+	}
+	// Tenant B must not see tenant A's audit row.
+	for _, r := range queryMCPAuditRowsAsAppRole(t, pool, tenantB, audit.ActionMCPGrantCreated) {
+		if r.targetID == mintedA.GrantID {
+			t.Fatal("CROSS-TENANT AUDIT LEAK: tenant B can read tenant A's mcp.grant.created row")
+		}
+	}
+}
+
+// TestMCPMintRefusesASiteScopedCollaboratorAsAppRole proves the org-scope guard
+// holds through the mounted route, as wpmgr_app, AND that nothing was written.
+//
+// A site-scoped collaborator minting an organisation-wide grant was a live
+// production defect on the consent path. This is the same class of write behind
+// the same class of gate, so it gets the same proof.
+func TestMCPMintRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open token lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-scope-"+suffix)
+	userID := seedUserRow(t, pool, "mint-scope-"+suffix+"@example.test")
+	siteID := seedSite(t, pool, tenantID, "https://s-"+suffix+".example.test")
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+
+	// An outside collaborator shared onto ONE site, holding admin ON THAT SITE.
+	// Still refused: a grant is an organisation-wide credential.
+	collaborator := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeSite, AllowedSiteIDs: []uuid.UUID{siteID},
+	}
+	eng := mountConnectionsLikeProduction(t, svc, collaborator)
+
+	before := countAllGrants(t, pool, tenantID)
+
+	var body map[string]any
+	code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "escalation attempt",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &body)
+	if code == http.StatusCreated {
+		t.Fatalf("A SITE-SCOPED COLLABORATOR MINTED AN ORG-WIDE CONNECTION TOKEN (201): %v", body)
+	}
+	if code != http.StatusForbidden {
+		t.Fatalf("mint answered %d, want 403", code)
+	}
+	// A refusal that still wrote is a refusal of the RESPONSE only.
+	if after := countAllGrants(t, pool, tenantID); after != before {
+		t.Fatalf("the refused mint still wrote: grants went from %d to %d", before, after)
+	}
+}
+
+// TestMCPMintScopeReferentsAsAppRole proves the two halves of the scope
+// decision against a REAL tag registry:
+//
+//	a real tag carrying zero sites -> ACCEPTED and stored as given
+//	a tag id naming no tag at all  -> REFUSED, by id
+//
+// Those are different questions and conflating them is the defect: the first is
+// a legitimate connection that reads nothing today, and refusing it would
+// contradict the owner's ruling; the second stores cleanly (scope_tag_ids is a
+// uuid[] with no foreign key) and then resolves to nothing forever.
+func TestMCPMintScopeReferentsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open token lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-scope-ref-"+suffix)
+	userID := seedUserRow(t, pool, "mint-ref-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://ref-"+suffix+".example.test")
+
+	// A REAL TAG CARRYING NO SITES. Created through the real service, so it is
+	// a genuine registry row rather than a hand-inserted one.
+	_, tagSvc := newSiteTagServices(pool)
+	emptyTag, err := tagSvc.Create(ctx, sitetag.CreateInput{
+		TenantID: tenantID, Name: "unused-" + suffix, Color: "#112233",
+	})
+	if err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	admin := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+	eng := mountConnectionsLikeProduction(t, svc, admin)
+
+	// ---- ACCEPTED, AND STORED AS GIVEN, NEVER WIDENED --------------------
+	var minted mintResponse
+	if code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "reads nothing yet",
+		"site_scope_mode": string(mcp.SiteScopeModeTags),
+		"scope_tag_ids":   []string{emptyTag.ID.String()},
+	}, nil, &minted); code != http.StatusCreated {
+		t.Fatalf("a real tag carrying zero sites was refused: mint answered %d, want 201", code)
+	}
+
+	grantID, err := uuid.Parse(minted.GrantID)
+	if err != nil {
+		t.Fatalf("parse grant id: %v", err)
+	}
+	mode, tagIDs := readStoredScope(t, pool, tenantID, grantID)
+	if mode != string(mcp.SiteScopeModeTags) {
+		t.Fatalf("THE SCOPE WAS WIDENED: stored site_scope_mode = %q, want %q",
+			mode, mcp.SiteScopeModeTags)
+	}
+	if len(tagIDs) != 1 || tagIDs[0] != emptyTag.ID {
+		t.Fatalf("the tag payload was not stored as given: %v", tagIDs)
+	}
+
+	// The connection authenticates, and its site scope resolves to NOTHING --
+	// which the read tool then refuses BY NAME rather than reporting as an
+	// empty fleet. That is the shape of a legitimately empty connection.
+	auth, err := svc.Authenticate(ctx, minted.Token)
+	if err != nil {
+		t.Fatalf("the empty-scope token does not authenticate: %v", err)
+	}
+	if !auth.Sites.IsEmpty() {
+		t.Fatalf("a tag carrying no sites resolved to %d sites", auth.Sites.Len())
+	}
+	if _, err := svc.ListSitesForModel(ctx, auth); err == nil {
+		t.Fatal("an empty site scope returned an empty LIST instead of a named refusal")
+	}
+
+	// ---- REFUSED, BY ID --------------------------------------------------
+	ghost := uuid.New()
+	var body map[string]any
+	code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "typo scope",
+		"site_scope_mode": string(mcp.SiteScopeModeTags),
+		"scope_tag_ids":   []string{ghost.String()},
+	}, nil, &body)
+	if code == http.StatusCreated {
+		t.Fatalf("a tag id naming NO TAG was accepted (201): the scope is silently narrowed to nothing: %v", body)
+	}
+	if code != http.StatusUnprocessableEntity && code != http.StatusBadRequest {
+		t.Fatalf("unknown tag answered %d, want a 4xx validation refusal", code)
+	}
+	raw, mErr := json.Marshal(body)
+	if mErr != nil {
+		t.Fatalf("marshal refusal body: %v", mErr)
+	}
+	if !strings.Contains(string(raw), ghost.String()) {
+		t.Fatalf("the refusal does not name the offending id %s, so it cannot be acted on: %s",
+			ghost, raw)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers. All read THROUGH THE POOL as wpmgr_app, inside the tenant
+// transaction the request path uses -- never a raw connection, which would read
+// past RLS and could report rows the application can never see.
+// ---------------------------------------------------------------------------
+
+// assertNoPlaintextStored proves the token row holds a hash and a prefix and
+// not the credential, and that the hash satisfies the column's CHECK shape.
+func assertNoPlaintextStored(t *testing.T, pool *db.Pool, tenantID, grantID uuid.UUID, plaintext, prefix string) {
+	t.Helper()
+	var storedHash, storedPrefix string
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT token_hash, token_prefix FROM mcp_connection_tokens
+			  WHERE tenant_id = $1 AND grant_id = $2`,
+			tenantID, grantID).Scan(&storedHash, &storedPrefix)
+	})
+	if err != nil {
+		t.Fatalf("read back the token row: %v", err)
+	}
+	if storedHash == plaintext {
+		t.Fatal("THE PLAINTEXT IS IN token_hash")
+	}
+	if storedPrefix != prefix {
+		t.Fatalf("stored token_prefix %q disagrees with the returned one %q", storedPrefix, prefix)
+	}
+	if storedPrefix == plaintext {
+		t.Fatal("token_prefix is the WHOLE credential, so the public handle is the secret")
+	}
+	// The column's CHECK is '^[0-9a-f]{64}$'. Asserted here too, because a
+	// value that satisfies it is by construction not the base64url plaintext.
+	if len(storedHash) != 64 {
+		t.Fatalf("token_hash is %d chars, want 64", len(storedHash))
+	}
+	for _, r := range storedHash {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			t.Fatalf("token_hash %q is not lower-case hex", storedHash)
+		}
+	}
+}
+
+// readStoredScope returns the grant's stored site scope, so a test can prove
+// the payload was stored AS GIVEN rather than widened.
+func readStoredScope(t *testing.T, pool *db.Pool, tenantID, grantID uuid.UUID) (string, []uuid.UUID) {
+	t.Helper()
+	var mode string
+	var tagIDs []uuid.UUID
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT site_scope_mode, scope_tag_ids FROM mcp_grants
+			  WHERE tenant_id = $1 AND id = $2`,
+			tenantID, grantID).Scan(&mode, &tagIDs)
+	})
+	if err != nil {
+		t.Fatalf("read stored scope: %v", err)
+	}
+	return mode, tagIDs
+}
+
+// countGrants counts the tenant's grants as wpmgr_app, so "nothing was written"
+// is a statement about what the application can see.
+func countAllGrants(t *testing.T, pool *db.Pool, tenantID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM mcp_grants WHERE tenant_id = $1`, tenantID).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count grants: %v", err)
+	}
+	return n
+}
+
+// assertGrantNotVisible proves one organisation's connections list does not
+// carry another's grant id.
+func assertGrantNotVisible(t *testing.T, eng *gin.Engine, grantID, who string) {
+	t.Helper()
+	var list struct {
+		Connections []struct {
+			ID string `json:"id"`
+		} `json:"connections"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodGet, mintPath, nil, nil, &list); code != http.StatusOK {
+		t.Fatalf("%s list answered %d, want 200", who, code)
+	}
+	for _, c := range list.Connections {
+		if c.ID == grantID {
+			t.Fatalf("CROSS-TENANT LEAK: %s can see grant %s", who, grantID)
+		}
+	}
+}


### PR DESCRIPTION
Adds `POST /api/v1/mcp/connections` — the non-OAuth path the wizard needs.

No MCP client documents a device-code flow and Claude Code cannot run browser sign-in non-interactively, so headless, SSH and CI installs have no route through `/authorize` + `/consent`. This is that route: one transaction creates the grant with the operator's name, site scope and capabilities, mints its first connection token, and returns the plaintext exactly once.

## What it reuses rather than rebuilds

It goes through the same grant-creation shape as consent, so m127's `capabilities` / `expires_at` columns and the `mcp.grant.created` audit event come with it. The credential is built by the existing `hashCredential` (lower-case hex SHA-256) and stored by the existing `CreateMCPConnectionToken`. The only thing that differs from the OAuth path is how the grant is authorised into being.

Audit metadata carries an `issuance` discriminator so a headless mint is distinguishable from a browser-consented one, plus the public `token_prefix` — never the plaintext.

## The org-scope guard

Applied at all three layers the consent path carries it at:

1. `authz.RequirePermission(authz.PermAPIKeyManage)` on the route — an `orgLevelPerms` member, so `RequirePermission` refuses any site-constrained principal outright.
2. `requireOrgScopedPrincipal` in the service.
3. `mcp_grants_site_scope_insert` in the database, reached because `CreateGrantWithToken` takes the principal and runs `RunTenantTx` rather than picking `InTenantTx` itself.

## Tag ids, not names — and why the refusal is loud

The wire takes tag and site **UUIDs**, matching `approvalRequestDTO.ScopeTagIDs`, so there is one vocabulary for a tag across both mint paths and the wizard reuses the consent screen's existing name→id map. Ids also survive a rename; a grant scoped by name would silently change which sites it covers the day somebody renames a tag.

`scope_tag_ids` and `scope_site_ids` are `uuid[]` with no foreign key, so an id naming nothing stores cleanly and then resolves to zero sites forever. Those ids are therefore verified against the tenant's own registry and refused **by id**.

That is deliberately **not** the same question as "does the scope resolve to any sites":

| input | outcome |
|---|---|
| real tag, zero sites today | accepted, stored as given |
| id naming no tag at all | refused, loudly, by id |

An empty scope is legitimate and is stored as empty, never widened to `all`. The structural refusals are unchanged — an empty allowlist is still not a way to ask for every site.

## Rate limit

Reuses `register_limit.go`'s two-layer bucket. The key is the session-resolved user id rather than `RemoteIP`: this endpoint is authenticated so the id cannot be set by a header, and the harm being bounded (one stolen session becoming many long-lived credentials) is a per-user quantity.

## Capabilities

An omitted list means the organisation default, never an empty set — an empty stored set is a connection `Authenticate` refuses on every request, so minting one would produce a credential that can never work. A named capability wider than the ceiling is refused rather than dropped.

## Status

Draft. Unit proofs, mutation sweep and `make test-integration` reported in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)