### PR TITLE
docs(db): correct stale idle-expiry prose in mcp_connections queries

### DIFF
--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -283,8 +283,14 @@ RETURNING *;
 -- nobody chose the terms of.
 --
 -- idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
--- meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
--- only safe one until TouchMCPGrantInTenantTx has a caller.
+-- meaningful value there ("never idle-expire"). m127 DECISION 4 made a non-NULL
+-- value conditional on the activity stamp being wired, and IT NOW IS:
+-- TouchMCPGrantInTenantTx is reached through Repo.TouchActivity, via
+-- Service.RecordActivity, from the transport's tools/list and tools/call arms.
+-- A non-NULL window is therefore representable. Callers still pass NULL because
+-- NOTHING ASKS THE OPERATOR FOR A WINDOW YET -- not because the stamp is
+-- missing. Read that distinction before removing the NULL: the guard is waiting
+-- on an input, not on a fix.
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
     client_id, created_by_user_id, capabilities, expires_at,
@@ -559,8 +565,13 @@ SELECT
         -- a grant never used is idle since it was created.
         --
         -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
-        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
-        -- NULL and this collapses to created_at + N days for every row.
+        -- TouchMCPGrantInTenantTx now runs on the request path -- through
+        -- Repo.TouchActivity, via Service.RecordActivity, from the transport's
+        -- tools/list and tools/call arms -- so last_used_at advances with real
+        -- use and this deadline advances with it. DECISION 4's prerequisite is
+        -- MET. The column stays NULL on every row today only because nothing
+        -- asks the operator for a window yet, and that is the reason to keep it
+        -- NULL: an actively used connection must never idle-expire.
         AND (g.idle_expire_after_days IS NULL
              OR COALESCE(g.last_used_at, g.created_at)
                 + make_interval(days => g.idle_expire_after_days) > now()),

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5709,13 +5709,25 @@ CREATE TABLE mcp_grants (
     -- time from coalesce(last_used_at, created_at) so it moves whenever the
     -- connection is used, which is what "expire it if unused for N days" means.
     --
-    -- WARNING (m127 DECISION 4): mcp_grants.last_used_at IS NEVER WRITTEN
-    -- TODAY. TouchMCPGrantInTenantTx has zero Go callers, so
-    -- coalesce(last_used_at, created_at) collapses to created_at permanently.
-    -- A non-NULL value here would therefore kill every affected connection N
-    -- days after CREATION however active it is. NULL with no default is what
-    -- makes that unreachable. Wiring the activity stamp is a PREREQUISITE of
-    -- writing this column, not a follow-up.
+    -- m127 DECISION 4 MADE A NON-NULL VALUE HERE CONDITIONAL ON THE ACTIVITY
+    -- STAMP BEING WIRED, AND IT NOW IS. TouchMCPGrantInTenantTx is reached
+    -- through Repo.TouchActivity, via Service.RecordActivity, from the
+    -- transport's tools/list and tools/call arms, so last_used_at advances with
+    -- real use and coalesce(last_used_at, created_at) advances with it.
+    --
+    -- THE HAZARD THAT PREREQUISITE GUARDED IS STILL REAL AND STILL WORTH
+    -- KNOWING: with the stamp unwired, coalesce(last_used_at, created_at)
+    -- collapses to created_at permanently, and a non-NULL value here would kill
+    -- every affected connection N days after CREATION however active it is. An
+    -- actively used connection must never idle-expire. That is why the stamp
+    -- had to land first, and it is why nothing may unwire it while this column
+    -- can hold a value.
+    --
+    -- THE COLUMN IS NEVERTHELESS NULL ON EVERY ROW TODAY, FOR A DIFFERENT
+    -- REASON: nothing asks the operator for a window yet. NULL with no default
+    -- is what keeps a window nobody chose unrepresentable. Do not read the
+    -- wiring above as permission to write a default -- what is missing now is
+    -- the operator input, not the stamp.
     idle_expire_after_days integer NULL,
     CONSTRAINT mcp_grants_idle_expire_after_days_check CHECK (
         idle_expire_after_days IS NULL

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -250,8 +250,14 @@ type CreateMCPGrantParams struct {
 // nobody chose the terms of.
 //
 // idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
-// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
-// only safe one until TouchMCPGrantInTenantTx has a caller.
+// meaningful value there ("never idle-expire"). m127 DECISION 4 made a non-NULL
+// value conditional on the activity stamp being wired, and IT NOW IS:
+// TouchMCPGrantInTenantTx is reached through Repo.TouchActivity, via
+// Service.RecordActivity, from the transport's tools/list and tools/call arms.
+// A non-NULL window is therefore representable. Callers still pass NULL because
+// NOTHING ASKS THE OPERATOR FOR A WINDOW YET -- not because the stamp is
+// missing. Read that distinction before removing the NULL: the guard is waiting
+// on an input, not on a fix.
 func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error) {
 	row := q.db.QueryRow(ctx, createMCPGrant,
 		arg.TenantID,
@@ -660,8 +666,13 @@ SELECT
         -- a grant never used is idle since it was created.
         --
         -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
-        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
-        -- NULL and this collapses to created_at + N days for every row.
+        -- TouchMCPGrantInTenantTx now runs on the request path -- through
+        -- Repo.TouchActivity, via Service.RecordActivity, from the transport's
+        -- tools/list and tools/call arms -- so last_used_at advances with real
+        -- use and this deadline advances with it. DECISION 4's prerequisite is
+        -- MET. The column stays NULL on every row today only because nothing
+        -- asks the operator for a window yet, and that is the reason to keep it
+        -- NULL: an actively used connection must never idle-expire.
         AND (g.idle_expire_after_days IS NULL
              OR COALESCE(g.last_used_at, g.created_at)
                 + make_interval(days => g.idle_expire_after_days) > now()),

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -629,8 +629,14 @@ type Querier interface {
 	// nobody chose the terms of.
 	//
 	// idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
-	// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
-	// only safe one until TouchMCPGrantInTenantTx has a caller.
+	// meaningful value there ("never idle-expire"). m127 DECISION 4 made a non-NULL
+	// value conditional on the activity stamp being wired, and IT NOW IS:
+	// TouchMCPGrantInTenantTx is reached through Repo.TouchActivity, via
+	// Service.RecordActivity, from the transport's tools/list and tools/call arms.
+	// A non-NULL window is therefore representable. Callers still pass NULL because
+	// NOTHING ASKS THE OPERATOR FOR A WINDOW YET -- not because the stamp is
+	// missing. Read that distinction before removing the NULL: the guard is waiting
+	// on an input, not on a fix.
 	CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error)
 	// ---------------------------------------------------------------------------
 	// backup_manifest_entries


### PR DESCRIPTION
Stacked on #615 (`worktree-agent-a60b501eb6c802e46`), so the diff here is two prose commits.

Both bot reviewers on #615 independently flagged a comment in `apps/api/db/query/mcp_connections.sql` asserting that `TouchMCPGrantInTenantTx` has no Go caller and that `mcp_grants.last_used_at` is therefore always NULL. Both halves are false as of #615 itself.

## What was false

`TouchMCPGrantInTenantTx` is called from `internal/mcp/repo.go:566` (`Repo.TouchActivity`), reached via `Service.RecordActivity` (`internal/mcp/service.go:1194`), reached via `TransportHandler.stampActivity` (`internal/mcp/transport.go:489`) from the `tools/list` (`:348`) and `tools/call` (`:359`) arms.

Three comment sites, not the one the bots reported:

- `db/query/mcp_connections.sql`, the `CreateMCPGrant` doc comment, which said NULL was "the only safe one until `TouchMCPGrantInTenantTx` has a caller";
- `db/query/mcp_connections.sql`, the inline comment inside `GetMCPConnectionTokenVerdict`'s idle-expiry predicate, which said the stamp has no caller so the deadline collapses to `created_at + N days` for every row;
- `db/schema.sql`, the `mcp_grants.idle_expire_after_days` comment, which said `last_used_at` IS NEVER WRITTEN TODAY and `TouchMCPGrantInTenantTx` has zero Go callers.

The bots saw two generated surfaces and there are three. A doc comment lands in both `mcp_connections.sql.go` and `querier.go`; an in-body comment lands only in the `const` string in `mcp_connections.sql.go`. `querier.go:632` was invisible to a reader working from the diff.

## Why it mattered

The conclusion those comments defend, keep `idle_expire_after_days` NULL, is still correct. The stated reason had expired. A reader trusting the old text keeps the guard for a reason that no longer holds, and removes it as soon as they notice the stamp is wired. The real reason to keep NULL is that nothing asks the operator for a window yet. `Service.Approve` (`internal/mcp/service.go:655-671`) already said exactly that, so the cohort disagreed with itself about one fact.

## What was deliberately not changed

m127 DECISION 4 and the fleet-outage rationale stay: an actively used connection must not idle-expire, and that reasoning is load-bearing. In the query file the `SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN` line is untouched. In `schema.sql` the hazard is kept and restated as why the prerequisite existed and why nothing may unwire the stamp while the column can hold a value.

**`apps/api/migrations/20260829000000_m127_...sql:175-184` is left as written, and that is deliberate.** It carries the same now-false claim. m127 is not on `main` yet, so it is technically still editable today and becomes frozen the moment this stack merges; the decision not to edit it is a choice, not an inability. A migration is a record of what was true when it was applied. The text was true when written on 2026-08-29, `schema.sql` now carries the corrected current-state version, and rewriting history to look prescient is worse than a dated record a reader can place. Editing applied DDL is also the silent no-op the migration rules warn about, since a database that has run m127 will never read the file again.

Please do not "fix" it later.

## Verification

- `sqlc` at `/Users/mosamgor/go/bin/sqlc`, `v1.31.1`, matching the tree stamp from `grep -h 'sqlc v' apps/api/internal/db/sqlc/*.go | sort -u`.
- Query-file change: three generations run; `git diff --quiet -- apps/api/internal/db/sqlc/` exits 0 against the committed tree after each of the last two.
- `schema.sql` change: `sqlc generate` run again afterwards, and the generated tree did not move. `git diff --quiet -- apps/api/internal/db/sqlc/` exit 0, with `git status --short` showing only `apps/api/db/schema.sql` modified. Confirmed by running it, not assumed from the fact that comments are not code.
- GH #597 hazard avoided: no doubled single quote written into either replacement. Both new regions inspected with `/bin/cat -vet`; only `$` and `^I` appear. The non-ASCII line set across the whole generated tree is byte-identical before and after (`diff` of the two captures exits 0, 361 lines each).
- `apps/api/internal/db/sqlc/mcp_connections.sql.go` and `querier.go` carry the doc comment word for word identically, so the #597 divergence symptom is absent.
- `go build ./...` and `go vet ./...` from `apps/api`, run after each commit: exit 0 each time.
- `go test ./internal/mcp/... ./internal/db/...`: ok.
- `grep -rn "no Go caller\|always NULL\|has no caller\|zero Go callers\|IS NEVER WRITTEN\|has a caller" apps/api/db/ apps/api/internal/db/sqlc/` returns nothing, exit 1. The only surviving mentions are m127's, above.

No schema change, no migration, no policy change: comments only. The RLS ledger gains no row, because no table, column, policy, cascade or lock was touched and no applied DDL differs, so a database on the earlier version needs no converge path.
