### PR TITLE
fix(mcp): 403 for an empty capability set, and pin the mint rollback probe

### DIFF
--- a/apps/api/cmd/dump-routes/routes.go
+++ b/apps/api/cmd/dump-routes/routes.go
@@ -286,7 +286,7 @@ func buildEngine() (engine *gin.Engine, omittedDepsFields []string, err error) {
 	// cmd/wpmgr/main.go wires it (mcp.NewService(mcp.NewRepo(pool)) etc.), so
 	// POST /mcp, the four OAuth paths and the three well-known discovery
 	// documents all mount.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, "dump-routes")
 	mcpOAuthH := mcp.NewHandler(mcpSvc)
 	mcpDiscoveryH := mcp.NewDiscoveryHandler("https://cp.example.test")

--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -540,7 +540,7 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	// would make POST /mcp answer 404, which is indistinguishable from a
 	// routing failure. Self-host reaches it too; the grant is what authorizes,
 	// and an installation with no grants simply has no valid bearer token.
-	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now)
+	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec)
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, version)
 	// The OAuth half, wired unconditionally for the same reason. Without it the
 	// transport above is mounted and correct and refuses every request forever,

--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -268,11 +268,29 @@ RETURNING *;
 -- either gets 23502 rather than a live organisation-wide grant (Decision 1).
 -- The caller passes status explicitly -- 'active' -- rather than relying on the
 -- schema to assume it.
+--
+-- m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+-- columns behave the same way: a caller that omits capabilities or expires_at
+-- gets 23502, NOT an unrestricted or never-expiring connection.
+--
+-- THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+-- CreateMCPGrantParams is a named-field struct literal at
+-- internal/mcp/service.go:570 and in three integration fixtures, so adding
+-- fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+-- which is NULL, which is refused at the INSERT. backend-architect must supply
+-- all three. A loud 23502 at creation is the correct failure and is strictly
+-- better than the alternative of a DEFAULT that quietly mints a credential
+-- nobody chose the terms of.
+--
+-- idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+-- meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+-- only safe one until TouchMCPGrantInTenantTx has a caller.
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, capabilities, expires_at,
+    idle_expire_after_days
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING *;
 
@@ -483,6 +501,21 @@ WHERE mcp_connection_tokens.token_hash = $1;
 -- The grant is joined on tenant_id as well as id: the token and its grant must
 -- belong to the same organisation, checked in the join rather than assumed
 -- from the foreign key.
+-- m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+-- a second read the caller might forget. A grant past its absolute expiry, or
+-- past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+-- Both are evaluated on the already-fetched grant row, so neither costs a round
+-- trip and neither needs an index.
+--
+-- The wireframe's "there is no silent read-only period" is a consequence of
+-- this shape: expiry flips one boolean to false outright and cannot degrade a
+-- connection to a reduced capability set, because there is one boolean here and
+-- not a tier.
+--
+-- g.capabilities is returned so the capability set is read from the SAME ROW
+-- and the SAME transaction as the verdict it was authorized under (S7's exit
+-- gate: discovery never grants what the registry does not hold, and it cannot
+-- hold what this row does not carry).
 SELECT
     g.id                          AS grant_id,
     g.name                        AS grant_name,
@@ -491,17 +524,47 @@ SELECT
     g.scope_tag_ids               AS scope_tag_ids,
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
+    g.capabilities                AS grant_capabilities,
+    g.expires_at                  AS grant_expires_at,
+    g.idle_expire_after_days      AS grant_idle_expire_after_days,
+    g.last_used_at                AS grant_last_used_at,
     t.id                          AS token_id,
     t.token_prefix                AS token_prefix,
     t.status                      AS token_status,
     t.expires_at                  AS token_expires_at,
+    -- The component reasons, so a refusal can be logged with its cause. Both
+    -- COALESCE to TRUE -- the FAIL-CLOSED direction for a negative flag, since
+    -- these say "expired". An absent value must never read as "still valid".
+    -- They are diagnostics; `authorized` below is the verdict.
+    COALESCE(g.expires_at <= now(), true)::boolean AS grant_absolute_expired,
+    COALESCE(g.idle_expire_after_days IS NOT NULL
+        AND COALESCE(g.last_used_at, g.created_at)
+            + make_interval(days => g.idle_expire_after_days) <= now(),
+        true)::boolean AS grant_idle_expired,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
     -- how a nil comes to be read as anything other than refusal.
     COALESCE(g.status = 'active'
         AND t.status = 'active'
-        AND (t.expires_at IS NULL OR t.expires_at > now()), false)::boolean AS authorized
+        AND (t.expires_at IS NULL OR t.expires_at > now())
+        -- ABSOLUTE EXPIRY. NO `IS NULL OR` BRANCH, and its absence is the
+        -- point: mcp_grants.expires_at is NOT NULL (m127 DECISION 2), so
+        -- unlike t.expires_at above there is no nullable case here for a
+        -- reader to get backwards.
+        AND g.expires_at > now()
+        -- IDLE EXPIRY. NULL means never idle-expire, which is a DIFFERENT fact
+        -- from the absolute expiry above and is why the NULL branch appears on
+        -- this line and not that one. coalesce(last_used_at, created_at):
+        -- a grant never used is idle since it was created.
+        --
+        -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
+        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
+        -- NULL and this collapses to created_at + N days for every row.
+        AND (g.idle_expire_after_days IS NULL
+             OR COALESCE(g.last_used_at, g.created_at)
+                + make_interval(days => g.idle_expire_after_days) > now()),
+        false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5641,6 +5641,37 @@ CREATE TABLE mcp_grants (
             AND cardinality(scope_site_ids) > 0
             AND cardinality(scope_tag_ids) = 0)
     ),
+    -- WHICH TOOLS this grant may reach (m127 DECISION 1). NOT NULL, NO
+    -- DEFAULT: a nullable capabilities column read as "no narrowing applied,
+    -- therefore everything" is the defect this surface exists to prevent. '{}'
+    -- is legal and means zero capabilities, which reaches no tool.
+    --
+    -- Deliberately the OPPOSITE of api_keys.capabilities, which is nullable --
+    -- that column had a `role` fallback and a live fleet to avoid stripping at
+    -- boot; this one has no second source of authority, so NULL would only
+    -- mean "unknown", and an unknown grant is refused.
+    capabilities text[] NOT NULL,
+    -- Shape, exactly as m120 checks api_keys.capabilities: one dimension (a
+    -- nested literal would be flattened by unnest() into capabilities nobody
+    -- granted), no NULL element, no empty string, and the 64 ceiling the
+    -- wireframe states as a property of the credential.
+    CONSTRAINT mcp_grants_capabilities_shape_check CHECK (
+        coalesce(array_ndims(capabilities), 1) = 1
+        AND cardinality(capabilities) <= 64
+        AND array_position(capabilities, NULL) IS NULL
+        AND NOT ('' = ANY (capabilities))
+    ),
+    -- CLOSED VOCABULARY, checked against the registry by name. This is S7's
+    -- exit gate -- discovery never grants what the registry does not hold --
+    -- pushed into the one place a call site cannot forget.
+    --
+    -- Keep in lockstep with capabilityVocabulary in internal/mcp/policy.go,
+    -- which holds exactly this one entry today. EXTENDING IT IS A MIGRATION,
+    -- and that coupling is the review gate m124 DECISION 1 asked for: a write
+    -- capability cannot reach this table until someone writes a migration
+    -- naming it. Adding a Capability to policy.go alone fails 23514 on INSERT.
+    CONSTRAINT mcp_grants_capabilities_vocabulary_check
+        CHECK (capabilities <@ ARRAY['mcp.sites.read']::text[]),
     -- The registered OAuth client, or NULL on the headless token path. No
     -- foreign key: neither ON DELETE action is right for a recorded fact.
     client_id text NULL,
