### PR TITLE
feat(mcp): connection status read for wizard Steps 8 and 9

### DIFF
--- a/apps/api/internal/mcp/connection_status.go
+++ b/apps/api/internal/mcp/connection_status.go
@@ -1,0 +1,694 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
+)
+
+// ---------------------------------------------------------------------------
+// CONNECTION STATUS -- the read the add-connection wizard polls for Steps 8
+// and 9 (wireframes S29, 2026-08-24 generation).
+//
+// ONE ENDPOINT FOR BOTH STEPS, AND THAT IS A DESIGN DECISION RATHER THAN A
+// CONVENIENCE. Steps 8 and 9 are two questions about ONE grant row, and the
+// wizard shows them stacked on one page. Two endpoints would mean two polls
+// against the same row at two instants, which makes an INCONSISTENT PAIR
+// representable: Step 9 answering "it read your fleet" while Step 8 still says
+// "waiting for the client" is a state that cannot occur in reality (nothing can
+// call a tool before it initializes) but is trivially producible by two reads
+// straddling a handshake. The wizard would then have to reconcile them, and the
+// reconciliation would live in the browser where nobody would test it. One
+// handler, one snapshot: the pair is consistent by construction.
+//
+// POLLING, NOT SSE, AND ALSO A DECISION. The wireframe says "this page updates
+// itself", which is a requirement about the USER's experience and not about the
+// transport. Against SSE: ogen cannot model text/event-stream (ogen.yaml sets
+// ignore_not_implemented), so a stream needs a hand-written transport, and the
+// only hand-written streaming transport in this package is the very file
+// another agent is completing in parallel. A stream would also hold a
+// connection open per wizard tab for a page whose whole lifetime is the two or
+// three minutes an operator spends pasting a config into a client. A poll costs
+// one indexed primary-key read per interval and depends on nothing that is
+// still moving. PollAfterMs is returned by the server so the interval is a
+// server-side decision the client cannot drift from.
+//
+// WHAT THIS ENDPOINT WILL NOT DO: it will not synthesise a verdict its columns
+// cannot support. Every state below is a fact read off a stored column, and the
+// two places where the data genuinely cannot answer the wireframe are named
+// explicitly in the types (HandshakeRefusal, FirstCallIndeterminate) rather than
+// being rounded to the nearest state that renders nicely. An absence rendered
+// as a fact is this feature's recurring defect and the reason those two fields
+// exist.
+// ---------------------------------------------------------------------------
+
+// statusPollAfterMs is the interval the wizard is told to wait between polls.
+//
+// Two seconds, because the human on the other side has just been told to start
+// a client and is watching a spinner: slower feels broken, and faster buys
+// nothing because the event being waited on is a person alt-tabbing to a
+// terminal. It is returned in the body rather than hard-coded in the browser so
+// that changing it is a control-plane deploy and not a dashboard release.
+const statusPollAfterMs = 2000
+
+// firstCallScanLimit bounds how many mcp.tool.called rows this endpoint reads
+// while looking for THIS grant's first one.
+//
+// A BOUND IS REQUIRED AND ITS BEING HIT IS NOT A FAILURE -- see
+// FirstCallIndeterminate. The available generated query filters by action
+// prefix and not by actor, so the oldest tool call for THIS connection can sit
+// behind an arbitrary number of tool calls belonging to the organisation's
+// OTHER connections. Reading a page and reporting "no call yet" when the page
+// filled with other grants' rows would be an absence manufactured out of a
+// pagination limit, which is precisely the defect class this file is written
+// against. So the scan is bounded, and the bound being reached without a match
+// is reported as its own third state.
+const firstCallScanLimit = 200
+
+// ---------------------------------------------------------------------------
+// Step 8 -- the handshake
+// ---------------------------------------------------------------------------
+
+// HandshakeState is which of the wireframe's Step 8 frames a grant is in.
+//
+// THE FIRST VALUE IS A NOT-YET AND EVERY OTHER VALUE IS A FACT ABOUT SOMETHING
+// THAT HAPPENED. Nothing here is a failure, and that is not an oversight: see
+// HandshakeRefusal for the one Step 8 frame this server cannot currently reach.
+type HandshakeState string
+
+const (
+	// HandshakeAwaitingClient: client_identity_recorded_at IS NULL. The
+	// credential exists and nothing has opened a session with it. NOT-YET,
+	// never a failure -- the wireframe's own words are "nothing is wrong yet".
+	HandshakeAwaitingClient HandshakeState = "awaiting_client"
+
+	// HandshakeConnected: the client initialized and sent a revision this
+	// server speaks. The wireframe's "connected, and what we recorded".
+	HandshakeConnected HandshakeState = "connected"
+
+	// HandshakeConnectedProtocolAssumed: the client initialized and sent NO
+	// MCP-Protocol-Version header, so the specification's floor was assumed.
+	// The wireframe's "no version header at all", and its subtitle -- "treated
+	// as the floor, deliberately not an error" -- is why this is a distinct
+	// SUCCESS state and not a warning.
+	HandshakeConnectedProtocolAssumed HandshakeState = "connected_protocol_assumed"
+
+	// HandshakeConnectedProtocolUnrecognised: a revision is stored that this
+	// server does not currently speak.
+	//
+	// NOT REACHABLE THROUGH TODAY'S LIVE TRANSPORT, and kept anyway. The
+	// transport negotiates the header at transport.go:222 and refuses at :236
+	// before dispatch, so a request carrying an unspeakable revision never
+	// reaches RecordConnect and never writes this column. What CAN produce this
+	// state is history: a revision that was inside supportedRevisions when it
+	// was recorded and was later removed from the window. Classifying that
+	// honestly costs one branch; rounding it to "connected" would print a
+	// revision we no longer speak as though we did.
+	HandshakeConnectedProtocolUnrecognised HandshakeState = "connected_protocol_unrecognised"
+)
+
+// HandshakeRefusal is the wireframe's Step 8 X frame -- "protocol version below
+// the floor" -- and it is ALWAYS nil today.
+//
+// ============================================================================
+// THIS IS A DATA GAP, STATED IN THE TYPE SO IT CANNOT BE MISTAKEN FOR A STATE.
+// ============================================================================
+//
+// The wireframe wants a connection that was refused for speaking a revision
+// below the floor to say so, with the exact error we returned, copyable. THE
+// CONTROL PLANE DOES NOT RECORD THAT EVENT. TransportHandler.dispatch
+// negotiates at transport.go:222 and calls writeProtocolRefusal at :236 (and
+// again for the initialize params at :413) -- both return BEFORE
+// Service.RecordConnect at :432. A refused client therefore writes NOTHING to
+// mcp_grants: client_identity_recorded_at stays NULL, which is byte-identical
+// to a client that has never been started at all.
+//
+// SO THIS ENDPOINT REPORTS A REFUSED CONNECTION AS HandshakeAwaitingClient,
+// WHICH IS THE TRUTHFUL READING OF THE ROW AND IS NOT THE WIREFRAME'S FRAME.
+// Reporting it as a refusal would be inventing an event out of a NULL. Closing
+// the gap needs somewhere to put the refusal -- a column or a small table --
+// and that is a migration, which belongs to database-engineer and not here.
+//
+// The Protocol block below still carries Floor, Target and Supported on every
+// response, because those are properties of THIS SERVER and are true whatever
+// the client did. The wizard can render "what our floor is" and the
+// known-good-clients affordance from any response; what it cannot render, and
+// must not, is "your client was refused" for a connection whose row cannot say
+// so.
+type HandshakeRefusal struct {
+	// Requested is the revision the client sent.
+	Requested string
+	// Message is the exact operator-facing sentence the endpoint returned.
+	Message string
+	// At is when the refusal happened.
+	At time.Time
+}
+
+// StatusProtocol is the Step 8 protocol block: what the client said, plus what
+// this server requires.
+//
+// It wraps ClientProtocol rather than replacing it. ClientProtocol's four
+// states are the vocabulary connection-model.ts already models on the
+// frontend, and inventing a second vocabulary here is how two layers come to
+// disagree about what "absent" means.
+type StatusProtocol struct {
+	// State and Version are ClassifyStoredProtocol's verdict, unchanged.
+	// Version is EMPTY for never_connected and for absent, because NULL means
+	// "the client sent no header" and never "unknown version".
+	State   ClientProtocolState
+	Version string
+
+	// Assumed is the revision the specification told us to assume, and it is
+	// set ONLY for ClientProtocolAbsent. It is a SEPARATE FIELD from Version on
+	// purpose: writing the floor into Version would print a header the client
+	// never sent, which is the exact manufacture ClassifyStoredProtocol's doc
+	// comment refuses. The frontend renders these two together as "No protocol
+	// header sent (treated as <floor>)".
+	Assumed string
+
+	// Floor, Target and Supported are properties of this server, true on every
+	// response including one for a client that has never connected.
+	Floor     string
+	Target    string
+	Supported []string
+}
+
+// ConnectionHandshake is the whole Step 8 answer.
+type ConnectionHandshake struct {
+	State HandshakeState
+	// RecordedAt is when the client identified itself. nil for
+	// HandshakeAwaitingClient and non-nil for every other state -- it is the
+	// column the state is derived from, returned so the wizard can show the
+	// timestamp the wireframe puts beside each completed check.
+	RecordedAt *time.Time
+	// ReportedClientName and ReportedClientVersion are the client's OWN
+	// unverified claims. nil, never "", when nothing was reported.
+	ReportedClientName    *string
+	ReportedClientVersion *string
+	Protocol              StatusProtocol
+	// Refusal is always nil. See the HandshakeRefusal doc comment.
+	Refusal *HandshakeRefusal
+}
+
+// ---------------------------------------------------------------------------
+// Step 9 -- the first read
+// ---------------------------------------------------------------------------
+
+// FirstCallState is which of the wireframe's Step 9 frames a grant is in.
+type FirstCallState string
+
+const (
+	// FirstCallAwaiting: the scan completed and found no mcp.tool.called row
+	// for this grant. A DEFINITIVE NOT-YET -- the scan saw fewer rows than its
+	// bound, so it saw all of them.
+	//
+	// This is BOTH of the wireframe's "L -- watching for the first call" and
+	// "X -- no call ever arrived". They are the same server-side fact and they
+	// differ only in how long the operator has been staring at it, which is a
+	// clock the browser owns. The server does not have a threshold past which
+	// a not-yet becomes a failure, must not invent one, and returns CreatedAt
+	// and the handshake's RecordedAt so the wizard can apply its own.
+	FirstCallAwaiting FirstCallState = "awaiting_call"
+
+	// FirstCallSucceeded: an mcp.tool.called row exists for this grant. The
+	// wireframe's "it worked".
+	FirstCallSucceeded FirstCallState = "succeeded"
+
+	// FirstCallIndeterminate: the scan hit firstCallScanLimit without finding a
+	// row for this grant, so this endpoint DOES NOT KNOW.
+	//
+	// A THIRD STATE RATHER THAN A ROUNDED-DOWN NOT-YET. The difference matters
+	// to the wizard: "no call yet" invites it to keep waiting and eventually to
+	// show the X frame's troubleshooting, which would be wrong advice for a
+	// connection that is working fine and merely sits behind 200 of its
+	// siblings' tool calls. The honest render is "we cannot tell from here",
+	// and the fix is the actor-filtered query named in FindFirstToolCall.
+	FirstCallIndeterminate FirstCallState = "indeterminate"
+)
+
+// ConnectionFirstCall is the whole Step 9 answer.
+type ConnectionFirstCall struct {
+	State FirstCallState
+
+	// CalledAt, ToolName and AuditEventID are set ONLY for
+	// FirstCallSucceeded. They are the wireframe's "Tool it called" and its
+	// "Audit row" line.
+	CalledAt     *time.Time
+	ToolName     string
+	AuditEventID *uuid.UUID
+
+	// LastUsedAt is mcp_grants.last_used_at, and it is REPORTED ALONGSIDE THE
+	// STATE RATHER THAN USED TO DERIVE IT.
+	//
+	// THIS IS THE TRAP IN STEP 9 AND IT IS WORTH THE PARAGRAPH. last_used_at
+	// looks like the cheap way to answer "has this connection done anything",
+	// and it is wrong for this question: Service.RecordActivity stamps it from
+	// the transport's tools/list arm as well as tools/call. Every MCP client
+	// issues tools/list immediately after initialize, without any user asking
+	// it to. Deriving Step 9 from this column would therefore flip the wizard
+	// to "Connected and working -- it read your fleet" for a client that has
+	// merely enumerated the tool list and read nothing at all. That is a FALSE
+	// SUCCESS on the one screen whose entire job is to prove a real read
+	// happened, so the state comes from the audit row and this column is
+	// returned only as the weaker, honestly-labelled fact it is.
+	LastUsedAt *time.Time
+
+	// Partial is the wireframe's "P -- partial multi-site success" frame, and
+	// it is ALWAYS nil.
+	//
+	// ========================================================================
+	// NOT ANSWERABLE TODAY, DELIBERATELY LEFT UNANSWERED RATHER THAN FAKED.
+	// ========================================================================
+	//
+	// The frame wants "17 answered, 3 stale, 2 unreachable -- and it still
+	// succeeded", with the same three numbers handed to the model in a typed
+	// result. internal/mcp has no typed per-site partial: a tool invocation
+	// returns a string or an error, and the only incompleteness it can express
+	// is whole-result truncation. The wireframe's own 2026-08-30 scoping block
+	// calls this out as an uncosted prerequisite and it has its own issue.
+	//
+	// The failure mode being avoided is named in the wireframe: the model "does
+	// not get a clean answer over an incomplete read -- that is how a fleet
+	// answer becomes quietly wrong". Synthesising counts here, or reporting
+	// FirstCallSucceeded as though coverage were complete when this endpoint
+	// has no way to know, would put that same wrongness on the operator's
+	// screen. So a successful call reports FirstCallSucceeded with Partial nil,
+	// meaning "a tool call happened and we cannot characterise its coverage" --
+	// never "it covered everything".
+	Partial *FirstCallPartial
+}
+
+// FirstCallPartial is the per-site coverage breakdown. Nothing constructs one
+// today; see the Partial field's doc comment.
+type FirstCallPartial struct {
+	SitesAsked  int
+	Answered    int
+	Stale       int
+	Unreachable int
+}
+
+// ConnectionStatus is the whole polled answer: one grant, both steps, one
+// instant.
+type ConnectionStatus struct {
+	ID uuid.UUID
+	// Status is the grant's stored liveness. A revoked connection still
+	// answers this endpoint -- the wizard needs to stop polling and say so,
+	// and a 404 would read as "wrong id".
+	Status    GrantStatus
+	CreatedAt time.Time
+	ExpiresAt time.Time
+
+	Handshake ConnectionHandshake
+	FirstCall ConnectionFirstCall
+
+	// ObservedAt is when this snapshot was taken, so the wizard's relative
+	// times ("4 seconds ago") are computed against the server's clock and not
+	// against a browser clock that may be minutes out.
+	ObservedAt time.Time
+	// PollAfterMs is how long the client should wait before asking again.
+	PollAfterMs int
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+// ConnectionStatus answers Steps 8 and 9 for one grant.
+//
+// requireOrgScopedPrincipal FIRST, before any read. This is the same gate
+// ListConnections and RevokeConnection take, and it is the permission-layer
+// half of what mcp_grants_site_scope_select does in the database: a grant is an
+// ORGANISATION-wide credential with no :siteId for RequireSiteAccess to key on,
+// so a site-constrained principal is refused outright rather than filtered. A
+// site-scoped collaborator reaching an org-wide grant was a live defect on this
+// exact surface, and this endpoint is a READ of the same object the defect was
+// about -- the client name, the client version and the protocol revision of the
+// organisation's AI connections are not facts a single-site collaborator is
+// entitled to.
+func (s *Service) ConnectionStatus(ctx context.Context, p domain.Principal, grantID uuid.UUID) (ConnectionStatus, error) {
+	if err := requireOrgScopedPrincipal(p); err != nil {
+		return ConnectionStatus{}, err
+	}
+	if grantID == uuid.Nil {
+		return ConnectionStatus{}, domain.NotFound("connection_not_found", "connection not found")
+	}
+
+	grant, err := s.store.GetGrant(ctx, p, grantID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Absent, another organisation's, or refused by RLS. All three are
+			// 404 and are deliberately INDISTINGUISHABLE to the caller: a 403
+			// on another tenant's grant id would confirm that the id exists,
+			// which is the cross-tenant leak this surface must not have.
+			return ConnectionStatus{}, domain.NotFound("connection_not_found", "connection not found")
+		}
+		return ConnectionStatus{}, fmt.Errorf("mcp connection status: %w", err)
+	}
+
+	call, err := s.store.FindFirstToolCall(ctx, p, grantID, firstCallScanLimit)
+	if err != nil {
+		// NOT swallowed into FirstCallAwaiting. A failed audit read that
+		// rendered as "no call yet" would send the operator to the wireframe's
+		// troubleshooting frame for a connection that may well be working --
+		// an infrastructure failure reported as a fact about the client.
+		return ConnectionStatus{}, fmt.Errorf("mcp connection status first call: %w", err)
+	}
+
+	return ConnectionStatus{
+		ID:          grant.ID,
+		Status:      GrantStatus(grant.Status),
+		CreatedAt:   grant.CreatedAt,
+		ExpiresAt:   grant.ExpiresAt,
+		Handshake:   handshakeFromGrant(grant),
+		FirstCall:   firstCallFrom(call, timestamptzTimeOrNil(grant.LastUsedAt)),
+		ObservedAt:  s.now().UTC(),
+		PollAfterMs: statusPollAfterMs,
+	}, nil
+}
+
+// handshakeFromGrant derives Step 8 from the two stored columns.
+//
+// The state is switched off ClassifyStoredProtocol's verdict rather than being
+// re-derived from the columns, so there is exactly ONE place the two columns
+// are read as four states and this function cannot drift from the frontend
+// vocabulary it feeds.
+func handshakeFromGrant(g sqlc.McpGrant) ConnectionHandshake {
+	// timestamptzTimeOrNil, the same helper connectionFromGrant uses: it is the
+	// one line that keeps SQL NULL out of the Go zero time, and reading the
+	// column any other way here would reintroduce 0001-01-01 as a handshake
+	// date on exactly the state that means "no handshake".
+	recordedAt := timestamptzTimeOrNil(g.ClientIdentityRecordedAt)
+	proto := ClassifyStoredProtocol(recordedAt, g.ProtocolVersion)
+
+	h := ConnectionHandshake{
+		RecordedAt:            recordedAt,
+		ReportedClientName:    g.ClientName,
+		ReportedClientVersion: g.ClientVersion,
+		Protocol: StatusProtocol{
+			State:     proto.State,
+			Version:   proto.Version,
+			Floor:     ProtocolFloor,
+			Target:    ProtocolTarget,
+			Supported: SupportedRevisions(),
+		},
+		// Always nil. See HandshakeRefusal.
+		Refusal: nil,
+	}
+
+	switch proto.State {
+	case ClientProtocolNeverConnected:
+		h.State = HandshakeAwaitingClient
+	case ClientProtocolAbsent:
+		h.State = HandshakeConnectedProtocolAssumed
+		// The one place the floor is attached, and it goes in Assumed rather
+		// than Version.
+		h.Protocol.Assumed = ProtocolFloor
+	case ClientProtocolRecognised:
+		h.State = HandshakeConnected
+	case ClientProtocolUnrecognised:
+		h.State = HandshakeConnectedProtocolUnrecognised
+	default:
+		// Unreachable while ClassifyStoredProtocol returns one of four. If a
+		// fifth is ever added, this reports the NOT-YET rather than inventing a
+		// success -- the fail-closed direction for a state machine whose
+		// success states are claims about a client we may not have heard from.
+		h.State = HandshakeAwaitingClient
+	}
+	return h
+}
+
+// firstCallFrom derives Step 9 from the audit scan's outcome.
+//
+// lastUsedAt is carried through to the struct and is NOT consulted for the
+// state; see ConnectionFirstCall.LastUsedAt for why that would be a false
+// success.
+func firstCallFrom(c FirstToolCall, lastUsedAt *time.Time) ConnectionFirstCall {
+	out := ConnectionFirstCall{LastUsedAt: lastUsedAt, Partial: nil}
+
+	switch {
+	case c.Found:
+		out.State = FirstCallSucceeded
+		at := c.At
+		id := c.EventID
+		out.CalledAt = &at
+		out.AuditEventID = &id
+		out.ToolName = c.ToolName
+	case c.Truncated:
+		out.State = FirstCallIndeterminate
+	default:
+		out.State = FirstCallAwaiting
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Repo
+// ---------------------------------------------------------------------------
+
+// FirstToolCall is what the audit scan found, with its own honesty flag.
+//
+// Found and Truncated are SEPARATE BOOLEANS rather than one tri-state enum
+// because the caller must not be able to read "not found" without also seeing
+// whether the search was complete. A single "found bool" would make the
+// truncated case indistinguishable from a definitive miss at the call site,
+// which is the whole defect.
+type FirstToolCall struct {
+	// Found reports that a matching row was seen.
+	Found bool
+	// Truncated reports that the scan reached its bound. Meaningful only when
+	// Found is false: a scan that found its row stopped looking.
+	Truncated bool
+
+	EventID  uuid.UUID
+	At       time.Time
+	ToolName string
+}
+
+// GetGrant reads ONE grant through RunTenantTx.
+//
+// RunTenantTx and not InTenantTx, for the reason ListGrants gives: mcp_grants
+// carries a RESTRICTIVE mcp_grants_site_scope_select policy as well as the
+// tenant-isolation one, and InTenantTx does not set app.site_scope or
+// app.allowed_site_ids, so the restrictive policy would be INERT and a
+// site-constrained principal would read an organisation-wide credential with a
+// 200 and no trace. Service.ConnectionStatus refuses such a principal before
+// reaching here; this is the second lock on the same door, in the layer that
+// still holds if somebody later mounts this read behind a different gate.
+//
+// pgx.ErrNoRows is returned VERBATIM so the caller can 404 on it.
+func (r *Repo) GetGrant(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.McpGrant, error) {
+	var out sqlc.McpGrant
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).GetMCPGrant(ctx, sqlc.GetMCPGrantParams{
+			TenantID: principal.TenantID,
+			ID:       grantID,
+		})
+		if err != nil {
+			return err
+		}
+		out = row
+		return nil
+	})
+	if err != nil {
+		return sqlc.McpGrant{}, err
+	}
+	return out, nil
+}
+
+// FindFirstToolCall looks for the OLDEST mcp.tool.called audit row belonging to
+// this grant.
+//
+// THE OLDEST, because Step 9 asks "did the first read happen", and the wizard
+// renders that one call. ListAuditEntriesFiltered orders newest-first, so the
+// match is taken by walking the scanned window BACKWARDS.
+//
+// WHY THIS SCANS INSTEAD OF FILTERING, AND WHAT IT WOULD TAKE TO STOP.
+// ListAuditEntriesFiltered is the only generated read over audit_log that this
+// package can reach, and it filters on action prefix, site and time -- NOT on
+// actor_id. mcp.tool.called rows carry the grant id in actor_id (audit.go's
+// ActorAssistant attribution), so the match has to happen in Go. The clean fix
+// is a generated query filtered by actor_type + actor_id, which is a .sql
+// change and therefore database-engineer's; with it, both the bound and the
+// FirstCallIndeterminate state disappear.
+//
+// THE BOUND IS REPORTED, NEVER SWALLOWED. limit+1 rows are requested so that
+// "the window was full" is distinguishable from "the window was exactly the
+// size of the data", and Truncated is set from that. A scan that fills its
+// window without matching returns Found=false AND Truncated=true, and the
+// service turns that pair into FirstCallIndeterminate rather than into a
+// not-yet.
+func (r *Repo) FindFirstToolCall(
+	ctx context.Context,
+	principal domain.Principal,
+	grantID uuid.UUID,
+	limit int,
+) (FirstToolCall, error) {
+	var out FirstToolCall
+	want := grantID.String()
+
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		rows, err := sqlc.New(tx).ListAuditEntriesFiltered(ctx, sqlc.ListAuditEntriesFilteredParams{
+			TenantID:     principal.TenantID,
+			ActionPrefix: audit.ActionMCPToolCalled,
+			// The disabled-filter sentinels this query documents: the zero uuid
+			// turns the site filter off, and the zero Timestamptz values are
+			// not Valid, which is the NULL that turns the time window off.
+			SiteID:    uuid.Nil.String(),
+			RowOffset: 0,
+			RowLimit:  int32(limit) + 1,
+		})
+		if err != nil {
+			return fmt.Errorf("scan mcp tool calls: %w", err)
+		}
+
+		out.Truncated = len(rows) > limit
+		if out.Truncated {
+			rows = rows[:limit]
+		}
+
+		// Newest-first, so walking BACKWARDS reaches the oldest row first and
+		// the first hit is the one Step 9 wants.
+		for i := len(rows) - 1; i >= 0; i-- {
+			row := rows[i]
+			// actor_type is checked as well as actor_id. actor_id is a free
+			// text column shared by every actor kind, so a uuid match alone
+			// would also accept a row written by a user or an api_key that
+			// happened to carry this id -- and the grant id and the user id
+			// live in the same column space. Both halves, or the attribution
+			// is a coincidence.
+			if row.ActorType != audit.ActorAssistant || row.ActorID != want {
+				continue
+			}
+			out.Found = true
+			// A found row ends the search, so Truncated stops being
+			// meaningful and is cleared rather than left set for the service
+			// to have to ignore.
+			out.Truncated = false
+			out.EventID = row.ID
+			out.At = row.CreatedAt
+			// target_id is the tool name -- RecordToolCall stores it there.
+			out.ToolName = row.TargetID
+			return nil
+		}
+		return nil
+	})
+	if err != nil {
+		return FirstToolCall{}, err
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// connectionStatus answers GET /api/v1/mcp/connections/:connectionId/status.
+//
+// PermAPIKeyRead, matching listConnections: this is a READ of the same object
+// the list renders, so it takes the read tier and not the manage one. That
+// permission is a member of authz.orgLevelPerms, which is what makes
+// RequirePermission refuse a site-constrained principal outright -- the
+// permission-layer half of the org-scope gate, restated at the route because a
+// handler that trusts its mount point is one refactor away from ungated.
+func (h *Handler) connectionStatus(c *gin.Context) {
+	principal, ok := domain.PrincipalFromContext(c.Request.Context())
+	if !ok {
+		// Unreachable behind RequireAuth; refusing anyway, because a handler
+		// that trusts its mount point is one refactor away from anonymous.
+		httpx.Error(c, domain.Unauthorized("unauthenticated", "authentication required"))
+		return
+	}
+
+	grantID, err := uuid.Parse(c.Param(connectionIDParam))
+	if err != nil {
+		// 404 and not 400. A malformed id and an id belonging to another
+		// organisation must answer identically, or the difference between the
+		// two answers becomes an oracle for which ids exist.
+		httpx.Error(c, domain.NotFound("connection_not_found", "connection not found"))
+		return
+	}
+
+	st, err := h.svc.ConnectionStatus(c.Request.Context(), principal, grantID)
+	if err != nil {
+		httpx.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, connectionStatusResponse(st))
+}
+
+// ---------------------------------------------------------------------------
+// DTO
+// ---------------------------------------------------------------------------
+
+// connectionStatusResponse maps the domain answer onto the wire.
+//
+// Every nullable stays nullable. A *time.Time that became a time.Time would
+// serialise the Go zero value as "0001-01-01T00:00:00Z", which is a real
+// timestamp on the wire and renders as a connection that handshook in the year
+// one -- an absence turned into a fact by a type choice.
+func connectionStatusResponse(s ConnectionStatus) gin.H {
+	h := gin.H{
+		"state":                   string(s.Handshake.State),
+		"recorded_at":             s.Handshake.RecordedAt,
+		"reported_client_name":    s.Handshake.ReportedClientName,
+		"reported_client_version": s.Handshake.ReportedClientVersion,
+		"protocol": gin.H{
+			"state":     string(s.Handshake.Protocol.State),
+			"version":   emptyToNil(s.Handshake.Protocol.Version),
+			"assumed":   emptyToNil(s.Handshake.Protocol.Assumed),
+			"floor":     s.Handshake.Protocol.Floor,
+			"target":    s.Handshake.Protocol.Target,
+			"supported": s.Handshake.Protocol.Supported,
+		},
+		// Always null; the key is present so the frontend can bind it now and
+		// light up when the refusal is recorded, rather than the shape changing
+		// under it later.
+		"refusal": nil,
+	}
+
+	f := gin.H{
+		"state":          string(s.FirstCall.State),
+		"called_at":      s.FirstCall.CalledAt,
+		"tool_name":      emptyToNil(s.FirstCall.ToolName),
+		"audit_event_id": s.FirstCall.AuditEventID,
+		"last_used_at":   s.FirstCall.LastUsedAt,
+		// Always null. See ConnectionFirstCall.Partial.
+		"partial": nil,
+	}
+
+	return gin.H{
+		"id":            s.ID,
+		"status":        string(s.Status),
+		"created_at":    s.CreatedAt,
+		"expires_at":    s.ExpiresAt,
+		"handshake":     h,
+		"first_call":    f,
+		"observed_at":   s.ObservedAt,
+		"poll_after_ms": s.PollAfterMs,
+	}
+}
+
+// emptyToNil keeps "" off the wire as a value.
+//
+// The domain types use "" for "not set" on the two protocol strings and on the
+// tool name, because ClientProtocol already does and matching it beats adding a
+// second convention. On the WIRE that must become null: a JSON "" is a value,
+// and a frontend rendering `version || "none"` behaves differently from one
+// rendering `version ?? "none"`. null makes both correct.
+func emptyToNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/apps/api/internal/mcp/connection_status.go
+++ b/apps/api/internal/mcp/connection_status.go
@@ -344,7 +344,11 @@ func (s *Service) ConnectionStatus(ctx context.Context, p domain.Principal, gran
 		return ConnectionStatus{}, domain.NotFound("connection_not_found", "connection not found")
 	}
 
-	grant, err := s.store.GetGrant(ctx, p, grantID)
+	// ONE call, because the two facts must come from ONE ordered read. See
+	// Store.ConnectionStatusSnapshot: the service is deliberately given no way
+	// to fetch the handshake and the first call separately, because doing so is
+	// what made the impossible pair representable.
+	snap, err := s.store.ConnectionStatusSnapshot(ctx, p, grantID, firstCallScanLimit)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			// Absent, another organisation's, or refused by RLS. All three are
@@ -353,25 +357,21 @@ func (s *Service) ConnectionStatus(ctx context.Context, p domain.Principal, gran
 			// which is the cross-tenant leak this surface must not have.
 			return ConnectionStatus{}, domain.NotFound("connection_not_found", "connection not found")
 		}
-		return ConnectionStatus{}, fmt.Errorf("mcp connection status: %w", err)
-	}
-
-	call, err := s.store.FindFirstToolCall(ctx, p, grantID, firstCallScanLimit)
-	if err != nil {
 		// NOT swallowed into FirstCallAwaiting. A failed audit read that
 		// rendered as "no call yet" would send the operator to the wireframe's
 		// troubleshooting frame for a connection that may well be working --
 		// an infrastructure failure reported as a fact about the client.
-		return ConnectionStatus{}, fmt.Errorf("mcp connection status first call: %w", err)
+		return ConnectionStatus{}, fmt.Errorf("mcp connection status: %w", err)
 	}
 
