### PR TITLE
release: 0.61.149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.149] - 2026-08-31
+
+### Added
+
+- Connection tokens can now be minted directly from the dashboard: `POST /api/v1/mcp/connections`, plus a wizard that walks an operator through picking a client, naming the connection, choosing which sites it may reach, choosing how it authenticates, and revealing the token exactly once. This is the headless path, for the cases the browser sign-in flow cannot reach: CI, an SSH session, a container.
+- A site-access explanation on the consent screen, stating plainly that scoping is a check made at the moment the assistant asks rather than a boundary enforced inside the database, and that a site added to a scoped tag later is included without anyone approving it.
+
+### Changed
+
+- Grants now carry an expiry, an idle expiry and a capability set, all enforced inside the same authorization check that already refused a revoked grant.
+- The connections list now records real activity. It previously reported every connection as "never used," including one actively reading the fleet; it now reports the truth.
+- The MCP surface now writes audit events for grant creation, revocation and tool calls, under a new assistant actor kind, inside the same transaction as the thing they record.
+
+### Fixed
+
+- A connection whose grant holds no capability now answers 403 rather than 401, so a client stops re-running an authentication handshake that could not change the outcome.
+- An empty site allowlist is now a valid thing to approve.
+- A tag selection that only partly resolves is now refused rather than silently narrowed.
+
 ## [0.61.148] - 2026-08-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
-## [0.61.149] - 2026-08-31
+## [0.61.149] - 2026-08-30
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.148**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.149**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.148
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.148
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.148
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.149
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.149
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.149
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.148   # omit to track :latest
+export WPMGR_VERSION=v0.61.149   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -51,7 +51,7 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 const RELEASES: ChangeEntry[] = [
   {
     version: "0.61.149",
-    date: "2026-08-31",
+    date: "2026-08-30",
     summary:
       "Connection tokens can now be minted straight from the dashboard, for the cases the browser sign-in flow cannot reach: CI, an SSH session, a container. Grants carry an expiry, an idle expiry and a capability set, the connections list now shows real activity instead of always reading \"never used,\" and every grant, revocation and tool call is now audited under a new assistant actor kind.",
     items: [

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,38 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.149",
+    date: "2026-08-31",
+    summary:
+      "Connection tokens can now be minted straight from the dashboard, for the cases the browser sign-in flow cannot reach: CI, an SSH session, a container. Grants carry an expiry, an idle expiry and a capability set, the connections list now shows real activity instead of always reading \"never used,\" and every grant, revocation and tool call is now audited under a new assistant actor kind.",
+    items: [
+      {
+        tag: "Added",
+        text: "Connection tokens can now be minted directly from the dashboard: a new endpoint plus a wizard that walks an operator through picking a client, naming the connection, choosing which sites it may reach, choosing how it authenticates, and revealing the token exactly once.",
+      },
+      {
+        tag: "Added",
+        text: "A site-access explanation on the consent screen, stating plainly that scoping is a check made at the moment the assistant asks rather than a boundary enforced inside the database, and that a site added to a scoped tag later is included without anyone approving it.",
+      },
+      {
+        tag: "Changed",
+        text: "Grants now carry an expiry, an idle expiry and a capability set, all enforced inside the same authorization check that already refused a revoked grant.",
+      },
+      {
+        tag: "Changed",
+        text: "The connections list now records real activity. It previously reported every connection as \"never used,\" including one actively reading the fleet; it now reports the truth.",
+      },
+      {
+        tag: "Changed",
+        text: "The MCP surface now writes audit events for grant creation, revocation and tool calls, under a new assistant actor kind, inside the same transaction as the thing they record.",
+      },
+      {
+        tag: "Fixed",
+        text: "A connection whose grant holds no capability now answers with a permission error rather than an authentication error, so a client stops re-running a handshake that could not change the outcome. An empty site allowlist is now a valid thing to approve, and a tag selection that only partly resolves is refused rather than silently narrowed.",
+      },
+    ],
+  },
+  {
     version: "0.61.148",
     date: "2026-08-30",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.148   # omit to track :latest
+export WPMGR_VERSION=v0.61.149   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.148
+  version: 0.61.149
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. The agent plugin does not move and stays at 0.61.147.

- CHANGELOG.md, packages/openapi/openapi.yaml, the marketing /changelog page, and the README/docs/install.md version pins move to 0.61.149.
- Ships the CHANGELOG-listed connection-token, grant, activity, audit and consent-screen work already merged to main, plus three fixes (403 instead of 401 for a capability-less grant, a valid empty site allowlist, refusal of a partly-resolving tag selection).

## Test plan

- [x] `make check-versions-test` (self-test): 76 passed, 0 failed, exit 0
- [x] `make check-versions`: exit 0, all surfaces at 0.61.149, agent frozen at 0.61.147
- [x] Docs vocabulary check (verbatim from ci.yml): no hits
- [x] `node apps/marketing/scripts/check-copy.mjs`: passed, no em/en dashes, no competitor names
- [x] Grepped tree for stray 0.61.148 (none outside historical CHANGELOG/marketing-changelog entries) and stray 0.61.147 (none outside apps/agent/**, which correctly does not move)
- [ ] CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create connection tokens directly from the dashboard using a guided wizard.
  * View clearer site-access scope explanations during consent.
  * See connection activity and richer grant details, including expiration and capabilities.
  * Review audit events for grant and tool-call activity.

* **Bug Fixes**
  * Capability-less grants now return the correct permission error.
  * Empty site allowlists are handled correctly.
  * Partially resolved tag selections are no longer accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->