### PR TITLE
build: exclude agent worktrees from the Cloud Build upload

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -33,5 +33,12 @@ infra/postgres/data
 **/*.log
 **/.DS_Store
 
+# Agent worktrees. Each is a full checkout of this repository, so without this
+# every `gcloud builds submit` uploads the source once per live worktree. On
+# 2026-08-14 that reached 9.3G across 32 of them, 12G of source in total, and
+# both the api and the web build failed with an HTTP 408: "your client has taken
+# too long to issue its request". Nothing in a worktree belongs in a build.
+.claude/worktrees
+
 # PHPUnit result cache (transient; can vanish mid-archive)
 **/.phpunit.result.cache


### PR DESCRIPTION
Each worktree under `.claude/worktrees` is a full checkout of this repository, so without this line every `gcloud builds submit` uploads the source once per live worktree.

Measured on this machine while cutting 0.61.149:

```
live worktrees:              57
size of .claude/worktrees:   18G
api build upload, with this: 21172 files, 614.1 MiB
```

That is the difference between a build that runs and one that fails the request — the comment in the file records an earlier occurrence that took out both the api and the web build with an HTTP 408.

The line already existed uncommitted on this machine, which meant it protected exactly one checkout and no CI runner or other clone. This commits it so it protects all of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded agent worktree files from Google Cloud Build uploads, helping reduce unnecessary build context and upload size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->