+	grant := snap.Grant
 	return ConnectionStatus{
 		ID:          grant.ID,
 		Status:      GrantStatus(grant.Status),
 		CreatedAt:   grant.CreatedAt,
 		ExpiresAt:   grant.ExpiresAt,
 		Handshake:   handshakeFromGrant(grant),
-		FirstCall:   firstCallFrom(call, timestamptzTimeOrNil(grant.LastUsedAt)),
+		FirstCall:   firstCallFrom(snap.FirstCall, timestamptzTimeOrNil(grant.LastUsedAt)),
 		ObservedAt:  s.now().UTC(),
 		PollAfterMs: statusPollAfterMs,
 	}, nil
@@ -475,39 +475,138 @@ type FirstToolCall struct {
 	ToolName string
 }
 
-// GetGrant reads ONE grant through RunTenantTx.
+// ConnectionSnapshot is the pair of reads Steps 8 and 9 are derived from.
+//
+// It exists so the two CANNOT be fetched independently. See
+// Repo.ConnectionStatusSnapshot for the ordering that makes the pair
+// consistent, and Store.ConnectionStatusSnapshot for why this replaced two
+// separately-callable reads rather than sitting alongside them.
+type ConnectionSnapshot struct {
+	Grant     sqlc.McpGrant
+	FirstCall FirstToolCall
+}
+
+// ConnectionStatusSnapshot reads the grant and the first tool call for Steps 8
+// and 9 in ONE transaction and, more importantly, in ONE ORDER.
+//
+// ============================================================================
+// THE ORDER IS THE FIX. THE SHARED TRANSACTION ALONE IS NOT.
+// ============================================================================
+//
+// The defect this replaces ran GetGrant and FindFirstToolCall as two separate
+// transactions. An initialize and a tool call committing between them produced
+// handshake=awaiting_client together with first_call=succeeded -- the exact
+// contradiction this endpoint was made a SINGLE endpoint to prevent. The
+// contradiction had simply moved inside the handler.
+//
+// Wrapping both reads in one transaction does NOT by itself fix it, and
+// believing it does is the trap here. Every helper in internal/db begins with
+// p.Begin, which is READ COMMITTED, and under READ COMMITTED each STATEMENT
+// takes its own snapshot -- so two statements in one transaction still straddle
+// a concurrent commit exactly as two transactions did. A true transaction-wide
+// snapshot needs REPEATABLE READ, which must be set at BEGIN; the tx helpers
+// set the RLS GUCs with SELECT set_config before fn runs, so by the time this
+// function has a tx the isolation level can no longer be changed. Raising it
+// would mean a new BeginTx-based helper in internal/db, which is the tenancy
+// boundary and a change of its own.
+//
+// So consistency is bought with ORDERING instead, which needs no isolation
+// change and no new helper:
+//
+//	   THE INVARIANT: mcp_grants.client_identity_recorded_at is stamped by
+//	   RecordClientIdentity (db/query/mcp_connections.sql, "client_identity_
+//	   recorded_at = now()") and is NEVER written back to NULL. A tool call's
+//	   audit row is written strictly after the initialize that recorded the
+//	   client. The handshake fact is therefore MONOTONIC and always at least as
+//	   old as the first-call fact.
+//
+//	   THE CONSEQUENCE: read the LATER fact first and the EARLIER fact last.
+//	   Anything that commits between the two reads can then only make the
+//	   handshake MORE advanced, never less. The reachable pairs become
+//	   awaiting_client+awaiting_call, connected+awaiting_call and
+//	   connected+succeeded -- all three real states. awaiting_client+succeeded
+//	   is unreachable by racing, which is the whole finding.
+//
+// Reversing steps 2 and 3 below reintroduces the defect, which is what the
+// regression test pins.
+//
+// WHY THE GRANT IS READ TWICE. Step 1 is an existence-and-RLS gate whose only
+// product is the 404: without it a poll for an absent or another tenant's grant
+// id would run the bounded audit scan -- up to firstCallScanLimit+1 rows --
+// before discovering it had nothing to answer about, turning a cheap 404 into
+// an audit-log scan any authenticated org principal could trigger by guessing
+// ids. Its returned row is DELIBERATELY DISCARDED: it is older than the scan
+// and using it would be the original bug. Step 3 re-reads the same primary key
+// inside the same open transaction -- an indexed single-row read -- and that
+// row is the one the handshake is derived from.
+//
+// THE AUDIT SCAN'S COST INSIDE THE TRANSACTION. findFirstToolCallTx reads at
+// most firstCallScanLimit+1 rows from one index and holds no locks; it is a
+// read-only transaction, so nothing here blocks a writer or pins a row. What
+// the longer transaction does cost is a pooled connection held for the scan's
+// duration rather than for two short reads, and one xmin held back for that
+// window. At a two-second poll per open wizard tab that is not a vacuum
+// concern, and it is strictly less connection churn than the two transactions
+// it replaces.
 //
 // RunTenantTx and not InTenantTx, for the reason ListGrants gives: mcp_grants
 // carries a RESTRICTIVE mcp_grants_site_scope_select policy as well as the
 // tenant-isolation one, and InTenantTx does not set app.site_scope or
 // app.allowed_site_ids, so the restrictive policy would be INERT and a
 // site-constrained principal would read an organisation-wide credential with a