@@ -5656,7 +5687,40 @@ CREATE TABLE mcp_grants (
     last_used_at timestamptz NULL,
     revoked_at   timestamptz NULL,
     CONSTRAINT mcp_grants_revoked_at_matches_status_check
-        CHECK ((status = 'revoked') = (revoked_at IS NOT NULL))
+        CHECK ((status = 'revoked') = (revoked_at IS NOT NULL)),
+
+    -- ABSOLUTE EXPIRY (m127 DECISION 2). NOT NULL, NO DEFAULT. NULL IS
+    -- UNREPRESENTABLE -- not "NULL means never". Step 5 of the wireframe offers
+    -- 30 days / 90 days / 1 year / on a date and NO "never" option, so a
+    -- never-expiring connection is not a thing the product offers and not a
+    -- thing the schema can hold. The point of NOT NULL here is that the
+    -- read-time predicate has NO NULL BRANCH for a caller to get backwards.
+    expires_at timestamptz NOT NULL,
+    -- A grant cannot be born already expired. Immediate termination is
+    -- REVOCATION (status = 'revoked'), not a backdated expiry; keeping the two
+    -- mechanisms distinct is what keeps revoked_at honest.
+    CONSTRAINT mcp_grants_expires_at_after_created_check
+        CHECK (expires_at > created_at),
+
+    -- IDLE EXPIRY (m127 DECISION 2), a WINDOW LENGTH IN DAYS and not an
+    -- instant. NULL MEANS NEVER IDLE-EXPIRE, and only that -- Step 5's second
+    -- control does offer "Never" beside 30 and 90 days, so this axis has three
+    -- states and the third is representable. The deadline is computed at read
+    -- time from coalesce(last_used_at, created_at) so it moves whenever the
+    -- connection is used, which is what "expire it if unused for N days" means.
+    --
+    -- WARNING (m127 DECISION 4): mcp_grants.last_used_at IS NEVER WRITTEN
+    -- TODAY. TouchMCPGrantInTenantTx has zero Go callers, so
+    -- coalesce(last_used_at, created_at) collapses to created_at permanently.
+    -- A non-NULL value here would therefore kill every affected connection N
+    -- days after CREATION however active it is. NULL with no default is what
+    -- makes that unreachable. Wiring the activity stamp is a PREREQUISITE of
+    -- writing this column, not a follow-up.
+    idle_expire_after_days integer NULL,
+    CONSTRAINT mcp_grants_idle_expire_after_days_check CHECK (
+        idle_expire_after_days IS NULL
+        OR (idle_expire_after_days >= 1 AND idle_expire_after_days <= 3650)
+    )
 );
 
 -- "Is this grant live right now" in one indexed read.

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -373,17 +373,21 @@ const (
 	// which adds issuance and token_prefix to Metadata).
 	//
 	// ActorID is NEVER the grant's own id -- it is the id of the credential
-	// that authorised it, and ActorType says which kind. ActorUser with the
-	// approving human's user id on the consent path; ActorAPIKey with the key's
-	// id when a machine mints headlessly, which is the mint's ordinary case
-	// (apikey.PrincipalFor sets APIKeyID and never UserID, so reading UserID
-	// there yields uuid.Nil -- see mcp.mintAuditActor, which is the only
-	// correct resolver). Metadata: grant_name, site_scope_mode.
+	// that authorised it, and ActorType says which kind. NEITHER PATH IS
+	// SINGLE-ACTOR-TYPE: both are mounted on the v1 group, which carries
+	// Auth.Authenticate(), so either can be driven by a session user
+	// (ActorUser, their user id) or by an API key (ActorAPIKey, the key's id).
+	// Browser-only consent is a convention about who usually calls it, never a
+	// constraint on who can. Resolve the pair with ActorFor and never compose
+	// it by hand. Metadata: grant_name, site_scope_mode.
 	ActionMCPGrantCreated = "mcp.grant.created"
 	// ActionMCPGrantRevoked is recorded on the SAME transaction as the revoke
-	// (internal/mcp.Service.RevokeConnection, via RecordInTx). ActorType is
-	// ActorUser -- the operator who revoked, ActorID their user id. Metadata:
-	// grant_name, grants_revoked, tokens_revoked, already_revoked.
+	// (internal/mcp.Service.RevokeConnection, via RecordInTx). Same two actor
+	// kinds as ActionMCPGrantCreated and for the same reason -- the revoke
+	// route is mounted by the same call as the headless mint -- so the pair
+	// comes from ActorFor. This is the row an auditor reaches for after an
+	// incident, so an actor it names must be one that exists. Metadata:
+	// grants_revoked, tokens_revoked, already_revoked.
 	ActionMCPGrantRevoked = "mcp.grant.revoked"
 	// ActionMCPToolCalled is recorded per successful tool invocation on the
 	// transport path (internal/mcp.Service.RecordToolCall), BEST-EFFORT like
@@ -403,6 +407,40 @@ const (
 	// tool.
 	ActionMCPToolCalled = "mcp.tool.called"
 )
+
+// ActorFor resolves the (ActorType, ActorID) pair for whichever credential
+// actually authenticated a request. It is the ONLY correct way to fill those
+// two fields from a domain.Principal, and it lives here rather than in a
+// calling package so that there is exactly one of it.
+//
+// IT EXISTS BECAUSE HARDCODING ActorUser OVER Principal.UserID IS WRONG FOR AN
+// API-KEY CALLER, AND SILENTLY SO. apikey.PrincipalFor sets APIKeyID and never
+// UserID, so every route mounted behind Auth.Authenticate() -- whose Bearer
+// branch returns exactly that principal -- can reach this with UserID ==
+// uuid.Nil. The row still writes, still hashes into the chain, and still
+// renders; it just asserts that a user acted and then names a user that does
+// not exist. That is worse than no row at all: a missing record prompts a
+// question, a wrong one answers it incorrectly.
+//
+// THE TYPE AND THE ID MUST MOVE TOGETHER, which is why this returns both and
+// why callers must not compose one of them by hand. ListAuditEntries and
+// ListAuditEntriesFiltered resolve ActorName with two LEFT JOINs gated on
+// actor_type ('user' -> users.name, 'api_key' -> api_keys.name), so a pair
+// that disagrees -- ActorUser beside an api_keys id, or ActorAPIKey beside a
+// users id -- matches neither arm and the row names nobody. Splitting the
+// resolution across two expressions is how the pair drifts apart.
+//
+// Principal.ActorID() is the id source (APIKeyID for an API-key principal,
+// UserID otherwise). A principal that names neither yields ActorUser over
+// uuid.Nil, which is the pre-existing shape for an unattributed row and is not
+// made worse here; the fix for that is to refuse the request upstream, where
+// the caller is still identifiable.
+func ActorFor(p domain.Principal) (actorType, actorID string) {
+	if p.Type == domain.PrincipalAPIKey {
+		return ActorAPIKey, p.ActorID()
+	}
+	return ActorUser, p.ActorID()
+}
 
 // Entry is one audit record.
 type Entry struct {

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -366,11 +366,19 @@ const (
 	// before this the surface wrote zero.
 	//
 	// ActionMCPGrantCreated is recorded on the SAME transaction as the grant
-	// insert (internal/mcp.Service.Approve, via RecordInTx), so a rolled-back
-	// grant leaves no row claiming one was created. ActorType is ActorUser:
-	// the grant belongs to the organisation of the human who approved it, and
-	// ActorID is that user's id, not the grant's. Metadata: grant_name,
-	// site_scope_mode.
+	// insert, so a rolled-back grant leaves no row claiming one was created.
+	// TWO paths write it and they differ only in how the grant was authorised:
+	// internal/mcp.Service.Approve (browser consent) and
+	// internal/mcp.Service.MintConnection (the headless connection-token mint,
+	// which adds issuance and token_prefix to Metadata).
+	//
+	// ActorID is NEVER the grant's own id -- it is the id of the credential
+	// that authorised it, and ActorType says which kind. ActorUser with the
+	// approving human's user id on the consent path; ActorAPIKey with the key's
+	// id when a machine mints headlessly, which is the mint's ordinary case
+	// (apikey.PrincipalFor sets APIKeyID and never UserID, so reading UserID
+	// there yields uuid.Nil -- see mcp.mintAuditActor, which is the only
+	// correct resolver). Metadata: grant_name, site_scope_mode.
 	ActionMCPGrantCreated = "mcp.grant.created"
 	// ActionMCPGrantRevoked is recorded on the SAME transaction as the revoke
 	// (internal/mcp.Service.RevokeConnection, via RecordInTx). ActorType is

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -28,6 +28,13 @@ const (
 	ActorUser   = "user"
 	ActorAPIKey = "api_key"
 	ActorSystem = "system"
+	// ActorAssistant is the model on the other end of an MCP connection --
+	// never a human and never the control plane itself. actor_type has no
+	// CHECK constraint (db/schema.sql), so this needed no migration.
+	// ActorID for this kind is the grant id (internal/mcp), NOT a user or key
+	// id: an MCP grant is the credential a model acts under, the way a user id
+	// or an api_key id is the credential a human or a script acts under.
+	ActorAssistant = "assistant"
 
 	ActionLoginSuccess = "auth.login.success"
 	ActionLoginFailure = "auth.login.failure"
@@ -352,6 +359,41 @@ const (
 	// ActionAdminBillingStateForced: metadata: reason, old_plan,
 	// old_plan_status, new_plan, new_plan_status.
 	ActionAdminBillingStateForced = "admin.billing.state.forced"
+
+	// The MCP connection surface (ADR-064). Approve, revoke, and every tool
+	// call are the three points where an MCP grant does something a human
+	// operator can be asked about afterward, and each needed a row here --
+	// before this the surface wrote zero.
+	//
+	// ActionMCPGrantCreated is recorded on the SAME transaction as the grant
+	// insert (internal/mcp.Service.Approve, via RecordInTx), so a rolled-back
+	// grant leaves no row claiming one was created. ActorType is ActorUser:
+	// the grant belongs to the organisation of the human who approved it, and
+	// ActorID is that user's id, not the grant's. Metadata: grant_name,
+	// site_scope_mode.
+	ActionMCPGrantCreated = "mcp.grant.created"
+	// ActionMCPGrantRevoked is recorded on the SAME transaction as the revoke
+	// (internal/mcp.Service.RevokeConnection, via RecordInTx). ActorType is
+	// ActorUser -- the operator who revoked, ActorID their user id. Metadata:
+	// grant_name, grants_revoked, tokens_revoked, already_revoked.
+	ActionMCPGrantRevoked = "mcp.grant.revoked"
+	// ActionMCPToolCalled is recorded per successful tool invocation on the
+	// transport path (internal/mcp.Service.RecordToolCall), BEST-EFFORT like
+	// most of this log (Record, not RecordInTx): there is no companion write
+	// to roll back alongside it, and a purely observational record must not
+	// take down the read path it observes. ActorType is ActorAssistant --
+	// this is the one action class in the whole log recorded as the MODEL's
+	// own act rather than the human who granted it access -- and ActorID is
+	// the mcp_grants id, not a user id. Metadata carries grant_name as the
+	// actor's display label: ListAuditEntries/ListAuditEntriesFiltered
+	// resolve ActorName by joining users/api_keys on actor_type, and neither
+	// join has an arm for "assistant" (that join lives in db/query/*.sql,
+	// database-engineer's surface, and a fourth JOIN did not land alongside
+	// this Go-only change) -- so the label travels in Metadata rather than in
+	// the ActorName column until that join exists. Also carries
+	// operator_permission (the dashboard authority the tool call mirrors) and
+	// tool.
+	ActionMCPToolCalled = "mcp.tool.called"
 )
 
 // Entry is one audit record.
@@ -372,6 +414,12 @@ type Entry struct {
 	// ActorType == ActorAPIKey. Nil for ActorSystem events and for any actor
 	// row that no longer exists (e.g. a deleted user). Only List and
 	// ListFiltered populate this field; Record's returned Entry does not.
+	//
+	// Also nil for ActorType == ActorAssistant: the join that would resolve it
+	// (mcp_grants.name, the same shape as the api_keys.name join above) does
+	// not exist in ListAuditEntries/ListAuditEntriesFiltered today. An
+	// ActionMCPToolCalled recorder carries the grant's name in Metadata
+	// instead, so the label is not lost, only not yet promoted to this column.
 	ActorName *string
 	// ActorEmail is the acting user's email when ActorType == ActorUser. Nil
 	// otherwise. Only List and ListFiltered populate this field.

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -188,22 +188,26 @@ const createMCPGrant = `-- name: CreateMCPGrant :one
 
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, capabilities, expires_at,
+    idle_expire_after_days
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days
 `
 
 type CreateMCPGrantParams struct {
-	TenantID        uuid.UUID   `json:"tenant_id"`
-	Name            string      `json:"name"`
-	Status          string      `json:"status"`
-	SiteScopeMode   string      `json:"site_scope_mode"`
-	ScopeTagIds     []uuid.UUID `json:"scope_tag_ids"`
-	ScopeSiteIds    []uuid.UUID `json:"scope_site_ids"`
-	ClientID        *string     `json:"client_id"`
-	CreatedByUserID pgtype.UUID `json:"created_by_user_id"`
+	TenantID            uuid.UUID   `json:"tenant_id"`
+	Name                string      `json:"name"`
+	Status              string      `json:"status"`
+	SiteScopeMode       string      `json:"site_scope_mode"`
+	ScopeTagIds         []uuid.UUID `json:"scope_tag_ids"`
+	ScopeSiteIds        []uuid.UUID `json:"scope_site_ids"`
+	ClientID            *string     `json:"client_id"`
+	CreatedByUserID     pgtype.UUID `json:"created_by_user_id"`
+	Capabilities        []string    `json:"capabilities"`
+	ExpiresAt           time.Time   `json:"expires_at"`
+	IdleExpireAfterDays *int32      `json:"idle_expire_after_days"`
 }
 
 // ===========================================================================
@@ -231,6 +235,23 @@ type CreateMCPGrantParams struct {
 // either gets 23502 rather than a live organisation-wide grant (Decision 1).
 // The caller passes status explicitly -- 'active' -- rather than relying on the
 // schema to assume it.
+//
+// m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+// columns behave the same way: a caller that omits capabilities or expires_at
+// gets 23502, NOT an unrestricted or never-expiring connection.
+//
+// THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+// CreateMCPGrantParams is a named-field struct literal at
+// internal/mcp/service.go:570 and in three integration fixtures, so adding
+// fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+// which is NULL, which is refused at the INSERT. backend-architect must supply
+// all three. A loud 23502 at creation is the correct failure and is strictly
+// better than the alternative of a DEFAULT that quietly mints a credential
+// nobody chose the terms of.
+//
+// idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+// only safe one until TouchMCPGrantInTenantTx has a caller.
 func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error) {
 	row := q.db.QueryRow(ctx, createMCPGrant,
 		arg.TenantID,
@@ -241,6 +262,9 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		arg.ScopeSiteIds,
 		arg.ClientID,
 		arg.CreatedByUserID,
+		arg.Capabilities,
+		arg.ExpiresAt,
+		arg.IdleExpireAfterDays,
 	)
 	var i McpGrant
 	err := row.Scan(
@@ -251,6 +275,7 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -260,6 +285,8 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }
@@ -413,7 +440,7 @@ func (q *Queries) GetMCPConnectionTokenByHashForLookup(ctx context.Context, toke
 }
 
 const getMCPGrant = `-- name: GetMCPGrant :one
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days FROM mcp_grants
 WHERE tenant_id = $1 AND id = $2
 `
 
@@ -436,6 +463,7 @@ func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGr
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -445,6 +473,8 @@ func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGr
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }
@@ -531,7 +561,7 @@ func (q *Queries) ListMCPConnectionTokensForGrant(ctx context.Context, arg ListM
 }
 
 const listMCPGrantsForOrg = `-- name: ListMCPGrantsForOrg :many
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days FROM mcp_grants
 WHERE tenant_id = $1
 ORDER BY created_at DESC, id DESC
 `
@@ -563,6 +593,7 @@ func (q *Queries) ListMCPGrantsForOrg(ctx context.Context, tenantID uuid.UUID) (
 			&i.SiteScopeMode,
 			&i.ScopeTagIds,
 			&i.ScopeSiteIds,
+			&i.Capabilities,
 			&i.ClientID,
 			&i.ClientName,
 			&i.ClientVersion,
@@ -572,6 +603,8 @@ func (q *Queries) ListMCPGrantsForOrg(ctx context.Context, tenantID uuid.UUID) (
 			&i.CreatedAt,
 			&i.LastUsedAt,
 			&i.RevokedAt,
+			&i.ExpiresAt,
+			&i.IdleExpireAfterDays,
 		); err != nil {
 			return nil, err
 		}
@@ -592,17 +625,47 @@ SELECT
     g.scope_tag_ids               AS scope_tag_ids,
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
+    g.capabilities                AS grant_capabilities,
+    g.expires_at                  AS grant_expires_at,
+    g.idle_expire_after_days      AS grant_idle_expire_after_days,
+    g.last_used_at                AS grant_last_used_at,
     t.id                          AS token_id,
     t.token_prefix                AS token_prefix,
     t.status                      AS token_status,
     t.expires_at                  AS token_expires_at,
+    -- The component reasons, so a refusal can be logged with its cause. Both
+    -- COALESCE to TRUE -- the FAIL-CLOSED direction for a negative flag, since
+    -- these say "expired". An absent value must never read as "still valid".
+    -- They are diagnostics; ` + "`" + `authorized` + "`" + ` below is the verdict.
+    COALESCE(g.expires_at <= now(), true)::boolean AS grant_absolute_expired,
+    COALESCE(g.idle_expire_after_days IS NOT NULL
+        AND COALESCE(g.last_used_at, g.created_at)
+            + make_interval(days => g.idle_expire_after_days) <= now(),
+        true)::boolean AS grant_idle_expired,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
     -- how a nil comes to be read as anything other than refusal.
     COALESCE(g.status = 'active'
         AND t.status = 'active'
-        AND (t.expires_at IS NULL OR t.expires_at > now()), false)::boolean AS authorized
+        AND (t.expires_at IS NULL OR t.expires_at > now())
+        -- ABSOLUTE EXPIRY. NO ` + "`" + `IS NULL OR` + "`" + ` BRANCH, and its absence is the
+        -- point: mcp_grants.expires_at is NOT NULL (m127 DECISION 2), so
+        -- unlike t.expires_at above there is no nullable case here for a
+        -- reader to get backwards.
+        AND g.expires_at > now()
+        -- IDLE EXPIRY. NULL means never idle-expire, which is a DIFFERENT fact
+        -- from the absolute expiry above and is why the NULL branch appears on
+        -- this line and not that one. coalesce(last_used_at, created_at):
+        -- a grant never used is idle since it was created.
+        --
+        -- SEE m127 DECISION 4 BEFORE WRITING A NON-NULL VALUE INTO THIS COLUMN.
+        -- TouchMCPGrantInTenantTx has no Go caller, so last_used_at is always
+        -- NULL and this collapses to created_at + N days for every row.
+        AND (g.idle_expire_after_days IS NULL
+             OR COALESCE(g.last_used_at, g.created_at)
+                + make_interval(days => g.idle_expire_after_days) > now()),
+        false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id
@@ -615,18 +678,24 @@ type ReCheckMCPRequestAuthorizationInTenantTxParams struct {
 }
 
 type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
-	GrantID        uuid.UUID          `json:"grant_id"`
-	GrantName      string             `json:"grant_name"`
-	GrantStatus    string             `json:"grant_status"`
-	SiteScopeMode  string             `json:"site_scope_mode"`
-	ScopeTagIds    []uuid.UUID        `json:"scope_tag_ids"`
-	ScopeSiteIds   []uuid.UUID        `json:"scope_site_ids"`
-	ClientID       *string            `json:"client_id"`
-	TokenID        uuid.UUID          `json:"token_id"`
-	TokenPrefix    string             `json:"token_prefix"`
-	TokenStatus    string             `json:"token_status"`
-	TokenExpiresAt pgtype.Timestamptz `json:"token_expires_at"`
-	Authorized     bool               `json:"authorized"`
+	GrantID                  uuid.UUID          `json:"grant_id"`
+	GrantName                string             `json:"grant_name"`
+	GrantStatus              string             `json:"grant_status"`
+	SiteScopeMode            string             `json:"site_scope_mode"`
+	ScopeTagIds              []uuid.UUID        `json:"scope_tag_ids"`
+	ScopeSiteIds             []uuid.UUID        `json:"scope_site_ids"`
+	ClientID                 *string            `json:"client_id"`
+	GrantCapabilities        []string           `json:"grant_capabilities"`
+	GrantExpiresAt           time.Time          `json:"grant_expires_at"`
+	GrantIdleExpireAfterDays *int32             `json:"grant_idle_expire_after_days"`
+	GrantLastUsedAt          pgtype.Timestamptz `json:"grant_last_used_at"`
+	TokenID                  uuid.UUID          `json:"token_id"`
+	TokenPrefix              string             `json:"token_prefix"`
+	TokenStatus              string             `json:"token_status"`
+	TokenExpiresAt           pgtype.Timestamptz `json:"token_expires_at"`
+	GrantAbsoluteExpired     bool               `json:"grant_absolute_expired"`
+	GrantIdleExpired         bool               `json:"grant_idle_expired"`
+	Authorized               bool               `json:"authorized"`
 }
 
 // Runs InTenantTx with the tenant the lookup above established. STEP 2 OF 2,
@@ -649,6 +718,21 @@ type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
 // The grant is joined on tenant_id as well as id: the token and its grant must
 // belong to the same organisation, checked in the join rather than assumed
 // from the foreign key.
+// m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+// a second read the caller might forget. A grant past its absolute expiry, or
+// past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+// Both are evaluated on the already-fetched grant row, so neither costs a round
+// trip and neither needs an index.
+//
+// The wireframe's "there is no silent read-only period" is a consequence of
+// this shape: expiry flips one boolean to false outright and cannot degrade a
+// connection to a reduced capability set, because there is one boolean here and
+// not a tier.
+//
+// g.capabilities is returned so the capability set is read from the SAME ROW
+// and the SAME transaction as the verdict it was authorized under (S7's exit
+// gate: discovery never grants what the registry does not hold, and it cannot
+// hold what this row does not carry).
 func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error) {
 	row := q.db.QueryRow(ctx, reCheckMCPRequestAuthorizationInTenantTx, arg.TenantID, arg.ID)
 	var i ReCheckMCPRequestAuthorizationInTenantTxRow
@@ -660,10 +744,16 @@ func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, 
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
 		&i.ClientID,
+		&i.GrantCapabilities,
+		&i.GrantExpiresAt,
+		&i.GrantIdleExpireAfterDays,
+		&i.GrantLastUsedAt,
 		&i.TokenID,
 		&i.TokenPrefix,
 		&i.TokenStatus,
 		&i.TokenExpiresAt,
+		&i.GrantAbsoluteExpired,
+		&i.GrantIdleExpired,
 		&i.Authorized,
 	)
 	return i, err
@@ -676,7 +766,7 @@ SET client_name                 = $3,
     protocol_version            = $5,
     client_identity_recorded_at = now()
 WHERE tenant_id = $1 AND id = $2
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days
 `
 
 type RecordMCPGrantClientIdentityInTenantTxParams struct {
@@ -714,6 +804,7 @@ func (q *Queries) RecordMCPGrantClientIdentityInTenantTx(ctx context.Context, ar
 		&i.SiteScopeMode,
 		&i.ScopeTagIds,
 		&i.ScopeSiteIds,
+		&i.Capabilities,
 		&i.ClientID,
 		&i.ClientName,
 		&i.ClientVersion,
@@ -723,6 +814,8 @@ func (q *Queries) RecordMCPGrantClientIdentityInTenantTx(ctx context.Context, ar
 		&i.CreatedAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.ExpiresAt,
+		&i.IdleExpireAfterDays,
 	)
 	return i, err
 }

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -486,6 +486,7 @@ type McpGrant struct {
 	SiteScopeMode            string             `json:"site_scope_mode"`
 	ScopeTagIds              []uuid.UUID        `json:"scope_tag_ids"`
 	ScopeSiteIds             []uuid.UUID        `json:"scope_site_ids"`
+	Capabilities             []string           `json:"capabilities"`
 	ClientID                 *string            `json:"client_id"`
 	ClientName               *string            `json:"client_name"`
 	ClientVersion            *string            `json:"client_version"`
@@ -495,6 +496,8 @@ type McpGrant struct {
 	CreatedAt                time.Time          `json:"created_at"`
 	LastUsedAt               pgtype.Timestamptz `json:"last_used_at"`
 	RevokedAt                pgtype.Timestamptz `json:"revoked_at"`
+	ExpiresAt                time.Time          `json:"expires_at"`
+	IdleExpireAfterDays      *int32             `json:"idle_expire_after_days"`
 }
 
 type McpOauthClient struct {

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -614,6 +614,23 @@ type Querier interface {
 	// either gets 23502 rather than a live organisation-wide grant (Decision 1).
 	// The caller passes status explicitly -- 'active' -- rather than relying on the
 	// schema to assume it.
+	//
+	// m127 EXTENDS THAT RULE TO EXPIRY AND CAPABILITIES, and the two new NOT NULL
+	// columns behave the same way: a caller that omits capabilities or expires_at
+	// gets 23502, NOT an unrestricted or never-expiring connection.
+	//
+	// THAT 23502 IS THE DESIGNED BEHAVIOUR AND IT IS CURRENTLY REACHABLE.
+	// CreateMCPGrantParams is a named-field struct literal at
+	// internal/mcp/service.go:570 and in three integration fixtures, so adding
+	// fields does NOT break the build -- it leaves them zero, which is nil/invalid,
+	// which is NULL, which is refused at the INSERT. backend-architect must supply
+	// all three. A loud 23502 at creation is the correct failure and is strictly
+	// better than the alternative of a DEFAULT that quietly mints a credential
+	// nobody chose the terms of.
+	//
+	// idle_expire_after_days is passed explicitly and MAY be NULL: NULL is a real,
+	// meaningful value there ("never idle-expire") and, per m127 DECISION 4, the
+	// only safe one until TouchMCPGrantInTenantTx has a caller.
 	CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error)
 	// ---------------------------------------------------------------------------
 	// backup_manifest_entries
@@ -3066,6 +3083,21 @@ type Querier interface {
 	// The grant is joined on tenant_id as well as id: the token and its grant must
 	// belong to the same organisation, checked in the join rather than assumed
 	// from the foreign key.
+	// m127 DECISION 3 ADDS BOTH GRANT EXPIRIES TO THIS SAME VERDICT, rather than to
+	// a second read the caller might forget. A grant past its absolute expiry, or
+	// past its idle deadline, now fails THE SAME PREDICATE a revoked grant fails.
+	// Both are evaluated on the already-fetched grant row, so neither costs a round
+	// trip and neither needs an index.
+	//
+	// The wireframe's "there is no silent read-only period" is a consequence of
+	// this shape: expiry flips one boolean to false outright and cannot degrade a
+	// connection to a reduced capability set, because there is one boolean here and
+	// not a tier.
+	//
+	// g.capabilities is returned so the capability set is read from the SAME ROW
+	// and the SAME transaction as the verdict it was authorized under (S7's exit
+	// gate: discovery never grants what the registry does not hold, and it cannot
+	// hold what this row does not carry).
 	ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error)
 	RecolorTag(ctx context.Context, arg RecolorTagParams) (SiteTag, error)
 	// Runs InTenantTx. Decision 10: there are TWO distinguishable absences in the

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -187,6 +187,74 @@ type connectionListDTO struct {
 	Connections []connectionDTO `json:"connections"`
 }
 
+// mintConnectionRequestDTO is the wizard's headless-connection request.
+//
+// THE TAG FIELD IS `scope_tag_ids` AND IT CARRIES UUIDs, deliberately spelled
+// the same as approvalRequestDTO.ScopeTagIDs (above) so there is ONE wire
+// vocabulary for a tag across both mint paths. The consent screen already holds
+// the name->id map and refuses its own submit when the tag registry went null
+// mid-flight; the wizard reuses that map rather than introducing a name form
+// this endpoint would have to disambiguate on case and duplicates.
+//
+// Ids also survive a rename and names do not: a grant scoped by name would
+// silently change which sites it covers the day somebody renames a tag, and
+// nothing would say so. The server-side half of the bargain is that an id
+// naming no tag is REFUSED by id rather than dropped -- see
+// ErrCodeUnknownScopeTag.
+type mintConnectionRequestDTO struct {
+	Name          string   `json:"name"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	ScopeTagIDs   []string `json:"scope_tag_ids"`
+	ScopeSiteIDs  []string `json:"scope_site_ids"`
+
+	// Capabilities is OPTIONAL and an omitted list means the organisation
+	// default, never an empty set. See Service.resolveMintCapabilities: an
+	// empty stored capability set is a connection that authenticates and can
+	// then reach no tool at all.
+	Capabilities []string `json:"capabilities"`
+}
+
+// mintConnectionResponseDTO carries the plaintext EXACTLY ONCE.
+//
+// `token` has no `omitempty` and is not a pointer: it is always present on a
+// 201 and there is no success shape in which it is absent. If this struct is
+// ever reused for a read-back it must lose the field entirely rather than let
+// it marshal as empty -- an empty `token` key on a later response would read as
+// "the credential is blank" rather than "it was never stored", and the second
+// is the truth. Nothing can read it back, because nothing holds it: the row
+// carries token_prefix and a SHA-256 hash.
+type mintConnectionResponseDTO struct {
+	GrantID string `json:"grant_id"`
+
+	// The plaintext. Once, here, in the response body -- never logged, never in
+	// a URL or query string, never persisted.
+	Token string `json:"token"`
+
+	// The PUBLIC handle. The schema says it "carries no authentication weight",
+	// so it is safe to display and log, and it is how an operator matches a
+	// token in a config file to a row in the connections list.
+	TokenPrefix string `json:"token_prefix"`
+
+	ExpiresAt     string   `json:"expires_at"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	Capabilities  []string `json:"capabilities"`
+}
+
+func toMintConnectionResponse(m MintedConnection) mintConnectionResponseDTO {
+	return mintConnectionResponseDTO{
+		GrantID:       m.GrantID.String(),
+		Token:         m.Token,
+		TokenPrefix:   m.TokenPrefix,
+		ExpiresAt:     m.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		SiteScopeMode: string(m.SiteScopeMode),
+		// Non-nil even when empty, so the field serialises as [] rather than
+		// null. MintConnection cannot return an empty set today; the guarantee
+		// is written here so a consumer never has to treat null as a third
+		// state.
+		Capabilities: capabilityNames(m.Capabilities),
+	}
+}
+
 // revokeResponseDTO reports WHAT THE REVOKE DID, not merely that it returned.
 //
 // The counts are on the wire because three different successes are possible and

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -151,6 +151,26 @@ func (h *Handler) RegisterConnections(r *gin.RouterGroup) {
 	g := r.Group(connectionsGroupPath)
 
 	g.GET("", authz.RequirePermission(authz.PermAPIKeyRead), h.listConnections)
+
+	// POST "" mints a connection token: the DOCUMENTED HEADLESS PATH, because
+	// no client documents a device-code flow and Claude Code cannot run browser
+	// sign-in non-interactively. It is not a fallback for a failed OAuth dance.
+	//
+	// PermAPIKeyManage, THE SAME PERMISSION AS REVOKE, and that pairing is the
+	// org-scope gate rather than a convenience. Both PermAPIKeyRead and
+	// PermAPIKeyManage are members of authz.orgLevelPerms, so RequirePermission
+	// refuses ANY site-constrained principal outright -- which is what closes
+	// the hole here, since a grant is an organisation-wide credential with no
+	// :siteId for RequireSiteAccess to key on. Reusing the API-key permissions
+	// rather than minting a new one is what guarantees that membership is not a
+	// step somebody has to remember: a fresh permission left out of orgLevelPerms
+	// would look identical on this line and gate nothing.
+	//
+	// Minting is at least as sensitive as revoking -- revoke removes authority,
+	// mint creates a long-lived bearer credential -- so it takes the manage
+	// tier, never the read one.
+	g.POST("", authz.RequirePermission(authz.PermAPIKeyManage), h.mintConnection)
+
 	g.POST("/:"+connectionIDParam+"/revoke",
 		authz.RequirePermission(authz.PermAPIKeyManage), h.revokeConnection)
 
@@ -160,7 +180,7 @@ func (h *Handler) RegisterConnections(r *gin.RouterGroup) {
 	// permission middleware on purpose -- the verb is wrong regardless of who is
 	// asking, and answering 403 to a DELETE sends an operator to check a role
 	// when the fix is to send a POST.
-	houseMethodNotAllowedExcept(g, "", http.MethodGet)
+	houseMethodNotAllowedExcept(g, "", http.MethodGet, http.MethodPost)
 	houseMethodNotAllowedExcept(g, "/:"+connectionIDParam+"/revoke", http.MethodPost)
 }
 
@@ -185,6 +205,85 @@ func (h *Handler) listConnections(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, toConnectionListDTO(conns))
+}
+
+// mintConnection answers POST /api/v1/mcp/connections.
+//
+// It returns 201 with the plaintext token in the body, ONCE. The plaintext is
+// never put in a URL, a query string, a header or a log line -- a URL is
+// written to browser history, proxy logs and Referer headers, and this
+// credential outlives the session that asked for it by up to ninety days.
+//
+// THE HANDLER DOES NO AUTHORIZATION OF ITS OWN beyond re-reading the principal.
+// The org-scope decision belongs to the service (and to the route's
+// RequirePermission, and to the RLS beneath), so there is no fourth opinion
+// here that could drift from the other three.
+func (h *Handler) mintConnection(c *gin.Context) {
+	principal, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		// Unreachable behind RequireAuth; refusing anyway, because a handler
+		// that trusts its mount point is one refactor away from anonymous.
+		httpx.Error(c, domain.Unauthorized("unauthenticated", "authentication required"))
+		return
+	}
+
+	// Capped like the OAuth bodies. This one IS authenticated, so the cap is
+	// not admission control -- it bounds a decoder fed a streamed body by a
+	// caller who is already inside, which is cheap insurance rather than a
+	// security boundary.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxOAuthBodyBytes)
+
+	var body mintConnectionRequestDTO
+	if err := c.ShouldBindJSON(&body); err != nil {
+		httpx.Error(c, domain.Validation(ErrCodeInvalidRequest,
+			"the request body is not valid JSON"))
+		return
+	}
+
+	// parseUUIDs REFUSES a malformed id rather than dropping it, and that is
+	// the point on this path: uuid.Parse failure decays to uuid.Nil, and a
+	// dropped tag id silently NARROWS the scope the operator thought they were
+	// minting -- or empties it entirely, which then looks like a deliberate
+	// choice. The error names which field so the wizard can point at it.
+	tagIDs, err := parseUUIDs(body.ScopeTagIDs)
+	if err != nil {
+		httpx.Error(c, domain.Validation(ErrCodeInvalidSiteScope,
+			"scope_tag_ids contains a value that is not a UUID"))
+		return
+	}
+	siteIDs, err := parseUUIDs(body.ScopeSiteIDs)
+	if err != nil {
+		httpx.Error(c, domain.Validation(ErrCodeInvalidSiteScope,
+			"scope_site_ids contains a value that is not a UUID"))
+		return
+	}
+
+	caps := make([]Capability, 0, len(body.Capabilities))
+	for _, name := range body.Capabilities {
+		caps = append(caps, Capability(name))
+	}
+
+	out, err := h.svc.MintConnection(c.Request.Context(), MintConnectionRequest{
+		// The WHOLE principal. Its Scope and AllowedSiteIDs are what route the
+		// grant insert to a site-scoped transaction, so narrowing this to
+		// (TenantID, UserID) would disarm the RLS layer beneath while still
+		// compiling -- the same trap ApprovalRequest.Principal documents.
+		Principal:    principal,
+		Name:         body.Name,
+		SiteScope:    SiteScopeRequest{Mode: SiteScopeMode(body.SiteScopeMode), TagIDs: tagIDs, SiteIDs: siteIDs},
+		Capabilities: caps,
+	})
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+
+	// Never cached, and never stored by an intermediary: the body holds a
+	// bearer credential. Same stance RFC 6749 5.1 takes on a token response,
+	// applied here because the payload is the same kind of thing.
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+	c.JSON(http.StatusCreated, toMintConnectionResponse(out))
 }
 
 // revokeConnection answers POST /api/v1/mcp/connections/:connectionId/revoke.

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -1,0 +1,494 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// THE CONNECTION-TOKEN MINT: the documented HEADLESS path, not a fallback.
+//
+// No MCP client documents a device-code flow and Claude Code cannot run browser
+// sign-in non-interactively, so headless, SSH and CI installs have no route
+// through /authorize + /consent at all. This endpoint is that route, and the
+// wireframes present it as the documented headless path rather than as
+// something an operator discovers after browser sign-in fails.
+//
+// WHAT IT SHARES WITH THE OAUTH PATH, AND WHY THAT IS THE WHOLE DESIGN. The
+// credential is built the same way (randomToken(32) -> hashCredential ->
+// token_prefix + token_hash), stored in the same table by the same generated
+// statement, expires on the same connectionTokenTTL, and hangs off a grant
+// created with the same m127 columns and the same mcp.grant.created audit
+// event. THE ONLY THING THAT DIFFERS IS HOW THE GRANT IS AUTHORISED INTO
+// BEING: consent authorises the OAuth grant, and an authenticated operator's
+// own request authorises this one. A parallel insert that reproduced the token
+// but skipped the grant path would produce a live credential that no audit row
+// explains, which is the state this file is written to make unrepresentable.
+// ---------------------------------------------------------------------------
+
+const (
+	// MintGlobalPerMin caps connection tokens this process mints per minute
+	// across ALL operators. Unspoofable and never evicted; this is the bound.
+	//
+	// MINTING CREDENTIALS UNTHROTTLED IS HOW ONE STOLEN SESSION BECOMES MANY.
+	// A session cookie that is replayed once buys one token; replayed in a loop
+	// against an unlimited mint it buys as many long-lived bearer credentials
+	// as the attacker cares to store, each surviving the session's own
+	// expiry and each needing its own revoke. The bound is what turns that from
+	// "unbounded" into "a handful, and the audit log names every one".
+	MintGlobalPerMin = 30
+
+	// MintPerUserPerMin caps tokens one operator may mint per minute.
+	//
+	// Sized to a human: setting up a headless connection is a deliberate act
+	// that produces one token, and an operator wiring several CI runners at
+	// once is still nowhere near this. It is deliberately far below
+	// MintGlobalPerMin so one compromised session cannot consume the process
+	// budget and lock every other operator out of the feature -- the same
+	// fairness reasoning register_limit.go gives for its per-peer layer.
+	MintPerUserPerMin = 5
+)
+
+// newMintLimiter builds the mint limiter, REUSING registrationLimiter rather
+// than restating its two-layer accounting.
+//
+// The type is named for its first caller, not for a property that excludes this
+// one: it is a global token bucket plus a capacity-bounded per-key bucket, it
+// charges nothing on a refused request, and a nil receiver refuses. All four
+// are exactly what this endpoint needs, and a second copy would be a second
+// place for the "reserve then release" bug register_limit.go documents having
+// already fixed once.
+//
+// THE KEY IS THE OPERATOR'S USER ID, NOT RemoteIP, AND THAT IS THE ONE REAL
+// DIFFERENCE. register_limit.go must key on the TCP peer because RFC 7591
+// registration is anonymous and every other identity on that request is
+// attacker-supplied. This endpoint is behind session auth, so the principal's
+// UserID is resolved by the session layer and cannot be set by a header --
+// it is a STRICTLY BETTER key than RemoteIP, and it is also the right one:
+// the harm being bounded is "one stolen session mints many credentials", and
+// that is a per-user quantity. Keying on RemoteIP here would instead collapse
+// every operator behind the load balancer into one bucket.
+func newMintLimiter() *registrationLimiter {
+	return newRegistrationLimiter(MintGlobalPerMin, MintPerUserPerMin)
+}
+
+// mintLimiterKey is the per-operator bucket key.
+//
+// A NIL user id gets a single shared reserved bucket rather than a fresh one,
+// for the reason registrationLimiter.allow gives the empty peer string: "we
+// could not identify who is asking" must be MORE restrictive than identifying
+// them, never less. RequireAuth makes uuid.Nil unreachable here in production;
+// this is what it costs to be wrong about that.
+func mintLimiterKey(userID uuid.UUID) string {
+	if userID == uuid.Nil {
+		return "\x00unattributed"
+	}
+	return userID.String()
+}
+
+// ErrCodeMintRateLimited is the refusal for an operator who has exhausted
+// either mint budget. It is a NAMED code rather than a bare 429 body so the
+// wizard can tell "slow down" from "you may not do this at all" -- the two need
+// different screens, and a client that cannot tell them apart shows the wrong
+// one.
+const ErrCodeMintRateLimited = "mcp_mint_rate_limited"
+
+// ErrCodeUnknownScopeTag is the LOUD refusal for a scope tag id that names no
+// tag in this organisation.
+//
+// IT EXISTS BECAUSE scope_tag_ids IS A uuid[] WITH NO FOREIGN KEY. PostgreSQL
+// has no referential integrity over array elements, so the column accepts any
+// UUID at all -- another organisation's tag, or a value that never named
+// anything. Such a grant stores cleanly, passes every CHECK, and then resolves
+// to zero sites forever at request time, where it is INDISTINGUISHABLE from a
+// deliberately narrow connection. That is scope silently narrowed to nothing
+// without anyone being told, which is the failure this endpoint is most likely
+// to produce and the one the operator has no way to diagnose.
+//
+// Refusing at mint time, naming the offending id, is the only moment the caller
+// still has the context to fix it.
+const ErrCodeUnknownScopeTag = "mcp_unknown_scope_tag"
+
+// ErrCodeUnknownScopeSite is the same refusal on the site axis. Same column
+// shape (uuid[], no foreign key), same silent-narrowing outcome, and it is
+// detected differently: a site id is verified by resolving it through the
+// audited chokepoint under tenant RLS, which drops every foreign id.
+const ErrCodeUnknownScopeSite = "mcp_unknown_scope_site"
+
+// MintConnectionRequest is an authenticated operator asking for a headless
+// connection token.
+//
+// Principal is the WHOLE principal for the reason ApprovalRequest's field doc
+// gives: its Scope and AllowedSiteIDs are what route the grant insert to a
+// site-scoped transaction, so narrowing this to (TenantID, UserID) would
+// disarm the RLS layer beneath while still compiling.
+type MintConnectionRequest struct {
+	Principal domain.Principal
+
+	// Name is the operator's own label for the connection. Required: an
+	// unnamed long-lived credential is one nobody can identify later in order
+	// to revoke it.
+	Name string
+
+	// SiteScope is the site axis, IN TAG AND SITE IDs.
+	//
+	// IDs AND NOT NAMES, AND THE CHOICE IS DELIBERATE. dto.go's
+	// approvalRequestDTO already puts `scope_tag_ids` on the wire as UUIDs, and
+	// the consent screen already holds the name->id map it needs to fill them
+	// in. Taking names here would create a SECOND wire vocabulary for the same
+	// concept and would reopen questions the id form has already closed --
+	// case-sensitivity, duplicate names, and what a rename does to a stored
+	// grant. A tag id is stable across a rename; a name is not, and a grant
+	// scoped by name would silently change meaning the day somebody renames a
+	// tag.
+	//
+	// The cost is that the caller must resolve names to ids, which the consent
+	// screen already does and refuses the submit when the registry is
+	// unavailable. What this endpoint adds, and what the consent path does not
+	// do, is VERIFY the ids server-side -- see ErrCodeUnknownScopeTag.
+	SiteScope SiteScopeRequest
+
+	// Capabilities is the tool axis. EMPTY MEANS "the organisation default",
+	// not "none": an empty stored capability set is a connection that
+	// authenticates and then reaches no tool, which Authenticate refuses by
+	// name, so writing one here would mint a credential that can never work.
+	// A non-empty list is NARROWED against the org ceiling, never widened past
+	// it -- CapabilitySet.NarrowTo refuses rather than intersects.
+	Capabilities []Capability
+}
+
+// MintedConnection is the response. Token is present exactly once, here.
+type MintedConnection struct {
+	GrantID uuid.UUID
+
+	// Token is the PLAINTEXT bearer credential. It exists in this struct, in
+	// the response body it is rendered into, and nowhere else: no column holds
+	// it, no log line prints it, and it is never put in a URL or a query
+	// string. Only TokenPrefix and the SHA-256 hash are persisted.
+	Token string
+
+	// TokenPrefix is the PUBLIC handle -- the schema says outright that it
+	// "carries no authentication weight". It is safe to log, display and store,
+	// and it is what lets an operator match a token in a config file against a
+	// row in the connections list without ever handling the secret.
+	TokenPrefix string
+
+	ExpiresAt     time.Time
+	SiteScopeMode SiteScopeMode
+	Capabilities  []Capability
+}
+
+// MintConnection creates a grant and its first connection token in ONE
+// transaction, and returns the plaintext once.
+//
+// THE ORDER OF THE REFUSALS IS THE SECURITY PROPERTY, and it mirrors Exchange:
+// everything that can refuse runs before anything is generated, the credential
+// is generated in memory only after the last refusal, and the write is a single
+// transaction that either lands whole or leaves no trace.
+func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest) (MintedConnection, error) {
+	// 1. THE ORG-SCOPE GUARD, restated in the service.
+	//
+	// A SITE-SCOPED COLLABORATOR MINTING AN ORG-WIDE GRANT WAS A LIVE
+	// PRODUCTION DEFECT on the sibling path: /register is unauthenticated, so
+	// one self-registered client and one POST to the writing route was the
+	// whole exploit -- no consent screen and no operator interaction. The fix
+	// there was to gate BOTH consent routes; the lesson here is that this path
+	// must carry the same gate or better, at every layer the other one does.
+	//
+	// It has three, outermost first, and requireOrgScopedPrincipal's own doc
+	// explains why none of them is redundant:
+	//   1. authz.RequirePermission(PermAPIKeyManage) on the route -- an
+	//      orgLevelPerms member, so RequirePermission refuses any
+	//      site-constrained principal outright.
+	//   2. THIS CALL.
+	//   3. mcp_grants_site_scope_insert, the RESTRICTIVE policy keyed on the
+	//      app.site_scope GUC that Repo's RunTenantTx sets.
+	// MUTATION M1 targets this line.
+	if err := requireOrgScopedPrincipal(req.Principal); err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 2. THE RATE LIMIT, charged before any work and keyed on the operator.
+	// Placed here rather than in the handler so that every mount of this
+	// service is limited, including a test harness -- a limiter that exists
+	// only in the route registration is one refactor away from being absent,
+	// which is the same reasoning Handler.Register gives for putting
+	// RequireOrgScope on the group. MUTATION M2 targets this block.
+	if ok, retryAfter := s.mintLimit.allow(mintLimiterKey(req.Principal.UserID)); !ok {
+		return MintedConnection{}, domain.RateLimited(ErrCodeMintRateLimited,
+			"too many connection tokens minted; retry shortly").
+			WithDetails(map[string]any{"retry_after_seconds": retryAfterSeconds(retryAfter)})
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return MintedConnection{}, domain.Validation(ErrCodeInvalidRequest,
+			"a connection name is required")
+	}
+
+	// 3. SITE SCOPE: the STRUCTURAL rules first, unchanged.
+	//
+	// ValidateSiteScopeRequest is the Go mirror of
+	// mcp_grants_site_scope_payload_check and it is reused verbatim: mode 'all'
+	// names nothing, mode 'tags' names at least one tag, mode 'list' names at
+	// least one site, and an absent mode is refused rather than read as 'all'.
+	// An empty allowlist is never a way to ask for every site.
+	if err := ValidateSiteScopeRequest(req.SiteScope); err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 4. SITE SCOPE: the REFERENTIAL check, which the structural one cannot do.
+	//
+	// This is where an id that names nothing is refused. See
+	// verifyScopeReferents -- and read its comment before adding any
+	// "resolves to no sites" refusal here, because that would be a defect
+	// rather than a hardening.
+	if err := s.verifyScopeReferents(ctx, req.Principal.TenantID, req.SiteScope); err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 5. CAPABILITIES: narrowed against the organisation's ceiling, never
+	// widened past it. NarrowTo REFUSES a capability the ceiling does not hold
+	// rather than dropping it, for the reason written on that method: a
+	// silently-dropped capability is a grant the operator did not ask for.
+	caps, err := s.resolveMintCapabilities(req.Capabilities)
+	if err != nil {
+		return MintedConnection{}, err
+	}
+
+	// 6. THE CREDENTIAL. Generated only now, after the last refusal, and held
+	// in memory alone: the insert takes the PREFIX and the HASH, never this.
+	// MUTATION M3 targets the two fields below.
+	secret, err := randomToken(32)
+	if err != nil {
+		return MintedConnection{}, fmt.Errorf("generate connection token: %w", err)
+	}
+	now := s.now().UTC()
+	tokenExpiry := now.Add(connectionTokenTTL)
+
+	grant, tok, err := s.store.CreateGrantWithToken(ctx, req.Principal,
+		sqlc.CreateMCPGrantParams{
+			TenantID:      req.Principal.TenantID,
+			Name:          name,
+			Status:        string(GrantStatusActive),
+			SiteScopeMode: string(req.SiteScope.Mode),
+			ScopeTagIds:   orEmpty(req.SiteScope.TagIDs),
+			ScopeSiteIds:  orEmpty(req.SiteScope.SiteIDs),
+
+			// NO client_id. A connection token has no RFC 7591 client behind
+			// it -- nothing registered, nothing to resolve -- and the column is
+			// nullable precisely so this path can say so. Inventing a
+			// synthetic client id here would put a registration in the row that
+			// no client ever performed, and the connections list renders
+			// client identity as the CLIENT's own unverified claim; a
+			// fabricated one would be rendered with the same weight as a real
+			// one. NULL is the honest answer and it is also the one that makes
+			// this path identifiable in the data.
+			ClientID:        nil,
+			CreatedByUserID: uuidToPG(req.Principal.UserID),
+
+			// m127's columns, ALL SUPPLIED EXPLICITLY, exactly as Approve
+			// supplies them. Two are NOT NULL with no default so a forgotten
+			// field is 23502 at the INSERT rather than an unrestricted or
+			// never-expiring connection.
+			Capabilities: capabilityNames(caps.Sorted()),
+			ExpiresAt:    now.Add(grantAbsoluteTTL),
+
+			// NULL means "never idle-expire" (m127 DECISION 4), and NULL is the
+			// answer rather than a placeholder. Nothing asks the operator for a
+			// window yet, and inventing one nobody chose is the credential-terms
+			// defect that column refuses to default.
+			IdleExpireAfterDays: nil,
+		},
+		func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams {
+			return sqlc.CreateMCPConnectionTokenParams{
+				TenantID: req.Principal.TenantID,
+				GrantID:  grantID,
+				// The PUBLIC handle and the HASH. hashCredential is the one
+				// construction this package uses -- lower-case hex SHA-256,
+				// matching the '^[0-9a-f]{64}$' CHECK and internal/apikey --
+				// and there is deliberately no second one.
+				TokenPrefix: secret[:tokenPrefixLen],
+				TokenHash:   hashCredential(secret),
+				Status:      string(GrantStatusActive),
+				ExpiresAt:   timestamptzAt(tokenExpiry),
+			}
+		},
+		// ActionMCPGrantCreated, in the SAME transaction as both inserts. If
+		// either insert or this append fails, the whole mint rolls back and
+		// there is no audit row for a grant that does not exist -- and,
+		// equally, no grant without the row that explains it.
+		func(tx pgx.Tx, gr sqlc.McpGrant) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   req.Principal.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    req.Principal.UserID.String(),
+				Action:     audit.ActionMCPGrantCreated,
+				TargetType: "mcp_grant",
+				TargetID:   gr.ID.String(),
+				Metadata: map[string]any{
+					"grant_name":      gr.Name,
+					"site_scope_mode": gr.SiteScopeMode,
+					// HOW the grant came to exist. The OAuth path and this one
+					// produce the same row shape, so without this an auditor
+					// cannot tell a browser-consented connection from a
+					// headless-minted one -- and they are authorised by
+					// different things, which is exactly what an audit log is
+					// for.
+					"issuance": "connection_token",
+					// The PUBLIC handle only. It carries no authentication
+					// weight, and it is what lets an operator match this audit
+					// row to a token in a config file. The plaintext is not
+					// here and must never be.
+					"token_prefix": secret[:tokenPrefixLen],
+				},
+			})
+			return aerr
+		})
+	if err != nil {
+		return MintedConnection{}, fmt.Errorf("mint mcp connection: %w", err)
+	}
+
+	return MintedConnection{
+		GrantID:       grant.ID,
+		Token:         secret, // once, here, never again
+		TokenPrefix:   tok.TokenPrefix,
+		ExpiresAt:     tokenExpiry,
+		SiteScopeMode: req.SiteScope.Mode,
+		Capabilities:  caps.Sorted(),
+	}, nil
+}
+
+// resolveMintCapabilities turns the operator's requested capability list into
+// the set that will be stored.
+//
+// AN EMPTY REQUEST MEANS THE ORGANISATION DEFAULT, NOT AN EMPTY SET, and the
+// difference is the whole function. mcp_grants.capabilities admits '{}' -- the
+// shape CHECK passes it, because '{}' is the RESTRICTIVE value -- so an empty
+// set is perfectly storable, and Authenticate then refuses the connection by
+// name on every request ("this connection holds no capability, so it can reach
+// no tool"). Writing one would therefore mint a credential that authenticates
+// and can never do anything, which m127 DECISION 3 says this boundary must not
+// be able to produce. The operator asking for nothing on the tool axis is an
+// ABSENCE, and absence here means "you did not narrow", not "narrow to zero".
+//
+// Note the asymmetry with the SITE axis and that it is deliberate: an empty
+// site scope is a coherent connection (it reads no sites, and may read some
+// tomorrow), whereas an empty capability set is a connection that cannot
+// function at all. The two axes are not symmetric because their empty values
+// mean different things.
+func (s *Service) resolveMintCapabilities(requested []Capability) (CapabilitySet, error) {
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	if err != nil {
+		return CapabilitySet{}, fmt.Errorf("resolve organisation capabilities: %w", err)
+	}
+	if len(requested) == 0 {
+		return ceiling, nil
+	}
+	// NarrowTo REFUSES anything the ceiling does not hold rather than dropping
+	// it. Dropping would be fail-closed and still wrong: the operator would be
+	// told they minted a connection with capabilities it does not have.
+	return ceiling.NarrowTo(requested)
+}
+
+// verifyScopeReferents refuses a scope payload naming an id that resolves to no
+// row in THIS organisation.
+//
+// WHY IT IS NOT "REFUSE IF THE SCOPE RESOLVES TO NO SITES". Those are two
+// different questions and conflating them breaks a rule the owner ruled on
+// directly. A grant scoped to a real tag that currently carries zero sites is
+// LEGITIMATE: it reads nothing today, it reads whatever gets tagged tomorrow,
+// and it must be ACCEPTED AND STORED AS GIVEN -- never refused, and above all
+// never widened to mode 'all' on the grounds that empty "must have been a
+// mistake". An empty allowlist is never every site, in either direction.
+//
+// What is NOT legitimate is an id that names nothing at all, because
+// scope_tag_ids and scope_site_ids are uuid[] columns with no foreign key and
+// therefore accept any UUID. That grant stores cleanly and then resolves to
+// zero sites FOREVER, indistinguishable from the legitimate case above. So:
+//
+//	real tag, zero sites today  -> accepted, stored as given   (empty scope)
+//	id naming no tag at all     -> refused, loudly, by id      (typo/foreign id)
+//
+// Distinguishing them is what makes the empty-scope acceptance safe. Without
+// this check, "accept empty" would also silently accept a typo.
+//
+// MUTATION M4 targets the tag arm; MUTATION M5 targets the acceptance above.
+func (s *Service) verifyScopeReferents(ctx context.Context, tenantID uuid.UUID, req SiteScopeRequest) error {
+	switch req.Mode {
+	case SiteScopeModeTags:
+		// The tenant's tag registry, read under tenant RLS. Tags are a small,
+		// unpaginated per-tenant set by construction (see the query's own note),
+		// so reading the registry and comparing in Go costs one round trip and
+		// needs no new statement.
+		known, err := s.store.ListTagIDs(ctx, tenantID)
+		if err != nil {
+			// A FAILED READ IS NOT AN EMPTY REGISTRY. Proceeding on an error
+			// here would refuse every tag as unknown, or -- worse, if the
+			// comparison were ever inverted -- accept every tag unchecked.
+			// Neither is an answer, so this is an infra error and the mint
+			// stops.
+			return fmt.Errorf("read tag registry for scope verification: %w", err)
+		}
+		for _, want := range req.TagIDs {
+			if !slices.Contains(known, want) {
+				return domain.Validation(ErrCodeUnknownScopeTag,
+					fmt.Sprintf("scope tag %s does not exist in this organisation", want)).
+					WithDetails(map[string]any{"unknown_tag_id": want.String()})
+			}
+		}
+		return nil
+
+	case SiteScopeModeList:
+		// Site ids are verified through the AUDITED CHOKEPOINT rather than a
+		// second query: ResolveScopeSites runs InTenantTx and joins through
+		// `sites`, so tenant RLS drops every foreign or non-existent id. Under
+		// mode 'list' the resolution is exactly the subset of the requested ids
+		// that exist here, so anything missing from the result names nothing.
+		//
+		// This arm has no empty-scope ambiguity to preserve: a site either
+		// exists in this tenant or it does not.
+		resolved, err := s.store.ResolveScopeSites(ctx, tenantID,
+			string(SiteScopeModeList), nil, req.SiteIDs)
+		if err != nil {
+			return fmt.Errorf("resolve site scope for verification: %w", err)
+		}
+		for _, want := range req.SiteIDs {
+			if !slices.Contains(resolved, want) {
+				return domain.Validation(ErrCodeUnknownScopeSite,
+					fmt.Sprintf("scope site %s does not exist in this organisation", want)).
+					WithDetails(map[string]any{"unknown_site_id": want.String()})
+			}
+		}
+		return nil
+
+	default:
+		// Mode 'all' names no ids, so there is nothing to verify. Any other
+		// value never reaches here: ValidateSiteScopeRequest refused it above.
+		return nil
+	}
+}
+
+// retryAfterSeconds renders a limiter wait as whole seconds, never below one.
+// A "retry after 0 seconds" tells a client to retry immediately into the same
+// refusal, which is a busy loop wearing the shape of advice.
+func retryAfterSeconds(d time.Duration) int {
+	secs := int(d.Seconds())
+	if secs < 1 {
+		return 1
+	}
+	return secs
+}

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -82,18 +82,53 @@ func newMintLimiter() *registrationLimiter {
 	return newRegistrationLimiter(MintGlobalPerMin, MintPerUserPerMin)
 }
 
-// mintLimiterKey is the per-operator bucket key.
+// mintLimiterKey is the per-CALLER bucket key, and the caller is whichever
+// credential actually authenticated -- a session user OR an API key.
 //
-// A NIL user id gets a single shared reserved bucket rather than a fresh one,
-// for the reason registrationLimiter.allow gives the empty peer string: "we
-// could not identify who is asking" must be MORE restrictive than identifying
-// them, never less. RequireAuth makes uuid.Nil unreachable here in production;
-// this is what it costs to be wrong about that.
-func mintLimiterKey(userID uuid.UUID) string {
-	if userID == uuid.Nil {
+// IT MUST NOT READ UserID DIRECTLY. apikey.PrincipalFor never sets UserID, and
+// this route is mounted under Auth.Authenticate() whose Bearer branch returns
+// exactly that principal, so uuid.Nil is REACHABLE here and reaching it is the
+// ordinary case rather than the exotic one: this is the documented HEADLESS
+// path and an API key is its natural caller. Keying on UserID therefore
+// collapsed every API-key mint in every tenant, process-wide, into the one
+// shared "\x00unattributed" bucket -- one tenant's CI runner could spend the
+// 5/min budget belonging to every other tenant's keys. Direction is fail-closed
+// so that was availability only, but the per-caller layer is the FAIRNESS
+// layer, and it degraded to nothing for exactly the caller class this endpoint
+// was built for.
+//
+// Principal.ActorID() is the only correct source (it returns APIKeyID for an
+// API-key principal, UserID otherwise), and the principal TYPE is prefixed so
+// the two id spaces cannot alias.
+//
+// A principal that names neither still gets a single shared reserved bucket
+// rather than a fresh one, for the reason registrationLimiter.allow gives the
+// empty peer string: "we could not identify who is asking" must be MORE
+// restrictive than identifying them, never less.
+func mintLimiterKey(p domain.Principal) string {
+	id := p.ActorID()
+	if id == "" || id == uuid.Nil.String() {
 		return "\x00unattributed"
 	}
-	return userID.String()
+	return string(p.Type) + ":" + id
+}
+
+// mintAuditActor resolves the audit actor for a mint, and it exists because
+// hardcoding ActorUser over req.Principal.UserID recorded "a user did this"
+// against a zero UUID for every API-key caller. The TYPE and the ID must move
+// together: the type drives audit.go's actor-name join (users.name for
+// ActorUser, api_keys.name for ActorAPIKey), so a mismatched pair resolves to
+// no name at all and the row names nobody.
+//
+// This is the one credential-issuance event this file exists to explain. An
+// entry asserting a human acted while naming a user that does not exist is
+// worse than no entry: a missing record prompts a question, a wrong one answers
+// it incorrectly.
+func mintAuditActor(p domain.Principal) (actorType, actorID string) {
+	if p.Type == domain.PrincipalAPIKey {
+		return audit.ActorAPIKey, p.ActorID()
+	}
+	return audit.ActorUser, p.ActorID()
 }
 
 // ErrCodeMintRateLimited is the refusal for an operator who has exhausted
@@ -217,26 +252,28 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 		return MintedConnection{}, err
 	}
 
-	// 2. THE RATE LIMIT, charged before any work and keyed on the operator.
-	// Placed here rather than in the handler so that every mount of this
-	// service is limited, including a test harness -- a limiter that exists
-	// only in the route registration is one refactor away from being absent,
-	// which is the same reasoning Handler.Register gives for putting
-	// RequireOrgScope on the group.
-	if ok, retryAfter := s.mintLimit.allow(mintLimiterKey(req.Principal.UserID)); !ok {
-		return MintedConnection{}, domain.RateLimited(ErrCodeMintRateLimited,
-			"too many connection tokens minted; retry shortly").
-			WithDetails(map[string]any{"retry_after_seconds": retryAfterSeconds(retryAfter)})
-	}
-
+	// 2. THE STRUCTURAL REFUSALS, WHICH ARE FREE, AND DELIBERATELY SO.
+	//
+	// Everything in this step is a PURE FUNCTION OF THE CALLER'S OWN REQUEST
+	// BODY -- a name that is blank after trimming, and the site-scope shape
+	// rules. Nothing here reads the database, so nothing here can answer a
+	// question about this organisation's data that the caller could not already
+	// answer offline.
+	//
+	// THEY RUN BEFORE THE CHARGE BECAUSE A TYPO MUST NOT SPEND BUDGET. With the
+	// charge first, five malformed requests exhausted the per-caller budget and
+	// the sixth -- the one that finally carried a real defect to report -- was
+	// answered "slow down" instead of "your name is blank". That is precisely
+	// the confusion ErrCodeMintRateLimited exists to prevent: the wizard must be
+	// able to tell "slow down" from "you may not do this at all", and a limiter
+	// charged ahead of validation makes the wrong one of those two the answer to
+	// the other's question.
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
 		return MintedConnection{}, domain.Validation(ErrCodeInvalidRequest,
 			"a connection name is required")
 	}
 
-	// 3. SITE SCOPE: the STRUCTURAL rules first, unchanged.
-	//
 	// ValidateSiteScopeRequest is the Go mirror of
 	// mcp_grants_site_scope_payload_check and it is reused verbatim: mode 'all'
 	// names nothing, mode 'tags' names at least one tag, mode 'list' names at
@@ -244,6 +281,34 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	// An empty allowlist is never a way to ask for every site.
 	if err := ValidateSiteScopeRequest(req.SiteScope); err != nil {
 		return MintedConnection{}, err
+	}
+
+	// 3. THE RATE LIMIT, charged on the last line before anything reads tenant
+	// data, and keyed on the CALLER (see mintLimiterKey).
+	//
+	// THIS PLACEMENT IS THE ORACLE BOUND, and it is the reason the charge did
+	// not simply move to the end. Step 4 below resolves scope ids against this
+	// organisation's tag registry and site table and names the offending id in
+	// its refusal, which makes it the only refusal on this endpoint that
+	// DISCLOSES ANYTHING -- "this uuid does or does not name a tag here". Every
+	// request that reaches it has therefore already paid, so referent probing
+	// stays bounded at MintPerUserPerMin per caller and MintGlobalPerMin
+	// process-wide, exactly as before this moved.
+	//
+	// What is now free is only step 2, whose answers the caller computes from
+	// its own payload, and which an anonymous attacker cannot reach at all:
+	// the route sits behind Auth.Authenticate() and
+	// authz.RequirePermission(PermAPIKeyManage).
+	//
+	// Charged in the service rather than in the handler so that every mount of
+	// this service is limited, including a test harness -- a limiter that exists
+	// only in the route registration is one refactor away from being absent,
+	// which is the same reasoning Handler.Register gives for putting
+	// RequireOrgScope on the group.
+	if ok, retryAfter := s.mintLimit.allow(mintLimiterKey(req.Principal)); !ok {
+		return MintedConnection{}, domain.RateLimited(ErrCodeMintRateLimited,
+			"too many connection tokens minted; retry shortly").
+			WithDetails(map[string]any{"retry_after_seconds": retryAfterSeconds(retryAfter)})
 	}
 
 	// 4. SITE SCOPE: the REFERENTIAL check, which the structural one cannot do.
@@ -292,7 +357,16 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 			// fabricated one would be rendered with the same weight as a real
 			// one. NULL is the honest answer and it is also the one that makes
 			// this path identifiable in the data.
-			ClientID:        nil,
+			ClientID: nil,
+
+			// NULL FOR AN API-KEY CALLER, AND THAT IS THE HONEST ANSWER, NOT A
+			// GAP. uuidToPG maps uuid.Nil to NULL rather than to a zero uuid
+			// that looks like a real author, and an API-key mint genuinely has
+			// no user behind it. Do not "fix" this by inventing one: the actor
+			// is recorded on the audit row, where an api_key actor_type has a
+			// name join of its own (see mintAuditActor), and this column means
+			// "the human who created it" -- an answer of "none" beats an answer
+			// naming a user that does not exist.
 			CreatedByUserID: uuidToPG(req.Principal.UserID),
 
 			// m127's columns, ALL SUPPLIED EXPLICITLY, exactly as Approve
@@ -330,10 +404,15 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 			if s.audit == nil {
 				return nil
 			}
+			// THE ACTOR IS WHICHEVER CREDENTIAL AUTHENTICATED, resolved by
+			// mintAuditActor rather than hardcoded. This is the headless path,
+			// so an API key is its natural caller and ActorUser over
+			// Principal.UserID named a user that does not exist.
+			actorType, actorID := mintAuditActor(req.Principal)
 			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
 				TenantID:   req.Principal.TenantID,
-				ActorType:  audit.ActorUser,
-				ActorID:    req.Principal.UserID.String(),
+				ActorType:  actorType,
+				ActorID:    actorID,
 				Action:     audit.ActionMCPGrantCreated,
 				TargetType: "mcp_grant",
 				TargetID:   gr.ID.String(),

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -213,7 +213,6 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	//   2. THIS CALL.
 	//   3. mcp_grants_site_scope_insert, the RESTRICTIVE policy keyed on the
 	//      app.site_scope GUC that Repo's RunTenantTx sets.
-	// MUTATION M1 targets this line.
 	if err := requireOrgScopedPrincipal(req.Principal); err != nil {
 		return MintedConnection{}, err
 	}
@@ -223,7 +222,7 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	// service is limited, including a test harness -- a limiter that exists
 	// only in the route registration is one refactor away from being absent,
 	// which is the same reasoning Handler.Register gives for putting
-	// RequireOrgScope on the group. MUTATION M2 targets this block.
+	// RequireOrgScope on the group.
 	if ok, retryAfter := s.mintLimit.allow(mintLimiterKey(req.Principal.UserID)); !ok {
 		return MintedConnection{}, domain.RateLimited(ErrCodeMintRateLimited,
 			"too many connection tokens minted; retry shortly").
@@ -268,7 +267,6 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 
 	// 6. THE CREDENTIAL. Generated only now, after the last refusal, and held
 	// in memory alone: the insert takes the PREFIX and the HASH, never this.
-	// MUTATION M3 targets the two fields below.
 	secret, err := randomToken(32)
 	if err != nil {
 		return MintedConnection{}, fmt.Errorf("generate connection token: %w", err)
@@ -426,7 +424,6 @@ func (s *Service) resolveMintCapabilities(requested []Capability) (CapabilitySet
 // Distinguishing them is what makes the empty-scope acceptance safe. Without
 // this check, "accept empty" would also silently accept a typo.
 //
-// MUTATION M4 targets the tag arm; MUTATION M5 targets the acceptance above.
 func (s *Service) verifyScopeReferents(ctx context.Context, tenantID uuid.UUID, req SiteScopeRequest) error {
 	switch req.Mode {
 	case SiteScopeModeTags:

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -113,24 +113,6 @@ func mintLimiterKey(p domain.Principal) string {
 	return string(p.Type) + ":" + id
 }
 
-// mintAuditActor resolves the audit actor for a mint, and it exists because
-// hardcoding ActorUser over req.Principal.UserID recorded "a user did this"
-// against a zero UUID for every API-key caller. The TYPE and the ID must move
-// together: the type drives audit.go's actor-name join (users.name for
-// ActorUser, api_keys.name for ActorAPIKey), so a mismatched pair resolves to
-// no name at all and the row names nobody.
-//
-// This is the one credential-issuance event this file exists to explain. An
-// entry asserting a human acted while naming a user that does not exist is
-// worse than no entry: a missing record prompts a question, a wrong one answers
-// it incorrectly.
-func mintAuditActor(p domain.Principal) (actorType, actorID string) {
-	if p.Type == domain.PrincipalAPIKey {
-		return audit.ActorAPIKey, p.ActorID()
-	}
-	return audit.ActorUser, p.ActorID()
-}
-
 // ErrCodeMintRateLimited is the refusal for an operator who has exhausted
 // either mint budget. It is a NAMED code rather than a bare 429 body so the
 // wizard can tell "slow down" from "you may not do this at all" -- the two need
@@ -364,7 +346,7 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 			// that looks like a real author, and an API-key mint genuinely has
 			// no user behind it. Do not "fix" this by inventing one: the actor
 			// is recorded on the audit row, where an api_key actor_type has a
-			// name join of its own (see mintAuditActor), and this column means
+			// name join of its own (see audit.ActorFor), and this column means
 			// "the human who created it" -- an answer of "none" beats an answer
 			// naming a user that does not exist.
 			CreatedByUserID: uuidToPG(req.Principal.UserID),
@@ -405,10 +387,10 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 				return nil
 			}
 			// THE ACTOR IS WHICHEVER CREDENTIAL AUTHENTICATED, resolved by
-			// mintAuditActor rather than hardcoded. This is the headless path,
+			// audit.ActorFor rather than hardcoded. This is the headless path,
 			// so an API key is its natural caller and ActorUser over
 			// Principal.UserID named a user that does not exist.
-			actorType, actorID := mintAuditActor(req.Principal)
+			actorType, actorID := audit.ActorFor(req.Principal)
 			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
 				TenantID:   req.Principal.TenantID,
 				ActorType:  actorType,

--- a/apps/api/internal/mcp/mint_test.go
+++ b/apps/api/internal/mcp/mint_test.go
@@ -295,6 +295,244 @@ func TestMintIsRateLimitedPerOperator(t *testing.T) {
 	}
 }
 
+// apiKeyPrincipal is EXACTLY what apikey.PrincipalFor builds for an org-scoped
+// key: APIKeyID set, UserID left at uuid.Nil. This route is mounted under
+// Auth.Authenticate(), whose Bearer branch returns that principal, so this is
+// the ordinary caller of the headless path and not an exotic one.
+func apiKeyPrincipal(tenantID uuid.UUID) domain.Principal {
+	return domain.Principal{
+		Type:      domain.PrincipalAPIKey,
+		APIKeyID:  uuid.New(),
+		TenantID:  tenantID,
+		Role:      "owner",
+		Scope:     domain.ScopeOrg,
+		AuthModel: domain.AuthModelRole,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3b -- TWO API KEYS DO NOT SHARE ONE BUCKET.
+//
+// mintLimiterKey used to read Principal.UserID, which apikey.PrincipalFor never
+// sets, so EVERY API-key mint in EVERY tenant collapsed into the single shared
+// "\x00unattributed" bucket: one tenant's CI runner spent the 5/min budget of
+// every other tenant's keys, process-wide. The per-caller layer is the fairness
+// layer, and it had degraded to nothing for exactly the caller class this
+// endpoint was built for.
+// ---------------------------------------------------------------------------
+
+func TestMintBudgetsAreIndependentPerAPIKeyAndAcrossTenants(t *testing.T) {
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	mint := func(p domain.Principal) error {
+		_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+			Principal: p, Name: "ci", SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+		})
+		return err
+	}
+	isLimited := func(err error) bool {
+		var domErr *domain.Error
+		return errors.As(err, &domErr) && domErr.Code == ErrCodeMintRateLimited
+	}
+
+	tenantA := uuid.New()
+	noisy := apiKeyPrincipal(tenantA)
+
+	// One key spends its whole budget and is then refused. Without this the
+	// rest of the test proves nothing: an unlimited limiter would also let
+	// every other key through.
+	for i := 0; i < MintPerUserPerMin; i++ {
+		if err := mint(noisy); err != nil {
+			t.Fatalf("mint %d of the noisy key's budget failed: %v", i+1, err)
+		}
+	}
+	err := mint(noisy)
+	if !isLimited(err) {
+		t.Fatalf("the noisy API key was not limited after %d mints: %v",
+			MintPerUserPerMin, err)
+	}
+
+	// A SECOND KEY IN THE SAME TENANT is untouched.
+	if err := mint(apiKeyPrincipal(tenantA)); err != nil {
+		t.Fatalf("a second API key in the same tenant was refused by the first key's budget: %v", err)
+	}
+	// A KEY IN A DIFFERENT TENANT is untouched. This is the cross-tenant half:
+	// with the old key, one tenant's runner locked out every other tenant.
+	if err := mint(apiKeyPrincipal(uuid.New())); err != nil {
+		t.Fatalf("ANOTHER TENANT'S API KEY WAS REFUSED BY THIS TENANT'S BUDGET: %v", err)
+	}
+	// And a session user is not in the key's bucket either.
+	if err := mint(orgPrincipal(tenantA)); err != nil {
+		t.Fatalf("a session user was refused by an API key's budget: %v", err)
+	}
+
+	// The key itself is STILL limited -- the exemptions above are per-caller,
+	// not a hole that resets the offender.
+	if err := mint(noisy); !isLimited(err) {
+		t.Fatalf("the noisy key's budget stopped applying to itself: %v", err)
+	}
+
+	// Every refusal wrote nothing. Successes: the noisy key's budget plus the
+	// three distinct callers admitted above.
+	wantWrites := MintPerUserPerMin + 3
+	if len(store.minted) != wantWrites {
+		t.Fatalf("want %d grants written, got %d: a refused mint still wrote",
+			wantWrites, len(store.minted))
+	}
+}
+
+// TestMintLimiterKeyDistinguishesEveryPrincipalKind is the direct unit on the
+// key function, so a regression names the cause rather than the symptom.
+func TestMintLimiterKeyDistinguishesEveryPrincipalKind(t *testing.T) {
+	tenant := uuid.New()
+	keyA, keyB := apiKeyPrincipal(tenant), apiKeyPrincipal(tenant)
+	userA := orgPrincipal(tenant)
+
+	if mintLimiterKey(keyA) == mintLimiterKey(keyB) {
+		t.Fatal("TWO DISTINCT API KEYS SHARE ONE BUCKET")
+	}
+	if mintLimiterKey(keyA) == "\x00unattributed" {
+		t.Fatal("an API-key principal fell into the shared unattributed bucket")
+	}
+	if mintLimiterKey(keyA) == mintLimiterKey(userA) {
+		t.Fatal("an API key and a session user share one bucket")
+	}
+	// Same underlying uuid on the two axes must NOT alias: the type is part of
+	// the key precisely so the two id spaces cannot collide.
+	shared := uuid.New()
+	asKey := domain.Principal{Type: domain.PrincipalAPIKey, APIKeyID: shared, TenantID: tenant}
+	asUser := domain.Principal{Type: domain.PrincipalUser, UserID: shared, TenantID: tenant}
+	if mintLimiterKey(asKey) == mintLimiterKey(asUser) {
+		t.Fatal("a key id and a user id with the same uuid alias onto one bucket")
+	}
+	// A principal naming neither is still MORE restricted, never less: it gets
+	// the single shared reserved bucket rather than a fresh one.
+	nameless := domain.Principal{Type: domain.PrincipalUser, TenantID: tenant}
+	if got := mintLimiterKey(nameless); got != "\x00unattributed" {
+		t.Fatalf("an unidentifiable principal got its own bucket %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3c -- A REQUEST REFUSED ON ITS OWN SHAPE SPENDS NO BUDGET.
+//
+// The charge used to run before the name check and both scope checks, so a
+// malformed request that would be refused 422 still consumed a mint token.
+// Five typos then made the sixth request answer "slow down" to a caller whose
+// actual problem was a typo -- the exact confusion ErrCodeMintRateLimited was
+// named to prevent.
+// ---------------------------------------------------------------------------
+
+func TestMintStructuralRefusalsDoNotSpendBudget(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+	p := orgPrincipal(tenant)
+
+	call := func(name string, scope SiteScopeRequest) error {
+		_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+			Principal: p, Name: name, SiteScope: scope,
+		})
+		return err
+	}
+	codeOf := func(t *testing.T, err error) string {
+		t.Helper()
+		var domErr *domain.Error
+		if !errors.As(err, &domErr) {
+			t.Fatalf("want a domain error, got %v", err)
+		}
+		return domErr.Code
+	}
+
+	// Every structurally invalid shape this endpoint refuses, sent well past
+	// the per-caller budget. None may be charged.
+	invalid := []struct {
+		what  string
+		name  string
+		scope SiteScopeRequest
+	}{
+		{"blank name", "   ", SiteScopeRequest{Mode: SiteScopeModeAll}},
+		{"absent mode", "ci", SiteScopeRequest{}},
+		{"tags mode, empty allowlist", "ci", SiteScopeRequest{Mode: SiteScopeModeTags}},
+		{"list mode, empty allowlist", "ci", SiteScopeRequest{Mode: SiteScopeModeList}},
+		{"all mode naming tags", "ci", SiteScopeRequest{
+			Mode: SiteScopeModeAll, TagIDs: []uuid.UUID{uuid.New()}}},
+	}
+	for round := 0; round < 3; round++ {
+		for _, c := range invalid {
+			err := call(c.name, c.scope)
+			if err == nil {
+				t.Fatalf("%s was accepted", c.what)
+			}
+			if got := codeOf(t, err); got == ErrCodeMintRateLimited {
+				t.Fatalf("%s was answered %q: the limiter shadowed a structural refusal",
+					c.what, ErrCodeMintRateLimited)
+			}
+		}
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("a structurally invalid mint wrote %d grants", len(store.minted))
+	}
+
+	// THE BLANK-NAME REFUSAL IS REACHABLE, AND IT IS THE NAMED ONE. The
+	// reviewer could not prove this before, because the 429 shadowed it.
+	if got := codeOf(t, call("   ", SiteScopeRequest{Mode: SiteScopeModeAll})); got != ErrCodeInvalidRequest {
+		t.Fatalf("blank name answered %q, want %q", got, ErrCodeInvalidRequest)
+	}
+
+	// AND THE BUDGET IS STILL WHOLE: the full allowance is available after all
+	// of that, so no invalid request was charged.
+	for i := 0; i < MintPerUserPerMin; i++ {
+		if err := call("ci", SiteScopeRequest{Mode: SiteScopeModeAll}); err != nil {
+			t.Fatalf("mint %d of an UNSPENT budget was refused: %v", i+1, err)
+		}
+	}
+	// It does not over-fire either: the limiter still bites on the valid path.
+	if err := call("ci", SiteScopeRequest{Mode: SiteScopeModeAll}); codeOf(t, err) != ErrCodeMintRateLimited {
+		t.Fatalf("the budget never ran out: moving the charge disarmed the limiter: %v", err)
+	}
+}
+
+// TestMintChargesBeforeTheReferentialCheck bounds the oracle. verifyScopeReferents
+// is the one refusal on this endpoint that discloses anything about the
+// organisation's data ("this uuid does or does not name a tag here"), so it must
+// sit BEHIND the charge -- otherwise moving the limiter past validation would
+// have bought unbounded referent probing.
+func TestMintChargesBeforeTheReferentialCheck(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{tagIDs: []uuid.UUID{uuid.New()}}
+	svc := mintService(store)
+	p := orgPrincipal(tenant)
+
+	probe := func() error {
+		_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+			Principal: p, Name: "probe",
+			// Structurally VALID, referentially unknown: it reaches the
+			// registry read and is refused there, naming the id.
+			SiteScope: SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{uuid.New()}},
+		})
+		return err
+	}
+	for i := 0; i < MintPerUserPerMin; i++ {
+		err := probe()
+		var domErr *domain.Error
+		if !errors.As(err, &domErr) || domErr.Code != ErrCodeUnknownScopeTag {
+			t.Fatalf("probe %d answered %v, want %q", i+1, err, ErrCodeUnknownScopeTag)
+		}
+	}
+	// The budget is spent by probing alone, so probing is bounded.
+	err := probe()
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) || domErr.Code != ErrCodeMintRateLimited {
+		t.Fatalf("UNBOUNDED REFERENT PROBING: probe %d answered %v, want %q",
+			MintPerUserPerMin+1, err, ErrCodeMintRateLimited)
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("a refused probe wrote %d grants", len(store.minted))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // PROOF 4 -- AN UNRESOLVABLE TAG IS REFUSED, LOUDLY AND BY ID.
 //

--- a/apps/api/internal/mcp/mint_test.go
+++ b/apps/api/internal/mcp/mint_test.go
@@ -1,0 +1,547 @@
+package mcp
+
+// Unit proofs for the connection-token mint. Everything here runs against
+// fakeStore, so it proves the GO branch structure and the payload that reaches
+// the INSERT -- never the RLS, which no fake can evaluate. The RLS half is
+// proved in apps/api/tests as wpmgr_app.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// mintRouter mounts the connections group with its REAL middleware and injects
+// a principal, the same shape newConnectionsRouter uses.
+func mintRouter(t *testing.T, store Store, p domain.Principal) *http.Handler {
+	t.Helper()
+	eng := newConnectionsRouter(t, store, p)
+	var h http.Handler = eng
+	return &h
+}
+
+// postMint sends a mint request and returns status plus the decoded body.
+func postMint(t *testing.T, h http.Handler, body map[string]any) (int, map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, APIV1Prefix+connectionsGroupPath, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	out := map[string]any{}
+	if rec.Body.Len() > 0 {
+		// A body that will not decode is a finding, not something to skip:
+		// every response on this surface is JSON by contract.
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode response (status %d): %v\nbody: %s", rec.Code, err, rec.Body.String())
+		}
+	}
+	return rec.Code, out
+}
+
+func mintService(store Store) *Service { return NewService(store) }
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- A SITE-SCOPED COLLABORATOR IS REFUSED, AND THE REFUSAL IS SAYABLE.
+//
+// This is the live production defect's shape on the sibling path: one
+// self-registered client and one POST minted an organisation-wide grant for a
+// principal shared onto a single site. The gate must refuse, it must say so
+// (never an empty success), and NOTHING MAY BE WRITTEN.
+// ---------------------------------------------------------------------------
+
+func TestMintRefusesASiteScopedCollaborator(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: siteScopedPrincipal(tenant),
+		Name:      "ci-runner",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+	})
+	if err == nil {
+		t.Fatal("a site-scoped collaborator minted an organisation-wide connection token")
+	}
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) {
+		t.Fatalf("want a typed domain refusal, got %T: %v", err, err)
+	}
+	if domErr.Code != ErrCodeOrgScopeRequired {
+		t.Fatalf("want code %q, got %q (%s)", ErrCodeOrgScopeRequired, domErr.Code, domErr.Message)
+	}
+	if domain.HTTPStatus(domErr) != http.StatusForbidden {
+		t.Fatalf("want 403 for a refused collaborator, got %d", domain.HTTPStatus(domErr))
+	}
+
+	// NOTHING WAS WRITTEN. A refusal that still reached the store would mean
+	// the grant exists and only the response was refused.
+	for _, call := range store.callLog() {
+		if call == "CreateGrantWithToken" {
+			t.Fatal("the store was reached despite the refusal: a grant was written for a refused principal")
+		}
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants minted, got %d", len(store.minted))
+	}
+}
+
+// The same refusal through the MOUNTED ROUTE, so the permission middleware and
+// the service refusal are both exercised. A gate that holds in the service and
+// is bypassed by the handler guards nothing.
+func TestMintRefusesASiteScopedCollaboratorThroughTheMountedRoute(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	h := mintRouter(t, store, siteScopedPrincipal(tenant))
+
+	status, body := postMint(t, *h, map[string]any{
+		"name": "ci-runner", "site_scope_mode": "all",
+	})
+	if status != http.StatusForbidden {
+		t.Fatalf("want 403 through the mounted route, got %d (body %v)", status, body)
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants minted, got %d", len(store.minted))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- THE PLAINTEXT IS RETURNED ONCE AND IS NEVER STORED OR LOGGED.
+// ---------------------------------------------------------------------------
+
+func TestMintReturnsThePlaintextOnceAndStoresOnlyTheHash(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	out, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "  headless-ci  ", // trimmed by the service
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if out.Token == "" {
+		t.Fatal("no plaintext returned: the caller has no credential")
+	}
+	if len(store.minted) != 1 {
+		t.Fatalf("want exactly 1 mint, got %d", len(store.minted))
+	}
+	got := store.minted[0]
+
+	if got.Grant.Name != "headless-ci" {
+		t.Fatalf("name not trimmed: %q", got.Grant.Name)
+	}
+
+	// THE PLAINTEXT IS NOT IN THE ROW. Checked against every string field the
+	// INSERT carries, not merely against token_hash: a future field that
+	// captured it would be just as bad.
+	if got.Token.TokenHash == out.Token {
+		t.Fatal("the PLAINTEXT was stored in token_hash")
+	}
+	if got.Token.TokenHash != hashCredential(out.Token) {
+		t.Fatalf("token_hash is not the SHA-256 of the plaintext:\n got %q\nwant %q",
+			got.Token.TokenHash, hashCredential(out.Token))
+	}
+	if !isLowerHex64(got.Token.TokenHash) {
+		t.Fatalf("token_hash %q does not satisfy the column's '^[0-9a-f]{64}$' CHECK", got.Token.TokenHash)
+	}
+
+	// The PREFIX is the public handle and is a genuine prefix of the
+	// plaintext -- that is what makes it match a token in a config file. It is
+	// short enough to carry no authentication weight.
+	if got.Token.TokenPrefix != out.Token[:tokenPrefixLen] {
+		t.Fatalf("token_prefix %q is not the plaintext's first %d bytes",
+			got.Token.TokenPrefix, tokenPrefixLen)
+	}
+	if len(got.Token.TokenPrefix) >= len(out.Token) {
+		t.Fatal("token_prefix is the whole credential, so it is not a handle")
+	}
+	if got.Token.TokenPrefix != out.TokenPrefix {
+		t.Fatalf("returned prefix %q disagrees with the stored one %q", out.TokenPrefix, got.Token.TokenPrefix)
+	}
+	if !got.Token.ExpiresAt.Valid {
+		t.Fatal("expires_at was written NULL: this token would never expire")
+	}
+}
+
+// The plaintext must not reach a log. This drives the MOUNTED ROUTE with a
+// slog handler capturing everything at DEBUG and greps the captured bytes.
+func TestMintDoesNotEmitThePlaintextToLogsOrTheURL(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+
+	var logs bytes.Buffer
+	// Captures EVERYTHING, including debug: a leak that only appears at debug
+	// level is still a leak, and this is the level at which one would appear.
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	h := mintRouter(t, store, orgPrincipal(tenant))
+	status, body := postMint(t, *h, map[string]any{
+		"name": "headless-ci", "site_scope_mode": "all",
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("want 201, got %d (body %v)", status, body)
+	}
+
+	token, _ := body["token"].(string)
+	if token == "" {
+		t.Fatalf("no token in the response body: %v", body)
+	}
+
+	// ONCE IN THE BODY. The body is the only place it may appear.
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("re-marshal body: %v", err)
+	}
+	if n := strings.Count(string(raw), token); n != 1 {
+		t.Fatalf("the plaintext appears %d times in the response body, want exactly 1", n)
+	}
+
+	// NOWHERE IN THE LOGS.
+	if strings.Contains(logs.String(), token) {
+		t.Fatalf("THE PLAINTEXT WAS LOGGED:\n%s", logs.String())
+	}
+
+	// The guard must be able to fail. If the token were a substring of
+	// something universally present the assertion above would be vacuous, so
+	// prove the buffer search actually finds a planted needle.
+	logs.WriteString("planted-needle-" + token)
+	if !strings.Contains(logs.String(), token) {
+		t.Fatal("the log search cannot find a string that IS in the buffer; the previous assertion was vacuous")
+	}
+}
+
+// isLowerHex64 mirrors the '^[0-9a-f]{64}$' CHECK on every hash column.
+func isLowerHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- THE RATE LIMIT BITES, AND IT IS PER OPERATOR.
+// ---------------------------------------------------------------------------
+
+func TestMintIsRateLimitedPerOperator(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+	victim := orgPrincipal(tenant)
+
+	mint := func(p domain.Principal) error {
+		_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+			Principal: p, Name: "ci", SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+		})
+		return err
+	}
+
+	// The per-user budget, spent exactly.
+	for i := 0; i < MintPerUserPerMin; i++ {
+		if err := mint(victim); err != nil {
+			t.Fatalf("mint %d of the per-user budget failed: %v", i+1, err)
+		}
+	}
+	// One more must be refused. This is the assertion the whole limiter exists
+	// for: one stolen session must not become an unbounded number of long-lived
+	// bearer credentials.
+	err := mint(victim)
+	if err == nil {
+		t.Fatalf("the %dth mint succeeded: the per-user budget of %d is not enforced",
+			MintPerUserPerMin+1, MintPerUserPerMin)
+	}
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) || domErr.Code != ErrCodeMintRateLimited {
+		t.Fatalf("want %q, got %v", ErrCodeMintRateLimited, err)
+	}
+	if domain.HTTPStatus(domErr) != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d", domain.HTTPStatus(domErr))
+	}
+
+	// A REFUSED MINT WROTE NOTHING. The count must be exactly the budget.
+	if len(store.minted) != MintPerUserPerMin {
+		t.Fatalf("want %d grants written, got %d: a refused mint still wrote",
+			MintPerUserPerMin, len(store.minted))
+	}
+
+	// AND IT DOES NOT OVER-FIRE: a DIFFERENT operator in the same organisation
+	// is unaffected. A limiter that refuses honest work gets switched off.
+	other := orgPrincipal(tenant)
+	if err := mint(other); err != nil {
+		t.Fatalf("a different operator was refused by the first operator's budget: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 4 -- AN UNRESOLVABLE TAG IS REFUSED, LOUDLY AND BY ID.
+//
+// scope_tag_ids is a uuid[] with no foreign key, so the database accepts any
+// UUID at all. A tag id that names nothing therefore stores cleanly and then
+// resolves to zero sites forever -- silently narrowing the scope to nothing,
+// indistinguishable from a deliberately narrow connection.
+// ---------------------------------------------------------------------------
+
+func TestMintRefusesATagIDThatNamesNoTag(t *testing.T) {
+	tenant := uuid.New()
+	known := uuid.New()
+	ghost := uuid.New()
+	store := &fakeStore{tagIDs: []uuid.UUID{known}}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "ci",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{known, ghost}},
+	})
+	if err == nil {
+		t.Fatal("a tag id naming no tag was accepted: the grant's scope is silently narrowed to nothing")
+	}
+	var domErr *domain.Error
+	if !errors.As(err, &domErr) || domErr.Code != ErrCodeUnknownScopeTag {
+		t.Fatalf("want %q, got %v", ErrCodeUnknownScopeTag, err)
+	}
+	// THE REFUSAL NAMES THE ID. A refusal that does not say which tag is
+	// unfixable by the operator who sent it.
+	if !strings.Contains(domErr.Message, ghost.String()) {
+		t.Fatalf("the refusal does not name the offending id %s: %q", ghost, domErr.Message)
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants written, got %d", len(store.minted))
+	}
+}
+
+// A FAILED REGISTRY READ IS NOT AN EMPTY REGISTRY. Proceeding on the error
+// would refuse every tag as unknown -- an infra failure wearing a 422, which
+// sends the operator to fix a tag that is fine.
+func TestMintTreatsAFailedTagRegistryReadAsInfraNotAsAnUnknownTag(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{tagIDsErr: errors.New("database is down")}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "ci",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{uuid.New()}},
+	})
+	if err == nil {
+		t.Fatal("a failed registry read produced a successful mint")
+	}
+	var domErr *domain.Error
+	if errors.As(err, &domErr) {
+		t.Fatalf("an infra failure was reported as the typed domain error %q: %v", domErr.Code, err)
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants written, got %d", len(store.minted))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 5 -- AN EMPTY SCOPE IS ACCEPTED AND STORED AS EMPTY, NEVER WIDENED.
+//
+// A real tag that carries zero sites today is a LEGITIMATE thing to mint: the
+// connection reads nothing now and reads whatever gets tagged later. The owner's
+// ruling on the 2026-08-24 wireframes is explicit that this must be accepted.
+// It must NOT be refused for resolving to nothing, and above all it must not be
+// widened to mode 'all' on the theory that empty "must have been a mistake".
+// ---------------------------------------------------------------------------
+
+func TestMintAcceptsATagThatResolvesToNoSitesAndStoresItAsGiven(t *testing.T) {
+	tenant := uuid.New()
+	emptyTag := uuid.New()
+	store := &fakeStore{
+		tagIDs: []uuid.UUID{emptyTag}, // the tag EXISTS
+		// ...and resolves to NO SITES. This is the state under test.
+		scopeSites: nil,
+	}
+	svc := mintService(store)
+
+	out, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant),
+		Name:      "reads-nothing-yet",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeTags, TagIDs: []uuid.UUID{emptyTag}},
+	})
+	if err != nil {
+		t.Fatalf("a real tag carrying zero sites was refused: %v", err)
+	}
+	if out.Token == "" {
+		t.Fatal("no token returned")
+	}
+	if len(store.minted) != 1 {
+		t.Fatalf("want 1 mint, got %d", len(store.minted))
+	}
+	got := store.minted[0].Grant
+
+	// NEVER WIDENED. The mode and the payload are exactly what was asked for.
+	if got.SiteScopeMode != string(SiteScopeModeTags) {
+		t.Fatalf("the scope was WIDENED: stored mode %q, want %q", got.SiteScopeMode, SiteScopeModeTags)
+	}
+	if len(got.ScopeTagIds) != 1 || got.ScopeTagIds[0] != emptyTag {
+		t.Fatalf("the tag payload was not stored as given: %v", got.ScopeTagIds)
+	}
+	if len(got.ScopeSiteIds) != 0 {
+		t.Fatalf("sites appeared in a 'tags' grant: %v", got.ScopeSiteIds)
+	}
+	if out.SiteScopeMode != SiteScopeModeTags {
+		t.Fatalf("the response reports mode %q, want %q", out.SiteScopeMode, SiteScopeModeTags)
+	}
+}
+
+// The STRUCTURAL rules are unchanged: an empty allowlist is still not a way to
+// ask for every site, in either scoped mode. This is the guard against reading
+// the acceptance above too broadly.
+func TestMintKeepsTheStructuralEmptyAllowlistRefusals(t *testing.T) {
+	tenant := uuid.New()
+	for _, tc := range []struct {
+		name  string
+		scope SiteScopeRequest
+	}{
+		{"tags mode naming no tags", SiteScopeRequest{Mode: SiteScopeModeTags}},
+		{"list mode naming no sites", SiteScopeRequest{Mode: SiteScopeModeList}},
+		{"absent mode", SiteScopeRequest{}},
+		{"unrecognised mode", SiteScopeRequest{Mode: SiteScopeMode("everything")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeStore{}
+			svc := mintService(store)
+			_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+				Principal: orgPrincipal(tenant), Name: "ci", SiteScope: tc.scope,
+			})
+			if err == nil {
+				t.Fatal("accepted: an empty or absent site scope was read as a valid grant")
+			}
+			var domErr *domain.Error
+			if !errors.As(err, &domErr) || domErr.Code != ErrCodeInvalidSiteScope {
+				t.Fatalf("want %q, got %v", ErrCodeInvalidSiteScope, err)
+			}
+			if len(store.minted) != 0 {
+				t.Fatalf("want 0 grants written, got %d", len(store.minted))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 6 -- CAPABILITIES. An omitted list is the org default, never an empty
+// set; a capability wider than the ceiling is REFUSED rather than dropped.
+// ---------------------------------------------------------------------------
+
+func TestMintNeverStoresAnEmptyCapabilitySet(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	if _, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant), Name: "ci",
+		SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+		// No capabilities named at all.
+	}); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	got := store.minted[0].Grant
+	if len(got.Capabilities) == 0 {
+		t.Fatal("an EMPTY capability set was stored: this connection would authenticate and reach no tool")
+	}
+	want := capabilityNames(DefaultGrantCapabilities())
+	if len(got.Capabilities) != len(want) {
+		t.Fatalf("stored capabilities %v, want the org default %v", got.Capabilities, want)
+	}
+}
+
+func TestMintRefusesACapabilityWiderThanTheOrgDefault(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+
+	_, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: orgPrincipal(tenant), Name: "ci",
+		SiteScope:    SiteScopeRequest{Mode: SiteScopeModeAll},
+		Capabilities: []Capability{Capability("mcp.sites.write")},
+	})
+	if err == nil {
+		t.Fatal("a capability the organisation does not hold was accepted")
+	}
+	if len(store.minted) != 0 {
+		t.Fatalf("want 0 grants written, got %d", len(store.minted))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 7 -- THE WHOLE PRINCIPAL REACHES THE STORE.
+//
+// The store method takes a principal and not a tenant id precisely because
+// db.RunTenantTx dispatches on it: flattening it here would leave the
+// site-scope GUC unset and the RESTRICTIVE insert policy inert, and everything
+// would still compile and still pass.
+// ---------------------------------------------------------------------------
+
+func TestMintHandsTheWholePrincipalToTheStore(t *testing.T) {
+	tenant := uuid.New()
+	store := &fakeStore{}
+	svc := mintService(store)
+	p := orgPrincipal(tenant)
+
+	if _, err := svc.MintConnection(context.Background(), MintConnectionRequest{
+		Principal: p, Name: "ci", SiteScope: SiteScopeRequest{Mode: SiteScopeModeAll},
+	}); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if store.grantPrincipal == nil {
+		t.Fatal("no principal reached the store: the site-scope dispatch has nothing to key on")
+	}
+	if store.grantPrincipal.GetTenantID() != tenant {
+		t.Fatalf("store got tenant %s, want %s", store.grantPrincipal.GetTenantID(), tenant)
+	}
+	if store.grantPrincipal.GetUserID() != p.UserID {
+		t.Fatalf("store got user %s, want %s: app.user_id would be wrong for the audit hash chain",
+			store.grantPrincipal.GetUserID(), p.UserID)
+	}
+	// The created_by column must name the operator, not NULL.
+	if !store.minted[0].Grant.CreatedByUserID.Valid {
+		t.Fatal("created_by_user_id was written NULL: this credential is unattributable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 8 -- THE ROUTE EXISTS AND THE WRONG VERB SAYS SO.
+//
+// A 404 on this path reads as "not deployed", which is exactly how the S6b-2
+// blocker presented and cost a debugging session.
+// ---------------------------------------------------------------------------
+
+func TestMintRouteAnswers405AndNot404OnAWrongVerb(t *testing.T) {
+	h := mintRouter(t, &fakeStore{}, orgPrincipal(uuid.New()))
+	req := httptest.NewRequest(http.MethodDelete, APIV1Prefix+connectionsGroupPath, nil)
+	rec := httptest.NewRecorder()
+	(*h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405 on DELETE, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	if !strings.Contains(allow, http.MethodPost) || !strings.Contains(allow, http.MethodGet) {
+		t.Fatalf("Allow header %q does not name both supported verbs", allow)
+	}
+}

--- a/apps/api/internal/mcp/model.go
+++ b/apps/api/internal/mcp/model.go
@@ -24,11 +24,19 @@ import (
 type Scope string
 
 // ScopeRead is the only scope this surface grants, and the surface is
-// read-only by construction rather than by configuration (m124 DECISION 1:
-// there is deliberately no capability column, because it would be the place a
-// write capability could later appear without a migration and without a
-// review). A write scope does not belong here; it belongs in its own migration
-// with its own review.
+// read-only by construction rather than by configuration.
+//
+// m127 DID MINT mcp_grants.capabilities, so the older statement here -- that
+// there is deliberately no capability column -- is no longer true and has been
+// removed rather than left to be believed. What it was protecting survives, and
+// survives in a stronger form: the column is NOT NULL with no default and
+// carries a CHECK closed over the same one-name vocabulary this package holds
+// (capabilityVocabulary), so a write capability STILL cannot appear in a row
+// without a migration and without a review. The column narrows what a
+// connection may do; it cannot widen it past what scopeCapabilities maps.
+//
+// A write scope does not belong here; it belongs in its own migration with its
+// own review.
 const ScopeRead Scope = "mcp:read"
 
 // SiteScopeMode says which sites a grant may read. It mirrors

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -141,6 +141,23 @@ type fakeStore struct {
 	// listPrincipals does the same for the list path.
 	listPrincipals []domain.Principal
 
+	// The headless mint surface.
+	//
+	// minted captures every CreateGrantWithToken call WHOLE (principal, grant
+	// params, token params), because the properties this endpoint has to hold
+	// are properties of what reached the INSERT: that the token row carries a
+	// hash and a prefix and not the plaintext, that the scope arrays were
+	// stored as given rather than widened, and that the principal was not
+	// flattened on the way down. mintErr forces the write itself to fail.
+	minted  []mintedGrant
+	mintErr error
+
+	// tagIDs is the tenant's tag registry and tagIDsErr forces the read to
+	// fail. Independent, so "the registry is empty" and "the registry could not
+	// be read" are separately reachable.
+	tagIDs    []uuid.UUID
+	tagIDsErr error
+
 	// call log. mu guards all four -- see note().
 	mu           sync.Mutex
 	consumeCalls int
@@ -284,6 +301,77 @@ func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPr
 		}
 	}
 	return grant, sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
+}
+
+// mintedGrant is one captured CreateGrantWithToken call. The TOKEN PARAMS are
+// captured whole, so a test can assert what was actually sent to the INSERT --
+// which is the only way to prove the plaintext was not among it.
+type mintedGrant struct {
+	Principal db.ScopedPrincipal
+	Grant     sqlc.CreateMCPGrantParams
+	Token     sqlc.CreateMCPConnectionTokenParams
+}
+
+// CreateGrantWithToken records the principal and BOTH parameter sets.
+//
+// Like CreateGrantWithCode, THIS FAKE CANNOT PROVE THE RLS: it runs no
+// transaction and evaluates no policy. What it pins is the plumbing and the
+// PAYLOAD -- that the scope-carrying principal reaches the store rather than
+// being flattened to a tenant id, and that the token row carries a hash and a
+// prefix and never the plaintext. The policy itself is proved in tests/, as
+// wpmgr_app.
+func (f *fakeStore) CreateGrantWithToken(
+	_ context.Context,
+	principal db.ScopedPrincipal,
+	g sqlc.CreateMCPGrantParams,
+	mkToken func(uuid.UUID) sqlc.CreateMCPConnectionTokenParams,
+	onCreated func(pgx.Tx, sqlc.McpGrant) error,
+) (sqlc.McpGrant, sqlc.McpConnectionToken, error) {
+	f.note("CreateGrantWithToken")
+	if f.mintErr != nil {
+		return sqlc.McpGrant{}, sqlc.McpConnectionToken{}, f.mintErr
+	}
+	id := uuid.New()
+	tp := mkToken(id)
+
+	f.mu.Lock()
+	f.grantPrincipal = principal
+	f.minted = append(f.minted, mintedGrant{Principal: principal, Grant: g, Token: tp})
+	f.tokensMinted++
+	f.mu.Unlock()
+
+	grant := sqlc.McpGrant{
+		ID: id, TenantID: g.TenantID, Name: g.Name,
+		Status: g.Status, SiteScopeMode: g.SiteScopeMode,
+		ScopeTagIds: g.ScopeTagIds, ScopeSiteIds: g.ScopeSiteIds,
+		Capabilities: g.Capabilities,
+	}
+	// No real tx, same reasoning as CreateGrantWithCode: MintConnection's
+	// callback checks s.audit == nil before touching tx, and no test in this
+	// package wires WithAudit.
+	if onCreated != nil {
+		if err := onCreated(nil, grant); err != nil {
+			return sqlc.McpGrant{}, sqlc.McpConnectionToken{}, err
+		}
+	}
+	return grant, sqlc.McpConnectionToken{
+		ID: uuid.New(), TenantID: tp.TenantID, GrantID: tp.GrantID,
+		TokenPrefix: tp.TokenPrefix, TokenHash: tp.TokenHash, Status: tp.Status,
+	}, nil
+}
+
+// ListTagIDs models the tenant tag registry.
+//
+// tagIDsErr is separate from an empty tagIDs so a test can drive "the registry
+// read FAILED" apart from "this organisation has no tags" -- the pair this
+// package keeps apart everywhere else, and the pair that decides whether an
+// unknown-tag refusal is honest or is an infra failure wearing a 422.
+func (f *fakeStore) ListTagIDs(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	f.note("ListTagIDs")
+	if f.tagIDsErr != nil {
+		return nil, f.tagIDsErr
+	}
+	return f.tagIDs, nil
 }
 
 func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -258,13 +258,22 @@ func (f *fakeStore) RedeemAuthorizationCode(_ context.Context, _, _ uuid.UUID, t
 // that the principal reaches the store at all, so a refactor which narrows
 // ApprovalRequest back to a bare tenant id fails here rather than silently in
 // production. The policy itself is proved in tests/, as wpmgr_app.
-func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
+func (f *fakeStore) CreateGrantWithCode(_ context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mk func(uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(pgx.Tx, sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	f.note("CreateGrantWithCode")
 	f.grantPrincipal = principal
 	id := uuid.New()
 	cp := mk(id)
-	return sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name},
-		sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
+	grant := sqlc.McpGrant{ID: id, TenantID: g.TenantID, Name: g.Name}
+	// No real tx to hand onCreated -- this fake runs no transaction at all.
+	// Service.Approve's callback checks s.audit == nil before touching tx, and
+	// no test in this package wires WithAudit, so nil here is never
+	// dereferenced.
+	if onCreated != nil {
+		if err := onCreated(nil, grant); err != nil {
+			return sqlc.McpGrant{}, sqlc.McpAuthorizationCode{}, err
+		}
+	}
+	return grant, sqlc.McpAuthorizationCode{ID: uuid.New(), TenantID: cp.TenantID}, nil
 }
 
 func (f *fakeStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
@@ -349,6 +358,7 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	_ context.Context,
 	p domain.Principal,
 	_ uuid.UUID,
+	onRevoked func(pgx.Tx, sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	f.note("RevokeGrantWithTokens")
 	f.mu.Lock()
@@ -356,6 +366,13 @@ func (f *fakeStore) RevokeGrantWithTokens(
 	f.mu.Unlock()
 	if f.revokeErr != nil {
 		return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, f.revokeErr
+	}
+	// No real tx, same reasoning as CreateGrantWithCode above: the callback
+	// checks s.audit == nil before touching it.
+	if onRevoked != nil {
+		if err := onRevoked(nil, f.revokeRow); err != nil {
+			return sqlc.RevokeMCPGrantWithTokensInTenantTxRow{}, err
+		}
 	}
 	return f.revokeRow, nil
 }

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -100,6 +100,16 @@ type fakeStore struct {
 	// coerced into a string.
 	identityCalls []recordedIdentity
 
+	// touchErr forces the activity stamp to fail, which the transport must
+	// surface as a REFUSED request rather than serve the tool anyway: an
+	// unrecorded use is indistinguishable from no use at all once
+	// idle_expire_after_days starts reading last_used_at.
+	touchErr error
+	// touchCalls records every TouchActivity argument set, so a test can assert
+	// the stamp happened, happened on the right ids, and did NOT happen on the
+	// methods that must not refresh an idle deadline.
+	touchCalls []touchedActivity
+
 	// sites is what ListSitesForRead returns; sitesMore is its page-bound
 	// overflow flag; sitesErr forces the read to fail.
 	sites     []sqlc.ListSitesRow
@@ -314,6 +324,30 @@ func (f *fakeStore) RecordClientIdentity(
 		Name: name, Version: version, ProtocolVersion: protocolVersion,
 	})
 	return f.identityErr
+}
+
+// touchedActivity is one TouchActivity call, recorded with all three ids so a
+// test can assert the stamp reached the grant AND the token, and reached them
+// under the tenant the request resolved to.
+type touchedActivity struct {
+	TenantID uuid.UUID
+	GrantID  uuid.UUID
+	TokenID  uuid.UUID
+}
+
+func (f *fakeStore) TouchActivity(
+	_ context.Context, tenantID, grantID, tokenID uuid.UUID,
+) (time.Time, error) {
+	f.note("TouchActivity")
+	f.touchCalls = append(f.touchCalls, touchedActivity{
+		TenantID: tenantID, GrantID: grantID, TokenID: tokenID,
+	})
+	if f.touchErr != nil {
+		// The zero time.Time goes back WITH the error, so a caller that ignores
+		// the error and uses the stamp gets year 1 rather than a plausible one.
+		return time.Time{}, f.touchErr
+	}
+	return time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC), nil
 }
 
 func (f *fakeStore) ListSitesForRead(_ context.Context, _ uuid.UUID, limit int32) ([]sqlc.ListSitesRow, bool, error) {
@@ -761,8 +795,10 @@ func TestAuthenticate_RevocationBitesOnTheNextRequest(t *testing.T) {
 		recheck: sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
 			GrantID: tok.GrantID, GrantStatus: "active",
 			SiteScopeMode: "all", TokenID: tok.ID, TokenStatus: "active",
-			TokenExpiresAt: tok.ExpiresAt,
-			Authorized:     true,
+			TokenExpiresAt:    tok.ExpiresAt,
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
+			Authorized:        true,
 		},
 		scopeSites: []uuid.UUID{siteID},
 	}
@@ -841,7 +877,10 @@ func TestAuthenticate_EmptyResolvedScopeGrantsNoSites(t *testing.T) {
 			GrantID: tok.GrantID, GrantStatus: "active",
 			SiteScopeMode: "tags", ScopeTagIds: []uuid.UUID{uuid.New()},
 			TokenID: tok.ID, TokenStatus: "active",
-			TokenExpiresAt: tok.ExpiresAt, Authorized: true,
+			TokenExpiresAt:    tok.ExpiresAt,
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
+			Authorized:        true,
 		},
 		scopeSites: nil, // the tag matched no site
 	}

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -110,6 +110,52 @@ func grantScopes() []Scope {
 	return []Scope{ScopeRead}
 }
 
+// DefaultGrantCapabilities is the capability set stamped onto mcp_grants.
+// capabilities when a NEW grant is created and the consent screen offered no
+// narrowing control.
+//
+// It is the vocabulary, which is also the org default while exactly one scope
+// is recognised. It is a FUNCTION and not a constant slice because a package
+// variable would be shared, mutable, and one append away from widening every
+// grant this surface has ever minted.
+//
+// This is where a chosen value replaces a defaulted one when Step 5's
+// capability control ships: the operator's selection arrives on
+// ApprovalRequest and is passed instead. It is deliberately NOT a database
+// DEFAULT -- see the column's NOT NULL and m127's reasoning about a credential
+// nobody chose the terms of.
+func DefaultGrantCapabilities() []Capability { return AllCapabilities() }
+
+// capabilityNames renders capabilities for the text[] column.
+func capabilityNames(caps []Capability) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, string(c))
+	}
+	return out
+}
+
+// capabilitiesFromColumn reads mcp_grants.capabilities back into the domain
+// type.
+//
+// IT DOES NOT FILTER, and that omission is deliberate. Dropping an unknown name
+// here would hand NarrowTo a set that had already been quietly reduced, so a
+// row carrying a capability outside this build's vocabulary would authenticate
+// as though it carried only the known ones. The refusal belongs at NarrowTo,
+// where an unheld capability rejects the whole set instead of being trimmed out
+// of it -- the same reasoning ParseRequestedScopes gives for refusing an
+// unrecognised scope rather than ignoring it.
+//
+// A nil or empty column yields an empty slice, which the caller must treat as
+// "no capability" and never as "unrestricted".
+func capabilitiesFromColumn(names []string) []Capability {
+	out := make([]Capability, 0, len(names))
+	for _, n := range names {
+		out = append(out, Capability(n))
+	}
+	return out
+}
+
 // CapabilitySet is a RESOLVED set of capabilities.
 //
 // It is a struct and not a []Capability on purpose, and the reasoning is
@@ -169,13 +215,17 @@ func (s CapabilitySet) Sorted() []Capability {
 // OrgDefaultCapabilities is the WIDEST capability set any connection in this
 // organisation may hold, derived from the scopes the surface granted it.
 //
-// There is no capabilities column on mcp_grants and that is m124 DECISION 1:
-// minting one would create the place a write capability could appear without a
-// migration and without a review. So the org default is DERIVED from the closed
-// scope registry rather than stored, and it cannot exceed what
-// scopeCapabilities maps. When a differentiated-read column does arrive it
-// arrives NOT NULL with no default and a closed CHECK, and it narrows this --
-// it never replaces it as the ceiling.
+// IT IS THE CEILING, NOT THE ANSWER. m127 added mcp_grants.capabilities -- NOT
+// NULL, no default, closed CHECK, exactly as m124 DECISION 1 required of any
+// such column -- so a live connection's capability set is now READ FROM THAT
+// ROW and then narrowed against this ceiling (Service.Authenticate). This
+// function is no longer what a request path may use on its own: doing so
+// answers from the scope registry rather than from the grant, which agrees with
+// the row only while the vocabulary holds one name.
+//
+// It stays derived rather than stored because a ceiling that could be raised by
+// writing a row is not a ceiling. scopeCapabilities is the only thing that can
+// widen it, and widening that map is a code change under review.
 //
 // An empty or nil scope list yields an EMPTY set and an error, never a
 // permissive one. Absence is refusal here exactly as it is in

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -51,6 +51,32 @@ type Store interface {
 	// exactly as an error from either insert would. May be nil.
 	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
 
+	// CreateGrantWithToken is CreateGrantWithCode's headless sibling: it mints
+	// the grant and its FIRST CONNECTION TOKEN in one transaction, for the
+	// non-OAuth path where no authorization code ever exists.
+	//
+	// It takes the principal for the identical reason, and the reason is the
+	// whole security boundary: only db.Pool.RunTenantTx sets app.site_scope,
+	// and mcp_grants_site_scope_insert is a RESTRICTIVE policy keyed on that
+	// GUC. A method taking a bare tenant id could only reach InTenantTx, which
+	// leaves the policy inert -- and this path writes a LONG-LIVED BEARER
+	// CREDENTIAL, so an inert insert policy here is strictly worse than on the
+	// consent path.
+	//
+	// onCreated runs INSIDE the same transaction, after both inserts, so
+	// Service.MintConnection can append ActionMCPGrantCreated over the SAME tx.
+	// An error from it rolls both inserts back, so there is never a live token
+	// whose grant has no audit row. May be nil.
+	CreateGrantWithToken(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkToken func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpConnectionToken, error)
+
+	// ListTagIDs returns every tag id in the tenant's registry.
+	//
+	// It exists so the mint path can REFUSE a scope tag id that names nothing,
+	// which no CHECK can do: scope_tag_ids is a uuid[] and PostgreSQL has no
+	// foreign key over array elements. See verifyScopeReferents for why this
+	// question is not the same as "does the scope resolve to any sites".
+	ListTagIDs(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error)
+
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
 	ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error)
@@ -307,6 +333,96 @@ func (r *Repo) CreateGrantWithCode(
 		return nil
 	})
 	return grant, code, err
+}
+
+// CreateGrantWithToken mints the grant and its first connection token in ONE
+// transaction, through RunTenantTx.
+//
+// RunTenantTx, NOT InTenantTx, for exactly the reason CreateGrantWithCode gives
+// above it: InScopedTenantTx is the only helper that sets app.site_scope, and
+// the RESTRICTIVE mcp_grants_site_scope_insert policy keys on that GUC. Picking
+// a helper here instead of dispatching on the principal is how a call site
+// silently falls outside the site-scope RLS -- and this one writes a bearer
+// credential that outlives the session that asked for it.
+//
+// THE TWO WRITES ARE ONE TRANSACTION and there is deliberately no way to
+// express half. A grant with no token is a connection an operator sees in the
+// list and can never use; a token with no grant is a credential
+// ReCheckAuthorization refuses on every request with nothing to explain it.
+// Both are states a two-commit version can leave behind after a crash, which is
+// the same argument RedeemAuthorizationCode makes for its own single
+// transaction.
+func (r *Repo) CreateGrantWithToken(
+	ctx context.Context,
+	principal db.ScopedPrincipal,
+	g sqlc.CreateMCPGrantParams,
+	mkToken func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams,
+	onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error,
+) (sqlc.McpGrant, sqlc.McpConnectionToken, error) {
+	var (
+		grant sqlc.McpGrant
+		token sqlc.McpConnectionToken
+	)
+	// Same guard as CreateGrantWithCode: a transaction scoped to one tenant
+	// while the INSERT names another is a row belonging to neither, and RLS
+	// would refuse it as a 42501 three frames down. Saying so here is one line.
+	if principal.GetTenantID() != g.TenantID {
+		return grant, token, fmt.Errorf(
+			"create mcp grant: principal tenant %s does not match grant tenant %s",
+			principal.GetTenantID(), g.TenantID)
+	}
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		q := sqlc.New(tx)
+		gr, err := q.CreateMCPGrant(ctx, g)
+		if err != nil {
+			return fmt.Errorf("create mcp grant: %w", err)
+		}
+		tk, err := q.CreateMCPConnectionToken(ctx, mkToken(gr.ID))
+		if err != nil {
+			// Rolls the grant insert back with it, so a failed mint leaves no
+			// half-built connection behind.
+			return fmt.Errorf("create mcp connection token: %w", err)
+		}
+		if onCreated != nil {
+			if err := onCreated(tx, gr); err != nil {
+				return err
+			}
+		}
+		grant, token = gr, tk
+		return nil
+	})
+	return grant, token, err
+}
+
+// ListTagIDs reads the tenant's tag registry inside InTenantTx, so `site_tags`
+// RLS scopes it to this organisation and a foreign tag can never appear in the
+// result a scope id is checked against.
+//
+// It returns ONLY the ids. The mint path asks one question of this registry --
+// "does this id name a tag here" -- and returning the whole row would invite a
+// caller to answer some other question from data it did not scope for.
+//
+// nil on error, never an empty slice: an empty registry and a failed read must
+// not be confusable, because the caller compares scope ids against this list
+// and an empty list would make every tag look unknown.
+func (r *Repo) ListTagIDs(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error) {
+	var out []uuid.UUID
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := sqlc.New(tx).ListTagsWithUsage(ctx, tenantID)
+		if err != nil {
+			return fmt.Errorf("list tag registry: %w", err)
+		}
+		ids := make([]uuid.UUID, 0, len(rows))
+		for _, row := range rows {
+			ids = append(ids, row.ID)
+		}
+		out = ids
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // LookupConnectionToken resolves a bearer token by hash under
@@ -603,6 +719,17 @@ func nullableText(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// timestamptzAt wraps a time as a VALID pgtype.Timestamptz.
+//
+// It exists so a mint cannot pass a zero-value Timestamptz by omission: that
+// value has Valid=false, which is SQL NULL, and expires_at is the column that
+// decides when a bearer credential dies. A NULL there is a never-expiring
+// token, so the conversion is written once, named, rather than open-coded at
+// each call site where the Valid flag can be forgotten.
+func timestamptzAt(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t, Valid: true}
 }
 
 // uuidToPG converts a uuid to the pgtype form CreateMCPGrantParams wants,

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -58,6 +59,23 @@ type Store interface {
 	// identity on the grant. protocolVersion is a *string and NOT a string so
 	// that "sent no header" survives as NULL -- see the method on Repo.
 	RecordClientIdentity(ctx context.Context, tenantID, grantID uuid.UUID, name, version string, protocolVersion *string) error
+
+	// TouchActivity stamps last_used_at on the grant AND on the token that
+	// carried the request, in ONE transaction.
+	//
+	// IT TAKES BOTH IDS AND WRITES BOTH ROWS BECAUSE THEY ANSWER DIFFERENT
+	// QUESTIONS AND MUST NOT DISAGREE. mcp_grants.last_used_at is what the
+	// connections list renders and what the idle-expiry predicate reads;
+	// mcp_connection_tokens.last_used_at is what tells an operator mid-rotation
+	// which of two live tokens is still in use. A grant stamped without its
+	// token would make the rotation UI claim a token nobody has retired is
+	// dead.
+	//
+	// It returns the stamped instant rather than nothing, so a caller can
+	// assert the write happened instead of trusting a nil error over a query
+	// that matched no row -- both underlying statements are :one for that
+	// reason, and pgx.ErrNoRows here means the row was not visible.
+	TouchActivity(ctx context.Context, tenantID, grantID, tokenID uuid.UUID) (time.Time, error)
 
 	// ListSitesForRead reads one bounded page of the tenant's sites for the
 	// list_sites tool. It returns the rows AND whether the bound was reached
@@ -404,6 +422,52 @@ func (r *Repo) RecordClientIdentity(
 		}
 		return nil
 	})
+}
+
+// TouchActivity stamps last_used_at on the grant and on its token.
+//
+// IT RUNS InTenantTx, NEVER THE TOKEN-LOOKUP TRANSACTION THAT JUST RESOLVED
+// THIS TOKEN. mcp_connection_tokens_lookup is FOR SELECT, so an UPDATE inside
+// that scope matches zero rows and reports success -- the same silent zero-row
+// write both queries' own comments warn about. That is also why both are :one:
+// a stamp that hit nothing is pgx.ErrNoRows here rather than a nil error over a
+// column that never moved.
+//
+// BOTH WRITES ARE IN ONE TRANSACTION so the two stamps cannot disagree about
+// whether this request happened.
+//
+// The returned instant comes from the GRANT's RETURNING clause, not from the Go
+// clock: now() is evaluated by the database, and reading it back is what makes
+// "the row moved" provable rather than assumed. LastUsedAt is checked for
+// validity because a NULL returned by an UPDATE that sets the column to now()
+// would mean the write did not land, and reporting that as a zero time.Time
+// would hand the caller a stamp from year 1 that reads as success.
+func (r *Repo) TouchActivity(ctx context.Context, tenantID, grantID, tokenID uuid.UUID) (time.Time, error) {
+	var stamped time.Time
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		q := sqlc.New(tx)
+
+		grantRow, err := q.TouchMCPGrantInTenantTx(ctx,
+			sqlc.TouchMCPGrantInTenantTxParams{TenantID: tenantID, ID: grantID})
+		if err != nil {
+			return fmt.Errorf("touch mcp grant: %w", err)
+		}
+		if !grantRow.LastUsedAt.Valid {
+			return fmt.Errorf("touch mcp grant: last_used_at came back NULL from an UPDATE that sets it to now()")
+		}
+
+		if _, err := q.TouchMCPConnectionTokenInTenantTx(ctx,
+			sqlc.TouchMCPConnectionTokenInTenantTxParams{TenantID: tenantID, ID: tokenID}); err != nil {
+			return fmt.Errorf("touch mcp connection token: %w", err)
+		}
+
+		stamped = grantRow.LastUsedAt.Time
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	return stamped, nil
 }
 
 // ListSitesForRead reads one bounded page of the tenant's sites inside

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -41,7 +41,14 @@ type Store interface {
 	// the RESTRICTIVE insert policy on mcp_grants is live. A tenant id alone
 	// cannot express that, which is how the site-scope GUC came to be unset on
 	// this path. See the method on Repo.
-	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
+	//
+	// onCreated runs INSIDE the same transaction as both inserts, after both
+	// succeed, so the caller (Service.Approve) can append the
+	// ActionMCPGrantCreated audit row via audit.Recorder.RecordInTx over the
+	// SAME tx -- a rolled-back grant then leaves no audit row claiming one
+	// exists, because an error from onCreated rolls the whole transaction back
+	// exactly as an error from either insert would. May be nil.
+	CreateGrantWithCode(ctx context.Context, principal db.ScopedPrincipal, g sqlc.CreateMCPGrantParams, mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams, onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error)
 
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
@@ -79,7 +86,14 @@ type Store interface {
 	// organisation's, or refused by RLS. It is the ONLY outcome meaning "not
 	// there"; a returned row of two zeroes is an idempotent success. See the
 	// query's four-outcome comment.
-	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
+	//
+	// onRevoked runs INSIDE the same transaction as the revoke statement,
+	// after it succeeds (any of the three non-error outcomes), so the caller
+	// (Service.RevokeConnection) can append the ActionMCPGrantRevoked audit
+	// row via audit.Recorder.RecordInTx over the SAME tx. It does NOT run on
+	// pgx.ErrNoRows -- nothing was written, so nothing should be attributed.
+	// May be nil.
+	RevokeGrantWithTokens(ctx context.Context, principal domain.Principal, grantID uuid.UUID, onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error)
 }
 
 // Repo is the live Store. Every method names the tx helper it runs under, and
@@ -239,6 +253,7 @@ func (r *Repo) CreateGrantWithCode(
 	principal db.ScopedPrincipal,
 	g sqlc.CreateMCPGrantParams,
 	mkCode func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams,
+	onCreated func(tx pgx.Tx, grant sqlc.McpGrant) error,
 ) (sqlc.McpGrant, sqlc.McpAuthorizationCode, error) {
 	var (
 		grant sqlc.McpGrant
@@ -262,6 +277,13 @@ func (r *Repo) CreateGrantWithCode(
 		cd, err := q.CreateMCPAuthorizationCode(ctx, mkCode(gr.ID))
 		if err != nil {
 			return fmt.Errorf("create mcp authorization code: %w", err)
+		}
+		// Inside the same tx, after both inserts. An error here rolls both of
+		// them back with it -- see the interface doc on onCreated.
+		if onCreated != nil {
+			if err := onCreated(tx, gr); err != nil {
+				return err
+			}
 		}
 		grant, code = gr, cd
 		return nil
@@ -481,6 +503,7 @@ func (r *Repo) RevokeGrantWithTokens(
 	ctx context.Context,
 	principal domain.Principal,
 	grantID uuid.UUID,
+	onRevoked func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error,
 ) (sqlc.RevokeMCPGrantWithTokensInTenantTxRow, error) {
 	var out sqlc.RevokeMCPGrantWithTokensInTenantTxRow
 	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
@@ -492,10 +515,16 @@ func (r *Repo) RevokeGrantWithTokens(
 		if err != nil {
 			// pgx.ErrNoRows is meaningful to the caller and is NOT wrapped in a
 			// message that would make errors.Is harder to reach for. Every
-			// other error is an infra failure.
+			// other error is an infra failure. Neither reaches onRevoked --
+			// nothing was written, so nothing should be attributed.
 			return err
 		}
 		out = row
+		if onRevoked != nil {
+			if err := onRevoked(tx, row); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -691,10 +691,26 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			if s.audit == nil {
 				return nil
 			}
+			// THE ACTOR IS WHICHEVER CREDENTIAL AUTHENTICATED, resolved by
+			// audit.ActorFor rather than hardcoded.
+			//
+			// "CONSENT IS BROWSER-ONLY" IS A CONVENTION, NOT A CONSTRAINT, and
+			// an audit row may not rest on one. /consent is mounted on v1
+			// (server.go's Register(v1), where v1 derives from
+			// sessionAuthGroup and therefore carries Auth.Authenticate()) --
+			// the same Bearer-accepting group as the mint and the revoke. An
+			// API-key holder can drive the OAuth flow headlessly, and then
+			// ActorUser over req.Principal.UserID recorded uuid.Nil against a
+			// grant that really was created.
+			//
+			// CreatedByUserID above stays as it is and stays NULL for a key:
+			// that column means "the human who created it", and "none" is the
+			// honest answer where this pair is the complete one.
+			actorType, actorID := audit.ActorFor(req.Principal)
 			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
 				TenantID:   req.Principal.TenantID,
-				ActorType:  audit.ActorUser,
-				ActorID:    req.Principal.UserID.String(),
+				ActorType:  actorType,
+				ActorID:    actorID,
 				Action:     audit.ActionMCPGrantCreated,
 				TargetType: "mcp_grant",
 				TargetID:   gr.ID.String(),
@@ -1448,10 +1464,24 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 			if s.audit == nil {
 				return nil
 			}
+			// THE ACTOR IS WHICHEVER CREDENTIAL AUTHENTICATED, resolved by
+			// audit.ActorFor rather than hardcoded.
+			//
+			// THIS ROUTE IS MOUNTED BY THE SAME CALL AS THE HEADLESS MINT --
+			// server.go's RegisterConnections(v1), one nil check below
+			// Register(v1) -- so an API key that can mint a connection can
+			// revoke one, today, with nothing in between. ActorUser over
+			// p.UserID therefore wrote uuid.Nil for exactly the caller class
+			// this surface was built for, and it wrote it on THE ROW AN
+			// AUDITOR REACHES FOR AFTER AN INCIDENT: "who killed this
+			// credential, and when" answered with a user id that resolves to
+			// no user and, because the name join is gated on actor_type, to no
+			// name either.
+			actorType, actorID := audit.ActorFor(p)
 			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
 				TenantID:   p.TenantID,
-				ActorType:  audit.ActorUser,
-				ActorID:    p.UserID.String(),
+				ActorType:  actorType,
+				ActorID:    actorID,
 				Action:     audit.ActionMCPGrantRevoked,
 				TargetType: "mcp_grant",
 				TargetID:   grantID.String(),

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -204,10 +204,30 @@ type Service struct {
 	// one is ever found is "this deploy path is unattributable", not "make the
 	// nil check quieter".
 	audit *audit.Recorder
+
+	// mintLimit bounds POST /api/v1/mcp/connections. It lives on the SERVICE
+	// and not on the Handler, unlike Handler.regLimit, and the placement is
+	// deliberate: /register is unauthenticated so its limiter can only key on
+	// the transport (RemoteIP), which only the handler can see, whereas this
+	// one keys on the authenticated operator and is therefore expressible at
+	// the service layer -- where every mount of MintConnection is covered,
+	// including a test harness that forgot the middleware.
+	//
+	// Never nil after NewService. registrationLimiter.allow refuses on a nil
+	// receiver anyway, so a Service built by a struct literal that skipped it
+	// mints NOTHING rather than minting unlimited.
+	mintLimit *registrationLimiter
 }
 
 func NewService(store Store) *Service {
-	return &Service{store: store, now: time.Now}
+	return &Service{
+		store: store,
+		now:   time.Now,
+		// Armed HERE rather than injected with a nil default, for the reason
+		// NewHandler gives about its own limiter: an unarmed limiter would be a
+		// wiring failure that presents as a working endpoint.
+		mintLimit: newMintLimiter(),
+	}
 }
 
 // WithClock returns a copy using the supplied clock. Test-only in practice.

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -29,6 +29,22 @@ const (
 	authorizationCodeTTL = 5 * time.Minute
 	connectionTokenTTL   = 90 * 24 * time.Hour
 	tokenPrefixLen       = 12
+
+	// grantAbsoluteTTL is the absolute lifetime stamped onto a new grant's
+	// mcp_grants.expires_at.
+	//
+	// IT IS A GO CONSTANT AND NOT A COLUMN DEFAULT, AND THE DIFFERENCE IS THE
+	// WHOLE OF m127 DECISION 2. The column is NOT NULL with no default, so this
+	// call site cannot omit the term and get one silently -- it gets 23502. The
+	// value is chosen here, once, where it is reviewable, rather than in the
+	// schema where it would apply to every future writer including one that
+	// meant to ask the operator.
+	//
+	// 90 days matches the consent wireframe's pre-selected option and the value
+	// m127 backfilled existing rows with. When Step 5's control ships, the
+	// operator's choice arrives on ApprovalRequest and REPLACES this default at
+	// this line; it does not become a second default anywhere else.
+	grantAbsoluteTTL = 90 * 24 * time.Hour
 )
 
 // Error codes. These are domain codes; the OAuth wire errors are mapped from
@@ -600,6 +616,39 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			// The RESOLVED client id, not the body's copy of it.
 			ClientID:        nullableText(client.ClientID),
 			CreatedByUserID: uuidToPG(req.Principal.UserID),
+
+			// m127's three columns, ALL SUPPLIED EXPLICITLY. Two of them are
+			// NOT NULL with no default precisely so that this literal cannot
+			// forget one: a missing field is the zero value, which is
+			// nil/invalid, which is NULL, which is 23502 at the INSERT rather
+			// than an unrestricted or never-expiring connection.
+			//
+			// Capabilities is the STORED per-connection capability set, and
+			// from here on it is the authority Authenticate reads -- not a
+			// value recomputed from the scope registry at request time. It is
+			// written as the org default because Phase 1's consent screen
+			// offers no narrowing control; the moment it does, the operator's
+			// choice arrives here and NarrowTo is what applies it.
+			Capabilities: capabilityNames(DefaultGrantCapabilities()),
+			ExpiresAt:    s.now().UTC().Add(grantAbsoluteTTL),
+
+			// IDLE EXPIRY IS WRITTEN NULL, AND NULL IS THE ANSWER, NOT A
+			// PLACEHOLDER. NULL means "never idle-expire" (m127 DECISION 4).
+			//
+			// A non-NULL value here is only safe once mcp_grants.last_used_at
+			// is actually written, because the deadline is
+			// coalesce(last_used_at, created_at) + N days: with the stamp
+			// unwired that collapses to created_at + N and every connection
+			// dies N days after creation however heavily it is used. The stamp
+			// IS wired now (RecordActivity, called from the transport's
+			// tools/list and tools/call arms), so a non-NULL window has become
+			// REPRESENTABLE -- but nothing yet asks the operator for one, and
+			// inventing a window nobody chose is exactly the "credential nobody
+			// chose the terms of" this column refuses to default.
+			//
+			// So: NULL until Step 5's second control ships and supplies a
+			// chosen value. The prerequisite is now met; the input is not.
+			IdleExpireAfterDays: nil,
 		},
 		func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 			return sqlc.CreateMCPAuthorizationCodeParams{
@@ -963,44 +1012,70 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	// they are independent: the site axis above says WHICH SITES, this one says
 	// WHICH TOOLS.
 	//
-	// THE ORG DEFAULT IS DERIVED, NOT STORED, AND THAT IS m124 DECISION 1. There
-	// is deliberately no capabilities column on mcp_grants, because minting one
-	// would create the place a write capability could appear without a
-	// migration and without a review. So the ceiling is computed from the closed
-	// scope registry, and every live grant on this surface holds ScopeRead by
-	// construction -- ParseRequestedScopes refuses anything else and
-	// recognisedScopes holds exactly that one entry.
+	// THE STORED COLUMN IS THE AUTHORITY, AND THAT IS WHAT m127 CHANGED.
+	// mcp_grants.capabilities now exists -- NOT NULL, no default, CHECKed
+	// against the same closed vocabulary this package holds -- and it is read
+	// off chk.GrantCapabilities, THE SAME ROW AND THE SAME TRANSACTION as the
+	// `authorized` verdict this request was admitted under.
 	//
-	// WHAT IS NOT WIRED YET, SAID PLAINLY RATHER THAN IMPLIED. Two gaps, and
-	// the second is a LATENT WIDENING rather than a missing narrowing:
+	// Recomputing the set from the scope registry instead, as this line did
+	// before m127, is a GUESS: it agrees with the row today only because the
+	// vocabulary holds one name, and it diverges the instant a grant is created
+	// holding anything else. It also answers "full capabilities" for a grant
+	// whose stored set is EMPTY, which is the case where the two disagree by
+	// everything.
 	//
-	//  1. There is no stored per-connection capability narrowing, so this value
-	//     IS the org default. CapabilitySet.NarrowTo is the mechanism that
-	//     applies one, and it refuses a request wider than the default rather
-	//     than granting it; the COLUMN it would read from arrives with its own
-	//     migration, NOT NULL, no default, closed CHECK, as DECISION 1
-	//     requires.
+	// THE ORG DEFAULT REMAINS THE CEILING; the stored value NARROWS it and
+	// never replaces it. That ordering is the only thing standing between a row
+	// and a capability the organisation's scopes do not confer, so a capability
+	// in the column that the default does not hold is REFUSED here -- not
+	// honoured, and not quietly dropped. Dropping would be fail-closed and
+	// still wrong, for the reason written on NarrowTo.
 	//
-	//  2. THE SCOPE LIST BELOW IS A CONSTANT, NOT THE GRANT'S OWN SCOPES.
-	//     mcp_grants has no scopes column, so there is nothing per-grant to
-	//     read; grantScopes() returns the one scope every live grant holds by
-	//     construction. That is exact TODAY and only because recognisedScopes
-	//     holds exactly one entry. The day a second scope joins it, a
-	//     connection granted ONLY that scope would still be handed ScopeRead's
-	//     capabilities here -- a widening, and one no existing test catches,
-	//     because TestEveryRecognisedScopeHasACapabilityMapping pins the map's
-	//     totality and not this function's input.
+	// ONE GAP SURVIVES m127, AND IT IS A LATENT WIDENING RATHER THAN A MISSING
+	// NARROWING: the scope list below is a CONSTANT, not the grant's own
+	// scopes. mcp_grants still has no scopes column, so there is nothing
+	// per-grant to read; grantScopes() returns the one scope every live grant
+	// holds by construction. That is exact TODAY and only because
+	// recognisedScopes holds exactly one entry. The day a second scope joins
+	// it, a connection granted ONLY that scope would still be handed
+	// ScopeRead's capabilities as its CEILING here -- a widening, and one no
+	// existing test catches, because
+	// TestEveryRecognisedScopeHasACapabilityMapping pins the map's totality and
+	// not this function's input.
 	//
-	//     TestGrantScopesIsExactOnlyWhileOneScopeExists goes red the moment
-	//     recognisedScopes grows, so whoever adds the second scope is forced to
-	//     come here and read a grant's scopes instead of a constant.
-	caps, err := OrgDefaultCapabilities(grantScopes())
+	// TestGrantScopesIsExactOnlyWhileOneScopeExists goes red the moment
+	// recognisedScopes grows, so whoever adds the second scope is forced to
+	// come here and read a grant's scopes instead of a constant.
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
 	if err != nil {
 		// A capability set that cannot be resolved is a REFUSAL, never an
 		// empty-but-proceeding one. An AuthorizedRequest with a zero-value
 		// CapabilitySet reaches no tool, so proceeding would produce a
 		// connection that authenticates and then refuses everything with no
 		// explanation anywhere.
+		return AuthorizedRequest{}, fmt.Errorf("resolve grant capabilities: %w", err)
+	}
+
+	// AN EMPTY STORED SET IS REFUSED BY NAME, not carried forward as an empty
+	// CapabilitySet. The column's shape CHECK admits '{}' -- the restrictive
+	// value passes the vocabulary containment test -- so the state is
+	// representable in the database even though no write path in this package
+	// mints it. Carrying it forward would authenticate a connection that then
+	// answers every tools/call with "not available" and every tools/list with
+	// nothing, which is precisely the half-working connection m127 DECISION 3
+	// says this boundary must not be able to produce.
+	stored := capabilitiesFromColumn(chk.GrantCapabilities)
+	if len(stored) == 0 {
+		return AuthorizedRequest{}, domain.Unauthorized(ErrCodeCapabilityUnmapped,
+			"this connection holds no capability, so it can reach no tool")
+	}
+
+	caps, err := ceiling.NarrowTo(stored)
+	if err != nil {
+		// Same refusal, same reason: a stored set that cannot be reconciled
+		// with the organisation's ceiling is not silently reduced to the
+		// intersection. See NarrowTo.
 		return AuthorizedRequest{}, fmt.Errorf("resolve grant capabilities: %w", err)
 	}
 
@@ -1034,6 +1109,55 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 func (s *Service) RecordConnect(ctx context.Context, auth AuthorizedRequest, name, version string, protocolHeader *string) error {
 	if err := s.store.RecordClientIdentity(ctx, auth.TenantID, auth.GrantID, name, version, protocolHeader); err != nil {
 		return fmt.Errorf("record mcp connect: %w", err)
+	}
+	return nil
+}
+
+// RecordActivity stamps mcp_grants.last_used_at (and the token's) for one
+// request that used this connection. GH #605.
+//
+// ============================================================================
+// WHAT COUNTS AS "USED", DECIDED EXPLICITLY: EVERY TOOL CALL, NOT CONNECT.
+// ============================================================================
+//
+// The caller is TransportHandler.dispatch, from the tools/list and tools/call
+// arms only. initialize, ping and notifications/initialized do NOT stamp.
+//
+// STAMPING ONCE PER SESSION AT CONNECT WAS THE ALTERNATIVE AND IT IS REJECTED,
+// for two reasons and not one:
+//
+//  1. IT WOULD MAKE THE COLUMN MEAN "last connected", which is a weaker claim
+//     than its name and than the connections list's "Last used" label. Renaming
+//     either to match would then be part of the change.
+//
+//  2. MORE IMPORTANTLY IT WOULD NOT BE SAFE TO IDLE-EXPIRE AGAINST. Streamable
+//     HTTP sessions are long-lived and initialize happens once at the start of
+//     one. A client that initialized in January and has called tools every day
+//     since would carry a January stamp, so a 30-day idle window would kill a
+//     demonstrably active connection in February. That is a smaller, quieter
+//     version of exactly the fleet outage m127 DECISION 4 describes, and the
+//     whole point of wiring this stamp is to make that outage impossible rather
+//     than rare.
+//
+// ping and notifications/initialized are excluded for the opposite reason: they
+// are transport keepalives that a stuck background process emits forever
+// without anyone using anything. Letting them refresh the deadline would make
+// "unused for 30 days" unfalsifiable and the feature decorative. Connecting is
+// still recorded -- RecordConnect stamps client_identity_recorded_at, which is
+// the separate fact "this client has connected at least once".
+//
+// THE ERROR IS RETURNED AND THE CALLER REFUSES THE REQUEST, deliberately unlike
+// RecordToolCall's best-effort audit append one function below. last_used_at is
+// an INPUT TO AN AUTHORIZATION DEADLINE, not an observation of one: a stamp
+// that silently fails leaves the connection's idle clock running while it is
+// being used, and the cost lands N days later as an expiry nobody can explain.
+// Refusing is loud, immediate, and local to the request that could not be
+// recorded -- and it costs nothing in practice, because a database that cannot
+// take this write also could not have served the two reads Authenticate just
+// made.
+func (s *Service) RecordActivity(ctx context.Context, auth AuthorizedRequest) error {
+	if _, err := s.store.TouchActivity(ctx, auth.TenantID, auth.GrantID, auth.TokenID); err != nil {
+		return fmt.Errorf("record mcp activity: %w", err)
 	}
 	return nil
 }

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1101,9 +1101,20 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	// answers every tools/call with "not available" and every tools/list with
 	// nothing, which is precisely the half-working connection m127 DECISION 3
 	// says this boundary must not be able to produce.
+	//
+	// IT IS 403, NOT 401, and the distinction is the client's control flow
+	// rather than a matter of taste. Authenticate's refusals reach
+	// TransportHandler.writeUnauthorized, and an MCP client that receives 401
+	// re-runs the OAuth handshake -- which cannot change a stored capability
+	// set, so the client loops and the operator is sent to rotate a credential
+	// that was never the problem. An empty capabilities column is a
+	// CONFIGURATION state: the credential is valid and the grant is not
+	// permitted. That is what 403 says, and it is what every other producer of
+	// ErrCodeCapabilityUnmapped already returns (all three in
+	// OrgDefaultCapabilities).
 	stored := capabilitiesFromColumn(chk.GrantCapabilities)
 	if len(stored) == 0 {
-		return AuthorizedRequest{}, domain.Unauthorized(ErrCodeCapabilityUnmapped,
+		return AuthorizedRequest{}, domain.Forbidden(ErrCodeCapabilityUnmapped,
 			"this connection holds no capability, so it can reach no tool")
 	}
 

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
@@ -177,6 +178,16 @@ type Clock func() time.Time
 type Service struct {
 	store Store
 	now   Clock
+	// audit is nil unless WithAudit is called. Every audit write in this
+	// package guards on it being nil first -- see Approve, RevokeConnection,
+	// and RecordToolCall -- so a Service built by the many unit tests in this
+	// package (fakeStore, no real Postgres pool to back an audit.Recorder)
+	// keeps working unaudited. Production wiring (cmd/wpmgr/main.go) always
+	// calls WithAudit; a Service that reaches a request path without it is a
+	// wiring bug, not a supported configuration, and the finding to raise if
+	// one is ever found is "this deploy path is unattributable", not "make the
+	// nil check quieter".
+	audit *audit.Recorder
 }
 
 func NewService(store Store) *Service {
@@ -187,6 +198,18 @@ func NewService(store Store) *Service {
 func (s *Service) WithClock(c Clock) *Service {
 	cp := *s
 	cp.now = c
+	return &cp
+}
+
+// WithAudit returns a copy that appends ActionMCPGrantCreated,
+// ActionMCPGrantRevoked and ActionMCPToolCalled through rec. Mirrors
+// WithClock's copy-and-return shape. cmd/wpmgr/main.go calls this on the one
+// Service the process constructs; a Service left without it (as most of this
+// package's unit tests are, deliberately, since they drive a fakeStore with no
+// backing Postgres pool) simply does not audit -- see the field doc on audit.
+func (s *Service) WithAudit(rec *audit.Recorder) *Service {
+	cp := *s
+	cp.audit = rec
 	return &cp
 }
 
@@ -589,6 +612,29 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 				RedirectUri:         req.Consent.RedirectURI,
 				ExpiresAt:           expiresAt,
 			}
+		},
+		// ActionMCPGrantCreated, in the SAME transaction as both inserts above.
+		// This is "the row written to the audit log" the operator-facing
+		// consent flow promises: if the grant or the code fails to insert, or
+		// this append fails, the whole approval rolls back and there is no
+		// mcp.grant.created row for a grant that does not exist.
+		func(tx pgx.Tx, gr sqlc.McpGrant) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   req.Principal.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    req.Principal.UserID.String(),
+				Action:     audit.ActionMCPGrantCreated,
+				TargetType: "mcp_grant",
+				TargetID:   gr.ID.String(),
+				Metadata: map[string]any{
+					"grant_name":      gr.Name,
+					"site_scope_mode": gr.SiteScopeMode,
+				},
+			})
+			return aerr
 		})
 	if err != nil {
 		return Approval{}, fmt.Errorf("create grant and code: %w", err)
@@ -848,6 +894,14 @@ type AuthorizedRequest struct {
 	TenantID uuid.UUID
 	GrantID  uuid.UUID
 	TokenID  uuid.UUID
+	// GrantName is the grant's operator-assigned name (mcp_grants.name), read
+	// at the same ReCheckAuthorization call that resolves GrantID -- no extra
+	// query. It exists so RecordToolCall can stamp a human-readable label onto
+	// an ActionMCPToolCalled event without a database join: ActorName
+	// resolution (ListAuditEntries) has no arm for ActorAssistant today, so
+	// this is how the label travels until it does. Never used for
+	// authorization, only for display.
+	GrantName string
 
 	// Sites is the resolved site scope: the PER-CONNECTION narrowing on the
 	// site axis. Zero value allows nothing.
@@ -955,6 +1009,7 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	return AuthorizedRequest{
 		TenantID:     tok.TenantID,
 		GrantID:      chk.GrantID,
+		GrantName:    chk.GrantName,
 		TokenID:      chk.TokenID,
 		Sites:        NewSiteSet(ids),
 		Capabilities: caps,
@@ -981,6 +1036,48 @@ func (s *Service) RecordConnect(ctx context.Context, auth AuthorizedRequest, nam
 		return fmt.Errorf("record mcp connect: %w", err)
 	}
 	return nil
+}
+
+// RecordToolCall appends the ActionMCPToolCalled audit row for one
+// successfully executed tool call. The caller (TransportHandler.callTool)
+// invokes this AFTER entry.invoke returns without error -- a refused call
+// never reaches a tenant's data, and is already visible in the operator log
+// TransportHandler writes at refusal time (h.log.WarnContext), so it earns no
+// row here.
+//
+// ActorType is ActorAssistant, the one actor kind in this whole log that
+// attributes the row to the MODEL rather than to the human who granted it
+// access: auth.GrantID identifies WHICH connection acted, which is the fact an
+// operator reviewing "what did this MCP client touch" actually wants, and it
+// is a fact ActorUser (the approving human, possibly long gone from the
+// account) cannot carry. operatorPermission and toolName both come from the
+// registry entry AuthorizeTool already resolved -- see the OperatorPermission
+// doc on ToolPolicy for why that field lands here.
+//
+// BEST-EFFORT, deliberately unlike Approve/RevokeConnection's RecordInTx:
+// there is no companion write in the same transaction to roll back alongside a
+// failed append (a tool call in this phase is a read), so failing the whole
+// tool call because its own audit trail could not be appended would let a
+// purely observational feature take down the read path it exists to observe.
+// The error is returned so the caller can log it, never to be treated as a
+// reason to withhold the tool's answer.
+func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, toolName string, operatorPermission string) error {
+	if s.audit == nil {
+		return nil
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:   auth.TenantID,
+		ActorType:  audit.ActorAssistant,
+		ActorID:    auth.GrantID.String(),
+		Action:     audit.ActionMCPToolCalled,
+		TargetType: "mcp_tool",
+		TargetID:   toolName,
+		Metadata: map[string]any{
+			"grant_name":          auth.GrantName,
+			"operator_permission": operatorPermission,
+		},
+	})
+	return err
 }
 
 // ListSitesForModel is the one Phase 1 read tool. It returns the rendered tool
@@ -1196,7 +1293,32 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 			"a connection id is required")
 	}
 
-	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID)
+	row, err := s.store.RevokeGrantWithTokens(ctx, p, grantID,
+		// ActionMCPGrantRevoked, in the SAME transaction as the revoke
+		// statement. Runs on all three non-error outcomes (freshly revoked,
+		// half-revoked repair, idempotent no-op): the operator explicitly
+		// asked for this credential to be revoked and the request is what is
+		// being attributed, not merely a state transition. It never runs
+		// alongside pgx.ErrNoRows -- see onRevoked's doc on the interface.
+		func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error {
+			if s.audit == nil {
+				return nil
+			}
+			_, aerr := s.audit.RecordInTx(ctx, tx, audit.Event{
+				TenantID:   p.TenantID,
+				ActorType:  audit.ActorUser,
+				ActorID:    p.UserID.String(),
+				Action:     audit.ActionMCPGrantRevoked,
+				TargetType: "mcp_grant",
+				TargetID:   grantID.String(),
+				Metadata: map[string]any{
+					"grants_revoked":  row.GrantsRevoked,
+					"tokens_revoked":  row.TokensRevoked,
+					"already_revoked": row.GrantsRevoked == 0,
+				},
+			})
+			return aerr
+		})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return RevokeOutcome{}, domain.NotFound(ErrCodeConnectionNotFound,

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -423,10 +423,15 @@ func (h *TransportHandler) initialize(
 	}
 	if err := h.svc.RecordConnect(c.Request.Context(), auth,
 		p.ClientInfo.Name, p.ClientInfo.Version, headerValue); err != nil {
-		// A failed audit write is NOT swallowed. The connect record is how an
+		// NOT an audit write -- RecordConnect updates mcp_grants (client name,
+		// version, protocol header) via Store.RecordClientIdentity, and that
+		// update is NOT swallowed on failure. The connect record is how an
 		// operator sees what is attached to their organisation, and a session
 		// that proceeded after failing to record itself would be an
-		// unattributable connection.
+		// unattributable connection. (The actual audit_events row for this
+		// surface is ActionMCPToolCalled, written per tool call by
+		// Service.RecordToolCall -- initialize itself is not a tool call and
+		// writes no audit row.)
 		h.log.ErrorContext(c.Request.Context(), "mcp connect record failed",
 			slog.String("tenant_id", auth.TenantID.String()),
 			slog.String("grant_id", auth.GrantID.String()),
@@ -540,6 +545,23 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 	if err != nil {
 		return h.toolError(req.ID, err)
 	}
+
+	// The operator-facing audit row (ActionMCPToolCalled), for this call and
+	// no other outcome: a refusal above never reached a tenant's data and is
+	// already covered by the WarnContext log at the refusal site. BEST-EFFORT
+	// like RecordConnect's client-identity write is not -- a failure here is
+	// logged, never returned to the caller, because withholding a successful
+	// read's answer over a failure to record having answered it would make an
+	// observational feature take down the read path it observes.
+	if err := h.svc.RecordToolCall(ctx, auth, entry.Name, string(entry.OperatorPermission)); err != nil {
+		h.log.ErrorContext(ctx, "mcp tool call audit write failed",
+			slog.String("tenant_id", auth.TenantID.String()),
+			slog.String("grant_id", auth.GrantID.String()),
+			slog.String("tool", entry.Name),
+			slog.String("error", err.Error()),
+		)
+	}
+
 	return newResponse(req.ID, map[string]any{
 		"content": []map[string]any{{"type": "text", "text": text}},
 	})

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -343,6 +343,11 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{}), http.StatusOK, true
 
 	case "tools/list":
+		// THE ACTIVITY STAMP IS BEFORE THE ANSWER, NOT AFTER IT. See
+		// stampActivity.
+		if resp, refused := h.stampActivity(ctx, auth, req); refused {
+			return resp, http.StatusOK, true
+		}
 		// VisibleTools, NOT Tools. Tools() is the whole registry and is not a
 		// request-path value; VisibleTools filters by this connection's
 		// capability set and site scope through the SAME predicate tools/call
@@ -351,6 +356,9 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{"tools": VisibleTools(auth)}), http.StatusOK, true
 
 	case "tools/call":
+		if resp, refused := h.stampActivity(ctx, auth, req); refused {
+			return resp, http.StatusOK, true
+		}
 		return h.callTool(ctx, auth, req), http.StatusOK, true
 
 	// Resources and prompts are OUT OF SCOPE for Phase 1 and are refused by
@@ -458,6 +466,39 @@ func (h *TransportHandler) initialize(
 type toolCallParams struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments"`
+}
+
+// stampActivity records that this connection was used, and reports whether the
+// request must be refused because the record could not be written. GH #605.
+//
+// IT RUNS BEFORE THE TOOL, AND THE ORDERING IS THE POINT. Stamping after a
+// successful call would leave every refused or failed call unrecorded, so a
+// connection whose calls are all being refused would look idle and would
+// eventually idle-expire -- silently converting a permissions problem into an
+// expired credential. What this column answers is "did anyone drive this
+// connection", and driving it is what the request already is by the time this
+// runs: Authenticate has passed, so the caller holds a live token on a live,
+// unexpired grant.
+//
+// A FAILED STAMP REFUSES THE REQUEST rather than being logged and dropped. See
+// Service.RecordActivity for why this one is not best-effort like the audit
+// append in callTool. The refusal is the INTERNAL code, never an auth or a
+// tool-availability code: nothing is wrong with the caller's token or its
+// capability set, and telling it otherwise would send an operator rotating a
+// credential that was never the problem.
+func (h *TransportHandler) stampActivity(ctx context.Context, auth AuthorizedRequest, req jsonrpcRequest) (jsonrpcResponse, bool) {
+	if err := h.svc.RecordActivity(ctx, auth); err != nil {
+		h.log.ErrorContext(ctx, "mcp activity stamp failed",
+			slog.String("tenant_id", auth.TenantID.String()),
+			slog.String("grant_id", auth.GrantID.String()),
+			slog.String("token_id", auth.TokenID.String()),
+			slog.String("method", req.Method),
+			slog.String("error", err.Error()),
+		)
+		return newErrorResponse(req.ID, codeInternalError,
+			"this request could not be recorded against the connection, so it was not served", nil), true
+	}
+	return jsonrpcResponse{}, false
 }
 
 // callTool is S7's EXIT GATE, and the gate is the absence of a `default` arm.

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -54,6 +54,14 @@ func liveGrantStore(siteIDs ...uuid.UUID) *fakeStore {
 			Authorized: true,
 			GrantID:    uuid.New(),
 			TokenID:    uuid.New(),
+			// m127: the capability set is READ FROM THIS ROW, so a fixture that
+			// omits it models a grant holding NO capability and every request
+			// against it is refused. That is the honest default -- leaving the
+			// field zero here and having the transport work anyway would mean
+			// the service was still computing capabilities instead of reading
+			// them.
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
 		},
 		scopeSites: siteIDs,
 	}

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -941,6 +942,113 @@ func TestNotification_ToolsCallWithNoIdDoesNotExecuteTheTool(t *testing.T) {
 	}
 	if !executed {
 		t.Fatal("the id-carrying control did not execute the tool either; the fixture is broken")
+	}
+}
+
+// TestActivityStamp_OnEveryToolCallAndNotOnKeepalives pins the decision GH #605
+// turns on: WHICH methods count as "used".
+//
+// The stamp is what makes mcp_grants.last_used_at real, and last_used_at is the
+// input to the idle-expiry deadline. Both directions are asserted because each
+// alone is a different bug:
+//
+//   - tools/list and tools/call MUST stamp. If they do not, an actively used
+//     connection reads as never used and idle-expires -- the fleet outage m127
+//     DECISION 4 describes.
+//   - ping and notifications/initialized MUST NOT. They are keepalives a stuck
+//     background process emits forever; letting them refresh the deadline makes
+//     "unused for 30 days" unfalsifiable and the feature decorative.
+//
+// initialize does not stamp either: RecordConnect already records that a client
+// connected (client_identity_recorded_at), which is the separate fact.
+func TestActivityStamp_OnEveryToolCallAndNotOnKeepalives(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantStamp bool
+	}{
+		{"tools/list stamps", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, true},
+		{"tools/call stamps",
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, true},
+		{"ping does not stamp", `{"jsonrpc":"2.0","id":1,"method":"ping"}`, false},
+		{"initialize does not stamp",
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"c","version":"1"}}}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := liveGrantStore(uuid.New())
+			r := newTransportRouter(t, store)
+
+			w := post(t, r, tc.body, nil)
+			if w.Code != http.StatusOK {
+				t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+			}
+
+			got := len(store.touchCalls) > 0
+			if got != tc.wantStamp {
+				t.Fatalf("%s: stamped=%v want %v (%d TouchActivity calls)",
+					tc.name, got, tc.wantStamp, len(store.touchCalls))
+			}
+			if !tc.wantStamp {
+				return
+			}
+			// The ids matter as much as the count: a stamp on the wrong grant
+			// keeps the wrong connection alive.
+			c := store.touchCalls[0]
+			if c.TenantID != store.token.TenantID {
+				t.Errorf("stamped tenant %s, want %s", c.TenantID, store.token.TenantID)
+			}
+			if c.GrantID != store.recheck.GrantID {
+				t.Errorf("stamped grant %s, want %s", c.GrantID, store.recheck.GrantID)
+			}
+			if c.TokenID != store.recheck.TokenID {
+				t.Errorf("stamped token %s, want %s", c.TokenID, store.recheck.TokenID)
+			}
+		})
+	}
+}
+
+// TestActivityStamp_FailureRefusesTheRequestAndDoesNotRunTheTool is the other
+// half of the decision: the stamp is NOT best-effort.
+//
+// A stamp that fails silently leaves the connection's idle clock running while
+// it is being used, and the cost lands N days later as an expiry nobody can
+// explain. So the request is refused -- with the INTERNAL code, never an auth
+// or tool-availability code, because nothing is wrong with the caller's token
+// or its capability set and telling it otherwise sends an operator rotating a
+// credential that was never the problem.
+func TestActivityStamp_FailureRefusesTheRequestAndDoesNotRunTheTool(t *testing.T) {
+	store := liveGrantStore(uuid.New())
+	store.touchErr = errors.New("simulated: the stamp could not be written")
+	r := newTransportRouter(t, store)
+
+	w := post(t, r,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+
+	var resp struct {
+		Error struct {
+			Code int `json:"code"`
+		} `json:"error"`
+		Result any `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (%s)", err, w.Body.String())
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Fatalf("error code = %d, want %d (internal): %s",
+			resp.Error.Code, codeInternalError, w.Body.String())
+	}
+	if resp.Result != nil {
+		t.Fatalf("a refused request still carried a result: %s", w.Body.String())
+	}
+
+	// AND THE TOOL DID NOT RUN. Serving the read anyway would mean the caller
+	// got its answer while the record that it asked says otherwise -- the stamp
+	// runs before the tool precisely so an unrecordable request is not served.
+	for _, c := range store.callLog() {
+		if c == "ListSitesForRead" {
+			t.Fatal("the tool executed despite the activity stamp failing")
+		}
 	}
 }
 

--- a/apps/api/migrations/20260829000000_m127_mcp_grant_expiry_capabilities.sql
+++ b/apps/api/migrations/20260829000000_m127_mcp_grant_expiry_capabilities.sql
@@ -1,0 +1,439 @@
+-- m127 - ADR-064 S4/S5: give an MCP grant an ABSOLUTE EXPIRY, an IDLE EXPIRY
+-- and an EXPLICIT PER-CONNECTION CAPABILITY SET.
+--
+-- This migration CORRECTS NOTHING. It edits no applied migration, it re-runs no
+-- earlier backfill, and no database in any state needs converging onto it
+-- beyond the one-time backfill in step (0) below, which is described in
+-- DECISION 9. There is no m114/m115-shaped follow-up owed.
+--
+-- WHY IT EXISTS. The connection wizard shipped with 3 of the 10 steps the
+-- wireframes specify. Steps 4 (choose what it may do) and 5 (expiry and
+-- security) cannot be built at all, because mcp_grants has nowhere to put their
+-- data: no expiry of either kind, and no capability set. m124 DECISION 1
+-- declined to mint a capabilities column and said why; internal/mcp/service.go
+-- names the exact column this migration must add, in the comment at the
+-- OrgDefaultCapabilities call site:
+--
+--     "the COLUMN it would read from arrives with its own migration, NOT NULL,
+--      no default, closed CHECK, as DECISION 1 requires."
+--
+-- That is the specification for DECISION 1 below, written by the code that will
+-- read the column. This file implements it literally.
+--
+-- ===========================================================================
+-- DECISION 1: THE CAPABILITY SET IS NOT NULL, HAS NO DEFAULT, AND ITS
+--             VOCABULARY IS CLOSED BY CHECK
+-- ===========================================================================
+--
+-- m124 DECISION 1 established the rule for the site axis: absence must be
+-- UNREPRESENTABLE or must mean REFUSED, never permitted. The capability axis
+-- gets the same treatment, by three separate mechanisms, because a single
+-- NOT NULL is not enough.
+--
+--   a. NOT NULL WITH NO DEFAULT. A nullable capabilities column that Go reads
+--      as "no narrowing applied, therefore every capability" is the precise
+--      defect this whole surface has been fighting, and it is the one shape
+--      CapabilitySet's zero value was designed to make impossible in Go. The
+--      column now makes it impossible in the database too: a caller that omits
+--      capabilities gets 23502, not an unrestricted connection.
+--
+--      THIS IS DELIBERATELY THE OPPOSITE OF api_keys.capabilities AT m120,
+--      which is NULLABLE with no default. m120's reasoning does not transfer
+--      and m124 DECISION 1(c) already said why: api_keys had a live fleet of
+--      pre-existing rows whose authority came from a `role` column, so '{}'
+--      would have stripped every key in the fleet at boot and NULL had to mean
+--      "this key has no capability set at all". mcp_grants has no second
+--      source of authority to fall back to. There is nothing for NULL to mean
+--      here except "unknown", and an unknown grant is refused, so the value is
+--      not worth being able to store.
+--
+--   b. AN EMPTY ARRAY IS PERMITTED AND MEANS EXACTLY ZERO CAPABILITIES. It is
+--      the restrictive direction: a connection holding '{}' reaches no tool.
+--      CapabilitySet in internal/mcp/policy.go has the same property and no
+--      method answering "does this mean everything", so the two agree.
+--
+--   c. THE VOCABULARY IS CLOSED BY CHECK, against the registry, BY NAME. This
+--      is the mechanism S7's exit gate asks for -- discovery never grants what
+--      the registry does not hold -- pushed down to the one place that cannot
+--      be forgotten at a call site.
+--
+--      THE VOCABULARY IS `mcp.sites.read`, AND THAT IS THE WHOLE LIST TODAY.
+--      internal/mcp/policy.go declares capabilityVocabulary as a closed map
+--      with exactly that one entry, and CapSitesRead is commented "the only
+--      capability the Phase 1 surface has". The CHECK below admits that one
+--      string and nothing else.
+--
+--      THE WIREFRAMES NAME THREE GROUPS AND THIS CHECK ADMITS ONE, ON PURPOSE.
+--      Step 4 draws site.content.read, site.inventory.read and
+--      site.content.propose. None of those exist in the registry. Admitting a
+--      name the registry does not hold would store a capability that resolves
+--      to no tool -- a grant the operator believes they made and the surface
+--      silently does not honour, which is the same shape as the dropped scope
+--      token scope.go already refuses. So Step 4 can be built now and will
+--      honestly offer one group until each further group arrives WITH ITS OWN
+--      MIGRATION EXTENDING THIS CHECK.
+--
+--      THAT COUPLING IS THE POINT, NOT AN INCONVENIENCE. m124 DECISION 1
+--      declined a capabilities column specifically because it "would create the
+--      place a write capability could appear without a migration and without a
+--      review". The closed CHECK is what buys the column back without buying
+--      that hazard: a write capability cannot reach this table until someone
+--      writes a migration naming it, which is a reviewed artefact. Adding a
+--      Capability to policy.go alone is NOT sufficient and will fail 23514 at
+--      the INSERT.
+--
+--   d. THE CEILING IS 64, AND IT IS A PROPERTY OF THE CREDENTIAL. The wireframe
+--      says so in those words ("A connection holds at most 64", "The ceiling is
+--      a property of the credential, not a licence tier"), and it is the same
+--      figure m120 chose for api_keys.capabilities. Shape is otherwise checked
+--      exactly as m120 checks it -- one dimension, no NULL element, no empty
+--      string -- using only IMMUTABLE expressions so the constraint is valid in
+--      a CHECK.
+--
+--      NOT CHECKED: element uniqueness. Deduplication needs a subquery
+--      (cardinality vs. a DISTINCT unnest) and CHECK forbids one. A duplicate
+--      is harmless to a set-membership read and merely consumes ceiling; the
+--      API layer should dedupe before insert.
+--
+-- ===========================================================================
+-- DECISION 2: TWO EXPIRIES, AND NULL MEANS A DIFFERENT THING IN EACH
+-- ===========================================================================
+--
+-- Absolute expiry and idle expiry are DIFFERENT FACTS. The brief requires that
+-- a NULL in either must not read as the other, nor as "never expires" when the
+-- operator chose a date. They are stated separately here because they are
+-- stored differently, and the difference is taken straight from the wireframe.
+--
+--   expires_at timestamptz NOT NULL, NO DEFAULT.
+--     NULL IS UNREPRESENTABLE. Not "NULL means never" -- there is no NULL.
+--     Step 5 offers four choices: 30 days, 90 days, 1 year, On a date. THERE IS
+--     NO "NEVER" OPTION ON THIS CONTROL. A never-expiring connection is not a
+--     thing the product offers, so it is not a thing the schema can hold, and
+--     the read-time predicate in DECISION 3 therefore has NO NULL BRANCH FOR A
+--     CALLER TO GET BACKWARDS. That is the entire reason this column is NOT
+--     NULL rather than nullable-with-a-convention.
+--
+--   idle_expire_after_days integer NULL, NO DEFAULT.
+--     NULL MEANS NEVER IDLE-EXPIRE, and it means only that. Step 5's second
+--     control does offer "Never" alongside 30 days and 90 days, so this axis
+--     genuinely has three states and the third is representable. It is an
+--     INTERVAL LENGTH, not an instant: the deadline is computed at read time
+--     from the activity stamp, so it moves whenever the connection is used,
+--     which is what "expire it if unused for 30 days" means. Storing a
+--     precomputed idle deadline would require rewriting the row on every
+--     request and would be wrong the moment a request was not recorded.
+--
+--     Stored as a day count rather than an interval because the control offers
+--     whole days, an integer needs no pgtype.Interval at the Go boundary, and a
+--     day count cannot smuggle a month or a microsecond into a security
+--     deadline.
+--
+--   THE TWO ARE INDEPENDENT AND BOTH BIND. A grant is refused if it is past its
+--   absolute expiry OR past its idle deadline. Neither can rescue the other.
+--
+-- ===========================================================================
+-- DECISION 3: EXPIRY IS PART OF THE `authorized` VERDICT, NOT A SECOND READ
+-- ===========================================================================
+--
+-- ReCheckMCPRequestAuthorizationInTenantTx already runs on EVERY REQUEST and
+-- already returns `authorized` as the whole verdict in one column, "computed
+-- here so that no caller reassembles it". Both expiries join that predicate in
+-- this migration's companion change to db/query/mcp_connections.sql.
+--
+-- A GRANT PAST EITHER EXPIRY NOW FAILS THE SAME PREDICATE A REVOKED GRANT
+-- FAILS. It is one boolean, one index probe on a primary key, no extra round
+-- trip, and no opportunity for a caller to forget the check -- which is the
+-- brief's requirement that expiry be enforceable at the point of use, cheaply.
+--
+-- THE WIREFRAME'S "no silent read-only period" IS A CONSEQUENCE OF THIS SHAPE.
+-- Expiry flips `authorized` to false outright; it does not degrade the
+-- connection to a reduced capability set. There is no code path here that could
+-- produce a half-working connection, because there is one boolean and not a
+-- tier.
+--
+-- NO SWEEP JOB IS REQUIRED FOR ENFORCEMENT. Expiry is evaluated at read time
+-- against now(), so a grant stops working at the instant it expires whether or
+-- not any background worker ran. A sweep is needed only for the wireframe's
+-- courtesy email ("14 days and 1 day before") and, optionally, for flipping
+-- status to a terminal value for display. Neither is an enforcement dependency,
+-- and a sweep that fails to run must never be able to extend a credential.
+--
+-- NO NEW INDEX. The hot path reaches the grant by primary key through the join
+-- on t.grant_id, so both expiry predicates are evaluated on an already-fetched
+-- row and index nothing. mcp_grants_live_idx (partial on status = 'active')
+-- already serves the notification sweep's candidate scan. Adding an index on
+-- expires_at would earn nothing on either path.
+--
+-- ===========================================================================
+-- DECISION 4: IDLE EXPIRY READS coalesce(last_used_at, created_at), AND IT IS
+--             INERT BY CONSTRUCTION UNTIL THE ACTIVITY STAMP IS WIRED
+-- ===========================================================================
+--
+-- THIS IS THE MOST DANGEROUS THING IN THIS MIGRATION AND IT IS WRITTEN DOWN
+-- RATHER THAN LEFT TO BE DISCOVERED.
+--
+-- mcp_grants.last_used_at IS NEVER WRITTEN TODAY. TouchMCPGrantInTenantTx
+-- exists in db/query/mcp_connections.sql, generates cleanly, and HAS ZERO GO
+-- CALLERS:
+--
+--   grep -rn "TouchMCPGrant" apps/api --include="*.go" | grep -v "internal/db/sqlc/"
+--     -> 0 matches
+--
+-- TouchMCPConnectionTokenInTenantTx is in the same state, also 0 callers. So
+-- every mcp_grants row in existence has last_used_at IS NULL regardless of how
+-- heavily its connection is used.
+--
+-- CONSEQUENCE, STATED PLAINLY: if a non-NULL idle_expire_after_days is ever
+-- written while the stamp is still unwired, coalesce(last_used_at, created_at)
+-- collapses to created_at permanently, and EVERY AFFECTED CONNECTION DIES
+-- idle_expire_after_days AFTER IT WAS CREATED NO MATTER HOW ACTIVE IT IS. With
+-- the wireframe's pre-selected 30 days that is a fleet-wide outage of every AI
+-- connection, thirty days after this ships, with no operator action and nothing
+-- in any log naming the cause.
+--
+-- THE SCHEMA IS SAFE BY CONSTRUCTION AGAINST THAT, AND ONLY BY CONSTRUCTION:
+-- idle_expire_after_days is NULL with NO DEFAULT, and NULL means never
+-- idle-expire, so no existing row and no row inserted by a caller that does not
+-- mention the column can idle-expire. The hazard is unreachable until Go
+-- deliberately writes a value into it.
+--
+-- THE ORDERING CONSTRAINT THIS PLACES ON backend-architect IS HARD:
+-- TouchMCPGrantInTenantTx must be called on the request path BEFORE the API is
+-- allowed to persist any non-NULL idle_expire_after_days. Wiring the stamp is a
+-- prerequisite of Step 5's second control, not a follow-up to it.
+--
+-- coalesce(last_used_at, created_at) is the right expression once the stamp is
+-- live -- a grant that has never been used is idle since it was created, which
+-- is precisely the credential the wireframe is aimed at ("a connection nobody
+-- has used in a month is a credential nobody is watching") -- and it is also
+-- what makes the unwired state degrade to "expires at created_at + N" rather
+-- than to something unbounded. It fails CLOSED, which is why the outage above
+-- is an outage and not a silent extension of every credential. That is the
+-- correct direction and it is still an outage.
+--
+-- ===========================================================================
+-- DECISION 5: RLS IS INHERITED, NOT ADDED, AND WHICH DISPATCH HELPER BINDS IT
+-- ===========================================================================
+--
+-- THIS MIGRATION CREATES NO TABLE AND NO POLICY. It adds three columns to
+-- mcp_grants, which m124 already put under ENABLE plus FORCE ROW LEVEL
+-- SECURITY with five policies: the permissive mcp_grants_tenant_isolation and
+-- the four RESTRICTIVE mcp_grants_site_scope_{select,insert,update,delete}.
+-- RLS filters ROWS, not columns, so a new column on a protected table is
+-- protected by the existing policies with no further statement. Adding a
+-- redundant policy here would be a second thing to keep in sync.
+--
+-- NO ROW IS OWED IN db/rls-cross-tenant-policies.txt. That ledger records
+-- policies that grant access ACROSS tenants. Every policy on mcp_grants is
+-- tenant-isolated, none of them is cross-tenant, and this migration adds no
+-- policy of any kind. The ledger is unchanged and check-rls-cross-tenant.sh
+-- must stay green without an edit.
+--
+-- WHICH DISPATCH HELPER A CALLER MUST USE: db.RunTenantTx, ALWAYS, AND THAT IS
+-- A CORRECTNESS REQUIREMENT AND NOT A CONVENTION. The four site_scope policies
+-- are RESTRICTIVE and each tests
+-- coalesce(current_setting('app.site_scope', true), '') <> 'on'. RunTenantTx
+-- (internal/db/db.go:772, dispatching through dispatchTenantTx at :755-763) is
+-- THE ONLY THING THAT SETS THAT GUC. A call site that picks InTenantTx,
+-- InTenantTxAsUser or InScopedTenantTx itself leaves it unset, the coalesced
+-- empty string is not equal to 'on', THE RESTRICTIVE CHECK PASSES, and the
+-- statement proceeds with no error raised anywhere.
+--
+-- A live privilege escalation of exactly that shape was fixed in this area on
+-- 2026-08-30: a call site used InTenantTx directly, app.site_scope was never
+-- set, and the policy admitted the write. A POLICY THAT TESTS A GUC IS INERT ON
+-- ANY PATH THAT DOES NOT SET IT. Capabilities and expiry are now part of what a
+-- site-scoped collaborator must not be able to widen, so every write to these
+-- three columns inherits that requirement.
+--
+-- ===========================================================================
+-- DECISION 6: THE BACKFILL PRESERVES TODAY'S EFFECTIVE AUTHORITY EXACTLY, AND
+--             IS NOT A PERMISSIVE DEFAULT
+-- ===========================================================================
+--
+-- Two of the three columns are NOT NULL, and mcp_grants is no longer guaranteed
+-- empty -- m124 applied on 2026-08-26 and this file lands on 2026-08-29, so a
+-- production row may exist. m124 DECISION 1(c) explicitly rested on "these
+-- tables start empty, so no such backfill hazard exists"; THAT SENTENCE HAS
+-- EXPIRED and this migration must handle rows.
+--
+-- A DEFAULT CLAUSE AND A ONE-TIME BACKFILL ARE NOT THE SAME THING. No column
+-- below carries a DEFAULT. Step (0) sets a value on rows that already exist and
+-- then the NOT NULL is armed, so every FUTURE insert must still say. The
+-- distinction is the whole of constraint 1 in the brief.
+--
+--   capabilities -> ARRAY['mcp.sites.read'].
+--     THIS GRANTS NOTHING NEW AND IT IS NOT A WILDCARD. It is the exact,
+--     complete set every existing grant already holds, read off the code rather
+--     than chosen: internal/mcp/service.go resolves the capability set as
+--     OrgDefaultCapabilities(grantScopes()), grantScopes() returns exactly
+--     {ScopeRead} for every live grant by construction, and scopeCapabilities
+--     maps ScopeRead to exactly {CapSitesRead}. So the backfill writes down what
+--     the running system already computes. Any existing connection keeps working
+--     with precisely the authority it has today, and gains none.
+--
+--     '{}' WAS CONSIDERED AND REJECTED. It is the more restrictive value, but it
+--     would silently strip every existing connection to zero capabilities the
+--     moment backend-architect wires the read, which is an outage caused by a
+--     migration rather than by an operator decision -- and it would be an
+--     outage justified as safety while the safe-and-correct value was known and
+--     derivable. Fail-closed is the right default when the answer is unknown.
+--     Here it is known.
+--
+--   expires_at -> now() + interval '90 days'.
+--     90 days is the wireframe's pre-selected choice. now() AND NOT
+--     created_at + 90 days, deliberately: keying off created_at would make any
+--     grant older than 90 days expire the instant this migration applies,
+--     inside main() at boot, on every install at once. now() + 90 days cannot
+--     be in the past for any row, so no existing connection is killed by
+--     applying this file, and every operator gets a full 90 days of notice to
+--     choose a real expiry. This is the m110/m111 lesson: a backfill that can
+--     land a row in an invalid or hostile state is the thing that needs the
+--     repair migration.
+--
+--   idle_expire_after_days -> left NULL.
+--     Nothing to backfill. NULL is a legal, meaningful value on this column
+--     (never idle-expire) and it is the only safe one while DECISION 4's stamp
+--     is unwired.
+--
+-- EVERY STATEMENT BELOW IS IDEMPOTENT AND THE FILE IS RE-RUNNABLE. The backfill
+-- is guarded by IS NULL so a second application updates zero rows and cannot
+-- push an operator-chosen expiry 90 days into the future.
+
+-- ---------------------------------------------------------------------------
+-- (0) Columns, added nullable so existing rows survive the ALTER.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "capabilities" text[];
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "expires_at" timestamptz;
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "idle_expire_after_days" integer;
+
+-- ---------------------------------------------------------------------------
+-- (1) Backfill. WHERE ... IS NULL makes this a no-op on a second run and
+--     protects a value an operator has already chosen. See DECISION 6.
+-- ---------------------------------------------------------------------------
+
+UPDATE "public"."mcp_grants"
+   SET "capabilities" = ARRAY['mcp.sites.read']::text[]
+ WHERE "capabilities" IS NULL;
+
+UPDATE "public"."mcp_grants"
+   SET "expires_at" = now() + interval '90 days'
+ WHERE "expires_at" IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- (2) Arm NOT NULL, now that no row violates it. SET NOT NULL is a no-op when
+--     the column is already NOT NULL, so this is safe to re-run.
+--     idle_expire_after_days stays NULLABLE -- NULL is a real value there.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."mcp_grants"
+    ALTER COLUMN "capabilities" SET NOT NULL;
+
+ALTER TABLE "public"."mcp_grants"
+    ALTER COLUMN "expires_at" SET NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- (3) Constraints. Each guarded by a pg_constraint probe so the file re-runs.
+-- ---------------------------------------------------------------------------
+
+-- Shape of the capability set. m120's constraint verbatim in intent: one
+-- dimension (a literal like '{{a},{b}}' would otherwise be flattened by
+-- unnest() into capabilities nobody granted), no NULL element, no empty string,
+-- and the 64 ceiling the wireframe states. IMMUTABLE expressions only.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_capabilities_shape_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_capabilities_shape_check"
+            CHECK (
+                coalesce(array_ndims("capabilities"), 1) = 1
+                AND cardinality("capabilities") <= 64
+                AND array_position("capabilities", NULL) IS NULL
+                AND NOT ('' = ANY ("capabilities"))
+            );
+    END IF;
+END;
+$$;
+
+-- Closed vocabulary. See DECISION 1(c). `<@` is array containment and is
+-- IMMUTABLE; the empty array is contained by every array, so '{}' -- zero
+-- capabilities, the restrictive value -- passes, which is intended.
+--
+-- EXTENDING THIS LIST IS A MIGRATION, and that is the review gate m124
+-- DECISION 1 asked for. Keep it in lockstep with capabilityVocabulary in
+-- apps/api/internal/mcp/policy.go.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_capabilities_vocabulary_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_capabilities_vocabulary_check"
+            CHECK ("capabilities" <@ ARRAY['mcp.sites.read']::text[]);
+    END IF;
+END;
+$$;
+
+-- A grant cannot be born already expired. Nonsense rather than danger -- an
+-- already-expired grant fails the DECISION 3 predicate and is refused -- but it
+-- is unrepresentable rather than merely harmless, which is the house standard.
+-- Immediate termination is REVOCATION (status = 'revoked'), not a backdated
+-- expiry, and keeping the two mechanisms distinct keeps revoked_at honest.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_expires_at_after_created_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_expires_at_after_created_check"
+            CHECK ("expires_at" > "created_at");
+    END IF;
+END;
+$$;
+
+-- The idle window is a positive number of days, or NULL for "never". Zero is
+-- refused because "expire it if unused for 0 days" has no meaning and would
+-- read as an immediate kill dressed up as a policy; ten years is the ceiling
+-- so a fat-fingered value cannot become an effectively-absent control.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_idle_expire_after_days_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_idle_expire_after_days_check"
+            CHECK (
+                "idle_expire_after_days" IS NULL
+                OR ("idle_expire_after_days" >= 1
+                    AND "idle_expire_after_days" <= 3650)
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- (4) Grants.
+--
+-- Nothing to add. m1's ALTER DEFAULT PRIVILEGES and m124's explicit
+-- GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_grants TO wpmgr_app are
+-- table-level and cover columns added later; PostgreSQL has no per-column
+-- grant in force on this table that a new column could fall outside of. Stated
+-- rather than left silent, because "the new column is invisible to wpmgr_app"
+-- is the kind of failure that looks like an RLS bug for a day.
+-- ---------------------------------------------------------------------------

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -96,7 +96,7 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("seed grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -85,6 +85,13 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  siteIDs,
 		ClientID:      &clientID,
+		// m127's three columns. capabilities and expires_at are NOT NULL with
+		// no default, so omitting either is a 23502 and not a permissive
+		// fixture. idle_expire_after_days is left NULL -- "never idle-expire" --
+		// which is what Service.Approve writes.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		return sqlc.CreateMCPAuthorizationCodeParams{
 			TenantID:            tenantID,

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -92,6 +92,10 @@ func s7GrantWithBearer(
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  siteIDs,
 		ClientID:      &clientID,
+		// m127: both NOT NULL with no default. See the s6b2 fixture.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		return sqlc.CreateMCPAuthorizationCodeParams{
 			TenantID:            tenantID,

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -103,7 +103,7 @@ func s7GrantWithBearer(
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("create grant for tenant %s: %v", tenantID, err)
 	}

--- a/apps/api/tests/mcp_audit_actor_attribution_integration_test.go
+++ b/apps/api/tests/mcp_audit_actor_attribution_integration_test.go
@@ -1,0 +1,332 @@
+// mcp_audit_actor_attribution_integration_test.go: the two remaining sites of
+// the nil-user audit-attribution defect -- Service.RevokeConnection and
+// Service.Approve -- proven against the REAL schema, RLS and application role,
+// through the SAME dispatch production uses.
+//
+// THE DEFECT. Both sites hardcoded `ActorType: audit.ActorUser` beside
+// `ActorID: Principal.UserID.String()`. apikey.PrincipalFor sets APIKeyID and
+// never UserID, so an API-key caller wrote uuid.Nil into actor_id under an
+// actor_type asserting a human acted. The row exists, hashes into the chain and
+// renders, and it explains nothing: actor_id names no user, and because
+// ListAuditEntries' name join is gated on actor_type ('user' -> users.name,
+// 'api_key' -> api_keys.name) the row resolves to no name either.
+//
+// WHY BOTH ARE REACHABLE BY A KEY, WHICH IS THE WHOLE PREMISE.
+//
+//	revoke   server.go's RegisterConnections(v1) mounts it from the SAME nil
+//	         check as the headless connection-token mint. An API key that can
+//	         mint can revoke, today, with nothing in between.
+//	consent  server.go's Register(v1) mounts /consent, and v1 derives from
+//	         sessionAuthGroup, which carries Auth.Authenticate() -- the same
+//	         Bearer-accepting group. "Consent is browser-only" is a convention
+//	         about who usually calls it, never a constraint on who can.
+//
+// THE REVOKE ROW IS THE CONSEQUENTIAL ONE. It is what an auditor reaches for
+// after an incident: "who killed this credential, and when". Answering that
+// with a user id that resolves to no user is worse than answering nothing.
+//
+// WHAT EVERY ASSERTION BELOW CHECKS, AND WHY IT IS BY VALUE. Each proof asserts
+// the actor_type and the actor_id it expects, BY VALUE, and each is paired with
+// a does-not-over-fire case driving the same route as a session user. A
+// resolver that answered "api_key" for every principal would satisfy the
+// API-key half alone; only the pair pins that the fix did not simply invert the
+// bug.
+//
+// Every write and every read goes through the same Service, the same Handler
+// and the same tx helpers server.New wires, on the app-role pool. No GUC is
+// hand-set anywhere in this file, and mcpAssertAndReportRole prints
+// current_user/rolsuper/rolbypassrls from pg_roles INSIDE the transaction under
+// test -- a proof that opened its own connection would leave every policy inert
+// and pass regardless.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// auditActorAPIKeyPrincipal builds EXACTLY what apikey.PrincipalFor produces
+// for an org-scoped owner key, and asserts the premise of every proof in this
+// file: that such a principal carries no UserID at all. If that ever stops
+// being true these tests still pass while proving nothing, so it is checked
+// rather than assumed.
+func auditActorAPIKeyPrincipal(t *testing.T, tenantID, keyID uuid.UUID) domain.Principal {
+	t.Helper()
+	p := domain.Principal{
+		Type: domain.PrincipalAPIKey, APIKeyID: keyID, TenantID: tenantID,
+		Role: "owner", Scope: domain.ScopeOrg, AuthModel: domain.AuthModelRole,
+	}
+	if p.UserID != uuid.Nil {
+		t.Fatal("an API-key principal carries a UserID; this whole file assumes it does not")
+	}
+	if p.ActorID() != keyID.String() {
+		t.Fatalf("ActorID() = %q, want the key id %s", p.ActorID(), keyID)
+	}
+	return p
+}
+
+// auditActorReportRole prints and asserts the role of the transaction the audit
+// read actually runs in.
+func auditActorReportRole(t *testing.T, pool *db.Pool, tenantID uuid.UUID) {
+	t.Helper()
+	if err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (the dispatch under test)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+}
+
+// findMCPAuditRow returns the single row for one action and target, failing if
+// there is none. "No row at all" and "a row naming the wrong actor" are
+// different defects and must not collapse into one assertion -- #613's own RLS
+// proof passed for the wrong reason by asserting only that something happened.
+func findMCPAuditRow(t *testing.T, pool *db.Pool, tenantID uuid.UUID,
+	action, targetID string) mcpAuditRow {
+	t.Helper()
+	var hits []mcpAuditRow
+	for _, r := range queryMCPAuditRowsAsAppRole(t, pool, tenantID, action) {
+		if r.targetID == targetID {
+			hits = append(hits, r)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("%s rows for target %s = %d, want exactly 1", action, targetID, len(hits))
+	}
+	return hits[0]
+}
+
+// assertActor is the by-value check. It never asserts merely that a row exists.
+func assertActor(t *testing.T, r mcpAuditRow, action, wantType, wantID string) {
+	t.Helper()
+	if r.actorID == uuid.Nil.String() {
+		t.Fatalf("%s actor_id is the ZERO UUID: the row exists and explains nothing", action)
+	}
+	if r.actorType != wantType {
+		t.Fatalf("%s actor_type = %q, want %q: the row attributes the act to a kind "+
+			"of actor that did not perform it, and the actor-name join is gated on "+
+			"this column", action, r.actorType, wantType)
+	}
+	if r.actorID != wantID {
+		t.Fatalf("%s actor_id = %q, want %q", action, r.actorID, wantID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SITE 1: Service.RevokeConnection (internal/mcp/service.go).
+//
+// The most consequential of the three instances. Mounted by the same call as
+// the mint, reachable by an API key today, and the row an incident review
+// starts from.
+// ---------------------------------------------------------------------------
+
+func TestMCPRevokeByAnAPIKeyNamesTheKeyInTheAuditRowAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-revoke-actor-"+suffix)
+	seedSite(t, pool, tenantID, "https://revokeactor-"+suffix+".example.test")
+	auditActorReportRole(t, pool, tenantID)
+
+	svc := mcp.NewService(mcp.NewRepo(pool)).
+		WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+
+	keyID := uuid.New()
+	keyEng := mountConnectionsLikeProduction(t, svc,
+		auditActorAPIKeyPrincipal(t, tenantID, keyID))
+
+	// Mint a connection with the key, then revoke it with the same key. Both
+	// halves go through RegisterConnections, which is the point: one mount,
+	// one credential, and until this fix only the mint recorded honestly.
+	var minted mintResponse
+	if code := mcpDoJSON(t, keyEng, http.MethodPost, mintPath, map[string]any{
+		"name":            "ci runner, revoked by its own key",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &minted); code != http.StatusCreated {
+		t.Fatalf("an API-key principal could not mint: %d", code)
+	}
+
+	var revoked struct {
+		GrantsRevoked int64 `json:"grants_revoked"`
+		TokensRevoked int64 `json:"tokens_revoked"`
+	}
+	if code := mcpDoJSON(t, keyEng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(minted.GrantID), nil, nil, &revoked); code != http.StatusOK {
+		t.Fatalf("an API-key principal could not revoke: %d", code)
+	}
+	if revoked.GrantsRevoked != 1 {
+		t.Fatalf("grants_revoked = %d, want 1 for a first revoke", revoked.GrantsRevoked)
+	}
+	if revoked.TokensRevoked != 1 {
+		t.Fatalf("tokens_revoked = %d, want 1: the cascade is the point of the method",
+			revoked.TokensRevoked)
+	}
+
+	row := findMCPAuditRow(t, pool, tenantID, audit.ActionMCPGrantRevoked, minted.GrantID)
+	assertActor(t, row, audit.ActionMCPGrantRevoked, audit.ActorAPIKey, keyID.String())
+	if row.metadata["already_revoked"] != false {
+		t.Fatalf("already_revoked = %v, want false for a first revoke", row.metadata["already_revoked"])
+	}
+	t.Logf("SITE 1 ok: mcp.grant.revoked attributed to api_key %s for grant %s",
+		keyID, minted.GrantID)
+
+	// DOES NOT OVER-FIRE. A session user revoking on the same route is still
+	// recorded as a user, with their own id.
+	userID := seedUserRow(t, pool, "revoke-actor-human-"+suffix+"@example.test")
+	humanEng := mountConnectionsLikeProduction(t, svc, domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	var humanMint mintResponse
+	if code := mcpDoJSON(t, humanEng, http.MethodPost, mintPath, map[string]any{
+		"name":            "human connection",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &humanMint); code != http.StatusCreated {
+		t.Fatalf("a session user could not mint: %d", code)
+	}
+	if code := mcpDoJSON(t, humanEng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(humanMint.GrantID), nil, nil, nil); code != http.StatusOK {
+		t.Fatalf("a session user could not revoke: %d", code)
+	}
+	humanRow := findMCPAuditRow(t, pool, tenantID, audit.ActionMCPGrantRevoked, humanMint.GrantID)
+	assertActor(t, humanRow, audit.ActionMCPGrantRevoked, audit.ActorUser, userID.String())
+	t.Logf("SITE 1 does not over-fire: a session user's revoke is still user %s", userID)
+}
+
+// ---------------------------------------------------------------------------
+// SITE 2: Service.Approve (internal/mcp/service.go), the /consent path.
+//
+// Scoped out of the earlier review on the grounds that consent is browser-only
+// in practice. That reasoning does not survive reading the mount: /consent sits
+// on the same Bearer-accepting group as the mint and the revoke, so an API-key
+// holder can drive the OAuth flow headlessly and did produce a zero-uuid row
+// when it did.
+// ---------------------------------------------------------------------------
+
+func TestMCPConsentByAnAPIKeyNamesTheKeyInTheAuditRowAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-consent-actor-"+suffix)
+	seedSite(t, pool, tenantID, "https://consentactor-"+suffix+".example.test")
+	auditActorReportRole(t, pool, tenantID)
+
+	svc := mcp.NewService(mcp.NewRepo(pool)).
+		WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+
+	keyID := uuid.New()
+	keyEng := mountLikeProduction(t, svc, auditActorAPIKeyPrincipal(t, tenantID, keyID))
+
+	keyGrantID := driveConsentAsPrincipal(t, keyEng, "api-key consent connection")
+	row := findMCPAuditRow(t, pool, tenantID, audit.ActionMCPGrantCreated, keyGrantID)
+	assertActor(t, row, audit.ActionMCPGrantCreated, audit.ActorAPIKey, keyID.String())
+	if _, ok := row.metadata["issuance"]; ok {
+		t.Fatalf("the consent path wrote an issuance key (%v); that field distinguishes "+
+			"a headless mint from a browser-consented grant and belongs only to the mint",
+			row.metadata["issuance"])
+	}
+	t.Logf("SITE 2 ok: mcp.grant.created via /consent attributed to api_key %s for grant %s",
+		keyID, keyGrantID)
+
+	// created_by_user_id stays NULL for a key. NULL is the honest answer, not a
+	// gap to fill with a synthetic uuid: that column means "the human who
+	// created it", and the actor lives on the audit row instead.
+	grantUUID, err := uuid.Parse(keyGrantID)
+	if err != nil {
+		t.Fatalf("parse grant id: %v", err)
+	}
+	var createdBy *uuid.UUID
+	if err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT created_by_user_id FROM mcp_grants WHERE tenant_id=$1 AND id=$2`,
+			tenantID, grantUUID).Scan(&createdBy)
+	}); err != nil {
+		t.Fatalf("read created_by_user_id: %v", err)
+	}
+	if createdBy != nil {
+		t.Fatalf("created_by_user_id = %v for an API-key consent, want NULL", *createdBy)
+	}
+
+	// DOES NOT OVER-FIRE. The browser path -- the one this site was assumed to
+	// be the only caller of -- still records the approving human.
+	userID := seedUserRow(t, pool, "consent-actor-human-"+suffix+"@example.test")
+	humanEng := mountLikeProduction(t, svc, domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	humanGrantID := driveConsentAsPrincipal(t, humanEng, "human consent connection")
+	humanRow := findMCPAuditRow(t, pool, tenantID, audit.ActionMCPGrantCreated, humanGrantID)
+	assertActor(t, humanRow, audit.ActionMCPGrantCreated, audit.ActorUser, userID.String())
+	t.Logf("SITE 2 does not over-fire: an approving human is still user %s", userID)
+}
+
+// driveConsentAsPrincipal runs register -> authorize -> consent against a
+// mounted engine and returns the grant id. The whole flow is driven rather than
+// the service being called directly, so the principal reaching Approve is the
+// one the route actually carries.
+func driveConsentAsPrincipal(t *testing.T, eng *gin.Engine, grantName string) string {
+	t.Helper()
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+
+	var reg struct {
+		ClientID string `json:"client_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.RegisterPath, map[string]any{
+		"redirect_uris":              []string{redirectURI},
+		"client_name":                "Claude Desktop",
+		"client_uri":                 "https://claude.ai",
+		"token_endpoint_auth_method": "none",
+	}, nil, &reg); code != http.StatusCreated {
+		t.Fatalf("register answered %d, want 201", code)
+	}
+
+	verifier := "actor-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", reg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "actor-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	if code := mcpDoJSON(t, eng, http.MethodGet,
+		mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		t.Fatalf("authorize answered %d, want 200", code)
+	}
+
+	var approval struct {
+		GrantID string `json:"grant_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConsentPath, map[string]any{
+		"client_id":             reg.ClientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "actor-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"name":                  grantName,
+		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+	}, nil, &approval); code != http.StatusOK {
+		t.Fatalf("consent answered %d, want 200", code)
+	}
+	if approval.GrantID == "" {
+		t.Fatal("consent returned no grant id")
+	}
+	return approval.GrantID
+}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -1,0 +1,371 @@
+// mcp_audit_events_integration_test.go: the three audit_events writes added to
+// the MCP connection surface -- ActionMCPGrantCreated, ActionMCPGrantRevoked,
+// ActionMCPToolCalled -- proven against the REAL schema, RLS and application
+// role, through the SAME code path production uses.
+//
+// WHY THIS FILE EXISTS. internal/mcp wrote ZERO rows to audit_log before this
+// slice: `grep -rn '\.Record(\|RecordInTx(' internal/mcp/*.go` matched nothing
+// outside _test.go's httptest.NewRecorder. An approve, a revoke or a tool call
+// that reaches a tenant's data left no attributable row. A unit test against
+// fakeStore cannot prove any of the three things that actually matter here:
+//
+//  1. mcp.grant.created lands in the SAME transaction as the grant insert
+//     (RecordInTx, not Record), so a rolled-back grant leaves no row claiming
+//     one exists -- see the rollback proof below.
+//  2. The row is readable back only through db.Pool as wpmgr_app -- NOSUPERUSER,
+//     NOBYPASSRLS -- which mcpAssertAndReportRole asserts and prints. A test
+//     that opened its own connection would leave every RLS policy inert and
+//     pass regardless; that is exactly how m112's proofs passed while the email
+//     domain was cross-site readable.
+//  3. A second tenant's InTenantTx cannot see the first tenant's assistant row,
+//     even though both share one physical audit_log table.
+//
+// So: every write and every read below goes through the same Service, the same
+// Handler, the same TransportHandler and the same tx helpers server.New wires,
+// with the app-role pool. No GUC is hand-set anywhere in this file.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpAuditRow is the slice of audit_log columns these proofs care about.
+type mcpAuditRow struct {
+	actorType string
+	actorID   string
+	targetID  string
+	metadata  map[string]any
+}
+
+// queryMCPAuditRowsAsAppRole reads audit_log for one tenant and action THROUGH
+// db.Pool.InTenantTx -- the same tx helper Recorder.List uses -- so RLS is live
+// for this read exactly as it is for the write under test.
+func queryMCPAuditRowsAsAppRole(t *testing.T, pool *db.Pool, tenantID uuid.UUID, action string) []mcpAuditRow {
+	t.Helper()
+	var out []mcpAuditRow
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(context.Background(),
+			`SELECT actor_type, actor_id, target_id, metadata FROM audit_log
+			  WHERE tenant_id = $1 AND action = $2`, tenantID, action)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var r mcpAuditRow
+			var metaRaw []byte
+			if err := rows.Scan(&r.actorType, &r.actorID, &r.targetID, &metaRaw); err != nil {
+				return err
+			}
+			if len(metaRaw) > 0 {
+				if err := json.Unmarshal(metaRaw, &r.metadata); err != nil {
+					return err
+				}
+			}
+			out = append(out, r)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		t.Fatalf("query audit_log action=%s for tenant %s: %v", action, tenantID, err)
+	}
+	return out
+}
+
+// TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole drives the
+// WHOLE MCP surface -- register, authorize, consent, exchange, a real tools/call
+// over the mounted transport, then revoke -- and asserts each of the three new
+// audit rows lands with the right actor, target and metadata. It also proves
+// tenant isolation: a second tenant's InTenantTx read sees none of it.
+func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion below.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-audit-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-audit-"+suffix+"@example.test")
+	siteURL := "https://" + suffix + ".example.test"
+	seedSite(t, pool, tenantID, siteURL)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	// An org-scoped admin: the role RegisterConnections' PermAPIKeyManage
+	// requires for revoke, and the only scope /consent admits.
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	eng := mountLikeProduction(t, svc, admin)
+
+	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
+	const grantName = "mcp audit events test connection"
+
+	// ------------------------------------------------------------------
+	// register -> authorize -> consent -> exchange, exactly as
+	// adr064_s6b3_mcp_oauth_end_to_end_test.go proves the flow composes.
+	// ------------------------------------------------------------------
+	var reg struct {
+		ClientID string `json:"client_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.RegisterPath, map[string]any{
+		"redirect_uris":              []string{redirectURI},
+		"client_name":                "Claude Desktop",
+		"client_uri":                 "https://claude.ai",
+		"token_endpoint_auth_method": "none",
+	}, nil, &reg); code != http.StatusCreated {
+		t.Fatalf("register answered %d, want 201", code)
+	}
+
+	verifier := "audit-verifier-" + uuid.NewString() + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", reg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", string(mcp.ScopeRead))
+	q.Set("state", "audit-state")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	if code := mcpDoJSON(t, eng, http.MethodGet, mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		t.Fatalf("authorize answered %d, want 200", code)
+	}
+
+	var approval struct {
+		GrantID string `json:"grant_id"`
+		Code    string `json:"code"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConsentPath, map[string]any{
+		"client_id":             reg.ClientID,
+		"redirect_uri":          redirectURI,
+		"scopes":                []string{string(mcp.ScopeRead)},
+		"state":                 "audit-state",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+		"name":                  grantName,
+		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+	}, nil, &approval); code != http.StatusOK {
+		t.Fatalf("consent answered %d, want 200", code)
+	}
+	grantID := approval.GrantID
+
+	// ------------------------------------------------------------------
+	// PROOF 1: mcp.grant.created landed, actor = the approving USER.
+	// ------------------------------------------------------------------
+	created := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	if len(created) != 1 {
+		t.Fatalf("mcp.grant.created rows = %d, want exactly 1", len(created))
+	}
+	if created[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.created actor_type = %q, want %q", created[0].actorType, audit.ActorUser)
+	}
+	if created[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.created actor_id = %q, want the approving user %q", created[0].actorID, userID)
+	}
+	if created[0].targetID != grantID {
+		t.Errorf("mcp.grant.created target_id = %q, want the grant id %q", created[0].targetID, grantID)
+	}
+	if got, _ := created[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.grant.created metadata.grant_name = %q, want %q", got, grantName)
+	}
+	t.Logf("PROOF 1 ok: mcp.grant.created attributed to user %s for grant %s", userID, grantID)
+
+	// ------------------------------------------------------------------
+	// Exchange the code, then call tools/call over the real transport.
+	// ------------------------------------------------------------------
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", approval.Code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", reg.ClientID)
+	form.Set("code_verifier", verifier)
+
+	tokReq := httptest.NewRequest(http.MethodPost, mcp.TokenPath, strings.NewReader(form.Encode()))
+	tokReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokReq.RemoteAddr = "203.0.113.7:5555"
+	tokW := httptest.NewRecorder()
+	eng.ServeHTTP(tokW, tokReq)
+	if tokW.Code != http.StatusOK {
+		t.Fatalf("token exchange answered %d, want 200: %s", tokW.Code, tokW.Body.String())
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(tokW.Body.Bytes(), &tok); err != nil {
+		t.Fatalf("token response is not JSON: %v", err)
+	}
+	if tok.AccessToken == "" {
+		t.Fatal("token exchange returned no access_token")
+	}
+
+	got := mcpRPC(t, eng, tok.AccessToken, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("tools/call %s answered %d, want 200: %s", mcp.ToolListSites, got.status, got.body)
+	}
+
+	// ------------------------------------------------------------------
+	// PROOF 2: mcp.tool.called landed, actor = the ASSISTANT (the grant),
+	// never the approving user.
+	// ------------------------------------------------------------------
+	called := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("mcp.tool.called rows = %d, want exactly 1", len(called))
+	}
+	if called[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.tool.called actor_type = %q, want %q", called[0].actorType, audit.ActorAssistant)
+	}
+	if called[0].actorID != grantID {
+		t.Errorf("mcp.tool.called actor_id = %q, want the grant id %q (NOT the user)", called[0].actorID, grantID)
+	}
+	if called[0].targetID != mcp.ToolListSites {
+		t.Errorf("mcp.tool.called target_id = %q, want the tool name %q", called[0].targetID, mcp.ToolListSites)
+	}
+	if got, _ := called[0].metadata["grant_name"].(string); got != grantName {
+		t.Errorf("mcp.tool.called metadata.grant_name = %q, want %q (the actor label)", got, grantName)
+	}
+	if got, _ := called[0].metadata["operator_permission"].(string); got != string(authz.PermSiteRead) {
+		t.Errorf("mcp.tool.called metadata.operator_permission = %q, want %q", got, authz.PermSiteRead)
+	}
+	t.Logf("PROOF 2 ok: mcp.tool.called attributed to assistant/grant %s, not to user %s", grantID, userID)
+
+	// ------------------------------------------------------------------
+	// PROOF 3 (tenant isolation): a SECOND tenant's InTenantTx read sees
+	// NONE of tenant 1's assistant row, even though both live in the same
+	// physical audit_log table.
+	// ------------------------------------------------------------------
+	otherTenant := seedTenant(t, pool, "mcp-audit-other-"+suffix)
+	cross := queryMCPAuditRowsAsAppRole(t, pool, otherTenant, audit.ActionMCPToolCalled)
+	if len(cross) != 0 {
+		t.Fatalf("PROOF 3: tenant %s's InTenantTx read %d mcp.tool.called row(s) belonging to "+
+			"tenant %s; RLS did not isolate the assistant actor's row across tenants",
+			otherTenant, len(cross), tenantID)
+	}
+	t.Logf("PROOF 3 ok: tenant %s cannot see tenant %s's assistant audit row", otherTenant, tenantID)
+
+	// ------------------------------------------------------------------
+	// PROOF 4: mcp.grant.revoked landed, actor = the revoking USER.
+	// ------------------------------------------------------------------
+	connEng := mountConnectionsLikeProduction(t, svc, admin)
+	var revoked struct {
+		GrantsRevoked int64 `json:"grants_revoked"`
+	}
+	if code := mcpDoJSON(t, connEng, http.MethodPost,
+		mcp.ConnectionRevokePathFor(grantID), nil, nil, &revoked); code != http.StatusOK {
+		t.Fatalf("revoke answered %d, want 200", code)
+	}
+	if revoked.GrantsRevoked != 1 {
+		t.Fatalf("revoke grants_revoked = %d, want 1 for a first revoke", revoked.GrantsRevoked)
+	}
+
+	revokedRows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantRevoked)
+	if len(revokedRows) != 1 {
+		t.Fatalf("mcp.grant.revoked rows = %d, want exactly 1", len(revokedRows))
+	}
+	if revokedRows[0].actorType != audit.ActorUser {
+		t.Errorf("mcp.grant.revoked actor_type = %q, want %q", revokedRows[0].actorType, audit.ActorUser)
+	}
+	if revokedRows[0].actorID != userID.String() {
+		t.Errorf("mcp.grant.revoked actor_id = %q, want the revoking user %q", revokedRows[0].actorID, userID)
+	}
+	if revokedRows[0].targetID != grantID {
+		t.Errorf("mcp.grant.revoked target_id = %q, want the grant id %q", revokedRows[0].targetID, grantID)
+	}
+	t.Logf("PROOF 4 ok: mcp.grant.revoked attributed to user %s for grant %s", userID, grantID)
+}
+
+// TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole is the
+// fail-closed half: Service.Approve wires the ActionMCPGrantCreated append
+// through Repo.CreateGrantWithCode's onCreated hook, which runs INSIDE the same
+// transaction as both inserts. This simulates an onCreated-shaped failure (the
+// exact hook the audit append uses) and asserts the whole write rolls back --
+// no mcp_grants row AND no audit_log row for the grant id that never committed.
+func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenantID := seedTenant(t, pool, "mcp-audit-rb-"+uuid.NewString()[:8])
+	repo := mcp.NewRepo(pool)
+	principal := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+
+	simulated := errors.New("simulated: mcp.grant.created append failed")
+	var capturedGrantID uuid.UUID
+	_, _, err := repo.CreateGrantWithCode(ctx, principal, sqlc.CreateMCPGrantParams{
+		TenantID:      tenantID,
+		Name:          "should not survive",
+		Status:        "active",
+		SiteScopeMode: "all",
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  []uuid.UUID{},
+	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+		capturedGrantID = grantID
+		return sqlc.CreateMCPAuthorizationCodeParams{
+			TenantID:            tenantID,
+			GrantID:             grantID,
+			ClientID:            "rollback-probe-client",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
+			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
+		}
+	}, func(tx pgx.Tx, gr sqlc.McpGrant) error {
+		return simulated
+	})
+
+	if err == nil {
+		t.Fatal("CreateGrantWithCode succeeded despite the onCreated hook failing, want an error")
+	}
+	if !errors.Is(err, simulated) {
+		t.Errorf("error = %v, want it to wrap the simulated failure", err)
+	}
+	if capturedGrantID == uuid.Nil {
+		t.Fatal("the grant id was never captured; the insert must run before onCreated for this proof to mean anything")
+	}
+
+	var grantCount int
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM mcp_grants WHERE id = $1`, capturedGrantID).Scan(&grantCount)
+	}); err != nil {
+		t.Fatalf("count mcp_grants: %v", err)
+	}
+	if grantCount != 0 {
+		t.Errorf("mcp_grants row for %s committed despite the audit hook failing, want 0 rows", capturedGrantID)
+	}
+
+	rows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPGrantCreated)
+	for _, r := range rows {
+		if r.targetID == capturedGrantID.String() {
+			t.Fatalf("found an mcp.grant.created row for grant %s, which never committed", capturedGrantID)
+		}
+	}
+	t.Logf("rollback proof ok: neither mcp_grants nor audit_log carries a row for %s", capturedGrantID)
+}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -325,6 +325,13 @@ func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *tes
 		SiteScopeMode: "all",
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  []uuid.UUID{},
+		// m127: both NOT NULL with no default. Supplied so the rollback this
+		// test asserts is the SIMULATED audit failure and not a 23502 that
+		// would roll the same transaction back for the wrong reason -- which
+		// would make the assertion pass while proving nothing.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		capturedGrantID = grantID
 		return sqlc.CreateMCPAuthorizationCodeParams{

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -331,7 +331,7 @@ func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *tes
 			TenantID:            tenantID,
 			GrantID:             grantID,
 			ClientID:            "rollback-probe-client",
-			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			CodeHash:            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 			CodeChallengeMethod: "S256",
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",

--- a/apps/api/tests/mcp_connection_token_mint_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_integration_test.go
@@ -1,0 +1,476 @@
+package tests
+
+// Integration proofs for the connection-token mint: the DOCUMENTED HEADLESS
+// PATH (POST /api/v1/mcp/connections).
+//
+// EVERYTHING HERE RUNS AS wpmgr_app, THROUGH THE POOL, THROUGH THE MOUNTED
+// ROUTE. That is the whole reason this file exists alongside the package's unit
+// proofs: a fake store evaluates no policy and a test that opens its own
+// connection leaves every RLS policy inert while staying green, which is
+// exactly how m112's proofs passed over a cross-site-readable domain. The
+// credential minted here is authenticated back through mcp.Service.Authenticate
+// -- the same call the live transport makes on every request.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/sitetag"
+)
+
+// mintPath is the route under test, built from the package's own constants so
+// this file cannot drift from the mount.
+const mintPath = mcp.APIV1Prefix + "/mcp/connections"
+
+// mintResponse is the 201 body. `token` is decoded into a plain string rather
+// than skipped, because the point of every test below is what that string can
+// then do.
+type mintResponse struct {
+	GrantID       string   `json:"grant_id"`
+	Token         string   `json:"token"`
+	TokenPrefix   string   `json:"token_prefix"`
+	ExpiresAt     string   `json:"expires_at"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	Capabilities  []string `json:"capabilities"`
+}
+
+// TestMCPMintedTokenAuthenticatesAndIsTenantBoundAsAppRole is the end-to-end
+// proof: mint through the mounted route, authenticate the returned plaintext
+// through the production dispatch, and prove the credential reaches its own
+// organisation and nothing else.
+func TestMCPMintedTokenAuthenticatesAndIsTenantBoundAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// THE ROLE IS LOAD-BEARING FOR EVERY ASSERTION BELOW. Printed, not
+	// assumed: a proof running as superuser or BYPASSRLS would pass with every
+	// policy switched off.
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open token lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+
+	// TWO ORGANISATIONS. The second is not decoration: a token that
+	// authenticates is only interesting alongside proof that it authenticates
+	// NOTHING next door.
+	tenantA := seedTenant(t, pool, "mcp-mint-a-"+suffix)
+	tenantB := seedTenant(t, pool, "mcp-mint-b-"+suffix)
+	userA := seedUserRow(t, pool, "mint-a-"+suffix+"@example.test")
+	userB := seedUserRow(t, pool, "mint-b-"+suffix+"@example.test")
+
+	siteAURL := "https://a-" + suffix + ".example.test"
+	siteBURL := "https://b-" + suffix + ".example.test"
+	seedSite(t, pool, tenantA, siteAURL)
+	seedSite(t, pool, tenantB, siteBURL)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	adminA := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+	adminB := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userB, TenantID: tenantB,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+	engA := mountConnectionsLikeProduction(t, svc, adminA)
+	engB := mountConnectionsLikeProduction(t, svc, adminB)
+
+	// ------------------------------------------------------------------
+	// MINT, through the mounted route with its real RequirePermission.
+	// ------------------------------------------------------------------
+	var mintedA mintResponse
+	if code := mcpDoJSON(t, engA, http.MethodPost, mintPath, map[string]any{
+		"name":            "headless ci runner",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &mintedA); code != http.StatusCreated {
+		t.Fatalf("mint answered %d, want 201", code)
+	}
+	if mintedA.Token == "" {
+		t.Fatal("the mint returned no plaintext: there is no credential to use")
+	}
+	if mintedA.TokenPrefix == "" || !strings.HasPrefix(mintedA.Token, mintedA.TokenPrefix) {
+		t.Fatalf("token_prefix %q is not a prefix of the plaintext", mintedA.TokenPrefix)
+	}
+	if len(mintedA.Capabilities) == 0 {
+		t.Fatal("the grant was minted with NO capabilities: it would authenticate and reach no tool")
+	}
+
+	// ------------------------------------------------------------------
+	// THE CREDENTIAL WORKS, through the same call the transport makes.
+	// ------------------------------------------------------------------
+	authA, err := svc.Authenticate(ctx, mintedA.Token)
+	if err != nil {
+		t.Fatalf("the minted token does not authenticate: %v", err)
+	}
+	if authA.TenantID != tenantA {
+		t.Fatalf("token resolved to tenant %s, want %s", authA.TenantID, tenantA)
+	}
+	if authA.GrantID.String() != mintedA.GrantID {
+		t.Fatalf("token resolved to grant %s, want %s", authA.GrantID, mintedA.GrantID)
+	}
+	if authA.Sites.IsEmpty() {
+		t.Fatal("a site_scope_mode='all' grant resolved to no sites")
+	}
+
+	// ------------------------------------------------------------------
+	// ONLY THE HASH IS STORED. Read back as wpmgr_app inside InTenantTx --
+	// the same transaction shape the request path uses.
+	// ------------------------------------------------------------------
+	assertNoPlaintextStored(t, pool, tenantA, authA.GrantID, mintedA.Token, mintedA.TokenPrefix)
+
+	// ------------------------------------------------------------------
+	// CROSS-TENANT. Tenant B mints its own token; neither reaches the other.
+	// ------------------------------------------------------------------
+	var mintedB mintResponse
+	if code := mcpDoJSON(t, engB, http.MethodPost, mintPath, map[string]any{
+		"name":            "tenant b runner",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &mintedB); code != http.StatusCreated {
+		t.Fatalf("tenant B mint answered %d, want 201", code)
+	}
+	authB, err := svc.Authenticate(ctx, mintedB.Token)
+	if err != nil {
+		t.Fatalf("tenant B's token does not authenticate: %v", err)
+	}
+	if authB.TenantID != tenantB {
+		t.Fatalf("tenant B's token resolved to tenant %s, want %s", authB.TenantID, tenantB)
+	}
+
+	// The load-bearing half: A's credential must reach A's fleet and NOT B's.
+	// Asserted on the rendered tool output, which is what a model would
+	// actually receive.
+	readA, err := svc.ListSitesForModel(ctx, authA)
+	if err != nil {
+		t.Fatalf("list sites under tenant A's token: %v", err)
+	}
+	if !strings.Contains(readA, siteAURL) {
+		t.Fatalf("tenant A's token cannot see tenant A's own site %s:\n%s", siteAURL, readA)
+	}
+	if strings.Contains(readA, siteBURL) {
+		t.Fatalf("CROSS-TENANT READ: tenant A's token saw tenant B's site %s:\n%s", siteBURL, readA)
+	}
+
+	readB, err := svc.ListSitesForModel(ctx, authB)
+	if err != nil {
+		t.Fatalf("list sites under tenant B's token: %v", err)
+	}
+	if strings.Contains(readB, siteAURL) {
+		t.Fatalf("CROSS-TENANT READ: tenant B's token saw tenant A's site %s:\n%s", siteAURL, readB)
+	}
+
+	// Tenant B's grant is invisible to tenant A's connections list, and vice
+	// versa. This reads through the operator surface rather than the token
+	// surface, so both RLS paths are exercised.
+	assertGrantNotVisible(t, engA, mintedB.GrantID, "tenant A")
+	assertGrantNotVisible(t, engB, mintedA.GrantID, "tenant B")
+
+	// ------------------------------------------------------------------
+	// THE AUDIT ROW EXISTS, in tenant A and only in tenant A.
+	// ------------------------------------------------------------------
+	rows := queryMCPAuditRowsAsAppRole(t, pool, tenantA, audit.ActionMCPGrantCreated)
+	var found bool
+	for _, r := range rows {
+		if r.targetID != mintedA.GrantID {
+			continue
+		}
+		found = true
+		if r.actorType != audit.ActorUser {
+			t.Errorf("mcp.grant.created actor_type = %q, want %q", r.actorType, audit.ActorUser)
+		}
+		if r.actorID != userA.String() {
+			t.Errorf("mcp.grant.created actor_id = %q, want the minting operator %s", r.actorID, userA)
+		}
+		// The issuance discriminator is what separates a headless mint from a
+		// browser-consented grant in the log. Without it an auditor cannot
+		// tell which authorisation produced the credential.
+		if got, _ := r.metadata["issuance"].(string); got != "connection_token" {
+			t.Errorf("mcp.grant.created metadata.issuance = %q, want %q", got, "connection_token")
+		}
+		// The PUBLIC handle travels; the plaintext must not.
+		if got, _ := r.metadata["token_prefix"].(string); got != mintedA.TokenPrefix {
+			t.Errorf("metadata.token_prefix = %q, want %q", got, mintedA.TokenPrefix)
+		}
+		meta, mErr := json.Marshal(r.metadata)
+		if mErr != nil {
+			t.Fatalf("re-marshal audit metadata: %v", mErr)
+		}
+		if strings.Contains(string(meta), mintedA.Token) {
+			t.Fatalf("THE PLAINTEXT WAS WRITTEN TO THE AUDIT LOG: %s", meta)
+		}
+	}
+	if !found {
+		t.Fatalf("no %s audit row for grant %s: this credential is unexplained",
+			audit.ActionMCPGrantCreated, mintedA.GrantID)
+	}
+	// Tenant B must not see tenant A's audit row.
+	for _, r := range queryMCPAuditRowsAsAppRole(t, pool, tenantB, audit.ActionMCPGrantCreated) {
+		if r.targetID == mintedA.GrantID {
+			t.Fatal("CROSS-TENANT AUDIT LEAK: tenant B can read tenant A's mcp.grant.created row")
+		}
+	}
+}
+
+// TestMCPMintRefusesASiteScopedCollaboratorAsAppRole proves the org-scope guard
+// holds through the mounted route, as wpmgr_app, AND that nothing was written.
+//
+// A site-scoped collaborator minting an organisation-wide grant was a live
+// production defect on the consent path. This is the same class of write behind
+// the same class of gate, so it gets the same proof.
+func TestMCPMintRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open token lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-scope-"+suffix)
+	userID := seedUserRow(t, pool, "mint-scope-"+suffix+"@example.test")
+	siteID := seedSite(t, pool, tenantID, "https://s-"+suffix+".example.test")
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+
+	// An outside collaborator shared onto ONE site, holding admin ON THAT SITE.
+	// Still refused: a grant is an organisation-wide credential.
+	collaborator := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeSite, AllowedSiteIDs: []uuid.UUID{siteID},
+	}
+	eng := mountConnectionsLikeProduction(t, svc, collaborator)
+
+	before := countAllGrants(t, pool, tenantID)
+
+	var body map[string]any
+	code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "escalation attempt",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &body)
+	if code == http.StatusCreated {
+		t.Fatalf("A SITE-SCOPED COLLABORATOR MINTED AN ORG-WIDE CONNECTION TOKEN (201): %v", body)
+	}
+	if code != http.StatusForbidden {
+		t.Fatalf("mint answered %d, want 403", code)
+	}
+	// A refusal that still wrote is a refusal of the RESPONSE only.
+	if after := countAllGrants(t, pool, tenantID); after != before {
+		t.Fatalf("the refused mint still wrote: grants went from %d to %d", before, after)
+	}
+}
+
+// TestMCPMintScopeReferentsAsAppRole proves the two halves of the scope
+// decision against a REAL tag registry:
+//
+//	a real tag carrying zero sites -> ACCEPTED and stored as given
+//	a tag id naming no tag at all  -> REFUSED, by id
+//
+// Those are different questions and conflating them is the defect: the first is
+// a legitimate connection that reads nothing today, and refusing it would
+// contradict the owner's ruling; the second stores cleanly (scope_tag_ids is a
+// uuid[] with no foreign key) and then resolves to nothing forever.
+func TestMCPMintScopeReferentsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open token lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-scope-ref-"+suffix)
+	userID := seedUserRow(t, pool, "mint-ref-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://ref-"+suffix+".example.test")
+
+	// A REAL TAG CARRYING NO SITES. Created through the real service, so it is
+	// a genuine registry row rather than a hand-inserted one.
+	_, tagSvc := newSiteTagServices(pool)
+	emptyTag, err := tagSvc.Create(ctx, sitetag.CreateInput{
+		TenantID: tenantID, Name: "unused-" + suffix, Color: "#112233",
+	})
+	if err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	admin := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+	eng := mountConnectionsLikeProduction(t, svc, admin)
+
+	// ---- ACCEPTED, AND STORED AS GIVEN, NEVER WIDENED --------------------
+	var minted mintResponse
+	if code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "reads nothing yet",
+		"site_scope_mode": string(mcp.SiteScopeModeTags),
+		"scope_tag_ids":   []string{emptyTag.ID.String()},
+	}, nil, &minted); code != http.StatusCreated {
+		t.Fatalf("a real tag carrying zero sites was refused: mint answered %d, want 201", code)
+	}
+
+	grantID, err := uuid.Parse(minted.GrantID)
+	if err != nil {
+		t.Fatalf("parse grant id: %v", err)
+	}
+	mode, tagIDs := readStoredScope(t, pool, tenantID, grantID)
+	if mode != string(mcp.SiteScopeModeTags) {
+		t.Fatalf("THE SCOPE WAS WIDENED: stored site_scope_mode = %q, want %q",
+			mode, mcp.SiteScopeModeTags)
+	}
+	if len(tagIDs) != 1 || tagIDs[0] != emptyTag.ID {
+		t.Fatalf("the tag payload was not stored as given: %v", tagIDs)
+	}
+
+	// The connection authenticates, and its site scope resolves to NOTHING --
+	// which the read tool then refuses BY NAME rather than reporting as an
+	// empty fleet. That is the shape of a legitimately empty connection.
+	auth, err := svc.Authenticate(ctx, minted.Token)
+	if err != nil {
+		t.Fatalf("the empty-scope token does not authenticate: %v", err)
+	}
+	if !auth.Sites.IsEmpty() {
+		t.Fatalf("a tag carrying no sites resolved to %d sites", auth.Sites.Len())
+	}
+	if _, err := svc.ListSitesForModel(ctx, auth); err == nil {
+		t.Fatal("an empty site scope returned an empty LIST instead of a named refusal")
+	}
+
+	// ---- REFUSED, BY ID --------------------------------------------------
+	ghost := uuid.New()
+	var body map[string]any
+	code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "typo scope",
+		"site_scope_mode": string(mcp.SiteScopeModeTags),
+		"scope_tag_ids":   []string{ghost.String()},
+	}, nil, &body)
+	if code == http.StatusCreated {
+		t.Fatalf("a tag id naming NO TAG was accepted (201): the scope is silently narrowed to nothing: %v", body)
+	}
+	if code != http.StatusUnprocessableEntity && code != http.StatusBadRequest {
+		t.Fatalf("unknown tag answered %d, want a 4xx validation refusal", code)
+	}
+	raw, mErr := json.Marshal(body)
+	if mErr != nil {
+		t.Fatalf("marshal refusal body: %v", mErr)
+	}
+	if !strings.Contains(string(raw), ghost.String()) {
+		t.Fatalf("the refusal does not name the offending id %s, so it cannot be acted on: %s",
+			ghost, raw)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers. All read THROUGH THE POOL as wpmgr_app, inside the tenant
+// transaction the request path uses -- never a raw connection, which would read
+// past RLS and could report rows the application can never see.
+// ---------------------------------------------------------------------------
+
+// assertNoPlaintextStored proves the token row holds a hash and a prefix and
+// not the credential, and that the hash satisfies the column's CHECK shape.
+func assertNoPlaintextStored(t *testing.T, pool *db.Pool, tenantID, grantID uuid.UUID, plaintext, prefix string) {
+	t.Helper()
+	var storedHash, storedPrefix string
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT token_hash, token_prefix FROM mcp_connection_tokens
+			  WHERE tenant_id = $1 AND grant_id = $2`,
+			tenantID, grantID).Scan(&storedHash, &storedPrefix)
+	})
+	if err != nil {
+		t.Fatalf("read back the token row: %v", err)
+	}
+	if storedHash == plaintext {
+		t.Fatal("THE PLAINTEXT IS IN token_hash")
+	}
+	if storedPrefix != prefix {
+		t.Fatalf("stored token_prefix %q disagrees with the returned one %q", storedPrefix, prefix)
+	}
+	if storedPrefix == plaintext {
+		t.Fatal("token_prefix is the WHOLE credential, so the public handle is the secret")
+	}
+	// The column's CHECK is '^[0-9a-f]{64}$'. Asserted here too, because a
+	// value that satisfies it is by construction not the base64url plaintext.
+	if len(storedHash) != 64 {
+		t.Fatalf("token_hash is %d chars, want 64", len(storedHash))
+	}
+	for _, r := range storedHash {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			t.Fatalf("token_hash %q is not lower-case hex", storedHash)
+		}
+	}
+}
+
+// readStoredScope returns the grant's stored site scope, so a test can prove
+// the payload was stored AS GIVEN rather than widened.
+func readStoredScope(t *testing.T, pool *db.Pool, tenantID, grantID uuid.UUID) (string, []uuid.UUID) {
+	t.Helper()
+	var mode string
+	var tagIDs []uuid.UUID
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT site_scope_mode, scope_tag_ids FROM mcp_grants
+			  WHERE tenant_id = $1 AND id = $2`,
+			tenantID, grantID).Scan(&mode, &tagIDs)
+	})
+	if err != nil {
+		t.Fatalf("read stored scope: %v", err)
+	}
+	return mode, tagIDs
+}
+
+// countGrants counts the tenant's grants as wpmgr_app, so "nothing was written"
+// is a statement about what the application can see.
+func countAllGrants(t *testing.T, pool *db.Pool, tenantID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM mcp_grants WHERE tenant_id = $1`, tenantID).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("count grants: %v", err)
+	}
+	return n
+}
+
+// assertGrantNotVisible proves one organisation's connections list does not
+// carry another's grant id.
+func assertGrantNotVisible(t *testing.T, eng *gin.Engine, grantID, who string) {
+	t.Helper()
+	var list struct {
+		Connections []struct {
+			ID string `json:"id"`
+		} `json:"connections"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodGet, mintPath, nil, nil, &list); code != http.StatusOK {
+		t.Fatalf("%s list answered %d, want 200", who, code)
+	}
+	for _, c := range list.Connections {
+		if c.ID == grantID {
+			t.Fatalf("CROSS-TENANT LEAK: %s can see grant %s", who, grantID)
+		}
+	}
+}

