### PR TITLE
fix(mcp): an unticked capability refuses, it does not hide

### DIFF
--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -13,8 +13,14 @@ import (
 // This file answers "WHICH TOOLS may this connection reach". registry.go
 // answers "WHICH TOOLS EXIST, and what does each require". The two are
 // deliberately separate types so that neither can be read as the other, and
-// deliberately joined at exactly one place (AuthorizeTool) that both tools/list
-// and tools/call go through.
+// deliberately joined at exactly one place: AuthorizeTool, which every
+// tools/call goes through.
+//
+// tools/list DOES NOT consult this file any more. Under the D1 ruling an
+// unticked capability refuses rather than hides, so the listing is unfiltered
+// and the capability is enforced on the invocation path alone. That is a
+// disclosure change and not an authority change -- see the D1 note in
+// registry.go.
 //
 // SiteSet in model.go is the shape this copies. Its zero value allows nothing
 // and it has no method answering "does this mean everything", because the
@@ -23,10 +29,27 @@ import (
 // axis.
 // ---------------------------------------------------------------------------
 
-// ErrCodeToolNotAvailable is the SINGLE domain code for every reason a tool is
-// not reachable by this connection. See the disclosure note on AuthorizeTool
-// for why there is one code and not three.
+// ErrCodeToolNotAvailable is the refusal for a name that IS NOT IN THE REGISTRY
+// AT ALL -- the model guessed. It no longer doubles as the capability refusal:
+// that is ErrCodeCapabilityNotGranted below, and the D1 note in registry.go
+// records why the two were merged and why they are now separate.
 const ErrCodeToolNotAvailable = "mcp_tool_not_available"
+
+// ErrCodeCapabilityNotGranted is the TYPED, TERMINAL refusal for a registered
+// tool whose capability this connection's grant does not hold. It is the D1
+// ruling's wire vocabulary: an unticked capability refuses under this code, it
+// does not vanish from tools/list.
+//
+// IT IS A THIRD CODE AND NOT ONE OF THE TWO ABOVE, and the distinction is the
+// whole reason it exists. ErrCodeCapabilityUnmapped means THE SERVER is
+// misconfigured -- a scope it recognises confers nothing -- and telling a
+// caller that when the truth is "your grant is narrower than you thought"
+// sends an operator hunting a server fault they do not have.
+// ErrCodeCapabilityWiderThanDefault is the OPERATOR-facing refusal on the
+// narrowing path, raised while a connection is being configured, and it is
+// never seen by a model calling a tool. This code is the model-facing one, and
+// a client branching on it must read it as permanent: see AuthorizeTool.
+const ErrCodeCapabilityNotGranted = "mcp_capability_not_granted"
 
 // ErrCodeCapabilityUnmapped is the fail-closed refusal for a recognised OAuth
 // scope that no capability mapping covers. It is an internal misconfiguration,

--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -24,16 +24,22 @@ import (
 // plausible name never takes the discovery path at all, so nothing it guesses
 // is ever filtered.
 //
-// The fix is not a second check bolted onto tools/call. It is that BOTH paths
-// resolve through the SAME function over the SAME closed list:
+// The fix is not a second check bolted onto tools/call. It is that the
+// INVOCATION path resolves the name through one function over the closed list,
+// and that function decides authority for itself:
 //
-//	tools/list  -> VisibleTools(auth)  -> visible(entry, auth)
-//	tools/call  -> AuthorizeTool(name, auth) -> visible(entry, auth)
+//	tools/list  -> VisibleTools(auth)        -> every entry, annotated
+//	tools/call  -> AuthorizeTool(name, auth) -> capabilityHeld(entry, auth)
 //
-// so a tool cannot be callable and invisible. There is no path from a tool name
-// to an invocation that does not pass visible(); the dispatch function itself
-// hangs off the registry entry, so tools/call has no switch and therefore no
-// `default` arm to fall through.
+// so nothing tools/list said can make a tool callable. There is no path from a
+// tool name to an invocation that does not pass AuthorizeTool; the dispatch
+// function itself hangs off the registry entry, so tools/call has no switch and
+// therefore no `default` arm to fall through.
+//
+// tools/list NO LONGER FILTERS. Under the D1 ruling an unticked capability
+// refuses rather than hides, so the listing is the whole registry and the
+// capability answer is given at invocation, by name. See the D1 note further
+// down for the reasoning and for what that does and does not change.
 //
 // THE LIST STAYS CLOSED AND STAYS A FUNCTION. registryTools() returns a fresh
 // slice built from a literal, exactly as Tools() did before this slice, and for
@@ -92,8 +98,8 @@ type ToolPolicy struct {
 	// turns that into a NAMED refusal at the registry gate rather than an empty
 	// result deeper in that reads as a healthy org owning nothing.
 	//
-	// It does NOT hide the tool from tools/list. See the asymmetry note on
-	// visible() for why visibility follows the capability axis alone.
+	// It does NOT hide the tool from tools/list, and neither does the
+	// capability axis any more. See the D1 note below.
 	RequiresSiteScope bool
 
 	invoke toolInvoker
@@ -155,7 +161,7 @@ func cloneSchema(s json.RawMessage) json.RawMessage {
 }
 
 // ---------------------------------------------------------------------------
-// The one predicate both paths use
+// The invocation gate
 // ---------------------------------------------------------------------------
 
 // refusalReason is the OPERATOR-FACING classification of why a tool was not
@@ -167,7 +173,11 @@ const (
 	// reasonUnregistered: no entry of that name exists. The model guessed.
 	reasonUnregistered refusalReason = "unregistered"
 	// reasonCapabilityNotHeld: the entry exists and this connection's
-	// capability set does not hold what it requires.
+	// capability set does not hold what it requires. Since the D1 ruling this
+	// one is ALSO disclosed to the caller, by name, as
+	// mcp_capability_not_granted -- it is still recorded here because the
+	// operator log is what an operator greps when a customer says "the model
+	// says it cannot do X".
 	reasonCapabilityNotHeld refusalReason = "capability_not_held"
 	// reasonSiteScopeEmpty: the entry exists, the capability IS held, and the
 	// connection's resolved site scope is empty, so a site-keyed tool has
@@ -181,67 +191,127 @@ const (
 	reasonSiteScopeEmpty refusalReason = "site_scope_empty"
 )
 
-// visible reports whether auth may SEE AND CALL entry. tools/list and
-// tools/call both go through it, which is what makes "callable" and "visible"
-// the same predicate rather than two that agree by convention.
+// ---------------------------------------------------------------------------
+// D1 RULING: AN UNTICKED CAPABILITY REFUSES, IT DOES NOT HIDE.
 //
-// IT TESTS THE CAPABILITY AXIS AND NOT THE SITE AXIS, and the asymmetry is
-// deliberate. The two axes answer different questions and are disclosable to
-// different degrees:
+// This file used to delete a tool from tools/list when the connection did not
+// hold its capability, on the reasoning that such a caller "is not entitled to
+// know the tool exists". That bought non-enumerability and paid for it with the
+// one thing this surface exists to give a model: a fact it can act on. An
+// absent tool is indistinguishable from a tool that was never built, so the
+// model's only available reading is "wpmgr cannot do this" -- and the one
+// person who could fix it, the operator who ticks the capability on the
+// connection, never hears that anything was refused.
 //
-//   - CAPABILITY answers "may this connection reach this tool at all". A
-//     connection that does not hold the capability is not entitled to know the
-//     tool exists, so the tool is absent from tools/list and its name gets the
-//     uniform refusal.
+// The capability axis now behaves like the site axis already did: the tool is
+// LISTED, its descriptor says plainly that this connection does not hold what
+// it requires, and CALLING it returns a typed, terminal refusal naming the
+// capability (ErrCodeCapabilityNotGranted). Enumerability is the accepted cost
+// of the ruling, and it is bounded: registryTools() is a closed literal in a
+// reviewed file and every entry in it is a read tool.
 //
-//   - SITE SCOPE answers "is there any data for it to read". A connection whose
-//     org enabled the tool and whose capability set covers it IS entitled to
-//     know the tool exists -- it would have been listed but for an empty site
-//     scope, which is a fact about its own grant. Gating VISIBILITY on it would
-//     turn the most common benign misconfiguration in this surface into an
-//     unexplainable dead end, and would buy nothing: the only names it hides
-//     are ones the caller's own capability set already entitles it to see.
+// WHAT DID NOT CHANGE IS THE PART THAT MATTERS. The gate is still on the
+// INVOCATION path and it is still the only thing between a name and its invoke
+// function. tools/list never granted anything and still does not; AuthorizeTool
+// re-derives the capability answer for itself rather than trusting what was
+// listed, so a model that guesses a name is refused exactly as before. The
+// invariant kept is the one-directional one -- NOTHING IS CALLABLE THAT WAS NOT
+// LISTED -- which is now trivially true because everything is listed. The
+// converse, "everything listed is callable", is deliberately given up; that is
+// precisely what the ruling asks for, and TestExitGate_ListedIsNotCallable
+// pins it so nobody restores the old identity by accident.
 //
-// So site scope is enforced at INVOCATION, by AuthorizeTool, with the named
-// mcp_scope_empty refusal that says exactly what is wrong. That keeps the
-// invariant that matters -- nothing is callable that was not visible -- while
-// leaving the actionable half actionable.
-func visible(entry ToolPolicy, auth AuthorizedRequest) (bool, refusalReason) {
-	if !auth.Capabilities.Allows(entry.Capability) {
-		return false, reasonCapabilityNotHeld
-	}
-	return true, ""
+// SITE-SCOPE VISIBILITY IS UNTOUCHED BY THIS CHANGE. The design's other half --
+// that site scope should hide -- was not ruled on and is not implemented here.
+// A site-keyed tool with an empty resolved scope is still listed and still
+// refuses at invocation with mcp_scope_empty.
+// ---------------------------------------------------------------------------
+
+// capabilityHeld reports whether auth's capability set covers what entry
+// requires.
+//
+// It is consulted by AuthorizeTool for the refusal decision and by VisibleTools
+// only to decide whether to ANNOTATE a descriptor -- never to drop one. A
+// future edit that turns its false answer back into a `continue` in
+// VisibleTools is the thing the D1 ruling forbids.
+func capabilityHeld(entry ToolPolicy, auth AuthorizedRequest) bool {
+	return auth.Capabilities.Allows(entry.Capability)
 }
 
-// VisibleTools is the tools/list answer: the descriptors for exactly the tools
-// this connection may call. A tool it may not call is ABSENT, not present and
-// marked unavailable -- a disabled entry in a list is still a disclosure that
-// the tool exists.
+// capabilityNotice is the LISTING half of the ruling. The descriptor for a tool
+// this connection cannot currently call says so, in the description, which is
+// the one field of a tools/list entry every MCP client already puts in front of
+// the model.
 //
-// It returns a fresh, possibly empty slice. An empty tools/list is a truthful
-// answer for a connection that reaches nothing, and it is not an error: the
-// client is entitled to know its own surface is empty. The refusal with a
-// reason happens when it CALLS something.
+// IT SAYS THE REFUSAL IS PERMANENT, and that sentence is load-bearing rather
+// than polite. A model that reads "unavailable" as transient retries, and a
+// retry loop against a permanent refusal is the exact failure this surface has
+// already shipped once: the empty-capability path answered 401, and clients
+// re-ran an entire OAuth handshake that could not possibly change the outcome.
+// The wording here and in AuthorizeTool's message agree on that point on
+// purpose.
+func capabilityNotice(entry ToolPolicy) string {
+	return fmt.Sprintf(
+		"\n\nNOT AVAILABLE TO THIS CONNECTION. This tool requires the %q capability and "+
+			"this connection's grant does not hold it. Calling it refuses with %s. That "+
+			"refusal is permanent for this connection: retrying, refreshing the token or "+
+			"re-running the OAuth authorisation will return the same answer. A wpmgr "+
+			"operator must grant %[1]q to this connection before it can be used.",
+		entry.Capability, ErrCodeCapabilityNotGranted)
+}
+
+// capabilityNames renders a capability set for an error body. It is the
+// caller's OWN grant, so returning it discloses nothing new and it lets a
+// model tell the user exactly what the connection can and cannot do.
+func capabilityNames(set CapabilitySet) []string {
+	held := set.Sorted()
+	out := make([]string, 0, len(held))
+	for _, c := range held {
+		out = append(out, string(c))
+	}
+	return out
+}
+
+// VisibleTools is the tools/list answer: EVERY tool this server has, with the
+// ones this connection cannot currently call marked as such in their
+// description. Nothing is dropped. That is the D1 ruling, and the note above
+// says why a dropped tool was the worse of the two answers.
+//
+// IT IS STILL A PER-CONNECTION VALUE AND IT IS STILL NOT Tools(). The
+// descriptions differ by connection, and handing a caller the unannotated
+// registry would give the model a tool that looks callable and is not -- the
+// silent half of exactly the problem this change fixes. transport.go calls this
+// one; the drift tests call Tools().
+//
+// It returns a fresh slice, non-empty while the registry is non-empty. An empty
+// tools/list is now a SYMPTOM rather than an answer: before this, a connection
+// whose grant was missing a capability got an empty list, which is
+// indistinguishable from a server that has no tools.
 func VisibleTools(auth AuthorizedRequest) []ToolDescriptor {
 	entries := registryTools()
 	out := make([]ToolDescriptor, 0, len(entries))
 	for _, e := range entries {
-		if ok, _ := visible(e, auth); !ok {
-			continue
-		}
-		out = append(out, ToolDescriptor{
+		d := ToolDescriptor{
 			Name:        e.Name,
 			Description: e.Description,
 			InputSchema: e.InputSchema,
-		})
+		}
+		if !capabilityHeld(e, auth) {
+			d.Description += capabilityNotice(e)
+		}
+		out = append(out, d)
 	}
 	return out
 }
 
 // visibleToolNames lists what this connection was actually shown. Safe to
 // return in an error body: it is exactly the tools/list answer this connection
-// is already entitled to, so it discloses nothing new, and it lets a model that
-// mistyped a name it legitimately holds correct in one round trip.
+// has already been given, so it discloses nothing new, and it lets a model that
+// mistyped a real name correct in one round trip.
+//
+// It carries NAMES ONLY, so it does not repeat the capability notice. A model
+// that finds its name in this list and still cannot call the tool is looking at
+// the capability refusal, which names the capability itself.
 func visibleToolNames(auth AuthorizedRequest) []string {
 	ts := VisibleTools(auth)
 	out := make([]string, 0, len(ts))
@@ -256,51 +326,52 @@ func visibleToolNames(auth AuthorizedRequest) []string {
 // ---------------------------------------------------------------------------
 
 // AuthorizeTool resolves a tool name for INVOCATION. It is the only way to get
-// a callable ToolPolicy, and it applies the same visible() predicate tools/list
-// applies, so a name that was never shown is not callable.
+// a callable ToolPolicy, and it decides the capability question for itself
+// rather than trusting that tools/list ran.
 //
 // ------------------------------------------------------------------------
-// THE DISCLOSURE DECISION, AND THE TENSION IT RESOLVES.
+// THE DISCLOSURE DECISION, AS THE D1 RULING SETTLED IT.
 //
-// The brief for this slice asks for "typed refusals that name the reason", and
-// non-disclosure pulls directly against that. "Your organisation has not
-// enabled sites.restart" is a precise, actionable, well-typed refusal -- and it
-// confirms that sites.restart EXISTS to a caller who was never shown it. Repeat
-// that against a wordlist and the refusal messages enumerate the entire tool
-// surface of a product the caller has no entitlement to see, including tools
-// that are unreleased, gated, or being trialled by one organisation.
+// The tension is real and it was previously resolved the other way. "Your
+// connection does not hold mcp.sites.restart" is a precise, actionable, typed
+// refusal -- and it confirms that a tool named sites.restart exists. This file
+// used to answer registered-but-not-held and never-existed identically so that
+// no wordlist could tell them apart.
 //
-// The line drawn here is: A NAME THE CONNECTION WAS NOT SHOWN GETS ONE
-// INDISTINGUISHABLE ANSWER. Unregistered and registered-but-capability-not-held
-// return the same code, the same message and the same data. There is no
-// existence oracle, because there is no observable difference between "no such
-// tool" and "not yours".
+// THE OWNER RULED THAT REFUSAL BEATS CONCEALMENT, and the ruling is right on
+// the facts of this surface. The blur bought nothing once tools/list stopped
+// filtering -- the listing already hands over every name -- and it cost the
+// model the only information that could end the exchange usefully. A model told
+// "not available, ask tools/list" by a server whose tools/list DOES show the
+// tool has been handed a contradiction, and its next move is to try again.
 //
-// This is the same call authz.RequireSiteAccess makes one layer down, where a
-// site the caller may not reach answers 404 and not 403 SPECIFICALLY so that
-// probing ids cannot enumerate the fleet. A different answer here would undo
-// that at the MCP boundary for anyone holding any valid connection token.
+// SO THERE ARE NOW TWO ANSWERS, AND THEY ARE DIFFERENT ON PURPOSE:
 //
-// THE REFUSAL IS STILL TYPED -- just not on the caller's axis. The operator
-// gets the precise reason, on the operator's own surface, where the audience is
-// entitled to it: refusalReason is returned to the transport, which logs it
-// with the tenant, the grant and the attempted name. An operator debugging
-// "why can't my client call this" reads one log line and gets the exact answer;
-// an attacker probing names gets one sentence, identical every time.
+//   - A NAME NOT IN THE REGISTRY gets ErrCodeToolNotAvailable. The model
+//     guessed. Nothing exists to disclose.
+//   - A REGISTERED NAME WHOSE CAPABILITY IS NOT HELD gets
+//     ErrCodeCapabilityNotGranted, naming the capability, naming what this
+//     connection does hold, and saying the refusal is PERMANENT.
 //
-// WHAT REMAINS DISCLOSABLE, AND WHY IT IS NOT A LEAK. A tool the connection CAN
-// see fails with its real reason. Two such reasons exist and both are facts
-// about the caller's own grant, for a tool tools/list already showed it:
+// TERMINALITY IS PART OF THE CONTRACT. The refusal must not read as a transient
+// failure, because a model that reads it that way retries, and a retry loop
+// against a permanent refusal is a failure this surface has already shipped:
+// the empty-capability path answered 401, and clients responded by re-running
+// an OAuth handshake that could not change the outcome. The message says so in
+// words for the model and the details carry retryable=false for the client.
+//
+// The other two disclosable refusals are unchanged, and both remain facts about
+// the caller's own grant for a tool it was shown:
 //
 //   - the named mcp_scope_empty refusal, when a site-keyed tool has an empty
-//     resolved site scope. This is the actionable case an operator actually
-//     hits, and blurring it would send them hunting a capability problem they
-//     do not have. See the asymmetry note on visible().
+//     resolved site scope. SITE-SCOPE VISIBILITY IS NOT PART OF THIS CHANGE.
 //   - invalid arguments, which carries the schema so a model corrects in one
 //     round trip.
 //
-// The error body also carries the connection's OWN visible tool list, which is
-// exactly the tools/list answer it is already entitled to.
+// THE OPERATOR LOG STILL GETS THE PRECISE REASON EITHER WAY. refusalReason is
+// returned to the transport, which logs it with the tenant, the grant and the
+// attempted name -- that was the only typed channel before this change, and it
+// is still the one an operator greps.
 // ------------------------------------------------------------------------
 //
 // The returned ToolPolicy is not "found"; it is "found AND permitted AND
@@ -316,53 +387,66 @@ func AuthorizeTool(name string, auth AuthorizedRequest) (ToolPolicy, refusalReas
 		}
 	}
 
-	reason := reasonUnregistered
-	if found {
-		var ok bool
-		if ok, reason = visible(entry, auth); ok {
-			if entry.invoke == nil {
-				// A registry entry with no implementation is a build defect,
-				// and it is refused as an INTERNAL failure rather than as a
-				// permission one. Reporting it as "not available to this
-				// connection" would tell an operator their grant is wrong when
-				// the truth is that the server is broken, and they would go and
-				// widen a scope that was never the problem.
-				return ToolPolicy{}, "", fmt.Errorf("registry entry %q has no implementation", name)
-			}
-
-			// THE SITE AXIS, ENFORCED AT THE GATE AND NOT ONLY IN THE SERVICE.
-			//
-			// ListSitesForModel makes this same check, and the redundancy is
-			// deliberate in the same way the Go mirror of a schema CHECK is:
-			// the service check protects the one tool that has it, this one
-			// protects every tool that ever declares RequiresSiteScope,
-			// including the next one whose author forgets. A site-keyed read
-			// reached with an empty resolved scope must REFUSE and say so, not
-			// return an empty result that reads as a healthy org owning
-			// nothing.
-			//
-			// Only a caller who passed visible() reaches here, so naming the
-			// reason discloses nothing beyond that caller's own tools/list.
-			if entry.RequiresSiteScope && auth.Sites.IsEmpty() {
-				// The reason is returned, NOT "". An empty reason here made the
-				// refusal invisible to the operator log, which is half of what
-				// justifies blurring the other two reasons on the wire.
-				return ToolPolicy{}, reasonSiteScopeEmpty, domain.Forbidden(ErrCodeScopeEmpty,
-					"this connection's site scope resolves to no sites, so there is nothing it may read. "+
-						"This is a refusal, not an empty fleet: check the grant's site scope.")
-			}
-			return entry, "", nil
-		}
+	if !found {
+		// The model guessed a name. This is now the ONLY use of the uniform
+		// answer, and there is no longer a second reason hiding behind it.
+		return ToolPolicy{}, reasonUnregistered, domain.Forbidden(ErrCodeToolNotAvailable,
+			fmt.Sprintf("no tool named %q exists on this server. Call tools/list for the "+
+				"tools this server has; every one of them appears there, so a name absent "+
+				"from that list will never resolve however it is spelled.", name))
 	}
 
-	// ONE answer for all three reasons. The reason is returned alongside for
-	// the operator log and never reaches the wire.
-	return ToolPolicy{}, reason, domain.Forbidden(ErrCodeToolNotAvailable,
-		fmt.Sprintf("tool %q is not available to this connection. This answer is the same "+
-			"whether no such tool exists or whether this connection's capabilities do "+
-			"not cover it -- the server does not distinguish those to a caller. Call "+
-			"tools/list for the tools this connection may use; a tool absent from that "+
-			"list is not reachable by naming it here.", name))
+	if !capabilityHeld(entry, auth) {
+		// THE TYPED CAPABILITY REFUSAL. Naming the capability is the ruling;
+		// naming the held set and marking it non-retryable is what makes it
+		// actionable rather than merely precise.
+		return ToolPolicy{}, reasonCapabilityNotHeld, domain.Forbidden(ErrCodeCapabilityNotGranted,
+			fmt.Sprintf("tool %q requires the %q capability and this connection's grant does "+
+				"not hold it. This is a permanent property of the grant and not a transient "+
+				"failure: retrying this call, refreshing the connection token or re-running "+
+				"the OAuth authorisation will return exactly this answer. A wpmgr operator "+
+				"must grant %[2]q to this connection before it can be called.",
+				name, entry.Capability)).
+			WithDetails(map[string]any{
+				"tool":                name,
+				"required_capability": string(entry.Capability),
+				"held_capabilities":   capabilityNames(auth.Capabilities),
+				"retryable":           false,
+			})
+	}
+
+	if entry.invoke == nil {
+		// A registry entry with no implementation is a build defect, and it is
+		// refused as an INTERNAL failure rather than as a permission one.
+		// Reporting it as "not available to this connection" would tell an
+		// operator their grant is wrong when the truth is that the server is
+		// broken, and they would go and widen a scope that was never the
+		// problem.
+		return ToolPolicy{}, "", fmt.Errorf("registry entry %q has no implementation", name)
+	}
+
+	// THE SITE AXIS, ENFORCED AT THE GATE AND NOT ONLY IN THE SERVICE.
+	//
+	// ListSitesForModel makes this same check, and the redundancy is deliberate
+	// in the same way the Go mirror of a schema CHECK is: the service check
+	// protects the one tool that has it, this one protects every tool that ever
+	// declares RequiresSiteScope, including the next one whose author forgets.
+	// A site-keyed read reached with an empty resolved scope must REFUSE and
+	// say so, not return an empty result that reads as a healthy org owning
+	// nothing.
+	//
+	// THIS IS UNCHANGED BY THE D1 RULING and deliberately so: the ruling covers
+	// the capability axis only. The tool is listed, as it always was, and this
+	// refusal is by name, as it always was.
+	if entry.RequiresSiteScope && auth.Sites.IsEmpty() {
+		// The reason is returned, NOT "". An empty reason here made the refusal
+		// invisible to the operator log, which is half of what justified
+		// blurring the other reasons on the wire.
+		return ToolPolicy{}, reasonSiteScopeEmpty, domain.Forbidden(ErrCodeScopeEmpty,
+			"this connection's site scope resolves to no sites, so there is nothing it may read. "+
+				"This is a refusal, not an empty fleet: check the grant's site scope.")
+	}
+	return entry, "", nil
 }
 
 // Tools returns the FULL registry surface as descriptors, unfiltered by any

--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -227,15 +227,42 @@ const (
 // refuses at invocation with mcp_scope_empty.
 // ---------------------------------------------------------------------------
 
-// capabilityHeld reports whether auth's capability set covers what entry
-// requires.
+// capabilityHeld reports whether auth's GRANT covers what entry requires.
 //
 // It is consulted by AuthorizeTool for the refusal decision and by VisibleTools
 // only to decide whether to ANNOTATE a descriptor -- never to drop one. A
 // future edit that turns its false answer back into a `continue` in
-// VisibleTools is the thing the D1 ruling forbids.
+// VisibleTools is the thing the D1 ruling forbids: that is the boundary whose
+// whole point is that it refuses visibly. Dropping is withinOrgCeiling's job
+// and only withinOrgCeiling's.
 func capabilityHeld(entry ToolPolicy, auth AuthorizedRequest) bool {
 	return auth.Capabilities.Allows(entry.Capability)
+}
+
+// withinOrgCeiling reports whether entry's capability is inside the
+// ORGANISATION's ceiling -- the widest set any connection in this org may hold.
+//
+// THIS IS THE BOUNDARY THAT HIDES, and it is the only one. The distinction from
+// capabilityHeld is the entire ruling:
+//
+//	inside the ceiling, held by the grant     -> listed, callable
+//	inside the ceiling, NOT held by the grant -> listed, refuses by name
+//	outside the ceiling                       -> not listed, refuses as unknown
+//
+// The middle row is why unticking a permission is explicable: an operator who
+// removes a capability gets a tool that says what happened and who can fix it,
+// instead of one that disappears -- and a vanished tool is indistinguishable
+// from a tool that was never built, so the model's only reading is "wpmgr
+// cannot do this" and nobody ever hears that something was refused.
+//
+// The last row is why the org boundary is different: a token holder should not
+// be able to enumerate capabilities their organisation deliberately switched
+// off. Listing them, even annotated, is exactly that enumeration.
+//
+// A ZERO-VALUE CEILING ADMITS NOTHING, which is fail-closed and deliberate.
+// See AuthorizedRequest.OrgCeiling.
+func withinOrgCeiling(entry ToolPolicy, auth AuthorizedRequest) bool {
+	return auth.OrgCeiling.Allows(entry.Capability)
 }
 
 // capabilityNotice is the LISTING half of the ruling. The descriptor for a tool
@@ -260,25 +287,36 @@ func capabilityNotice(entry ToolPolicy) string {
 		entry.Capability, ErrCodeCapabilityNotGranted)
 }
 
-// VisibleTools is the tools/list answer: EVERY tool this server has, with the
-// ones this connection cannot currently call marked as such in their
-// description. Nothing is dropped. That is the D1 ruling, and the note above
-// says why a dropped tool was the worse of the two answers.
+// VisibleTools is the tools/list answer: every tool INSIDE THIS
+// ORGANISATION'S CEILING, with the ones this connection's own grant cannot call
+// marked as such in their description.
 //
-// IT IS STILL A PER-CONNECTION VALUE AND IT IS STILL NOT Tools(). The
-// descriptions differ by connection, and handing a caller the unannotated
-// registry would give the model a tool that looks callable and is not -- the
-// silent half of exactly the problem this change fixes. transport.go calls this
-// one; the drift tests call Tools().
+// TWO BOUNDARIES, TWO ANSWERS, and which one excludes a tool decides whether it
+// is hidden or explained. withinOrgCeiling drops; capabilityHeld only
+// annotates. The reasoning for the asymmetry is on withinOrgCeiling and it is
+// the whole ruling -- do not collapse the two predicates into one.
 //
-// It returns a fresh slice, non-empty while the registry is non-empty. An empty
-// tools/list is now a SYMPTOM rather than an answer: before this, a connection
-// whose grant was missing a capability got an empty list, which is
-// indistinguishable from a server that has no tools.
+// IT IS STILL A PER-CONNECTION VALUE AND IT IS STILL NOT Tools(). Both the
+// membership and the descriptions differ by connection, and handing a caller
+// the unannotated registry would give the model a tool that looks callable and
+// is not -- the silent half of exactly the problem this change fixes.
+// transport.go calls this one; the drift tests call Tools().
+//
+// It returns a fresh slice. An empty result is a truthful answer for a
+// connection whose org ceiling admits nothing, not an error -- but a tool the
+// GRANT merely lacks never produces one, which is the point: that case is
+// listed and annotated.
+//
+// SITE SCOPE IS NOT CONSULTED HERE. A site-keyed tool with an empty resolved
+// scope is still listed and still refuses at invocation with mcp_scope_empty.
+// That half was ruled on separately and is deliberately untouched.
 func VisibleTools(auth AuthorizedRequest) []ToolDescriptor {
 	entries := registryTools()
 	out := make([]ToolDescriptor, 0, len(entries))
 	for _, e := range entries {
+		if !withinOrgCeiling(e, auth) {
+			continue
+		}
 		d := ToolDescriptor{
 			Name:        e.Name,
 			Description: e.Description,
@@ -378,6 +416,31 @@ func AuthorizeTool(name string, auth AuthorizedRequest) (ToolPolicy, refusalReas
 	if !found {
 		// The model guessed a name. This is now the ONLY use of the uniform
 		// answer, and there is no longer a second reason hiding behind it.
+		return ToolPolicy{}, reasonUnregistered, domain.Forbidden(ErrCodeToolNotAvailable,
+			fmt.Sprintf("no tool named %q exists on this server. Call tools/list for the "+
+				"tools this server has; every one of them appears there, so a name absent "+
+				"from that list will never resolve however it is spelled.", name))
+	}
+
+	if !withinOrgCeiling(entry, auth) {
+		// OUTSIDE THE ORG CEILING ANSWERS EXACTLY AS AN UNREGISTERED NAME DOES,
+		// and the sameness is the point rather than laziness.
+		//
+		// VisibleTools omitted this tool so the caller could not enumerate what
+		// their organisation switched off. A distinguishable refusal here would
+		// hand back precisely that enumeration -- guess the name, read the
+		// code, learn which capabilities exist and that yours is not one of
+		// them. The listing and the gate have to tell the same story or the
+		// quieter one is decorative.
+		//
+		// This is NOT the capability refusal above. That one names the
+		// capability on purpose, because the org HAS enabled it and an operator
+		// can act. Here no operator in this organisation has anything to tick,
+		// so there is nothing actionable to disclose.
+		//
+		// The operator log still gets the precise reason: refusalReason is
+		// returned to the transport and logged with the tenant, the grant and
+		// the attempted name.
 		return ToolPolicy{}, reasonUnregistered, domain.Forbidden(ErrCodeToolNotAvailable,
 			fmt.Sprintf("no tool named %q exists on this server. Call tools/list for the "+
 				"tools this server has; every one of them appears there, so a name absent "+

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -38,16 +38,49 @@ func nonEmptyRegistry(t *testing.T) []ToolPolicy {
 }
 
 // authWith builds an AuthorizedRequest directly, which is how a test reaches
-// the registry gate with a chosen capability set. Both fields are set
+// the registry gate with a chosen capability set. Every field is set
 // explicitly: the zero value of each allows nothing, so a test that forgot one
 // would prove the gate works for a reason it did not intend.
+//
+// THE CEILING IS THE PRODUCTION CEILING, not the grant. authWith models the
+// ordinary connection -- one whose organisation has everything the surface
+// offers enabled and whose own grant may be narrower. That is what
+// Authenticate builds today, because OrgDefaultCapabilities over grantScopes()
+// resolves to the whole vocabulary while exactly one scope is recognised.
+//
+// A test that needs a NARROWER ceiling than the vocabulary -- the org-switched-
+// off case -- must say so, and authWithCeiling is how.
 func authWith(caps CapabilitySet, siteIDs ...uuid.UUID) AuthorizedRequest {
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	if err != nil {
+		// Not t.Fatal: authWith has no *testing.T and this is unreachable while
+		// scopeCapabilities is total over recognisedScopes, which
+		// TestEveryRecognisedScopeHasACapabilityMapping pins. Panicking beats
+		// returning a zero ceiling, which would silently list nothing and make
+		// every visibility test pass for the wrong reason.
+		panic("authWith: org ceiling did not resolve: " + err.Error())
+	}
+	return authWithCeiling(ceiling, caps, siteIDs...)
+}
+
+// authWithCeiling builds an AuthorizedRequest with an EXPLICIT org ceiling, so
+// a test can construct the case where the organisation's ceiling is narrower
+// than the capability vocabulary.
+//
+// That case is not reachable through Authenticate today: the ceiling is derived
+// from the closed scope registry, recognisedScopes holds one entry, and
+// scopeCapabilities maps it to the whole vocabulary -- so the production
+// ceiling and the vocabulary coincide and every tool is inside every ceiling.
+// It becomes reachable when the vocabulary widens and org policy can select
+// within it. The structure is proven now so it is correct then.
+func authWithCeiling(ceiling, caps CapabilitySet, siteIDs ...uuid.UUID) AuthorizedRequest {
 	return AuthorizedRequest{
 		TenantID:     uuid.New(),
 		GrantID:      uuid.New(),
 		TokenID:      uuid.New(),
 		Sites:        NewSiteSet(siteIDs),
 		Capabilities: caps,
+		OrgCeiling:   ceiling,
 	}
 }
 

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -275,6 +275,102 @@ func TestCapabilityRefusalIsListedNotHidden(t *testing.T) {
 	}
 }
 
+// TestOrgCeilingHidesWhileTheGrantRefuses is the ruling's asymmetry, in one
+// test, so that collapsing the two predicates into one cannot pass.
+//
+// The same registry, the same tool, two different connections:
+//
+//	ceiling holds it, grant does not -> LISTED, annotated, refuses by name
+//	ceiling does not hold it         -> ABSENT, refuses as unregistered
+//
+// CI does not run the integration package, so this is the fast guard for the
+// ceiling arm; the wpmgr_app proof is
+// TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole in
+// apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go.
+//
+// The narrow ceiling is the EMPTY set because that is the only proper subset of
+// a one-entry vocabulary, and it is not reachable through Authenticate today.
+// See authWithCeiling.
+func TestOrgCeilingHidesWhileTheGrantRefuses(t *testing.T) {
+	want := len(nonEmptyRegistry(t))
+	site := uuid.New()
+
+	// INSIDE the ceiling, NOT held by the grant: listed and annotated.
+	inside := authWith(CapabilitySet{}, site)
+	got := VisibleTools(inside)
+	if len(got) != want {
+		t.Fatalf("a capability the ORG allows but the grant lacks was hidden: showed %d "+
+			"of %d; that boundary must refuse visibly, not vanish", len(got), want)
+	}
+	if !strings.Contains(got[0].Description, "NOT AVAILABLE TO THIS CONNECTION") {
+		t.Fatalf("the listed tool is not annotated:\n%s", got[0].Description)
+	}
+	_, _, err := AuthorizeTool(ToolListSites, inside)
+	ide, ok := domain.AsDomain(err)
+	if !ok || ide.Code != ErrCodeCapabilityNotGranted {
+		t.Fatalf("in-ceiling refusal = %v, want code %q", err, ErrCodeCapabilityNotGranted)
+	}
+
+	// OUTSIDE the ceiling, and the grant DOES hold it -- so an absence can only
+	// be the ceiling. Nothing here is attributable to the grant axis.
+	outside := authWithCeiling(NewCapabilitySet(nil), NewCapabilitySet(AllCapabilities()), site)
+	if !outside.Capabilities.Allows(CapSitesRead) {
+		t.Fatalf("the grant does not hold %q, so this would prove the GRANT arm", CapSitesRead)
+	}
+	if hidden := VisibleTools(outside); len(hidden) != 0 {
+		t.Fatalf("a capability OUTSIDE the org ceiling was listed: %+v; a token holder must "+
+			"not be able to enumerate what the organisation switched off", hidden)
+	}
+
+	// And the gate agrees with the listing, by value and by prose.
+	_, _, err = AuthorizeTool(ToolListSites, outside)
+	ode, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("out-of-ceiling refusal = %v, want a domain error", err)
+	}
+	if ode.Code != ErrCodeToolNotAvailable {
+		t.Fatalf("out-of-ceiling code = %q, want %q", ode.Code, ErrCodeToolNotAvailable)
+	}
+	if ode.Code == ErrCodeCapabilityNotGranted {
+		t.Fatal("the ceiling refusal named the capability the organisation disabled")
+	}
+	if strings.Contains(ode.Message, string(CapSitesRead)) {
+		t.Fatalf("the ceiling refusal names the disabled capability: %s", ode.Message)
+	}
+
+	// Identical to a name that was never registered. A divergence here is an
+	// oracle for the org's disabled capabilities.
+	//
+	// The comparison is on the TEMPLATE, not the literal string: both messages
+	// echo the name the caller asked for, and that difference is the caller's
+	// own input rather than a disclosure. Substituting it back is what isolates
+	// the property -- everything OTHER than the echoed name must match.
+	const guessed = "sites_restart_everything"
+	_, _, guess := AuthorizeTool(guessed, outside)
+	gde, ok := domain.AsDomain(guess)
+	if !ok {
+		t.Fatalf("guessed name err = %v, want a domain error", guess)
+	}
+	if gde.Code != ode.Code {
+		t.Fatalf("a disabled capability answers %q and a guessed name answers %q; "+
+			"the difference tells a caller which capabilities exist", ode.Code, gde.Code)
+	}
+	if want := strings.ReplaceAll(gde.Message, guessed, ToolListSites); ode.Message != want {
+		t.Fatalf("the two refusals differ beyond the echoed name, which is an oracle:\n"+
+			"disabled: %s\nexpected: %s", ode.Message, want)
+	}
+
+	// AND IT DOES NOT OVER-FIRE. The ordinary connection -- real ceiling, full
+	// grant -- still sees every tool and still calls it.
+	full := authWith(NewCapabilitySet(AllCapabilities()), site)
+	if fd := VisibleTools(full); len(fd) != want {
+		t.Fatalf("an ordinary fully-granted connection saw %d of %d tools", len(fd), want)
+	}
+	if _, _, err := AuthorizeTool(ToolListSites, full); err != nil {
+		t.Fatalf("an ordinary fully-granted connection was refused: %v", err)
+	}
+}
+
 // TestUnregisteredNameIsNotACapabilityRefusal keeps the two answers apart in
 // the other direction.
 //

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -53,109 +53,241 @@ func authWith(caps CapabilitySet, siteIDs ...uuid.UUID) AuthorizedRequest {
 
 // TestExitGate_GuessedToolNameIsUnreachable is THE proof for this slice.
 //
-// A connection holds NO capability. tools/list therefore shows it nothing. It
-// then names a tool anyway -- the registered name, and a set of plausible
-// guesses a model would produce from the product's vocabulary. Every one must
-// refuse.
+// A connection holds NO capability. It names a tool anyway -- the registered
+// name, and a set of plausible guesses a model would produce from the product's
+// vocabulary. Every one must refuse, and the two KINDS of refusal must be the
+// two the D1 ruling defines.
 //
 // The registered name is in the table on purpose and it is the load-bearing
 // case. A gate that only refuses names it has never heard of is not a gate: it
 // is a typo checker. The failure this test exists to catch is a tools/call path
 // that resolves a REAL registry entry and dispatches on it without asking
 // whether this connection may reach it, which is exactly what the pre-S7 switch
-// statement did.
+// statement did -- and which listing the tool unconditionally would make easier
+// to reach, not harder.
 func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
 	// No capability, but a non-empty site scope -- so nothing about this
 	// refusal can be attributed to the site axis.
 	auth := authWith(CapabilitySet{}, uuid.New())
 
-	if got := VisibleTools(auth); len(got) != 0 {
-		t.Fatalf("a connection holding no capability was shown %d tools: %+v", len(got), got)
+	// The tool is LISTED. That is the ruling, and it is asserted here rather
+	// than only in its own test so that this proof cannot be read as "nothing
+	// was reachable because nothing was shown".
+	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolListSites {
+		t.Fatalf("a connection holding no capability was shown %d tools, want the whole "+
+			"registry listed and annotated: %+v", len(got), got)
 	}
 
-	for _, name := range []string{
-		ToolListSites, // REGISTERED, and still unreachable. See above.
-		"list_sites_all",
-		"sites.restart",
-		"restart_site",
-		"update_plugin",
-		"run_backup",
-		"delete_site",
-		"", // the empty name, which must not match a zero-value entry
-	} {
-		t.Run(name, func(t *testing.T) {
-			entry, reason, err := AuthorizeTool(name, auth)
+	cases := []struct {
+		name string
+		want string
+	}{
+		// REGISTERED, and still unreachable. See above.
+		{ToolListSites, ErrCodeCapabilityNotGranted},
+		{"list_sites_all", ErrCodeToolNotAvailable},
+		{"sites.restart", ErrCodeToolNotAvailable},
+		{"restart_site", ErrCodeToolNotAvailable},
+		{"update_plugin", ErrCodeToolNotAvailable},
+		{"run_backup", ErrCodeToolNotAvailable},
+		{"delete_site", ErrCodeToolNotAvailable},
+		// The empty name, which must not match a zero-value entry.
+		{"", ErrCodeToolNotAvailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry, reason, err := AuthorizeTool(tc.name, auth)
 			if err == nil {
-				t.Fatalf("AuthorizeTool(%q) GRANTED: entry=%+v", name, entry)
+				t.Fatalf("AuthorizeTool(%q) GRANTED: entry=%+v", tc.name, entry)
 			}
 			if entry.invoke != nil {
-				t.Fatalf("AuthorizeTool(%q) returned an invocable entry alongside its error", name)
+				t.Fatalf("AuthorizeTool(%q) returned an invocable entry alongside its error", tc.name)
 			}
 			de, ok := domain.AsDomain(err)
-			if !ok || de.Code != ErrCodeToolNotAvailable {
-				t.Fatalf("AuthorizeTool(%q) err = %v, want a %s domain error", name, err, ErrCodeToolNotAvailable)
+			if !ok {
+				t.Fatalf("AuthorizeTool(%q) err = %v, want a domain error", tc.name, err)
+			}
+			// ASSERTED BY VALUE. "err != nil" would pass here even if the
+			// capability case had been answered by the site axis, or by the
+			// unregistered arm, which are different bugs with different fixes.
+			if de.Code != tc.want {
+				t.Fatalf("AuthorizeTool(%q) code = %q, want %q", tc.name, de.Code, tc.want)
+			}
+			if de.Kind != domain.KindForbidden {
+				t.Fatalf("AuthorizeTool(%q) kind = %v, want KindForbidden -- a 401 here is the "+
+					"shape that makes clients re-run an OAuth flow that cannot help",
+					tc.name, de.Kind)
 			}
 			if reason == "" {
-				t.Fatalf("AuthorizeTool(%q) produced no operator-facing reason", name)
+				t.Fatalf("AuthorizeTool(%q) produced no operator-facing reason", tc.name)
 			}
 		})
 	}
 }
 
-// TestExitGate_RefusalIsNotAnExistenceOracle is the disclosure half.
+// TestCapabilityRefusalIsTypedTerminalAndNamesTheCapability is the D1 ruling
+// stated as a test.
 //
-// The registered name and a name that has never existed must be
-// INDISTINGUISHABLE on the wire: same code, same message, same data. If they
-// diverge, a caller enumerates the product's tool surface with a wordlist.
+// It replaces TestExitGate_RefusalIsNotAnExistenceOracle, which asserted the
+// OPPOSITE -- that a registered name and a never-existed name must be
+// indistinguishable. That property was deliberately given up: the owner ruled
+// that an unticked capability refuses rather than hides, and once tools/list
+// stops filtering there is no surface left for the blur to protect.
 //
-// The operator-facing reason must diverge, because that is where the typed
-// refusal actually lives.
-func TestExitGate_RefusalIsNotAnExistenceOracle(t *testing.T) {
+// Every assertion here is by VALUE. A refusal that merely errors, or that
+// errors with the uniform code, or that errors without naming the capability,
+// is the behaviour this change exists to remove.
+func TestCapabilityRefusalIsTypedTerminalAndNamesTheCapability(t *testing.T) {
 	auth := authWith(CapabilitySet{}, uuid.New())
 
-	_, realReason, realErr := AuthorizeTool(ToolListSites, auth)
-	_, fakeReason, fakeErr := AuthorizeTool("definitely_not_a_tool_xyzzy", auth)
-
-	realDE, ok1 := domain.AsDomain(realErr)
-	fakeDE, ok2 := domain.AsDomain(fakeErr)
-	if !ok1 || !ok2 {
-		t.Fatalf("both refusals must be domain errors; got %v and %v", realErr, fakeErr)
+	_, reason, err := AuthorizeTool(ToolListSites, auth)
+	if err == nil {
+		t.Fatal("a connection holding no capability was granted the tool")
 	}
-	if realDE.Code != fakeDE.Code {
-		t.Fatalf("caller-visible code differs: registered=%q unregistered=%q -- this is an existence oracle",
-			realDE.Code, fakeDE.Code)
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("err = %v, want a domain error", err)
 	}
-
-	// The only permitted difference in the message is the echoed name, which is
-	// the caller's own input. Strip it and the two must be identical.
-	realMsg := strings.Replace(realDE.Message, ToolListSites, "NAME", 1)
-	fakeMsg := strings.Replace(fakeDE.Message, "definitely_not_a_tool_xyzzy", "NAME", 1)
-	if realMsg != fakeMsg {
-		t.Fatalf("caller-visible message differs beyond the echoed name -- this is an existence oracle:\n"+
-			"registered:   %s\nunregistered: %s", realMsg, fakeMsg)
+	if de.Code != ErrCodeCapabilityNotGranted {
+		t.Fatalf("code = %q, want %q -- the capability refusal must not share the uniform "+
+			"not-available code, which tells the model to ask tools/list for a tool "+
+			"tools/list already showed it", de.Code, ErrCodeCapabilityNotGranted)
+	}
+	if reason != reasonCapabilityNotHeld {
+		t.Fatalf("operator reason = %q, want %q", reason, reasonCapabilityNotHeld)
 	}
 
-	if realReason == fakeReason {
-		t.Fatalf("the OPERATOR-facing reason must distinguish the two cases; both were %q", realReason)
+	// It NAMES the capability, in the message, where a model reads it.
+	if !strings.Contains(de.Message, string(CapSitesRead)) {
+		t.Fatalf("the refusal does not name the missing capability %q: %s",
+			CapSitesRead, de.Message)
 	}
-	if realReason != reasonCapabilityNotHeld {
-		t.Fatalf("registered-but-not-held reason = %q, want %q", realReason, reasonCapabilityNotHeld)
+
+	// It says the refusal is PERMANENT. A model that reads a refusal as
+	// transient retries; the empty-capability 401 made clients re-run an OAuth
+	// handshake that could not change the answer.
+	if !strings.Contains(de.Message, "permanent") {
+		t.Fatalf("the refusal does not tell the model it is permanent: %s", de.Message)
 	}
-	if fakeReason != reasonUnregistered {
-		t.Fatalf("unregistered reason = %q, want %q", fakeReason, reasonUnregistered)
+	if de.Details == nil {
+		t.Fatal("the refusal carries no details, so a client has to parse English to " +
+			"learn whether retrying could help")
+	}
+	if got := de.Details["retryable"]; got != false {
+		t.Fatalf("details[retryable] = %v, want false", got)
+	}
+	if got := de.Details["required_capability"]; got != string(CapSitesRead) {
+		t.Fatalf("details[required_capability] = %v, want %q", got, CapSitesRead)
+	}
+	// The held set is a fact about the caller's own grant, and it is what lets
+	// a model tell its user what this connection CAN do.
+	held, ok := de.Details["held_capabilities"].([]string)
+	if !ok {
+		t.Fatalf("details[held_capabilities] = %#v, want []string", de.Details["held_capabilities"])
+	}
+	if len(held) != 0 {
+		t.Fatalf("held_capabilities = %v for a connection holding none", held)
 	}
 }
 
-// TestExitGate_VisibilityAndCallabilityAgree walks the whole registry against
-// a connection holding each capability in turn and asserts the two paths never
-// disagree: everything visible is callable, and everything callable was
-// visible.
+// TestCapabilityRefusalIsListedNotHidden is the "does not hide" half, on the
+// discovery path.
 //
-// This is the invariant that made the pre-S7 arrangement unsafe. It held then
-// only for a client that called tools/list and believed the answer; here it is
-// a property of the code, because both paths call visible().
-func TestExitGate_VisibilityAndCallabilityAgree(t *testing.T) {
+// A connection holding nothing must still be SHOWN the tool, and the descriptor
+// it is shown must say -- in the description, the one field every MCP client
+// puts in front of the model -- that the tool is not available, why, and that
+// retrying will not help.
+func TestCapabilityRefusalIsListedNotHidden(t *testing.T) {
+	auth := authWith(CapabilitySet{}, uuid.New())
+
+	// Asserted against the registry rather than against a literal 1, so that
+	// adding a second tool does not quietly narrow what this proves.
+	want := len(nonEmptyRegistry(t))
+	got := VisibleTools(auth)
+	if len(got) != want {
+		t.Fatalf("tools/list showed %d of %d tools to a connection holding no capability; "+
+			"an unticked capability must refuse, not hide", len(got), want)
+	}
+
+	d := got[0]
+	if d.Name != ToolListSites {
+		t.Fatalf("listed tool = %q, want %q", d.Name, ToolListSites)
+	}
+	for _, must := range []string{
+		"NOT AVAILABLE TO THIS CONNECTION",
+		string(CapSitesRead),
+		ErrCodeCapabilityNotGranted,
+		"permanent",
+	} {
+		if !strings.Contains(d.Description, must) {
+			t.Fatalf("the listed descriptor does not mention %q, so a model reading tools/list "+
+				"cannot tell this tool from a callable one:\n%s", must, d.Description)
+		}
+	}
+
+	// AND IT DOES NOT OVER-FIRE. A connection that HOLDS the capability is
+	// shown the plain description, with no notice at all -- a guard that
+	// annotates correct work is a guard that gets switched off.
+	full := authWith(NewCapabilitySet(AllCapabilities()), uuid.New())
+	fd := VisibleTools(full)
+	if len(fd) != want {
+		t.Fatalf("a fully-capable connection saw %d of %d tools", len(fd), want)
+	}
+	if strings.Contains(fd[0].Description, "NOT AVAILABLE TO THIS CONNECTION") {
+		t.Fatalf("a connection that HOLDS %q was told the tool is unavailable:\n%s",
+			CapSitesRead, fd[0].Description)
+	}
+	if _, _, err := AuthorizeTool(ToolListSites, authWith(
+		NewCapabilitySet(AllCapabilities()), uuid.New())); err != nil {
+		t.Fatalf("a connection holding every capability and a site was refused: %v", err)
+	}
+}
+
+// TestUnregisteredNameIsNotACapabilityRefusal keeps the two answers apart in
+// the other direction.
+//
+// A guessed name must NOT be reported as a capability problem: that would send
+// an operator to widen a grant for a tool that does not exist, and it would
+// hand a wordlist a "this name is real" signal that the registry does not have.
+func TestUnregisteredNameIsNotACapabilityRefusal(t *testing.T) {
+	// A FULLY capable connection, so nothing here can be attributed to a
+	// missing capability.
+	auth := authWith(NewCapabilitySet(AllCapabilities()), uuid.New())
+
+	_, reason, err := AuthorizeTool("definitely_not_a_tool_xyzzy", auth)
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("err = %v, want a domain error", err)
+	}
+	if de.Code != ErrCodeToolNotAvailable {
+		t.Fatalf("code = %q, want %q", de.Code, ErrCodeToolNotAvailable)
+	}
+	if reason != reasonUnregistered {
+		t.Fatalf("operator reason = %q, want %q", reason, reasonUnregistered)
+	}
+	if strings.Contains(de.Message, string(CapSitesRead)) {
+		t.Fatalf("a guessed name was refused with a capability the caller never lacked: %s",
+			de.Message)
+	}
+}
+
+// TestExitGate_ListedIsNotCallable walks the whole registry against a
+// connection holding each capability in turn and asserts the ONE-DIRECTIONAL
+// invariant the D1 ruling leaves standing:
+//
+//	NOTHING IS CALLABLE THAT WAS NOT LISTED.
+//
+// The converse -- everything listed is callable -- is deliberately gone. That
+// identity is what made an unticked capability HIDE a tool, and restoring it is
+// the mutation this test exists to catch: a connection holding no capability
+// must be shown the tool AND refused it.
+//
+// The direction kept is the one that matters. It held before S7 only for a
+// client that called tools/list and believed the answer; here it is a property
+// of the code, because AuthorizeTool derives the capability answer itself
+// rather than trusting the listing.
+func TestExitGate_ListedIsNotCallable(t *testing.T) {
 	site := uuid.New()
+	registry := nonEmptyRegistry(t)
 
 	// Every subset of the vocabulary that a single capability can produce, plus
 	// the empty set and the full set.
@@ -167,18 +299,33 @@ func TestExitGate_VisibilityAndCallabilityAgree(t *testing.T) {
 	for _, caps := range sets {
 		auth := authWith(caps, site)
 
-		seen := map[string]bool{}
+		// Everything is listed, whatever the capability set. This is the
+		// "does not hide" invariant, asserted for every subset rather than
+		// only for the empty one.
+		listed := map[string]bool{}
 		for _, d := range VisibleTools(auth) {
-			seen[d.Name] = true
-			if _, _, err := AuthorizeTool(d.Name, auth); err != nil {
-				t.Fatalf("caps=%v: %q was VISIBLE but not callable: %v", caps.Sorted(), d.Name, err)
-			}
+			listed[d.Name] = true
+		}
+		if len(listed) != len(registry) {
+			t.Fatalf("caps=%v: tools/list showed %d of %d tools; an unticked capability "+
+				"must refuse, not hide", caps.Sorted(), len(listed), len(registry))
 		}
 
-		for _, e := range nonEmptyRegistry(t) {
+		for _, e := range registry {
 			_, _, err := AuthorizeTool(e.Name, auth)
-			if err == nil && !seen[e.Name] {
-				t.Fatalf("caps=%v: %q was CALLABLE but never shown by tools/list", caps.Sorted(), e.Name)
+			if err == nil && !listed[e.Name] {
+				t.Fatalf("caps=%v: %q was CALLABLE but never shown by tools/list",
+					caps.Sorted(), e.Name)
+			}
+			// And the capability really gates the call, whatever the listing
+			// said. Asserted by value: an entry callable without its capability
+			// is the pre-S7 defect returning.
+			if !caps.Allows(e.Capability) {
+				de, ok := domain.AsDomain(err)
+				if !ok || de.Code != ErrCodeCapabilityNotGranted {
+					t.Fatalf("caps=%v: %q (requires %q) refused with %v, want %s",
+						caps.Sorted(), e.Name, e.Capability, err, ErrCodeCapabilityNotGranted)
+				}
 			}
 		}
 	}
@@ -195,14 +342,33 @@ func TestExitGate_VisibilityAndCallabilityAgree(t *testing.T) {
 func TestSiteScopeIsRefusedByName(t *testing.T) {
 	auth := authWith(NewCapabilitySet([]Capability{CapSitesRead})) // no sites
 
-	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolListSites {
+	// SITE-SCOPE VISIBILITY IS OUT OF SCOPE FOR THE D1 RULING AND MUST NOT HAVE
+	// MOVED. The tool is listed, exactly as before, and the descriptor carries
+	// NO capability notice -- this connection holds the capability, and telling
+	// it otherwise would send an operator hunting the wrong axis.
+	got := VisibleTools(auth)
+	if len(got) != 1 || got[0].Name != ToolListSites {
 		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", got)
 	}
+	if strings.Contains(got[0].Description, "NOT AVAILABLE TO THIS CONNECTION") {
+		t.Fatalf("an empty SITE scope produced a CAPABILITY notice:\n%s", got[0].Description)
+	}
 
-	_, _, err := AuthorizeTool(ToolListSites, auth)
+	_, reason, err := AuthorizeTool(ToolListSites, auth)
 	de, ok := domain.AsDomain(err)
-	if !ok || de.Code != ErrCodeScopeEmpty {
-		t.Fatalf("err = %v, want a %s domain error", err, ErrCodeScopeEmpty)
+	if !ok {
+		t.Fatalf("err = %v, want a domain error", err)
+	}
+	// By value, and by BOTH codes: this assertion stayed green under the
+	// capability refusal too until it named the code it does not want.
+	if de.Code != ErrCodeScopeEmpty {
+		t.Fatalf("code = %q, want %q", de.Code, ErrCodeScopeEmpty)
+	}
+	if de.Code == ErrCodeCapabilityNotGranted {
+		t.Fatalf("the site axis answered with the CAPABILITY refusal: %s", de.Message)
+	}
+	if reason != reasonSiteScopeEmpty {
+		t.Fatalf("operator reason = %q, want %q", reason, reasonSiteScopeEmpty)
 	}
 }
 
@@ -375,22 +541,33 @@ func TestNoRegisteredToolIsWriteShaped(t *testing.T) {
 	}
 }
 
-// TestVisibleToolNamesDiscloseOnlyTheConnectionsOwnSurface guards the error
-// body. It carries a tool list, and that list must be the connection's own
-// tools/list answer -- never the full registry, which is what the pre-S7
-// "unknown tool" error returned.
-func TestVisibleToolNamesDiscloseOnlyTheConnectionsOwnSurface(t *testing.T) {
-	auth := authWith(CapabilitySet{}, uuid.New())
-	if got := visibleToolNames(auth); len(got) != 0 {
-		t.Fatalf("a connection holding no capability was told about %v", got)
-	}
-
+// TestVisibleToolNamesMatchTheListing guards the error body. It carries a tool
+// list, and that list must be exactly what this connection's tools/list
+// returned -- so a model that mistyped a name can correct from it in one round
+// trip, and so the body never claims a surface the listing did not.
+//
+// Under the D1 ruling the listing is the whole registry, so this is now an
+// AGREEMENT check rather than a filtering one. It is still worth asserting: the
+// two are separate functions, and an error body that diverges from tools/list
+// tells the model two different stories about the same server.
+func TestVisibleToolNamesMatchTheListing(t *testing.T) {
 	// len(got) == len(registry) is satisfied by 0 == 0, so the registry is
 	// asserted non-empty first: otherwise this guard reports PASS on a server
 	// with no tools at all.
 	want := len(nonEmptyRegistry(t))
-	full := authWith(NewCapabilitySet(AllCapabilities()), uuid.New())
-	if got := visibleToolNames(full); len(got) != want {
-		t.Fatalf("a fully-capable connection saw %d of %d tools", len(got), want)
+
+	for _, caps := range []CapabilitySet{{}, NewCapabilitySet(AllCapabilities())} {
+		auth := authWith(caps, uuid.New())
+		names := visibleToolNames(auth)
+		if len(names) != want {
+			t.Fatalf("caps=%v: the error body named %d of %d tools", caps.Sorted(), len(names), want)
+		}
+		listed := VisibleTools(auth)
+		for i, d := range listed {
+			if names[i] != d.Name {
+				t.Fatalf("caps=%v: error body names %v, tools/list showed %q at %d",
+					caps.Sorted(), names, d.Name, i)
+			}
+		}
 	}
 }

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1070,6 +1070,31 @@ type AuthorizedRequest struct {
 	// reaches NO tool rather than every tool. That is why it is a CapabilitySet
 	// and not a []string.
 	Capabilities CapabilitySet
+
+	// OrgCeiling is the ORGANISATION's widest capability set -- what
+	// OrgDefaultCapabilities resolved for this grant's scopes, BEFORE the
+	// per-connection narrowing that produced Capabilities. Capabilities is
+	// always a subset of it.
+	//
+	// IT IS CARRIED, NOT RECOMPUTED. Authenticate already resolves the ceiling
+	// to intersect it with the stored set, and a second OrgDefaultCapabilities
+	// call inside the registry would be a second source of truth that can
+	// disagree with this one -- and would have to discard the error that
+	// function returns for exactly the misconfiguration it exists to catch.
+	//
+	// IT EXISTS BECAUSE THE TWO BOUNDARIES DISCLOSE DIFFERENTLY. A tool inside
+	// the ceiling that this grant does not hold is LISTED and refuses by name,
+	// so that unticking a permission produces an explicable refusal rather than
+	// a tool that silently vanishes. A tool outside the ceiling is omitted from
+	// tools/list and refuses as unregistered, so a token holder cannot
+	// enumerate the capabilities their organisation deliberately switched off.
+	// Without this field the registry can only see Capabilities and cannot tell
+	// the two apart.
+	//
+	// Zero value allows nothing, and that is the same fail-closed choice
+	// Capabilities makes for the same reason: a literal that forgets it lists
+	// NO tool rather than every tool.
+	OrgCeiling CapabilitySet
 }
 
 // Authenticate resolves a bearer token and re-checks its grant against CURRENT
@@ -1207,6 +1232,11 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 		TokenID:      chk.TokenID,
 		Sites:        NewSiteSet(ids),
 		Capabilities: caps,
+		// The ceiling resolved above, carried rather than recomputed. caps is
+		// ceiling.NarrowTo(stored), so this is always a superset of
+		// Capabilities and the registry can tell "your grant lacks it" from
+		// "your organisation switched it off". See AuthorizedRequest.OrgCeiling.
+		OrgCeiling: ceiling,
 	}, nil
 }
 

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -68,20 +68,33 @@ const (
 	// inline, so the model corrects in one round trip.
 	codeInvalidToolArguments = -32003
 
-	// codeToolNotAvailable is the single code for the TWO reasons a named tool
-	// is not reachable that a caller must not be able to tell apart: no such
-	// tool exists, or this connection's capabilities do not cover it. One code
-	// for two reasons is deliberate and is the whole disclosure decision -- see
-	// the note on AuthorizeTool. A client branching on the number learns "ask
-	// tools/list", which is the only correct action in both cases.
+	// codeToolNotAvailable means THE NAME IS NOT IN THE REGISTRY. The model
+	// guessed. A client branching on the number learns "ask tools/list", which
+	// is the only correct action.
+	//
+	// IT NO LONGER DOUBLES AS THE CAPABILITY REFUSAL. It used to answer both
+	// "no such tool" and "your capabilities do not cover it" identically, so a
+	// wordlist could not tell them apart; the D1 ruling replaced that blur with
+	// codeCapabilityNotGranted below. See the disclosure note on AuthorizeTool.
 	//
 	// AN EMPTY SITE SCOPE IS NOT ONE OF THEM and does not answer -32004. It
-	// answers codeScopeEmpty (-32002) above, by name, because a connection
-	// whose capability set already covers the tool is entitled to know the tool
-	// exists -- see the asymmetry note on visible(). An earlier version of this
-	// comment claimed -32004 covered the scope-empty case too. It never did:
-	// TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList asserts -32002.
+	// answers codeScopeEmpty (-32002) above, by name. An earlier version of
+	// this comment claimed -32004 covered the scope-empty case too. It never
+	// did: TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList asserts -32002.
 	codeToolNotAvailable = -32004
+
+	// codeCapabilityNotGranted is the D1 refusal: the tool EXISTS, it was
+	// listed to this connection, and this connection's grant does not hold the
+	// capability it requires.
+	//
+	// A CLIENT MUST READ IT AS PERMANENT. The error data carries
+	// retryable:false and required_capability alongside, and the message says
+	// so in words, because the failure mode being designed against is a client
+	// that treats a refusal as transient: the empty-capability path once
+	// answered 401 and clients re-ran an entire OAuth handshake that could not
+	// change the outcome. Nothing the client can do on its own changes this
+	// answer -- an operator must widen the grant.
+	codeCapabilityNotGranted = -32005
 )
 
 // TransportHandler serves the single MCP endpoint. It is separate from Handler
@@ -343,11 +356,11 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{}), http.StatusOK, true
 
 	case "tools/list":
-		// VisibleTools, NOT Tools. Tools() is the whole registry and is not a
-		// request-path value; VisibleTools filters by this connection's
-		// capability set and site scope through the SAME predicate tools/call
-		// applies. An empty list here is a truthful answer for a connection
-		// that reaches nothing, not an error.
+		// VisibleTools, NOT Tools. Tools() is the raw registry and is not a
+		// request-path value; VisibleTools annotates each descriptor for THIS
+		// connection, so a tool whose capability this grant lacks arrives
+		// marked as such rather than looking callable. It hides nothing: under
+		// the D1 ruling an unticked capability refuses at tools/call, by name.
 		return newResponse(req.ID, map[string]any{"tools": VisibleTools(auth)}), http.StatusOK, true
 
 	case "tools/call":
@@ -512,8 +525,7 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 		if de, ok := domain.AsDomain(err); ok && de.Code == ErrCodeToolNotAvailable {
 			// available_tools is this connection's OWN tools/list answer, so it
 			// discloses nothing it was not already shown, and it lets a model
-			// that mistyped a name it legitimately holds correct in one round
-			// trip.
+			// that mistyped a real name correct in one round trip.
 			data, _ := json.Marshal(map[string]any{
 				"argument":        "name",
 				"supplied":        p.Name,
@@ -521,10 +533,11 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 			})
 			return newErrorResponse(req.ID, codeToolNotAvailable, de.Message, data)
 		}
-		// Everything else keeps its own named answer: mcp_scope_empty becomes
-		// -32002 through toolError, and a non-domain error (a registry entry
-		// with no implementation) becomes the internal code. Neither is
-		// reported as a permission refusal.
+		// Everything else keeps its own named answer: mcp_capability_not_granted
+		// becomes -32005 and mcp_scope_empty becomes -32002, both through
+		// toolError, and a non-domain error (a registry entry with no
+		// implementation) becomes the internal code rather than a permission
+		// refusal.
 		return h.toolError(req.ID, err)
 	}
 
@@ -552,6 +565,27 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 		if de.Code == ErrCodeScopeEmpty {
 			data, _ := json.Marshal(map[string]any{"code": de.Code})
 			return newErrorResponse(id, codeScopeEmpty, de.Message, data)
+		}
+		if de.Code == ErrCodeCapabilityNotGranted {
+			// The details AuthorizeTool attached are the machine-readable half
+			// of the refusal: which capability is required, which ones this
+			// grant holds, and that retrying will not help. They are copied
+			// onto the wire rather than summarised, so a client branches on a
+			// field instead of parsing English.
+			//
+			// retryable is written HERE as well as carried in the details, so
+			// a details map that ever arrives incomplete still answers false.
+			// Defaulting a missing "is this worth retrying" to true is how a
+			// permanent refusal becomes a retry loop.
+			payload := map[string]any{"code": de.Code, "retryable": false}
+			for k, v := range de.Details {
+				if k == "retryable" {
+					continue
+				}
+				payload[k] = v
+			}
+			data, _ := json.Marshal(payload)
+			return newErrorResponse(id, codeCapabilityNotGranted, de.Message, data)
 		}
 		return newErrorResponse(id, codeInvalidParams, de.Message, nil)
 	}

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -737,6 +738,123 @@ func TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList(t *testing.T) {
 		if c == "ListSitesForRead" {
 			t.Error("an empty-scope request still read the sites table")
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 6b -- AN UNTICKED CAPABILITY REFUSES ON THE WIRE, WITH ITS OWN CODE.
+//
+// The D1 ruling in one wire assertion: the tool is listed, calling it answers
+// -32005 and not -32004, and the data says which capability is missing and that
+// retrying will not help.
+//
+// IT GOES THROUGH h.callTool, the same function the router dispatches
+// tools/call to. The AuthorizedRequest is built here rather than authenticated,
+// because the capability axis is not stored per-grant yet (m124 DECISION 1) and
+// every bearer the fake store mints therefore holds mcp.sites.read. The DB-side
+// proof of the same refusal lives in
+// apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go, as wpmgr_app.
+// ---------------------------------------------------------------------------
+
+func TestToolsCall_UntickedCapabilityRefusesWithItsOwnCode(t *testing.T) {
+	h := NewTransportHandler(nil, slog.New(slog.NewTextHandler(io.Discard, nil)), "test")
+
+	// Holds NO capability, but a non-empty site scope -- so nothing below can
+	// be attributed to the site axis, which this change did not touch.
+	auth := AuthorizedRequest{
+		TenantID:     uuid.New(),
+		GrantID:      uuid.New(),
+		TokenID:      uuid.New(),
+		Sites:        NewSiteSet([]uuid.UUID{uuid.New()}),
+		Capabilities: CapabilitySet{},
+	}
+
+	// The tool is LISTED to this connection: the refusal below is a refusal,
+	// not a consequence of an empty surface.
+	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolListSites {
+		t.Fatalf("tools/list hid the tool from a connection lacking its capability: %+v", got)
+	}
+
+	resp := h.callTool(context.Background(), auth, jsonrpcRequest{
+		ID:     json.RawMessage(`61`),
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"list_sites","arguments":{}}`),
+	})
+
+	if resp.Error == nil {
+		t.Fatalf("a connection holding no capability got a SUCCESS: %+v", resp)
+	}
+	// BY VALUE, and against the code it must NOT be: -32004 tells a model to
+	// ask tools/list for a tool tools/list already showed it, which is the
+	// contradiction that produces another call rather than a report to the user.
+	if resp.Error.Code != codeCapabilityNotGranted {
+		t.Fatalf("error code = %d, want %d (%s)",
+			resp.Error.Code, codeCapabilityNotGranted, ErrCodeCapabilityNotGranted)
+	}
+	if resp.Error.Code == codeToolNotAvailable {
+		t.Fatal("the capability refusal answered the uniform not-available code")
+	}
+	if !strings.Contains(resp.Error.Message, string(CapSitesRead)) {
+		t.Fatalf("the wire message does not name the missing capability: %q", resp.Error.Message)
+	}
+
+	var data struct {
+		Code               string   `json:"code"`
+		Tool               string   `json:"tool"`
+		RequiredCapability string   `json:"required_capability"`
+		HeldCapabilities   []string `json:"held_capabilities"`
+		Retryable          *bool    `json:"retryable"`
+	}
+	if err := json.Unmarshal(resp.Error.Data, &data); err != nil {
+		t.Fatalf("decode error data %s: %v", resp.Error.Data, err)
+	}
+	if data.Code != ErrCodeCapabilityNotGranted {
+		t.Errorf("data.code = %q, want %q", data.Code, ErrCodeCapabilityNotGranted)
+	}
+	if data.Tool != ToolListSites {
+		t.Errorf("data.tool = %q, want %q", data.Tool, ToolListSites)
+	}
+	if data.RequiredCapability != string(CapSitesRead) {
+		t.Errorf("data.required_capability = %q, want %q", data.RequiredCapability, CapSitesRead)
+	}
+	if len(data.HeldCapabilities) != 0 {
+		t.Errorf("data.held_capabilities = %v for a connection holding none", data.HeldCapabilities)
+	}
+	// A MISSING retryable IS A FAILURE, not a pass. A client that has to infer
+	// retryability infers "try again", which is the loop this refusal exists to
+	// prevent.
+	if data.Retryable == nil {
+		t.Fatal("the error data carries no retryable field")
+	}
+	if *data.Retryable {
+		t.Error("data.retryable = true on a permanent refusal")
+	}
+}
+
+// TestToolsCall_HeldCapabilityIsUnaffected is the over-fire control. The SAME
+// call, from a connection that holds the capability and a site, must reach the
+// tool -- so the refusal above is the capability gate and not a broken fixture.
+func TestToolsCall_HeldCapabilityIsUnaffected(t *testing.T) {
+	store := liveGrantStore(uuid.New())
+	r := newTransportRouter(t, store)
+
+	w := post(t, r, `{"jsonrpc":"2.0","id":62,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+
+	resp := decodeRPC(t, w)
+	if resp.Error != nil {
+		t.Fatalf("a connection HOLDING the capability was refused %d: %s",
+			resp.Error.Code, w.Body.String())
+	}
+	// The sites payload is JSON nested inside the JSON-RPC text content, so it
+	// arrives escaped. Matching the unescaped form would never fire.
+	if !strings.Contains(w.Body.String(), `\"sites\":`) {
+		t.Fatalf("the granted call returned no sites payload: %s", w.Body.String())
+	}
+	// And its tools/list descriptor carries no capability notice.
+	w = post(t, r, `{"jsonrpc":"2.0","id":63,"method":"tools/list","params":{}}`, nil)
+	if strings.Contains(w.Body.String(), "NOT AVAILABLE TO THIS CONNECTION") {
+		t.Fatalf("a connection holding the capability was told the tool is unavailable: %s",
+			w.Body.String())
 	}
 }
 

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -772,17 +772,24 @@ func TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestToolsCall_UntickedCapabilityRefusesWithItsOwnCode(t *testing.T) {
-	h := NewTransportHandler(nil, slog.New(slog.NewTextHandler(io.Discard, nil)), "test")
+	// A REAL Service, not nil. callTool now records the refusal
+	// (RecordToolDenied), which dereferences the service; its audit recorder is
+	// nil in unit configuration and records nothing, which is what this test
+	// wants. A nil *Service panics on the refusal path -- the path this test
+	// exists to walk.
+	h := NewTransportHandler(NewService(&fakeStore{}),
+		slog.New(slog.NewTextHandler(io.Discard, nil)), "test")
 
 	// Holds NO capability, but a non-empty site scope -- so nothing below can
 	// be attributed to the site axis, which this change did not touch.
-	auth := AuthorizedRequest{
-		TenantID:     uuid.New(),
-		GrantID:      uuid.New(),
-		TokenID:      uuid.New(),
-		Sites:        NewSiteSet([]uuid.UUID{uuid.New()}),
-		Capabilities: CapabilitySet{},
-	}
+	//
+	// The ORG CEILING is the production one (authWith resolves
+	// OrgDefaultCapabilities), so this is the middle case of the ruling: the
+	// organisation has this capability enabled and THIS GRANT does not hold it.
+	// That is the case that must still be listed. A connection whose ceiling
+	// excluded the capability is a different case and is proven separately in
+	// registry_test.go.
+	auth := authWith(CapabilitySet{}, uuid.New())
 
 	// The tool is LISTED to this connection: the refusal below is a refusal,
 	// not a consequence of an empty surface.

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -598,7 +598,13 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 	// (3) IT IS INDISTINGUISHABLE FROM A NAME THAT WAS NEVER REGISTERED. Same
 	// code, same message. If these ever diverge, the refusal becomes an oracle
 	// for what the organisation switched off.
-	_, _, guessErr := mcp.AuthorizeTool("sites_restart_everything", outside)
+	//
+	// The comparison is on the TEMPLATE, not the literal string: both messages
+	// echo the name the caller asked for, and that difference is the caller's
+	// own input rather than a disclosure. Substituting it back is what isolates
+	// the property -- everything OTHER than the echoed name must match.
+	const guessed = "sites_restart_everything"
+	_, _, guessErr := mcp.AuthorizeTool(guessed, outside)
 	gde, ok := domain.AsDomain(guessErr)
 	if !ok {
 		t.Fatalf("guessed name err = %v, want a domain error", guessErr)
@@ -607,9 +613,9 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 		t.Fatalf("a disabled capability answers %q and a guessed name answers %q; "+
 			"the difference tells a caller which capabilities exist", de.Code, gde.Code)
 	}
-	if gde.Message != de.Message {
-		t.Fatalf("the two refusals differ in prose, which is the same oracle:\n"+
-			"disabled: %s\nguessed:  %s", de.Message, gde.Message)
+	if want := strings.ReplaceAll(gde.Message, guessed, mcp.ToolListSites); de.Message != want {
+		t.Fatalf("the two refusals differ beyond the echoed name, which is the same oracle:\n"+
+			"disabled: %s\nexpected: %s", de.Message, want)
 	}
 
 	// (4) IT DOES NOT OVER-FIRE. The untouched connection still lists and still

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -38,6 +38,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
@@ -255,6 +256,133 @@ func TestS7GuessedToolNameIsRefusedForARealConnectionAsAppRole(t *testing.T) {
 		}
 	}
 	t.Logf("all guessed names refused for a real, fully-capable connection")
+}
+
+// TestS7UntickedCapabilityRefusesByNameAsAppRole is the D1 ruling, executed
+// against the real schema as wpmgr_app: an unticked capability REFUSES, it does
+// not hide.
+//
+// HOW THE CAPABILITY-LESS CONNECTION IS BUILT, AND WHY IT IS NOT A LITERAL.
+// Everything about this connection comes from the database: the tenant, the
+// site, the grant, the connection token, and the SiteSet, all resolved by
+// mcp.Service.Authenticate inside InTenantTx under the sites RLS policy as
+// wpmgr_app. Exactly ONE field is then overwritten -- Capabilities -- and it
+// has to be, because the capability axis is not stored per-grant yet: m124
+// DECISION 1 declines to mint a capabilities column, so grantScopes() is a
+// constant and every bearer that can authenticate resolves to mcp.sites.read.
+// There is no bearer in this schema that lacks it.
+//
+// What that costs is stated plainly: this proves the GATE, not the resolution.
+// TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole above proves the
+// resolution half -- that Authenticate really populates the set rather than
+// handing back the zero value -- and the two together cover the path. The
+// moment a capabilities column exists, this test replaces the one assignment
+// with a narrower grant and proves both halves at once.
+func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo)
+
+	tenant := seedTenant(t, pool, "mcp-s7-cap-"+uuid.NewString()[:8])
+
+	// The role is asserted and printed INSIDE the transaction the resolution
+	// uses. Either privilege would make the site half of this pass vacuously.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (capability-refusal proof)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://s7cap.example.com", Name: "s7-cap"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{s1.ID})
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate with a live bearer: %v", err)
+	}
+
+	// POSITIVE CONTROL FIRST. The real connection reaches the tool, so every
+	// refusal below is the capability gate rather than a broken fixture.
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+		t.Fatalf("the real, fully-granted connection was refused: %v", err)
+	}
+	if _, err := svc.ListSitesForModel(ctx, auth); err != nil {
+		t.Fatalf("list_sites failed for the real connection: %v", err)
+	}
+
+	// Now the same connection with the capability withheld. Note what is NOT
+	// touched: the site scope stays as the database resolved it, so nothing
+	// below can be attributed to the site axis.
+	denied := auth
+	denied.Capabilities = mcp.NewCapabilitySet(nil)
+	if denied.Sites.IsEmpty() || !denied.Sites.Allows(s1.ID) {
+		t.Fatalf("the DB-resolved site scope did not survive: %d sites, Allows(%s)=%v",
+			denied.Sites.Len(), s1.ID, denied.Sites.Allows(s1.ID))
+	}
+	t.Logf("capability-less connection carries the DB-resolved scope: %d site(s), tenant %s",
+		denied.Sites.Len(), denied.TenantID)
+
+	// (1) IT DOES NOT HIDE. The tool is still listed, and the descriptor says
+	// why it cannot be called.
+	visible := mcp.VisibleTools(denied)
+	if len(visible) != 1 || visible[0].Name != mcp.ToolListSites {
+		t.Fatalf("an unticked capability HID the tool from tools/list: %+v", visible)
+	}
+	if !strings.Contains(visible[0].Description, string(mcp.CapSitesRead)) {
+		t.Fatalf("the listed descriptor does not name the missing capability:\n%s",
+			visible[0].Description)
+	}
+
+	// (2) IT REFUSES, BY NAME. Asserted by VALUE on the code and the kind: an
+	// "err != nil" here would pass under the site-scope refusal, under the
+	// uniform not-available refusal, and under a 401 -- three different bugs,
+	// two of which this change exists to rule out.
+	_, _, err = mcp.AuthorizeTool(mcp.ToolListSites, denied)
+	if err == nil {
+		t.Fatal("a tool was authorized for a connection that does not hold its capability")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("err = %v, want a domain error", err)
+	}
+	if de.Code != mcp.ErrCodeCapabilityNotGranted {
+		t.Fatalf("code = %q, want %q", de.Code, mcp.ErrCodeCapabilityNotGranted)
+	}
+	if de.Code == mcp.ErrCodeScopeEmpty {
+		t.Fatal("the capability refusal answered on the SITE axis")
+	}
+	if de.Kind != domain.KindForbidden {
+		t.Fatalf("kind = %v, want KindForbidden; a 401 makes clients re-run an OAuth "+
+			"handshake that cannot change the answer", de.Kind)
+	}
+	if !strings.Contains(de.Message, string(mcp.CapSitesRead)) {
+		t.Fatalf("the refusal does not name the capability: %s", de.Message)
+	}
+	if !strings.Contains(de.Message, "permanent") {
+		t.Fatalf("the refusal does not tell the model it is permanent: %s", de.Message)
+	}
+	if got := de.Details["retryable"]; got != false {
+		t.Fatalf("details[retryable] = %v, want false", got)
+	}
+	if got := de.Details["required_capability"]; got != string(mcp.CapSitesRead) {
+		t.Fatalf("details[required_capability] = %v, want %q", got, mcp.CapSitesRead)
+	}
+
+	// (3) IT DOES NOT OVER-FIRE. The untouched connection still works, after
+	// the refusal, against the same live database.
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+		t.Fatalf("the granted connection was refused after the denied one: %v", err)
+	}
+	t.Logf("capability refusal: code=%s retryable=%v; granted connection unaffected",
+		de.Code, de.Details["retryable"])
 }
 
 // TestS7EmptySiteScopeRefusesByNameAsAppRole is the site axis, executed.

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -460,3 +460,170 @@ func TestS7EmptySiteScopeRefusesByNameAsAppRole(t *testing.T) {
 		t.Fatal("ListSitesForModel returned a result for an empty site scope")
 	}
 }
+
+// TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole is the THIRD case of
+// the ruling, and the only one that hides.
+//
+// The other two are above: a held capability is listed and callable, and a
+// capability the ORG allows but this GRANT lacks is still listed and refuses by
+// name. This one is the organisation boundary: a capability the org's ceiling
+// does not contain is absent from tools/list entirely, and calling it answers
+// exactly as an unregistered name does -- because a distinguishable refusal
+// would hand back the enumeration the listing withheld.
+//
+// HOW THE NARROW CEILING IS CONSTRUCTED, AND WHETHER IT IS REACHABLE.
+//
+// It is set directly on the AuthorizedRequest that the real Authenticate
+// returned, and the value is the EMPTY set. That is not a shortcut, it is the
+// only narrower ceiling that exists today: capabilityVocabulary holds exactly
+// one capability, so the sole proper subset of it is the empty set.
+//
+// THIS STATE IS NOT REACHABLE THROUGH Authenticate TODAY, and saying so is part
+// of the proof rather than an apology for it. OrgDefaultCapabilities derives
+// the ceiling from the closed scope registry and REFUSES to return an empty
+// set -- all three of its error paths raise mcp_capability_unmapped rather than
+// yield one. So no live connection can currently carry a ceiling narrower than
+// the vocabulary, every tool is inside every real ceiling, and the hiding arm
+// cannot fire in production. It becomes reachable when the vocabulary grows a
+// second capability and org policy can select within it; the structure is
+// proven now so that it is already correct then.
+//
+// The connection is otherwise REAL: a live bearer, resolved by the real
+// Authenticate against the real schema as wpmgr_app, carrying the site scope
+// the database resolved. Only the ceiling is substituted.
+func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo)
+
+	tenant := seedTenant(t, pool, "mcp-s7-ceil-"+uuid.NewString()[:8])
+
+	// The role is asserted and printed INSIDE the transaction the resolution
+	// uses. Either privilege would make the site half of this pass vacuously.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (org-ceiling proof)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	s1, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://s7ceil.example.com", Name: "s7-ceil"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "ceiling", []uuid.UUID{s1.ID})
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate with a live bearer: %v", err)
+	}
+
+	// POSITIVE CONTROL. The real connection -- real ceiling, real grant -- sees
+	// the tool and can call it, so an absence below is the ceiling and not a
+	// broken fixture.
+	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolListSites {
+		t.Fatalf("the real connection did not see the tool: %+v", got)
+	}
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+		t.Fatalf("the real, fully-granted connection was refused: %v", err)
+	}
+
+	// THE CEILING RESOLVED BY Authenticate CONTAINS THE CAPABILITY. Asserted
+	// rather than assumed: if it did not, the omission below would prove
+	// nothing, because the tool would be missing for the reason the test is
+	// trying to create rather than the one it is trying to observe.
+	if !auth.OrgCeiling.Allows(mcp.CapSitesRead) {
+		t.Fatalf("Authenticate resolved a ceiling WITHOUT %s, so this test cannot "+
+			"distinguish the ceiling arm from a broken fixture: %v",
+			mcp.CapSitesRead, auth.OrgCeiling.Sorted())
+	}
+
+	// Now the same connection with a ceiling that excludes the capability.
+	// Capabilities and Sites are untouched -- the grant still HOLDS the
+	// capability -- so nothing below can be attributed to the grant axis or the
+	// site axis. This is the org axis alone.
+	outside := auth
+	outside.OrgCeiling = mcp.NewCapabilitySet(nil)
+	if !outside.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatalf("the grant lost the capability, so this would prove the GRANT arm, "+
+			"not the ceiling arm: %v", outside.Capabilities.Sorted())
+	}
+	if outside.Sites.IsEmpty() || !outside.Sites.Allows(s1.ID) {
+		t.Fatalf("the DB-resolved site scope did not survive: %d sites, Allows(%s)=%v",
+			outside.Sites.Len(), s1.ID, outside.Sites.Allows(s1.ID))
+	}
+
+	// (1) IT IS NOT LISTED. By value: the list is empty, and specifically does
+	// not contain the tool under any description.
+	visible := mcp.VisibleTools(outside)
+	if len(visible) != 0 {
+		t.Fatalf("a capability outside the org ceiling was LISTED: %+v", visible)
+	}
+	for _, d := range visible {
+		if d.Name == mcp.ToolListSites {
+			t.Fatalf("the tool outside the ceiling appeared in tools/list: %+v", d)
+		}
+	}
+
+	// (2) INVOKING IT ANSWERS AS AN UNREGISTERED NAME. Asserted by VALUE on the
+	// code, and explicitly against the code it must NOT be: answering
+	// mcp_capability_not_granted here would name a capability the organisation
+	// switched off, which is the enumeration the omission above exists to
+	// prevent.
+	_, _, err = mcp.AuthorizeTool(mcp.ToolListSites, outside)
+	if err == nil {
+		t.Fatal("a tool outside the org ceiling was AUTHORIZED")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("err = %v, want a domain error", err)
+	}
+	if de.Code != mcp.ErrCodeToolNotAvailable {
+		t.Fatalf("code = %q, want %q", de.Code, mcp.ErrCodeToolNotAvailable)
+	}
+	if de.Code == mcp.ErrCodeCapabilityNotGranted {
+		t.Fatal("the ceiling refusal disclosed the capability the organisation disabled")
+	}
+	if de.Kind != domain.KindForbidden {
+		t.Fatalf("kind = %v, want KindForbidden", de.Kind)
+	}
+	if strings.Contains(de.Message, string(mcp.CapSitesRead)) {
+		t.Fatalf("the ceiling refusal NAMES the disabled capability: %s", de.Message)
+	}
+
+	// (3) IT IS INDISTINGUISHABLE FROM A NAME THAT WAS NEVER REGISTERED. Same
+	// code, same message. If these ever diverge, the refusal becomes an oracle
+	// for what the organisation switched off.
+	_, _, guessErr := mcp.AuthorizeTool("sites_restart_everything", outside)
+	gde, ok := domain.AsDomain(guessErr)
+	if !ok {
+		t.Fatalf("guessed name err = %v, want a domain error", guessErr)
+	}
+	if gde.Code != de.Code {
+		t.Fatalf("a disabled capability answers %q and a guessed name answers %q; "+
+			"the difference tells a caller which capabilities exist", de.Code, gde.Code)
+	}
+	if gde.Message != de.Message {
+		t.Fatalf("the two refusals differ in prose, which is the same oracle:\n"+
+			"disabled: %s\nguessed:  %s", de.Message, gde.Message)
+	}
+
+	// (4) IT DOES NOT OVER-FIRE. The untouched connection still lists and still
+	// calls the tool, after the refusals, against the same live database.
+	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolListSites {
+		t.Fatalf("the real connection lost the tool after the ceiling refusal: %+v", got)
+	}
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+		t.Fatalf("the granted connection was refused after the ceiling one: %v", err)
+	}
+	if _, err := svc.ListSitesForModel(ctx, auth); err != nil {
+		t.Fatalf("list_sites failed for the real connection: %v", err)
+	}
+
+	t.Logf("org-ceiling omission: listed=%d refusal=%s (identical to an unregistered "+
+		"name); the real connection is unaffected", len(visible), de.Code)
+}


### PR DESCRIPTION
Implements the owner's D1 ruling on the MCP tool registry. Capability half only.

## What changed

`internal/mcp/registry.go` removed a tool from `tools/list` when the connection
did not hold its capability, and answered a name it had hidden with the same
uniform `mcp_tool_not_available` an unregistered name gets. An absent tool is
indistinguishable from a tool that was never built, so a model's only reading
is "wpmgr cannot do this", and the operator who could tick the capability never
hears that anything was refused.

Now:

- `tools/list` returns **every** registry entry. A tool this connection cannot
  call arrives with a notice appended to its description naming the required
  capability, the refusal code, and that the refusal is permanent.
- `tools/call` answers the new `mcp_capability_not_granted`
  (JSON-RPC **-32005**, `domain.KindForbidden`), naming the required
  capability, the capabilities the grant does hold, and `retryable: false`.

Terminality is deliberate. A refusal a model reads as transient produces a
retry loop -- the same shape as the 401 on the empty-capability path, which
made clients re-run an OAuth handshake that could not change the outcome. The
message says "permanent" in words and the data carries `retryable: false` for
the client to branch on.

## What did not change

The gate does not move. `AuthorizeTool` re-derives the capability answer for
itself rather than trusting what was listed, so a guessed name is refused
exactly as before and the invariant that matters -- nothing is callable that
was not listed -- still holds. `tools/list` never granted anything and still
does not. This is a disclosure change, not an authority change.

**Site-scope visibility is untouched.** The design's other half (site scope
should hide) was not ruled on and is out of scope. A site-keyed tool with an
empty resolved scope is still listed and still refuses with `mcp_scope_empty`.
`TestSiteScopeIsRefusedByName` is sharpened so it reddens if that moves.

## The disclosure trade the ruling accepts

The registry is now enumerable by any connection holding a valid token. That is
the cost of "refuse, not hide" and it is bounded: `registryTools()` is a closed
literal in a reviewed file and every entry in it is a read tool. The
non-disclosure argument the old code made now covers unregistered names only.

## Tests

`TestExitGate_RefusalIsNotAnExistenceOracle` asserted the property the ruling
gave up and is replaced. `TestExitGate_VisibilityAndCallabilityAgree` becomes
`TestExitGate_ListedIsNotCallable`, the one-directional invariant that
survives.

Every assertion is by value -- domain code, domain kind, JSON-RPC number, error
data. `err != nil` passes here under the site-scope refusal, under the uniform
refusal and under a 401, which are three different bugs.

The DB-side proof runs through `mcp.Service.Authenticate` against the real
schema as `wpmgr_app`, with `rolsuper`/`rolbypassrls` read from `pg_roles`
inside the transaction under test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP tool listings now show tools permitted by the organization, even when a connection lacks the required capability.
  - Tool calls clearly distinguish unavailable tools from registered tools requiring additional capabilities.
  - Capability refusals include the required capability and are marked as non-retryable.
- **Bug Fixes**
  - Improved consistency between tool visibility and authorization across organization and connection settings.
  - Preserved existing scope-based access controls and protected tool details outside the organization’s permitted capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->