-// 200 and no trace. Service.ConnectionStatus refuses such a principal before
+// 200 and no trace. Combining the reads did NOT force the plain helper: both
+// reads were already on RunTenantTx and they still are, now on ONE dispatch
+// instead of two. Service.ConnectionStatus refuses such a principal before
 // reaching here; this is the second lock on the same door, in the layer that
 // still holds if somebody later mounts this read behind a different gate.
 //
 // pgx.ErrNoRows is returned VERBATIM so the caller can 404 on it.
-func (r *Repo) GetGrant(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.McpGrant, error) {
-	var out sqlc.McpGrant
+func (r *Repo) ConnectionStatusSnapshot(
+	ctx context.Context,
+	principal domain.Principal,
+	grantID uuid.UUID,
+	limit int,
+) (ConnectionSnapshot, error) {
+	var out ConnectionSnapshot
 	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
-		row, err := sqlc.New(tx).GetMCPGrant(ctx, sqlc.GetMCPGrantParams{
-			TenantID: principal.TenantID,
-			ID:       grantID,
-		})
+		// 1. Gate. Existence and RLS only; the row itself is thrown away.
+		if _, err := getGrantTx(ctx, tx, principal.TenantID, grantID); err != nil {
+			return err
+		}
+
+		// 2. The LATER fact.
+		call, err := findFirstToolCallTx(ctx, tx, principal.TenantID, grantID, limit)
 		if err != nil {
 			return err
 		}
-		out = row
+
+		// 3. The EARLIER fact, read last so it can only be fresher than the
+		//    scan. This is the row the handshake state comes from.
+		grant, err := getGrantTx(ctx, tx, principal.TenantID, grantID)
+		if err != nil {
+			return err
+		}
+
+		out = ConnectionSnapshot{Grant: grant, FirstCall: call}
 		return nil
 	})
 	if err != nil {
-		return sqlc.McpGrant{}, err
+		return ConnectionSnapshot{}, err
 	}
 	return out, nil
 }
 
-// FindFirstToolCall looks for the OLDEST mcp.tool.called audit row belonging to
-// this grant.
+// getGrantTx is the single-row grant read, on an already-open transaction so
+// the caller owns the ordering. pgx.ErrNoRows passes through untouched.
+func getGrantTx(ctx context.Context, tx pgx.Tx, tenantID, grantID uuid.UUID) (sqlc.McpGrant, error) {
+	return sqlc.New(tx).GetMCPGrant(ctx, sqlc.GetMCPGrantParams{
+		TenantID: tenantID,
+		ID:       grantID,
+	})
+}
+
+// findFirstToolCallTx looks for the OLDEST mcp.tool.called audit row belonging
+// to this grant.
 //
 // THE OLDEST, because Step 9 asks "did the first read happen", and the wizard
 // renders that one call. ListAuditEntriesFiltered orders newest-first, so the