--- a/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
@@ -1,0 +1,559 @@
+package tests
+
+// Integration proofs for the connection-token mint's LAYERS, alongside the
+// end-to-end proofs in mcp_connection_token_mint_integration_test.go.
+//
+// WHY A SECOND FILE. The end-to-end proofs drive the mounted route, so every
+// layer is stacked and a passing test cannot say WHICH layer refused. The
+// proofs here each remove the layers above the one under test:
+//
+//   - the RESTRICTIVE mcp_grants_site_scope_insert policy, reached with BOTH
+//     app-layer guards bypassed, because a policy that is only ever exercised
+//     behind two guards that already refuse is a policy nothing would notice
+//     the loss of;
+//   - the transaction boundary, by making the second insert and then the audit
+//     append fail on purpose;
+//   - the ACTOR on the audit row, for the API-key caller that is this headless
+//     endpoint's natural one.
+//
+// EVERYTHING HERE RUNS AS wpmgr_app THROUGH db.Pool, never a raw connection: a
+// test that opens its own connection leaves every policy inert and still
+// passes, which is exactly how m112's proofs stayed green over a
+// cross-site-readable domain.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/sitetag"
+)
+
+// ---------------------------------------------------------------------------
+// LAYER 3, ON ITS OWN: THE RESTRICTIVE INSERT POLICY.
+//
+// The mint has three gates against a site-scoped collaborator minting an
+// organisation-wide credential: authz.RequirePermission(PermAPIKeyManage) on
+// the route, requireOrgScopedPrincipal in the service, and
+// mcp_grants_site_scope_insert in the database. Driven through the mounted
+// route, the FIRST one answers and the other two are never consulted -- so the
+// route-level proof stays green with requireOrgScopedPrincipal deleted, and
+// green with the POLICY DROPPED. Nothing would report the loss.
+//
+// This reaches Repo.CreateGrantWithToken directly, which skips both app-layer
+// gates and leaves the policy as the only thing standing. It is the only shape
+// that can tell whether layer 3 is real or merely shadowed.
+// ---------------------------------------------------------------------------
+
+func TestMCPMintRLSInsertPolicyRefusesASiteScopedPrincipalAloneAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion in this file: as a
+	// superuser or a BYPASSRLS role the policy below is inert and this test
+	// would pass while proving nothing.
+	if err := pool.InTenantTx(ctx, uuid.New(), func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-rls-"+suffix)
+	userID := seedUserRow(t, pool, "mint-rls-"+suffix+"@example.test")
+	siteID := seedSite(t, pool, tenantID, "https://mintrls-"+suffix+".example.test")
+
+	repo := mcp.NewRepo(pool)
+
+	// An outside collaborator shared onto ONE site. RunTenantTx dispatches this
+	// principal to InScopedTenantTx, which is the only helper that sets
+	// app.site_scope -- the GUC the RESTRICTIVE policy keys on.
+	collaborator := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeSite, AllowedSiteIDs: []uuid.UUID{siteID},
+	}
+
+	before := countAllGrants(t, pool, tenantID)
+	_, _, err := repo.CreateGrantWithToken(ctx, collaborator, mintProbeGrant(tenantID, "rls layer probe"),
+		mintProbeToken(tenantID, "rls_probe_", strings.Repeat("a", 64)), nil)
+	if err == nil {
+		t.Fatal("THE RESTRICTIVE INSERT POLICY DID NOT FIRE: a site-scoped principal " +
+			"inserted an mcp_grants row with both app-layer guards bypassed")
+	}
+	t.Logf("layer 3 refused on its own: %v", err)
+	if after := countAllGrants(t, pool, tenantID); after != before {
+		t.Fatalf("the refused insert still wrote: grants %d -> %d", before, after)
+	}
+
+	// AND IT DOES NOT OVER-FIRE. Without this the test above would also pass if
+	// the insert were broken for everybody, which would make it a proof of
+	// nothing. The same call by an ORG-scoped principal must succeed.
+	admin := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+	if _, _, err := repo.CreateGrantWithToken(ctx, admin, mintProbeGrant(tenantID, "org control"),
+		mintProbeToken(tenantID, "org_probe_", strings.Repeat("d", 64)), nil); err != nil {
+		t.Fatalf("an ORG-scoped principal was also refused, so the refusal above "+
+			"proves nothing about site scope: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE TRANSACTION BOUNDARY. Two inserts and an audit append are one unit, and
+// there is deliberately no way to express half of it.
+// ---------------------------------------------------------------------------
+
+// TestMCPMintRollsBackTheGrantWhenTheTokenInsertFailsAsAppRole makes the SECOND
+// insert fail (duplicate token_hash) and proves the first did not survive. A
+// grant with no token is a connection the operator sees in the list and can
+// never use.
+func TestMCPMintRollsBackTheGrantWhenTheTokenInsertFailsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-2ins-"+suffix)
+	userID := seedUserRow(t, pool, "mint-2ins-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://mint2ins-"+suffix+".example.test")
+
+	repo := mcp.NewRepo(pool)
+	admin := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+
+	// The FIRST mint must succeed, or the collision below never happens and the
+	// whole probe is vacuous.
+	sharedHash := strings.Repeat("b", 64)
+	mkTok := mintProbeToken(tenantID, "dup_probe_", sharedHash)
+	if _, _, err := repo.CreateGrantWithToken(ctx, admin,
+		mintProbeGrant(tenantID, "first"), mkTok, nil); err != nil {
+		t.Fatalf("the first mint must succeed for this probe to mean anything: %v", err)
+	}
+
+	before := countAllGrants(t, pool, tenantID)
+	_, _, err := repo.CreateGrantWithToken(ctx, admin,
+		mintProbeGrant(tenantID, "second, duplicate hash"), mkTok, nil)
+	if err == nil {
+		t.Fatal("a duplicate token_hash was accepted; this probe proves nothing")
+	}
+	t.Logf("token insert failed as designed: %v", err)
+	if after := countAllGrants(t, pool, tenantID); after != before {
+		t.Fatalf("A GRANT SURVIVED A FAILED TOKEN INSERT: grants %d -> %d", before, after)
+	}
+	assertNoOrphanMCPGrant(t, pool, tenantID)
+}
+
+// TestMCPMintRollsBackTheCredentialWhenTheAuditAppendFailsAsAppRole is the
+// invariant mint.go is written around: "a live credential that no audit row
+// explains" must be unrepresentable. onCreated runs INSIDE the transaction, so
+// an error from it has to destroy both inserts.
+func TestMCPMintRollsBackTheCredentialWhenTheAuditAppendFailsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-aud-"+suffix)
+	userID := seedUserRow(t, pool, "mint-aud-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://mintaud-"+suffix+".example.test")
+
+	repo := mcp.NewRepo(pool)
+	admin := domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	}
+
+	beforeGrants := countAllGrants(t, pool, tenantID)
+	beforeTokens := countAllMCPTokens(t, pool, tenantID)
+	_, _, err := repo.CreateGrantWithToken(ctx, admin,
+		mintProbeGrant(tenantID, "audit fails"),
+		mintProbeToken(tenantID, "aud_probe_", strings.Repeat("c", 64)),
+		func(tx pgx.Tx, gr sqlc.McpGrant) error { return errMintAuditProbe })
+	if err == nil {
+		t.Fatal("an onCreated error did not abort the mint")
+	}
+	if after := countAllGrants(t, pool, tenantID); after != beforeGrants {
+		t.Fatalf("A CREDENTIAL SURVIVED A FAILED AUDIT APPEND: grants %d -> %d",
+			beforeGrants, after)
+	}
+	if after := countAllMCPTokens(t, pool, tenantID); after != beforeTokens {
+		t.Fatalf("A TOKEN SURVIVED A FAILED AUDIT APPEND: tokens %d -> %d",
+			beforeTokens, after)
+	}
+	t.Logf("audit failure rolled the whole mint back: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// THE ACTOR ON THE AUDIT ROW.
+//
+// This is the HEADLESS path, so an API key is its natural caller: the route is
+// mounted under Auth.Authenticate(), whose Bearer branch returns
+// apikey.PrincipalFor's principal, and that principal NEVER carries a UserID.
+// Recording ActorUser over Principal.UserID therefore attributed the one
+// credential-issuance event this surface exists to explain to a user that does
+// not exist, over a zero UUID, with created_by_user_id NULL -- a trail naming
+// neither the key nor a person.
+// ---------------------------------------------------------------------------
+
+func TestMCPMintByAnAPIKeyNamesTheKeyInTheAuditRowAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InTenantTx(ctx, uuid.New(), func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (the dispatch the audit read uses)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-mint-key-"+suffix)
+	seedSite(t, pool, tenantID, "https://mintkey-"+suffix+".example.test")
+
+	svc := mcp.NewService(mcp.NewRepo(pool)).
+		WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+
+	// EXACTLY what apikey.PrincipalFor builds for an org-scoped owner key.
+	keyID := uuid.New()
+	keyPrincipal := domain.Principal{
+		Type: domain.PrincipalAPIKey, APIKeyID: keyID, TenantID: tenantID,
+		Role: "owner", Scope: domain.ScopeOrg, AuthModel: domain.AuthModelRole,
+	}
+	if keyPrincipal.UserID != uuid.Nil {
+		t.Fatal("this proof assumes an API-key principal carries no UserID")
+	}
+	eng := mountConnectionsLikeProduction(t, svc, keyPrincipal)
+
+	var minted mintResponse
+	code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "ci runner via api key",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &minted)
+	if code != http.StatusCreated {
+		t.Fatalf("an API-key principal could not mint: %d", code)
+	}
+
+	// The audit row, read back through the same tx helper Recorder.List uses.
+	var found bool
+	for _, r := range queryMCPAuditRowsAsAppRole(t, pool, tenantID, "mcp.grant.created") {
+		if r.targetID != minted.GrantID {
+			continue
+		}
+		found = true
+		if r.actorType != audit.ActorAPIKey {
+			t.Fatalf("actor_type = %q, want %q: the mint attributed a machine's act "+
+				"to a kind of actor it was not", r.actorType, audit.ActorAPIKey)
+		}
+		if r.actorID != keyID.String() {
+			t.Fatalf("actor_id = %q, want the API key's id %s: the trail names "+
+				"neither the key nor a person", r.actorID, keyID)
+		}
+		if r.actorID == uuid.Nil.String() {
+			t.Fatal("actor_id is the zero UUID: the row explains nothing")
+		}
+		if r.metadata["issuance"] != "connection_token" {
+			t.Fatalf("issuance = %v, want connection_token", r.metadata["issuance"])
+		}
+	}
+	if !found {
+		t.Fatalf("NO mcp.grant.created ROW FOR GRANT %s: a live credential that no "+
+			"audit row explains is the state mint.go exists to make unrepresentable",
+			minted.GrantID)
+	}
+
+	// created_by_user_id stays NULL, and that is the HONEST answer rather than
+	// a gap: an API-key mint genuinely has no human author, and a zero UUID
+	// here would look like a real one.
+	var createdBy *uuid.UUID
+	grantID, err := uuid.Parse(minted.GrantID)
+	if err != nil {
+		t.Fatalf("parse grant id: %v", err)
+	}
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT created_by_user_id FROM mcp_grants WHERE tenant_id=$1 AND id=$2`,
+			tenantID, grantID).Scan(&createdBy)
+	}); err != nil {
+		t.Fatalf("read created_by_user_id: %v", err)
+	}
+	if createdBy != nil {
+		t.Fatalf("created_by_user_id = %v for an API-key mint, want NULL", *createdBy)
+	}
+
+	// AND IT DOES NOT OVER-FIRE: a session user on the same route is still
+	// recorded as a user, with their own id. A resolver that answered
+	// "api_key" for everybody would pass the assertions above.
+	userID := seedUserRow(t, pool, "mint-key-human-"+suffix+"@example.test")
+	humanEng := mountConnectionsLikeProduction(t, svc, domain.Principal{
+		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+	var humanMint mintResponse
+	if code := mcpDoJSON(t, humanEng, http.MethodPost, mintPath, map[string]any{
+		"name":            "human minted",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	}, nil, &humanMint); code != http.StatusCreated {
+		t.Fatalf("a session user could not mint: %d", code)
+	}
+	var sawHuman bool
+	for _, r := range queryMCPAuditRowsAsAppRole(t, pool, tenantID, "mcp.grant.created") {
+		if r.targetID != humanMint.GrantID {
+			continue
+		}
+		sawHuman = true
+		if r.actorType != audit.ActorUser || r.actorID != userID.String() {
+			t.Fatalf("a session user's mint recorded actor_type=%q actor_id=%q, "+
+				"want %q and %s", r.actorType, r.actorID, audit.ActorUser, userID)
+		}
+	}
+	if !sawHuman {
+		t.Fatalf("no mcp.grant.created row for the human's grant %s", humanMint.GrantID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CROSS-TENANT SCOPE REFERENTS.
+//
+// The committed suite proves a GHOST id (naming nothing anywhere) is refused.
+// These prove the harder case: a REAL row that belongs to another organisation.
+// scope_tag_ids and scope_site_ids are uuid[] columns with no foreign key, so
+// the database itself would store either happily; the refusal has to come from
+// resolving the id under this tenant's RLS, and only a real foreign row can
+// tell a working tenant scope from a lucky one.
+// ---------------------------------------------------------------------------
+
+func TestMCPMintRefusesAnotherTenantsTagIDAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InTenantTx(ctx, uuid.New(), func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (the dispatch ListTagIDs uses)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantA := seedTenant(t, pool, "mcp-mint-xt-a-"+suffix)
+	tenantB := seedTenant(t, pool, "mcp-mint-xt-b-"+suffix)
+	userA := seedUserRow(t, pool, "mint-xt-a-"+suffix+"@example.test")
+	seedSite(t, pool, tenantA, "https://mintxta-"+suffix+".example.test")
+	seedSite(t, pool, tenantB, "https://mintxtb-"+suffix+".example.test")
+
+	_, tagSvc := newSiteTagServices(pool)
+	tagB, err := tagSvc.Create(ctx, sitetag.CreateInput{
+		TenantID: tenantB, Name: "foreign-" + suffix, Color: "#445566",
+	})
+	if err != nil {
+		t.Fatalf("create tenant B tag: %v", err)
+	}
+
+	// The registry read the refusal rests on is tenant-scoped, BOTH WAYS: B's
+	// tag is absent from A, and present under B. Without the second half the
+	// first is vacuous -- an always-empty ListTagIDs would satisfy it.
+	repo := mcp.NewRepo(pool)
+	idsA, err := repo.ListTagIDs(ctx, tenantA)
+	if err != nil {
+		t.Fatalf("ListTagIDs(A): %v", err)
+	}
+	for _, id := range idsA {
+		if id == tagB.ID {
+			t.Fatalf("TENANCY LEAK: ListTagIDs(tenantA) returned tenant B's tag %s", tagB.ID)
+		}
+	}
+	idsB, err := repo.ListTagIDs(ctx, tenantB)
+	if err != nil {
+		t.Fatalf("ListTagIDs(B): %v", err)
+	}
+	var seen bool
+	for _, id := range idsB {
+		seen = seen || id == tagB.ID
+	}
+	if !seen {
+		t.Fatalf("ListTagIDs(tenantB) did not return tenant B's own tag %s; the "+
+			"negative above would then be vacuous", tagB.ID)
+	}
+
+	svc := mcp.NewService(repo)
+	eng := mountConnectionsLikeProduction(t, svc, domain.Principal{
+		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+
+	before := countAllGrants(t, pool, tenantA)
+	var body map[string]any
+	code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "foreign tag scope",
+		"site_scope_mode": string(mcp.SiteScopeModeTags),
+		"scope_tag_ids":   []string{tagB.ID.String()},
+	}, nil, &body)
+	raw, mErr := json.Marshal(body)
+	if mErr != nil {
+		t.Fatalf("marshal refusal body: %v", mErr)
+	}
+	if code == http.StatusCreated {
+		t.Fatalf("ANOTHER TENANT'S TAG ID WAS ACCEPTED (201): %s", raw)
+	}
+	if code != http.StatusUnprocessableEntity && code != http.StatusBadRequest {
+		t.Fatalf("foreign tag answered %d, want a 4xx validation refusal; body=%s", code, raw)
+	}
+	if !strings.Contains(string(raw), tagB.ID.String()) {
+		t.Fatalf("the refusal does not name the offending id, so it cannot be acted on: %s", raw)
+	}
+	if after := countAllGrants(t, pool, tenantA); after != before {
+		t.Fatalf("the refused mint still wrote: grants %d -> %d", before, after)
+	}
+	t.Logf("foreign tag refused with %d: %s", code, raw)
+}
+
+func TestMCPMintRefusesAnotherTenantsSiteIDAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+
+	suffix := uuid.NewString()[:8]
+	tenantA := seedTenant(t, pool, "mcp-mint-xs-a-"+suffix)
+	tenantB := seedTenant(t, pool, "mcp-mint-xs-b-"+suffix)
+	userA := seedUserRow(t, pool, "mint-xs-a-"+suffix+"@example.test")
+	siteA := seedSite(t, pool, tenantA, "https://mintxsa-"+suffix+".example.test")
+	siteB := seedSite(t, pool, tenantB, "https://mintxsb-"+suffix+".example.test")
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	eng := mountConnectionsLikeProduction(t, svc, domain.Principal{
+		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,
+		Role: "admin", Scope: domain.ScopeOrg,
+	})
+
+	before := countAllGrants(t, pool, tenantA)
+	var body map[string]any
+	code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "foreign site scope",
+		"site_scope_mode": string(mcp.SiteScopeModeList),
+		"scope_site_ids":  []string{siteB.String()},
+	}, nil, &body)
+	raw, mErr := json.Marshal(body)
+	if mErr != nil {
+		t.Fatalf("marshal refusal body: %v", mErr)
+	}
+	if code == http.StatusCreated {
+		t.Fatalf("ANOTHER TENANT'S SITE ID WAS ACCEPTED (201): %s", raw)
+	}
+	if code != http.StatusUnprocessableEntity && code != http.StatusBadRequest {
+		t.Fatalf("foreign site answered %d, want a 4xx validation refusal; body=%s", code, raw)
+	}
+	if !strings.Contains(string(raw), siteB.String()) {
+		t.Fatalf("the refusal does not name the offending site id: %s", raw)
+	}
+	if after := countAllGrants(t, pool, tenantA); after != before {
+		t.Fatalf("the refused mint still wrote: grants %d -> %d", before, after)
+	}
+
+	// AND IT DOES NOT OVER-FIRE: tenant A's OWN site is accepted on the same
+	// route. A resolver that dropped every id would satisfy the refusal above.
+	var minted mintResponse
+	if code := mcpDoJSON(t, eng, http.MethodPost, mintPath, map[string]any{
+		"name":            "own site scope",
+		"site_scope_mode": string(mcp.SiteScopeModeList),
+		"scope_site_ids":  []string{siteA.String()},
+	}, nil, &minted); code != http.StatusCreated {
+		t.Fatalf("tenant A's OWN site was refused (%d), so the refusal above proves "+
+			"nothing about tenancy", code)
+	}
+	t.Logf("foreign site refused with %d: %s", code, raw)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers. Every read goes THROUGH THE POOL as wpmgr_app, inside the tenant
+// transaction the request path uses.
+// ---------------------------------------------------------------------------
+
+// mintProbeGrant is the minimal valid CreateMCPGrantParams for a repo-level
+// probe: org-wide scope, one capability, and an absolute expiry, so the only
+// thing that can refuse it is the layer under test.
+func mintProbeGrant(tenantID uuid.UUID, name string) sqlc.CreateMCPGrantParams {
+	return sqlc.CreateMCPGrantParams{
+		TenantID:      tenantID,
+		Name:          name,
+		Status:        "active",
+		SiteScopeMode: "all",
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  []uuid.UUID{},
+		ClientID:      nil,
+		Capabilities:  []string{"mcp.sites.read"},
+		ExpiresAt:     time.Now().UTC().Add(24 * time.Hour),
+	}
+}
+
+// mintProbeToken builds the companion token params. The hash is a caller-chosen
+// constant so a test can force the UNIQUE collision deliberately.
+func mintProbeToken(tenantID uuid.UUID, prefix, hash string) func(uuid.UUID) sqlc.CreateMCPConnectionTokenParams {
+	return func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams {
+		return sqlc.CreateMCPConnectionTokenParams{
+			TenantID:    tenantID,
+			GrantID:     grantID,
+			TokenPrefix: prefix,
+			TokenHash:   hash,
+			Status:      "active",
+			ExpiresAt:   pgtype.Timestamptz{Time: time.Now().UTC().Add(time.Hour), Valid: true},
+		}
+	}
+}
+
+// errMintAuditProbe is the deliberate onCreated failure. A named value rather
+// than errors.New at the call site so a rollback assertion cannot accidentally
+// match some real error.
+var errMintAuditProbe = &mintProbeError{}
+
+type mintProbeError struct{}
+
+func (*mintProbeError) Error() string { return "mint probe: audit append failed" }
+
+// countAllMCPTokens counts a tenant's connection tokens through InTenantTx --
+// the same tx shape the request path uses. A raw connection would read past RLS
+// and could report rows the application can never see.
+func countAllMCPTokens(t *testing.T, pool *db.Pool, tenantID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	if err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM mcp_connection_tokens WHERE tenant_id = $1`,
+			tenantID).Scan(&n)
+	}); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	return n
+}
+
+// assertNoOrphanMCPGrant fails if any grant exists with neither a token nor an
+// authorization code. That is the half-built connection an operator sees in the
+// list and can never use, and it is what a two-commit mint leaves behind.
+func assertNoOrphanMCPGrant(t *testing.T, pool *db.Pool, tenantID uuid.UUID) {
+	t.Helper()
+	var n int64
+	if err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM mcp_grants g
+			  WHERE g.tenant_id = $1
+			    AND NOT EXISTS (SELECT 1 FROM mcp_connection_tokens t
+			                     WHERE t.grant_id = g.id)
+			    AND NOT EXISTS (SELECT 1 FROM mcp_authorization_codes c
+			                     WHERE c.grant_id = g.id)`, tenantID).Scan(&n)
+	}); err != nil {
+		t.Fatalf("count orphan grants: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("%d grant(s) exist with neither a token nor a code", n)
+	}
+}

--- a/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
@@ -24,6 +24,7 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -202,6 +203,25 @@ func TestMCPMintRollsBackTheCredentialWhenTheAuditAppendFailsAsAppRole(t *testin
 	if err == nil {
 		t.Fatal("an onCreated error did not abort the mint")
 	}
+
+	// THE ERROR IS PINNED TO THE PROBE, not merely observed to be non-nil.
+	// The mint can fail BEFORE onCreated ever runs -- a 23502 from a NOT NULL
+	// grant column, or a CHECK violation on expires_at or capabilities. In
+	// that case nothing was ever inserted, both count assertions below still
+	// pass, and this test stays green while proving nothing about the
+	// transaction boundary it is named for.
+	//
+	// mintProbeGrant supplies Capabilities and ExpiresAt today, so the probe
+	// does reach onCreated right now. The point is that WITHOUT THIS CHECK
+	// this test cannot report the day that stops being true. Same approach as
+	// the sibling probe,
+	// TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole.
+	if !errors.Is(err, errMintAuditProbe) {
+		t.Fatalf("the mint failed with %v, which is NOT the injected onCreated failure. "+
+			"The insert aborted before onCreated ran, so the rollback assertions below "+
+			"are vacuous and this probe proves nothing about the transaction boundary.", err)
+	}
+
 	if after := countAllGrants(t, pool, tenantID); after != beforeGrants {
 		t.Fatalf("A CREDENTIAL SURVIVED A FAILED AUDIT APPEND: grants %d -> %d",
 			beforeGrants, after)

--- a/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
@@ -93,6 +93,22 @@ func TestMCPMintRLSInsertPolicyRefusesASiteScopedPrincipalAloneAsAppRole(t *test
 		t.Fatal("THE RESTRICTIVE INSERT POLICY DID NOT FIRE: a site-scoped principal " +
 			"inserted an mcp_grants row with both app-layer guards bypassed")
 	}
+
+	// THE REFUSAL MUST NAME THIS POLICY, and "some error happened" is not good
+	// enough. mcp_grants carries a SECOND restrictive site-scope policy whose
+	// USING clause Postgres also applies here, so with
+	// mcp_grants_site_scope_insert DROPPED the insert is still refused -- by
+	// the other one. An err != nil assertion therefore stays GREEN through the
+	// deletion of the policy it claims to prove, which is the same shadowing
+	// defect this whole file exists to remove one layer up.
+	const policy = "mcp_grants_site_scope_insert"
+	if !strings.Contains(err.Error(), policy) {
+		t.Fatalf("the insert was refused, but NOT by %s -- so this proof would "+
+			"survive that policy being dropped: %v", policy, err)
+	}
+	if !strings.Contains(err.Error(), "42501") {
+		t.Fatalf("want an RLS violation (SQLSTATE 42501), got: %v", err)
+	}
 	t.Logf("layer 3 refused on its own: %v", err)
 	if after := countAllGrants(t, pool, tenantID); after != before {
 		t.Fatalf("the refused insert still wrote: grants %d -> %d", before, after)

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -328,7 +328,7 @@ func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T
 			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
 			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
 		}
-	})
+	}, nil)
 	if err == nil {
 		t.Fatal("CreateGrantWithCode accepted a site-scoped principal. The write " +
 			"reached mcp_grants with app.site_scope unset, so the RESTRICTIVE " +

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -317,6 +317,11 @@ func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  []uuid.UUID{},
 		ClientID:      &clientID,
+		// m127: both NOT NULL with no default. Supplied so this proof fails on
+		// the RLS refusal it is actually about, not on a 23502.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 		return sqlc.CreateMCPAuthorizationCodeParams{
 			TenantID:            tenantID,

--- a/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
+++ b/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
@@ -48,6 +48,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
 	"testing"
 	"time"
 
@@ -563,13 +564,43 @@ func TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole(t *testing.T) {
 		t.Fatalf("grant_capabilities = %v after emptying, want []", chk.GrantCapabilities)
 	}
 
-	if _, err := svc.Authenticate(ctx, bearer); err == nil {
+	_, err = svc.Authenticate(ctx, bearer)
+	if err == nil {
 		t.Fatal("Authenticate ADMITTED a grant whose stored capability set is empty. " +
 			"The capability set is being computed from the scope registry instead of " +
 			"read from the grant, so the column is decorative and a narrowed connection " +
 			"would hold the org default regardless of what was stored.")
 	}
-	t.Log("a grant with capabilities = '{}' is REFUSED: the stored column is the authority")
+
+	// THE STATUS IS ASSERTED BY VALUE, not as "an error occurred". This
+	// assertion was previously `err == nil` alone, which is green under 401
+	// and under 403 alike -- so the refusal could change kind underneath it
+	// without anything going red.
+	//
+	// It must be 403. Authenticate's refusals reach writeUnauthorized, and an
+	// MCP client that gets 401 re-runs the OAuth handshake, which cannot
+	// refill an empty capabilities column: the client loops forever and the
+	// operator is sent to rotate a working credential. 403 says the credential
+	// is valid and the grant is not permitted, which is the true state.
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("Authenticate returned a non-domain error %v; the refusal must be a "+
+			"typed domain error or httpx cannot map it to anything but 500", err)
+	}
+	if de.Kind != domain.KindForbidden {
+		t.Fatalf("empty-capabilities refusal Kind = %d (HTTP %d), want %d (HTTP %d). "+
+			"401 makes an MCP client re-run the OAuth handshake, which cannot change a "+
+			"stored capability set, so the client loops.",
+			de.Kind, domain.HTTPStatus(err), domain.KindForbidden, http.StatusForbidden)
+	}
+	if got := domain.HTTPStatus(err); got != http.StatusForbidden {
+		t.Fatalf("empty-capabilities refusal HTTPStatus = %d, want %d", got, http.StatusForbidden)
+	}
+	if de.Code != mcp.ErrCodeCapabilityUnmapped {
+		t.Fatalf("empty-capabilities refusal Code = %q, want %q", de.Code, mcp.ErrCodeCapabilityUnmapped)
+	}
+	t.Logf("a grant with capabilities = '{}' is REFUSED %d/%s: the stored column is the authority",
+		domain.HTTPStatus(err), de.Code)
 }
 
 // repoTouch issues the activity stamp through the Store interface the service

--- a/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
+++ b/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
@@ -1,0 +1,516 @@
+// mcp_grant_expiry_activity_integration_test.go: m127's three grant columns
+// and GH #605's activity stamp, executed against the REAL schema as wpmgr_app.
+//
+// WHY THIS FILE EXISTS. m127 wrote its own hazard down rather than leaving it
+// to be discovered, and the hazard is not decidable by reading Go:
+//
+//	"if a non-NULL idle_expire_after_days is ever written while the stamp is
+//	 still unwired, coalesce(last_used_at, created_at) collapses to created_at
+//	 permanently, and EVERY AFFECTED CONNECTION DIES idle_expire_after_days
+//	 AFTER IT WAS CREATED NO MATTER HOW ACTIVE IT IS."
+//
+// The Go change that closes it is one call to Repo.TouchActivity. Whether that
+// call actually MOVES THE COLUMN THE PREDICATE READS is a property of the
+// query, the tx helper, the RLS policies and the role together -- exactly the
+// combination m112's proofs got wrong by opening their own connections, so
+// every policy was inert and every test was green.
+//
+// FOUR THINGS ARE IN QUESTION HERE, and each is executed rather than argued:
+//
+//  1. Service.Approve supplies all three of m127's columns. capabilities and
+//     expires_at are NOT NULL with no default, so an omission is 23502; and
+//     idle_expire_after_days must come back NULL, because NULL is the answer
+//     ("never idle-expire"), not a placeholder.
+//
+//  2. The stamp lands. last_used_at is NULL on a fresh grant and non-NULL after
+//     one RecordActivity, read back through the same verdict query the request
+//     path reads.
+//
+//  3. THE FLEET-OUTAGE CASE, BOTH DIRECTIONS. A grant older than its idle
+//     window is refused when it has never been used, and the SAME grant is
+//     authorized once the stamp has run. Without direction two this is just a
+//     test that expiry works; without direction one it is a test that proves
+//     nothing about expiry at all.
+//
+//  4. Absolute expiry still bites, and ACTIVITY CANNOT RESCUE IT. The two
+//     expiries are independent facts (m127 DECISION 2) and a stamp that
+//     extended the absolute one would silently make every connection immortal.
+//
+// HOW IT IS TESTED. Through mcp.Repo and mcp.Service -- the same methods the
+// transport calls, the same generated queries, the same tx helpers. GUCs are
+// never hand-set and no connection is opened by this file. The role is
+// load-bearing and is asserted inside the transaction under test: wpmgr_app is
+// NOSUPERUSER NOBYPASSRLS, and either privilege would make all of this pass
+// vacuously.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// mcpAgeGrant rewrites created_at and idle_expire_after_days on one grant, so a
+// test can construct "this connection is older than its idle window" without
+// waiting days for it.
+//
+// IT GOES THROUGH pool.InTenantTx, NOT ITS OWN CONNECTION. A raw connection
+// here would set no GUC, so the UPDATE would run with the policies inert -- and
+// then the test would be constructing its fixture through a path the request
+// path does not have, which is the failure mode this whole file exists to
+// avoid. Under InTenantTx as wpmgr_app the write only lands if the tenant
+// policy actually admits it.
+func mcpAgeGrant(t *testing.T, pool interface {
+	InTenantTx(context.Context, uuid.UUID, func(pgx.Tx) error) error
+}, tenantID, grantID uuid.UUID, createdAgo time.Duration, idleDays *int32) {
+	t.Helper()
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(context.Background(),
+			`UPDATE mcp_grants
+			    SET created_at = now() - $3::interval,
+			        idle_expire_after_days = $4
+			  WHERE tenant_id = $1 AND id = $2`,
+			tenantID, grantID, createdAgo.String(), idleDays)
+		if err != nil {
+			return err
+		}
+		// A zero-row UPDATE that reports success is the exact silent failure
+		// m124 obligation 1 names. If the fixture did not land, every
+		// assertion below would be measuring an untouched grant.
+		if tag.RowsAffected() != 1 {
+			t.Fatalf("aging fixture updated %d rows, want 1 -- the fixture did not land, "+
+				"so nothing below is testing what it claims", tag.RowsAffected())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("age grant %s: %v", grantID, err)
+	}
+}
+
+// mcpReadGrantColumns reads the three m127 columns plus last_used_at straight
+// off the row, under InTenantTx as wpmgr_app.
+func mcpReadGrantColumns(t *testing.T, pool interface {
+	InTenantTx(context.Context, uuid.UUID, func(pgx.Tx) error) error
+}, tenantID, grantID uuid.UUID) (caps []string, expiresAt time.Time, idleDays *int32, lastUsed *time.Time) {
+	t.Helper()
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT capabilities, expires_at, idle_expire_after_days, last_used_at
+			   FROM mcp_grants WHERE tenant_id = $1 AND id = $2`,
+			tenantID, grantID).Scan(&caps, &expiresAt, &idleDays, &lastUsed)
+	})
+	if err != nil {
+		t.Fatalf("read grant columns for %s: %v", grantID, err)
+	}
+	return caps, expiresAt, idleDays, lastUsed
+}
+
+// TestMCPApproveSuppliesM127ColumnsAsAppRole is question 1: the consent flow's
+// own minting path, end to end, against the real NOT NULL columns.
+//
+// THE 23502 IS THE DESIGNED FAILURE AND THIS TEST IS WHAT MAKES IT VISIBLE. A
+// CreateMCPGrantParams literal that omits either NOT NULL field still COMPILES
+// -- the field is simply left zero, which is nil/invalid, which is NULL -- so
+// the build says nothing and only an executed INSERT can. That is why this
+// proof drives Service.Approve rather than asserting on the struct.
+func TestMCPApproveSuppliesM127ColumnsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-m127-approve-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (Approve read-back path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	clientID := "m127-client-" + uuid.NewString()
+	secretHash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if n, err := repo.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        &secretHash,
+		TokenEndpointAuthMethod: "client_secret_basic",
+		RedirectUris:            []string{"https://claude.ai/api/mcp/auth_callback"},
+	}); err != nil || n != 1 {
+		t.Fatalf("seed client: affected=%d err=%v", n, err)
+	}
+
+	before := time.Now().UTC()
+	approval, err := svc.Approve(ctx, mcp.ApprovalRequest{
+		Principal: domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg},
+		GrantName: "m127 column proof",
+		SiteScope: mcp.SiteScopeRequest{Mode: mcp.SiteScopeModeAll},
+		Consent: mcp.ConsentContext{
+			ClientID:            clientID,
+			RedirectURI:         "https://claude.ai/api/mcp/auth_callback",
+			Scopes:              []mcp.Scope{mcp.ScopeRead},
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+		},
+	})
+	if err != nil {
+		// A 23502 lands HERE, and it is the failure this whole change exists to
+		// remove. Naming it in the message means the next reader does not have
+		// to decode the SQLSTATE.
+		t.Fatalf("Approve failed -- if this is SQLSTATE 23502 then a NOT NULL m127 "+
+			"column is not being supplied at internal/mcp/service.go's "+
+			"CreateMCPGrantParams literal: %v", err)
+	}
+	after := time.Now().UTC()
+
+	caps, expiresAt, idleDays, lastUsed := mcpReadGrantColumns(t, pool, tenant, approval.GrantID)
+
+	// capabilities: the stored set, not an empty array and not a guess.
+	if len(caps) != 1 || caps[0] != string(mcp.CapSitesRead) {
+		t.Fatalf("capabilities = %v, want exactly [%q]", caps, mcp.CapSitesRead)
+	}
+
+	// expires_at: NOT NULL, in the future, and roughly the 90-day term. The
+	// window is deliberately loose on the low side and tight on the high side:
+	// the assertion that matters is that SOMETHING chose a bounded term, not
+	// that a clock agreed to the second.
+	if !expiresAt.After(after) {
+		t.Fatalf("expires_at = %s is not in the future (now ~%s)", expiresAt, after)
+	}
+	wantLo := before.Add(89 * 24 * time.Hour)
+	wantHi := after.Add(91 * 24 * time.Hour)
+	if expiresAt.Before(wantLo) || expiresAt.After(wantHi) {
+		t.Fatalf("expires_at = %s, want between %s and %s (the 90-day term)",
+			expiresAt, wantLo, wantHi)
+	}
+
+	// idle_expire_after_days: NULL, and NULL is the answer.
+	//
+	// A NON-NULL VALUE HERE WOULD BE THE FLEET OUTAGE, not a stricter default:
+	// m127 DECISION 4 is that a window may only be persisted once the stamp is
+	// wired AND an operator has chosen one. The stamp is wired now; no control
+	// asks for a window yet, so writing one would be inventing a deadline
+	// nobody chose.
+	if idleDays != nil {
+		t.Fatalf("idle_expire_after_days = %d, want NULL -- a window nobody chose "+
+			"would expire this connection %d days after creation", *idleDays, *idleDays)
+	}
+
+	// last_used_at: NULL on a grant that has never served a request. This is
+	// the baseline the stamp test moves.
+	if lastUsed != nil {
+		t.Fatalf("last_used_at = %s on a brand new grant, want NULL", *lastUsed)
+	}
+
+	t.Logf("Approve wrote capabilities=%v expires_at=%s idle_expire_after_days=NULL last_used_at=NULL",
+		caps, expiresAt.Format(time.RFC3339))
+}
+
+// TestMCPActivityStampLandsAsAppRole is question 2, and it is GH #605 itself:
+// mcp_grants.last_used_at was never written, so the connections list reported
+// every connection as "Never used" including one actively reading the fleet.
+//
+// The read-back is through ReCheckAuthorization -- THE SAME QUERY THE REQUEST
+// PATH READS THE VERDICT FROM -- rather than a bespoke SELECT, so this also
+// establishes that the column the idle predicate consults is the column the
+// stamp moved.
+func TestMCPActivityStampLandsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-605-stamp-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (TouchActivity path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://stamp.example.com", Name: "stamp-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	// BASELINE: never used. If this were already non-NULL the assertion below
+	// would pass without the stamp doing anything.
+	if _, _, _, lastUsed := mcpReadGrantColumns(t, pool, tenant, grant.ID); lastUsed != nil {
+		t.Fatalf("last_used_at = %s before any request, want NULL", *lastUsed)
+	}
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate with a live bearer: %v", err)
+	}
+
+	// THE STAMP, through the method the transport's tools/list and tools/call
+	// arms call.
+	if err := svc.RecordActivity(ctx, auth); err != nil {
+		t.Fatalf("RecordActivity: %v", err)
+	}
+
+	// Read it back through the VERDICT QUERY, under the same tenant.
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, auth.TokenID)
+	if err != nil {
+		t.Fatalf("re-check after stamp: %v", err)
+	}
+	if !chk.GrantLastUsedAt.Valid {
+		t.Fatal("last_used_at is still NULL after RecordActivity -- the stamp did not " +
+			"land, and every connection will still read as \"Never used\" (GH #605)")
+	}
+	if chk.GrantLastUsedAt.Time.Before(grant.CreatedAt.Add(-time.Second)) {
+		t.Fatalf("last_used_at = %s is before the grant's own created_at %s",
+			chk.GrantLastUsedAt.Time, grant.CreatedAt)
+	}
+	t.Logf("grant.last_used_at stamped to %s and read back through the verdict query",
+		chk.GrantLastUsedAt.Time.Format(time.RFC3339))
+
+	// THE TOKEN HALF. The rotation UI tells two live tokens apart by
+	// last_used_at, so a grant stamped without its token would make it claim a
+	// token nobody has retired is dead.
+	var tokenLastUsed *time.Time
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT last_used_at FROM mcp_connection_tokens WHERE tenant_id = $1 AND id = $2`,
+			tenant, auth.TokenID).Scan(&tokenLastUsed)
+	}); err != nil {
+		t.Fatalf("read token last_used_at: %v", err)
+	}
+	if tokenLastUsed == nil {
+		t.Fatal("mcp_connection_tokens.last_used_at is still NULL after RecordActivity -- " +
+			"TouchMCPConnectionTokenInTenantTx is still unwired")
+	}
+	t.Logf("token.last_used_at stamped to %s in the same transaction",
+		tokenLastUsed.Format(time.RFC3339))
+}
+
+// TestMCPActiveConnectionDoesNotIdleExpireAsAppRole is question 3, and it is
+// the fleet outage m127 DECISION 4 describes, constructed and executed in both
+// directions on ONE grant.
+//
+// The grant is aged 10 days with a 1-day idle window. Direction one is the
+// outage as it would have shipped: last_used_at NULL, so
+// coalesce(last_used_at, created_at) is created_at, so the connection is
+// refused despite nothing being wrong with it. Direction two is the fix: one
+// RecordActivity, and the same grant with the same window is authorized.
+//
+// BOTH HALVES ARE REQUIRED. Direction one alone is a test that idle expiry
+// works. Direction two alone is a test that could pass with idle expiry
+// disabled entirely. Only together do they say "the deadline moves with use".
+func TestMCPActiveConnectionDoesNotIdleExpireAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-127-idle-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (idle expiry path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://idle.example.com", Name: "idle-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	oneDay := int32(1)
+	mcpAgeGrant(t, pool, tenant, grant.ID, 10*24*time.Hour, &oneDay)
+
+	// ---- DIRECTION ONE: never used, and therefore idle-expired. ----
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, mcpTokenIDFor(t, repo, ctx, bearer))
+	if err != nil {
+		t.Fatalf("re-check before stamp: %v", err)
+	}
+	if chk.GrantLastUsedAt.Valid {
+		t.Fatalf("fixture is wrong: last_used_at = %s, want NULL for the never-used case",
+			chk.GrantLastUsedAt.Time)
+	}
+	if !chk.GrantIdleExpired {
+		t.Fatal("a grant created 10 days ago with a 1-day idle window and no recorded " +
+			"use is not reported idle-expired; the idle predicate is not binding")
+	}
+	if chk.Authorized {
+		t.Fatal("an idle-expired grant came back authorized -- idle expiry is not part " +
+			"of the verdict")
+	}
+	if _, err := svc.Authenticate(ctx, bearer); err == nil {
+		t.Fatal("Authenticate admitted a grant past its idle window")
+	}
+	t.Log("direction one: never-used grant older than its idle window is REFUSED")
+
+	// ---- DIRECTION TWO: the same grant, actively used. ----
+	//
+	// The stamp has to be issued outside Authenticate, because Authenticate now
+	// refuses this grant -- which is exactly the state a real connection is
+	// never in, since a real connection is stamped on every tool call from its
+	// first one. Constructing the stamp directly is what lets ONE grant carry
+	// both directions and makes the comparison exact.
+	if err := repoTouch(ctx, repo, tenant, grant.ID, chk.TokenID); err != nil {
+		t.Fatalf("stamp activity: %v", err)
+	}
+
+	chk2, err := repo.ReCheckAuthorization(ctx, tenant, chk.TokenID)
+	if err != nil {
+		t.Fatalf("re-check after stamp: %v", err)
+	}
+	if chk2.GrantIdleExpired {
+		t.Fatal("THE FLEET OUTAGE: a connection used seconds ago is still reported " +
+			"idle-expired. coalesce(last_used_at, created_at) is still collapsing to " +
+			"created_at, so every connection dies N days after creation however " +
+			"active it is (m127 DECISION 4)")
+	}
+	if !chk2.Authorized {
+		t.Fatalf("an actively used grant is not authorized: grant_status=%q token_status=%q "+
+			"absolute_expired=%v idle_expired=%v",
+			chk2.GrantStatus, chk2.TokenStatus, chk2.GrantAbsoluteExpired, chk2.GrantIdleExpired)
+	}
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate refused an actively used connection: %v", err)
+	}
+	if !auth.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatal("an actively used connection resolved to no capability")
+	}
+	t.Logf("direction two: the SAME grant, stamped, is AUTHORIZED with %d capability and %d site",
+		auth.Capabilities.Len(), auth.Sites.Len())
+}
+
+// TestMCPAbsoluteExpiryRefusesAndActivityCannotRescueItAsAppRole is question 4.
+//
+// The two expiries are independent facts and neither can rescue the other
+// (m127 DECISION 2). The direction that matters is this one: if the activity
+// stamp extended the ABSOLUTE expiry as well as the idle one, every connection
+// that is used at all would be immortal and the 90-day term would be
+// decorative -- a silent extension of every credential, which is the failure
+// direction m127 says the schema must never take.
+func TestMCPAbsoluteExpiryRefusesAndActivityCannotRescueItAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-127-abs-"+uuid.NewString()[:8])
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://abs.example.com", Name: "abs-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	// It authenticates first, so the refusal below is attributable to the
+	// expiry and not to a broken fixture.
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate before expiry: %v", err)
+	}
+	tokenID := auth.TokenID
+
+	// Push expires_at into the past. created_at moves with it because
+	// mcp_grants_expires_at_after_created_check requires expires_at >
+	// created_at, and a fixture that violates a CHECK would fail for a reason
+	// this test is not about.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE mcp_grants
+			    SET created_at = now() - interval '100 days',
+			        expires_at = now() - interval '1 hour'
+			  WHERE tenant_id = $1 AND id = $2`,
+			tenant, grant.ID)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			t.Fatalf("expiry fixture updated %d rows, want 1", tag.RowsAffected())
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("expire grant: %v", err)
+	}
+
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, tokenID)
+	if err != nil {
+		t.Fatalf("re-check after expiry: %v", err)
+	}
+	if !chk.GrantAbsoluteExpired {
+		t.Fatal("a grant whose expires_at is in the past is not reported absolute-expired")
+	}
+	if chk.Authorized {
+		t.Fatal("an expired grant came back authorized -- absolute expiry is not part of " +
+			"the verdict")
+	}
+	if _, err := svc.Authenticate(ctx, bearer); err == nil {
+		t.Fatal("Authenticate admitted a grant past its absolute expiry")
+	}
+	t.Log("a grant past expires_at is REFUSED")
+
+	// THE RESCUE ATTEMPT. Stamp it, hard, and confirm the verdict does not
+	// move.
+	if err := repoTouch(ctx, repo, tenant, grant.ID, tokenID); err != nil {
+		t.Fatalf("stamp activity on an expired grant: %v", err)
+	}
+	chk2, err := repo.ReCheckAuthorization(ctx, tenant, tokenID)
+	if err != nil {
+		t.Fatalf("re-check after stamping an expired grant: %v", err)
+	}
+	if !chk2.GrantLastUsedAt.Valid {
+		t.Fatal("fixture is wrong: the stamp did not land, so the rescue is untested")
+	}
+	if chk2.Authorized || !chk2.GrantAbsoluteExpired {
+		t.Fatal("USE EXTENDED AN ABSOLUTE EXPIRY: a stamped grant past expires_at came " +
+			"back authorized. The two expiries are independent and activity must move " +
+			"only the idle one")
+	}
+	t.Log("the same grant, freshly stamped, is STILL refused: activity moves the idle " +
+		"deadline and never the absolute one")
+}
+
+// repoTouch issues the activity stamp through the Store interface the service
+// uses, so this file never reimplements the UPDATE it is testing.
+func repoTouch(ctx context.Context, repo *mcp.Repo, tenantID, grantID, tokenID uuid.UUID) error {
+	_, err := repo.TouchActivity(ctx, tenantID, grantID, tokenID)
+	return err
+}
+
+// mcpTokenIDFor resolves the token id for a bearer WITHOUT going through
+// Authenticate, which refuses an expired grant and therefore cannot be used to
+// learn the id of the token whose expiry is under test.
+//
+// It uses Repo.LookupConnectionToken -- step 1 of the real two-query
+// authentication, under InMCPTokenLookupTx -- so even the fixture reaches the
+// row the way production does.
+func mcpTokenIDFor(t *testing.T, repo *mcp.Repo, ctx context.Context, bearer string) uuid.UUID {
+	t.Helper()
+	sum := sha256.Sum256([]byte(bearer))
+	row, err := repo.LookupConnectionToken(ctx, hex.EncodeToString(sum[:]))
+	if err != nil {
+		t.Fatalf("resolve token id: %v", err)
+	}
+	return row.ID
+}

