### PR TITLE
feat(ai-connections): mint a connection token from the wizard

### DIFF
--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, fireEvent, within } from "@testing-library/react";
 
 import { renderWithProviders } from "@/test/render";
@@ -10,6 +10,7 @@ import { useSites, DEFAULT_SITES_LIMIT } from "@/features/sites/use-sites";
 import { useTags } from "@/features/tags/use-tags";
 import { snapshotFromPage } from "@/features/mcp-consent/site-scope";
 import { fleetTotal, scopeCountLabel } from "./site-step";
+import { CONNECTIONS_PATH } from "./use-ai-connections";
 import type { Site, SiteTag } from "@wpmgr/api";
 
 // Step 3 reads the fleet and the tag registry through the same two hooks the
@@ -501,5 +502,199 @@ describe("changing the client recomputes rather than carrying a stale answer", (
     await pickClient("Claude Desktop");
     expect(screen.queryByText(/set this up inside/i)).not.toBeInTheDocument();
     expect(authCard("token")).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Minting a connection token (step 6's one-time reveal)
+//
+// The fetch is stubbed at the network boundary, not the mutation hook, for
+// the same reason routes/_authed/ai/-index.test.tsx gives: the real queryFn,
+// the real zod parse and the real state mapping all run, and a hook mock here
+// would only prove the component renders whatever it is handed.
+// ---------------------------------------------------------------------------
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Stub fetch for exactly the mint POST; anything else fails the test loudly. */
+function stubMintFetch(impl: (init: RequestInit | undefined) => Response | Promise<Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = urlOf(input);
+      const method = init?.method ?? "GET";
+      if (url === CONNECTIONS_PATH && method === "POST") {
+        return Promise.resolve(impl(init));
+      }
+      throw new Error(`unstubbed fetch in mint test: ${method} ${url}`);
+    }),
+  );
+}
+
+const MINTED = {
+  grant_id: "11111111-1111-1111-1111-111111111111",
+  token: "wpm_conn_test_token_value_do_not_reuse",
+  token_prefix: "wpm_conn_ab12",
+  expires_at: "2026-11-27T00:00:00Z",
+  site_scope_mode: "list",
+  capabilities: ["read_fleet", "propose_changes"],
+};
+
+/** Client and method picked, fleet loaded, sitting at the mint button. */
+async function reachMintButton() {
+  renderWizard();
+  await pickClient("Cursor");
+  fireEvent.click(authCard("token"));
+  return screen.findByRole("button", { name: /generate connection token/i });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("minting a connection token", () => {
+  it("reveals the plaintext exactly once, stating the scope and capabilities it covers", async () => {
+    loadedFleet(3);
+    stubMintFetch(() => jsonResponse(MINTED, 201));
+
+    fireEvent.click(await reachMintButton());
+
+    expect(
+      await screen.findByText(/this is the only time this token is shown/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(MINTED.token)).toBeInTheDocument();
+    expect(screen.getByText(/read_fleet, propose_changes/i)).toBeInTheDocument();
+    // No "mint again" affordance beside a token that is supposedly shown once.
+    expect(
+      screen.queryByRole("button", { name: /generate connection token/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears the reveal the moment an input it was minted for changes", async () => {
+    loadedFleet(3);
+    stubMintFetch(() => jsonResponse(MINTED, 201));
+
+    fireEvent.click(await reachMintButton());
+    await screen.findByText(/this is the only time this token is shown/i);
+
+    fireEvent.change(screen.getByLabelText(/name this connection/i), {
+      target: { value: "Fleet manager, renamed" },
+    });
+
+    expect(screen.queryByText(/this is the only time this token is shown/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(MINTED.token)).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /generate connection token/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("sends the tag ids the registry resolved, never the tag names the operator clicked", async () => {
+    loadedFleet(3, () => ["prod"]);
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ data: [{ id: "tag-uuid-1", name: "prod" } as SiteTag] }),
+    );
+    const requestBodies: Record<string, unknown>[] = [];
+    stubMintFetch((init) => {
+      // The mutation always sends a JSON string body (use-ai-connections.ts
+      // calls JSON.stringify), so this narrows rather than stringifying an
+      // arbitrary BodyInit.
+      requestBodies.push(JSON.parse(init?.body as string) as Record<string, unknown>);
+      return jsonResponse({ ...MINTED, site_scope_mode: "tags" }, 201);
+    });
+
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    fireEvent.click(screen.getByRole("radio", { name: /by tag/i }));
+    fireEvent.click(screen.getByRole("button", { name: /\+ add tags/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+    fireEvent.click(await screen.findByRole("button", { name: /generate connection token/i }));
+
+    await screen.findByText(/this is the only time this token is shown/i);
+    expect(requestBodies).toHaveLength(1);
+    const sentBody = requestBodies[0];
+    expect(sentBody?.scope_tag_ids).toEqual(["tag-uuid-1"]);
+    expect(JSON.stringify(sentBody)).not.toContain("prod");
+  });
+
+  it("refuses to mint on an unresolved tag scope, with a remedy distinct from a server failure", async () => {
+    // tags stays null (the registry has not finished loading) while mode is
+    // "tags" -- resolveTagIds returns null regardless of what is selected, so
+    // this is the client-side refusal the mint panel exists to make loud
+    // rather than silently narrowing the request.
+    loadedFleet(3);
+    mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: undefined, isPending: true }));
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    fireEvent.click(screen.getByRole("radio", { name: /by tag/i }));
+
+    expect(await screen.findByText(/tag scope could not be resolved/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /generate connection token/i })).toBeDisabled();
+  });
+
+  it("renders a network failure as a network failure, never a confident empty state", async () => {
+    loadedFleet(3);
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new TypeError("Failed to fetch"))));
+
+    fireEvent.click(await reachMintButton());
+
+    expect(await screen.findByText(/did not reach the server/i)).toBeInTheDocument();
+    expect(screen.queryByText(/this is the only time this token is shown/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the 403 org-scope refusal with its own remedy, distinct from every other failure", async () => {
+    loadedFleet(3);
+    stubMintFetch(() =>
+      jsonResponse(
+        {
+          code: "mcp_org_scope_required",
+          message:
+            "an AI connection is an organisation-wide credential, so listing or revoking one requires full organisation membership. This is a refusal, not an empty list.",
+        },
+        403,
+      ),
+    );
+
+    fireEvent.click(await reachMintButton());
+
+    expect(await screen.findByText(/cannot mint a connection token/i)).toBeInTheDocument();
+    expect(screen.getByText(/organisation-wide credential/i)).toBeInTheDocument();
+    // Not the 429 copy, not the network copy, not the tag copy.
+    expect(screen.queryByText(/too many connection tokens/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/did not reach the server/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the 429 rate limit with the server's own retry-after, distinct from a 403", async () => {
+    loadedFleet(3);
+    stubMintFetch(() =>
+      jsonResponse(
+        {
+          code: "mcp_mint_rate_limited",
+          message: "too many connection tokens minted; retry shortly",
+          details: { retry_after_seconds: 42 },
+        },
+        429,
+      ),
+    );
+
+    fireEvent.click(await reachMintButton());
+
+    expect(await screen.findByText(/too many connection tokens minted recently/i)).toBeInTheDocument();
+    expect(screen.getByText(/wait about 42 seconds/i)).toBeInTheDocument();
+    expect(screen.queryByText(/organisation-wide credential/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -585,12 +585,50 @@ const MINTED = {
   capabilities: ["read_fleet", "propose_changes"],
 };
 
-/** Client and method picked, fleet loaded, sitting at the mint button. */
+/** The site checkboxes inside step 3's picker. Throws rather than returning []. */
+function pickerBoxes(): HTMLElement[] {
+  return within(screen.getByTestId("site-step-picker")).getAllByRole("checkbox");
+}
+
+/**
+ * Client and method picked, fleet loaded, ONE SITE PICKED, sitting at the mint
+ * button.
+ *
+ * The site is picked deliberately and is not scaffolding. The wizard opens on
+ * mode 'list' with nothing selected, and ValidateSiteScopeRequest
+ * (apps/api/internal/mcp/scope.go) refuses mode 'list' with no site ids, so a
+ * mint from the opening state is a 400 rather than a token. These tests are
+ * about what happens to a token that WAS minted, which needs a scope the
+ * server would actually accept.
+ */
 async function reachMintButton() {
   renderWizard();
   await pickClient("Cursor");
   fireEvent.click(authCard("token"));
+  await screen.findByTestId("site-step-count");
+  fireEvent.click(screen.getByRole("button", { name: /\+ add sites/i }));
+  fireEvent.click(pickerBoxes()[0]!);
   return screen.findByRole("button", { name: /generate connection token/i });
+}
+
+/**
+ * A mint whose response is held open until the returned `release` is called.
+ *
+ * Every in-flight test uses this rather than racing a resolved stub. A test
+ * that assumed the operator acted before the response landed would pass
+ * against a component that does the wrong thing, because the wrong thing would
+ * never get the chance to happen.
+ */
+function heldMint(body: unknown = MINTED, status = 201) {
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  stubMintFetch(async () => {
+    await held;
+    return jsonResponse(body, status);
+  });
+  return { release: () => release() };
 }
 
 afterEach(() => {
@@ -615,7 +653,22 @@ describe("minting a connection token", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("clears the reveal the moment an input it was minted for changes", async () => {
+  // -------------------------------------------------------------------------
+  // A MINTED TOKEN IS NEVER LOST. Three routes reached the same outcome: a
+  // live organisation credential that authenticates, whose plaintext was shown
+  // to nobody, that nobody knows to revoke because nobody knows it exists.
+  // Each is pinned separately, because they are three different mechanisms and
+  // a single test would let two of them come back.
+  // -------------------------------------------------------------------------
+
+  it("keeps a revealed token when an input it was minted for changes", async () => {
+    // THE TRIPWIRE THAT USED TO POINT THE OTHER WAY. This test previously
+    // asserted that editing the name CLEARED the reveal, which was written to
+    // stop a token being shown beside a configuration it was not minted for.
+    // MintedReveal made that unconstructible -- the reveal carries the scope
+    // and client the request was sent with -- and what the clearing did after
+    // that was destroy the only copy of a live credential on one keystroke.
+    // The property being pinned is the inverse, and with the same force.
     loadedFleet(3);
     stubMintFetch(() => jsonResponse(MINTED, 201));
 
@@ -625,12 +678,102 @@ describe("minting a connection token", () => {
     fireEvent.change(screen.getByLabelText(/name this connection/i), {
       target: { value: "Fleet manager, renamed" },
     });
+    // And the scope too: the other half of what configKey watched.
+    fireEvent.click(pickerBoxes()[1]!);
+    expect(await screen.findByTestId("site-step-summary")).toHaveTextContent(/2 sites/i);
 
-    expect(screen.queryByText(/this is the only time this token is shown/i)).not.toBeInTheDocument();
+    expect(screen.getByText(MINTED.token)).toBeInTheDocument();
+    expect(screen.getByText(/this is the only time this token is shown/i)).toBeInTheDocument();
+    // Still labelled with what it was minted FOR, not with the newer scope --
+    // surviving the edit must not mean drifting into describing it.
+    expect(screen.getByText(/Capabilities:/)).toHaveTextContent(/1 site, listed below/i);
+  });
+
+  it("gives up the token only when the operator says they have saved it", async () => {
+    // The over-fire case for the test above. A reveal that can never be
+    // dismissed is its own defect: the operator cannot mint a second token and
+    // the screen is stuck.
+    loadedFleet(3);
+    stubMintFetch(() => jsonResponse(MINTED, 201));
+
+    fireEvent.click(await reachMintButton());
+    await screen.findByText(MINTED.token);
+
+    fireEvent.click(screen.getByRole("button", { name: /i have saved this token/i }));
+
     expect(screen.queryByText(MINTED.token)).not.toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: /generate connection token/i }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps the token on screen after the step that minted it is gone", async () => {
+    // THE UNMOUNT DEFECT, PINNED AT ITS ROOT. The reveal used to live in
+    // TokenMintPanel, which step 4 renders only for method 'token'. Anything
+    // that unmounted that panel took the token with it. Switching to OAuth
+    // here unmounts the panel completely -- step 4 renders NextSteps instead --
+    // and the token must still be on screen, because a credential the server
+    // has already created cannot be un-created by a click.
+    loadedFleet(3);
+    stubMintFetch(() => jsonResponse(MINTED, 201));
+
+    fireEvent.click(await reachMintButton());
+    await screen.findByText(MINTED.token);
+
+    fireEvent.click(authCard("oauth"));
+
+    // The panel is genuinely gone, so this is not passing by nothing happening.
+    expect(await screen.findByText(/start the connection in cursor/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /generate connection token/i })).toBeNull();
+    // And the token survived it.
+    expect(screen.getByText(MINTED.token)).toBeInTheDocument();
+    expect(screen.getByText(/this is the only time this token is shown/i)).toBeInTheDocument();
+  });
+
+  it("refuses to unmount the panel while its request is still in the air", async () => {
+    // THE OUTER LAYER. Lifting the state is what makes the bad outcome
+    // impossible; this is what stops the operator walking into it in the first
+    // place. Both are here because a guard that depends on the operator not
+    // clicking during a round trip is not a guard, and state that survives an
+    // unmount is not a reason to offer the unmount.
+    loadedFleet(3);
+    const { release } = heldMint();
+
+    fireEvent.click(await reachMintButton());
+    // IN FLIGHT, AND PROVABLY SO. Every assertion below is vacuous if the
+    // response has already landed.
+    expect(await screen.findByRole("button", { name: /minting/i })).toBeInTheDocument();
+
+    expect(authCard("oauth")).toBeDisabled();
+    expect(authCard("token")).toBeDisabled();
+    expect(screen.getByRole("button", { name: /claude desktop/i })).toBeDisabled();
+    // Said out loud, not silently greyed out.
+    expect(screen.getByRole("status")).toHaveTextContent(/strand a live credential nobody holds/i);
+
+    // Clicking anyway changes nothing, which is what "refuses" has to mean.
+    fireEvent.click(authCard("oauth"));
+    expect(await screen.findByRole("button", { name: /minting/i })).toBeInTheDocument();
+
+    release();
+
+    expect(await screen.findByText(MINTED.token)).toBeInTheDocument();
+    // And the controls come back once nothing is outstanding -- the lock is
+    // for the duration of the request, not for the rest of the session.
+    expect(authCard("oauth")).toBeEnabled();
+    expect(screen.getByRole("button", { name: /claude desktop/i })).toBeEnabled();
+  });
+
+  it("names the credential it just made, so a lost plaintext is still revocable", async () => {
+    // If anything goes wrong between this screen and the operator's password
+    // manager, the prefix is what lets them find and kill this exact
+    // credential. Without it, "revoke the one I just made" is a guess.
+    loadedFleet(3);
+    stubMintFetch(() => jsonResponse(MINTED, 201));
+
+    fireEvent.click(await reachMintButton());
+
+    await screen.findByText(MINTED.token);
+    expect(screen.getByText(MINTED.token_prefix)).toBeInTheDocument();
   });
 
   it("describes the scope the token was minted FOR when the scope changed mid-flight", async () => {
@@ -737,6 +880,103 @@ describe("minting a connection token", () => {
 
     expect(await screen.findByText(/tag scope could not be resolved/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /generate connection token/i })).toBeDisabled();
+  });
+
+  // -------------------------------------------------------------------------
+  // THE PAYLOAD THE SERVER WOULD REFUSE IS NEVER SENT. ValidateSiteScopeRequest
+  // (apps/api/internal/mcp/scope.go lines 168-200) refuses mode 'tags' with no
+  // tag ids, mode 'list' with no site ids, and mode 'all' that carries either.
+  // The gate on this screen asked isScopeApprovable instead, which holds an
+  // empty scope to be a working state, so the button was enabled for requests
+  // the server answers with a 400 the operator can do nothing about.
+  // -------------------------------------------------------------------------
+
+  it("refuses to mint from the state the wizard opens in, with a local remedy", async () => {
+    // Reachable by doing nothing: the wizard opens on mode 'list' with no
+    // sites picked, so this was pick a client, pick the token method, press
+    // the button, get a 400.
+    loadedFleet(3);
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+
+    const button = await screen.findByRole("button", { name: /generate connection token/i });
+    expect(button).toBeDisabled();
+    expect(screen.getByText(/no site is picked/i)).toHaveTextContent(
+      /pick at least one site in step 3, or switch that step to all sites/i,
+    );
+    // The remedy is the operator's own, not "the server said no".
+    expect(screen.queryByText(/the server refused this request/i)).toBeNull();
+  });
+
+  it("refuses a by-tag scope with no tag picked, distinctly from an unreadable registry", async () => {
+    // The registry HAS loaded and does contain tags. Nothing is unresolved
+    // here; the operator has simply picked none, and telling them to go and
+    // fix a tag registry that is working is a remedy they cannot follow.
+    loadedFleet(3, () => ["prod"]);
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ data: [{ id: "tag-uuid-1", name: "prod" } as SiteTag] }),
+    );
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    fireEvent.click(screen.getByRole("radio", { name: /by tag/i }));
+
+    expect(
+      await screen.findByRole("button", { name: /generate connection token/i }),
+    ).toBeDisabled();
+    expect(screen.getByText(/no tag is picked/i)).toBeInTheDocument();
+    expect(screen.queryByText(/tag scope could not be resolved/i)).toBeNull();
+  });
+
+  it("sends no site ids under 'all sites', even when sites were picked first", async () => {
+    // Step 3 KEEPS the other mode's selection when the segmented control is
+    // flipped, on purpose, so a mode changed by accident does not throw away
+    // the other answer. That is right for the picker and wrong for the wire:
+    // mode 'all' carrying site ids is refused outright.
+    loadedFleet(3);
+    const requestBodies: Record<string, unknown>[] = [];
+    stubMintFetch((init) => {
+      requestBodies.push(JSON.parse(init?.body as string) as Record<string, unknown>);
+      return jsonResponse({ ...MINTED, site_scope_mode: "all" }, 201);
+    });
+
+    const button = await reachMintButton();
+    expect(button).toBeEnabled();
+    fireEvent.click(screen.getByRole("radio", { name: /all sites/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /generate connection token/i }));
+
+    await screen.findByText(MINTED.token);
+    expect(requestBodies).toHaveLength(1);
+    expect(requestBodies[0]?.site_scope_mode).toBe("all");
+    expect(requestBodies[0]?.scope_site_ids).toEqual([]);
+    expect(requestBodies[0]?.scope_tag_ids).toEqual([]);
+  });
+
+  it("sends no site ids under 'by tag', even when sites were picked first", async () => {
+    // The same leak in the other direction: mode 'tags' must not also name
+    // sites, and the picked site ids were going out beside the tag ids.
+    loadedFleet(3, () => ["prod"]);
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ data: [{ id: "tag-uuid-1", name: "prod" } as SiteTag] }),
+    );
+    const requestBodies: Record<string, unknown>[] = [];
+    stubMintFetch((init) => {
+      requestBodies.push(JSON.parse(init?.body as string) as Record<string, unknown>);
+      return jsonResponse({ ...MINTED, site_scope_mode: "tags" }, 201);
+    });
+
+    await reachMintButton();
+    fireEvent.click(screen.getByRole("radio", { name: /by tag/i }));
+    fireEvent.click(screen.getByRole("button", { name: /\+ add tags/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+    fireEvent.click(await screen.findByRole("button", { name: /generate connection token/i }));
+
+    await screen.findByText(MINTED.token);
+    expect(requestBodies).toHaveLength(1);
+    expect(requestBodies[0]?.scope_tag_ids).toEqual(["tag-uuid-1"]);
+    expect(requestBodies[0]?.scope_site_ids).toEqual([]);
   });
 
   it("renders a network failure as a network failure, never a confident empty state", async () => {

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -214,14 +214,21 @@ describe("the setup artefact is generated per client", () => {
     expect(document.body.textContent ?? "").not.toMatch(/[A-Z]:\\|%APPDATA%/);
   });
 
-  it("tells the user a token cannot be minted here yet rather than showing a fake one", async () => {
+  it("shows the config placeholder alongside a real mint button, not the old refusal", async () => {
+    // The endpoint this refusal predated now exists (POST CONNECTIONS_PATH),
+    // so the stale "you cannot mint a token here yet" copy is gone. The config
+    // block above still shows the placeholder -- buildSnippet emits the real
+    // token only when one has actually been minted, and none has yet here.
     renderWizard();
     await pickClient("Cursor");
     fireEvent.click(authCard("token"));
 
     const text = (await screen.findByText(/"mcpServers"/)).textContent ?? "";
     expect(text).toContain("YOUR_CONNECTION_TOKEN");
-    expect(screen.getByText(/cannot mint a token here yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/cannot mint a token here yet/i)).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /generate connection token/i }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1,10 +1,57 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent, within } from "@testing-library/react";
 
 import { renderWithProviders } from "@/test/render";
+import { mockQueryResult } from "@/test/query-mocks";
 
 import { Route } from "@/routes/_authed/ai/connect";
 import { MCP_CLIENTS } from "./client-table";
+import { useSites, DEFAULT_SITES_LIMIT } from "@/features/sites/use-sites";
+import { useTags } from "@/features/tags/use-tags";
+import { snapshotFromPage } from "@/features/mcp-consent/site-scope";
+import { fleetTotal, scopeCountLabel } from "./site-step";
+import type { Site, SiteTag } from "@wpmgr/api";
+
+// Step 3 reads the fleet and the tag registry through the same two hooks the
+// consent screen uses, so they are mocked the same way (see
+// routes/_authed/-connect.ai.test.tsx). What matters on this screen is that a
+// FAILED read and an EMPTY one produce different screens, which is only
+// testable if the test can put the hook into each state deliberately.
+vi.mock("@/features/sites/use-sites", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/sites/use-sites")>();
+  return { ...actual, useSites: vi.fn() };
+});
+vi.mock("@/features/tags/use-tags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/tags/use-tags")>();
+  return { ...actual, useTags: vi.fn() };
+});
+
+const mockedSites = vi.mocked(useSites);
+const mockedTags = vi.mocked(useTags);
+
+function fakeSite(n: number, tags: string[] = []): Site {
+  return {
+    id: `s${n}`,
+    name: `site-${n}.example`,
+    url: `https://site-${n}.example`,
+    tags,
+  } as Site;
+}
+
+/** A loaded fleet of `count` sites, short of the page limit so it is complete. */
+function loadedFleet(count: number, tagsFor: (n: number) => string[] = () => []) {
+  mockedSites.mockReturnValue(
+    mockQueryResult<Site[]>({
+      data: Array.from({ length: count }, (_, i) => fakeSite(i, tagsFor(i))),
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadedFleet(0);
+  mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: [] }));
+});
 
 // The wizard, through the real route component, the real router and a real
 // QueryClient -- not by calling a hook or rendering a subcomponent in
@@ -205,6 +252,233 @@ describe("the wizard does not promise things it cannot deliver", () => {
     // or in dev the copied URL reaches the SPA. Saying nothing would hand
     // someone a web page and let them debug their AI client.
     expect(screen.getByText(/reverse proxy must forward \/mcp to the API/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 -- "Choose which sites this connection may touch"
+// ---------------------------------------------------------------------------
+
+/** Get as far as step 3, which needs a client and a method behind it. */
+async function reachSiteStep() {
+  renderWizard();
+  await pickClient("Claude Code");
+  fireEvent.click(authCard("oauth"));
+  return await screen.findByTestId("site-step-count");
+}
+
+describe("step 3 exists at all, and sits before capabilities", () => {
+  it("renders a site step between the method and the setup artefact", async () => {
+    await reachSiteStep();
+    // The three modes the schema permits, on screen, as one radiogroup.
+    const modes = screen.getByRole("radiogroup", { name: /site scope/i });
+    for (const label of ["All sites", "By tag", "Named sites"]) {
+      expect(within(modes).getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("names the ordering as a decision rather than leaving it implied", async () => {
+    await reachSiteStep();
+    expect(screen.getByText(/chosen before capabilities, on purpose/i)).toBeInTheDocument();
+  });
+
+  it("numbers the setup artefact after it, so the rail and the page agree", async () => {
+    await reachSiteStep();
+    expect(screen.getByRole("heading", { name: /^4\. Set it up$/ })).toBeInTheDocument();
+    // And the rail no longer claims sites are chosen somewhere else.
+    expect(screen.queryByText(/4\. Choose sites and permissions/i)).not.toBeInTheDocument();
+  });
+
+  it("does not invent a numbered step for capabilities, which has no backend", async () => {
+    await reachSiteStep();
+    expect(screen.queryByRole("heading", { name: /what this connection may do/i })).toBeNull();
+    expect(screen.getByText(/permissions are chosen on the approval screen/i)).toBeInTheDocument();
+  });
+});
+
+describe("the count, and the fleet size it is entitled to claim", () => {
+  it("opens on the wireframe's empty ratio against a fleet it could read", async () => {
+    loadedFleet(60);
+    const count = await reachSiteStep();
+
+    // Derived from the same function the component calls, so a reworded
+    // sentence does not redden this and a wrong NUMBER does.
+    const expected = scopeCountLabel(
+      { kind: "none", because: "no-selection" },
+      fleetTotal(snapshotFromPage(Array.from({ length: 60 }, () => null as never), DEFAULT_SITES_LIMIT)),
+    );
+    expect(count).toHaveTextContent(expected);
+    expect(count.textContent?.startsWith("0 of 60")).toBe(true);
+  });
+
+  it("counts up as sites are picked, and back down as they are removed", async () => {
+    loadedFleet(60);
+    await reachSiteStep();
+
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    const picker = await screen.findByTestId("site-step-picker");
+    const boxes = within(picker).getAllByRole("checkbox");
+    fireEvent.click(boxes[0]!);
+    fireEvent.click(boxes[1]!);
+    expect(screen.getByTestId("site-step-count").textContent?.startsWith("2 of 60")).toBe(true);
+
+    // The token is the removal affordance, and removing must move the count.
+    fireEvent.click(screen.getAllByRole("button", { name: /^remove /i })[0]!);
+    expect(screen.getByTestId("site-step-count").textContent?.startsWith("1 of 60")).toBe(true);
+  });
+
+  it("refuses to state a fleet size when the page it read came back full", async () => {
+    // A full page is byte-identical to a full page with more behind it, so the
+    // denominator is a floor and the copy has to say so.
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    const count = await reachSiteStep();
+    expect(count.textContent).toMatch(/at least/i);
+  });
+
+  it("states the fleet size plainly when the page was short", async () => {
+    loadedFleet(7);
+    const count = await reachSiteStep();
+    expect(count.textContent).not.toMatch(/at least/i);
+    expect(count.textContent?.startsWith("0 of 7")).toBe(true);
+  });
+});
+
+describe("an empty scope is a working state, not an error", () => {
+  it("says so in as many words, and styles nothing as a failure", async () => {
+    loadedFleet(60);
+    await reachSiteStep();
+
+    const empty = screen.getByTestId("site-step-empty");
+    expect(empty).toHaveTextContent(/working state, not an error/i);
+    expect(empty).toHaveTextContent(/read nothing and propose nothing/i);
+    // Not an alert, because it is not one. An empty scope announced by a
+    // screen reader as an error is the same defect as rendering it in red.
+    expect(screen.queryByTestId("site-step-blocked")).toBeNull();
+    expect(empty.getAttribute("role")).toBeNull();
+  });
+
+  it("does not block the wizard on it", async () => {
+    loadedFleet(60);
+    await reachSiteStep();
+    // The setup artefact is reachable with nothing selected. An earlier
+    // revision of this surface disabled Continue here; that is the behaviour
+    // being corrected.
+    expect(screen.getByRole("heading", { name: /^4\. Set it up$/ })).toBeInTheDocument();
+    expect(await screen.findByText(/"mcpServers"/)).toBeInTheDocument();
+  });
+});
+
+describe("a failed load is not an empty fleet", () => {
+  it("holds the step and says the list did not load, rather than showing a zero", async () => {
+    mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined }));
+    await reachSiteStep();
+
+    expect(screen.getByTestId("site-step-blocked")).toHaveTextContent(/could not read/i);
+    // And no count is asserted over the top of it.
+    expect(screen.getByTestId("site-step-count").textContent).not.toMatch(/\d/);
+    // The empty-state sentence must NOT appear: "you have chosen nothing" and
+    // "we could not read the list" are different facts.
+    expect(screen.queryByTestId("site-step-empty")).toBeNull();
+  });
+
+  it("offers no site picker to choose from when the fleet is unknown", async () => {
+    mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined }));
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    expect(await screen.findByTestId("site-step-sites-failed")).toHaveTextContent(
+      /not the same as having no sites/i,
+    );
+    expect(screen.queryByTestId("site-step-picker")).toBeNull();
+  });
+
+  it("distinguishes a failed tag registry from an organisation with no tags", async () => {
+    loadedFleet(3);
+    mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: undefined }));
+    await reachSiteStep();
+
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("By tag"));
+    fireEvent.click(screen.getByRole("button", { name: /add tags/i }));
+    expect(await screen.findByTestId("site-step-tags-failed")).toBeInTheDocument();
+    expect(screen.queryByTestId("site-step-tags-empty")).toBeNull();
+  });
+});
+
+describe("a tag matching nothing in a partial page is not a zero", () => {
+  it("holds the step rather than claiming the tag reaches no site", async () => {
+    // A full page, and a tag that matches nothing in it. We have not seen every
+    // site, so "matches nothing" is a claim we cannot make.
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ data: [{ id: "t1", name: "seo-2026" } as SiteTag] }),
+    );
+    await reachSiteStep();
+
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("By tag"));
+    fireEvent.click(screen.getByRole("button", { name: /add tags/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+
+    expect(screen.getByTestId("site-step-blocked")).toBeInTheDocument();
+    expect(screen.getByTestId("site-step-count").textContent).not.toMatch(/\d/);
+  });
+
+  it("resolves the tag to a real set when the fleet is fully in hand", async () => {
+    loadedFleet(10, (n) => (n < 4 ? ["client-retainer"] : []));
+    mockedTags.mockReturnValue(
+      mockQueryResult<SiteTag[]>({ data: [{ id: "t1", name: "client-retainer" } as SiteTag] }),
+    );
+    await reachSiteStep();
+
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("By tag"));
+    fireEvent.click(screen.getByRole("button", { name: /add tags/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+
+    expect(screen.getByTestId("site-step-count").textContent?.startsWith("4 of 10")).toBe(true);
+    expect(screen.queryByTestId("site-step-blocked")).toBeNull();
+    // A tag is re-resolved per request, and the screen says so rather than
+    // letting the operator read the list as frozen.
+    expect(screen.getByText(/resolved to a site list at every request/i)).toBeInTheDocument();
+    // The token carries the tag: prefix so it cannot be misread as a hostname.
+    // Scoped to the field, because the picker below renders the same label.
+    expect(
+      within(screen.getByTestId("site-step-tokenfield")).getByText("tag:client-retainer"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("the picker discloses what it could not offer", () => {
+  it("warns that the choices are not all of them when the page came back full", async () => {
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    expect(await screen.findByTestId("site-step-picker-truncated")).toHaveTextContent(
+      /not all of them/i,
+    );
+  });
+
+  it("says nothing of the sort when it listed the whole fleet", async () => {
+    loadedFleet(9);
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    await screen.findByTestId("site-step-picker");
+    expect(screen.queryByTestId("site-step-picker-truncated")).toBeNull();
+  });
+
+  it("does not offer a never-reach count it cannot compute", async () => {
+    loadedFleet(DEFAULT_SITES_LIMIT);
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+    fireEvent.click(within(await screen.findByTestId("site-step-picker")).getAllByRole("checkbox")[0]!);
+    expect(screen.queryByTestId("site-step-excluded")).toBeNull();
+  });
+});
+
+describe("the wizard does not promise to carry the scope it collected", () => {
+  it("says plainly that the approval screen asks again", async () => {
+    loadedFleet(5);
+    await reachSiteStep();
+    expect(
+      screen.getByText(/nothing carries this selection to the approval screen/i),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -399,6 +399,40 @@ describe("a failed load is not an empty fleet", () => {
     expect(screen.queryByTestId("site-step-picker")).toBeNull();
   });
 
+  it("says the read is still running rather than that it failed, while it is still running", async () => {
+    // `fleet === null` covers two different worlds -- we asked and it failed,
+    // and we have not finished asking -- and the picker used to render the
+    // failure copy for both. That is this feature's recurring defect: a load
+    // in progress stated as a fact about the organisation. It is worse here
+    // than a bare spinner would be, because the add control stays live beside
+    // it, so an operator can act on a failure that has not happened.
+    mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined, isPending: true }));
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+
+    expect(await screen.findByTestId("site-step-sites-loading")).toHaveTextContent(
+      /still reading/i,
+    );
+    expect(screen.queryByTestId("site-step-sites-failed")).toBeNull();
+    // Still no picker: nothing is tickable yet either way. The claim being
+    // corrected is about WHY, not about what is offered.
+    expect(screen.queryByTestId("site-step-picker")).toBeNull();
+  });
+
+  it("still says the read failed once it is no longer running", async () => {
+    // The other half of the guard. A loading branch that swallowed the failure
+    // branch would be the same defect pointing the other way, and this is the
+    // case that would catch it.
+    mockedSites.mockReturnValue(
+      mockQueryResult<Site[]>({ data: undefined, isPending: false, isError: true }),
+    );
+    await reachSiteStep();
+    fireEvent.click(screen.getByRole("button", { name: /add sites/i }));
+
+    expect(await screen.findByTestId("site-step-sites-failed")).toBeInTheDocument();
+    expect(screen.queryByTestId("site-step-sites-loading")).toBeNull();
+  });
+
   it("distinguishes a failed tag registry from an organisation with no tags", async () => {
     loadedFleet(3);
     mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: undefined }));
@@ -597,6 +631,65 @@ describe("minting a connection token", () => {
     expect(
       await screen.findByRole("button", { name: /generate connection token/i }),
     ).toBeInTheDocument();
+  });
+
+  it("describes the scope the token was minted FOR when the scope changed mid-flight", async () => {
+    // THE RACE, AND THE WORST OUTCOME THIS SCREEN CAN PRODUCE. The mint is a
+    // round trip; the site scope is an input the operator can go on clicking
+    // while it is open. A reveal that reads the scope at RESPONSE time pairs a
+    // real, shown-once credential with a description of access it does not
+    // carry -- on the one screen whose whole job is saying what was just made,
+    // at the only moment the token is ever visible. Nothing downstream can
+    // correct it: the operator reads that line and deploys the token.
+    //
+    // The response is held open deliberately rather than raced against a
+    // timer. A test that depended on the operator being slower than a stubbed
+    // fetch would pass on a fixed component and on a broken one.
+    loadedFleet(3);
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    stubMintFetch(async () => {
+      await held;
+      return jsonResponse(MINTED, 201);
+    });
+
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    fireEvent.click(screen.getByRole("button", { name: /\+ add sites/i }));
+
+    const boxes = () =>
+      within(screen.getByTestId("site-step-picker")).getAllByRole("checkbox");
+    fireEvent.click(boxes()[0]!);
+    expect(await screen.findByTestId("site-step-summary")).toHaveTextContent(
+      /1 site, listed below/i,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /generate connection token/i }));
+    // In flight, and provably so: the assertions below mean nothing if the
+    // scope was widened after the response had already landed.
+    expect(await screen.findByRole("button", { name: /minting/i })).toBeInTheDocument();
+
+    // The operator widens the scope from one site to three, mid-request.
+    fireEvent.click(boxes()[1]!);
+    fireEvent.click(boxes()[2]!);
+    expect(await screen.findByTestId("site-step-summary")).toHaveTextContent(
+      /3 sites, listed below/i,
+    );
+
+    release();
+
+    expect(await screen.findByText(MINTED.token)).toBeInTheDocument();
+    const scopeLine = screen.getByText(/Capabilities:/);
+    expect(scopeLine).toHaveTextContent(/1 site, listed below/i);
+    expect(scopeLine).not.toHaveTextContent(/3 sites/i);
+    // And the live step still shows the operator's newer, wider selection, so
+    // the reveal is not merely lagging the whole screen -- the two disagree on
+    // purpose, because they are describing two different things.
+    expect(screen.getByTestId("site-step-summary")).toHaveTextContent(/3 sites, listed below/i);
   });
 
   it("sends the tag ids the registry resolved, never the tag names the operator clicked", async () => {

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen, fireEvent, within } from "@testing-library/react";
+import { screen, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
 
-import { renderWithProviders } from "@/test/render";
+import { renderWithProviders, createTestQueryClient } from "@/test/render";
 import { mockQueryResult } from "@/test/query-mocks";
 
 import { Route } from "@/routes/_authed/ai/connect";
@@ -603,12 +611,71 @@ function pickerBoxes(): HTMLElement[] {
  */
 async function reachMintButton() {
   renderWizard();
+  return advanceToMintButton();
+}
+
+/**
+ * The same walk to the mint button, on a wizard that is ALREADY RENDERED. Split
+ * out of `reachMintButton` so the route-blocker tests can reach the same state
+ * through a router they hold a handle on, rather than duplicating the steps and
+ * letting the two copies drift.
+ */
+async function advanceToMintButton() {
   await pickClient("Cursor");
   fireEvent.click(authCard("token"));
   await screen.findByTestId("site-step-count");
   fireEvent.click(screen.getByRole("button", { name: /\+ add sites/i }));
   fireEvent.click(pickerBoxes()[0]!);
   return screen.findByRole("button", { name: /generate connection token/i });
+}
+
+/**
+ * The wizard inside a REAL router with a REAL second route, returning the
+ * router so a test can assert where the operator actually ended up.
+ *
+ * This is not `renderWithProviders({ withRouter: true })` and cannot be. That
+ * harness builds a bare root route deliberately (see its module doc), so every
+ * path resolves to no matched route, and the blocker under test is route
+ * behaviour: a test that cannot observe the location cannot tell "the
+ * navigation was refused" from "the navigation happened and the notice
+ * rendered anyway". Two matched routes make the difference observable, and
+ * `router.state.location.pathname` is the assertion that a rendered banner
+ * cannot fake.
+ */
+function renderWizardInRouter() {
+  const rootRoute = createRootRoute();
+  const connectRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/ai/connect",
+    component: ConnectPage,
+  });
+  const listRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/ai",
+    component: () => <p>the AI connections list</p>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([connectRoute, listRoute]),
+    history: createMemoryHistory({ initialEntries: ["/ai/connect"] }),
+  });
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+  return router;
+}
+
+/**
+ * Attempt to leave for /ai, the way the page header's back link does.
+ *
+ * The promise is caught rather than awaited. A blocked navigation is not an
+ * error, but nothing in the router's contract promises this settles when the
+ * navigation never happens, and a bare `await` on it would hang the test
+ * instead of failing it. What the test waits on is the observable outcome.
+ */
+function attemptLeave(router: { navigate: (opts: { to: string }) => Promise<void> }) {
+  void router.navigate({ to: "/ai" }).catch(() => {});
 }
 
 /**
@@ -761,6 +828,127 @@ describe("minting a connection token", () => {
     // for the duration of the request, not for the rest of the session.
     expect(authCard("oauth")).toBeEnabled();
     expect(screen.getByRole("button", { name: /claude desktop/i })).toBeEnabled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // THE FOURTH ROUTE OUT, AND THE ONE THE OTHER THREE DO NOT COVER: leaving the
+  // page. Lifting the mint to the wizard makes the response land on a mounted
+  // surface for every click INSIDE the screen, and does nothing at all when the
+  // screen itself goes away. The back link, a sidebar entry and the browser's
+  // back button all unmount the wizard with the POST still open, and the
+  // credential the server has already created is then a live grant whose
+  // plaintext was shown to no one.
+  //
+  // Every test below holds the response open on a promise and proves the
+  // in-flight state was genuinely reached before it acts. A test that raced a
+  // resolved stub would pass against a component with no blocker at all.
+  // ---------------------------------------------------------------------------
+
+  it("refuses to leave the route while a mint is in the air, and says why", async () => {
+    loadedFleet(3);
+    const { release } = heldMint();
+    const router = renderWizardInRouter();
+
+    fireEvent.click(await advanceToMintButton());
+    // IN FLIGHT, AND PROVABLY SO. Everything below is vacuous otherwise.
+    expect(await screen.findByRole("button", { name: /minting/i })).toBeInTheDocument();
+    // And nothing is claiming to hold anyone yet, so the assertion after the
+    // navigation is about the navigation and not about a banner that was
+    // always there.
+    expect(screen.queryByTestId("navigation-held")).toBeNull();
+
+    attemptLeave(router);
+
+    // THE REASON. A refusal the operator cannot see is indistinguishable from
+    // a broken link.
+    await waitFor(() => {
+      expect(screen.getByTestId("navigation-held")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("navigation-held")).toHaveTextContent(/shown once/i);
+    expect(screen.getByTestId("navigation-held")).toHaveTextContent(
+      /live credential .* nobody holds/i,
+    );
+    // THE REFUSAL ITSELF, which the banner cannot fake: the location never
+    // moved and the other route never rendered.
+    expect(router.state.location.pathname).toBe("/ai/connect");
+    expect(screen.queryByText(/the ai connections list/i)).toBeNull();
+    expect(screen.getByRole("button", { name: /minting/i })).toBeInTheDocument();
+
+    release();
+    expect(await screen.findByText(MINTED.token)).toBeInTheDocument();
+  });
+
+  it("lifts the block when the mint succeeds", async () => {
+    // A blocker that outlives its request strands the operator on a page they
+    // cannot leave, which is a worse defect than the one it was added to fix.
+    loadedFleet(3);
+    const { release } = heldMint();
+    const router = renderWizardInRouter();
+
+    fireEvent.click(await advanceToMintButton());
+    expect(await screen.findByRole("button", { name: /minting/i })).toBeInTheDocument();
+    attemptLeave(router);
+    await waitFor(() => {
+      expect(screen.getByTestId("navigation-held")).toBeInTheDocument();
+    });
+
+    release();
+    expect(await screen.findByText(MINTED.token)).toBeInTheDocument();
+    // The reason goes with the request that caused it, rather than sitting
+    // there telling the operator they are held when they are not.
+    expect(screen.queryByTestId("navigation-held")).toBeNull();
+
+    attemptLeave(router);
+    expect(await screen.findByText(/the ai connections list/i)).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/ai");
+  });
+
+  it("lifts the block when the mint fails", async () => {
+    // The half that a blocker keyed on "a mint was started" would get wrong.
+    // A 500 creates no credential and leaves nothing to protect, so holding
+    // the operator after it would be a trap with no purpose at all.
+    loadedFleet(3);
+    const { release } = heldMint({ error: "internal" }, 500);
+    const router = renderWizardInRouter();
+
+    fireEvent.click(await advanceToMintButton());
+    expect(await screen.findByRole("button", { name: /minting/i })).toBeInTheDocument();
+    attemptLeave(router);
+    await waitFor(() => {
+      expect(screen.getByTestId("navigation-held")).toBeInTheDocument();
+    });
+    expect(router.state.location.pathname).toBe("/ai/connect");
+
+    release();
+    // The request settled as a failure, and provably so: the button came back
+    // and no token was revealed.
+    expect(
+      await screen.findByRole("button", { name: /generate connection token/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(MINTED.token)).toBeNull();
+    expect(screen.queryByTestId("navigation-held")).toBeNull();
+
+    attemptLeave(router);
+    expect(await screen.findByText(/the ai connections list/i)).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/ai");
+  });
+
+  it("does not block a route change when no mint is outstanding", async () => {
+    // THE OVER-FIRE CASE. A blocker that fires on a screen with nothing in the
+    // air makes the wizard a room with no door, and the first operator it
+    // traps is the one who opened it to read the instructions.
+    loadedFleet(3);
+    const router = renderWizardInRouter();
+
+    // All the way to the mint button, and deliberately no further: every input
+    // the wizard has is filled in and still nothing has been sent.
+    await advanceToMintButton();
+
+    attemptLeave(router);
+
+    expect(await screen.findByText(/the ai connections list/i)).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/ai");
+    expect(screen.queryByTestId("navigation-held")).toBeNull();
   });
 
   it("names the credential it just made, so a lost plaintext is still revocable", async () => {

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tanstack/react-router";
 
 import { renderWithProviders, createTestQueryClient } from "@/test/render";
+import { formatAbsolute } from "@/features/updates/schedule";
 import { mockQueryResult } from "@/test/query-mocks";
 
 import { Route } from "@/routes/_authed/ai/connect";
@@ -962,6 +963,30 @@ describe("minting a connection token", () => {
 
     await screen.findByText(MINTED.token);
     expect(screen.getByText(MINTED.token_prefix)).toBeInTheDocument();
+  });
+
+  it("dates the expiry for a person to read, not in the wire format", async () => {
+    // `expires_at` arrives as ISO-8601 and was printed straight into an
+    // English sentence, so the operator read "2026-11-27T00:00:00Z" mid-line
+    // on the one screen they see once and cannot return to.
+    loadedFleet(3);
+    stubMintFetch(() => jsonResponse(MINTED, 201));
+
+    fireEvent.click(await reachMintButton());
+    await screen.findByText(MINTED.token);
+
+    // Not merely joined by a formatted copy elsewhere: the machine string is
+    // off the screen entirely.
+    expect(document.body.textContent).not.toContain(MINTED.expires_at);
+    // And what replaced it is the app's shared formatter, zone included,
+    // rather than a second hand-rolled one that could drift from the rest of
+    // the app.
+    expect(screen.getByText(/Listed as/)).toHaveTextContent(
+      formatAbsolute(MINTED.expires_at),
+    );
+    // The guard on the guard: if formatAbsolute were a passthrough, the
+    // assertion above would hold while the defect stood.
+    expect(formatAbsolute(MINTED.expires_at)).not.toContain("T00:00:00Z");
   });
 
   it("describes the scope the token was minted FOR when the scope changed mid-flight", async () => {

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
+import type { UseMutationResult } from "@tanstack/react-query";
 import { AlertTriangle, Check, ExternalLink, Lock } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -24,6 +25,7 @@ import { SiteScopeStep, type SiteScopeSelection } from "./site-scope-step";
 import {
   ConnectionsRequestError,
   useMintConnection,
+  type MintConnectionInput,
   type MintedConnection,
 } from "./use-ai-connections";
 import {
@@ -661,27 +663,112 @@ function NextSteps({ clientName }: { clientName: string }) {
   );
 }
 
+/** The site-scope fields a mint request carries, exactly as they go on the wire. */
+interface MintScope {
+  readonly siteScopeMode: SiteScopeSelection["mode"];
+  readonly scopeTagIds: readonly string[];
+  readonly scopeSiteIds: readonly string[];
+}
+
+type MintScopeRequest =
+  | { readonly ok: true; readonly scope: MintScope }
+  | {
+      readonly ok: false;
+      readonly because: "tags-unresolved" | "names-nothing";
+      readonly refusal: string;
+    };
+
+/**
+ * The site-scope payload for the CURRENT selection, or the reason there is none.
+ *
+ * THE GATE AND THE REQUEST ARE THE SAME VALUE. They used to be two derivations
+ * of one selection, and they disagreed: the gate asked `isScopeApprovable`,
+ * which says an empty scope is a working state (site-scope.ts, the 2026-08-23
+ * wireframe revision), while the request sent whatever was in state. So a
+ * button the screen had enabled produced a 400 the operator could do nothing
+ * with. Returning the payload and the refusal from one function means an
+ * enabled button always has a payload, and it is that payload that is sent.
+ *
+ * TWO THINGS THE SERVER REFUSES, AND THE SCREEN MUST NOT SEND:
+ *
+ *   NAMING NOTHING. ValidateSiteScopeRequest (apps/api/internal/mcp/scope.go
+ *   lines 168-200) refuses mode 'tags' with no tag ids and mode 'list' with no
+ *   site ids, both with the same reason: "an empty tag list grants nothing and
+ *   is not a way to request every site". The wizard OPENS on mode 'list' with
+ *   nothing selected, so this was reachable by doing nothing at all: pick a
+ *   client, pick the token method, press the button, get a 400.
+ *
+ *   NAMING THE WRONG KIND. The same function refuses mode 'all' that also
+ *   carries tags or sites, and mode 'tags' that also carries sites. Step 3
+ *   deliberately KEEPS the other mode's selection when the segmented control
+ *   is flipped (site-scope-step.tsx: "a mode flipped by accident does not throw
+ *   away the other answer"), which is right for the picker and wrong for the
+ *   wire. Ticking three sites and then choosing "All sites" sent mode 'all'
+ *   with three site ids. Only the ids belonging to the live mode are carried.
+ */
+function mintScopeRequest(
+  mode: SiteScopeSelection["mode"],
+  scopeTagIds: readonly string[] | null,
+  scopeSiteIds: readonly string[],
+): MintScopeRequest {
+  if (mode === "all") {
+    return { ok: true, scope: { siteScopeMode: "all", scopeTagIds: [], scopeSiteIds: [] } };
+  }
+  if (mode === "tags") {
+    if (scopeTagIds === null) {
+      return {
+        ok: false,
+        because: "tags-unresolved",
+        refusal:
+          "This connection's tag scope could not be resolved to ids -- the tag registry has not finished loading, or a tag you picked is no longer in it. Reopen step 3, confirm your tags once it loads, and try again.",
+      };
+    }
+    if (scopeTagIds.length === 0) {
+      return {
+        ok: false,
+        because: "names-nothing",
+        refusal:
+          "This connection is scoped by tag and no tag is picked, so there is nothing to mint it against. Pick at least one tag in step 3, or switch that step to All sites. An empty tag list is refused rather than read as every site.",
+      };
+    }
+    return { ok: true, scope: { siteScopeMode: "tags", scopeTagIds, scopeSiteIds: [] } };
+  }
+  if (scopeSiteIds.length === 0) {
+    return {
+      ok: false,
+      because: "names-nothing",
+      refusal:
+        "This connection is scoped to named sites and no site is picked, so there is nothing to mint it against. Pick at least one site in step 3, or switch that step to All sites. An empty list is refused rather than read as every site.",
+    };
+  }
+  return { ok: true, scope: { siteScopeMode: "list", scopeTagIds: [], scopeSiteIds } };
+}
+
 /**
  * The reason minting is refused, or null when it is not.
  *
  * Every branch here is a FAILURE, rendered with a remedy, never a silently
- * disabled button. `tagsResolved` being false is the client-side half of the
- * refusal this whole panel exists to make loud: see resolveTagIds.
+ * disabled button.
+ *
+ * THE ORDER IS LOAD-BEARING. An unresolved tag registry is reported first,
+ * because a selection that cannot be translated is not the same complaint as a
+ * selection that is empty. A fleet still loading is reported before "you have
+ * picked nothing", because telling an operator to pick a site out of a list
+ * that has not arrived is a remedy they cannot follow.
  */
 function mintBlockedReason(
   nameOk: boolean,
   scope: ResolvedSiteScope,
-  tagsResolved: boolean,
+  scopeRequest: MintScopeRequest,
 ): string | null {
   if (!nameOk) return "Name this connection before minting a token.";
-  if (!tagsResolved) {
-    return "This connection's tag scope could not be resolved to ids -- the tag registry has not finished loading, or a tag you picked is no longer in it. Reopen step 3, confirm your tags once it loads, and try again.";
-  }
+  if (!scopeRequest.ok && scopeRequest.because === "tags-unresolved") return scopeRequest.refusal;
   if (!isScopeApprovable(scope)) {
     return scope.kind === "unresolved" && scope.because === "loading"
       ? "Still reading this organisation's sites for step 3. Wait for that to finish before minting."
       : "This organisation's sites could not be read for step 3, so we cannot tell what this connection would cover. Fix that above before minting.";
   }
+  if (!scopeRequest.ok) return scopeRequest.refusal;
   return null;
 }
 
@@ -771,45 +858,45 @@ type MintedReveal = {
  * it correctly costs nothing and loses nothing.
  */
 function TokenMintPanel({
+  mint,
+  revealed,
+  onMinted,
   clientName,
   name,
   scope,
-  siteScopeMode,
-  scopeTagIds,
-  scopeSiteIds,
+  scopeRequest,
 }: {
+  /**
+   * The mutation, OWNED BY THE WIZARD. This panel drives it and reads it, and
+   * deliberately does not hold it: a mutation whose lifetime is this
+   * component's lifetime is a request that dies when the operator changes the
+   * method, which is the whole defect.
+   */
+  mint: UseMutationResult<MintedConnection, Error, MintConnectionInput>;
+  /** A token is already on screen, rendered by the wizard above every step. */
+  revealed: boolean;
+  onMinted: (reveal: MintedReveal) => void;
   clientName: string;
   name: string;
   scope: ResolvedSiteScope;
-  siteScopeMode: SiteScopeSelection["mode"];
-  scopeTagIds: readonly string[] | null;
-  scopeSiteIds: readonly string[];
+  scopeRequest: MintScopeRequest;
 }) {
-  const mint = useMintConnection();
-  const [reveal, setReveal] = useState<MintedReveal | null>(null);
   const trimmedName = name.trim();
-
-  const configKey = `${siteScopeMode}|${scopeSiteIds.join(",")}|${(scopeTagIds ?? []).join(",")}|${trimmedName}`;
-  // React's own "adjusting state when a prop changes" pattern -- state, not a
-  // ref, so this stays a value the compiler can reason about. Comparing and
-  // resetting DURING RENDER (React bails out and re-renders before committing)
-  // is what keeps a token or an error from ever painting even once beside a
-  // configuration it was not produced for; a useEffect here would let that
-  // one stale paint through first.
-  const [lastConfigKey, setLastConfigKey] = useState(configKey);
-  if (lastConfigKey !== configKey) {
-    setLastConfigKey(configKey);
-    if (reveal !== null) setReveal(null);
-    if (mint.isError || mint.isSuccess) mint.reset();
-  }
-
   const nameOk = trimmedName.length > 0;
-  const tagsResolved = scopeTagIds !== null;
-  const blocked = mintBlockedReason(nameOk, scope, tagsResolved);
+  const blocked = mintBlockedReason(nameOk, scope, scopeRequest);
   const canMint = blocked === null && !mint.isPending;
 
-  if (reveal !== null) {
-    return <TokenReveal reveal={reveal} />;
+  if (revealed) {
+    // The reveal itself is rendered at the top of the wizard, not here, so
+    // that no step condition governs whether a live credential is visible.
+    // What belongs here is a pointer to it, because an operator who scrolled
+    // to step 4 to press a button must not find the button simply gone.
+    return (
+      <p className="text-sm text-[var(--color-muted-foreground)]">
+        This connection's token is shown at the top of this page. It is shown once and is not
+        shown again, so copy it before you dismiss it.
+      </p>
+    );
   }
 
   return (
@@ -846,18 +933,19 @@ function TokenMintPanel({
         type="button"
         disabled={!canMint}
         onClick={() => {
+          // canMint already proved this, and an enabled button with no payload
+          // would be the gate and the request disagreeing again. Refusing here
+          // rather than sending `?? []` keeps that impossible instead of quiet.
+          if (!scopeRequest.ok) return;
           // Read here, at the moment the request is built, and closed over.
           // Reading them again inside onSuccess is the whole defect: that runs
           // after a round trip the operator can type through.
           const mintedFor = { scope, clientName };
           mint.mutate(
-            {
-              name: trimmedName,
-              siteScopeMode,
-              scopeTagIds: scopeTagIds ?? [],
-              scopeSiteIds,
-            },
-            { onSuccess: (token) => setReveal({ token, ...mintedFor }) },
+            { name: trimmedName, ...scopeRequest.scope },
+            // onMinted writes state the WIZARD owns, so this callback lands on
+            // a mounted component whatever happened to this panel meanwhile.
+            { onSuccess: (token) => onMinted({ token, ...mintedFor }) },
           );
         }}
       >
@@ -878,7 +966,7 @@ function TokenMintPanel({
  * ships is the reveal itself, matching the wireframe's non-negotiables; the
  * setup-command shape is outstanding.
  */
-function TokenReveal({ reveal }: { reveal: MintedReveal }) {
+function TokenReveal({ reveal, onDismiss }: { reveal: MintedReveal; onDismiss: () => void }) {
   // Destructured from the one snapshot, and there is deliberately no second
   // source: this component takes no live prop it could describe the token
   // with, so a stale label is not a race that has to be won but a state that
@@ -920,7 +1008,28 @@ function TokenReveal({ reveal }: { reveal: MintedReveal }) {
           {describeSiteScope(scope)} Capabilities: {capabilities}. Revocable from the connections
           list, immediately, at the next request.
         </p>
+        {/* THE HANDLE FOR REVOKING IT, shown beside the secret rather than
+            only in a list the operator has not opened. If anything goes wrong
+            between here and their password manager, this prefix is what lets
+            them find and kill this exact credential; without it, "revoke the
+            one I just made" is a guess. It is not the secret and is safe to
+            leave on screen. */}
+        <p className="mt-1 text-xs text-[var(--color-muted-foreground)]">
+          Listed as <span className="font-mono">{token.tokenPrefix}</span> in the connections
+          list. Expires {token.expiresAt}.
+        </p>
       </div>
+
+      {/* DISMISSAL IS AN ACT, NEVER A SIDE EFFECT. This panel used to clear
+          itself whenever an input it was minted for changed, which meant one
+          keystroke in the name field destroyed the only copy of a live
+          credential -- the same accounting hole as losing the response to an
+          unmount, reached by a shorter route. The reveal carries the
+          configuration it was minted FOR, so it cannot go stale and has
+          nothing to be cleared about. */}
+      <Button type="button" variant="outline" onClick={onDismiss}>
+        I have saved this token
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -19,6 +19,8 @@ import {
   type McpClientRow,
 } from "./client-table";
 import { buildSnippet, type Snippet } from "./snippet";
+import { SiteScopeStep, type SiteScopeSelection } from "./site-scope-step";
+import type { FleetSnapshot } from "@/features/mcp-consent/site-scope";
 
 // The connection wizard (design §18). Client first, method second.
 //
@@ -28,18 +30,27 @@ import { buildSnippet, type Snippet } from "./snippet";
 // generic 'unavailable'. Asking a user to choose an auth method their client
 // cannot use is asking them to fail."
 //
-// WHAT THIS RENDERS AND WHAT IT DOES NOT. Steps 1, 2, 5 and 6 live here. Steps
-// 3 and 4 -- which sites, what capabilities -- are collected on the approval
-// screen at /connect/ai, because that is where the grant is actually created
-// (features/mcp-consent/consent-screen.tsx). Duplicating them here would build
-// a second, unwired copy of a consent decision, and a wizard that appears to
-// grant scope it cannot grant is worse than one that says where the choice
-// happens. The step rail below says so on screen.
+// WHAT THIS RENDERS AND WHAT IT DOES NOT. Steps 1, 2, 3 and the setup artefact
+// live here. STEP 3 IS NEW AND IS A REAL DECISION SURFACE: the wireframe puts
+// "which sites" before "what it may do" on purpose, and mcp_grants already
+// carries site_scope_mode, scope_tag_ids and scope_site_ids, so nothing about
+// the selection is blocked on the backend.
+//
+// WHAT STEP 3 STILL CANNOT DO, SAID ON SCREEN RATHER THAN HIDDEN. The grant is
+// created by the approval screen at /connect/ai, which the CLIENT redirects
+// into; this wizard never calls it and has no channel to hand it an answer.
+// So the choice made here is the operator arriving with the answer, not the
+// answer being written. The same is already true of the connection name two
+// sections down, and it is stated the same way rather than implied.
+//
+// Step 4 (capabilities) and the token artefact are NOT stubbed here. Their
+// schema and their endpoint do not exist yet, and a disabled control for a
+// feature with no backend is a promise this file cannot keep.
 //
 // NO SNIPPET IS WRITTEN IN THIS FILE. Every block comes from buildSnippet, and
 // snippet.test.ts fails the build if a config literal appears here.
 
-type Step = 1 | 2 | 3;
+type Step = 1 | 2 | 3 | 4;
 
 interface StepDef {
   readonly n: Step;
@@ -49,20 +60,48 @@ interface StepDef {
 const STEPS: readonly StepDef[] = [
   { n: 1, label: "Pick your client" },
   { n: 2, label: "How it signs in" },
-  { n: 3, label: "Set it up" },
+  { n: 3, label: "Sites it may reach" },
+  { n: 4, label: "Set it up" },
 ];
 
 export interface ConnectWizardProps {
   /** Absolute MCP endpoint for this deployment. Passed in, never assembled here. */
   endpointUrl: string;
+  /**
+   * What the route loaded of the fleet, or null when the load has not finished
+   * or failed. NULL IS NOT AN EMPTY SNAPSHOT, and a full page is NOT a whole
+   * fleet. Both facts travel inside FleetSnapshot rather than being re-derived
+   * on this screen.
+   */
+  fleet: FleetSnapshot | null;
+  /** The tag registry, or null when we could not read it. Null is not empty. */
+  tags: readonly { readonly id: string; readonly name: string }[] | null;
+  tagsBySiteId: Readonly<Record<string, readonly string[]>>;
+  sitesLoading: boolean;
   /** Where the approval flow lives, for the closing instructions. */
   className?: string;
 }
 
-export function ConnectWizard({ endpointUrl, className }: ConnectWizardProps) {
+export function ConnectWizard({
+  endpointUrl,
+  fleet,
+  tags,
+  tagsBySiteId,
+  sitesLoading,
+  className,
+}: ConnectWizardProps) {
   const [clientId, setClientId] = useState<string | null>(null);
   const [method, setMethod] = useState<AuthMethod | null>(null);
   const [name, setName] = useState("Fleet manager");
+  // NO DEFAULT 'all'. The consent screen refuses one for the same reason
+  // (m124 DECISION 1) and so does the schema: a scope nobody chose must not
+  // begin life as the widest one. 'list' holding nothing is the wireframe's
+  // opening state, and it is empty on purpose.
+  const [selection, setSelection] = useState<SiteScopeSelection>({
+    mode: "list",
+    tagNames: [],
+    siteIds: [],
+  });
 
   const client = useMemo(
     () => MCP_CLIENTS.find((c) => c.id === clientId) ?? null,
@@ -161,6 +200,33 @@ export function ConnectWizard({ endpointUrl, className }: ConnectWizardProps) {
       {client !== null && method !== null ? (
         <Section
           n={3}
+          title="Sites this connection may reach"
+          hint="Chosen before capabilities, on purpose. What a connection may do is only meaningful once you have fixed what it may do it to."
+        >
+          <SiteScopeStep
+            selection={selection}
+            onSelectionChange={setSelection}
+            fleet={fleet}
+            tags={tags}
+            tagsBySiteId={tagsBySiteId}
+            sitesLoading={sitesLoading}
+          />
+          {/* The same correction as the name field below, for the same reason.
+              The client opens the approval screen itself, so this page has no
+              channel into it and cannot hand it a scope. Deciding it here is
+              how you arrive with the answer; the approval screen is where it
+              is written, and it asks again. */}
+          <p className="mt-3 text-xs text-[var(--color-muted-foreground)]">
+            Nothing carries this selection to the approval screen. The client opens that
+            screen itself, so it asks for the scope again and that is where it is written.
+            Deciding it here is how you get there with the answer ready.
+          </p>
+        </Section>
+      ) : null}
+
+      {client !== null && method !== null ? (
+        <Section
+          n={4}
           title="Set it up"
           hint="Generated for this client. Every difference below is a real difference between clients."
         >
@@ -232,10 +298,11 @@ function StepRail({ current }: { current: Step }) {
       ))}
       <li className="flex items-center gap-2">
         <span aria-hidden="true">/</span>
-        {/* Named so the wizard does not look like it is hiding the consent
-            decision. It is made on the approval screen, which is where the
-            grant is created. */}
-        <span>4. Choose sites and permissions when you approve</span>
+        {/* Capabilities are NOT a numbered step in this rail. The grant columns
+            behind them do not exist yet, and a number for a screen that cannot
+            be built is a promise the rail has no way to keep. What it names
+            instead is where that decision is made today. */}
+        <span>Permissions are chosen on the approval screen</span>
       </li>
     </ol>
   );

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type ReactNode } from "react";
 import type { UseMutationResult } from "@tanstack/react-query";
+import { useBlocker } from "@tanstack/react-router";
 import { AlertTriangle, Check, ExternalLink, Lock } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -184,6 +185,48 @@ export function ConnectWizard({
   // second half, and it is the half that holds when this one is bypassed.
   const mintInFlight = mint.isPending;
 
+  // THE ROUTE IS A CONTROL TOO. Locking the client and method cards closed the
+  // doors inside this screen and left the front one open: the back link in the
+  // page header, a sidebar entry, the browser's own back button all unmount the
+  // wizard mid-request, and the response then lands on nothing. The server has
+  // already created a working credential whose one-time plaintext is shown to
+  // no one, that nobody knows to revoke because nobody knows it exists. So the
+  // same reasoning that disables the cards is extended to the route.
+  //
+  // `disabled` is what makes this NOT a trap. When no mint is open the blocker
+  // is never installed at all, so shouldBlockFn cannot run and cannot decide
+  // wrongly; when the mint settles -- resolved OR rejected -- isPending goes
+  // false, the effect tears the block down, and the operator leaves freely. A
+  // block that outlived its request would strand them on a page they cannot
+  // exit, which is a worse defect than the one being fixed.
+  const [navigationHeld, setNavigationHeld] = useState(false);
+  // WHAT THIS DOES NOT COVER, said here rather than left to be discovered:
+  // closing the tab, reloading, or typing an address. Those never reach the
+  // router. `enableBeforeUnload` is off on purpose rather than by omission --
+  // the browser's prompt is generic, cannot name the credential, is suppressed
+  // without prior interaction, and preserves nothing if the operator confirms.
+  // It would make this screen look protected against a case it does not
+  // protect, which this file refuses to do elsewhere for the same reason. Only
+  // owning the mint response outside the render tree closes those, and that is
+  // filed separately.
+  useBlocker({
+    disabled: !mintInFlight,
+    enableBeforeUnload: false,
+    shouldBlockFn: () => {
+      // A refusal the operator cannot see reads as a broken link, and they
+      // click it again harder. Recording it here is what puts a reason on the
+      // screen naming the credential being created and shown once.
+      setNavigationHeld(true);
+      return true;
+    },
+  });
+  // The reason is scoped to the request that caused it. Once nothing is in
+  // flight there is nothing being held, so a notice still claiming otherwise
+  // would be a false statement about the page the operator is now free to
+  // leave. Adjusted during render, the same way the stale-error reset below
+  // is, rather than in an effect that would paint the lie for one frame.
+  if (navigationHeld && !mintInFlight) setNavigationHeld(false);
+
   // Clearing a STALE ERROR when the configuration changes, and NOTHING ELSE.
   // This used to clear the reveal too, which is the same defect as the unmount
   // race wearing different clothes: a single keystroke in the name field, after
@@ -240,6 +283,19 @@ export function ConnectWizard({
             mint.reset();
           }}
         />
+      ) : null}
+
+      {navigationHeld ? (
+        <p
+          role="alert"
+          data-testid="navigation-held"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 text-sm text-[var(--color-foreground)]"
+        >
+          We kept you on this page. A connection token is being created right now, and it is shown
+          once, so leaving before it arrives would leave a live credential on your organisation
+          that nobody holds and nobody knows to revoke. This releases the moment the request
+          finishes, whether it succeeds or fails.
+        </p>
       ) : null}
 
       {mintInFlight ? (

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -589,7 +589,7 @@ function mintBlockedReason(
 ): string | null {
   if (!nameOk) return "Name this connection before minting a token.";
   if (!tagsResolved) {
-    return "A tag you picked in step 3 no longer resolves to an id -- the tag list may have reloaded since you chose it. Re-open step 3, re-pick it, and try again.";
+    return "This connection's tag scope could not be resolved to ids -- the tag registry has not finished loading, or a tag you picked is no longer in it. Reopen step 3, confirm your tags once it loads, and try again.";
   }
   if (!isScopeApprovable(scope)) {
     return scope.kind === "unresolved" && scope.because === "loading"
@@ -792,7 +792,11 @@ function TokenReveal({
           <Badge variant="muted">Shown once</Badge>
         </div>
         <div className="mt-2">
-          <CopyableMono value={token.token} label="Copy the connection token" truncate />
+          {/* NOT truncate. This is the one and only time the operator sees this
+              value; middle-truncating it here would hide characters they may
+              need to visually verify against what lands in their password
+              manager, for a secret that cannot be looked up again to check. */}
+          <CopyableMono value={token.token} label="Copy the connection token" />
         </div>
         <p className="mt-2 text-xs text-[var(--color-muted-foreground)]">
           {describeSiteScope(scope)} Capabilities: {capabilities}. Revocable from the connections

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -29,6 +29,7 @@ import {
   type MintConnectionInput,
   type MintedConnection,
 } from "./use-ai-connections";
+import { formatAbsolute } from "@/features/updates/schedule";
 import {
   describeSiteScope,
   isScopeApprovable,
@@ -1070,9 +1071,16 @@ function TokenReveal({ reveal, onDismiss }: { reveal: MintedReveal; onDismiss: (
             them find and kill this exact credential; without it, "revoke the
             one I just made" is a guess. It is not the secret and is safe to
             leave on screen. */}
+        {/* EXPIRY IS FOR A PERSON TO READ, so it is not the wire format. This
+            printed `expiresAt` raw and put "2026-09-06T12:00:00Z" inside an
+            English sentence, on the one screen the operator reads once and
+            cannot come back to. formatAbsolute is the same helper the update
+            runs use and it always names the zone it resolved the time in: an
+            expiry without a zone is not an answer to "when does this stop
+            working", and this token's whole value is knowing that. */}
         <p className="mt-1 text-xs text-[var(--color-muted-foreground)]">
           Listed as <span className="font-mono">{token.tokenPrefix}</span> in the connections
-          list. Expires {token.expiresAt}.
+          list. Expires {formatAbsolute(token.expiresAt)}.
         </p>
       </div>
 

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -106,6 +106,19 @@ export function ConnectWizard({
   const [clientId, setClientId] = useState<string | null>(null);
   const [method, setMethod] = useState<AuthMethod | null>(null);
   const [name, setName] = useState("Fleet manager");
+  // THE MINT AND ITS REVEAL LIVE HERE, ABOVE EVERY CONTROL THAT CAN UNMOUNT
+  // THE PANEL. They used to live inside TokenMintPanel, which step 4 renders
+  // only for method 'token' on a client that offers it; changing the method,
+  // or picking a client that cannot use a token, unmounted that panel WHILE
+  // ITS REQUEST WAS STILL OPEN. The server had already created the credential,
+  // and the response then wrote the one-time plaintext through a setState on a
+  // component nobody was looking at. The outcome is the worst this screen can
+  // produce: a live organisation credential that authenticates, whose plaintext
+  // was shown to no one, that nobody knows to revoke because nobody knows it
+  // exists. Holding the state at the wizard means a response always lands on a
+  // mounted surface, whatever the operator clicked while it was in the air.
+  const mint = useMintConnection();
+  const [reveal, setReveal] = useState<MintedReveal | null>(null);
   // NO DEFAULT 'all'. The consent screen refuses one for the same reason
   // (m124 DECISION 1) and so does the schema: a scope nobody chose must not
   // begin life as the widest one. 'list' holding nothing is the wireframe's
@@ -154,6 +167,35 @@ export function ConnectWizard({
     [selection.mode, selection.tagNames, tags],
   );
 
+  // The exact site-scope fields a mint would send, or the reason it can send
+  // none. Built ONCE, here, and both the gate and the request read this same
+  // value -- the gate cannot approve a payload different from the one that
+  // goes out, because there is only one payload.
+  const scopeRequest = useMemo(
+    () => mintScopeRequest(selection.mode, scopeTagIds, selection.siteIds),
+    [selection.mode, scopeTagIds, selection.siteIds],
+  );
+
+  // A mint is a network round trip, and every control above is live during it.
+  // Disabling them is the FIRST half of the fix (the operator is not offered a
+  // way to walk out on an open request); holding the state above them is the
+  // second half, and it is the half that holds when this one is bypassed.
+  const mintInFlight = mint.isPending;
+
+  // Clearing a STALE ERROR when the configuration changes, and NOTHING ELSE.
+  // This used to clear the reveal too, which is the same defect as the unmount
+  // race wearing different clothes: a single keystroke in the name field, after
+  // a token had been revealed, destroyed the only copy of a live credential.
+  // The reveal now carries the configuration it was minted for (MintedReveal),
+  // so it cannot go stale and has no reason to be thrown away; it is dismissed
+  // by an explicit act and by nothing else.
+  const configKey = `${selection.mode}|${selection.siteIds.join(",")}|${(scopeTagIds ?? []).join(",")}|${name.trim()}`;
+  const [lastConfigKey, setLastConfigKey] = useState(configKey);
+  if (lastConfigKey !== configKey) {
+    setLastConfigKey(configKey);
+    if (mint.isError) mint.reset();
+  }
+
   const snippet: Snippet | null = useMemo(() => {
     if (client === null || method === null) return null;
     try {
@@ -182,6 +224,33 @@ export function ConnectWizard({
     <div className={cn("space-y-6", className)}>
       <StepRail current={step} />
 
+      {/* THE ONE AND ONLY PLACE A REVEAL IS RENDERED, and it is deliberately
+          outside every step. A second render site inside step 4 would restore
+          exactly the fragility being removed: the token would be visible only
+          while the conditions that mount step 4 happen to hold. Here it is
+          governed by one thing, whether a token exists, so no client, method or
+          step change can take it off the screen. */}
+      {reveal !== null ? (
+        <TokenReveal
+          reveal={reveal}
+          onDismiss={() => {
+            setReveal(null);
+            mint.reset();
+          }}
+        />
+      ) : null}
+
+      {mintInFlight ? (
+        <p
+          role="status"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 text-sm text-[var(--color-foreground)]"
+        >
+          Minting a connection token. The client and sign-in choices are held until it finishes,
+          because the token it produces is shown once and leaving now would strand a live
+          credential nobody holds.
+        </p>
+      ) : null}
+
       <Section
         n={1}
         title="Pick your client"
@@ -193,6 +262,7 @@ export function ConnectWizard({
               <ClientCard
                 client={c}
                 selected={c.id === clientId}
+                locked={mintInFlight}
                 onSelect={() => chooseClient(c)}
               />
             </li>
@@ -213,6 +283,7 @@ export function ConnectWizard({
               body="You approve the connection here, and the client stores its own key. Nothing to copy or keep secret."
               availability={client.auth.oauth}
               selected={method === "oauth"}
+              locked={mintInFlight}
               onSelect={() => setMethod("oauth")}
             />
             <AuthCard
@@ -221,6 +292,7 @@ export function ConnectWizard({
               body="The documented path for CI, containers and SSH sessions, where no browser can open."
               availability={client.auth.token}
               selected={method === "token"}
+              locked={mintInFlight}
               onSelect={() => setMethod("token")}
             />
           </div>
@@ -309,12 +381,13 @@ export function ConnectWizard({
               <NextSteps clientName={client.name} />
             ) : (
               <TokenMintPanel
+                mint={mint}
+                revealed={reveal !== null}
+                onMinted={setReveal}
                 clientName={client.name}
                 name={name}
                 scope={scope}
-                siteScopeMode={selection.mode}
-                scopeTagIds={scopeTagIds}
-                scopeSiteIds={selection.siteIds}
+                scopeRequest={scopeRequest}
               />
             )}
           </div>
@@ -385,20 +458,25 @@ function Section({
 function ClientCard({
   client,
   selected,
+  locked,
   onSelect,
 }: {
   client: McpClientRow;
   selected: boolean;
+  /** A mint is open. Changing the client here would unmount its panel. */
+  locked: boolean;
   onSelect: () => void;
 }) {
   return (
     <button
       type="button"
       onClick={onSelect}
+      disabled={locked}
       aria-pressed={selected}
       className={cn(
         "flex h-full w-full flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]",
+        locked && "cursor-not-allowed opacity-70",
         selected
           ? "border-[var(--color-primary)] bg-[var(--color-accent)]"
           : "border-[var(--color-border)] hover:bg-[var(--color-accent)]",
@@ -429,6 +507,7 @@ function AuthCard({
   body,
   availability,
   selected,
+  locked,
   onSelect,
 }: {
   method: AuthMethod;
@@ -436,9 +515,16 @@ function AuthCard({
   body: string;
   availability: AuthAvailability;
   selected: boolean;
+  /**
+   * A mint is open. Switching method here unmounts the panel that owns the
+   * request, so it is refused for as long as the request is in the air. The
+   * reason is stated once at the top of the wizard rather than repeated on
+   * every card, because it is one fact about the page, not four.
+   */
+  locked: boolean;
   onSelect: () => void;
 }) {
-  const disabled = availability.state !== "available";
+  const disabled = availability.state !== "available" || locked;
   return (
     <button
       type="button"

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -640,6 +640,21 @@ function mintErrorCopy(error: Error): { title: string; body: string } {
 }
 
 /**
+ * A minted token together with the configuration it was minted FOR.
+ *
+ * The three fields travel as one value on purpose. Splitting the token from
+ * its scope is what let the reveal pair a real secret with a description read
+ * from state that had moved on; keeping them in one object means the reveal
+ * cannot be handed a token without also being handed the scope that token
+ * actually carries.
+ */
+type MintedReveal = {
+  readonly token: MintedConnection;
+  readonly scope: ResolvedSiteScope;
+  readonly clientName: string;
+};
+
+/**
  * Step 6's one-time reveal, and the button that produces it (design §S29,
  * revision 2026-08-24; the wireframe's own header badge marks this the
  * governing generation).
@@ -652,6 +667,22 @@ function mintErrorCopy(error: Error): { title: string; body: string } {
  * state with it. Editing an input THIS panel depends on without leaving also
  * clears it, below, so a revealed token can never be shown beside a
  * configuration it was not actually minted for.
+ *
+ * THE REVEAL IS BUILT FROM THE REQUEST, NOT FROM LIVE STATE. Clearing on edit
+ * cannot cover the in-flight window: a mint started against one configuration
+ * and finishing after the operator edited the name or the scope arrived at an
+ * `onSuccess` that fired unconditionally, and the reveal then described the
+ * scope it read at that moment -- a real token beside access it does not
+ * carry, on the one screen whose whole job is saying what was just made, at
+ * the only moment the token is ever visible. `MintedReveal` snapshots the
+ * scope and client the request was sent with and stores them WITH the
+ * response, so the reveal has no live-state input at all to be stale about.
+ *
+ * DISCARDING THE STALE MINT WOULD HAVE BEEN THE OTHER FIX, AND IS WORSE: the
+ * server has already created that credential. Refusing to show it leaves a
+ * live token in the organisation that nobody holds and nobody was told to
+ * revoke, which trades a mislabelled secret for an unaccounted one. Labelling
+ * it correctly costs nothing and loses nothing.
  */
 function TokenMintPanel({
   clientName,
@@ -669,7 +700,7 @@ function TokenMintPanel({
   scopeSiteIds: readonly string[];
 }) {
   const mint = useMintConnection();
-  const [token, setToken] = useState<MintedConnection | null>(null);
+  const [reveal, setReveal] = useState<MintedReveal | null>(null);
   const trimmedName = name.trim();
 
   const configKey = `${siteScopeMode}|${scopeSiteIds.join(",")}|${(scopeTagIds ?? []).join(",")}|${trimmedName}`;
@@ -682,7 +713,7 @@ function TokenMintPanel({
   const [lastConfigKey, setLastConfigKey] = useState(configKey);
   if (lastConfigKey !== configKey) {
     setLastConfigKey(configKey);
-    if (token !== null) setToken(null);
+    if (reveal !== null) setReveal(null);
     if (mint.isError || mint.isSuccess) mint.reset();
   }
 
@@ -691,8 +722,8 @@ function TokenMintPanel({
   const blocked = mintBlockedReason(nameOk, scope, tagsResolved);
   const canMint = blocked === null && !mint.isPending;
 
-  if (token !== null) {
-    return <TokenReveal clientName={clientName} scope={scope} token={token} />;
+  if (reveal !== null) {
+    return <TokenReveal reveal={reveal} />;
   }
 
   return (
@@ -729,6 +760,10 @@ function TokenMintPanel({
         type="button"
         disabled={!canMint}
         onClick={() => {
+          // Read here, at the moment the request is built, and closed over.
+          // Reading them again inside onSuccess is the whole defect: that runs
+          // after a round trip the operator can type through.
+          const mintedFor = { scope, clientName };
           mint.mutate(
             {
               name: trimmedName,
@@ -736,7 +771,7 @@ function TokenMintPanel({
               scopeTagIds: scopeTagIds ?? [],
               scopeSiteIds,
             },
-            { onSuccess: (data) => setToken(data) },
+            { onSuccess: (token) => setReveal({ token, ...mintedFor }) },
           );
         }}
       >
@@ -757,15 +792,12 @@ function TokenMintPanel({
  * ships is the reveal itself, matching the wireframe's non-negotiables; the
  * setup-command shape is outstanding.
  */
-function TokenReveal({
-  clientName,
-  scope,
-  token,
-}: {
-  clientName: string;
-  scope: ResolvedSiteScope;
-  token: MintedConnection;
-}) {
+function TokenReveal({ reveal }: { reveal: MintedReveal }) {
+  // Destructured from the one snapshot, and there is deliberately no second
+  // source: this component takes no live prop it could describe the token
+  // with, so a stale label is not a race that has to be won but a state that
+  // cannot be constructed.
+  const { clientName, scope, token } = reveal;
   const capabilities =
     token.capabilities.length > 0 ? token.capabilities.join(", ") : "no capabilities";
   return (

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from "react";
 import { AlertTriangle, Check, ExternalLink, Lock } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CopyableMono } from "@/components/shared/copyable-mono";
@@ -20,7 +21,19 @@ import {
 } from "./client-table";
 import { buildSnippet, type Snippet } from "./snippet";
 import { SiteScopeStep, type SiteScopeSelection } from "./site-scope-step";
-import type { FleetSnapshot } from "@/features/mcp-consent/site-scope";
+import {
+  ConnectionsRequestError,
+  useMintConnection,
+  type MintedConnection,
+} from "./use-ai-connections";
+import {
+  describeSiteScope,
+  isScopeApprovable,
+  resolveSiteScope,
+  resolveTagIds,
+  type FleetSnapshot,
+  type ResolvedSiteScope,
+} from "@/features/mcp-consent/site-scope";
 
 // The connection wizard (design §18). Client first, method second.
 //
@@ -114,6 +127,32 @@ export function ConnectWizard({
   // answers. Picking a different client with an incompatible method drops the
   // method rather than carrying a stale one into step 3.
   const step: Step = client === null ? 1 : method === null ? 2 : 3;
+
+  // Resolved once here rather than inside the mint panel, so the SAME answer
+  // gates the mint button and is described back in the one-time reveal -- a
+  // panel that re-resolved its own copy could disagree with the gate that let
+  // it run.
+  const scope: ResolvedSiteScope = useMemo(
+    () =>
+      resolveSiteScope({
+        mode: selection.mode,
+        selectedTagNames: selection.tagNames,
+        selectedSiteIds: selection.siteIds,
+        fleet,
+        tagsBySiteId,
+        sitesLoading,
+      }),
+    [selection, fleet, tagsBySiteId, sitesLoading],
+  );
+
+  // NULL means a selected tag name no longer resolves to an id -- see
+  // resolveTagIds. The mint panel refuses to submit on null rather than
+  // sending the smaller array that survives, because that would narrow the
+  // connection's reach without telling the operator.
+  const scopeTagIds: readonly string[] | null = useMemo(
+    () => (selection.mode === "tags" ? resolveTagIds(selection.tagNames, tags) : []),
+    [selection.mode, selection.tagNames, tags],
+  );
 
   const snippet: Snippet | null = useMemo(() => {
     if (client === null || method === null) return null;
@@ -266,7 +305,18 @@ export function ConnectWizard({
               <SnippetBlock client={client} snippet={snippet} />
             )}
 
-            <NextSteps method={method} clientName={client.name} />
+            {method === "oauth" ? (
+              <NextSteps clientName={client.name} />
+            ) : (
+              <TokenMintPanel
+                clientName={client.name}
+                name={name}
+                scope={scope}
+                siteScopeMode={selection.mode}
+                scopeTagIds={scopeTagIds}
+                scopeSiteIds={selection.siteIds}
+              />
+            )}
           </div>
         </Section>
       ) : null}
@@ -512,28 +562,243 @@ function SnippetBlock({ client, snippet }: { client: McpClientRow; snippet: Snip
   );
 }
 
-function NextSteps({ method, clientName }: { method: AuthMethod; clientName: string }) {
-  if (method === "oauth") {
-    return (
-      <div className="rounded-md border border-[var(--color-border)] p-3 text-sm text-[var(--color-foreground)]">
-        <p className="font-medium">What happens next</p>
-        <p className="mt-1 text-[var(--color-muted-foreground)]">
-          Start the connection in {clientName}. It sends you back here to approve, and that approval
-          screen is where you choose which sites it may touch and what it may do. Nothing is created
-          until you approve.
-        </p>
-      </div>
-    );
-  }
+function NextSteps({ clientName }: { clientName: string }) {
   return (
     <div className="rounded-md border border-[var(--color-border)] p-3 text-sm text-[var(--color-foreground)]">
-      <p className="font-medium">You cannot mint a token here yet</p>
+      <p className="font-medium">What happens next</p>
       <p className="mt-1 text-[var(--color-muted-foreground)]">
-        The config above is correct and ready, but the dashboard has no way to issue a connection
-        token today, so the placeholder in it stays a placeholder. Use browser sign-in if{" "}
-        {clientName} supports it. We would rather tell you this now than after you have pasted a
-        config that cannot authenticate.
+        Start the connection in {clientName}. It sends you back here to approve, and that approval
+        screen is where you choose which sites it may touch and what it may do. Nothing is created
+        until you approve.
       </p>
+    </div>
+  );
+}
+
+/**
+ * The reason minting is refused, or null when it is not.
+ *
+ * Every branch here is a FAILURE, rendered with a remedy, never a silently
+ * disabled button. `tagsResolved` being false is the client-side half of the
+ * refusal this whole panel exists to make loud: see resolveTagIds.
+ */
+function mintBlockedReason(
+  nameOk: boolean,
+  scope: ResolvedSiteScope,
+  tagsResolved: boolean,
+): string | null {
+  if (!nameOk) return "Name this connection before minting a token.";
+  if (!tagsResolved) {
+    return "A tag you picked in step 3 no longer resolves to an id -- the tag list may have reloaded since you chose it. Re-open step 3, re-pick it, and try again.";
+  }
+  if (!isScopeApprovable(scope)) {
+    return scope.kind === "unresolved" && scope.because === "loading"
+      ? "Still reading this organisation's sites for step 3. Wait for that to finish before minting."
+      : "This organisation's sites could not be read for step 3, so we cannot tell what this connection would cover. Fix that above before minting.";
+  }
+  return null;
+}
+
+/** Title and remedy for a failed mint. Every branch is distinct and named. */
+function mintErrorCopy(error: Error): { title: string; body: string } {
+  if (!(error instanceof ConnectionsRequestError)) {
+    // A raw fetch failure -- offline, DNS, a dropped connection -- never
+    // reaches readHouseError, so it is never a ConnectionsRequestError. It is
+    // still a failure and still gets a remedy, not the fact-shaped silence of
+    // an empty catch.
+    return {
+      title: "The request did not reach the server",
+      body: "Check your connection and try again. Nothing was created.",
+    };
+  }
+  if (error.status === 403) {
+    return {
+      title: "Your role cannot mint a connection token",
+      body: "An AI connection is an organisation-wide credential, so minting one needs full organisation membership, not access to one site. Ask an organisation admin to mint it, or ask them to raise your role.",
+    };
+  }
+  if (error.status === 429) {
+    const retry =
+      typeof error.details?.retry_after_seconds === "number"
+        ? error.details.retry_after_seconds
+        : null;
+    return {
+      title: "Too many connection tokens minted recently",
+      body:
+        retry !== null
+          ? `Wait about ${retry} second${retry === 1 ? "" : "s"} and try again.`
+          : "Wait a short while and try again.",
+    };
+  }
+  if (error.code === "mcp_unknown_scope_tag" || error.code === "mcp_unknown_scope_site") {
+    return {
+      title: "A site or tag from step 3 no longer exists",
+      body: "Something in the scope you picked was deleted since step 3 loaded. Reopen step 3, re-pick sites or tags, and try again.",
+    };
+  }
+  return { title: "The server refused this request", body: error.message };
+}
+
+/**
+ * Step 6's one-time reveal, and the button that produces it (design §S29,
+ * revision 2026-08-24; the wireframe's own header badge marks this the
+ * governing generation).
+ *
+ * THE TOKEN LIVES ONLY IN THIS COMPONENT'S OWN STATE. It is never handed to
+ * TanStack Query's cache (useMintConnection.onSuccess invalidates the list, it
+ * does not setQueryData the token), so there is no cache key that could hand
+ * it back. Leaving this step -- picking a different client or method, which
+ * unmounts this panel, or navigating away from the route entirely -- drops the
+ * state with it. Editing an input THIS panel depends on without leaving also
+ * clears it, below, so a revealed token can never be shown beside a
+ * configuration it was not actually minted for.
+ */
+function TokenMintPanel({
+  clientName,
+  name,
+  scope,
+  siteScopeMode,
+  scopeTagIds,
+  scopeSiteIds,
+}: {
+  clientName: string;
+  name: string;
+  scope: ResolvedSiteScope;
+  siteScopeMode: SiteScopeSelection["mode"];
+  scopeTagIds: readonly string[] | null;
+  scopeSiteIds: readonly string[];
+}) {
+  const mint = useMintConnection();
+  const [token, setToken] = useState<MintedConnection | null>(null);
+  const trimmedName = name.trim();
+
+  const configKey = `${siteScopeMode}|${scopeSiteIds.join(",")}|${(scopeTagIds ?? []).join(",")}|${trimmedName}`;
+  // React's own "adjusting state when a prop changes" pattern -- state, not a
+  // ref, so this stays a value the compiler can reason about. Comparing and
+  // resetting DURING RENDER (React bails out and re-renders before committing)
+  // is what keeps a token or an error from ever painting even once beside a
+  // configuration it was not produced for; a useEffect here would let that
+  // one stale paint through first.
+  const [lastConfigKey, setLastConfigKey] = useState(configKey);
+  if (lastConfigKey !== configKey) {
+    setLastConfigKey(configKey);
+    if (token !== null) setToken(null);
+    if (mint.isError || mint.isSuccess) mint.reset();
+  }
+
+  const nameOk = trimmedName.length > 0;
+  const tagsResolved = scopeTagIds !== null;
+  const blocked = mintBlockedReason(nameOk, scope, tagsResolved);
+  const canMint = blocked === null && !mint.isPending;
+
+  if (token !== null) {
+    return <TokenReveal clientName={clientName} scope={scope} token={token} />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--color-muted-foreground)]">
+        Mint a connection token for {clientName}. It is shown once, here, and never again.
+      </p>
+
+      {blocked !== null ? (
+        <p
+          role="alert"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 text-sm text-[var(--color-foreground)]"
+        >
+          {blocked}
+        </p>
+      ) : null}
+
+      {mint.isError
+        ? (() => {
+            const { title, body } = mintErrorCopy(mint.error);
+            return (
+              <div
+                role="alert"
+                className="rounded-md border border-[var(--color-destructive)]/40 bg-[var(--color-destructive)]/5 p-3 text-sm"
+              >
+                <p className="font-medium text-[var(--color-foreground)]">{title}</p>
+                <p className="mt-1 text-[var(--color-muted-foreground)]">{body}</p>
+              </div>
+            );
+          })()
+        : null}
+
+      <Button
+        type="button"
+        disabled={!canMint}
+        onClick={() => {
+          mint.mutate(
+            {
+              name: trimmedName,
+              siteScopeMode,
+              scopeTagIds: scopeTagIds ?? [],
+              scopeSiteIds,
+            },
+            { onSuccess: (data) => setToken(data) },
+          );
+        }}
+      >
+        {mint.isPending ? "Minting..." : "Generate connection token"}
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * The one-time reveal itself. Rendered exactly once per mint, from state the
+ * parent never repopulates -- see TokenMintPanel's own doc.
+ *
+ * THE SHELL SETUP COMMAND FOR {clientName} IS NOT RENDERED HERE. This client's
+ * table entry (client-table.ts) emits a JSON or raw config, not a CLI
+ * invocation, so there is no `claude mcp add`-shaped command in this codebase
+ * to fill in without inventing a third snippet kind under time pressure. What
+ * ships is the reveal itself, matching the wireframe's non-negotiables; the
+ * setup-command shape is outstanding.
+ */
+function TokenReveal({
+  clientName,
+  scope,
+  token,
+}: {
+  clientName: string;
+  scope: ResolvedSiteScope;
+  token: MintedConnection;
+}) {
+  const capabilities =
+    token.capabilities.length > 0 ? token.capabilities.join(", ") : "no capabilities";
+  return (
+    <div className="space-y-3">
+      <div
+        role="alert"
+        className="rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 text-sm"
+      >
+        <p className="flex items-center gap-1.5 font-medium text-[var(--color-foreground)]">
+          <AlertTriangle aria-hidden="true" className="size-4" />
+          This is the only time this token is shown
+        </p>
+        <p className="mt-1 text-[var(--color-muted-foreground)]">
+          We store a hash, not the token. Copy it into your password manager now, or rotate the
+          connection later and reconfigure {clientName}. There is no showing it again.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-[var(--color-border)] p-3">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs font-medium text-[var(--color-foreground)]">
+            Your connection token
+          </span>
+          <Badge variant="muted">Shown once</Badge>
+        </div>
+        <div className="mt-2">
+          <CopyableMono value={token.token} label="Copy the connection token" truncate />
+        </div>
+        <p className="mt-2 text-xs text-[var(--color-muted-foreground)]">
+          {describeSiteScope(scope)} Capabilities: {capabilities}. Revocable from the connections
+          list, immediately, at the next request.
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/ai-connections/site-scope-step.tsx
+++ b/apps/web/src/features/ai-connections/site-scope-step.tsx
@@ -1,0 +1,405 @@
+import { useMemo, useState } from "react";
+import { X } from "lucide-react";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+import {
+  describeSiteScope,
+  resolveSiteScope,
+  type FleetSnapshot,
+  type ResolvedSiteScope,
+  type SiteScopeMode,
+} from "@/features/mcp-consent/site-scope";
+import {
+  SITE_STEP_MODES,
+  canLeaveSiteStep,
+  emptyTokenFieldLabel,
+  excludedSitesLabel,
+  fleetTotal,
+  scopeCountLabel,
+  scopeTokenLabel,
+  siteStepBlockedReason,
+} from "./site-step";
+
+// Step 3 of the connection wizard: which sites this connection may touch.
+//
+// WHY IT SITS BEFORE CAPABILITIES. The wireframe states the ordering as a
+// decision rather than a layout: "Chosen before capabilities, on purpose". A
+// capability list is meaningless until its blast radius is fixed, and asking
+// "what may it do" before "to what" produces a screen where every answer has to
+// be revised once the second question is answered.
+//
+// EVERY SENTENCE WITH A NUMBER IN IT COMES FROM site-step.ts OR site-scope.ts.
+// Nothing here computes a count inline, so there is exactly one place where a
+// partial page could be rendered as a whole fleet, and it is a pure function
+// with tests around it.
+
+export interface SiteScopeSelection {
+  readonly mode: SiteScopeMode;
+  readonly tagNames: readonly string[];
+  readonly siteIds: readonly string[];
+}
+
+export interface SiteScopeStepProps {
+  readonly selection: SiteScopeSelection;
+  readonly onSelectionChange: (next: SiteScopeSelection) => void;
+  /**
+   * What we loaded of the fleet, or null when the load has not finished or
+   * failed. NULL IS NOT AN EMPTY SNAPSHOT. See site-scope.ts.
+   */
+  readonly fleet: FleetSnapshot | null;
+  /**
+   * The tag registry, or null when we could not load it. Null is not an empty
+   * registry: one is a fact about the organisation, the other about our request.
+   */
+  readonly tags: readonly { readonly id: string; readonly name: string }[] | null;
+  readonly tagsBySiteId: Readonly<Record<string, readonly string[]>>;
+  readonly sitesLoading: boolean;
+}
+
+export function SiteScopeStep({
+  selection,
+  onSelectionChange,
+  fleet,
+  tags,
+  tagsBySiteId,
+  sitesLoading,
+}: SiteScopeStepProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { mode, tagNames, siteIds } = selection;
+
+  const scope: ResolvedSiteScope = useMemo(
+    () =>
+      resolveSiteScope({
+        mode,
+        selectedTagNames: tagNames,
+        selectedSiteIds: siteIds,
+        fleet,
+        tagsBySiteId,
+        sitesLoading,
+      }),
+    [mode, tagNames, siteIds, fleet, tagsBySiteId, sitesLoading],
+  );
+
+  const total = fleetTotal(fleet);
+  const blocked = siteStepBlockedReason(scope);
+  const excluded = excludedSitesLabel(scope, total);
+
+  function setMode(next: SiteScopeMode) {
+    // The selections are kept rather than cleared when the mode changes. They
+    // are separate fields on the wire (scope_tag_ids and scope_site_ids) and
+    // resolveSiteScope only ever reads the one belonging to the current mode,
+    // so a mode flipped by accident does not throw away the other answer.
+    onSelectionChange({ ...selection, mode: next });
+    setPickerOpen(false);
+  }
+
+  function toggleTag(name: string) {
+    onSelectionChange({
+      ...selection,
+      tagNames: tagNames.includes(name)
+        ? tagNames.filter((t) => t !== name)
+        : [...tagNames, name],
+    });
+  }
+
+  function toggleSite(id: string) {
+    onSelectionChange({
+      ...selection,
+      siteIds: siteIds.includes(id) ? siteIds.filter((s) => s !== id) : [...siteIds, id],
+    });
+  }
+
+  const tokens: readonly { key: string; label: string; remove: () => void }[] =
+    mode === "tags"
+      ? tagNames.map((name) => ({
+          key: name,
+          label: scopeTokenLabel("tags", name),
+          remove: () => toggleTag(name),
+        }))
+      : mode === "list"
+        ? siteIds.map((id) => ({
+            key: id,
+            label: scopeTokenLabel(
+              "list",
+              fleet?.sites.find((s) => s.id === id)?.name ?? id,
+            ),
+            remove: () => toggleSite(id),
+          }))
+        : [];
+
+  return (
+    <div className="space-y-3">
+      <SegmentedControl<SiteScopeMode>
+        aria-label="Site scope"
+        value={mode}
+        onChange={setMode}
+        options={SITE_STEP_MODES.map((m) => ({ value: m.value, label: m.label }))}
+      />
+
+      {/* The L state. A tag being resolved is a real wait, and the wireframe
+          gives it skeleton rows rather than a spinner, because what is arriving
+          is a list. */}
+      {scope.kind === "unresolved" && scope.because === "loading" ? (
+        <div data-testid="site-step-resolving" className="space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      ) : null}
+
+      {mode !== "all" ? (
+        <div>
+          <div
+            data-testid="site-step-tokenfield"
+            className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--color-border)] p-2"
+          >
+            {tokens.length === 0 ? (
+              <span className="px-1 text-xs text-[var(--color-muted-foreground)]">
+                {emptyTokenFieldLabel(mode)}
+              </span>
+            ) : (
+              tokens.map((t) => (
+                <span
+                  key={t.key}
+                  className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 px-2 py-0.5 text-xs text-[var(--color-foreground)]"
+                >
+                  <span className="font-mono">{t.label}</span>
+                  <button
+                    type="button"
+                    onClick={t.remove}
+                    aria-label={`Remove ${t.label}`}
+                    className="rounded-sm text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                  >
+                    <X aria-hidden="true" className="size-3" />
+                  </button>
+                </span>
+              ))
+            )}
+            <button
+              type="button"
+              onClick={() => setPickerOpen((open) => !open)}
+              aria-expanded={pickerOpen}
+              className="ml-auto rounded-md border border-[var(--color-border)] px-2 py-1 text-xs text-[var(--color-foreground)] hover:bg-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+            >
+              {/* Named for what the picker below actually lists. The wireframe
+                  writes "Add sites" on both modes; a control that opens a list
+                  of tags and calls them sites is the kind of small lie this
+                  screen exists to avoid. */}
+              {mode === "tags" ? "+ Add tags" : "+ Add sites"}
+            </button>
+          </div>
+
+          {pickerOpen ? (
+            <Picker
+              mode={mode}
+              fleet={fleet}
+              tags={tags}
+              tagNames={tagNames}
+              siteIds={siteIds}
+              onToggleTag={toggleTag}
+              onToggleSite={toggleSite}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      <p
+        data-testid="site-step-count"
+        className={cn(
+          "text-sm font-medium",
+          canLeaveSiteStep(scope)
+            ? "text-[var(--color-foreground)]"
+            : "text-[var(--color-destructive)]",
+        )}
+      >
+        {scopeCountLabel(scope, total)}
+      </p>
+
+      {/* THE EMPTY STATE, AND THE ONE SENTENCE THAT MAKES IT A STATE RATHER THAN
+          A FAILURE. Nothing here is styled as an error and nothing blocks on it:
+          an empty scope is a credential that reaches nothing yet, which is a
+          thing an operator is allowed to want. */}
+      {scope.kind === "none" && scope.because === "no-selection" ? (
+        <p
+          data-testid="site-step-empty"
+          className="text-sm text-[var(--color-muted-foreground)]"
+        >
+          A connection with an empty scope can read nothing and propose nothing. That is a
+          working state, not an error. It is how you mint a credential now and decide its
+          reach later.
+        </p>
+      ) : (
+        <p
+          data-testid="site-step-summary"
+          className="text-sm text-[var(--color-muted-foreground)]"
+        >
+          {describeSiteScope(scope)}
+        </p>
+      )}
+
+      {blocked !== null ? (
+        <p
+          role="alert"
+          data-testid="site-step-blocked"
+          className="rounded-md border border-[var(--color-destructive)]/30 p-3 text-sm text-[var(--color-destructive)]"
+        >
+          {blocked}
+        </p>
+      ) : null}
+
+      {excluded !== null ? (
+        <p data-testid="site-step-excluded" className="text-xs text-[var(--color-muted-foreground)]">
+          {excluded}
+        </p>
+      ) : null}
+
+      {mode === "tags" ? (
+        <p className="text-xs text-[var(--color-muted-foreground)]">
+          A tag is resolved to a site list at every request, not frozen here. Add a site to
+          the tag next month and this connection reaches it.
+        </p>
+      ) : null}
+
+      <p className="text-xs text-[var(--color-muted-foreground)]">
+        A site outside this scope is not greyed out with a reason when the model asks for
+        it. It is not listed at all. Telling a caller that a site exists but is off limits
+        is itself a disclosure.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The add panel.
+ *
+ * A FAILED REGISTRY AND AN EMPTY ONE GET DIFFERENT PANELS. `tags === null` is
+ * our request failing and says so; `tags === []` is a claim about the
+ * organisation and is only made when we actually read the registry. Same split
+ * for the fleet one branch down.
+ */
+function Picker({
+  mode,
+  fleet,
+  tags,
+  tagNames,
+  siteIds,
+  onToggleTag,
+  onToggleSite,
+}: {
+  mode: SiteScopeMode;
+  fleet: FleetSnapshot | null;
+  tags: readonly { readonly id: string; readonly name: string }[] | null;
+  tagNames: readonly string[];
+  siteIds: readonly string[];
+  onToggleTag: (name: string) => void;
+  onToggleSite: (id: string) => void;
+}) {
+  if (mode === "tags") {
+    if (tags === null) {
+      return (
+        <PickerNote testId="site-step-tags-failed" tone="error">
+          We could not load this organisation&apos;s tags, so there is nothing to pick
+          from. That is not the same as having no tags.
+        </PickerNote>
+      );
+    }
+    if (tags.length === 0) {
+      return (
+        <PickerNote testId="site-step-tags-empty" tone="muted">
+          This organisation has no tags yet. Create one on a site, or pick named sites
+          instead.
+        </PickerNote>
+      );
+    }
+    return (
+      <div data-testid="site-step-picker" className="mt-2 max-h-56 space-y-2 overflow-y-auto rounded-md border border-[var(--color-border)] p-2">
+        {tags.map((tag) => (
+          <label key={tag.id} className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={tagNames.includes(tag.name)}
+              onChange={() => onToggleTag(tag.name)}
+            />
+            <span className="font-mono text-xs">{scopeTokenLabel("tags", tag.name)}</span>
+          </label>
+        ))}
+      </div>
+    );
+  }
+
+  if (fleet === null) {
+    return (
+      <PickerNote testId="site-step-sites-failed" tone="error">
+        We could not load this organisation&apos;s sites, so there is nothing to pick from.
+        That is not the same as having no sites.
+      </PickerNote>
+    );
+  }
+
+  return (
+    <div data-testid="site-step-picker" className="mt-2 space-y-2">
+      {/* The picker is where truncation costs CHOICE rather than accuracy: the
+          grant is exactly what was ticked, but a site that never rendered
+          could not be ticked. Said here, beside the list it applies to. */}
+      {!fleet.complete ? (
+        <p
+          role="alert"
+          data-testid="site-step-picker-truncated"
+          className="rounded-md border border-[var(--color-destructive)]/30 p-2 text-xs text-[var(--color-destructive)]"
+        >
+          This organisation has more sites than we can list here, so the choices below are
+          not all of them. Anything you do not see is not covered.
+        </p>
+      ) : null}
+      {fleet.sites.length === 0 ? (
+        <PickerNote testId="site-step-sites-empty" tone="muted">
+          This organisation has no sites yet, so there is nothing to scope this connection
+          to.
+        </PickerNote>
+      ) : (
+        <div className="max-h-56 space-y-2 overflow-y-auto rounded-md border border-[var(--color-border)] p-2">
+          {fleet.sites.map((site) => (
+            <label key={site.id} className="flex items-start gap-2 text-sm">
+              <Checkbox
+                checked={siteIds.includes(site.id)}
+                onChange={() => onToggleSite(site.id)}
+              />
+              <span>
+                <span className="font-medium">{site.name}</span>{" "}
+                <span className="text-[var(--color-muted-foreground)]">{site.url}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PickerNote({
+  testId,
+  tone,
+  children,
+}: {
+  testId: string;
+  tone: "error" | "muted";
+  children: React.ReactNode;
+}) {
+  return (
+    <p
+      role={tone === "error" ? "alert" : undefined}
+      data-testid={testId}
+      className={cn(
+        "mt-2 rounded-md border p-2 text-xs",
+        tone === "error"
+          ? "border-[var(--color-destructive)]/30 text-[var(--color-destructive)]"
+          : "border-[var(--color-border)] text-[var(--color-muted-foreground)]",
+      )}
+    >
+      {children}
+    </p>
+  );
+}

--- a/apps/web/src/features/ai-connections/site-scope-step.tsx
+++ b/apps/web/src/features/ai-connections/site-scope-step.tsx
@@ -200,6 +200,7 @@ export function SiteScopeStep({
               tags={tags}
               tagNames={tagNames}
               siteIds={siteIds}
+              sitesLoading={sitesLoading}
               onToggleTag={toggleTag}
               onToggleSite={toggleSite}
             />
@@ -280,6 +281,14 @@ export function SiteScopeStep({
  * our request failing and says so; `tags === []` is a claim about the
  * organisation and is only made when we actually read the registry. Same split
  * for the fleet one branch down.
+ *
+ * AND A LOAD IN PROGRESS IS NEITHER. `fleet === null` covers both "we asked and
+ * it failed" and "we have not finished asking", so the failure panel used to
+ * render over a read that was still running -- a load in progress stated as a
+ * fact about the world, on the one panel whose job is to be honest about what
+ * we know. `sitesLoading` splits them, and it is checked FIRST because the
+ * failure copy is only true once there is nothing still in flight to be waiting
+ * on.
  */
 function Picker({
   mode,
@@ -287,6 +296,7 @@ function Picker({
   tags,
   tagNames,
   siteIds,
+  sitesLoading,
   onToggleTag,
   onToggleSite,
 }: {
@@ -295,6 +305,7 @@ function Picker({
   tags: readonly { readonly id: string; readonly name: string }[] | null;
   tagNames: readonly string[];
   siteIds: readonly string[];
+  sitesLoading: boolean;
   onToggleTag: (name: string) => void;
   onToggleSite: (id: string) => void;
 }) {
@@ -331,6 +342,13 @@ function Picker({
   }
 
   if (fleet === null) {
+    if (sitesLoading) {
+      return (
+        <PickerNote testId="site-step-sites-loading" tone="muted">
+          Still reading this organisation&apos;s sites. Nothing is missing yet.
+        </PickerNote>
+      );
+    }
     return (
       <PickerNote testId="site-step-sites-failed" tone="error">
         We could not load this organisation&apos;s sites, so there is nothing to pick from.

--- a/apps/web/src/features/ai-connections/site-step.test.ts
+++ b/apps/web/src/features/ai-connections/site-step.test.ts
@@ -160,19 +160,27 @@ describe("an empty scope is a working state, and this is where that is decided",
     expect(canLeaveSiteStep(scope)).toBe(true);
   });
 
-  it("disagrees with the approval gate on exactly that input", () => {
-    // Two gates exist because they differ here and nowhere else. If these ever
-    // agree on every input, one of them is redundant and the empty state has
-    // silently become an error again.
+  it("now agrees with the approval gate on the empty scope, and both still refuse unresolved", () => {
+    // The 2026-08-23 revision (wireframes.html:3559) made an empty scope
+    // approvable, so isScopeApprovable was changed to
+    // `scope.kind !== "unresolved"` -- the same rule canLeaveSiteStep already
+    // used. The two gates used to disagree on exactly one input (empty); pin
+    // that they now agree on it, with equal force in both directions: neither
+    // gate may go back to refusing empty, and neither may start accepting
+    // unresolved.
     const fleet = fleetOf(60, 200);
     const empty = resolve({ mode: "list", fleet });
     const picked = resolve({ mode: "list", siteIds: ["s1"], fleet });
     const every = resolve({ mode: "all", fleet });
     const unknown = resolve({ mode: "list", fleet: null });
 
-    expect([canLeaveSiteStep(empty), isScopeApprovable(empty)]).toEqual([true, false]);
-    // And they agree everywhere else.
-    for (const scope of [picked, every, unknown]) {
+    expect(empty.kind).toBe("none");
+    expect(unknown.kind).toBe("unresolved");
+
+    expect([canLeaveSiteStep(empty), isScopeApprovable(empty)]).toEqual([true, true]);
+    expect([canLeaveSiteStep(unknown), isScopeApprovable(unknown)]).toEqual([false, false]);
+    // And they agree everywhere else, as they always have.
+    for (const scope of [empty, picked, every, unknown]) {
       expect(canLeaveSiteStep(scope)).toBe(isScopeApprovable(scope));
     }
   });

--- a/apps/web/src/features/ai-connections/site-step.test.ts
+++ b/apps/web/src/features/ai-connections/site-step.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  isScopeApprovable,
+  resolveSiteScope,
+  snapshotFromPage,
+  type FleetSnapshot,
+  type ResolvedSiteScope,
+  type ScopedSite,
+} from "@/features/mcp-consent/site-scope";
+
+import {
+  SITE_STEP_MODES,
+  canLeaveSiteStep,
+  emptyTokenFieldLabel,
+  excludedSitesLabel,
+  fleetTotal,
+  scopeCountLabel,
+  scopeTokenLabel,
+  siteStepBlockedReason,
+  sitesInScope,
+} from "./site-step";
+
+// Step 3's arithmetic, which is the half of the screen that can lie with a
+// number rather than with a sentence.
+//
+// NO EXPECTED STRING IS FROZEN HERE. Every assertion is either a number, a
+// property of the string (contains this digit, contains no digit, does not
+// contain this word), or a string built from the same function under test with
+// different inputs. Freezing prose is how five separate tests on this surface
+// ended up asserting that the copy had not changed rather than that it was
+// true, and a reworded sentence should not redden a suite that is about
+// arithmetic.
+
+function site(n: number): ScopedSite {
+  return { id: `s${n}`, name: `site-${n}.example`, url: `https://site-${n}.example` };
+}
+
+function fleetOf(count: number, limit: number): FleetSnapshot {
+  return snapshotFromPage(
+    Array.from({ length: count }, (_, i) => site(i)),
+    limit,
+  );
+}
+
+const NO_TAGS: Readonly<Record<string, readonly string[]>> = {};
+
+function resolve(over: {
+  mode: "all" | "tags" | "list";
+  tagNames?: readonly string[];
+  siteIds?: readonly string[];
+  fleet: FleetSnapshot | null;
+  tagsBySiteId?: Readonly<Record<string, readonly string[]>>;
+  sitesLoading?: boolean;
+}): ResolvedSiteScope {
+  return resolveSiteScope({
+    mode: over.mode,
+    selectedTagNames: over.tagNames ?? [],
+    selectedSiteIds: over.siteIds ?? [],
+    fleet: over.fleet,
+    tagsBySiteId: over.tagsBySiteId ?? NO_TAGS,
+    sitesLoading: over.sitesLoading ?? false,
+  });
+}
+
+describe("the denominator never invents a fleet size", () => {
+  it("reports unknown, not zero, when the fleet did not load", () => {
+    // A failed load rendered as "0 of 0" is the failure-as-empty defect. The
+    // total must have no number in it at all.
+    expect(fleetTotal(null)).toEqual({ kind: "unknown" });
+  });
+
+  it("reports an exact total only when the page came back short", () => {
+    const total = fleetTotal(fleetOf(60, 200));
+    expect(total).toEqual({ kind: "exact", n: 60 });
+  });
+
+  it("reports a floor, not an exact total, when the page came back full", () => {
+    // 200 rows out of a 200-row request is indistinguishable from 200 out of
+    // 5000. Anything that reads this as a fleet size is claiming a row it does
+    // not hold.
+    const total = fleetTotal(fleetOf(200, 200));
+    expect(total.kind).toBe("floor");
+    expect(total).not.toEqual({ kind: "exact", n: 200 });
+  });
+});
+
+describe("the count line", () => {
+  it("prints the wireframe's ratio for an empty selection against a known fleet", () => {
+    const fleet = fleetOf(60, 200);
+    const scope = resolve({ mode: "list", fleet });
+    const label = scopeCountLabel(scope, fleetTotal(fleet));
+
+    // The shape the wireframe specifies, asserted as its parts rather than as
+    // a frozen sentence: zero in scope, sixty in the fleet, in that order.
+    expect(sitesInScope(scope)).toBe(0);
+    expect(label.startsWith("0 of 60")).toBe(true);
+    expect(label).not.toMatch(/at least/i);
+  });
+
+  it("degrades the denominator to a floor when the fleet page was full", () => {
+    const full = fleetOf(200, 200);
+    const short = fleetOf(200, 500);
+    const scope = (f: FleetSnapshot) => resolve({ mode: "list", fleet: f });
+
+    const floored = scopeCountLabel(scope(full), fleetTotal(full));
+    const exact = scopeCountLabel(scope(short), fleetTotal(short));
+
+    // Same numerator, same row count, different entitlement to claim it.
+    expect(floored).toMatch(/at least/i);
+    expect(exact).not.toMatch(/at least/i);
+    expect(floored).not.toBe(exact);
+  });
+
+  it("counts the selected sites, not the fleet, once something is picked", () => {
+    const fleet = fleetOf(60, 200);
+    const scope = resolve({ mode: "list", siteIds: ["s0", "s1", "s2"], fleet });
+    expect(sitesInScope(scope)).toBe(3);
+    expect(scopeCountLabel(scope, fleetTotal(fleet)).startsWith("3 of 60")).toBe(true);
+  });
+
+  it("prints NO number at all while the answer is still being worked out", () => {
+    // "Loading" must not render as a zero. A zero here is a confident answer,
+    // and the screen does not have one yet.
+    const scope = resolve({ mode: "tags", tagNames: ["a"], fleet: null, sitesLoading: true });
+    expect(scope.kind).toBe("unresolved");
+    expect(sitesInScope(scope)).toBeNull();
+    expect(scopeCountLabel(scope, fleetTotal(null))).not.toMatch(/\d/);
+  });
+
+  it("prints NO number at all when the fleet load failed", () => {
+    const scope = resolve({ mode: "list", siteIds: ["s0"], fleet: null, sitesLoading: false });
+    expect(scope.kind).toBe("unresolved");
+    expect(scopeCountLabel(scope, fleetTotal(null))).not.toMatch(/\d/);
+  });
+
+  it("distinguishes the pending answer from the failed one", () => {
+    const loading = resolve({ mode: "list", fleet: null, sitesLoading: true });
+    const failed = resolve({ mode: "list", fleet: null, sitesLoading: false });
+    expect(scopeCountLabel(loading, fleetTotal(null))).not.toBe(
+      scopeCountLabel(failed, fleetTotal(null)),
+    );
+    expect(siteStepBlockedReason(loading)).not.toBe(siteStepBlockedReason(failed));
+  });
+
+  it("says nothing is blocked when the scope resolved", () => {
+    const fleet = fleetOf(3, 200);
+    expect(siteStepBlockedReason(resolve({ mode: "list", fleet }))).toBeNull();
+    expect(siteStepBlockedReason(resolve({ mode: "all", fleet }))).toBeNull();
+  });
+});
+
+describe("an empty scope is a working state, and this is where that is decided", () => {
+  it("lets the operator leave step 3 with nothing selected", () => {
+    // The wireframe, verbatim on this point: an empty scope "is a working
+    // state, not an error". An earlier revision of this surface blocked the
+    // step here, and that is the behaviour being corrected.
+    const scope = resolve({ mode: "list", fleet: fleetOf(60, 200) });
+    expect(scope).toEqual({ kind: "none", because: "no-selection" });
+    expect(canLeaveSiteStep(scope)).toBe(true);
+  });
+
+  it("disagrees with the approval gate on exactly that input", () => {
+    // Two gates exist because they differ here and nowhere else. If these ever
+    // agree on every input, one of them is redundant and the empty state has
+    // silently become an error again.
+    const fleet = fleetOf(60, 200);
+    const empty = resolve({ mode: "list", fleet });
+    const picked = resolve({ mode: "list", siteIds: ["s1"], fleet });
+    const every = resolve({ mode: "all", fleet });
+    const unknown = resolve({ mode: "list", fleet: null });
+
+    expect([canLeaveSiteStep(empty), isScopeApprovable(empty)]).toEqual([true, false]);
+    // And they agree everywhere else.
+    for (const scope of [picked, every, unknown]) {
+      expect(canLeaveSiteStep(scope)).toBe(isScopeApprovable(scope));
+    }
+  });
+
+  it("still refuses to move on when nobody has read the fleet", () => {
+    const scope = resolve({ mode: "list", siteIds: ["s1"], fleet: null });
+    expect(canLeaveSiteStep(scope)).toBe(false);
+    expect(siteStepBlockedReason(scope)).not.toBeNull();
+  });
+
+  it("holds the step when a tag matches nothing in a page that is not the whole fleet", () => {
+    // "Matches nothing" is a claim that needs every site. Against a full page
+    // it is unresolved, not zero, and unresolved blocks.
+    const fleet = fleetOf(200, 200);
+    const scope = resolve({ mode: "tags", tagNames: ["nope"], fleet, tagsBySiteId: {} });
+    expect(scope.kind).toBe("unresolved");
+    expect(canLeaveSiteStep(scope)).toBe(false);
+  });
+
+  it("calls it a real zero once the page is known to be the whole fleet", () => {
+    const fleet = fleetOf(60, 200);
+    const scope = resolve({ mode: "tags", tagNames: ["nope"], fleet, tagsBySiteId: {} });
+    expect(scope).toEqual({ kind: "none", because: "no-matches" });
+    expect(canLeaveSiteStep(scope)).toBe(true);
+  });
+});
+
+describe("the sites this connection cannot reach", () => {
+  it("offers the excluded count only against an exact fleet", () => {
+    const exact = fleetOf(60, 200);
+    const floored = fleetOf(200, 200);
+    const pick = (f: FleetSnapshot) => resolve({ mode: "list", siteIds: ["s0", "s1"], fleet: f });
+
+    const label = excludedSitesLabel(pick(exact), fleetTotal(exact));
+    expect(label).not.toBeNull();
+    expect(label).toContain(String(60 - 2));
+
+    // A floor denominator makes the subtraction meaningless: the rows we never
+    // loaded are in neither half.
+    expect(excludedSitesLabel(pick(floored), fleetTotal(floored))).toBeNull();
+  });
+
+  it("says never only for a fixed list, because a tag is not fixed", () => {
+    const fleet = fleetOf(10, 200);
+    const byList = resolve({ mode: "list", siteIds: ["s0"], fleet });
+    const byTag = resolve({
+      mode: "tags",
+      tagNames: ["seo"],
+      fleet,
+      tagsBySiteId: { s0: ["seo"] },
+    });
+
+    expect(excludedSitesLabel(byList, fleetTotal(fleet))).toMatch(/never/i);
+    // A site given that tag next month IS reached, so "never" would be false.
+    expect(excludedSitesLabel(byTag, fleetTotal(fleet))).not.toMatch(/never/i);
+  });
+
+  it("offers nothing to see when the mode excludes nothing", () => {
+    const fleet = fleetOf(10, 200);
+    expect(excludedSitesLabel(resolve({ mode: "all", fleet }), fleetTotal(fleet))).toBeNull();
+  });
+
+  it("offers nothing while the scope is unresolved", () => {
+    const fleet = fleetOf(200, 200);
+    const scope = resolve({ mode: "tags", tagNames: ["x"], fleet, tagsBySiteId: {} });
+    expect(excludedSitesLabel(scope, fleetTotal(fleet))).toBeNull();
+  });
+});
+
+describe("the modes and their labels", () => {
+  it("offers exactly the three the schema permits, in the wireframe's order", () => {
+    expect(SITE_STEP_MODES.map((m) => m.value)).toEqual(["all", "tags", "list"]);
+  });
+
+  it("never puts a wire value on screen", () => {
+    // 'list' is the column value; "Named sites" is what a person reads.
+    for (const mode of SITE_STEP_MODES) {
+      expect(mode.label).not.toBe(mode.value);
+    }
+  });
+
+  it("prefixes a tag token and leaves a site token alone", () => {
+    expect(scopeTokenLabel("tags", "client-retainer")).toBe("tag:client-retainer");
+    expect(scopeTokenLabel("list", "acme.example")).toBe("acme.example");
+  });
+
+  it("names the thing the empty field is missing, per mode", () => {
+    expect(emptyTokenFieldLabel("tags")).not.toBe(emptyTokenFieldLabel("list"));
+  });
+});

--- a/apps/web/src/features/ai-connections/site-step.ts
+++ b/apps/web/src/features/ai-connections/site-step.ts
@@ -1,0 +1,202 @@
+// Wizard step 3 -- "Choose which sites this connection may touch".
+//
+// The RESOLUTION lives in features/mcp-consent/site-scope.ts and is not
+// duplicated here. That module already carries the two rules this screen must
+// obey (an empty resolved set means NO SITES, never every site; and the page we
+// hold is neither exhaustive nor fixed), and it was hardened on the consent
+// screen where the same mistakes cost consent. What lives HERE is only what
+// step 3 needs and the consent screen does not:
+//
+//   1. THE COUNT IN THE WIREFRAME'S SHAPE -- "0 of 60 sites." The consent
+//      screen deliberately never prints a fleet size, because it prints a
+//      sentence about coverage instead. Step 3 prints a ratio, and a ratio has
+//      a denominator, so the denominator is where the truncation trap lands on
+//      this screen. `FleetTotal` is that denominator made explicit: exact when
+//      the page came back short, a FLOOR when it came back full, and unknown
+//      when we could not read the fleet at all. No branch invents a total.
+//
+//   2. A DIFFERENT GATE. `isScopeApprovable` refuses `none`, because approving
+//      an empty grant mints a credential that reads nothing. Step 3 is not an
+//      approval and MUST NOT refuse `none`: the wireframe states in as many
+//      words that an empty scope "is a working state, not an error. It is how
+//      you mint a credential now and decide its reach later." The two gates
+//      disagree on exactly one input and that is the point of having two.
+//
+// Every string a caller renders comes from a function in this file, so the copy
+// for every branch is readable in one place and a test can derive its
+// expectation from the same function rather than freezing a sentence.
+
+import type {
+  FleetSnapshot,
+  ResolvedSiteScope,
+  SiteScopeMode,
+} from "@/features/mcp-consent/site-scope";
+
+/**
+ * The denominator of the count, and how much we are entitled to claim about it.
+ *
+ * `floor` is not a smaller `exact`. It means "we hold n rows and cannot see
+ * past them", which supports "at least n" and supports NO assertion that an
+ * n+1th site exists -- a fleet of exactly n satisfies it. `unknown` is not a
+ * zero: it is the failed or pending read, and it prints no number at all.
+ */
+export type FleetTotal =
+  | { readonly kind: "exact"; readonly n: number }
+  | { readonly kind: "floor"; readonly n: number }
+  | { readonly kind: "unknown" };
+
+/**
+ * Read the denominator off the snapshot.
+ *
+ * NULL IS `unknown`, NOT ZERO. A failed site load rendered as "0 of 0 sites" is
+ * the failure-as-empty defect this surface has already shipped three times.
+ */
+export function fleetTotal(fleet: FleetSnapshot | null): FleetTotal {
+  if (fleet === null) return { kind: "unknown" };
+  return fleet.complete
+    ? { kind: "exact", n: fleet.sites.length }
+    : { kind: "floor", n: fleet.sites.length };
+}
+
+/**
+ * How many sites the scope resolves to, or null when that is not knowable.
+ *
+ * `all` counts the rows we hold, which is a floor and is labelled as one by the
+ * denominator beside it. `unresolved` is null and never zero: "we do not know"
+ * and "none" are different answers and the count line renders them differently.
+ */
+export function sitesInScope(scope: ResolvedSiteScope): number | null {
+  switch (scope.kind) {
+    case "all":
+      return scope.shown.length;
+    case "sites":
+      return scope.sites.length;
+    case "none":
+      return 0;
+    case "unresolved":
+      return null;
+  }
+}
+
+function plural(n: number): string {
+  return n === 1 ? "site" : "sites";
+}
+
+/**
+ * The count line, in the wireframe's shape: "0 of 60 sites."
+ *
+ * The ratio is only printed when both halves are knowable. When the fleet page
+ * came back full the denominator becomes "at least 60", because a full page and
+ * a full page with more behind it are the same response; when the fleet did not
+ * load there is no ratio at all, and the line says so rather than printing a
+ * zero that reads as a confident answer.
+ */
+export function scopeCountLabel(scope: ResolvedSiteScope, total: FleetTotal): string {
+  const n = sitesInScope(scope);
+
+  if (n === null) {
+    return scope.kind === "unresolved" && scope.because === "loading"
+      ? "Working out how many sites this reaches."
+      : "We could not read this organisation's sites, so we cannot tell you how many this reaches.";
+  }
+
+  switch (total.kind) {
+    case "unknown":
+      // Unreachable while resolveSiteScope returns `unresolved` for a null
+      // fleet, and written out rather than thrown because the honest sentence
+      // costs one line and a crash costs the step.
+      return "We could not read this organisation's sites, so we cannot tell you how many this reaches.";
+    case "exact":
+      return `${n} of ${total.n} ${plural(total.n)}.`;
+    case "floor":
+      return `${n} of at least ${total.n} ${plural(total.n)}.`;
+  }
+}
+
+/**
+ * The sites this connection can NOT reach, when that is a number we may state.
+ *
+ * Null means "do not offer this", and it is null far more often than not:
+ *
+ *   - a FLOOR denominator makes the subtraction meaningless, because the sites
+ *     we never loaded are neither in the scope nor in the excluded count;
+ *   - mode `all` excludes nothing, so there is no set to show;
+ *   - an unresolved scope has no numerator to subtract.
+ *
+ * The WORD is chosen from the basis, because the wireframe's "can never reach"
+ * is true of a fixed list and false of a tag: a site given that tag next month
+ * is reached, and the tag branch says so instead.
+ */
+export function excludedSitesLabel(
+  scope: ResolvedSiteScope,
+  total: FleetTotal,
+): string | null {
+  if (total.kind !== "exact") return null;
+  if (scope.kind === "all" || scope.kind === "unresolved") return null;
+  const covered = scope.kind === "none" ? 0 : scope.sites.length;
+  const excluded = total.n - covered;
+  if (excluded <= 0) return null;
+  const basis = scope.kind === "sites" ? scope.basis : "list";
+  return basis === "list"
+    ? `See the ${excluded} this connection can never reach`
+    : `See the ${excluded} it does not reach today`;
+}
+
+/**
+ * Whether the wizard may move past step 3.
+ *
+ * THIS IS NOT `isScopeApprovable`, AND THE DIFFERENCE IS THE WHOLE POINT OF THE
+ * SCREEN. An empty scope passes here. The wireframe is explicit that it is "a
+ * working state, not an error", and an earlier revision of this surface that
+ * blocked the step on an empty allowlist is the behaviour being corrected.
+ *
+ * `unresolved` still blocks, for the reason it blocks everywhere else: carrying
+ * a selection whose meaning nobody has read is not a decision, and the count
+ * beside it would be a number we cannot stand behind.
+ */
+export function canLeaveSiteStep(scope: ResolvedSiteScope): boolean {
+  return scope.kind !== "unresolved";
+}
+
+/** Why the step is held, for the operator, or null when it is not held. */
+export function siteStepBlockedReason(scope: ResolvedSiteScope): string | null {
+  if (scope.kind !== "unresolved") return null;
+  return scope.because === "loading"
+    ? "Reading this organisation's sites."
+    : "We could not read this organisation's sites, so we cannot tell you what this selection covers. Nothing is wrong with your choice; the list did not load.";
+}
+
+export interface SiteScopeModeOption {
+  readonly value: SiteScopeMode;
+  readonly label: string;
+}
+
+/**
+ * The three modes, in the wireframe's order and wording.
+ *
+ * Order is load-bearing only in that the wireframe fixes it; the VALUES are the
+ * three the schema permits (mcp_grants.site_scope_mode) and the labels are the
+ * operator-facing names for them. `list` is "Named sites" on screen and `list`
+ * on the wire, and nothing renders the wire word.
+ */
+export const SITE_STEP_MODES: readonly SiteScopeModeOption[] = [
+  { value: "all", label: "All sites" },
+  { value: "tags", label: "By tag" },
+  { value: "list", label: "Named sites" },
+];
+
+/** The label on a token in the field. Tags carry the `tag:` prefix; sites do not. */
+export function scopeTokenLabel(mode: SiteScopeMode, value: string): string {
+  return mode === "tags" ? `tag:${value}` : value;
+}
+
+/**
+ * What the empty field says when nothing is picked.
+ *
+ * Mode `all` never reaches this: it has no tokens by construction and an empty
+ * token field there would read as "nothing selected" on the one mode that
+ * selects everything.
+ */
+export function emptyTokenFieldLabel(mode: SiteScopeMode): string {
+  return mode === "tags" ? "No tags selected" : "No sites selected";
+}

--- a/apps/web/src/features/ai-connections/use-ai-connections.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.ts
@@ -143,11 +143,24 @@ export function parseConnectionList(body: unknown): AiConnection[] {
 export class ConnectionsRequestError extends Error {
   readonly code: string;
   readonly status: number;
-  constructor(code: string, message: string, status: number) {
+  /**
+   * The house envelope's optional `details` object (respond.go), e.g.
+   * `retry_after_seconds` on a 429 or `unknown_tag_id` / `unknown_site_id` on
+   * the mint endpoint's referential refusals. Undefined, never a fabricated
+   * empty object, when the response carried none.
+   */
+  readonly details?: Readonly<Record<string, unknown>>;
+  constructor(
+    code: string,
+    message: string,
+    status: number,
+    details?: Readonly<Record<string, unknown>>,
+  ) {
     super(message || code);
     this.name = "ConnectionsRequestError";
     this.code = code;
     this.status = status;
+    this.details = details;
   }
 }
 
@@ -156,12 +169,16 @@ async function readHouseError(res: Response): Promise<ConnectionsRequestError> {
   // error, never a success with empty fields.
   let code = "server_error";
   let message = "";
+  let details: Record<string, unknown> | undefined;
   try {
     const body: unknown = await res.json();
     if (body && typeof body === "object") {
       const rec = body as Record<string, unknown>;
       if (typeof rec.code === "string" && rec.code.length > 0) code = rec.code;
       if (typeof rec.message === "string") message = rec.message;
+      if (rec.details && typeof rec.details === "object") {
+        details = rec.details as Record<string, unknown>;
+      }
     }
   } catch {
     // Defaults stand; `code` is already the pessimistic value.
@@ -175,7 +192,7 @@ async function readHouseError(res: Response): Promise<ConnectionsRequestError> {
         ? "Your role cannot view AI connections. They are organisation-wide credentials, so this needs an admin."
         : "The server did not answer with a list we could read.";
   }
-  return new ConnectionsRequestError(code, message, res.status);
+  return new ConnectionsRequestError(code, message, res.status, details);
 }
 
 export function useAiConnections(): UseQueryResult<AiConnection[], Error> {
@@ -192,6 +209,102 @@ export function useAiConnections(): UseQueryResult<AiConnection[], Error> {
       // that resolves to a partial list, because a partial list renders as a
       // complete one.
       return parseConnectionList((await res.json()) as unknown);
+    },
+  });
+}
+
+/**
+ * A headless mint request: an authenticated operator asking for a connection
+ * token directly, without the OAuth dance.
+ *
+ * `scopeTagIds` and `scopeSiteIds` ARE UUIDs, never names. dto.go's
+ * mintConnectionRequestDTO spells the tag field `scope_tag_ids` -- the same
+ * wire vocabulary approvalRequestDTO already uses -- because an id survives a
+ * tag rename and a name does not; a grant scoped by name would silently
+ * change which sites it covers the day somebody renames a tag. The caller
+ * resolves names to ids itself (see resolveTagIds in mcp-consent/site-scope)
+ * and refuses to call this at all when a chosen name has none.
+ */
+export interface MintConnectionInput {
+  readonly name: string;
+  readonly siteScopeMode: string;
+  readonly scopeTagIds: readonly string[];
+  readonly scopeSiteIds: readonly string[];
+}
+
+/**
+ * The mint response. `token` is the plaintext bearer credential and it is
+ * ONLY EVER HERE: the server holds a token_prefix and a SHA-256 hash, nothing
+ * that can reconstruct it, and there is no read-back endpoint. Whatever calls
+ * this mutation must render `token` once and let it go -- not stash it in a
+ * query cache, not carry it past the component that shows it.
+ */
+export interface MintedConnection {
+  readonly grantId: string;
+  readonly token: string;
+  readonly tokenPrefix: string;
+  readonly expiresAt: string;
+  readonly siteScopeMode: string;
+  readonly capabilities: readonly string[];
+}
+
+const mintResponseSchema = z.object({
+  grant_id: z.string(),
+  token: z.string(),
+  token_prefix: z.string(),
+  expires_at: z.string(),
+  site_scope_mode: z.string(),
+  capabilities: z.array(z.string()),
+});
+
+function toMintedConnection(raw: z.infer<typeof mintResponseSchema>): MintedConnection {
+  return {
+    grantId: raw.grant_id,
+    token: raw.token,
+    tokenPrefix: raw.token_prefix,
+    expiresAt: raw.expires_at,
+    siteScopeMode: raw.site_scope_mode,
+    capabilities: raw.capabilities,
+  };
+}
+
+/**
+ * Mint a connection token: POST the same CONNECTIONS_PATH the list GETs.
+ *
+ * INVALIDATES ON SUCCESS so a freshly-minted connection shows up in the list
+ * without a manual refresh, same as revoke.
+ *
+ * NEVER CACHED BY QUERY. This is a mutation, not a query -- its `data` lives
+ * only in the calling component's render and in TanStack's in-memory mutation
+ * state, never in `queryClient`'s cache, and nothing here calls
+ * `setQueryData`. A remount (leaving the step, navigating back) starts over
+ * with no token in scope, which is the property the one-time reveal depends
+ * on.
+ */
+export function useMintConnection(): UseMutationResult<
+  MintedConnection,
+  Error,
+  MintConnectionInput
+> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: MintConnectionInput): Promise<MintedConnection> => {
+      const res = await fetch(CONNECTIONS_PATH, {
+        method: "POST",
+        credentials: "include",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: input.name,
+          site_scope_mode: input.siteScopeMode,
+          scope_tag_ids: [...input.scopeTagIds],
+          scope_site_ids: [...input.scopeSiteIds],
+        }),
+      });
+      if (!res.ok) throw await readHouseError(res);
+      return toMintedConnection(mintResponseSchema.parse((await res.json()) as unknown));
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: connectionKeys.all });
     },
   });
 }

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -138,16 +138,32 @@ describe("ConsentScreen — what it can do and what it cannot", () => {
   });
 });
 
-describe("ConsentScreen — an empty site scope is not everything", () => {
-  it("starts with nothing selected and cannot be approved", () => {
+describe("ConsentScreen — an empty site scope is a working state, not an error (2026-08-23 revision)", () => {
+  it("starts with nothing selected, states the consequence, and CAN be approved", () => {
+    // Superseded framing (pre-2026-08-23): this blocked approval. The current
+    // wireframe rules an empty allowlist mints a credential that reads and
+    // proposes nothing, decided later -- a working state, not an error.
     renderWithProviders(<ConsentScreen {...props()} />);
-    expect(screen.getByTestId("consent-scope-summary").textContent).toMatch(
-      /No sites are selected yet/i,
-    );
-    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    const summary = screen.getByTestId("consent-scope-summary").textContent ?? "";
+    expect(summary).toMatch(/No sites are selected/i);
+    expect(summary).toMatch(/read nothing and propose nothing/i);
+    expect(summary).toMatch(/working state, not an error/i);
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
   });
 
-  it("a tag matching no site says so, never that it covers everything", () => {
+  it("submits an empty list-mode scope when approved with nothing selected", () => {
+    const onApprove = vi.fn();
+    renderWithProviders(<ConsentScreen {...props({ onApprove })} />);
+    fireEvent.submit(screen.getByTestId("consent-approve").closest("form")!);
+    expect(onApprove).toHaveBeenCalledWith({
+      name: "Claude Desktop",
+      siteScopeMode: "list",
+      scopeTagIds: [],
+      scopeSiteIds: [],
+    });
+  });
+
+  it("a tag matching no site says so, states the consequence, and CAN be approved", () => {
     renderWithProviders(
       <ConsentScreen
         {...props({ tags: [{ id: "t9", name: "archived" }], tagsBySiteId: { s1: [], s2: [] } })}
@@ -157,9 +173,10 @@ describe("ConsentScreen — an empty site scope is not everything", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /archived/i }));
     const summary = screen.getByTestId("consent-scope-summary");
     expect(summary.textContent).toMatch(/matches no sites/i);
-    expect(summary.textContent).toMatch(/read nothing/i);
+    expect(summary.textContent).toMatch(/read nothing and propose nothing/i);
+    expect(summary.textContent).toMatch(/working state, not an error/i);
     expect(screen.queryByTestId("consent-scope-sites")).toBeNull();
-    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
+    expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
   });
 
   it("a failed site load blocks approval instead of resolving to zero or to all", () => {

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -25,6 +25,7 @@ import {
   type ScopedSite,
   type SiteScopeMode,
 } from "./site-scope";
+import { SiteEnforcementBox } from "./site-enforcement-box";
 
 // The consent screen (design Step 7).
 //
@@ -433,6 +434,12 @@ function SiteScopeBlock({
         Your organisation&apos;s records decide what this connection reads on each
         request, not this list. The list is what this dashboard could load just now.
       </p>
+
+      {/* Screen 8 (wireframes.html#s8) — the enforcement box. No `refusals`
+          prop: this connection does not exist yet (approval has not
+          happened), so there is no refusal history, tracked or otherwise, to
+          have an opinion about. See site-enforcement-box.tsx's module doc. */}
+      <SiteEnforcementBox scope={scope} />
     </section>
   );
 }

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -20,6 +20,7 @@ import {
   describeSiteScope,
   isScopeApprovable,
   resolveSiteScope,
+  resolveTagIds,
   type FleetSnapshot,
   type ResolvedSiteScope,
   type ScopedSite,
@@ -587,9 +588,7 @@ export function ConsentScreen({
   // already holds -- and the half that keeps the button honest.
   const tagPayload = useMemo((): readonly string[] | null => {
     if (mode !== "tags") return [];
-    if (tags === null) return null;
-    const ids = tags.filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id);
-    return ids.length === 0 ? null : ids;
+    return resolveTagIds(selectedTagNames, tags);
   }, [mode, tags, selectedTagNames]);
 
   const canApprove = scopeOk && scopesOk && tagPayload !== null && !isApproving;

--- a/apps/web/src/features/mcp-consent/site-enforcement-box.test.tsx
+++ b/apps/web/src/features/mcp-consent/site-enforcement-box.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { SiteEnforcementBox } from "./site-enforcement-box";
+import { bannedWordHits } from "./site-enforcement";
+import type { ResolvedSiteScope, ScopedSite } from "./site-scope";
+
+const SITES: ScopedSite[] = [
+  { id: "s1", name: "Alpha", url: "https://alpha.example" },
+  { id: "s2", name: "Beta", url: "https://beta.example" },
+];
+
+const LIST_SCOPE: ResolvedSiteScope = {
+  kind: "sites",
+  sites: SITES,
+  basis: "list",
+  listComplete: true,
+};
+
+const TAG_SCOPE: ResolvedSiteScope = {
+  kind: "sites",
+  sites: SITES,
+  basis: "tags",
+  listComplete: true,
+};
+
+const ALL_SCOPE: ResolvedSiteScope = {
+  kind: "all",
+  shown: SITES,
+  listComplete: true,
+};
+
+describe("SiteEnforcementBox — named-sites mode", () => {
+  it("states the request-time check and that no other site is covered", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} />);
+    const box = screen.getByTestId("site-enforcement-box");
+    expect(box.textContent).toMatch(/checked against this list before WPMgr contacts any site/i);
+    expect(box.textContent).toMatch(/refused and recorded in the audit log/i);
+    expect(box.textContent).toMatch(/no other site is covered/i);
+    // The drift sentence belongs to tag mode only.
+    expect(box.textContent).not.toMatch(/included automatically/i);
+  });
+
+  it("omits the refusals line when no refusals summary is supplied", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} />);
+    expect(screen.queryByTestId("site-enforcement-refusals")).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — tag mode states the drift consequence", () => {
+  it("says sites added to the tag later are included automatically, without approval", () => {
+    renderWithProviders(<SiteEnforcementBox scope={TAG_SCOPE} />);
+    const box = screen.getByTestId("site-enforcement-box");
+    expect(box.textContent).toMatch(/included automatically/i);
+    expect(box.textContent).toMatch(/without anyone approving it/i);
+  });
+});
+
+describe("SiteEnforcementBox — every-site mode replaces the box rather than decorating it", () => {
+  it("says nothing is checked because there is no list", () => {
+    renderWithProviders(<SiteEnforcementBox scope={ALL_SCOPE} />);
+    const box = screen.getByTestId("site-enforcement-box");
+    expect(box.dataset.mode).toBe("all");
+    expect(box.textContent).toMatch(/nothing is checked against a list because there is no list/i);
+  });
+
+  it("has no 'how we check this' link — every-site mode has no list to explain", () => {
+    renderWithProviders(<SiteEnforcementBox scope={ALL_SCOPE} />);
+    expect(screen.queryByText(/how we check this/i)).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — 'none' and 'unresolved' render nothing", () => {
+  it("renders no box when nothing is selected", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={{ kind: "none", because: "no-selection" }} />,
+    );
+    expect(screen.queryByTestId("site-enforcement-box")).toBeNull();
+  });
+
+  it("renders no box while the scope is unresolved", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={{ kind: "unresolved", because: "loading" }} />,
+    );
+    expect(screen.queryByTestId("site-enforcement-box")).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — the refusals block, when supplied", () => {
+  it("renders an explicit not-tracked sentence rather than a zero or a dash", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} refusals={{ kind: "unavailable" }} />);
+    const line = screen.getByTestId("site-enforcement-refusals");
+    expect(line.textContent).toMatch(/do not yet track/i);
+    expect(line.textContent?.trim()).not.toBe("0");
+  });
+
+  it("renders a real zero as a stated fact", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={LIST_SCOPE} refusals={{ kind: "zero", windowDays: 7 }} />,
+    );
+    expect(screen.getByTestId("site-enforcement-refusals").textContent).toMatch(
+      /no requests have been refused/i,
+    );
+  });
+
+  it("renders a real count", () => {
+    renderWithProviders(
+      <SiteEnforcementBox scope={LIST_SCOPE} refusals={{ kind: "count", count: 2, windowDays: 7 }} />,
+    );
+    expect(screen.getByTestId("site-enforcement-refusals").textContent).toMatch(
+      /refused 2 times in the last 7 days/i,
+    );
+  });
+});
+
+describe("SiteEnforcementBox — the 'How we check this' dialog", () => {
+  it("opens on click and says this is a check the application makes, not a database boundary", () => {
+    renderWithProviders(<SiteEnforcementBox scope={TAG_SCOPE} />);
+    fireEvent.click(screen.getByText(/how we check this/i));
+    expect(screen.getByText("How WPMgr checks site access")).toBeTruthy();
+    expect(screen.getByText(/is a check WPMgr makes when the assistant asks/i)).toBeTruthy();
+    expect(screen.getByText(/not a separate boundary inside the database/i)).toBeTruthy();
+  });
+
+  it("closes on the Close button", () => {
+    renderWithProviders(<SiteEnforcementBox scope={TAG_SCOPE} />);
+    fireEvent.click(screen.getByText(/how we check this/i));
+    fireEvent.click(screen.getByText("Close"));
+    expect(screen.queryByText("How WPMgr checks site access")).toBeNull();
+  });
+});
+
+describe("SiteEnforcementBox — banned-word guard over the mounted screen", () => {
+  // Plant the guard against what actually renders, not against the source
+  // file: a component could import clean constants and still interpolate a
+  // banned word around them.
+  it("every mode's rendered text is free of the wireframe's banned words", () => {
+    for (const scope of [LIST_SCOPE, TAG_SCOPE, ALL_SCOPE]) {
+      const { unmount } = renderWithProviders(
+        <SiteEnforcementBox
+          scope={scope}
+          refusals={{ kind: "count", count: 2, windowDays: 7 }}
+        />,
+      );
+      const box = screen.getByTestId("site-enforcement-box");
+      expect(bannedWordHits(box.textContent ?? "")).toEqual([]);
+      unmount();
+    }
+  });
+
+  it("the 'How we check this' dialog is free of the wireframe's banned words", () => {
+    renderWithProviders(<SiteEnforcementBox scope={LIST_SCOPE} />);
+    fireEvent.click(screen.getByText(/how we check this/i));
+    const dialogText = screen.getByText("How WPMgr checks site access").closest("div")?.parentElement
+      ?.textContent;
+    expect(bannedWordHits(dialogText ?? "")).toEqual([]);
+  });
+});

--- a/apps/web/src/features/mcp-consent/site-enforcement-box.tsx
+++ b/apps/web/src/features/mcp-consent/site-enforcement-box.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import type { ResolvedSiteScope } from "./site-scope";
+import {
+  ENFORCEMENT_ALL_MODE_SENTENCE,
+  ENFORCEMENT_CHECK_SENTENCE,
+  ENFORCEMENT_LIST_MODE_SENTENCE,
+  ENFORCEMENT_TAG_DRIFT_SENTENCE,
+  HOW_WE_CHECK_AUDIT_PATH,
+  HOW_WE_CHECK_HEADING,
+  HOW_WE_CHECK_MECHANISM,
+  HOW_WE_CHECK_REMEDY,
+  HOW_WE_CHECK_SCOPE,
+  HOW_WE_CHECK_TITLE,
+  describeRefusals,
+  type RefusalsSummary,
+} from "./site-enforcement";
+
+// Screen 8 (wireframes.html#s8) — "How site access is enforced".
+//
+// THREE STATES, ONE STRING SET, per the wireframe's own framing. Named-sites
+// and tag-mode share the neutral box and its opening sentence; every-site
+// REPLACES the box with a warning-toned one rather than decorating the same
+// box, because "nothing is checked" is a materially different fact from "this
+// list is checked" and dressing one as the other would be the exact collapse
+// this screen exists to prevent.
+//
+// `refusals` IS OPTIONAL AND DELIBERATELY OMITTED BY EVERY CALLER TODAY. No
+// endpoint on the control plane counts refusals per connection
+// (use-ai-connections.ts's wire schema carries only `site_scope_mode`), and
+// the one caller wired so far (the consent screen) has no connection id yet
+// at all -- approval has not happened, so there is no history to have an
+// opinion about, "not tracked yet" included. Passing `refusals` renders the
+// explicit not-a-count sentence from site-enforcement.ts; omitting it leaves
+// the block out entirely. Both are honest; which one applies depends on
+// whether a connection exists to ask about.
+export interface SiteEnforcementBoxProps {
+  readonly scope: ResolvedSiteScope;
+  readonly refusals?: RefusalsSummary;
+}
+
+export function SiteEnforcementBox({ scope, refusals }: SiteEnforcementBoxProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // 'none' and 'unresolved' have no enforcement story of their own: the
+  // site-scope summary above this box already says there is nothing to
+  // check (no-selection/no-matches) or that the check cannot be described
+  // yet (loading/failed). Rendering this box for either would either repeat
+  // that sentence in different words or assert a mechanism over a scope we
+  // do not yet know.
+  if (scope.kind === "none" || scope.kind === "unresolved") return null;
+
+  const isEveryMode = scope.kind === "all";
+
+  return (
+    <div className="mt-4">
+      <div
+        data-testid="site-enforcement-box"
+        data-mode={isEveryMode ? "all" : scope.basis}
+        className={
+          isEveryMode
+            ? "rounded-md border border-[var(--color-warning)]/40 bg-warning-subtle p-3 text-sm text-warning-subtle-fg"
+            : "rounded-md border border-[var(--color-border)] p-3 text-sm text-[var(--color-foreground)]"
+        }
+      >
+        <p className="font-medium">
+          {isEveryMode ? (
+            <>
+              <AlertTriangle aria-hidden="true" className="mr-1.5 inline size-4 align-text-bottom" />
+              Every site in this organisation
+            </>
+          ) : (
+            "How site access is enforced"
+          )}
+        </p>
+
+        {isEveryMode ? (
+          <p className="mt-2">{ENFORCEMENT_ALL_MODE_SENTENCE}</p>
+        ) : (
+          <>
+            <p className="mt-2 text-[var(--color-muted-foreground)]">{ENFORCEMENT_CHECK_SENTENCE}</p>
+            <p className="mt-2 text-[var(--color-muted-foreground)]">
+              {scope.basis === "tags" ? ENFORCEMENT_TAG_DRIFT_SENTENCE : ENFORCEMENT_LIST_MODE_SENTENCE}
+            </p>
+          </>
+        )}
+
+        {refusals !== undefined && (
+          <p data-testid="site-enforcement-refusals" className="mt-2 text-[var(--color-muted-foreground)]">
+            {describeRefusals(refusals)}
+          </p>
+        )}
+
+        {!isEveryMode && (
+          <p className="mt-2 text-right">
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              className="h-auto p-0"
+              onClick={() => setDialogOpen(true)}
+            >
+              How we check this →
+            </Button>
+          </p>
+        )}
+      </div>
+
+      <HowWeCheckDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
+    </div>
+  );
+}
+
+/**
+ * The "How we check this" dialog (wireframes.html:2898-2922). Its job is to
+ * say plainly that scoping is a request-time check the application makes, not
+ * a boundary the database enforces, and to hand over the stronger lever
+ * (pausing the assistant, or removing the site from every list) rather than
+ * asking anyone to evaluate a threat model.
+ */
+export function HowWeCheckDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogContent ariaLabelledBy="how-we-check-title" className="max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle id="how-we-check-title">{HOW_WE_CHECK_TITLE}</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="text-sm text-[var(--color-muted-foreground)]">
+          <p>{HOW_WE_CHECK_MECHANISM}</p>
+          <p>{HOW_WE_CHECK_SCOPE}</p>
+          <p className="font-medium text-[var(--color-foreground)]">{HOW_WE_CHECK_HEADING}</p>
+          <p>{HOW_WE_CHECK_REMEDY}</p>
+          <p>
+            You can see every refusal:{" "}
+            <span className="font-mono text-[var(--color-foreground)]">{HOW_WE_CHECK_AUDIT_PATH}</span>
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/mcp-consent/site-enforcement.test.ts
+++ b/apps/web/src/features/mcp-consent/site-enforcement.test.ts
@@ -51,7 +51,7 @@ describe("bannedWordHits — fires on the wireframe's own banned words", () => {
 // reddens a truthful warning is a guard someone switches off.
 // ---------------------------------------------------------------------------
 
-describe("bannedWordHits — the word-boundary contract, which the comment must keep matching", () => {
+describe("bannedWordHits: the word-boundary contract, which the comment must keep matching", () => {
   it.each([
     ["a prefixed form", "Treat every connection as unsafe until you have scoped it."],
     ["a suffixed form", "Read our safety guidance before connecting an assistant."],

--- a/apps/web/src/features/mcp-consent/site-enforcement.test.ts
+++ b/apps/web/src/features/mcp-consent/site-enforcement.test.ts
@@ -36,6 +36,49 @@ describe("bannedWordHits — fires on the wireframe's own banned words", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// The word-boundary contract, pinned.
+//
+// The comment above bannedWordPattern used to claim "safe" fires on "unsafe".
+// It never did: \b needs a boundary before the "s", and "n" and "s" are both
+// word characters, so there is none. A comment that describes coverage the
+// guard does not have is worse than no comment, because the next reader trusts
+// it and ships the phrasing it says is caught. These cases hold the comment to
+// the behaviour in both directions, so neither can drift alone.
+//
+// The exclusion is deliberate, not a gap to close later. "unsafe" is the
+// OPPOSITE of the overclaim this list exists to catch, and a guard that
+// reddens a truthful warning is a guard someone switches off.
+// ---------------------------------------------------------------------------
+
+describe("bannedWordHits — the word-boundary contract, which the comment must keep matching", () => {
+  it.each([
+    ["a prefixed form", "Treat every connection as unsafe until you have scoped it."],
+    ["a suffixed form", "Read our safety guidance before connecting an assistant."],
+    ["prefixed and suffixed at once", "An unsafely scoped connection is still yours to fix."],
+    ["a banned word inside a longer word", "This is insecurely configured."],
+  ] as const)("%s does not fire the single-word guard", (_label, text) => {
+    expect(bannedWordHits(text)).toEqual([]);
+  });
+
+  it.each([
+    ["a trailing full stop", "Nothing about this is safe."],
+    ["a trailing comma", "It is not safe, and we will not pretend otherwise."],
+    ["a leading capital at the start of a sentence", "Safe is a word this screen may not use."],
+    ["surrounded by punctuation", "The scope is (safe) once you have read this."],
+  ] as const)("%s does fire it", (_label, text) => {
+    expect(bannedWordHits(text)).toContain("safe");
+  });
+
+  it("matches a multi-word phrase as a bare substring, with no boundary required", () => {
+    // The asymmetry is real and worth pinning: the phrase branch escapes but
+    // does not wrap in \b, so a phrase straddling longer words still hits.
+    // Nothing on this screen is phrased that way, and a phrase overclaim is
+    // the more dangerous miss of the two.
+    expect(bannedWordHits("The request was stonewalled offhand.")).toContain("walled off");
+  });
+});
+
 describe("bannedWordHits — does not over-fire on the shipped copy", () => {
   it("every string this screen renders is clean", () => {
     for (const text of allEnforcementScreenStrings()) {

--- a/apps/web/src/features/mcp-consent/site-enforcement.test.ts
+++ b/apps/web/src/features/mcp-consent/site-enforcement.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ENFORCEMENT_ALL_MODE_SENTENCE,
+  ENFORCEMENT_BANNED_WORDS,
+  ENFORCEMENT_CHECK_SENTENCE,
+  ENFORCEMENT_LIST_MODE_SENTENCE,
+  ENFORCEMENT_TAG_DRIFT_SENTENCE,
+  allEnforcementScreenStrings,
+  bannedWordHits,
+  describeRefusals,
+} from "./site-enforcement";
+
+// A guard nobody has seen fail is not known to guard anything. This file
+// proves the banned-word guard both fires on a real violation and does not
+// over-fire on the honest copy this screen actually ships.
+
+describe("bannedWordHits — fires on the wireframe's own banned words", () => {
+  it.each(ENFORCEMENT_BANNED_WORDS)("catches %s inside a sentence", (word) => {
+    const poisoned = `This connection is completely ${word} from every other request.`;
+    expect(bannedWordHits(poisoned)).toContain(word);
+  });
+
+  it("catches a multi-word phrase written with different surrounding case", () => {
+    expect(bannedWordHits("Nothing outside the Walled Off area can be reached.")).toContain(
+      "walled off",
+    );
+  });
+
+  it("does not fire on a word that merely shares a prefix with a banned word", () => {
+    // "safety" must not trip "safe": \bsafe\b requires a boundary right after
+    // "safe", and "safety" has no boundary there.
+    expect(bannedWordHits("Read our safety guidance before connecting an assistant.")).toEqual(
+      [],
+    );
+  });
+});
+
+describe("bannedWordHits — does not over-fire on the shipped copy", () => {
+  it("every string this screen renders is clean", () => {
+    for (const text of allEnforcementScreenStrings()) {
+      expect(bannedWordHits(text)).toEqual([]);
+    }
+  });
+
+  it.each([
+    ["the shared check sentence", ENFORCEMENT_CHECK_SENTENCE],
+    ["the named-list sentence", ENFORCEMENT_LIST_MODE_SENTENCE],
+    ["the tag-drift sentence", ENFORCEMENT_TAG_DRIFT_SENTENCE],
+    ["the every-site sentence", ENFORCEMENT_ALL_MODE_SENTENCE],
+  ] as const)("%s is clean", (_label, text) => {
+    expect(bannedWordHits(text)).toEqual([]);
+  });
+});
+
+describe("ENFORCEMENT_TAG_DRIFT_SENTENCE — the sharpest sentence on the screen", () => {
+  it("states the drift consequence in the wireframe's own terms", () => {
+    expect(ENFORCEMENT_TAG_DRIFT_SENTENCE).toMatch(/included automatically/i);
+    expect(ENFORCEMENT_TAG_DRIFT_SENTENCE).toMatch(/without anyone approving it/i);
+  });
+});
+
+describe("ENFORCEMENT_ALL_MODE_SENTENCE — every-site mode", () => {
+  it("says there is no list, in the wireframe's own words", () => {
+    expect(ENFORCEMENT_ALL_MODE_SENTENCE).toMatch(
+      /Nothing is checked against a list because there is no list\./,
+    );
+  });
+});
+
+describe("describeRefusals — three states, never collapsed", () => {
+  it("renders an explicit not-tracked sentence for 'unavailable', never a zero", () => {
+    const text = describeRefusals({ kind: "unavailable" });
+    expect(text).toMatch(/do not yet track/i);
+    expect(text).not.toMatch(/^0/);
+    expect(text).not.toBe("0");
+  });
+
+  it("renders a real zero as a stated fact, distinct from 'unavailable'", () => {
+    expect(describeRefusals({ kind: "zero", windowDays: 7 })).toBe(
+      "No requests have been refused.",
+    );
+  });
+
+  it("renders a count with its window and correct pluralisation", () => {
+    expect(describeRefusals({ kind: "count", count: 2, windowDays: 7 })).toBe(
+      "Refused 2 times in the last 7 days.",
+    );
+    expect(describeRefusals({ kind: "count", count: 1, windowDays: 7 })).toBe(
+      "Refused 1 time in the last 7 days.",
+    );
+  });
+
+  it("unavailable and zero never render the same sentence", () => {
+    expect(describeRefusals({ kind: "unavailable" })).not.toBe(
+      describeRefusals({ kind: "zero", windowDays: 7 }),
+    );
+  });
+});

--- a/apps/web/src/features/mcp-consent/site-enforcement.ts
+++ b/apps/web/src/features/mcp-consent/site-enforcement.ts
@@ -1,0 +1,161 @@
+// Screen 8 (wireframes.html#s8, "Revised 2026-08-24") — the site-allowlist
+// honesty surface. Pure copy and a banned-word guard, kept separate from the
+// rendering component so the guard test can run over plain strings.
+//
+// WHAT THIS SCREEN EXISTS TO STOP. Site scoping is a check WPMgr makes when an
+// assistant asks to do something. It is NOT a boundary inside the database:
+// there is no per-connection database role, no row-level policy keyed on a
+// grant, nothing that would stop a bug elsewhere in this codebase from
+// reaching a site outside the list. The check is real and it runs on every
+// request, but it is one gate in application code, not a wall. Copy on this
+// screen must say exactly that and nothing stronger.
+//
+// THE BANNED LIST IS THE WIREFRAME'S OWN (wireframes.html:2844-2846), not a
+// paraphrase of it: "isolated, isolation, sandboxed, walled off, cannot
+// reach, impossible, guaranteed, secure, safe, airtight, hard limit." Every
+// one of those words claims a boundary this feature does not have.
+export const ENFORCEMENT_BANNED_WORDS: readonly string[] = [
+  "isolated",
+  "isolation",
+  "sandboxed",
+  "walled off",
+  "cannot reach",
+  "impossible",
+  "guaranteed",
+  "secure",
+  "safe",
+  "airtight",
+  "hard limit",
+];
+
+function bannedWordPattern(word: string): RegExp {
+  // Multi-word phrases match as a literal substring. Single words match at a
+  // word boundary so "safe" fires on "Safe." and "unsafe" alike (both start a
+  // fresh word after a boundary) but not inside "safety", which shares no
+  // boundary with the "e" that would need to end the match.
+  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(word.includes(" ") ? escaped : `\\b${escaped}\\b`, "i");
+}
+
+/**
+ * Every banned word or phrase found in `text`, in list order. Empty means
+ * clean. Used both by the guard test (over the literal strings below) and by
+ * a render test (over the mounted screen's text content), because a guard
+ * that only ever reads its own source can be satisfied by a source that lies
+ * about what actually renders.
+ */
+export function bannedWordHits(text: string): string[] {
+  return ENFORCEMENT_BANNED_WORDS.filter((word) => bannedWordPattern(word).test(text));
+}
+
+/**
+ * The sentence every enforcement box opens with, for the two modes that carry
+ * an actual list (named sites, and sites-by-tag). It states the mechanism
+ * (checked per request, before any site is contacted) and the consequence of
+ * missing the list (refused, recorded), without saying WHERE the check lives
+ * relative to anything else.
+ */
+export const ENFORCEMENT_CHECK_SENTENCE =
+  "Every request from this assistant is checked against this list before WPMgr contacts any site. A request for a site that is not on the list is refused and recorded in the audit log.";
+
+/**
+ * Named-sites mode (basis 'list'). The set is fixed by construction — the
+ * operator picked it — so the only thing left to say is that nothing else is
+ * covered, including a site enrolled afterwards.
+ */
+export const ENFORCEMENT_LIST_MODE_SENTENCE =
+  "This is a fixed list. No other site is covered by this connection, including one added to the organisation later.";
+
+/**
+ * Tag mode's drift sentence (wireframes.html:2884-2885, and this screen's
+ * whole reason for existing per the build brief). NOT SOFTENED: it says
+ * "included automatically" and "without anyone approving it" in exactly
+ * those words, because that is the fact an operator choosing tag mode is
+ * agreeing to and the one this screen must not let them miss.
+ */
+export const ENFORCEMENT_TAG_DRIFT_SENTENCE =
+  "Sites added to these tags later will be included automatically, without anyone approving it.";
+
+/**
+ * Every-site mode. Quoted from wireframes.html:2890-2891 verbatim: there is
+ * no list to check against, so the sentence says that rather than describing
+ * an absent list as a boundary.
+ */
+export const ENFORCEMENT_ALL_MODE_SENTENCE =
+  "Nothing is checked against a list because there is no list. This connection can read any site in the organisation, including one added after you approved it.";
+
+/**
+ * What we know about how often this assistant has been refused a site.
+ *
+ * THREE STATES, NOT A NUMBER. `unavailable` is today's only real value: no
+ * endpoint on the control plane counts refusals per connection yet (grep
+ * confirms `/api/v1/mcp/connections` returns only `site_scope_mode`, not a
+ * count). `zero` and `count` exist so the box is ready the day that endpoint
+ * ships, and so a test can pin the difference between "none happened" and
+ * "we don't know" — the exact collapse this screen exists to prevent.
+ * Rendering `unavailable` as `zero` would fabricate a fact nobody measured;
+ * rendering it as a bare 0 or a dash would read as data.
+ */
+export type RefusalsSummary =
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "zero"; readonly windowDays: number }
+  | { readonly kind: "count"; readonly count: number; readonly windowDays: number };
+
+/**
+ * The sentence for a refusals summary, or null for `unavailable` when the
+ * caller has chosen to omit the block entirely rather than render an explicit
+ * placeholder (see `describeRefusalsExplicit` for the other choice).
+ */
+export function describeRefusals(summary: RefusalsSummary): string {
+  switch (summary.kind) {
+    case "unavailable":
+      return "We do not yet track how many requests have been refused for this connection.";
+    case "zero":
+      return "No requests have been refused.";
+    case "count":
+      return `Refused ${summary.count} time${summary.count === 1 ? "" : "s"} in the last ${summary.windowDays} days.`;
+  }
+}
+
+// "How we check this" dialog copy (wireframes.html:2904-2914), kept as named
+// constants so the render test and the banned-word guard both read the exact
+// strings that ship, not a re-typed approximation of them.
+export const HOW_WE_CHECK_TITLE = "How WPMgr checks site access";
+
+export const HOW_WE_CHECK_MECHANISM =
+  "When an assistant asks to do something, WPMgr resolves which sites the request covers, then checks each one against that assistant's list. Sites that are not on the list are dropped from the request and written to the audit log as refused. The assistant is told which sites were refused and why.";
+
+export const HOW_WE_CHECK_SCOPE =
+  "This check runs in one place, on every assistant request, and it runs before anything reaches a site.";
+
+export const HOW_WE_CHECK_HEADING = "What this does not do";
+
+export const HOW_WE_CHECK_REMEDY =
+  "It is a check WPMgr makes when the assistant asks. It is not a separate boundary inside the database. If a site must never be touched by any assistant, pause the assistant or take the site off every list, rather than relying on the check alone.";
+
+export const HOW_WE_CHECK_AUDIT_PATH = "Security → Audit → Denied";
+
+/**
+ * Every user-facing string this screen ships, gathered in one place so the
+ * banned-word guard can scan the whole surface without depending on a render.
+ * A NEW STRING ADDED TO THIS SCREEN AND NOT ADDED HERE IS NOT GUARDED — the
+ * render-level test in site-enforcement-box.test.tsx is the backstop for
+ * that gap.
+ */
+export function allEnforcementScreenStrings(): readonly string[] {
+  return [
+    ENFORCEMENT_CHECK_SENTENCE,
+    ENFORCEMENT_LIST_MODE_SENTENCE,
+    ENFORCEMENT_TAG_DRIFT_SENTENCE,
+    ENFORCEMENT_ALL_MODE_SENTENCE,
+    describeRefusals({ kind: "unavailable" }),
+    describeRefusals({ kind: "zero", windowDays: 7 }),
+    describeRefusals({ kind: "count", count: 2, windowDays: 7 }),
+    HOW_WE_CHECK_TITLE,
+    HOW_WE_CHECK_MECHANISM,
+    HOW_WE_CHECK_SCOPE,
+    HOW_WE_CHECK_HEADING,
+    HOW_WE_CHECK_REMEDY,
+    HOW_WE_CHECK_AUDIT_PATH,
+  ];
+}

--- a/apps/web/src/features/mcp-consent/site-enforcement.ts
+++ b/apps/web/src/features/mcp-consent/site-enforcement.ts
@@ -29,10 +29,14 @@ export const ENFORCEMENT_BANNED_WORDS: readonly string[] = [
 ];
 
 function bannedWordPattern(word: string): RegExp {
-  // Multi-word phrases match as a literal substring. Single words match at a
-  // word boundary so "safe" fires on "Safe." and "unsafe" alike (both start a
-  // fresh word after a boundary) but not inside "safety", which shares no
-  // boundary with the "e" that would need to end the match.
+  // Multi-word phrases match as a literal substring. Single words need a word
+  // boundary on BOTH sides, so "safe" fires on "Safe." and on "safe," but not
+  // inside "safety" and NOT inside "unsafe": "un" and "safe" are both word
+  // characters, so there is no boundary between "n" and "s" for the leading
+  // \b to match. PREFIXED AND SUFFIXED FORMS ARE OUT OF REACH BY DESIGN and
+  // widening the pattern would redden honest copy -- "unsafe" is the opposite
+  // of the overclaim this list exists to catch, and a guard that flags a
+  // truthful warning is a guard someone switches off.
   const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(word.includes(" ") ? escaped : `\\b${escaped}\\b`, "i");
 }

--- a/apps/web/src/features/mcp-consent/site-scope.test.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.test.ts
@@ -72,9 +72,9 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
     expect(scope.kind).toBe("none");
   });
 
-  it("an empty resolution is not approvable", () => {
-    expect(isScopeApprovable(resolveSiteScope(input({ mode: "tags", selectedTagNames: ["gone"] })))).toBe(false);
-    expect(isScopeApprovable(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })))).toBe(false);
+  it("an empty resolution IS approvable -- reading nothing is a working state, not an error (2026-08-23 revision)", () => {
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "tags", selectedTagNames: ["gone"] })))).toBe(true);
+    expect(isScopeApprovable(resolveSiteScope(input({ mode: "list", selectedSiteIds: [] })))).toBe(true);
   });
 
   it("only mode 'all' ever produces kind 'all'", () => {
@@ -92,6 +92,24 @@ describe("resolveSiteScope — an empty resolution is never everything", () => {
     const scope = resolveSiteScope(input({ mode: "all", fleet: { sites: [], complete: true } }));
     expect(scope.kind).toBe("all");
     expect(describeSiteScope(scope)).toMatch(/added later/i);
+  });
+});
+
+describe("isScopeApprovable — an empty allowlist is approvable, an unread one never is", () => {
+  // The 2026-08-23 wireframe revision (line 3559) rules that a connection with
+  // an empty allowlist "can read nothing and propose nothing. That is a
+  // working state, not an error." This block pins BOTH halves of that with
+  // equal force: `none` (however it was reached) now passes, and `unresolved`
+  // (however it was reached) still fails. Weakening either half back to the
+  // pre-2026-08-23 shape must redden this block, not just the copy tests.
+  it("accepts a resolved-to-nothing scope, from no selection and from no matches alike", () => {
+    expect(isScopeApprovable({ kind: "none", because: "no-selection" })).toBe(true);
+    expect(isScopeApprovable({ kind: "none", because: "no-matches" })).toBe(true);
+  });
+
+  it("still refuses a scope nobody has read, whether pending or failed", () => {
+    expect(isScopeApprovable({ kind: "unresolved", because: "loading" })).toBe(false);
+    expect(isScopeApprovable({ kind: "unresolved", because: "failed" })).toBe(false);
   });
 });
 

--- a/apps/web/src/features/mcp-consent/site-scope.test.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.test.ts
@@ -4,6 +4,7 @@ import {
   describeSiteScope,
   isScopeApprovable,
   resolveSiteScope,
+  resolveTagIds,
   snapshotFromPage,
   type ResolveInput,
   type ScopedSite,
@@ -290,5 +291,75 @@ describe("no branch asserts that more sites exist", () => {
       expect(sentence).not.toMatch(/\b1 sites\b/);
       expect(sentence).not.toMatch(/\b1 sites? carry\b/);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTagIds
+//
+// The whole value of this function is the distinction between three answers
+// that a `.filter()` collapses into one: the ids (send this), `[]` (send an
+// empty scope, which is a choice) and `null` (send NOTHING, because we cannot
+// build the payload the operator asked for). The failure it exists to stop is
+// silent NARROWING, which no error surface ever reports because the request
+// succeeds -- the operator ticks two tags, one no longer resolves, and a
+// credential goes out covering half of what its own screen says it covers.
+// ---------------------------------------------------------------------------
+
+const REGISTRY = [
+  { id: "tag-uuid-prod", name: "prod" },
+  { id: "tag-uuid-staging", name: "staging" },
+];
+
+describe("resolveTagIds", () => {
+  it("resolves every ticked name to its id, in the order they were ticked", () => {
+    expect(resolveTagIds(["staging", "prod"], REGISTRY)).toEqual([
+      "tag-uuid-staging",
+      "tag-uuid-prod",
+    ]);
+  });
+
+  it("refuses the whole payload when one of two ticked tags no longer resolves", () => {
+    // THE REGRESSION. Filtering the registry down to the ticked names returned
+    // ["tag-uuid-prod"] here: one real id, a request the server accepts, and a
+    // token covering one tag while the screen that minted it named two. The
+    // only honest answer is that this payload cannot be built.
+    expect(resolveTagIds(["prod", "deleted-since-step-3"], REGISTRY)).toBeNull();
+    expect(resolveTagIds(["deleted-since-step-3", "prod"], REGISTRY)).toBeNull();
+  });
+
+  it("refuses when NO ticked name resolves, rather than falling back to an empty scope", () => {
+    // A narrowing all the way down to nothing is still a narrowing, and `[]`
+    // is a different sentence to the operator: it means "covers nothing on
+    // purpose", not "we lost your selection".
+    expect(resolveTagIds(["gone", "also-gone"], REGISTRY)).toBeNull();
+  });
+
+  it("refuses on an unread registry even when nothing is ticked", () => {
+    // null registry is our request, not the organisation. Distinct from the
+    // empty-selection case directly below, which is the operator's answer.
+    expect(resolveTagIds([], null)).toBeNull();
+    expect(resolveTagIds(["prod"], null)).toBeNull();
+  });
+
+  it("returns an empty array, NOT null, for an empty selection", () => {
+    const resolved = resolveTagIds([], REGISTRY);
+    expect(resolved).toEqual([]);
+    // The two must be distinguishable at a call site, because they lead to
+    // different screens: connect-wizard.tsx:153 feeds this into
+    // mintBlockedReason as `scopeTagIds !== null` and reports null as a
+    // registry failure the operator is told to fix. An empty tick list is not
+    // a failure and must not be reported as one.
+    expect(resolved).not.toBeNull();
+    expect(resolveTagIds([], REGISTRY) === null).toBe(false);
+  });
+
+  it("collapses a duplicated name to one id rather than sending it twice", () => {
+    expect(resolveTagIds(["prod", "prod"], REGISTRY)).toEqual(["tag-uuid-prod"]);
+  });
+
+  it("resolves against an empty registry only when nothing is ticked", () => {
+    expect(resolveTagIds([], [])).toEqual([]);
+    expect(resolveTagIds(["prod"], [])).toBeNull();
   });
 });

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -296,12 +296,33 @@ export function isScopeApprovable(scope: ResolvedSiteScope): boolean {
  * array missing exactly the tag the operator chose -- narrowing the request
  * without telling anyone. Null is "cannot build this payload" and every caller
  * must refuse to submit on it, loudly, rather than sending the smaller set.
+ *
+ * PARTIAL RESOLUTION IS THE SAME ABSENCE. Filtering the registry down to the
+ * ticked names returns whatever survived, so a selection of two tags where one
+ * was deleted resolved to the ONE that remained and the request went out
+ * covering half of what was chosen. Narrowing is not the safer direction when
+ * nobody is told it happened: the operator reads the scope line, sees both
+ * tags they ticked, and deploys a credential that carries one. Every selected
+ * name must resolve or the whole payload is null.
+ *
+ * EMPTY IN, EMPTY OUT. No ticked names resolves to `[]`, not null: there is
+ * nothing unresolved about choosing nothing. It is NOT a mintable payload --
+ * ValidateSiteScopeRequest (apps/api/internal/mcp/scope.go:177-182) refuses
+ * mode 'tags' with an empty list, and mint.go:264 runs the same check -- but
+ * that refusal belongs to the callers' gates, stated in their own words, not
+ * smuggled in here as a null that every caller then reports as a registry
+ * failure the operator cannot act on.
  */
 export function resolveTagIds(
   selectedTagNames: readonly string[],
   tags: readonly { readonly id: string; readonly name: string }[] | null,
 ): readonly string[] | null {
   if (tags === null) return null;
-  const ids = tags.filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id);
-  return ids.length === 0 ? null : ids;
+  const ids: string[] = [];
+  for (const name of selectedTagNames) {
+    const tag = tags.find((candidate) => candidate.name === name);
+    if (tag === undefined) return null;
+    if (!ids.includes(tag.id)) ids.push(tag.id);
+  }
+  return ids;
 }

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -279,3 +279,29 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
 export function isScopeApprovable(scope: ResolvedSiteScope): boolean {
   return scope.kind !== "unresolved";
 }
+
+/**
+ * Resolve selected tag NAMES to the ids a mint or approval request must carry.
+ *
+ * SHARED BETWEEN THE CONSENT SCREEN AND THE WIZARD, because both hold tag
+ * choices as names (what the operator clicked) and both wire endpoints
+ * (approvalRequestDTO, mintConnectionRequestDTO) want `scope_tag_ids` as
+ * UUIDs. A tag id survives a rename; a name does not, so translating late and
+ * once, here, is what keeps a renamed tag from silently changing which sites a
+ * stored grant covers.
+ *
+ * NULL, NOT A SHORTER ARRAY, when a selected name no longer resolves. The
+ * registry can go null after a name is ticked (still loading, or reloaded
+ * without that tag), and `(tags ?? []).filter(...)` would silently produce an
+ * array missing exactly the tag the operator chose -- narrowing the request
+ * without telling anyone. Null is "cannot build this payload" and every caller
+ * must refuse to submit on it, loudly, rather than sending the smaller set.
+ */
+export function resolveTagIds(
+  selectedTagNames: readonly string[],
+  tags: readonly { readonly id: string; readonly name: string }[] | null,
+): readonly string[] | null {
+  if (tags === null) return null;
+  const ids = tags.filter((t) => selectedTagNames.includes(t.name)).map((t) => t.id);
+  return ids.length === 0 ? null : ids;
+}

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -240,9 +240,13 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
       return `${siteCount(scope.sites.length)} ${verb} these tags today, listed below. ${future}`;
     }
     case "none":
+      // 2026-08-23 revision (wireframes.html:3559): an empty allowlist "is a
+      // working state, not an error -- it is how you mint a credential now and
+      // decide its reach later." Both branches say that consequence plainly
+      // rather than treating the choice as incomplete.
       return scope.because === "no-selection"
-        ? "No sites are selected yet. Choose what this client may read before approving."
-        : "This selection matches no sites, so this connection would be able to read nothing. That is not the same as covering every site.";
+        ? "No sites are selected. That is a working state, not an error: this connection will read nothing and propose nothing until you give it sites to cover, now or later."
+        : "This selection matches no sites, so this connection will read nothing and propose nothing right now. That is a working state, not an error: you can widen its scope later.";
     case "unresolved":
       return scope.because === "loading"
         ? "Working out which sites this covers."
@@ -253,11 +257,19 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
 /**
  * Whether a scope may be approved.
  *
- * `none` is refusable rather than blocked-with-a-warning: server-side, an empty
- * payload is unstorable for mode 'list' and a tag matching nothing resolves to
- * an empty set, so approving it creates a grant that reads nothing. Better to
- * say that on this screen than to mint a credential that silently does nothing.
- * `unresolved` is blocked because consenting to an unread set is not consent.
+ * 2026-08-23 revision (wireframes.html:3559): "A connection with an empty
+ * allowlist can read nothing and propose nothing. That is a working state, not
+ * an error -- it is how you mint a credential now and decide its reach later."
+ * `none` is therefore approvable, on equal footing with `all` and `sites`.
+ * Narrowing to nothing is not refused here because it is enforced where it
+ * actually matters: by which tools are registered for the connection
+ * (wireframes.html:1743, "narrowing is applied by unregistering the tool, not
+ * by denying it at call time"), not by a client-side gate on this screen. The
+ * older rule that blocked an empty allowlist (wireframes.html:1293) is
+ * superseded.
+ *
+ * `unresolved` is the only kind that still blocks. Consenting to a scope
+ * nobody has read is not consent, whether the read is pending or failed.
  *
  * A TRUNCATED LIST DOES NOT BLOCK. It is disclosed instead. Blocking would
  * refuse every organisation past the page size, and the operator choosing "every
@@ -265,5 +277,5 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
  * is a false count or a list that poses as the whole fleet.
  */
 export function isScopeApprovable(scope: ResolvedSiteScope): boolean {
-  return scope.kind === "all" || scope.kind === "sites";
+  return scope.kind !== "unresolved";
 }

--- a/apps/web/src/routes/_authed/ai/connect.tsx
+++ b/apps/web/src/routes/_authed/ai/connect.tsx
@@ -1,8 +1,16 @@
+import { useMemo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { PageHeader } from "@/components/shared/page-header";
 import { ConnectWizard } from "@/features/ai-connections/connect-wizard";
 import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
+import {
+  snapshotFromPage,
+  type FleetSnapshot,
+  type ScopedSite,
+} from "@/features/mcp-consent/site-scope";
+import { DEFAULT_SITES_LIMIT, useSites } from "@/features/sites/use-sites";
+import { useTags } from "@/features/tags/use-tags";
 
 // /ai/connect — the connection wizard (design §18).
 //
@@ -20,6 +28,39 @@ export const Route = createFileRoute("/_authed/ai/connect")({
 });
 
 function ConnectAiClientPage() {
+  const sitesQuery = useSites({ view: "active" });
+  const tagsQuery = useTags();
+
+  // NULL, NOT [], WHEN WE CANNOT SEE THE FLEET, and a full page is NOT a whole
+  // fleet. Both readings are the consent route's (routes/_authed/connect.ai.tsx)
+  // and the reasoning is identical, so the assembly is identical rather than
+  // re-invented: an empty snapshot is a fleet with no sites, null is a fleet we
+  // did not read, and snapshotFromPage carries the "at least this many" fact
+  // that a paged listSites forces on anyone printing a count.
+  const fleet: FleetSnapshot | null = useMemo(() => {
+    if (sitesQuery.data === undefined) return null;
+    const sites: ScopedSite[] = sitesQuery.data.map((s) => ({
+      id: s.id,
+      name: s.name,
+      url: s.url,
+    }));
+    return snapshotFromPage(sites, DEFAULT_SITES_LIMIT);
+  }, [sitesQuery.data]);
+
+  const tagsBySiteId = useMemo(() => {
+    const out: Record<string, readonly string[]> = {};
+    for (const site of sitesQuery.data ?? []) out[site.id] = site.tags ?? [];
+    return out;
+  }, [sitesQuery.data]);
+
+  // NULL, NOT [], WHEN THE REGISTRY DID NOT LOAD. `?? []` here would turn a
+  // failed request into "this organisation has no tags yet", which is a claim
+  // about the organisation made out of a fact about our own request.
+  const tags = useMemo(() => {
+    if (tagsQuery.data === undefined) return null;
+    return tagsQuery.data.map((t) => ({ id: t.id, name: t.name }));
+  }, [tagsQuery.data]);
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -27,7 +68,13 @@ function ConnectAiClientPage() {
         subline="Pick your client first. Everything after that is computed from it, because the setup differs per client in ways that fail quietly."
         backTo={{ to: "/ai", label: "AI connections" }}
       />
-      <ConnectWizard endpointUrl={mcpEndpointUrl()} />
+      <ConnectWizard
+        endpointUrl={mcpEndpointUrl()}
+        fleet={fleet}
+        tags={tags}
+        tagsBySiteId={tagsBySiteId}
+        sitesLoading={sitesQuery.isPending}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Wires the wizard's token-auth step to `POST /api/v1/mcp/connections` (the mint endpoint from commit `7eb5850c`, currently on `origin/worktree-agent-a14d06d8f125c882a`, not yet merged to main) instead of declaring it absent.
- Step 6's one-time reveal: the plaintext token is shown exactly once in full (not middle-truncated), states the site scope and capabilities it covers, and is never cached, refetched, or recoverable after leaving the step or editing an input the mint depended on.
- A failed mint renders as a distinct, remedy-bearing failure for: a network error, a 403 org-scope refusal, a 429 rate limit (using the server's `retry_after_seconds`), and an unresolvable site-tag scope — never a confident empty/placeholder state.
- Extracted `resolveTagIds` (tag name -> id, refusing loudly on an unresolved name) out of the consent screen into `mcp-consent/site-scope.ts` and reused it in the wizard, rather than re-deriving the lookup.
- Carries the `site-step.test.ts` fix for the cross-PR tripwire named in the brief: `isScopeApprovable` and `canLeaveSiteStep` now agree on an empty scope (#606), so the test pins that agreement instead of the stale disagreement.

## Known gap
- The wireframe's Step 6 shell-command form (`read -rs WPMGR_CONNECTION_TOKEN`, leading space, `claude mcp add ...`) is **not built**. `client-table.ts`'s Claude Code entry is a JSON-config client, not a CLI-shell one, so there is no snippet kind today that produces that shape without inventing a third one under time pressure. The reveal itself (token, warning, scope/capabilities) is complete and matches the wireframe's non-negotiables; the setup-command shape is outstanding.
- This branch does not include the backend mint endpoint itself (out of `apps/web` scope) — it must land together with `7eb5850c` for the button to work end to end against a live API.

## Mutation sweep
Swept against `connect-wizard.tsx`, each mutation reddened the test naming that property and was reverted immediately after observing red (no marker comments left in source; `git grep "MUTATION M" -- apps/web` returns nothing):
- the one-time-reveal clearing guard (disabling it left a stale token/error on screen after an input changed)
- the tag-id resolution (bypassing `resolveTagIds` sent raw names and also disabled the unresolved-tag refusal)
- the stale-refusal removal (reintroducing "You cannot mint a token here yet" broke the removal test and every mint test depending on the button)
- the three error-copy branches (collapsing them to one generic message reddened the network/403/429 distinct-copy tests together)

Not swept: the leading-space/shell-command property has no implementation (see "Known gap" above), so there is nothing to mutate.

## Test plan
- [x] `pnpm -C apps/web typecheck` — pass (exit 0)
- [x] `pnpm -C apps/web lint` — pass (exit 0; 10 pre-existing warnings, unrelated)
- [x] `pnpm -C apps/web test` — 2071/2071 passing (exit 0)
- [x] `pnpm -C apps/web build` — pass (exit 0); `routeTree.gen.ts` unchanged, nothing to commit
- [x] `impeccable detect` on touched directories — clean (exit 0)
- [x] Rendered through the real route, router and QueryClient; fetch stubbed at the network boundary, not the mutation hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added site-scope selection for all sites, tags, or named sites.
  * Added site counts, loading and empty states, selection summaries, and excluded-site notices.
  * Added connection-token generation with one-time reveal, scope details, capabilities, expiry, and token-prefix information.
  * Added site-enforcement guidance explaining access checks and refusal summaries.
* **Bug Fixes**
  * Empty resolved scopes are now valid working states.
  * Improved handling of unresolved data, scope changes, and token-generation errors.
  * Prevented navigation while token generation is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->