@@ -528,63 +627,62 @@ func (r *Repo) GetGrant(ctx context.Context, principal domain.Principal, grantID
 // window without matching returns Found=false AND Truncated=true, and the
 // service turns that pair into FirstCallIndeterminate rather than into a
 // not-yet.
-func (r *Repo) FindFirstToolCall(
+//
+// It runs on an ALREADY-OPEN transaction rather than opening its own, so that
+// ConnectionStatusSnapshot owns the order in which this read and the grant read
+// happen. That ordering is load-bearing; see ConnectionStatusSnapshot.
+func findFirstToolCallTx(
 	ctx context.Context,
-	principal domain.Principal,
+	tx pgx.Tx,
+	tenantID uuid.UUID,
 	grantID uuid.UUID,
 	limit int,
 ) (FirstToolCall, error) {
 	var out FirstToolCall
 	want := grantID.String()
 
-	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
-		rows, err := sqlc.New(tx).ListAuditEntriesFiltered(ctx, sqlc.ListAuditEntriesFilteredParams{
-			TenantID:     principal.TenantID,
-			ActionPrefix: audit.ActionMCPToolCalled,
-			// The disabled-filter sentinels this query documents: the zero uuid
-			// turns the site filter off, and the zero Timestamptz values are
-			// not Valid, which is the NULL that turns the time window off.
-			SiteID:    uuid.Nil.String(),
-			RowOffset: 0,
-			RowLimit:  int32(limit) + 1,
-		})
-		if err != nil {
-			return fmt.Errorf("scan mcp tool calls: %w", err)
-		}
-
-		out.Truncated = len(rows) > limit
-		if out.Truncated {
-			rows = rows[:limit]
-		}
-
-		// Newest-first, so walking BACKWARDS reaches the oldest row first and
-		// the first hit is the one Step 9 wants.
-		for i := len(rows) - 1; i >= 0; i-- {
-			row := rows[i]
-			// actor_type is checked as well as actor_id. actor_id is a free
-			// text column shared by every actor kind, so a uuid match alone
-			// would also accept a row written by a user or an api_key that
-			// happened to carry this id -- and the grant id and the user id
-			// live in the same column space. Both halves, or the attribution
-			// is a coincidence.
-			if row.ActorType != audit.ActorAssistant || row.ActorID != want {
-				continue
-			}
-			out.Found = true
-			// A found row ends the search, so Truncated stops being
-			// meaningful and is cleared rather than left set for the service
-			// to have to ignore.
-			out.Truncated = false
-			out.EventID = row.ID
-			out.At = row.CreatedAt
-			// target_id is the tool name -- RecordToolCall stores it there.
-			out.ToolName = row.TargetID
-			return nil
-		}
-		return nil
+	rows, err := sqlc.New(tx).ListAuditEntriesFiltered(ctx, sqlc.ListAuditEntriesFilteredParams{
+		TenantID:     tenantID,
+		ActionPrefix: audit.ActionMCPToolCalled,
+		// The disabled-filter sentinels this query documents: the zero uuid
+		// turns the site filter off, and the zero Timestamptz values are
+		// not Valid, which is the NULL that turns the time window off.
+		SiteID:    uuid.Nil.String(),
+		RowOffset: 0,
+		RowLimit:  int32(limit) + 1,
 	})
 	if err != nil {
-		return FirstToolCall{}, err
+		return FirstToolCall{}, fmt.Errorf("scan mcp tool calls: %w", err)
+	}
+
+	out.Truncated = len(rows) > limit
+	if out.Truncated {
+		rows = rows[:limit]
+	}
+
+	// Newest-first, so walking BACKWARDS reaches the oldest row first and
+	// the first hit is the one Step 9 wants.
+	for i := len(rows) - 1; i >= 0; i-- {
+		row := rows[i]
+		// actor_type is checked as well as actor_id. actor_id is a free
+		// text column shared by every actor kind, so a uuid match alone
+		// would also accept a row written by a user or an api_key that
+		// happened to carry this id -- and the grant id and the user id
+		// live in the same column space. Both halves, or the attribution
+		// is a coincidence.
+		if row.ActorType != audit.ActorAssistant || row.ActorID != want {
+			continue
+		}
+		out.Found = true
+		// A found row ends the search, so Truncated stops being
+		// meaningful and is cleared rather than left set for the service
+		// to have to ignore.
+		out.Truncated = false
+		out.EventID = row.ID
+		out.At = row.CreatedAt
+		// target_id is the tool name -- RecordToolCall stores it there.
+		out.ToolName = row.TargetID
+		return out, nil
 	}
 	return out, nil
 }

--- a/apps/api/internal/mcp/connection_status_race_test.go
+++ b/apps/api/internal/mcp/connection_status_race_test.go
@@ -1,0 +1,692 @@
+// connection_status_race_test.go -- the regression proof for
+// Repo.ConnectionStatusSnapshot's STATEMENT ORDER.
+//
+// ===========================================================================
+// WHY THIS FILE IS IN internal/mcp AND NOT IN tests/
+// ===========================================================================
+//
+// The seam under test is BETWEEN TWO STATEMENTS INSIDE ONE TRANSACTION.
+// getGrantTx and findFirstToolCallTx are unexported, and the ordering that
+// makes the pair consistent is invisible from outside the package: through the
+// HTTP surface a caller sees one JSON body and cannot say which read produced
+// which half of it. package tests can only assert the endpoint's output, which
+// is exactly the weaker test that would pass against the broken code whenever
+// the race did not happen to be provoked.
+//
+// ===========================================================================
+// WHY THIS IS NOT A TEST ABOUT ATOMICITY, AND WHY ONE WOULD BE A FAKE PROOF
+// ===========================================================================
+//
+// The obvious reading of the fix is "the two reads now share a transaction, so
+// they are consistent". They are not, and asserting that would pin a property
+// the code does not have. Every helper in internal/db opens with p.Begin --
+// there is no BeginTx and no pgx.TxOptions anywhere in the package, so every
+// transaction is READ COMMITTED, and under READ COMMITTED EACH STATEMENT TAKES
+// ITS OWN SNAPSHOT. Two statements in one transaction straddle a concurrent
+// commit exactly as two transactions did. The shared transaction buys the
+// shared RLS GUCs; it does not buy a shared instant.
+//
+// What makes the pair consistent is ORDER. mcp_grants.client_identity_recorded_
+// at is stamped by RecordClientIdentity and never written back to NULL, so the
+// handshake fact is monotonic and always at least as old as a tool call's audit
+// row. Reading the LATER fact first (the audit scan) and the EARLIER fact last
+// (the grant) means anything committing in between can only make the handshake
+// MORE advanced. So this file provokes a real concurrent commit at the seam and
+// asserts the PAIR BY VALUE.
+//
+// ===========================================================================
+// HOW THE COMMIT IS PLACED AT THE SEAM WITHOUT A SLEEP OR A GOROUTINE
+// ===========================================================================
+//
+// A timing-dependent test would be worse than no test: it would go green on a
+// fast machine against the broken code. So there is no sleep, no goroutine and
+// no scheduler dependency here.
+//
+// Instead a pgx.QueryTracer counts the CONTENT statements the snapshot
+// transaction issues (the mcp_grants reads and the audit_log scan; BEGIN,
+// COMMIT and the set_config GUC statements are not content and are not
+// counted) and performs the concurrent write synchronously in TraceQueryEnd of
+// the SECOND one, on a different pooled connection, before the third statement
+// is ever sent. The injection point is POSITIONAL -- "after content statement
+// 2" -- and that is deliberate, because it is what makes the mutation redden:
+//
+//	CORRECT ORDER   [gate grant, audit scan, grant]
+//	                write lands after the scan, so the scan saw no call and the
+//	                grant read that follows sees the handshake => connected +
+//	                awaiting_call. A REAL state.
+//
+//	SWAPPED (BUG)   [gate grant, grant, audit scan]
+//	                write lands after the grant read, so the handshake is stale
+//	                and the scan that follows sees the call => awaiting_client +
+//	                succeeded. THE IMPOSSIBLE PAIR.
+//
+// The tracer observes; it never reorders. The statements are the production
+// ones, issued by the production function, on a pool connected as wpmgr_app.
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/tests/testinfra"
+)
+
+// ---------------------------------------------------------------------------
+// The statement tracer -- the deterministic seam.
+// ---------------------------------------------------------------------------
+
+// stmtKind is what a traced statement was about. Only these two are content;
+// everything else the transaction issues (begin, commit, the set_config calls
+// that install the RLS GUCs) is infrastructure and is not counted, because
+// counting it would make the injection point depend on how many GUCs the
+// dispatch helper happens to set.
+type stmtKind string
+
+const (
+	stmtGrant stmtKind = "grant" // a single-row read of mcp_grants
+	stmtAudit stmtKind = "audit" // the bounded audit_log scan
+)
+
+// seamTracer records the ORDER of content statements and fires a callback
+// immediately after the Nth of them completes.
+//
+// It is a pgx.QueryTracer, so it sits on the real connection and sees the real
+// statements the real repo issues. It changes nothing about them.
+type seamTracer struct {
+	mu sync.Mutex
+
+	// recording is off until the test arms it, so the container bootstrap, the
+	// migrations and the seeds are not counted.
+	recording bool
+	seen      []stmtKind
+
+	// injectAfter is the 1-based content-statement position after which inject
+	// runs. Zero disables injection (used by the 404 proof, which only needs
+	// the recording).
+	injectAfter int
+	inject      func()
+	injected    bool
+}
+
+// seamKindKey carries the classification from TraceQueryStart to
+// TraceQueryEnd. pgx.TraceQueryEndData exposes only the CommandTag and the
+// error -- the SQL text is available at START only -- and the context returned
+// by TraceQueryStart is the one handed back to TraceQueryEnd, which is the
+// documented channel for exactly this.
+//
+// The injection must happen at END and not at START: the statement whose
+// position we are counting has to have COMPLETED before the concurrent write
+// commits, or the write would land in the middle of the read it is supposed to
+// follow.
+type seamKindKey struct{}
+
+func (s *seamTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	kind, ok := classifyStatement(data.SQL)
+	if !ok {
+		return ctx
+	}
+	return context.WithValue(ctx, seamKindKey{}, kind)
+}
+
+func (s *seamTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, _ pgx.TraceQueryEndData) {
+	kind, ok := ctx.Value(seamKindKey{}).(stmtKind)
+	if !ok {
+		return
+	}
+
+	s.mu.Lock()
+	if !s.recording {
+		s.mu.Unlock()
+		return
+	}
+	s.seen = append(s.seen, kind)
+	n := len(s.seen)
+	fire := s.inject != nil && !s.injected && s.injectAfter > 0 && n == s.injectAfter
+	if fire {
+		// Disarm BEFORE running, and disable recording for the duration. The
+		// injected write issues its own statements on another connection of the
+		// same pool, and this tracer would otherwise see them, count them, and
+		// re-enter itself.
+		s.injected = true
+		s.recording = false
+	}
+	s.mu.Unlock()
+
+	if !fire {
+		return
+	}
+	s.inject()
+	s.mu.Lock()
+	s.recording = true
+	s.mu.Unlock()
+}
+
+// arm starts recording. injectAfter is the 1-based content-statement position
+// after which inject fires; pass 0 and nil to record only.
+func (s *seamTracer) arm(injectAfter int, inject func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recording, s.seen, s.injectAfter, s.inject, s.injected = true, nil, injectAfter, inject, false
+}
+
+func (s *seamTracer) disarm() []stmtKind {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recording = false
+	out := make([]stmtKind, len(s.seen))
+	copy(out, s.seen)
+	return out
+}
+
+func (s *seamTracer) didInject() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.injected
+}
+
+// classifyStatement decides whether a SQL string is one of the two content
+// reads. It matches on the TABLE rather than on a generated query name, because
+// sqlc's emitted SQL is what reaches the wire.
+func classifyStatement(sql string) (stmtKind, bool) {
+	lowered := strings.ToLower(sql)
+	if !strings.Contains(lowered, "select") {
+		return "", false
+	}
+	switch {
+	case strings.Contains(lowered, "audit_log"):
+		return stmtAudit, true
+	case strings.Contains(lowered, "mcp_grants"):
+		return stmtGrant, true
+	default:
+		// begin / commit / set_config / pool health checks.
+		return "", false
+	}
+}
+
+func kindsString(k []stmtKind) string {
+	parts := make([]string, len(k))
+	for i, v := range k {
+		parts[i] = string(v)
+	}
+	return "[" + strings.Join(parts, " -> ") + "]"
+}
+
+// ---------------------------------------------------------------------------
+// The harness -- Postgres, real migrations, real wpmgr_app role, plus a tracer.
+// ---------------------------------------------------------------------------
+
+// startTracedPostgres mirrors tests.startPostgres -- ephemeral Postgres, the
+// embedded migrations applied as the bootstrap superuser, then a pool connected
+// as the NON-SUPERUSER, NON-BYPASSRLS wpmgr_app role -- and additionally
+// installs a QueryTracer on the application pool.
+//
+// The role is not a detail. Under a superuser or a BYPASSRLS role every policy
+// on mcp_grants is inert and this proof would pass having tested nothing, which
+// is precisely how m112's proofs passed while the email domain was cross-site
+// readable. assertAppRoleForSnapshot prints the role from pg_roles INSIDE the
+// transaction under test.
+//
+// db.Pool is `struct{ *pgxpool.Pool }` with an exported embedded field, so the
+// traced pool is a real db.Pool and every helper in internal/db -- including
+// RunTenantTx, the dispatch the production read uses -- works on it unchanged.
+func startTracedPostgres(t *testing.T) (*db.Pool, *seamTracer) {
+	t.Helper()
+	ctx := context.Background()
+
+	testinfra.SkipIfDockerUnavailable(t, ctx, "postgres")
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("wpmgr"),
+		tcpostgres.WithUsername("wpmgr"),
+		tcpostgres.WithPassword("wpmgr"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	// Registered BEFORE err is inspected: tcpostgres.Run can return a non-nil
+	// container alongside a non-nil error on a partial start, and SetupFatalf
+	// calls t.Fatalf, which never returns.
+	if container != nil {
+		t.Cleanup(func() { _ = container.Terminate(ctx) })
+	}
+	if err != nil {
+		testinfra.SetupFatalf(t, err, "postgres: container start")
+	}
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		testinfra.SetupFatalf(t, err, "postgres: connection string")
+	}
+
+	adminPool, err := db.Connect(ctx, adminDSN)
+	if err != nil {
+		testinfra.SetupFatalf(t, err, "postgres: connect as bootstrap superuser")
+	}
+	if err := adminPool.Migrate(ctx); err != nil {
+		testinfra.SetupFatalf(t, err, "postgres: run embedded migrations")
+	}
+	for _, stmt := range []string{
+		"ALTER ROLE wpmgr_app LOGIN PASSWORD 'app'",
+		"GRANT USAGE ON SCHEMA public TO wpmgr_app",
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO wpmgr_app",
+		// audit_log is append-only in production. Re-revoking is what stops
+		// this test running with privileges no real install has.
+		"REVOKE UPDATE, DELETE, TRUNCATE ON audit_log FROM wpmgr_app",
+		"REVOKE UPDATE, DELETE, TRUNCATE ON org_context_versions FROM wpmgr_app",
+		"REVOKE UPDATE, DELETE, TRUNCATE ON site_context_versions FROM wpmgr_app",
+	} {
+		if _, err := adminPool.Exec(ctx, stmt); err != nil {
+			testinfra.SetupFatalf(t, err, "postgres: provision app role ("+stmt+")")
+		}
+	}
+	adminPool.Close()
+
+	appDSN := strings.Replace(adminDSN, "wpmgr:wpmgr@", "wpmgr_app:app@", 1)
+	cfg, err := pgxpool.ParseConfig(appDSN)
+	if err != nil {
+		testinfra.SetupFatalf(t, err, "postgres: parse app dsn")
+	}
+	tracer := &seamTracer{}
+	cfg.ConnConfig.Tracer = tracer
+	// More than one connection is required: the injected write must commit on a
+	// DIFFERENT connection while the snapshot transaction is still open.
+	cfg.MinConns = 2
+	cfg.MaxConns = 6
+
+	raw, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		testinfra.SetupFatalf(t, err, "postgres: connect as wpmgr_app")
+	}
+	pool := &db.Pool{Pool: raw}
+	t.Cleanup(pool.Close)
+
+	return pool, tracer
+}
+
+// assertAppRoleForSnapshot prints and enforces the connection's own role from
+// inside the transaction under test.
+func assertAppRoleForSnapshot(t *testing.T, tx pgx.Tx, where string) {
+	t.Helper()
+	var role string
+	var super, bypass bool
+	if err := tx.QueryRow(context.Background(),
+		`SELECT current_user, rolsuper, rolbypassrls
+		   FROM pg_roles WHERE rolname = current_user`).Scan(&role, &super, &bypass); err != nil {
+		t.Fatalf("%s: read the connection's own role: %v", where, err)
+	}
+	t.Logf("%s: current_user=%s rolsuper=%t rolbypassrls=%t", where, role, super, bypass)
+	if super || bypass {
+		t.Fatalf("%s: running as %q with rolsuper=%v rolbypassrls=%v; either one bypasses "+
+			"every policy and this proof would pass without testing anything",
+			where, role, super, bypass)
+	}
+	if role != "wpmgr_app" {
+		t.Fatalf("%s: running as %q, not wpmgr_app, which is the role every real install "+
+			"connects as", where, role)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Seeds
+// ---------------------------------------------------------------------------
+
+func seedSnapshotTenant(t *testing.T, pool *db.Pool, slug string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := pool.QueryRow(context.Background(),
+		"INSERT INTO tenants (name, slug) VALUES ($1, $2) RETURNING id", slug, slug).Scan(&id); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	return id
+}
+
+func seedSnapshotUser(t *testing.T, pool *db.Pool, email string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := pool.QueryRow(context.Background(),
+		"INSERT INTO users (email) VALUES ($1) RETURNING id", email).Scan(&id); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+// seedSnapshotGrant inserts one active grant through RunTenantTx -- the same
+// dispatch the production write uses, so the RESTRICTIVE
+// mcp_grants_site_scope_insert policy is live for the INSERT too.
+func seedSnapshotGrant(t *testing.T, pool *db.Pool, p domain.Principal, name string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.RunTenantTx(context.Background(), p, func(tx pgx.Tx) error {
+		row, err := sqlc.New(tx).CreateMCPGrant(context.Background(), sqlc.CreateMCPGrantParams{
+			TenantID:            p.TenantID,
+			Name:                name,
+			Status:              string(GrantStatusActive),
+			SiteScopeMode:       string(SiteScopeModeAll),
+			ScopeTagIds:         []uuid.UUID{},
+			ScopeSiteIds:        []uuid.UUID{},
+			ClientID:            nil,
+			CreatedByUserID:     uuidToPG(p.UserID),
+			Capabilities:        capabilityNames(DefaultGrantCapabilities()),
+			ExpiresAt:           time.Now().UTC().Add(grantAbsoluteTTL),
+			IdleExpireAfterDays: nil,
+			SetupClient:         nil,
+		})
+		if err != nil {
+			return err
+		}
+		id = row.ID
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+	return id
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- a handshake and a tool call committing AT THE SEAM cannot produce
+// awaiting_client + succeeded.
+// ---------------------------------------------------------------------------
+
+func TestConnectionStatusSnapshot_ConcurrentInitializeCannotProduceTheImpossiblePair(t *testing.T) {
+	ctx := context.Background()
+	pool, tracer := startTracedPostgres(t)
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedSnapshotTenant(t, pool, "mcp-seam-"+suffix)
+	userID := seedSnapshotUser(t, pool, "mcp-seam-"+suffix+"@example.test")
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+
+	grantID := seedSnapshotGrant(t, pool, admin, "seam "+suffix)
+
+	repo := NewRepo(pool)
+	svc := NewService(repo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+
+	// The transport's own two writes, in the transport's own order. These are
+	// the calls TransportHandler makes at transport.go:432 (initialize) and
+	// transport.go:597 (a successful tools/call). A NORMAL INITIALIZE COMES
+	// FIRST -- the separately-filed "a client can skip initialize" gap is not
+	// what this test is about, and constructing the case without the
+	// initialize would confuse the two.
+	auth := AuthorizedRequest{TenantID: tenantID, GrantID: grantID, GrantName: "seam " + suffix}
+	protocol := ProtocolTarget
+	var injectErr error
+	inject := func() {
+		if err := svc.RecordConnect(ctx, auth, "Claude Desktop", "1.2.3", &protocol); err != nil {
+			injectErr = fmt.Errorf("record connect: %w", err)
+			return
+		}
+		if err := svc.RecordToolCall(ctx, auth, "list_sites", "read"); err != nil {
+			injectErr = fmt.Errorf("record tool call: %w", err)
+		}
+	}
+
+	// Fire after the SECOND content statement, whichever read that turns out to
+	// be. See this file's header for why the position and not the identity is
+	// what catches the swap.
+	tracer.arm(2, inject)
+
+	snap, err := repo.ConnectionStatusSnapshot(ctx, admin, grantID, firstCallScanLimit)
+	order := tracer.disarm()
+	if err != nil {
+		t.Fatalf("ConnectionStatusSnapshot: %v", err)
+	}
+	if injectErr != nil {
+		t.Fatalf("the concurrent handshake/tool-call did not commit: %v", injectErr)
+	}
+
+	// The seam must actually have been reached. Without this the whole test
+	// could pass having provoked nothing -- a guard that finds nothing going
+	// green is this repository's signature defect.
+	if !tracer.didInject() {
+		t.Fatalf("the concurrent write never fired: the snapshot issued %s, fewer than 2 "+
+			"content statements. This test proved NOTHING", kindsString(order))
+	}
+	if len(order) != 3 {
+		t.Fatalf("the snapshot issued %s, want exactly 3 content statements "+
+			"(gate grant, audit scan, grant)", kindsString(order))
+	}
+	t.Logf("statement order under test: %s, concurrent commit injected after #2", kindsString(order))
+
+	// Confirm the concurrent write really landed and is visible afterwards --
+	// otherwise "no impossible pair" could just mean "nothing happened".
+	var recordedAt *time.Time
+	if err := pool.RunTenantTx(ctx, admin, func(tx pgx.Tx) error {
+		g, err := getGrantTx(ctx, tx, tenantID, grantID)
+		if err != nil {
+			return err
+		}
+		recordedAt = timestamptzTimeOrNil(g.ClientIdentityRecordedAt)
+		return nil
+	}); err != nil {
+		t.Fatalf("re-read the grant after the injected commit: %v", err)
+	}
+	if recordedAt == nil {
+		t.Fatal("the injected initialize did not stamp client_identity_recorded_at, so no " +
+			"handshake was ever concurrent with the read and this test proved nothing")
+	}
+
+	// ===================================================================
+	// THE ASSERTION. Both halves BY VALUE, together. Asserting that the two
+	// fields are merely present would pass against the broken version.
+	// ===================================================================
+	gotHandshake := handshakeFromGrant(snap.Grant).State
+	gotFirstCall := firstCallFrom(snap.FirstCall, timestamptzTimeOrNil(snap.Grant.LastUsedAt)).State
+
+	if gotHandshake == HandshakeAwaitingClient && gotFirstCall == FirstCallSucceeded {
+		t.Fatalf("THE IMPOSSIBLE PAIR: handshake.state=%q with first_call.state=%q. "+
+			"Nothing can call a tool before it initializes, so this pair is a "+
+			"contradiction the wizard would render as a broken connection that is in "+
+			"fact working. The snapshot read the EARLIER fact (the grant) before the "+
+			"LATER fact (the audit scan), so a commit between them made the handshake "+
+			"stale. Statement order was %s; steps 2 and 3 of "+
+			"Repo.ConnectionStatusSnapshot are the wrong way round",
+			gotHandshake, gotFirstCall, kindsString(order))
+	}
+
+	// And the pair must be the specific real state this interleaving produces,
+	// not merely "not the impossible one": the scan ran before the write so it
+	// saw no call, and the grant was read after it so the handshake is fresh.
+	if gotHandshake != HandshakeConnected || gotFirstCall != FirstCallAwaiting {
+		t.Fatalf("pair = (%q, %q), want (%q, %q). The write was injected between the "+
+			"audit scan and the grant read, so the scan must miss the call and the "+
+			"grant read must see the handshake. Statement order was %s",
+			gotHandshake, gotFirstCall,
+			HandshakeConnected, FirstCallAwaiting, kindsString(order))
+	}
+	t.Logf("PROOF 1 ok: a handshake and a tool call committing at the seam yielded "+
+		"(%q, %q) -- a real state", gotHandshake, gotFirstCall)
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- the fix did not cost the cheap 404.
+//
+// The grant is read TWICE on purpose, and the first read is an existence-and-
+// RLS gate. Without it, a poll for an absent or another organisation's grant id
+// would run the bounded audit scan -- up to firstCallScanLimit+1 rows -- before
+// discovering it had nothing to answer about. That turns a cheap 404 into an
+// audit-log scan ANY AUTHENTICATED ORG PRINCIPAL COULD TRIGGER BY GUESSING IDS.
+//
+// The property is asserted on the STATEMENTS ISSUED, not on the response: a
+// test that only checked for pgx.ErrNoRows would pass whether or not the scan
+// ran.
+// ---------------------------------------------------------------------------
+
+func TestConnectionStatusSnapshot_UnknownGrantDoesNotRunTheAuditScan(t *testing.T) {
+	ctx := context.Background()
+	pool, tracer := startTracedPostgres(t)
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedSnapshotTenant(t, pool, "mcp-404-"+suffix)
+	userID := seedSnapshotUser(t, pool, "mcp-404-"+suffix+"@example.test")
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+
+	// Prove the role inside the very transaction the read opens.
+	if err := pool.RunTenantTx(ctx, admin, func(tx pgx.Tx) error {
+		assertAppRoleForSnapshot(t, tx, "RunTenantTx (ConnectionStatusSnapshot read path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	repo := NewRepo(pool)
+
+	// Record only; nothing is injected.
+	tracer.arm(0, nil)
+	_, err := repo.ConnectionStatusSnapshot(ctx, admin, uuid.New(), firstCallScanLimit)
+	order := tracer.disarm()
+
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("an unknown grant id returned %v, want pgx.ErrNoRows verbatim so the "+
+			"service can 404 on it", err)
+	}
+	if len(order) == 0 {
+		t.Fatalf("the snapshot issued NO content statements for an unknown id; the tracer " +
+			"saw nothing, so this test cannot distinguish a working gate from a broken " +
+			"one and proves nothing")
+	}
+	for i, k := range order {
+		if k == stmtAudit {
+			t.Fatalf("a poll for an UNKNOWN grant id ran the bounded audit scan "+
+				"(statement #%d of %s). The existence-and-RLS gate is gone or has moved "+
+				"after the scan, so any authenticated org principal can make the server "+
+				"read up to %d audit_log rows by guessing ids, and every 404 now costs "+
+				"an audit-log scan", i+1, kindsString(order), firstCallScanLimit+1)
+		}
+	}
+	if len(order) != 1 {
+		t.Fatalf("an unknown grant id issued %s, want exactly one statement -- the gate "+
+			"read that produces the 404", kindsString(order))
+	}
+	t.Logf("PROOF 2 ok: an unknown grant id issued %s and no audit scan", kindsString(order))
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- the existing states still behave, read through the same ordered
+// snapshot. Awaiting, connected, and BOTH protocol variants.
+//
+// These are the states the reordering must not have disturbed. They are
+// asserted through Repo.ConnectionStatusSnapshot rather than through a fake, so
+// the columns, the RLS policies and the derivation are all the real ones.
+// ---------------------------------------------------------------------------
+
+func TestConnectionStatusSnapshot_ExistingStatesSurviveTheReordering(t *testing.T) {
+	ctx := context.Background()
+	pool, tracer := startTracedPostgres(t)
+	tracer.arm(0, nil)
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedSnapshotTenant(t, pool, "mcp-states-"+suffix)
+	userID := seedSnapshotUser(t, pool, "mcp-states-"+suffix+"@example.test")
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+
+	repo := NewRepo(pool)
+	svc := NewService(repo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+
+	target := ProtocolTarget
+	unrecognised := "1999-01-01"
+
+	cases := []struct {
+		name string
+		// protocol is the MCP-Protocol-Version header value the client sent.
+		// nil means it connected and sent NO header, which is a different fact
+		// from never having connected (connect=false).
+		connect       bool
+		protocol      *string
+		wantHandshake HandshakeState
+	}{
+		{
+			name:          "never connected",
+			connect:       false,
+			wantHandshake: HandshakeAwaitingClient,
+		},
+		{
+			name:          "connected with a revision we speak",
+			connect:       true,
+			protocol:      &target,
+			wantHandshake: HandshakeConnected,
+		},
+		{
+			name:          "connected sending no version header at all",
+			connect:       true,
+			protocol:      nil,
+			wantHandshake: HandshakeConnectedProtocolAssumed,
+		},
+		{
+			name:          "connected with a revision we no longer speak",
+			connect:       true,
+			protocol:      &unrecognised,
+			wantHandshake: HandshakeConnectedProtocolUnrecognised,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			grantID := seedSnapshotGrant(t, pool, admin, tc.name+" "+suffix)
+			auth := AuthorizedRequest{TenantID: tenantID, GrantID: grantID, GrantName: tc.name}
+
+			if tc.connect {
+				if err := svc.RecordConnect(ctx, auth, "Claude Desktop", "1.2.3", tc.protocol); err != nil {
+					t.Fatalf("record connect: %v", err)
+				}
+			}
+
+			snap, err := repo.ConnectionStatusSnapshot(ctx, admin, grantID, firstCallScanLimit)
+			if err != nil {
+				t.Fatalf("ConnectionStatusSnapshot: %v", err)
+			}
+
+			gotHandshake := handshakeFromGrant(snap.Grant).State
+			gotFirstCall := firstCallFrom(snap.FirstCall, timestamptzTimeOrNil(snap.Grant.LastUsedAt)).State
+
+			// Both halves, by value, together -- the same bar as PROOF 1. No
+			// tool call has happened in any of these cases, so the first-call
+			// half must be the NOT-YET in every one of them.
+			if gotHandshake != tc.wantHandshake || gotFirstCall != FirstCallAwaiting {
+				t.Fatalf("pair = (%q, %q), want (%q, %q)",
+					gotHandshake, gotFirstCall, tc.wantHandshake, FirstCallAwaiting)
+			}
+
+			// A tool call now happens, with no concurrency at all: the ordinary
+			// connected+succeeded state the wizard's success frame renders.
+			if !tc.connect {
+				return
+			}
+			if err := svc.RecordToolCall(ctx, auth, "list_sites", "read"); err != nil {
+				t.Fatalf("record tool call: %v", err)
+			}
+			snap, err = repo.ConnectionStatusSnapshot(ctx, admin, grantID, firstCallScanLimit)
+			if err != nil {
+				t.Fatalf("ConnectionStatusSnapshot after the tool call: %v", err)
+			}
+			gotHandshake = handshakeFromGrant(snap.Grant).State
+			gotFirstCall = firstCallFrom(snap.FirstCall, timestamptzTimeOrNil(snap.Grant.LastUsedAt)).State
+			if gotHandshake != tc.wantHandshake || gotFirstCall != FirstCallSucceeded {
+				t.Fatalf("after a tool call, pair = (%q, %q), want (%q, %q)",
+					gotHandshake, gotFirstCall, tc.wantHandshake, FirstCallSucceeded)
+			}
+			if snap.FirstCall.ToolName != "list_sites" {
+				t.Errorf("first call tool_name = %q, want %q", snap.FirstCall.ToolName, "list_sites")
+			}
+		})
+	}
+}

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -174,6 +174,16 @@ func (h *Handler) RegisterConnections(r *gin.RouterGroup) {
 	g.POST("/:"+connectionIDParam+"/revoke",
 		authz.RequirePermission(authz.PermAPIKeyManage), h.revokeConnection)
 
+	// GET /:connectionId/status -- the add-connection wizard's Step 8 and
+	// Step 9 poll (S29). PermAPIKeyRead, the SAME permission as the list
+	// above, because it reads the same object: a caller who may list the
+	// organisation's connections may read the handshake state of one of them,
+	// and a caller who may not must not learn it a row at a time. Both are
+	// org-level perms, so a site-constrained principal is refused here for the
+	// same reason it is refused on the list.
+	g.GET("/:"+connectionIDParam+"/status",
+		authz.RequirePermission(authz.PermAPIKeyRead), h.connectionStatus)
+
 	// 405 rather than gin's bare 404 on a wrong verb, for the reason
 	// RegisterPublic gives: a 404 reads as "not deployed", which is exactly how
 	// the S6b-2 blocker presented and cost a debugging session. These carry NO
@@ -182,6 +192,7 @@ func (h *Handler) RegisterConnections(r *gin.RouterGroup) {
 	// when the fix is to send a POST.
 	houseMethodNotAllowedExcept(g, "", http.MethodGet, http.MethodPost)
 	houseMethodNotAllowedExcept(g, "/:"+connectionIDParam+"/revoke", http.MethodPost)
+	houseMethodNotAllowedExcept(g, "/:"+connectionIDParam+"/status", http.MethodGet)
 }
 
 // listConnections answers GET /api/v1/mcp/connections.

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -125,6 +125,18 @@ type fakeStore struct {
 	grants    []sqlc.McpGrant
 	grantsErr error
 
+	// getErr forces GetGrant to fail; getPrincipals records what was passed to
+	// the two principal-taking status reads.
+	getErr        error
+	getPrincipals []domain.Principal
+	// firstCall is what FindFirstToolCall returns and firstCallErr forces it
+	// to fail. The zero FirstToolCall is Found=false/Truncated=false, which is
+	// the DEFINITIVE not-yet -- the correct default for a fixture, since a
+	// test that forgets to set it gets "nothing has happened" rather than a
+	// spurious success.
+	firstCall    FirstToolCall
+	firstCallErr error
+
 	// revokeRow is what RevokeGrantWithTokens returns and revokeErr is the
 	// error it returns instead. revokeErr set to pgx.ErrNoRows models THE
 	// GRANT NOT BEING VISIBLE -- the only outcome that means "not there" --
@@ -466,6 +478,49 @@ func (f *fakeStore) ListGrants(_ context.Context, p domain.Principal) ([]sqlc.Mc
 		return nil, f.grantsErr
 	}
 	return f.grants, nil
+}
+
+// GetGrant models Repo.GetGrant, INCLUDING its pgx.ErrNoRows contract: getErr
+// is returned VERBATIM so a test can set pgx.ErrNoRows and drive the
+// "grant not visible" branch through errors.Is exactly as the real repo does.
+//
+// It records the principal for the same reason ListGrants does -- the
+// signature takes a principal precisely so the RESTRICTIVE _site_scope policy
+// is reachable, and a test asserting that gate needs to see what was passed.
+func (f *fakeStore) GetGrant(_ context.Context, p domain.Principal, id uuid.UUID) (sqlc.McpGrant, error) {
+	f.note("GetGrant")
+	f.mu.Lock()
+	f.getPrincipals = append(f.getPrincipals, p)
+	f.mu.Unlock()
+	if f.getErr != nil {
+		return sqlc.McpGrant{}, f.getErr
+	}
+	for _, g := range f.grants {
+		if g.ID == id {
+			return g, nil
+		}
+	}
+	// pgx.ErrNoRows and NOT a zero struct with a nil error. A fake that
+	// returned (sqlc.McpGrant{}, nil) for an absent id would let a service
+	// that never checks the error render a grant with a zero uuid and a zero
+	// timestamp as though it were real -- the absence-as-fact defect,
+	// manufactured in the fixture.
+	return sqlc.McpGrant{}, pgx.ErrNoRows
+}
+
+// FindFirstToolCall models Repo.FindFirstToolCall. firstCall is returned as
+// given so a test can assert every one of the three Step 9 states, INCLUDING
+// the Found=false/Truncated=true pair that must become indeterminate rather
+// than a not-yet.
+func (f *fakeStore) FindFirstToolCall(_ context.Context, p domain.Principal, _ uuid.UUID, _ int) (FirstToolCall, error) {
+	f.note("FindFirstToolCall")
+	f.mu.Lock()
+	f.getPrincipals = append(f.getPrincipals, p)
+	f.mu.Unlock()
+	if f.firstCallErr != nil {
+		return FirstToolCall{}, f.firstCallErr
+	}
+	return f.firstCall, nil
 }
 
 // RevokeGrantWithTokens models the four-outcome contract of

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -480,14 +480,41 @@ func (f *fakeStore) ListGrants(_ context.Context, p domain.Principal) ([]sqlc.Mc
 	return f.grants, nil
 }
 
-// GetGrant models Repo.GetGrant, INCLUDING its pgx.ErrNoRows contract: getErr
+// ConnectionStatusSnapshot models Repo.ConnectionStatusSnapshot: the ONE read
+// the status service is allowed to make, returning both halves together.
+//
+// It composes the two unexported fixture halves below so that every existing
+// fixture field -- getErr, grants, firstCall, firstCallErr -- keeps driving the
+// branch it always drove. The GATE ORDER IS MODELLED TOO: the grant lookup runs
+// first and its error wins, because the real repo 404s on a missing grant
+// without running the audit scan, and a fake that scanned first would let a
+// service reordering slip through green.
+//
+// It does NOT model the intra-transaction ordering that makes the pair
+// consistent. That is a property of two statements against a live database and
+// no in-process fake can express it; it is pinned by the integration test.
+func (f *fakeStore) ConnectionStatusSnapshot(
+	ctx context.Context, p domain.Principal, id uuid.UUID, limit int,
+) (ConnectionSnapshot, error) {
+	grant, err := f.getGrant(ctx, p, id)
+	if err != nil {
+		return ConnectionSnapshot{}, err
+	}
+	call, err := f.findFirstToolCall(ctx, p, id, limit)
+	if err != nil {
+		return ConnectionSnapshot{}, err
+	}
+	return ConnectionSnapshot{Grant: grant, FirstCall: call}, nil
+}
+
+// getGrant models the grant half, INCLUDING its pgx.ErrNoRows contract: getErr
 // is returned VERBATIM so a test can set pgx.ErrNoRows and drive the
 // "grant not visible" branch through errors.Is exactly as the real repo does.
 //
 // It records the principal for the same reason ListGrants does -- the
 // signature takes a principal precisely so the RESTRICTIVE _site_scope policy
 // is reachable, and a test asserting that gate needs to see what was passed.
-func (f *fakeStore) GetGrant(_ context.Context, p domain.Principal, id uuid.UUID) (sqlc.McpGrant, error) {
+func (f *fakeStore) getGrant(_ context.Context, p domain.Principal, id uuid.UUID) (sqlc.McpGrant, error) {
 	f.note("GetGrant")
 	f.mu.Lock()
 	f.getPrincipals = append(f.getPrincipals, p)
@@ -508,11 +535,11 @@ func (f *fakeStore) GetGrant(_ context.Context, p domain.Principal, id uuid.UUID
 	return sqlc.McpGrant{}, pgx.ErrNoRows
 }
 
-// FindFirstToolCall models Repo.FindFirstToolCall. firstCall is returned as
-// given so a test can assert every one of the three Step 9 states, INCLUDING
-// the Found=false/Truncated=true pair that must become indeterminate rather
-// than a not-yet.
-func (f *fakeStore) FindFirstToolCall(_ context.Context, p domain.Principal, _ uuid.UUID, _ int) (FirstToolCall, error) {
+// findFirstToolCall models the audit half. firstCall is returned as given so a
+// test can assert every one of the three Step 9 states, INCLUDING the
+// Found=false/Truncated=true pair that must become indeterminate rather than a
+// not-yet.
+func (f *fakeStore) findFirstToolCall(_ context.Context, p domain.Principal, _ uuid.UUID, _ int) (FirstToolCall, error) {
 	f.note("FindFirstToolCall")
 	f.mu.Lock()
 	f.getPrincipals = append(f.getPrincipals, p)

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -120,6 +120,21 @@ type Store interface {
 	// db.dispatchTenantTx's hands instead of this package's memory.
 	ListGrants(ctx context.Context, principal domain.Principal) ([]sqlc.McpGrant, error)
 
+	// GetGrant and FindFirstToolCall are the wizard's Step 8 / Step 9 pair
+	// (S29). GetGrant TAKES THE PRINCIPAL for exactly the reason ListGrants
+	// does, above: it reads mcp_grants, so a tenantID-only signature could
+	// only reach InTenantTx and would leave the RESTRICTIVE _site_scope
+	// SELECT policy inert on a single-row read of an organisation-wide
+	// credential.
+	//
+	// FindFirstToolCall takes it too, and that is NOT copy-paste. It reads
+	// audit_log rather than mcp_grants, but it is called in the same request
+	// as GetGrant and about the same grant; giving it the weaker signature
+	// would put the two reads of one answer on two different dispatch paths,
+	// which is how one of them later gets the GUCs and the other does not.
+	FindFirstToolCall(ctx context.Context, principal domain.Principal, grantID uuid.UUID, limit int) (FirstToolCall, error)
+	GetGrant(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.McpGrant, error)
+
 	// RevokeGrantWithTokens flips the grant AND every active token in ONE
 	// statement. There is deliberately no grant-only revoke on this interface:
 	// a security review of this stack observed `grant_status revoked /

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -120,20 +120,25 @@ type Store interface {
 	// db.dispatchTenantTx's hands instead of this package's memory.
 	ListGrants(ctx context.Context, principal domain.Principal) ([]sqlc.McpGrant, error)
 
-	// GetGrant and FindFirstToolCall are the wizard's Step 8 / Step 9 pair
-	// (S29). GetGrant TAKES THE PRINCIPAL for exactly the reason ListGrants
-	// does, above: it reads mcp_grants, so a tenantID-only signature could
-	// only reach InTenantTx and would leave the RESTRICTIVE _site_scope
-	// SELECT policy inert on a single-row read of an organisation-wide
-	// credential.
+	// ConnectionStatusSnapshot is the wizard's Step 8 / Step 9 pair (S29), and
+	// it is ONE METHOD RETURNING BOTH FACTS RATHER THAN TWO METHODS.
 	//
-	// FindFirstToolCall takes it too, and that is NOT copy-paste. It reads
-	// audit_log rather than mcp_grants, but it is called in the same request
-	// as GetGrant and about the same grant; giving it the weaker signature
-	// would put the two reads of one answer on two different dispatch paths,
-	// which is how one of them later gets the GUCs and the other does not.
-	FindFirstToolCall(ctx context.Context, principal domain.Principal, grantID uuid.UUID, limit int) (FirstToolCall, error)
-	GetGrant(ctx context.Context, principal domain.Principal, grantID uuid.UUID) (sqlc.McpGrant, error)
+	// It replaced a GetGrant/FindFirstToolCall pair, and the pair is gone from
+	// this interface rather than kept alongside it. Two separately-callable
+	// reads are what let the service answer from two different instants, which
+	// produced handshake=awaiting_client together with first_call=succeeded --
+	// a state that cannot occur in reality and the exact contradiction this
+	// endpoint was made a single endpoint to prevent. Leaving the two methods
+	// reachable would leave that recombination one refactor away, so the
+	// interface no longer offers it.
+	//
+	// IT TAKES THE PRINCIPAL for exactly the reason ListGrants does, above: it
+	// reads mcp_grants, so a tenantID-only signature could only reach
+	// InTenantTx and would leave the RESTRICTIVE _site_scope SELECT policy
+	// inert on a single-row read of an organisation-wide credential. The audit
+	// half of the snapshot rides the same dispatch, which is the point: one
+	// principal, one RunTenantTx, one set of GUCs for both reads.
+	ConnectionStatusSnapshot(ctx context.Context, principal domain.Principal, grantID uuid.UUID, limit int) (ConnectionSnapshot, error)
 
 	// RevokeGrantWithTokens flips the grant AND every active token in ONE
 	// statement. There is deliberately no grant-only revoke on this interface:

--- a/apps/api/tests/mcp_connection_status_integration_test.go
+++ b/apps/api/tests/mcp_connection_status_integration_test.go
@@ -503,6 +503,44 @@ func TestMCPConnectionStatus_StepsEightAndNine_AsAppRole(t *testing.T) {
 	t.Logf("PROOF 7 ok: site-scoped principal refused 403 by RequirePermission(%s)",
 		authz.PermAPIKeyRead)
 
+	// ==================================================================
+	// PROOF 8 -- THE ROUTE'S TIER, NOT JUST THE SERVICE'S SCOPE GATE.
+	//
+	// PROOF 7 ALONE DOES NOT PROVE THE ROUTE PERMISSION IS RIGHT, and a
+	// mutation sweep is what showed it: downgrading this route from
+	// PermAPIKeyRead to PermSiteRead left PROOF 7 green, because
+	// Service.ConnectionStatus's own requireOrgScopedPrincipal refuses a
+	// site-scoped principal on its own and returns the same 403. The
+	// route gate could therefore be wrong and nothing would notice.
+	//
+	// An ORG-SCOPED VIEWER separates the two layers. It passes
+	// requireOrgScopedPrincipal (its scope IS org), so the only thing
+	// left to refuse it is the route permission -- and the two candidate
+	// permissions disagree about it: minRoleFor(PermAPIKeyRead) is admin
+	// and minRoleFor(PermSiteRead) is viewer. Under the correct
+	// permission this is 403; under the downgrade it would be 200.
+	//
+	// An MCP grant is a long-lived organisation-wide bearer credential,
+	// the same class of object as an API key, so reading its state is an
+	// admin-tier fact and not a viewer-tier one.
+	// ==================================================================
+	orgViewer := domain.Principal{
+		UserID:   userID,
+		TenantID: tenantID,
+		Role:     "viewer",
+		Scope:    domain.ScopeOrg,
+	}
+	viewerEng := mountStatusLikeProduction(t, svc, orgViewer)
+	if code, _ = getStatus(t, viewerEng, freshID); code != http.StatusForbidden {
+		t.Errorf("org-scoped VIEWER reading a connection status answered %d, want 403. "+
+			"This principal clears the service's org-scope gate, so only the route's "+
+			"RequirePermission(%s) -- an admin-tier, org-level permission -- can refuse "+
+			"it. A 200 here means the route is gated at the viewer tier",
+			code, authz.PermAPIKeyRead)
+	}
+	t.Logf("PROOF 8 ok: org-scoped viewer refused 403 by the route's admin tier, "+
+		"which PROOF 7 alone could not distinguish from the service's scope gate")
+
 	// A closing role print, so the file states its precondition at the end as
 	// well as the start: nothing above ran as a superuser.
 	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {

--- a/apps/api/tests/mcp_connection_status_integration_test.go
+++ b/apps/api/tests/mcp_connection_status_integration_test.go
@@ -1,0 +1,514 @@
+// mcp_connection_status_integration_test.go: the add-connection wizard's Step 8
+// and Step 9 read (S29), proven against the REAL schema, the REAL RLS policies
+// and the REAL application role, through the SAME dispatch production uses.
+//
+// WHAT A UNIT TEST CANNOT PROVE HERE, AND THIS FILE THEREFORE MUST:
+//
+//  1. The read runs as wpmgr_app -- NOSUPERUSER, NOBYPASSRLS. Every assertion
+//     below is worthless under a superuser, because mcp_grants' RESTRICTIVE
+//     _site_scope policy and its tenant-isolation policy are both inert for a
+//     role that bypasses RLS. mcpAssertAndReportRole prints current_user,
+//     rolsuper and rolbypassrls from pg_roles INSIDE the transaction under
+//     test, so the proof states its own preconditions rather than assuming
+//     them. That is exactly how m112's proofs passed while the email domain was
+//     cross-site readable.
+//  2. One tenant learns NOTHING about another's connection -- not the state,
+//     not the client name, not even that the id exists.
+//  3. A site-scoped collaborator is refused OUTRIGHT. Minting an org-wide grant
+//     from a site-scoped session was a live defect on this exact surface, and
+//     this endpoint READS the same object.
+//  4. THE last_used_at TRAP. tools/list stamps last_used_at, and every client
+//     issues tools/list unprompted right after initialize. A Step 9 derived
+//     from that column would report "it read your fleet" for a client that read
+//     nothing. Proving this needs the real transport stamping the real column,
+//     which no fake can do.
+//
+// Every state is asserted BY VALUE -- the state string, the recorded fields,
+// the protocol block -- never by "a response arrived".
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// statusBody is the wire shape the wizard consumes. It is decoded into typed
+// POINTERS wherever the endpoint promises null, so that a field which wrongly
+// serialises as a zero value fails a nil check here instead of reading as a
+// plausible date or an empty string.
+type statusBody struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	Handshake struct {
+		State                 string  `json:"state"`
+		RecordedAt            *string `json:"recorded_at"`
+		ReportedClientName    *string `json:"reported_client_name"`
+		ReportedClientVersion *string `json:"reported_client_version"`
+		Protocol              struct {
+			State     string   `json:"state"`
+			Version   *string  `json:"version"`
+			Assumed   *string  `json:"assumed"`
+			Floor     string   `json:"floor"`
+			Target    string   `json:"target"`
+			Supported []string `json:"supported"`
+		} `json:"protocol"`
+		Refusal any `json:"refusal"`
+	} `json:"handshake"`
+	FirstCall struct {
+		State        string  `json:"state"`
+		CalledAt     *string `json:"called_at"`
+		ToolName     *string `json:"tool_name"`
+		AuditEventID *string `json:"audit_event_id"`
+		LastUsedAt   *string `json:"last_used_at"`
+		Partial      any     `json:"partial"`
+	} `json:"first_call"`
+	PollAfterMs int `json:"poll_after_ms"`
+}
+
+// mcpRPCWithProtocol is mcpRPC with EXPLICIT control of the
+// MCP-Protocol-Version header, including sending none at all.
+//
+// mcpRPC cannot be reused: it sets no protocol header, so every call through it
+// lands in NegotiateProtocol's absent branch. This file has to distinguish
+// "sent 2025-11-25", "sent nothing" and "sent 2024-11-05" -- three different
+// stored outcomes and the whole substance of Step 8 -- so the header has to be
+// a parameter. An empty protocol means the header is NOT SET, which is a
+// different request from one carrying an empty value.
+func mcpRPCWithProtocol(t *testing.T, eng *gin.Engine, bearer, protocol string,
+	payload map[string]any) rpcResult {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal rpc payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, mcp.TransportPath, strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.RemoteAddr = "203.0.113.7:5555"
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if protocol != "" {
+		req.Header.Set(mcp.ProtocolHeader, protocol)
+	}
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+	return rpcResult{status: w.Code, body: w.Body.String()}
+}
+
+// mountStatusLikeProduction mounts the connections surface WITH THE REAL
+// authz.RequirePermission middleware.
+//
+// This differs from mountLikeProduction deliberately: that helper mounts
+// Handler.Register (the OAuth half) and does NOT call RegisterConnections, so
+// it cannot exercise the permission gate at all. The gate is the authorisation
+// half of this proof, so it has to be the real one -- a stand-in middleware
+// here would prove only that this file can add middleware.
+func mountStatusLikeProduction(t *testing.T, svc *mcp.Service, principal domain.Principal) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	eng := gin.New()
+	authed := eng.Group("/api/v1")
+	authed.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), principal))
+		c.Next()
+	})
+	// The REAL RegisterConnections, carrying its own RequirePermission per
+	// route. Nothing here relaxes it.
+	mcp.NewHandler(svc).RegisterConnections(authed)
+	return eng
+}
+
+// getStatus issues the wizard's poll and returns the code with the decoded body.
+func getStatus(t *testing.T, eng *gin.Engine, grantID string) (int, statusBody) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/connections/"+grantID+"/status", nil)
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+
+	var body statusBody
+	if w.Code == http.StatusOK {
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("status response is not JSON: %v (%s)", err, w.Body.String())
+		}
+	}
+	return w.Code, body
+}
+
+// mintGrant creates a connection through the REAL mint endpoint and returns the
+// grant id and the plaintext token.
+func mintGrant(t *testing.T, eng *gin.Engine, name string) (string, string) {
+	t.Helper()
+	var out struct {
+		GrantID string `json:"grant_id"`
+		Token   string `json:"token"`
+	}
+	body, err := json.Marshal(map[string]any{
+		"name":            name,
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	})
+	if err != nil {
+		t.Fatalf("marshal mint request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/connections", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("mint answered %d, want 201: %s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("mint response is not JSON: %v", err)
+	}
+	if out.GrantID == "" || out.Token == "" {
+		t.Fatalf("mint returned grant_id=%q token present=%t", out.GrantID, out.Token != "")
+	}
+	return out.GrantID, out.Token
+}
+
+func TestMCPConnectionStatus_StepsEightAndNine_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion below, printed from inside a
+	// transaction opened by the same helper the read under test uses.
+	if err := pool.InTenantTx(ctx, uuid.New(), func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (connection status read path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-status-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-status-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://"+suffix+".example.test")
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	eng := mountStatusLikeProduction(t, svc, admin)
+	// The transport, mounted exactly as server.New does, so initialize and
+	// tools/* drive the real columns.
+	transportEng := mountLikeProduction(t, svc, admin)
+
+	// ==================================================================
+	// PROOF 1 -- NOT-YET. A freshly minted grant has heard from nobody.
+	// Both steps must say so, and neither may render as a failure.
+	// ==================================================================
+	freshID, freshTok := mintGrant(t, eng, "status fresh "+suffix)
+
+	code, got := getStatus(t, eng, freshID)
+	if code != http.StatusOK {
+		t.Fatalf("status on a fresh grant answered %d, want 200", code)
+	}
+	if got.Handshake.State != "awaiting_client" {
+		t.Errorf("fresh handshake.state = %q, want %q", got.Handshake.State, "awaiting_client")
+	}
+	if got.Handshake.Protocol.State != string(mcp.ClientProtocolNeverConnected) {
+		t.Errorf("fresh protocol.state = %q, want %q",
+			got.Handshake.Protocol.State, mcp.ClientProtocolNeverConnected)
+	}
+	// The NULLs that keep an absence from reading as a fact.
+	if got.Handshake.RecordedAt != nil {
+		t.Errorf("fresh recorded_at = %q, want null -- nothing has connected", *got.Handshake.RecordedAt)
+	}
+	if got.Handshake.Protocol.Version != nil {
+		t.Errorf("fresh protocol.version = %q, want null", *got.Handshake.Protocol.Version)
+	}
+	if got.Handshake.Protocol.Assumed != nil {
+		t.Errorf("fresh protocol.assumed = %q, want null -- nothing was assumed for a client "+
+			"that never spoke", *got.Handshake.Protocol.Assumed)
+	}
+	if got.FirstCall.State != "awaiting_call" {
+		t.Errorf("fresh first_call.state = %q, want %q", got.FirstCall.State, "awaiting_call")
+	}
+	if got.FirstCall.LastUsedAt != nil {
+		t.Errorf("fresh last_used_at = %q, want null", *got.FirstCall.LastUsedAt)
+	}
+	// The server's own facts are present even before any client speaks -- this
+	// is what lets the wizard render the floor without claiming a refusal.
+	if got.Handshake.Protocol.Floor != mcp.ProtocolFloor {
+		t.Errorf("protocol.floor = %q, want %q", got.Handshake.Protocol.Floor, mcp.ProtocolFloor)
+	}
+	if got.Handshake.Protocol.Target != mcp.ProtocolTarget {
+		t.Errorf("protocol.target = %q, want %q", got.Handshake.Protocol.Target, mcp.ProtocolTarget)
+	}
+	if len(got.Handshake.Protocol.Supported) != len(mcp.SupportedRevisions()) {
+		t.Errorf("protocol.supported = %v, want %v",
+			got.Handshake.Protocol.Supported, mcp.SupportedRevisions())
+	}
+	if got.PollAfterMs <= 0 {
+		t.Errorf("poll_after_ms = %d, want a positive interval", got.PollAfterMs)
+	}
+	t.Logf("PROOF 1 ok: fresh grant reports awaiting_client/awaiting_call with every "+
+		"client-reported field null (floor=%s target=%s)",
+		got.Handshake.Protocol.Floor, got.Handshake.Protocol.Target)
+
+	// ==================================================================
+	// PROOF 2 -- THE last_used_at TRAP. initialize WITH a recognised
+	// header, then tools/list AND NOTHING ELSE.
+	//
+	// Step 8 must flip to connected. Step 9 MUST NOT: no tool has been
+	// called. last_used_at is non-null by now, which is precisely why
+	// deriving Step 9 from it would be a false success.
+	// ==================================================================
+	initRes := mcpRPCWithProtocol(t, transportEng, freshTok, mcp.ProtocolTarget, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{
+			"protocolVersion": mcp.ProtocolTarget,
+			"clientInfo":      map[string]any{"name": "claude-code", "version": "2.4.1"},
+			"capabilities":    map[string]any{},
+		},
+	})
+	if initRes.status != http.StatusOK {
+		t.Fatalf("initialize answered %d, want 200: %s", initRes.status, initRes.body)
+	}
+	listRes := mcpRPCWithProtocol(t, transportEng, freshTok, mcp.ProtocolTarget, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{},
+	})
+	if listRes.status != http.StatusOK {
+		t.Fatalf("tools/list answered %d, want 200: %s", listRes.status, listRes.body)
+	}
+
+	code, got = getStatus(t, eng, freshID)
+	if code != http.StatusOK {
+		t.Fatalf("status after initialize answered %d, want 200", code)
+	}
+	if got.Handshake.State != "connected" {
+		t.Errorf("after initialize handshake.state = %q, want %q", got.Handshake.State, "connected")
+	}
+	if got.Handshake.Protocol.State != string(mcp.ClientProtocolRecognised) {
+		t.Errorf("after initialize protocol.state = %q, want %q",
+			got.Handshake.Protocol.State, mcp.ClientProtocolRecognised)
+	}
+	if got.Handshake.Protocol.Version == nil || *got.Handshake.Protocol.Version != mcp.ProtocolTarget {
+		t.Errorf("after initialize protocol.version = %v, want %q",
+			got.Handshake.Protocol.Version, mcp.ProtocolTarget)
+	}
+	// What the client SAID, recorded verbatim -- the wireframe's "we wrote
+	// down what it said".
+	if got.Handshake.ReportedClientName == nil || *got.Handshake.ReportedClientName != "claude-code" {
+		t.Errorf("reported_client_name = %v, want %q", got.Handshake.ReportedClientName, "claude-code")
+	}
+	if got.Handshake.ReportedClientVersion == nil || *got.Handshake.ReportedClientVersion != "2.4.1" {
+		t.Errorf("reported_client_version = %v, want %q", got.Handshake.ReportedClientVersion, "2.4.1")
+	}
+	if got.Handshake.RecordedAt == nil {
+		t.Error("recorded_at is null after a successful initialize, want a timestamp")
+	}
+	// THE ASSERTION THIS WHOLE FILE IS FOR.
+	if got.FirstCall.LastUsedAt == nil {
+		t.Fatal("last_used_at is null after tools/list -- the premise of the next " +
+			"assertion is gone, so it would pass vacuously")
+	}
+	if got.FirstCall.State != "awaiting_call" {
+		t.Errorf("first_call.state = %q after tools/list with NO tools/call, want %q. "+
+			"last_used_at is set (%s), so this is the false success that would be "+
+			"produced by deriving Step 9 from that column",
+			got.FirstCall.State, "awaiting_call", *got.FirstCall.LastUsedAt)
+	}
+	if got.FirstCall.ToolName != nil {
+		t.Errorf("first_call.tool_name = %q with no tool called, want null", *got.FirstCall.ToolName)
+	}
+	t.Logf("PROOF 2 ok: tools/list stamped last_used_at=%s and Step 9 correctly stayed "+
+		"awaiting_call; Step 8 reports connected as claude-code 2.4.1 on %s",
+		*got.FirstCall.LastUsedAt, *got.Handshake.Protocol.Version)
+
+	// ==================================================================
+	// PROOF 3 -- IT WORKED. One real tools/call flips Step 9, by value.
+	// ==================================================================
+	callRes := mcpRPCWithProtocol(t, transportEng, freshTok, mcp.ProtocolTarget, map[string]any{
+		"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if callRes.status != http.StatusOK {
+		t.Fatalf("tools/call answered %d, want 200: %s", callRes.status, callRes.body)
+	}
+
+	code, got = getStatus(t, eng, freshID)
+	if code != http.StatusOK {
+		t.Fatalf("status after tools/call answered %d, want 200", code)
+	}
+	if got.FirstCall.State != "succeeded" {
+		t.Errorf("first_call.state = %q after a real tools/call, want %q",
+			got.FirstCall.State, "succeeded")
+	}
+	if got.FirstCall.ToolName == nil || *got.FirstCall.ToolName != mcp.ToolListSites {
+		t.Errorf("first_call.tool_name = %v, want %q", got.FirstCall.ToolName, mcp.ToolListSites)
+	}
+	if got.FirstCall.CalledAt == nil {
+		t.Error("first_call.called_at is null on a succeeded call, want the audit row's timestamp")
+	}
+	if got.FirstCall.AuditEventID == nil {
+		t.Error("first_call.audit_event_id is null on a succeeded call, want the audit row id")
+	}
+	// The gap that must stay a gap rather than becoming a clean success.
+	if got.FirstCall.Partial != nil {
+		t.Errorf("first_call.partial = %v, want null -- internal/mcp has no typed "+
+			"per-site partial, so any value here is invented", got.FirstCall.Partial)
+	}
+	t.Logf("PROOF 3 ok: Step 9 succeeded on tool %q with audit row %s, partial correctly null",
+		*got.FirstCall.ToolName, *got.FirstCall.AuditEventID)
+
+	// ==================================================================
+	// PROOF 4 -- NO PROTOCOL HEADER AT ALL. A separate grant, initialized
+	// with NO MCP-Protocol-Version header. This is a SUCCESS state and it
+	// must not print a version the client never sent.
+	// ==================================================================
+	bareID, bareTok := mintGrant(t, eng, "status bare "+suffix)
+	bareRes := mcpRPCWithProtocol(t, transportEng, bareTok, "", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{
+			"clientInfo":   map[string]any{"name": "wpmgr-example-client", "version": "0.1.0"},
+			"capabilities": map[string]any{},
+		},
+	})
+	if bareRes.status != http.StatusOK {
+		t.Fatalf("header-less initialize answered %d, want 200 (absence is NOT an error): %s",
+			bareRes.status, bareRes.body)
+	}
+
+	code, got = getStatus(t, eng, bareID)
+	if code != http.StatusOK {
+		t.Fatalf("status on the header-less grant answered %d, want 200", code)
+	}
+	if got.Handshake.State != "connected_protocol_assumed" {
+		t.Errorf("header-less handshake.state = %q, want %q",
+			got.Handshake.State, "connected_protocol_assumed")
+	}
+	if got.Handshake.Protocol.State != string(mcp.ClientProtocolAbsent) {
+		t.Errorf("header-less protocol.state = %q, want %q",
+			got.Handshake.Protocol.State, mcp.ClientProtocolAbsent)
+	}
+	// version stays NULL and assumed carries the floor. Collapsing these two
+	// would print a header the client never sent.
+	if got.Handshake.Protocol.Version != nil {
+		t.Errorf("header-less protocol.version = %q, want null -- the client sent no header",
+			*got.Handshake.Protocol.Version)
+	}
+	if got.Handshake.Protocol.Assumed == nil || *got.Handshake.Protocol.Assumed != mcp.ProtocolFloor {
+		t.Errorf("header-less protocol.assumed = %v, want %q",
+			got.Handshake.Protocol.Assumed, mcp.ProtocolFloor)
+	}
+	// It is CONNECTED, not waiting: the two absences stay apart.
+	if got.Handshake.RecordedAt == nil {
+		t.Error("header-less recorded_at is null; a client that connected without a " +
+			"header must stay distinguishable from one that never connected")
+	}
+	t.Logf("PROOF 4 ok: header-less client reports connected_protocol_assumed, "+
+		"version=null assumed=%s", *got.Handshake.Protocol.Assumed)
+
+	// ==================================================================
+	// PROOF 5 -- BELOW THE FLOOR. The known gap, asserted as a gap.
+	//
+	// A client speaking 2024-11-05 is refused at the transport BEFORE
+	// RecordConnect, so nothing is written and the row still reads
+	// awaiting_client. This asserts the CURRENT TRUTH so that the day a
+	// refusal is recorded, this test fails and is updated deliberately
+	// rather than the gap being discovered by an operator.
+	// ==================================================================
+	floorID, floorTok := mintGrant(t, eng, "status floor "+suffix)
+	refused := mcpRPCWithProtocol(t, transportEng, floorTok, "2024-11-05", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2024-11-05",
+			"clientInfo":      map[string]any{"name": "ancient-client", "version": "0.0.1"},
+			"capabilities":    map[string]any{},
+		},
+	})
+	if refused.status != http.StatusBadRequest {
+		t.Fatalf("below-floor initialize answered %d, want 400: %s", refused.status, refused.body)
+	}
+
+	code, got = getStatus(t, eng, floorID)
+	if code != http.StatusOK {
+		t.Fatalf("status on the refused grant answered %d, want 200", code)
+	}
+	if got.Handshake.State != "awaiting_client" {
+		t.Errorf("refused handshake.state = %q, want %q -- the refusal is NOT recorded, "+
+			"so the truthful reading of the row is still the not-yet",
+			got.Handshake.State, "awaiting_client")
+	}
+	if got.Handshake.Refusal != nil {
+		t.Errorf("handshake.refusal = %v, want null -- nothing records a below-floor "+
+			"refusal today, so any value here is invented from a NULL", got.Handshake.Refusal)
+	}
+	if got.Handshake.ReportedClientName != nil {
+		t.Errorf("refused reported_client_name = %q, want null -- a refused client "+
+			"never reaches RecordConnect", *got.Handshake.ReportedClientName)
+	}
+	t.Logf("PROOF 5 ok: a 400-refused below-floor client leaves the row untouched; " +
+		"status reports awaiting_client with refusal=null (documented gap, needs a migration)")
+
+	// ==================================================================
+	// PROOF 6 -- TENANT ISOLATION. A second organisation's admin must
+	// learn NOTHING about the first's connection, including whether the
+	// id exists.
+	// ==================================================================
+	otherTenant := seedTenant(t, pool, "mcp-status-other-"+suffix)
+	otherUser := seedUserRow(t, pool, "mcp-status-other-"+suffix+"@example.test")
+	otherAdmin := domain.Principal{
+		UserID: otherUser, TenantID: otherTenant, Role: "admin", Scope: domain.ScopeOrg,
+	}
+	otherEng := mountStatusLikeProduction(t, svc, otherAdmin)
+
+	code, _ = getStatus(t, otherEng, freshID)
+	if code != http.StatusNotFound {
+		t.Errorf("tenant %s reading tenant %s's connection answered %d, want 404",
+			otherTenant, tenantID, code)
+	}
+	// And the same principal CAN read its own, so the 404 above is isolation
+	// and not a broken mount that 404s everything.
+	otherID, _ := mintGrant(t, otherEng, "status other "+suffix)
+	if code, _ = getStatus(t, otherEng, otherID); code != http.StatusOK {
+		t.Fatalf("tenant %s reading its OWN connection answered %d, want 200 -- the 404 "+
+			"above would otherwise prove nothing", otherTenant, code)
+	}
+	t.Logf("PROOF 6 ok: cross-tenant read 404s while the same principal's own read 200s")
+
+	// ==================================================================
+	// PROOF 7 -- AUTHORISATION. A site-scoped collaborator is refused
+	// outright, by the same org-level permission the list and the mint
+	// take.
+	// ==================================================================
+	siteScoped := domain.Principal{
+		UserID:   userID,
+		TenantID: tenantID,
+		Role:     "admin", // admin ON ONE SITE -- the role is not what refuses it
+		Scope:    domain.ScopeSite,
+	}
+	scopedEng := mountStatusLikeProduction(t, svc, siteScoped)
+	if code, _ = getStatus(t, scopedEng, freshID); code != http.StatusForbidden {
+		t.Errorf("site-scoped principal reading a connection status answered %d, want 403. "+
+			"A grant is an ORGANISATION-wide credential and a site-scoped session must not "+
+			"read it -- minting one from such a session was a live defect on this surface",
+			code)
+	}
+	t.Logf("PROOF 7 ok: site-scoped principal refused 403 by RequirePermission(%s)",
+		authz.PermAPIKeyRead)
+
+	// A closing role print, so the file states its precondition at the end as
+	// well as the start: nothing above ran as a superuser.
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (after all proofs)")
+		return nil
+	}); err != nil {
+		t.Fatalf("closing tenant tx: %v", err)
+	}
+}


### PR DESCRIPTION
Backend for the add-connection wizard's Step 8 (connection liveness) and Step 9 (first-call verification), from Screen S29 of the wireframes.

## Wire shape

`GET /api/v1/mcp/connections/:connectionId/status`, `PermAPIKeyRead`, org-scoped principals only.

```json
{
  "id": "...", "status": "active", "created_at": "...", "expires_at": "...",
  "observed_at": "...", "poll_after_ms": 2000,
  "handshake": {
    "state": "awaiting_client|connected|connected_protocol_assumed|connected_protocol_unrecognised",
    "recorded_at": null, "reported_client_name": null, "reported_client_version": null,
    "protocol": {
      "state": "never_connected|absent|recognised|unrecognised",
      "version": null, "assumed": null,
      "floor": "2025-03-26", "target": "2025-11-25", "supported": ["..."]
    },
    "refusal": null
  },
  "first_call": {
    "state": "awaiting_call|succeeded|indeterminate",
    "called_at": null, "tool_name": null, "audit_event_id": null,
    "last_used_at": null, "partial": null
  }
}
```

`protocol.state` reuses the existing four-state `ClientProtocol` vocabulary, so it matches `connection-model.ts` rather than introducing a second one. `version` and `assumed` are separate fields: a header-less client reports `version: null, assumed: "2025-03-26"`, never a header it did not send.

## Decisions

**One endpoint, not two.** Steps 8 and 9 are two questions about one grant row. Two polls straddling a handshake could return an inconsistent pair ("it read your fleet" over "waiting for the client"), which the browser would then have to reconcile.

**Polling, not SSE.** ogen cannot model `text/event-stream`, the wizard page lives for minutes, and a poll depends on none of the streaming transport work in flight. `poll_after_ms` is server-decided so the interval is a deploy and not a dashboard release.

**Step 9 is NOT derived from `last_used_at`.** That column is stamped by `tools/list` too, which every client issues unprompted right after `initialize`. Deriving Step 9 from it would report "it read your fleet" for a client that read nothing. The state comes from the `mcp.tool.called` audit row; `last_used_at` is returned only as the weaker, labelled fact it is.

## Two gaps, named in the types rather than faked

- **`handshake.refusal` is always null.** A below-floor client is refused at `transport.go:236` / `:413`, both before `RecordConnect` at `:432`, so nothing is written and the row is byte-identical to a client that never started. Rendering the wireframe's refusal frame would invent an event out of a NULL. Recording it needs somewhere to put it, which is a migration and `database-engineer`'s.
- **`first_call.partial` is always null.** There is no typed per-site partial in `internal/mcp` — an invocation returns a string or an error — so there is no honest source for "17 answered, 3 stale, 2 unreachable".

`first_call.state: "indeterminate"` exists because the only reachable generated audit query filters by action prefix and not by actor: the scan is bounded and reports its own truncation rather than manufacturing a not-yet out of a pagination limit. An actor-filtered query would remove both the bound and the state.

## Proof

Eight proofs in `apps/api/tests/mcp_connection_status_integration_test.go`, all through `db.Pool` as `wpmgr_app` with `rolsuper` and `rolbypassrls` printed from `pg_roles` inside the transaction under test, and all asserted by value:

1. Fresh grant reports `awaiting_client` / `awaiting_call`, every client-reported field null.
2. The `last_used_at` trap: `initialize` + `tools/list` and nothing else leaves Step 9 at `awaiting_call` while `last_used_at` is demonstrably set.
3. One real `tools/call` flips Step 9 to `succeeded`, naming the tool and the audit row.
4. Header-less client reports `connected_protocol_assumed`, `version` null, `assumed` the floor.
5. Below-floor client is refused 400 and leaves the row untouched.
6. Tenant isolation: a second organisation 404s while reading its own successfully.
7. Site-scoped principal refused 403.
8. Org-scoped viewer refused 403 by the route's admin tier.

Five-mutation sweep; all five redden. The sweep found a real weakness in proof 7: it alone did not pin the route permission, because the service's own org gate returns the same 403 when the route is downgraded. Proof 8 separates the two layers.

## For the frontend

The route is not in `packages/openapi/openapi.yaml`, and neither are the sibling connections routes (issue #611) — follow the existing raw-fetch convention.