--- a/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
+++ b/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
@@ -491,6 +491,87 @@ func TestMCPAbsoluteExpiryRefusesAndActivityCannotRescueItAsAppRole(t *testing.T
 		"deadline and never the absolute one")
 }
 
+// TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole is the proof that
+// Authenticate READS the capability column rather than recomputing it.
+//
+// IT IS THE ONLY CONSTRUCTION IN WHICH THE TWO ANSWERS DIFFER TODAY. The
+// vocabulary holds exactly one name, so for any grant carrying
+// [mcp.sites.read] the stored set and the set computed from grantScopes() are
+// identical and no test can tell them apart. An EMPTY stored set is the
+// discriminator: the column's shape CHECK admits '{}' (the restrictive value
+// passes the vocabulary containment test), the computed answer is still
+// [mcp.sites.read], and only a path that reads the row refuses.
+//
+// Deleting the verdict-row read and restoring OrgDefaultCapabilities(
+// grantScopes()) makes this test, and only this test, go red.
+func TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenant := seedTenant(t, pool, "mcp-127-caps-"+uuid.NewString()[:8])
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://caps.example.com", Name: "caps-alpha"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	grant, bearer := s7GrantWithBearer(t, repo, tenant, "list", []uuid.UUID{s1.ID})
+
+	// It authenticates with the seeded capability, so the refusal below is
+	// attributable to the emptied column and not to a broken fixture.
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate before emptying capabilities: %v", err)
+	}
+	if !auth.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatal("the seeded grant did not resolve to its own capability")
+	}
+
+	// Empty the column. The grant stays 'active' and unexpired -- ONLY the
+	// capability set changes, so nothing else can explain the refusal.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE mcp_grants SET capabilities = '{}'::text[]
+			  WHERE tenant_id = $1 AND id = $2`, tenant, grant.ID)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			t.Fatalf("capability fixture updated %d rows, want 1", tag.RowsAffected())
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("empty capabilities: %v", err)
+	}
+
+	// The verdict itself is unchanged: an empty capability set is not an
+	// expiry and not a revocation, so `authorized` stays true. That is what
+	// makes this a test of the Go read and not of the SQL predicate.
+	chk, err := repo.ReCheckAuthorization(ctx, tenant, auth.TokenID)
+	if err != nil {
+		t.Fatalf("re-check after emptying capabilities: %v", err)
+	}
+	if !chk.Authorized {
+		t.Fatalf("emptying capabilities changed the SQL verdict; this test can no longer "+
+			"isolate the Go read (grant_status=%q)", chk.GrantStatus)
+	}
+	if len(chk.GrantCapabilities) != 0 {
+		t.Fatalf("grant_capabilities = %v after emptying, want []", chk.GrantCapabilities)
+	}
+
+	if _, err := svc.Authenticate(ctx, bearer); err == nil {
+		t.Fatal("Authenticate ADMITTED a grant whose stored capability set is empty. " +
+			"The capability set is being computed from the scope registry instead of " +
+			"read from the grant, so the column is decorative and a narrowed connection " +
+			"would hold the org default regardless of what was stored.")
+	}
+	t.Log("a grant with capabilities = '{}' is REFUSED: the stored column is the authority")
+}
+
 // repoTouch issues the activity stamp through the Store interface the service
 // uses, so this file never reimplements the UPDATE it is testing.
 func repoTouch(ctx context.Context, repo *mcp.Repo, tenantID, grantID, tokenID uuid.UUID) error {


### PR DESCRIPTION
Two fixes from the bot review of #615. Go only; no `.sql` touched.

## Fix 1 — a 401 that makes clients loop

`internal/mcp/service.go` returned `domain.Unauthorized(ErrCodeCapabilityUnmapped, ...)` for an empty stored capability set, while every other producer of that code returns `domain.Forbidden` — all three refusals in `OrgDefaultCapabilities` (`internal/mcp/policy.go:235,244,256`).

The consequence is on the client. `Authenticate` failures reach `TransportHandler.writeUnauthorized`, and an MCP client that receives 401 re-runs the OAuth handshake — which cannot refill a stored capability column. So the client loops, and the operator is sent to rotate a credential that was never the problem. An empty `capabilities` column is a configuration state; 403 says the credential is valid and the grant is not permitted.

`TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole` asserted only that `Authenticate` returned *an error*, so it was green under 401 and 403 alike. It now asserts `Kind`, `HTTPStatus` and `Code` by value.

## Fix 2 — a rollback probe that proved nothing

The mint rollback probe asserted only `err != nil`. The mint can fail *before* `onCreated` ever runs — a `23502` from a NOT NULL grant column, or a CHECK violation on `expires_at` or `capabilities`. In that case nothing was inserted, both count assertions still pass, and the test stays green while proving nothing about the transaction boundary it names.

Pinned with `errors.Is(err, errMintAuditProbe)`, matching the sibling probe `TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole`.

## Proofs

Both mutations were planted, observed red, and reverted; the working tree is clean and carries no markers.

Fix 1, `Forbidden` reverted to `Unauthorized`:

```
--- FAIL: TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole (1.96s)
    empty-capabilities refusal Kind = 5 (HTTP 401), want 4 (HTTP 403).
```

Fix 2, the grant insert forced to abort before `onCreated` (invalid `site_scope_mode`):

```
--- FAIL: TestMCPMintRollsBackTheCredentialWhenTheAuditAppendFailsAsAppRole (1.97s)
    the mint failed with ... violates check constraint "mcp_grants_site_scope_mode_check"
    (SQLSTATE 23514), which is NOT the injected onCreated failure.
```

With that same insert failure planted and the new pin disabled, the test passes (`ok ... 2.848s`) — which is the vacuous green the pin removes.
