### PR TITLE
ci: MCP site-scope containment guard (ADR-061 A11 item 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,53 @@ jobs:
           CGO_ENABLED: "0"
         run: scripts/check-urlmap-routes.sh
 
+      # ---- MCP site-scope containment (ADR-061 A11 item 4) -------------------
+      # "No handler on this surface may take a site id from a request and pass
+      # it anywhere but the chokepoint."
+      #
+      # The chokepoint is mcp.Repo.ResolveScopeSites, which resolves a grant's
+      # stored scope inside InTenantTx so `sites` RLS drops every foreign UUID —
+      # scope_site_ids is a uuid[] and PostgreSQL has no foreign key over array
+      # elements, so that column accepts any site id in the world. The
+      # chokepoint shipped. NOTHING STOPPED THE NEXT HANDLER GOING ROUND IT,
+      # and ADR-060's freeze clause counts that an open auth-boundary item.
+      # These two steps are what close it.
+      #
+      # IT RUNS ON EVERY PR AND NOT ONLY ON CHANGES UNDER internal/mcp. A
+      # bypass can be added from anywhere: a Store method declared in one
+      # commit and called in another, a new file in the package, a second
+      # database path. A path filter here would be the guard agreeing not to
+      # look at the diff that needs looking at.
+      #
+      # It lives in this job for the same reason the url-map guard above does:
+      # it reads the mcp.Store interface through `go doc`, i.e. Go's own parser
+      # after the package type-checks, rather than by grepping repo.go — so a
+      # wrapped signature or a method moved to another file in the package
+      # cannot make it quietly match less. That needs the Go toolchain, and
+      # this is the job that already has it set up and cached. It needs no
+      # database and no cloud credentials, so it runs on fork PRs too.
+      #
+      # THE GUARD'S THREE EXIT CODES ARE DISTINCT AND THAT IS THE POINT: 0 all
+      # reviewed, 1 a containment violation or a stale allowlist entry, 2 GUARD
+      # BROKEN — an empty extraction, a control pattern that stopped matching,
+      # a package that will not compile. There is deliberately no exit code
+      # meaning "checked nothing, fine".
+      #
+      # Self-test FIRST, so a guard broken into failing open cannot pass by
+      # reporting success over its own errors. The suite is hermetic (fixture
+      # trees, no Go toolchain, no network) and plants each bypass and each
+      # broken-input state as a real case.
+      - name: MCP site-containment guard self-test (ADR-061 A11)
+        working-directory: ${{ github.workspace }}
+        run: scripts/check-mcp-site-containment_test.sh
+
+      - name: MCP site-containment guard (no request site id may bypass the chokepoint)
+        working-directory: ${{ github.workspace }}
+        env:
+          GOWORK: "off"
+          CGO_ENABLED: "0"
+        run: scripts/check-mcp-site-containment.sh
+
   # ---- JS / web ----
   js:
     name: JS (web)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,15 @@ jobs:
       # look at the diff that needs looking at.
       #
       # It lives in this job for the same reason the url-map guard above does:
-      # it reads the mcp.Store interface through `go doc`, i.e. Go's own parser
-      # after the package type-checks, rather than by grepping repo.go — so a
-      # wrapped signature or a method moved to another file in the package
-      # cannot make it quietly match less. That needs the Go toolchain, and
-      # this is the job that already has it set up and cached. It needs no
-      # database and no cloud credentials, so it runs on fork PRs too.
+      # it reads the mcp.Store interface through `go doc`, i.e. Go's own parser,
+      # rather than by grepping repo.go — so a wrapped signature or a method
+      # moved to another file in the package cannot make it quietly match less.
+      # That needs the Go toolchain, and this is the job that already has it set
+      # up and cached. It needs no database and no cloud credentials, so it runs
+      # on fork PRs too. `go doc` parses rather than type-checks (measured: with
+      # a bypass planted, `go build ./internal/mcp` exits 1 and `go doc -u
+      # ./internal/mcp Store` exits 0), so the guard fires on a bypass in
+      # progress rather than waiting for the branch to compile.
       #
       # THE GUARD'S THREE EXIT CODES ARE DISTINCT AND THAT IS THE POINT: 0 all
       # reviewed, 1 a containment violation or a stale allowlist entry, 2 GUARD

--- a/Makefile
+++ b/Makefile
@@ -270,9 +270,11 @@ check-rls-cross-tenant-test: ## Run the RLS cross-tenant guard's regression suit
 # stopped the next handler going round it, and ADR-060's freeze clause calls
 # that an open auth-boundary item. This is what closes it.
 #
-# It reads the mcp.Store interface through `go doc`, i.e. Go's own parser after
-# the package type-checks, so it needs the Go toolchain but NO database and NO
-# cloud credentials — which is why it runs on every PR. The reviewed surface is
+# It reads the mcp.Store interface through `go doc`, i.e. Go's own parser
+# rather than a grep over repo.go, so it needs the Go toolchain but NO database
+# and NO cloud credentials — which is why it runs on every PR. `go doc` parses
+# and does not type-check, so the guard fires on a bypass in progress before
+# the branch compiles. The reviewed surface is
 # infra/mcp-site-containment-allowlist.txt and it is checked in both
 # directions: an unreviewed call site, uuid parameter or tool-argument binding
 # is a violation, and so is an allowlist entry that no longer matches anything.

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,28 @@ check-rls-cross-tenant: ## Audit cross-tenant RLS policies against the ledger (D
 check-rls-cross-tenant-test: ## Run the RLS cross-tenant guard's regression suite (hermetic, no DB)
 	scripts/check-rls-cross-tenant_test.sh
 
+# ADR-061 A11 item 4: the containment test. No handler on the assistant surface
+# may take a site id from a request and pass it anywhere but the ONE audited
+# chokepoint, mcp.Repo.ResolveScopeSites. The chokepoint shipped; nothing
+# stopped the next handler going round it, and ADR-060's freeze clause calls
+# that an open auth-boundary item. This is what closes it.
+#
+# It reads the mcp.Store interface through `go doc`, i.e. Go's own parser after
+# the package type-checks, so it needs the Go toolchain but NO database and NO
+# cloud credentials — which is why it runs on every PR. The reviewed surface is
+# infra/mcp-site-containment-allowlist.txt and it is checked in both
+# directions: an unreviewed call site, uuid parameter or tool-argument binding
+# is a violation, and so is an allowlist entry that no longer matches anything.
+# check-mcp-containment-test is the guard's own regression suite (hermetic, no
+# Go toolchain needed); run it after editing the guard itself.
+.PHONY: check-mcp-containment
+check-mcp-containment: ## Check no MCP handler can pass a request site id round the chokepoint (ADR-061 A11)
+	scripts/check-mcp-site-containment.sh
+
+.PHONY: check-mcp-containment-test
+check-mcp-containment-test: ## Run the MCP site-containment guard's regression suite (hermetic)
+	scripts/check-mcp-site-containment_test.sh
+
 # ---- Agent harness (.claude) ------------------------------------------------
 # The shell guards that used to live in scripts/claude/ are gone: deciding what
 # a shell command will write by parsing its text is undecidable (eval, bash -c,

--- a/infra/mcp-site-containment-allowlist.txt
+++ b/infra/mcp-site-containment-allowlist.txt
@@ -66,7 +66,13 @@ PARAM ListTagIDs.tenantID                               # tenant of the resolved
 PARAM ListSitesForRead.tenantID                         # tenant of the resolved principal; the list_sites tool then filters the rows through SiteSet.Allows
 PARAM ReCheckAuthorization.tenantID                     # tenant of the resolved principal
 PARAM ReCheckAuthorization.tokenID                      # token row id, from the token lookup
-PARAM ResolveScopeSites.tenantID                        # the chokepoint itself; tenant of the resolved principal
+# ResolveScopeSites.tenantID is GONE, deliberately not replaced. #649 changed
+# the chokepoint to take `principal db.ScopedPrincipal` instead of a bare
+# tenant uuid, so the chokepoint can route on scope rather than be handed a
+# tenant with no scope attached. ScopedPrincipal is not a uuid type, so Rule B
+# does not extract it and it needs no entry -- the parameter this line used to
+# describe does not exist, and an entry naming it would be exactly the stale
+# allowlist the both-directions check exists to catch.
 PARAM ResolveScopeSites.tagIDs                          # THE CHOKEPOINT'S OWN INPUT: stored grant scope, resolved under RLS
 PARAM ResolveScopeSites.siteIDs                         # THE CHOKEPOINT'S OWN INPUT: stored grant scope, resolved under RLS
 PARAM RecordClientIdentity.tenantID                     # tenant of the resolved principal

--- a/infra/mcp-site-containment-allowlist.txt
+++ b/infra/mcp-site-containment-allowlist.txt
@@ -75,6 +75,35 @@ PARAM TouchActivity.tenantID                            # tenant of the resolved
 PARAM TouchActivity.grantID                             # grant row id, from the authenticated grant
 PARAM TouchActivity.tokenID                             # token row id, from the authenticated token
 PARAM RevokeGrantWithTokens.grantID                     # operator-facing revoke, dashboard principal, not the MCP surface
+# grantID here IS request-supplied -- it is the :connectionId path parameter of
+# GET /api/v1/mcp/connections/:connectionId/status (handler.go:184). It is
+# allowlisted because it can only ever be INTERPRETED as a grant id: it binds
+# to mcp_grants.id in GetMCPGrant (db/query/mcp_connections.sql:326-327), and in
+# the audit half it is compared in Go against audit_log.actor_id with
+# actor_type='assistant', never pushed into SQL -- that query's site filter is
+# hard-wired off with the uuid.Nil sentinel (connection_status.go:649). A
+# foreign uuid therefore misses and 404s. The read runs under RunTenantTx, and
+# mcp_grants carries a RESTRICTIVE _site_scope SELECT policy (schema.sql:5851)
+# that returns zero rows to any site-constrained principal, so this endpoint is
+# org-scoped principals only, refused three independent ways.
+PARAM ConnectionStatusSnapshot.grantID                  # :connectionId path param; only ever bound to mcp_grants.id, never to a site column
 
 # ---- Tool argument surface -------------------------------------------------
-# Intentionally empty. See TOOLARGS above.
+# Intentionally empty, and still the Phase 1 state: registry.go's one tool
+# discards its arguments (`_ json.RawMessage`).
+#
+# It was briefly NOT empty by accident. Rule C used to key on the parameter
+# name `auth` followed by a named json.RawMessage, and matched
+# transport.go:1045 -- writeProtocolRefusal, where that json.RawMessage is the
+# JSON-RPC envelope id being echoed back into an error response. Adding
+# `TOOLARGS internal/mcp/transport.go` here would have been the obvious way to
+# make CI quiet, and because Rule C's granularity is the FILE it would have
+# switched the rule off for the one file that actually dispatches tools. The
+# rule now matches the toolInvoker type sequence instead, so no entry is needed
+# and none should be added to silence a hit without reading it first.
+
+# ---- Second database paths in package mcp (Rule D) -------------------------
+# Rule D is default-closed on every file of package mcp except repo.go. This is
+# the reviewed-exception list, and an entry is a promise that the file is part
+# of the Store implementation rather than a path around it.
+DBPATH internal/mcp/connection_status.go                # Repo split across files: getGrantTx (:601) and findFirstToolCallTx (:634) are unexported, take a pgx.Tx they do not open, and are reached ONLY from Repo.ConnectionStatusSnapshot (:573,:578,:585) inside r.pool.RunTenantTx (:571) -- the same audited boundary Rule B watches

--- a/infra/mcp-site-containment-allowlist.txt
+++ b/infra/mcp-site-containment-allowlist.txt
@@ -75,17 +75,30 @@ PARAM TouchActivity.tenantID                            # tenant of the resolved
 PARAM TouchActivity.grantID                             # grant row id, from the authenticated grant
 PARAM TouchActivity.tokenID                             # token row id, from the authenticated token
 PARAM RevokeGrantWithTokens.grantID                     # operator-facing revoke, dashboard principal, not the MCP surface
-# grantID here IS request-supplied -- it is the :connectionId path parameter of
-# GET /api/v1/mcp/connections/:connectionId/status (handler.go:184). It is
-# allowlisted because it can only ever be INTERPRETED as a grant id: it binds
-# to mcp_grants.id in GetMCPGrant (db/query/mcp_connections.sql:326-327), and in
-# the audit half it is compared in Go against audit_log.actor_id with
-# actor_type='assistant', never pushed into SQL -- that query's site filter is
-# hard-wired off with the uuid.Nil sentinel (connection_status.go:649). A
-# foreign uuid therefore misses and 404s. The read runs under RunTenantTx, and
-# mcp_grants carries a RESTRICTIVE _site_scope SELECT policy (schema.sql:5851)
-# that returns zero rows to any site-constrained principal, so this endpoint is
-# org-scoped principals only, refused three independent ways.
+# grantID here IS request-supplied -- the :connectionId path parameter of
+# GET /api/v1/mcp/connections/:connectionId/status (handler.go:184). Allowlisted
+# because it can only ever be INTERPRETED as a grant id: it binds to
+# mcp_grants.id in GetMCPGrant (db/query/mcp_connections.sql:326-327), and the
+# audit half compares it in Go, never in SQL.
+#
+# THREE LAYERS, AND THEY ARE NOT INDEPENDENT OF EACH OTHER. Route middleware,
+# the service guard, and the RESTRICTIVE _site_scope SELECT policy on
+# mcp_grants (schema.sql:5851) each refuse a site-constrained principal on
+# their own, so they hold independently against three real regressions: a route
+# mounted without middleware, a refactor that drops the service guard, and a
+# handler swapping RunTenantTx for InTenantTx. They all read the SAME
+# predicate, domain.IsSiteConstrained (internal/domain/principal.go:163), and
+# all three fall together if it -- or whatever populates Principal.Scope and
+# AllowedSiteIDs -- is wrong. Do not read "three layers" as three independent
+# probabilities. That is the accepted tenancy architecture, not a defect of
+# this endpoint; tracked in #646.
+#
+# THIS ENTRY IS FALSIFIED IF ANY OF THESE CHANGES:
+#   - connection_status.go:650 stops being the literal SiteID: uuid.Nil.String()
+#     (the sentinel that holds the audit query's site filter off)
+#   - findFirstToolCallTx uses grantID for anything but the Go-side comparison
+#     at connection_status.go:642
+#   - connection_status.go:571 stops being RunTenantTx
 PARAM ConnectionStatusSnapshot.grantID                  # :connectionId path param; only ever bound to mcp_grants.id, never to a site column
 
 # ---- Tool argument surface -------------------------------------------------

--- a/infra/mcp-site-containment-allowlist.txt
+++ b/infra/mcp-site-containment-allowlist.txt
@@ -1,0 +1,80 @@
+# infra/mcp-site-containment-allowlist.txt
+#
+# The reviewed surface of ADR-061 A11 item 4 -- the containment test.
+#
+# ADR-061 A11.1 says the chokepoint is "the only way this surface names a
+# site". scripts/check-mcp-site-containment.sh reconciles that sentence
+# against the code on every PR. This file is the other half of it: the set of
+# places that are ALLOWED to be on the site-scope boundary, each with the
+# reason somebody reviewed it.
+#
+# It is checked in BOTH directions. An entry here that no longer matches
+# anything in the tree is a FAILURE, not a no-op -- a stale allowlist is how a
+# guard comes to be checking a surface that has moved.
+#
+# FORMAT. One record per line, `KIND value` plus an optional `# reason`.
+# Blank lines and lines starting with `#` are ignored. Three kinds:
+#
+#   CALL <path> <func>        A non-test call to the chokepoint
+#                             (ResolveScopeSites) or to NewSiteSet, identified
+#                             by its file relative to apps/api and its
+#                             enclosing function. Line numbers are deliberately
+#                             NOT part of the identity: an allowlist that goes
+#                             stale on every unrelated edit gets deleted.
+#
+#   PARAM <Method>.<param>    A uuid.UUID / []uuid.UUID parameter on the Store
+#                             interface. EVERY uuid parameter on that interface
+#                             needs an entry, not only the site-looking ones,
+#                             because `GetSiteByID(ctx, tenantID, id uuid.UUID)`
+#                             is a site id wearing a name a pattern would not
+#                             match. Default-closed is the point.
+#
+#   TOOLARGS <path>           A file in internal/mcp that BINDS the tool
+#                             invoker's `args json.RawMessage` to a name --
+#                             i.e. reads request-supplied tool arguments.
+#                             Phase 1's one tool discards them (`_`), so there
+#                             are deliberately NO entries of this kind below.
+#                             The first tool that takes an argument turns CI
+#                             red until a reviewer writes the reason here and
+#                             checks that any site id in it goes through the
+#                             chokepoint.
+#
+# ADDING AN ENTRY IS THE REVIEW. If you are here because CI went red, the
+# question to answer in the reason column is A11's question: can a site id
+# supplied by the request reach the database through this, without passing
+# ResolveScopeSites?
+
+# ---- Chokepoint call sites -------------------------------------------------
+CALL internal/mcp/mint.go verifyScopeReferents          # mint path: resolves the requested scope before the grant is written
+CALL internal/mcp/service.go Authenticate               # request path: resolves the stored scope into the SiteSet on every request
+
+# ---- SiteSet construction --------------------------------------------------
+# NewSiteSet is the second half of the chokepoint: it turns resolved ids into
+# the set the tools filter on. Constructing one from UNRESOLVED ids (a request
+# body, a cache, a grant column read directly) defeats the resolution entirely,
+# which is why its callers are enumerated here and not left free.
+# (Service.Authenticate builds it from the ids ResolveScopeSites returned, in
+# the same function, so it needs no second CALL entry.)
+
+# ---- Store interface uuid parameters ---------------------------------------
+# Each of these was read and is not a request-supplied site id.
+PARAM RedeemAuthorizationCode.tenantID                  # tenant of the resolved principal
+PARAM RedeemAuthorizationCode.codeID                    # authorization code row id, from the code lookup
+PARAM CreateGrantWithCode.grantID                       # callback parameter: the id of the row just inserted
+PARAM CreateGrantWithToken.grantID                      # callback parameter: the id of the row just inserted
+PARAM ListTagIDs.tenantID                               # tenant of the resolved principal
+PARAM ListSitesForRead.tenantID                         # tenant of the resolved principal; the list_sites tool then filters the rows through SiteSet.Allows
+PARAM ReCheckAuthorization.tenantID                     # tenant of the resolved principal
+PARAM ReCheckAuthorization.tokenID                      # token row id, from the token lookup
+PARAM ResolveScopeSites.tenantID                        # the chokepoint itself; tenant of the resolved principal
+PARAM ResolveScopeSites.tagIDs                          # THE CHOKEPOINT'S OWN INPUT: stored grant scope, resolved under RLS
+PARAM ResolveScopeSites.siteIDs                         # THE CHOKEPOINT'S OWN INPUT: stored grant scope, resolved under RLS
+PARAM RecordClientIdentity.tenantID                     # tenant of the resolved principal
+PARAM RecordClientIdentity.grantID                      # grant row id, from the authenticated grant
+PARAM TouchActivity.tenantID                            # tenant of the resolved principal
+PARAM TouchActivity.grantID                             # grant row id, from the authenticated grant
+PARAM TouchActivity.tokenID                             # token row id, from the authenticated token
+PARAM RevokeGrantWithTokens.grantID                     # operator-facing revoke, dashboard principal, not the MCP surface
+
+# ---- Tool argument surface -------------------------------------------------
+# Intentionally empty. See TOOLARGS above.

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -606,17 +606,35 @@ find "$MCP_DIR" -name '*.go' -type f 2>/dev/null | grep -v '_test\.go$' | sort >
 #   the one file that actually dispatches tools. A guard that reddens correct
 #   work gets made quiet, and a guard that has been made quiet is off.
 #
-# So the match is the toolInvoker TYPE SEQUENCE, with every parameter name
-# free: context.Context, *Service, AuthorizedRequest, json.RawMessage, closing
-# to (string, error). That shape is what makes a function assignable to
-# toolInvoker, it is what a reviewer means by "a tool", and it cannot be
-# renamed out of. The file is flattened to one whitespace-collapsed stream
-# first, so a signature broken across lines reads the same as one on a line.
-# The trailing `,?` before the closing paren is not cosmetic: gofmt puts a
-# trailing comma on the last parameter of every signature it wraps across
-# lines, so without it the rule would see the one-line form and miss the
-# wrapped one -- which is the formatting a long signature actually gets.
-TOOLARGS_SIG='\([ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+context\.Context[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+\*[ ]*Service[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+AuthorizedRequest[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+json\.RawMessage[ ]*,?[ ]*\)[ ]*\([ ]*string[ ]*,[ ]*error[ ]*\)'
+# So the match is the toolInvoker TYPE SEQUENCE, with every identifier free on
+# BOTH halves: context.Context, *Service, AuthorizedRequest, json.RawMessage,
+# closing to string, error. That shape is what makes a function assignable to
+# toolInvoker, and it is what a reviewer means by "a tool".
+#
+# NAME-TOLERANCE IS A PROPERTY OF THE PATTERN, NOT OF THE SHAPE, and it has to
+# be maintained on every half. An earlier version of this comment claimed the
+# shape "cannot be renamed out of"; that was wrong for the RESULT half, which
+# demanded a literal `(string, error)` while the parameter half already
+# admitted names. `(out string, err error)` is the same Go type, and a handler
+# written that way passed unseen. The rule is: wherever Go permits an
+# identifier, this pattern must permit one too.
+#
+# The file is flattened to one whitespace-collapsed stream first, so a
+# signature broken across lines reads the same as one on a line.
+# NAMES ARE OPTIONAL ON BOTH HALVES, and the second half is why: this pattern
+# used to admit a name on every PARAMETER and none on either RESULT. Go does
+# not care -- `(out string, err error)` is the same type as `(string, error)`
+# and just as assignable to toolInvoker -- so a handler declaring named results
+# was omitted from FOUND_TOOLARGS and the guard reported successful containment
+# over a live request-input channel. Same asymmetry, same failure, as the
+# parameter half before it: any half of a signature where the rule demands a
+# literal is a half that ordinary Go can be written round.
+#
+# The trailing `,?` on each list is not cosmetic: gofmt puts a trailing comma
+# on the last entry of every parameter AND result list it wraps across lines,
+# so without it the rule would see the one-line form and miss the wrapped one
+# -- which is the formatting a long signature actually gets.
+TOOLARGS_SIG='\([ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+context\.Context[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+\*[ ]*Service[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+AuthorizedRequest[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+json\.RawMessage[ ]*,?[ ]*\)[ ]*\([ ]*([A-Za-z_][A-Za-z0-9_]*[ ]+)?string[ ]*,[ ]*([A-Za-z_][A-Za-z0-9_]*[ ]+)?error[ ]*,?[ ]*\)'
 
 # Control. The flattening plus this pattern must still find the toolInvoker
 # declaration itself in registry.go. If it does not, the shape changed and the

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -124,6 +124,31 @@
 # below has been checked against the implementation as it stands, not inherited
 # from an earlier version of it.
 #
+#   0. THE BIGGEST GAP IS THE METHOD, AND IT IS NOT CLOSED BY THE LIST BELOW.
+#      Rules A, C and D match REGULAR EXPRESSIONS against a CONTEXT-FREE
+#      GRAMMAR. That is not a bug in any one pattern; it is a category error
+#      that no pattern can fix, and the evidence is the changelog of this file.
+#      Eight distinct bypasses have been found and closed here, every one of
+#      them a Go spelling a pattern did not know:
+#
+#        a space before a paren; a call split across a line break; a renamed
+#        parameter; a gofmt-wrapped signature; named results; a line-oriented
+#        pgx match; a comment between two parameters; a dot-imported New.
+#
+#      Each fix teaches the pattern one more spelling. Go always has another --
+#      a type alias for json.RawMessage, a method value registered instead of a
+#      function literal, a parenthesised type, a semicolon-separated parameter
+#      list, generics. DO NOT READ A GREEN FROM RULES A, C OR D AS PROOF OF
+#      CONTAINMENT. Read it as "no surface matching the shapes this file
+#      currently knows was found unreviewed".
+#
+#      The sound version is go/parser: comments, names, line breaks, dot
+#      imports and argument shapes all disappear into the AST, and every one of
+#      the eight becomes unrepresentable rather than fixed. That is a separate
+#      job, deliberately not grown inside this one. Rule B is already there --
+#      it reads the interface through `go doc`, i.e. Go's own parser, which is
+#      exactly why Rule B is not on the list above.
+#
 #   1. It is a STRUCTURAL guard, not a taint analysis. It proves that every
 #      channel by which a site id could reach the database has been looked at
 #      by a human, and that no new one appeared unnoticed. It does not prove the

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -48,11 +48,20 @@
 #      someone who is not trying to be caught, and, more to the point, by
 #      someone who has never read this file.
 #
-#      The interface is read with `go doc -u`, i.e. through Go's own parser
-#      after type-checking the package, NOT by grepping repo.go. A signature
-#      reformatted across lines, a method moved to another file in the package,
-#      or a package that no longer compiles all behave correctly: the first two
-#      are invisible to this guard by construction, and the third is loud.
+#      The interface is read with `go doc -u`, i.e. through Go's own parser,
+#      NOT by grepping repo.go. A signature reformatted across lines and a
+#      method moved to another file in the package are both invisible to this
+#      guard by construction, which a grep over one file cannot manage.
+#
+#      `go doc` PARSES; IT DOES NOT TYPE-CHECK, and that was measured rather
+#      than assumed. With a bypass planted in this tree -- a Store method with
+#      no implementation on Repo, a handler calling a Service method that does
+#      not exist -- `go build ./internal/mcp` exits 1 with three errors and
+#      `go doc -u ./internal/mcp Store` exits 0 and prints the interface. That
+#      is the behaviour this guard wants: it fires on a bypass IN PROGRESS,
+#      before the branch compiles, rather than waiting for it to be finished.
+#      It also means a non-compiling package is not by itself an exit-2 state
+#      here; only a `go doc` that fails or prints something unrecognisable is.
 #
 #   C. THE TOOL ARGUMENT SURFACE. mcp.toolInvoker's last parameter is the
 #      request-supplied tool arguments (`args json.RawMessage`). Phase 1's one

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -1,0 +1,576 @@
+#!/usr/bin/env bash
+# scripts/check-mcp-site-containment.sh
+#
+# ADR-061 A11 item 4: the containment test.
+#
+#   "No handler on this surface may take a site id from a request and pass it
+#    anywhere but the chokepoint."
+#
+# The chokepoint is Repo.ResolveScopeSites (apps/api/internal/mcp/repo.go),
+# documented there as "the ONE audited chokepoint of m124 obligation 2". It
+# resolves a grant's stored scope into real site ids INSIDE InTenantTx, so
+# `sites` RLS drops every foreign UUID -- scope_site_ids is a uuid[] and
+# PostgreSQL has no foreign key over array elements, so that column accepts any
+# UUID in the world, including another organisation's site id.
+#
+# WHAT WAS MISSING. The chokepoint existed; nothing stopped the NEXT handler
+# going round it. ADR-060's freeze clause calls site scoping an auth-boundary
+# item and forbids new externally-reachable surface while one is open, and the
+# MCP endpoint shipped anyway. This guard is what closes the item, so it has to
+# hold rather than merely exist.
+#
+# WHY THIS AND NOT A GREP FOR A FUNCTION NAME. A grep for "ResolveScopeSites"
+# proves the string is present. It cannot see the handler that never calls it,
+# which is the entire failure mode. This guard inverts that: it enumerates the
+# ways a site id could reach the database on this surface, and requires each one
+# to be in a committed, reasoned allowlist that is checked in BOTH directions.
+# Default-closed. New surface is red until a human writes down why it is safe.
+#
+# THE THREE RULES.
+#
+#   A. CHOKEPOINT CALL SITES. Every non-test call to ResolveScopeSites or
+#      NewSiteSet under apps/api is identified by file + enclosing function and
+#      must appear in the allowlist. NewSiteSet is included because it is the
+#      chokepoint's second half: a SiteSet built from unresolved ids (a request
+#      body, a cache, the grant column read directly) is a resolution that never
+#      happened, and its own doc comment says so.
+#
+#   B. THE STORE INTERFACE'S uuid SURFACE. Package mcp reaches the database
+#      through exactly one interface, mcp.Store. Every uuid.UUID / []uuid.UUID
+#      parameter on it must be allowlisted BY NAME -- not only the ones spelled
+#      "site". A bypass does not announce itself:
+#
+#          GetSiteByID(ctx context.Context, tenantID, id uuid.UUID) (...)
+#
+#      is a request-supplied site id reaching the database, and a pattern
+#      hunting for /site/i matches nothing in it. Requiring an entry for EVERY
+#      uuid parameter is what makes the guard survive a bypass written by
+#      someone who is not trying to be caught, and, more to the point, by
+#      someone who has never read this file.
+#
+#      The interface is read with `go doc -u`, i.e. through Go's own parser
+#      after type-checking the package, NOT by grepping repo.go. A signature
+#      reformatted across lines, a method moved to another file in the package,
+#      or a package that no longer compiles all behave correctly: the first two
+#      are invisible to this guard by construction, and the third is loud.
+#
+#   C. THE TOOL ARGUMENT SURFACE. mcp.toolInvoker's last parameter is the
+#      request-supplied tool arguments (`args json.RawMessage`). Phase 1's one
+#      tool discards them (`_ json.RawMessage`) and therefore cannot name a
+#      site at all. Any file that BINDS that parameter to a name is a file where
+#      request-supplied arguments start being read, and must be allowlisted.
+#      That is the exact moment A11's sentence becomes possible to violate, so
+#      it is the moment a reviewer is made to look.
+#
+# WHAT THIS CANNOT CATCH -- read this before trusting it. See the block at the
+# bottom of this header.
+#
+# WHY IT IS A SCRIPT AND NOT A CI STEP. Build-gating logic in a YAML block
+# scalar is untested logic: nobody can run it, so nobody can check their work.
+# scripts/check-mcp-site-containment_test.sh drives this file with fixture
+# inputs and asserts exit codes, so a hole that gets reopened turns a test red.
+# Same reasoning, and the same shape, as check-version-surfaces.sh,
+# check-license-surfaces.sh and check-urlmap-routes.sh.
+#
+# RUN IT:
+#   make check-mcp-containment        # reads the Store interface via go doc
+#   make check-mcp-containment-test   # the guard's own regression suite
+#   scripts/check-mcp-site-containment.sh --store-doc /tmp/store.txt   # offline
+#
+# EXIT CODES. There is deliberately no exit code that means "checked nothing,
+# fine":
+#   0  every site-scope surface in the tree is allowlisted, and every allowlist
+#      entry still matches something.
+#   1  a real containment violation, or a stale allowlist entry.
+#   2  GUARD BROKEN -- missing input, unreadable file, a source that produced
+#      nothing, a control pattern that no longer matches. A guard whose input
+#      vanished must go red; reporting a clean bill of health from an extraction
+#      that produced zero rows is this project's signature defect.
+#
+# PORTABILITY. bash 3.2 (what macOS ships) and POSIX tools, so it behaves the
+# same on a darwin laptop with BSD grep/sed/awk and on the ubuntu CI runner with
+# the GNU ones. No mapfile, no associative arrays, no sed -i, no grep -P.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS GUARD CANNOT CATCH
+#
+#   1. It is a STRUCTURAL guard, not a taint analysis. It proves that every
+#      channel by which a site id could reach the database has been looked at
+#      by a human, and that no new one appeared unnoticed. It does not prove the
+#      human looked correctly. An allowlist entry with a wrong reason passes.
+#
+#   2. Rule B's subject is the mcp.Store interface. A handler that reaches the
+#      database WITHOUT going through Store -- a second interface, a *db.Pool
+#      held directly, an sqlc.Queries built in a handler -- is outside its
+#      reach. Rule D below is a partial backstop: it refuses a direct sqlc or
+#      pgx import in any file of package mcp other than repo.go, which is where
+#      such a second path would have to start. It is a backstop and not a proof:
+#      a new Repo method wired through a NEW interface declared elsewhere in the
+#      package would satisfy both rules.
+#
+#   3. Rule C's granularity is the FILE, not the tool. Once one file is
+#      allowlisted for reading tool arguments, a second tool added to that same
+#      file inherits the allowance. The allowlist reason is therefore a promise
+#      about the file, and a reviewer adding a tool to an allowlisted file gets
+#      no signal from this guard.
+#
+#   4. It checks the mcp package only, because A11 is about this surface. A site
+#      id taken from a request by some OTHER package and handed to mcp is not in
+#      scope here.
+#
+#   5. It is a compile-time, source-level check. It says nothing about whether
+#      the chokepoint's own SQL is correct; that is the integration proof's job
+#      (A11 item 6), and this guard is not a substitute for it.
+# ---------------------------------------------------------------------------
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+
+API_ROOT="$REPO_ROOT/apps/api"
+MCP_PKG_REL="internal/mcp"
+ALLOWLIST="$REPO_ROOT/infra/mcp-site-containment-allowlist.txt"
+STORE_DOC=""
+STORE_DOC_CMD_DEFAULT="${WPMGR_MCP_STORE_DOC_CMD:-go doc -u ./internal/mcp Store}"
+
+# The chokepoint, and the SiteSet constructor that is its second half. Named
+# once, here, so the two rules and the error messages cannot drift apart.
+CHOKEPOINT="ResolveScopeSites"
+SITESET_CTOR="NewSiteSet"
+
+usage() {
+  printf '%s\n' \
+    'usage: check-mcp-site-containment.sh [options]' \
+    '' \
+    '  --api-root DIR     apps/api tree to check (default: <repo>/apps/api)' \
+    '  --allowlist FILE   reviewed site-scope surface, with reasons' \
+    "                     (default: infra/mcp-site-containment-allowlist.txt)" \
+    '  --store-doc FILE   read the mcp.Store interface from FILE instead of' \
+    '                     running `go doc` (the self-test uses this; so can you,' \
+    "                     on a machine with no Go toolchain)" \
+    '  -h, --help         this text' \
+    '' \
+    'exit 0 = every site-scope surface is allowlisted and every entry is live' \
+    'exit 1 = a containment violation, or a stale allowlist entry' \
+    'exit 2 = GUARD BROKEN (missing input, empty extraction, control pattern gone)'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --api-root)   API_ROOT="${2:-}";   shift 2 ;;
+    --allowlist)  ALLOWLIST="${2:-}";  shift 2 ;;
+    --store-doc)  STORE_DOC="${2:-}";  shift 2 ;;
+    -h|--help)    usage; exit 0 ;;
+    *) printf 'check-mcp-site-containment: unknown argument: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+MCP_DIR="$API_ROOT/$MCP_PKG_REL"
+
+# GUARD BROKEN is exit 2 and says so in those words, so that a reader of a CI
+# log can tell "the boundary is violated" from "this check no longer works".
+broken() { printf 'check-mcp-site-containment: GUARD BROKEN: %s\n' "$1" >&2; exit 2; }
+
+VIOLATIONS=0
+violation() {
+  VIOLATIONS=$((VIOLATIONS + 1))
+  printf 'check-mcp-site-containment: VIOLATION: %s\n' "$1" >&2
+}
+
+[ -d "$API_ROOT" ] || broken "api root does not exist: $API_ROOT"
+[ -d "$MCP_DIR" ]  || broken "the mcp package is not at $MCP_DIR -- moved or renamed, which is not 'no violations'"
+[ -f "$ALLOWLIST" ] || broken "allowlist not found: $ALLOWLIST"
+[ -r "$ALLOWLIST" ] || broken "allowlist is not readable: $ALLOWLIST"
+
+TMPDIR_RUN="$(mktemp -d 2>/dev/null)" || broken "could not create a temp dir"
+trap 'rm -rf "$TMPDIR_RUN"' EXIT INT TERM
+
+ALLOW_CALL="$TMPDIR_RUN/allow.call"
+ALLOW_PARAM="$TMPDIR_RUN/allow.param"
+ALLOW_TOOLARGS="$TMPDIR_RUN/allow.toolargs"
+FOUND_CALL="$TMPDIR_RUN/found.call"
+FOUND_PARAM="$TMPDIR_RUN/found.param"
+FOUND_TOOLARGS="$TMPDIR_RUN/found.toolargs"
+: >"$ALLOW_CALL"; : >"$ALLOW_PARAM"; : >"$ALLOW_TOOLARGS"
+: >"$FOUND_CALL"; : >"$FOUND_PARAM"; : >"$FOUND_TOOLARGS"
+
+# ---------------------------------------------------------------------------
+# 0. The allowlist.
+#
+# Parsed into three sorted sets. An unrecognised KIND is exit 2 and not a
+# warning: a typo'd kind silently removes an entry from the comparison, which
+# turns a reviewed surface back into an unreviewed one with nothing said.
+# ---------------------------------------------------------------------------
+ALLOW_LINES=0
+while IFS= read -r line || [ -n "$line" ]; do
+  # Strip the reason column, then trailing whitespace.
+  rec="${line%%#*}"
+  rec="$(printf '%s' "$rec" | sed 's/[[:space:]]*$//')"
+  [ -n "$rec" ] || continue
+  ALLOW_LINES=$((ALLOW_LINES + 1))
+  kind="$(printf '%s' "$rec" | awk '{print $1}')"
+  case "$kind" in
+    CALL)
+      value="$(printf '%s' "$rec" | awk '{print $2" "$3}')"
+      case "$value" in
+        *" ") broken "malformed CALL entry in $ALLOWLIST (needs '<path> <func>'): $line" ;;
+      esac
+      printf '%s\n' "$value" >>"$ALLOW_CALL"
+      ;;
+    PARAM)
+      value="$(printf '%s' "$rec" | awk '{print $2}')"
+      case "$value" in
+        *.*) : ;;
+        *) broken "malformed PARAM entry in $ALLOWLIST (needs '<Method>.<param>'): $line" ;;
+      esac
+      printf '%s\n' "$value" >>"$ALLOW_PARAM"
+      ;;
+    TOOLARGS)
+      printf '%s\n' "$(printf '%s' "$rec" | awk '{print $2}')" >>"$ALLOW_TOOLARGS"
+      ;;
+    *)
+      broken "unrecognised allowlist kind '$kind' in $ALLOWLIST: $line"
+      ;;
+  esac
+done <"$ALLOWLIST"
+
+# An empty allowlist is not a pass. The chokepoint has call sites in HEAD and
+# the Store interface has uuid parameters in HEAD; a file that lists none of
+# them is a file that was truncated, not a tree that is clean.
+[ "$ALLOW_LINES" -gt 0 ] || broken "allowlist $ALLOWLIST contains no entries -- truncated or emptied, which is not 'nothing to allow'"
+
+sort -u "$ALLOW_CALL"     -o "$ALLOW_CALL"
+sort -u "$ALLOW_PARAM"    -o "$ALLOW_PARAM"
+sort -u "$ALLOW_TOOLARGS" -o "$ALLOW_TOOLARGS"
+
+# ---------------------------------------------------------------------------
+# RULE A. Chokepoint and SiteSet call sites.
+#
+# Identity is <path relative to apps/api> <enclosing func>. Line numbers are
+# deliberately excluded: an allowlist that goes stale on every unrelated edit
+# above the call gets switched off, and a switched-off guard guards nothing.
+#
+# The enclosing function is found by walking the file, not by regexing the call
+# line, so a call inside a closure is attributed to the top-level function that
+# contains it -- which is the unit a reviewer reads anyway.
+#
+# `_test.go` is excluded. Tests construct SiteSets from literal ids constantly
+# and that is what a test is for; a rule that reddened them would be switched
+# off inside a week. It is also the guard's largest honest gap and is named as
+# such in the header.
+# ---------------------------------------------------------------------------
+GO_FILES="$TMPDIR_RUN/gofiles"
+find "$API_ROOT" -name '*.go' -type f 2>/dev/null | grep -v '_test\.go$' | sort >"$GO_FILES"
+[ -s "$GO_FILES" ] || broken "no non-test .go files found under $API_ROOT -- the tree moved, which is not 'no call sites'"
+
+# Control. If neither name exists in the tree at all, the two rules below are
+# measuring nothing and would report a clean surface. The chokepoint is
+# DEFINED in HEAD, so zero occurrences means it was renamed or deleted.
+if ! grep -q "func (r \*Repo) $CHOKEPOINT(" "$MCP_DIR/repo.go" 2>/dev/null; then
+  broken "$CHOKEPOINT is not defined in $MCP_PKG_REL/repo.go -- renamed, moved or deleted. Rules A and B measure nothing until this is corrected."
+fi
+if ! grep -q "func $SITESET_CTOR(" "$MCP_DIR/model.go" 2>/dev/null; then
+  broken "$SITESET_CTOR is not defined in $MCP_PKG_REL/model.go -- renamed, moved or deleted. Rule A measures nothing until this is corrected."
+fi
+
+while IFS= read -r f; do
+  rel="${f#"$API_ROOT"/}"
+  awk -v rel="$rel" -v chk="$CHOKEPOINT" -v ctor="$SITESET_CTOR" '
+    /^func / {
+      fn = $0
+      sub(/^func +/, "", fn)
+      sub(/^\([^)]*\) */, "", fn)     # strip the receiver
+      sub(/[ (].*$/, "", fn)          # keep the identifier
+      cur = fn
+      next
+    }
+    {
+      # The call forms. `.Chokepoint(` is the method-call form and excludes the
+      # declaration and the interface line, exactly as ADR-061 Decision 4
+      # spells out for InScopedTenantTx. The constructor has no receiver, so it
+      # is matched bare and its own `func NewSiteSet(` declaration is excluded
+      # by the /^func / branch above having already consumed that line.
+      if (index($0, "." chk "(") > 0 || index($0, ctor "(") > 0) {
+        if (cur == "") cur = "(file scope)"
+        print rel " " cur
+      }
+    }
+  ' "$f" >>"$FOUND_CALL"
+done <"$GO_FILES"
+
+sort -u "$FOUND_CALL" -o "$FOUND_CALL"
+
+# Zero call sites is GUARD BROKEN and not a pass. The control greps above prove
+# both functions are DEFINED; if nothing CALLS them, either the surface was
+# rewritten wholesale or this extraction stopped working, and both need a human.
+[ -s "$FOUND_CALL" ] || broken "found zero calls to $CHOKEPOINT / $SITESET_CTOR under $API_ROOT, yet both are defined -- the extraction produced nothing and cannot report containment"
+
+while IFS= read -r entry; do
+  if ! grep -qxF "$entry" "$ALLOW_CALL"; then
+    set -- $entry
+    violation "unreviewed site-scope call site: $MCP_PKG_REL-adjacent file '$1', function '$2'
+    Rule A (ADR-061 A11.1): every call to $CHOKEPOINT or $SITESET_CTOR is part of
+    the site-scope boundary and must be reviewed. If this call resolves a scope
+    that came from the REQUEST rather than from the stored grant, it is the
+    violation A11 item 4 exists to catch -- a site id the client chose being
+    turned into an allowed set. If it is legitimate, add to $ALLOWLIST:
+        CALL $1 $2   # why this is not a request-supplied site id"
+  fi
+done <"$FOUND_CALL"
+
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  if ! grep -qxF "$entry" "$FOUND_CALL"; then
+    violation "stale allowlist entry: CALL $entry matches no call site in the tree.
+    A stale entry means the guard is watching a surface that has moved. Delete
+    it, or correct it to name where the call went."
+  fi
+done <"$ALLOW_CALL"
+
+# ---------------------------------------------------------------------------
+# RULE B. Every uuid parameter on the mcp.Store interface.
+#
+# Read through Go's own parser, after the package type-checks, rather than by
+# grepping repo.go: a wrapped signature, a method moved to another file in the
+# package, or a package that stopped compiling must not be able to make this
+# rule quietly match less.
+# ---------------------------------------------------------------------------
+STORE_DOC_FILE="$TMPDIR_RUN/store.doc"
+if [ -n "$STORE_DOC" ]; then
+  [ -f "$STORE_DOC" ] || broken "--store-doc file does not exist: $STORE_DOC"
+  [ -r "$STORE_DOC" ] || broken "--store-doc file is not readable: $STORE_DOC"
+  cat "$STORE_DOC" >"$STORE_DOC_FILE"
+else
+  # A DoD step that cannot find its binary fails loudly, never skips.
+  command -v go >/dev/null 2>&1 || broken "the go toolchain is not on PATH, so the Store interface cannot be read. Install Go, or pass --store-doc FILE. This check is NOT skippable."
+  ( cd "$API_ROOT" && GOWORK=off $STORE_DOC_CMD_DEFAULT ) >"$STORE_DOC_FILE" 2>"$TMPDIR_RUN/store.err"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf 'check-mcp-site-containment: `%s` failed (exit %d) in %s:\n' "$STORE_DOC_CMD_DEFAULT" "$rc" "$API_ROOT" >&2
+    sed 's/^/    /' "$TMPDIR_RUN/store.err" >&2
+    broken "could not read the mcp.Store interface. A package that does not compile is not a package with no violations."
+  fi
+fi
+
+[ -s "$STORE_DOC_FILE" ] || broken "the mcp.Store interface extraction produced NO OUTPUT. Rule B cannot report containment on an empty interface."
+grep -q 'type Store interface' "$STORE_DOC_FILE" \
+  || broken "the extraction does not contain 'type Store interface' -- the interface was renamed, or the doc format changed. Rule B is measuring nothing."
+grep -q "$CHOKEPOINT(" "$STORE_DOC_FILE" \
+  || broken "the mcp.Store interface no longer declares $CHOKEPOINT. Either the chokepoint left the interface, or the extraction is wrong; both mean Rule B's baseline is gone."
+
+# Method lines: one tab, an upper-case identifier, an open paren. Doc comments
+# in the extraction start `\t//`, blank lines separate, and the closing brace is
+# at column 0, so this selects declarations and nothing else.
+METHODS="$TMPDIR_RUN/store.methods"
+grep -E '^	[A-Z][A-Za-z0-9_]*\(' "$STORE_DOC_FILE" | sed 's/^	//' >"$METHODS"
+[ -s "$METHODS" ] || broken "parsed ZERO methods out of the mcp.Store interface. The doc format changed; Rule B would pass on any tree at all in this state."
+
+# For each method, every parameter binding whose type is uuid.UUID or
+# []uuid.UUID. Go groups names: `tenantID, grantID, tokenID uuid.UUID` binds
+# three. Each is emitted as Method.name.
+#
+# THE PARSE IS SEGMENT-BASED AND NOT A REGEX OVER THE WHOLE SIGNATURE. The
+# obvious regex -- `<name>( *, *<name>)* +uuid.UUID` -- matched the TYPE half of
+# a qualified name: in `ctx context.Context, tenantID uuid.UUID` it started at
+# `Context` and reported a parameter called `Context`. It reported `string` out
+# of `mode string, tagIDs, siteIDs []uuid.UUID` for the same reason. Both are
+# noise that a reviewer would allowlist to make the guard quiet, and a guard
+# that has been made quiet is off. So: cut the parameter list at its matching
+# paren, flatten nested func(...) types into the same comma-separated stream,
+# and walk the segments the way the Go grammar reads them -- bare segments are
+# names sharing the type of the segment that terminates the group.
+awk '
+  function emit_group(m, acc, n, i, names) {
+    n = split(acc, names, "\001")
+    for (i = 1; i <= n; i++) if (names[i] != "") print m "." names[i]
+  }
+  {
+    line = $0
+    m = line
+    sub(/\(.*$/, "", m)                       # method name
+
+    # 1. The parameter list, cut at the paren that closes it.
+    start = index(line, "(")
+    if (start == 0) next
+    depth = 0; params = ""
+    for (i = start; i <= length(line); i++) {
+      c = substr(line, i, 1)
+      if (c == "(") { depth++; if (depth == 1) continue }
+      else if (c == ")") { depth--; if (depth == 0) break }
+      params = params c
+    }
+    if (params == "") next
+
+    # 2. Flatten nested parens so callback parameters -- `mkCode func(grantID
+    #    uuid.UUID) sqlc.X` -- are walked too. They are part of the reviewed
+    #    surface: a callback taking a site id is a site id crossing the
+    #    boundary in the other direction.
+    gsub(/[()]/, ",", params)
+
+    # 3. Walk the segments.
+    n = split(params, segs, ",")
+    acc = ""
+    for (i = 1; i <= n; i++) {
+      s = segs[i]
+      gsub(/^[ \t]+|[ \t]+$/, "", s)
+      if (s == "") continue
+      if (s ~ /^[A-Za-z_][A-Za-z0-9_]*$/) {
+        # A bare identifier: either a grouped name awaiting its type, or an
+        # unnamed parameter whose type happens to be unqualified. Carrying it
+        # is the safe direction -- a spurious entry is visible, a dropped one
+        # is not.
+        acc = (acc == "" ? s : acc "\001" s)
+        continue
+      }
+      # `name type`. Only the first two tokens matter.
+      nm = s; ty = s
+      sub(/[ \t].*$/, "", nm)
+      sub(/^[^ \t]+[ \t]+/, "", ty)
+      if (ty == "uuid.UUID" || ty == "[]uuid.UUID") {
+        if (nm ~ /^[A-Za-z_][A-Za-z0-9_]*$/ && nm !~ /\./) {
+          acc = (acc == "" ? nm : acc "\001" nm)
+          emit_group(m, acc)
+        }
+      }
+      acc = ""
+    }
+  }
+' "$METHODS" | sort -u >"$FOUND_PARAM"
+
+# Zero uuid parameters on an interface that HEAD declares with many is an
+# extraction failure, not a clean surface.
+[ -s "$FOUND_PARAM" ] || broken "found ZERO uuid parameters on mcp.Store. HEAD declares several, so this is a parse failure, and a parse failure that reports containment is the defect this guard exists to prevent."
+
+while IFS= read -r entry; do
+  if ! grep -qxF "$entry" "$ALLOW_PARAM"; then
+    meth="${entry%%.*}"
+    parm="${entry#*.}"
+    loc="$(grep -n "$meth(" "$MCP_DIR/repo.go" 2>/dev/null | head -1 | cut -d: -f1)"
+    [ -n "$loc" ] || loc="?"
+    violation "unreviewed uuid parameter on the mcp.Store database boundary:
+    $MCP_PKG_REL/repo.go:$loc  $meth(... $parm ...)
+    Rule B (ADR-061 A11.4): '$parm' is a uuid this surface hands to the database.
+    If it is a SITE ID that came from a request, this is the bypass: A11 says no
+    handler may pass a request-supplied site id anywhere but $CHOKEPOINT, and a
+    Store method taking one goes round it. Route it through $CHOKEPOINT and
+    filter with SiteSet.Allows. If it is not a site id, add to $ALLOWLIST:
+        PARAM $entry   # what this id is and where it comes from"
+  fi
+done <"$FOUND_PARAM"
+
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  if ! grep -qxF "$entry" "$FOUND_PARAM"; then
+    violation "stale allowlist entry: PARAM $entry is not on the mcp.Store interface.
+    The method or the parameter was renamed or removed. Delete the entry, or
+    correct it -- an allowlist naming things that no longer exist is not
+    protecting the things that do."
+  fi
+done <"$ALLOW_PARAM"
+
+# ---------------------------------------------------------------------------
+# RULE C. The tool argument surface.
+#
+# toolInvoker's last parameter is the request's own tool arguments. Phase 1's
+# single tool discards it. The first file that binds it to a name is the first
+# file where a client-chosen site id can enter, and A11 item 4's sentence
+# becomes violable there and nowhere earlier.
+# ---------------------------------------------------------------------------
+INVOKER_DECL='type toolInvoker func('
+grep -qF "$INVOKER_DECL" "$MCP_DIR/registry.go" 2>/dev/null \
+  || broken "the toolInvoker declaration is not in $MCP_PKG_REL/registry.go. Rule C's subject moved or was renamed; it is matching nothing."
+
+# Bind = the args parameter has a name. `_ json.RawMessage` is a discard and is
+# the compliant form. The type declaration itself names the parameter and is
+# excluded, since a type is not a handler.
+find "$MCP_DIR" -name '*.go' -type f 2>/dev/null | grep -v '_test\.go$' | sort >"$TMPDIR_RUN/mcpfiles"
+[ -s "$TMPDIR_RUN/mcpfiles" ] || broken "no non-test .go files in $MCP_DIR -- the package moved, which is not 'no tool arguments'"
+
+while IFS= read -r f; do
+  rel="${f#"$API_ROOT"/}"
+  # `_ json.RawMessage` is the compliant discard and must NOT match. A single
+  # underscore is a legal Go identifier, so `[A-Za-z_][A-Za-z0-9_]*` matched it
+  # and reported the one compliant tool in HEAD as a violation. The alternation
+  # below admits `_foo` (a real, if unusual, binding) and excludes bare `_`.
+  grep -nE 'auth AuthorizedRequest,[ ]*(_[A-Za-z0-9_]+|[A-Za-z][A-Za-z0-9_]*)[ ]+json\.RawMessage' "$f" 2>/dev/null \
+    | grep -v '^[0-9]*:type ' \
+    | while IFS= read -r hit; do
+        printf '%s\n' "$rel"
+      done
+done <"$TMPDIR_RUN/mcpfiles" | sort -u >"$FOUND_TOOLARGS"
+
+# NOTE: an empty result here is CORRECT and is not GUARD BROKEN -- the compliant
+# state of this rule is zero matches. That is why the control grep above (the
+# toolInvoker declaration must exist) is load-bearing: it is what separates
+# "no tool reads its arguments" from "this rule stopped matching anything".
+
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  if ! grep -qxF "$entry" "$ALLOW_TOOLARGS"; then
+    violation "unreviewed tool-argument surface: $entry binds toolInvoker's
+    request arguments to a name, so a client can now put values in them.
+    Rule C (ADR-061 A11.4): if any of those values is a site id, it MUST reach
+    $CHOKEPOINT and be filtered through the resolved SiteSet -- it must never be
+    handed to the database or compared against a grant column directly. Review
+    it, then add to $ALLOWLIST:
+        TOOLARGS $entry   # which arguments this file reads, and how site ids in them are contained"
+  fi
+done <"$FOUND_TOOLARGS"
+
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  if ! grep -qxF "$entry" "$FOUND_TOOLARGS"; then
+    violation "stale allowlist entry: TOOLARGS $entry no longer reads tool arguments.
+    Delete the entry so the file goes back to being default-closed."
+  fi
+done <"$ALLOW_TOOLARGS"
+
+# ---------------------------------------------------------------------------
+# RULE D. The backstop named in gap 2 of the header.
+#
+# Rule B's subject is the Store interface. A file in package mcp that imports
+# the sqlc package or pgx directly is a file that could talk to the database
+# without going through Store at all, which is where a second, unwatched path
+# would begin. repo.go is the one file whose job that is.
+# ---------------------------------------------------------------------------
+while IFS= read -r f; do
+  rel="${f#"$API_ROOT"/}"
+  case "$rel" in
+    "$MCP_PKG_REL/repo.go") continue ;;
+  esac
+  if grep -qE '"github\.com/jackc/pgx/v5"' "$f" 2>/dev/null; then
+    # pgx types appear in callback signatures the Store interface hands out
+    # (onCreated func(tx pgx.Tx, ...)), so an import alone is not a finding
+    # unless the file also builds its own queries.
+    if grep -qE 'sqlc\.New\(' "$f" 2>/dev/null; then
+      violation "$rel builds its own sqlc.Queries.
+    Rule D (backstop for ADR-061 A11.4): package mcp reaches the database
+    through the Store interface, which is what Rule B watches. A second path
+    built here is outside that watch, and a site id could travel it. Move the
+    query behind a Store method so it is covered."
+    fi
+  fi
+done <"$TMPDIR_RUN/mcpfiles"
+
+# ---------------------------------------------------------------------------
+# Report.
+# ---------------------------------------------------------------------------
+n_call="$(grep -c . "$FOUND_CALL")"
+n_param="$(grep -c . "$FOUND_PARAM")"
+n_toolargs="$(grep -c . "$FOUND_TOOLARGS")"
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  printf '\ncheck-mcp-site-containment: FAILED with %d violation(s).\n' "$VIOLATIONS" >&2
+  printf 'ADR-061 A11 item 4: no handler on the assistant surface may take a site id\n' >&2
+  printf 'from a request and pass it anywhere but %s.\n' "$CHOKEPOINT" >&2
+  printf 'Allowlist: %s\n' "$ALLOWLIST" >&2
+  exit 1
+fi
+
+printf 'check-mcp-site-containment: OK\n'
+printf '  Rule A  %s chokepoint / %s call site(s), all reviewed\n' "$n_call" "$SITESET_CTOR"
+printf '  Rule B  %s uuid parameter(s) on the mcp.Store boundary, all reviewed\n' "$n_param"
+printf '  Rule C  %s file(s) reading tool arguments (0 is the Phase 1 state)\n' "$n_toolargs"
+printf '  Rule D  no second database path in package mcp\n'
+exit 0

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -300,24 +300,43 @@ fi
 while IFS= read -r f; do
   rel="${f#"$API_ROOT"/}"
   awk -v rel="$rel" -v chk="$CHOKEPOINT" -v ctor="$SITESET_CTOR" '
+    # THE MATCH IS WHITESPACE-INSENSITIVE AND SPANS A LINE BREAK, because both
+    # are ordinary Go that the old index() form did not see:
+    #
+    #     s.store.ResolveScopeSites (ctx, ...)     <- a space before the paren
+    #     s.store.                                 <- receiver dot, then a
+    #         ResolveScopeSites(ctx, ...)             newline
+    #
+    # Both compile, both are what gofmt leaves alone, and neither contains the
+    # substring ".ResolveScopeSites(". A containment guard that ordinary
+    # formatting defeats is worse than none: it reports green while the
+    # property is unenforced. So the test runs over a two-line window with
+    # whitespace runs collapsed, which is the smallest normalisation that makes
+    # every valid layout of a single call look the same.
+    BEGIN {
+      callre = "\\.[ ]*" chk "[ ]*\\("
+      ctorre = "(^|[^A-Za-z0-9_.])" ctor "[ ]*\\("
+    }
     /^func / {
       fn = $0
       sub(/^func +/, "", fn)
       sub(/^\([^)]*\) */, "", fn)     # strip the receiver
       sub(/[ (].*$/, "", fn)          # keep the identifier
       cur = fn
+      # The declaration line is not a call site, and clearing the window is
+      # what keeps `func NewSiteSet(` from being matched as a bare constructor
+      # call by the NEXT line`s window.
+      prev = ""
       next
     }
     {
-      # The call forms. `.Chokepoint(` is the method-call form and excludes the
-      # declaration and the interface line, exactly as ADR-061 Decision 4
-      # spells out for InScopedTenantTx. The constructor has no receiver, so it
-      # is matched bare and its own `func NewSiteSet(` declaration is excluded
-      # by the /^func / branch above having already consumed that line.
-      if (index($0, "." chk "(") > 0 || index($0, ctor "(") > 0) {
+      win = prev " " $0
+      gsub(/[ \t]+/, " ", win)
+      if (win ~ callre || win ~ ctorre) {
         if (cur == "") cur = "(file scope)"
         print rel " " cur
       }
+      prev = $0
     }
   ' "$f" >>"$FOUND_CALL"
 done <"$GO_FILES"
@@ -510,15 +529,69 @@ grep -qF "$INVOKER_DECL" "$MCP_DIR/registry.go" 2>/dev/null \
 find "$MCP_DIR" -name '*.go' -type f 2>/dev/null | grep -v '_test\.go$' | sort >"$TMPDIR_RUN/mcpfiles"
 [ -s "$TMPDIR_RUN/mcpfiles" ] || broken "no non-test .go files in $MCP_DIR -- the package moved, which is not 'no tool arguments'"
 
+# THE SUBJECT IS THE SIGNATURE SHAPE, NOT A PARAMETER NAME.
+#
+# The first form of this rule keyed on the literal text `auth AuthorizedRequest,`
+# followed by a named json.RawMessage. That was wrong in both directions, and
+# both were measured on this tree rather than imagined:
+#
+#   IT UNDER-FIRED. The name `auth` is the tool author's choice. A handler
+#   written `func(ctx context.Context, svc *Service, req AuthorizedRequest,
+#   args json.RawMessage)` is a conforming toolInvoker that reads its
+#   arguments, and the old pattern did not see it. So did a signature wrapped
+#   across lines, which is what gofmt does to a long one.
+#
+#   IT OVER-FIRED, which is worse. On this tree it matched
+#   internal/mcp/transport.go:1045, `writeProtocolRefusal(c *gin.Context, auth
+#   AuthorizedRequest, id json.RawMessage, neg Negotiation, phase string)`,
+#   where the json.RawMessage is the JSON-RPC ENVELOPE ID being echoed back
+#   into an error response -- not tool arguments at all. The obvious way to
+#   quiet that is `TOOLARGS internal/mcp/transport.go`, and Rule C's
+#   granularity is the file, so that entry would have switched Rule C off for
+#   the one file that actually dispatches tools. A guard that reddens correct
+#   work gets made quiet, and a guard that has been made quiet is off.
+#
+# So the match is the toolInvoker TYPE SEQUENCE, with every parameter name
+# free: context.Context, *Service, AuthorizedRequest, json.RawMessage, closing
+# to (string, error). That shape is what makes a function assignable to
+# toolInvoker, it is what a reviewer means by "a tool", and it cannot be
+# renamed out of. The file is flattened to one whitespace-collapsed stream
+# first, so a signature broken across lines reads the same as one on a line.
+# The trailing `,?` before the closing paren is not cosmetic: gofmt puts a
+# trailing comma on the last parameter of every signature it wraps across
+# lines, so without it the rule would see the one-line form and miss the
+# wrapped one -- which is the formatting a long signature actually gets.
+TOOLARGS_SIG='\([ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+context\.Context[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+\*[ ]*Service[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+AuthorizedRequest[ ]*,[ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+json\.RawMessage[ ]*,?[ ]*\)[ ]*\([ ]*string[ ]*,[ ]*error[ ]*\)'
+
+# Control. The flattening plus this pattern must still find the toolInvoker
+# declaration itself in registry.go. If it does not, the shape changed and the
+# rule is matching nothing -- which would report the compliant state.
+FLAT_REGISTRY="$TMPDIR_RUN/flat.registry"
+tr '\n' ' ' <"$MCP_DIR/registry.go" 2>/dev/null | tr -s ' \t' ' ' >"$FLAT_REGISTRY"
+grep -qE "$TOOLARGS_SIG" "$FLAT_REGISTRY" 2>/dev/null \
+  || broken "the toolInvoker signature shape no longer matches $MCP_PKG_REL/registry.go. Rule C's pattern is stale and would report zero tool-argument surfaces on any tree."
+
 while IFS= read -r f; do
   rel="${f#"$API_ROOT"/}"
-  # `_ json.RawMessage` is the compliant discard and must NOT match. A single
-  # underscore is a legal Go identifier, so `[A-Za-z_][A-Za-z0-9_]*` matched it
-  # and reported the one compliant tool in HEAD as a violation. The alternation
-  # below admits `_foo` (a real, if unusual, binding) and excludes bare `_`.
-  grep -nE 'auth AuthorizedRequest,[ ]*(_[A-Za-z0-9_]+|[A-Za-z][A-Za-z0-9_]*)[ ]+json\.RawMessage' "$f" 2>/dev/null \
-    | grep -v '^[0-9]*:type ' \
-    | while IFS= read -r hit; do
+  flat="$TMPDIR_RUN/flat.one"
+  # The `type toolInvoker func(...)` declaration has the shape by definition --
+  # it IS the shape -- and a type is not a handler. It is DELETED from the
+  # stream rather than compared against, because a conforming handler is
+  # textually identical to the declaration once both are flattened, so any
+  # equality test would discard the handler along with the type.
+  tr '\n' ' ' <"$f" 2>/dev/null | tr -s ' \t' ' ' \
+    | sed -E "s/type[ ]+toolInvoker[ ]+func[ ]*$TOOLARGS_SIG//g" >"$flat"
+
+  # Every remaining occurrence of the shape, one per line. `_ json.RawMessage`
+  # is the compliant discard: a bare underscore binds nothing, so the tool
+  # cannot name a site at all. `_foo` IS a real binding and must match, which is
+  # why the discard is excluded by an exact test on the parameter name rather
+  # than by an alternation that a leading underscore slips through.
+  grep -oE "$TOOLARGS_SIG" "$flat" 2>/dev/null \
+    | while IFS= read -r sig; do
+        # The args parameter name: the token before `json.RawMessage`.
+        argname="$(printf '%s' "$sig" | sed 's/.*,[ ]*\([A-Za-z_][A-Za-z0-9_]*\)[ ]*json\.RawMessage.*/\1/')"
+        [ "$argname" = "_" ] && continue
         printf '%s\n' "$rel"
       done
 done <"$TMPDIR_RUN/mcpfiles" | sort -u >"$FOUND_TOOLARGS"

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -304,7 +304,7 @@ broken() { printf 'check-mcp-site-containment: GUARD BROKEN: %s\n' "$1" >&2; exi
 # Handles: line comments, block comments, interpreted strings with escapes, raw
 # backtick strings, and rune literals. State persists across lines, so
 # multi-line block comments and raw strings are handled too.
-flatten_go() {
+strip_comments_go() {
   awk '
     BEGIN { st = "code" }
     {
@@ -336,9 +336,18 @@ flatten_go() {
       }
       print out
     }
-  ' "$1" 2>/dev/null \
-    | tr '\n' ' ' \
-    | tr -s ' \t' ' '
+  ' "$1" 2>/dev/null
+}
+
+# Flatten = strip comments, then join to one line.
+#
+# The two are SEPARATE because Rule A needs the stripped-but-still-line-
+# structured form: it attributes every call to its enclosing function by
+# walking lines and watching for `^func `, so it cannot use a flattened file.
+# It also cannot use the RAW file, which is what made it read English prose as
+# Go. See the note on Rule A's window.
+flatten_go() {
+  strip_comments_go "$1" | tr '\n' ' ' | tr -s ' \t' ' '
 }
 
 VIOLATIONS=0
@@ -450,7 +459,7 @@ fi
 
 while IFS= read -r f; do
   rel="${f#"$API_ROOT"/}"
-  awk -v rel="$rel" -v chk="$CHOKEPOINT" -v ctor="$SITESET_CTOR" '
+  strip_comments_go "$f" | awk -v rel="$rel" -v chk="$CHOKEPOINT" -v ctor="$SITESET_CTOR" '
     # THE MATCH IS WHITESPACE-INSENSITIVE AND SPANS A LINE BREAK, because both
     # are ordinary Go that the old index() form did not see:
     #
@@ -464,6 +473,21 @@ while IFS= read -r f; do
     # property is unenforced. So the test runs over a two-line window with
     # whitespace runs collapsed, which is the smallest normalisation that makes
     # every valid layout of a single call look the same.
+    #
+    # THE INPUT IS COMMENT-STRIPPED, AND THAT IS NOT OPTIONAL. English prose
+    # ends sentences with a full stop, so a doc comment reading
+    #
+    #     // ... must justify it there.
+    #     ResolveScopeSites(ctx context.Context, ...)
+    #
+    # puts a period at the end of one line and the chokepoint name at the
+    # start of the next -- which is character-for-character the receiver-dot
+    # split this window exists to catch. It fired on exactly that in repo.go
+    # and reported the declaration on the Store interface as an unreviewed
+    # call site at "(file scope)". Over-firing is worse than missing: a guard
+    # that reddens correct work gets switched off, and then it guards nothing.
+    # NOTE: no apostrophes in this block -- it is inside a single-quoted awk
+    # program, and one would end it.
     BEGIN {
       callre = "\\.[ ]*" chk "[ ]*\\("
       ctorre = "(^|[^A-Za-z0-9_.])" ctor "[ ]*\\("
@@ -489,7 +513,7 @@ while IFS= read -r f; do
       }
       prev = $0
     }
-  ' "$f" >>"$FOUND_CALL"
+  ' >>"$FOUND_CALL"
 done <"$GO_FILES"
 
 sort -u "$FOUND_CALL" -o "$FOUND_CALL"

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -725,6 +725,12 @@ PGXPOOL_RE='"github\.com/jackc/pgx/v5/pgxpool"'
 dbpath_mechanism() {
   # Prints the mechanism this file uses to execute SQL, or nothing.
   _f="$1"
+  # FLATTENED FIRST, for the same reason Rule C is: `tx.QueryRow(` with its
+  # context argument on the next line is ordinary gofmt output, and a
+  # line-oriented grep does not match it -- which would drop the file from
+  # DBPATH_HITS and report successful containment over a live database path.
+  _flat="$TMPDIR_RUN/flat.dbpath"
+  tr '\n' ' ' <"$_f" 2>/dev/null | tr -s ' \t' ' ' >"$_flat"
   # The local name bound to the sqlc package in THIS file, alias or not.
   _sqlc="$(sed -nE 's|^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)?[[:space:]]*"github\.com/mosamlife/wpmgr/apps/api/internal/db/sqlc".*|\1|p' "$_f" 2>/dev/null | head -1)"
   [ -n "$_sqlc" ] || _sqlc="sqlc"
@@ -732,7 +738,7 @@ dbpath_mechanism() {
     printf 'builds its own %s.Queries via %s.New(\n' "$_sqlc" "$_sqlc"
     return 0
   fi
-  if grep -qE "$PGX_OPS_RE" "$_f" 2>/dev/null; then
+  if grep -qE "$PGX_OPS_RE" "$_flat" 2>/dev/null; then
     printf 'executes SQL directly (pgx Query/Exec/SendBatch/CopyFrom)\n'
     return 0
   fi

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -165,11 +165,25 @@ usage() {
     'exit 2 = GUARD BROKEN (missing input, empty extraction, control pattern gone)'
 }
 
+# An option with no value is exit 2, not a hang. `shift 2` with one argument
+# left FAILS and shifts nothing, so `$1` is still the option and the loop
+# spins forever -- a CI job that never finishes and never reports, which is the
+# worst of the three outcomes because it looks like a slow runner rather than a
+# broken guard. Checked before the assignment, so the arity error is reported
+# rather than a default being silently substituted for the missing value.
+need_value() {
+  [ "$2" -ge 2 ] || {
+    printf 'check-mcp-site-containment: %s requires a value\n' "$1" >&2
+    usage >&2
+    exit 2
+  }
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --api-root)   API_ROOT="${2:-}";   shift 2 ;;
-    --allowlist)  ALLOWLIST="${2:-}";  shift 2 ;;
-    --store-doc)  STORE_DOC="${2:-}";  shift 2 ;;
+    --api-root)   need_value --api-root  $#; API_ROOT="$2";  shift 2 ;;
+    --allowlist)  need_value --allowlist $#; ALLOWLIST="$2"; shift 2 ;;
+    --store-doc)  need_value --store-doc $#; STORE_DOC="$2"; shift 2 ;;
     -h|--help)    usage; exit 0 ;;
     *) printf 'check-mcp-site-containment: unknown argument: %s\n' "$1" >&2; usage >&2; exit 2 ;;
   esac

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -71,6 +71,20 @@
 #      That is the exact moment A11's sentence becomes possible to violate, so
 #      it is the moment a reviewer is made to look.
 #
+#      The subject is the toolInvoker TYPE SEQUENCE, not any parameter NAME.
+#      Names are the tool author's choice, so a rule keyed on one is a rule
+#      that renaming defeats -- and, on this tree, one that collided with an
+#      unrelated function whose json.RawMessage was a JSON-RPC envelope id.
+#
+#   D. SECOND DATABASE PATHS. Rules A to C all assume the database is reached
+#      through mcp.Store. Rule D is the backstop for a file that goes round it,
+#      and its subject is EXECUTING SQL -- an sqlc Queries built through
+#      whatever local name the file's import block binds, a direct pgx
+#      Query/QueryRow/Exec/SendBatch/CopyFrom, or a held pgxpool. repo.go is
+#      exempt because that is its job; any other file needs a DBPATH entry,
+#      which is how a Store implementation legitimately split across files is
+#      recorded. Checked in both directions, like every other kind.
+#
 # WHAT THIS CANNOT CATCH -- read this before trusting it. See the block at the
 # bottom of this header.
 #
@@ -103,25 +117,42 @@
 # ---------------------------------------------------------------------------
 # WHAT THIS GUARD CANNOT CATCH
 #
+# THIS BLOCK IS THE POINT OF THE GUARD AS MUCH AS THE RULES ARE. It is what
+# stops the next person trusting it further than it goes, so it is kept
+# accurate: when a rule gets stronger, the corresponding entry here shrinks,
+# and when a fix leaves a residue, the residue is written down. Everything
+# below has been checked against the implementation as it stands, not inherited
+# from an earlier version of it.
+#
 #   1. It is a STRUCTURAL guard, not a taint analysis. It proves that every
 #      channel by which a site id could reach the database has been looked at
 #      by a human, and that no new one appeared unnoticed. It does not prove the
 #      human looked correctly. An allowlist entry with a wrong reason passes.
+#      This is the big one and no amount of parsing fixes it.
 #
 #   2. Rule B's subject is the mcp.Store interface. A handler that reaches the
-#      database WITHOUT going through Store -- a second interface, a *db.Pool
-#      held directly, an sqlc.Queries built in a handler -- is outside its
-#      reach. Rule D below is a partial backstop: it refuses a direct sqlc or
-#      pgx import in any file of package mcp other than repo.go, which is where
-#      such a second path would have to start. It is a backstop and not a proof:
-#      a new Repo method wired through a NEW interface declared elsewhere in the
-#      package would satisfy both rules.
+#      database WITHOUT going through Store is outside its reach. Rule D is the
+#      backstop and now covers all three mechanisms available in this package
+#      -- an sqlc Queries built through any local name for the package, a
+#      direct pgx Query/QueryRow/Exec/SendBatch/CopyFrom, and a held pgxpool --
+#      in every file except repo.go and the reviewed DBPATH exceptions.
+#      WHAT STILL GETS THROUGH: a file that executes no SQL itself but calls a
+#      helper in ANOTHER package that holds the pool; and `database/sql` or a
+#      query builder, neither of which this repo uses. A new Repo method wired
+#      through a NEW interface declared inside the package no longer passes
+#      silently -- Rule D catches the file that executes the SQL -- but it is
+#      caught as an unreviewed DBPATH, not as an unreviewed interface, so the
+#      reviewer is pointed at the file rather than at the interface.
 #
 #   3. Rule C's granularity is the FILE, not the tool. Once one file is
 #      allowlisted for reading tool arguments, a second tool added to that same
 #      file inherits the allowance. The allowlist reason is therefore a promise
 #      about the file, and a reviewer adding a tool to an allowlisted file gets
-#      no signal from this guard.
+#      no signal from this guard. Rule C also matches the toolInvoker TYPE
+#      SEQUENCE exactly; a tool reached through an adapter with a different
+#      signature, a method value, or a generic wrapper is not that shape and is
+#      not seen. The control grep against registry.go is what catches the
+#      whole shape going stale, not a change of shape in one handler.
 #
 #   4. It checks the mcp package only, because A11 is about this surface. A site
 #      id taken from a request by some OTHER package and handed to mcp is not in
@@ -130,6 +161,25 @@
 #   5. It is a compile-time, source-level check. It says nothing about whether
 #      the chokepoint's own SQL is correct; that is the integration proof's job
 #      (A11 item 6), and this guard is not a substitute for it.
+#
+#   6. RULE A'S WINDOW IS TWO LINES. `s.store.` then a newline then
+#      `ResolveScopeSites(` is caught; a call broken across THREE or more lines,
+#      or with a comment line interposed between the receiver and the method
+#      name, is not. gofmt does not produce either, so this catches every
+#      layout the formatter will leave in the tree, and not a layout chosen
+#      specifically to evade it.
+#
+#   7. RULES A, C AND D READ TEXT WITH COMMENTS AND STRING LITERALS INTACT.
+#      The chokepoint's name inside a comment or a string produces a phantom
+#      call site. That is the safe direction -- it over-reports, and an
+#      unreviewed entry is visible -- but it is noise a reviewer may be tempted
+#      to allowlist, and an allowlist entry written to quiet noise is an
+#      allowlist entry with a wrong reason. See 1.
+#
+#   8. Rule D's mechanisms are matched per file, so a file that both executes
+#      SQL legitimately (a reviewed DBPATH) and grows a second, illegitimate
+#      query later gets no new signal -- the same file-granularity limit as
+#      Rule C in 3.
 # ---------------------------------------------------------------------------
 
 set -uo pipefail
@@ -212,10 +262,11 @@ trap 'rm -rf "$TMPDIR_RUN"' EXIT INT TERM
 ALLOW_CALL="$TMPDIR_RUN/allow.call"
 ALLOW_PARAM="$TMPDIR_RUN/allow.param"
 ALLOW_TOOLARGS="$TMPDIR_RUN/allow.toolargs"
+ALLOW_DBPATH="$TMPDIR_RUN/allow.dbpath"
 FOUND_CALL="$TMPDIR_RUN/found.call"
 FOUND_PARAM="$TMPDIR_RUN/found.param"
 FOUND_TOOLARGS="$TMPDIR_RUN/found.toolargs"
-: >"$ALLOW_CALL"; : >"$ALLOW_PARAM"; : >"$ALLOW_TOOLARGS"
+: >"$ALLOW_CALL"; : >"$ALLOW_PARAM"; : >"$ALLOW_TOOLARGS"; : >"$ALLOW_DBPATH"
 : >"$FOUND_CALL"; : >"$FOUND_PARAM"; : >"$FOUND_TOOLARGS"
 
 # ---------------------------------------------------------------------------
@@ -252,6 +303,9 @@ while IFS= read -r line || [ -n "$line" ]; do
     TOOLARGS)
       printf '%s\n' "$(printf '%s' "$rec" | awk '{print $2}')" >>"$ALLOW_TOOLARGS"
       ;;
+    DBPATH)
+      printf '%s\n' "$(printf '%s' "$rec" | awk '{print $2}')" >>"$ALLOW_DBPATH"
+      ;;
     *)
       broken "unrecognised allowlist kind '$kind' in $ALLOWLIST: $line"
       ;;
@@ -266,6 +320,7 @@ done <"$ALLOWLIST"
 sort -u "$ALLOW_CALL"     -o "$ALLOW_CALL"
 sort -u "$ALLOW_PARAM"    -o "$ALLOW_PARAM"
 sort -u "$ALLOW_TOOLARGS" -o "$ALLOW_TOOLARGS"
+sort -u "$ALLOW_DBPATH"   -o "$ALLOW_DBPATH"
 
 # ---------------------------------------------------------------------------
 # RULE A. Chokepoint and SiteSet call sites.
@@ -630,24 +685,98 @@ done <"$ALLOW_TOOLARGS"
 # without going through Store at all, which is where a second, unwatched path
 # would begin. repo.go is the one file whose job that is.
 # ---------------------------------------------------------------------------
+# THE OLD FORM GATED EVERYTHING ON ONE IMPORT AND ONE LITERAL, and both halves
+# leaked:
+#
+#   The outer test required the exact root import "github.com/jackc/pgx/v5".
+#   sqlc.New takes a DBTX, so `sqlc.New(pool)` with a *pgxpool.Pool -- a
+#   different import path -- built a second Queries and the outer grep never
+#   ran the inner one.
+#
+#   The inner test required the literal `sqlc.New(`. A file that imports pgx
+#   and runs tx.Query / tx.Exec directly executes SQL without ever calling it,
+#   and Rule D then printed "no second database path in package mcp" over a
+#   second database path.
+#
+# So the subject is now EXECUTING SQL, by any of the three mechanisms available
+# in this package, and the import gate is gone. The sqlc constructor is
+# resolved through the file's own import block so an alias
+# (`q "…/internal/db/sqlc"` then `q.New(tx)`) is not a way round it.
+#
+# Rule D is a BACKSTOP and it has reviewed exceptions -- the Store
+# implementation is allowed to be split across more than one file -- so it
+# reads DBPATH entries from the allowlist and is checked in both directions
+# like every other rule. Before this, its only exception was the hard-coded
+# name repo.go, and a reviewed second file was unrepresentable.
+DBPATH_HITS="$TMPDIR_RUN/found.dbpath"
+: >"$DBPATH_HITS"
+
+# Every way this package can execute SQL. The shape of the first argument --
+# an identifier followed by a comma -- is what separates a pgx call from an
+# unrelated .Exec on some other value: pgx takes a context first on all five.
+# It deliberately does NOT require that identifier to be spelled `ctx`, because
+# the parameter name is the author's choice and keying on it would make
+# `tx.Query(reqCtx, ...)` a way round the rule -- the same mistake Rule C made
+# with `auth`. Measured against the real tree: this matches no non-test file in
+# package mcp outside repo.go, so the broader form costs no false positives.
+PGX_OPS_RE='\.(Query|QueryRow|Exec|SendBatch|CopyFrom)[ ]*\([ ]*[A-Za-z_][A-Za-z0-9_]*[ ]*,'
+PGXPOOL_RE='"github\.com/jackc/pgx/v5/pgxpool"'
+
+dbpath_mechanism() {
+  # Prints the mechanism this file uses to execute SQL, or nothing.
+  _f="$1"
+  # The local name bound to the sqlc package in THIS file, alias or not.
+  _sqlc="$(sed -nE 's|^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)?[[:space:]]*"github\.com/mosamlife/wpmgr/apps/api/internal/db/sqlc".*|\1|p' "$_f" 2>/dev/null | head -1)"
+  [ -n "$_sqlc" ] || _sqlc="sqlc"
+  if grep -qE "(^|[^A-Za-z0-9_.])${_sqlc}\.New[ ]*\(" "$_f" 2>/dev/null; then
+    printf 'builds its own %s.Queries via %s.New(\n' "$_sqlc" "$_sqlc"
+    return 0
+  fi
+  if grep -qE "$PGX_OPS_RE" "$_f" 2>/dev/null; then
+    printf 'executes SQL directly (pgx Query/Exec/SendBatch/CopyFrom)\n'
+    return 0
+  fi
+  if grep -qE "$PGXPOOL_RE" "$_f" 2>/dev/null; then
+    printf 'holds a pgxpool connection pool\n'
+    return 0
+  fi
+  return 1
+}
+
+# CONTROL. repo.go is the file whose job this is, so it MUST match at least one
+# mechanism. If it does not, the patterns are stale and Rule D would report a
+# clean package whatever the package contained -- the failure mode this whole
+# guard exists to refuse.
+dbpath_mechanism "$MCP_DIR/repo.go" >/dev/null \
+  || broken "Rule D's database-access patterns match nothing in $MCP_PKG_REL/repo.go, the one file whose job that is. The patterns are stale and Rule D would report 'no second database path' on any tree."
+
 while IFS= read -r f; do
   rel="${f#"$API_ROOT"/}"
   case "$rel" in
     "$MCP_PKG_REL/repo.go") continue ;;
   esac
-  if grep -qE '"github\.com/jackc/pgx/v5"' "$f" 2>/dev/null; then
-    # pgx types appear in callback signatures the Store interface hands out
-    # (onCreated func(tx pgx.Tx, ...)), so an import alone is not a finding
-    # unless the file also builds its own queries.
-    if grep -qE 'sqlc\.New\(' "$f" 2>/dev/null; then
-      violation "$rel builds its own sqlc.Queries.
+  mech="$(dbpath_mechanism "$f")" || continue
+  printf '%s\n' "$rel" >>"$DBPATH_HITS"
+  if ! grep -qxF "$rel" "$ALLOW_DBPATH"; then
+    violation "$rel $mech
     Rule D (backstop for ADR-061 A11.4): package mcp reaches the database
     through the Store interface, which is what Rule B watches. A second path
     built here is outside that watch, and a site id could travel it. Move the
-    query behind a Store method so it is covered."
-    fi
+    query behind a Store method so it is covered -- or, if this file IS part of
+    the Store implementation (Repo split across files), record that in $ALLOWLIST:
+        DBPATH $rel   # which Repo method reaches this, and why it is on the audited boundary"
   fi
 done <"$TMPDIR_RUN/mcpfiles"
+
+sort -u "$DBPATH_HITS" -o "$DBPATH_HITS"
+
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  if ! grep -qxF "$entry" "$DBPATH_HITS"; then
+    violation "stale allowlist entry: DBPATH $entry no longer touches the database.
+    Delete the entry so the file goes back to being default-closed under Rule D."
+  fi
+done <"$ALLOW_DBPATH"
 
 # ---------------------------------------------------------------------------
 # Report.

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -128,12 +128,22 @@
 #      Rules A, C and D match REGULAR EXPRESSIONS against a CONTEXT-FREE
 #      GRAMMAR. That is not a bug in any one pattern; it is a category error
 #      that no pattern can fix, and the evidence is the changelog of this file.
-#      Eight distinct bypasses have been found and closed here, every one of
-#      them a Go spelling a pattern did not know:
+#      Ten distinct bypasses have been found and closed here, every one of them
+#      a Go spelling a pattern did not know:
 #
 #        a space before a paren; a call split across a line break; a renamed
 #        parameter; a gofmt-wrapped signature; named results; a line-oriented
-#        pgx match; a comment between two parameters; a dot-imported New.
+#        pgx match; a comment between two parameters; a dot-imported New; a
+#        non-identifier first argument to a pgx method; and a block comment
+#        containing `//`, which defeated the two-pass comment stripper.
+#
+#      The last of those is the clearest evidence that the METHOD is the
+#      problem rather than any pattern: the bug was not in a regex at all but
+#      in the ORDER of two text passes, and no ordering was correct. An
+#      eleventh was introduced here while fixing the ninth -- a sed whose `|`
+#      was both delimiter and alternation, which returned empty and read as
+#      "no sqlc import", silently disabling a whole mechanism. The suite caught
+#      it. That is what this approach costs to maintain.
 #
 #      Each fix teaches the pattern one more spelling. Go always has another --
 #      a type alias for json.RawMessage, a method value registered instead of a
@@ -272,21 +282,63 @@ broken() { printf 'check-mcp-site-containment: GUARD BROKEN: %s\n' "$1" >&2; exi
 
 # Flatten a Go file to ONE whitespace-collapsed line with comments removed.
 #
-# Comments are stripped because they are legal between any two tokens, so a
-# block comment sitting between two parameters survives flattening and defeats
-# a pattern that admits only whitespace there. Line comments go first, per
-# line, before the join -- afterwards a `//` would swallow the rest of the file.
+# Comments are stripped because they are legal between any two Go tokens, so a
+# comment sitting between two parameters survives flattening and defeats a
+# pattern that admits only whitespace there.
 #
-# THIS IS AN APPROXIMATION AND IT IS DOCUMENTED AS ONE: `//` inside a string
-# literal (a URL) is stripped as though it were a comment. That direction loses
-# text rather than inventing it, so it can only ever hide a call, never fabricate
-# one -- and see the blind-spot block: this whole layer is approximate by
-# construction.
+# THIS IS ONE LEFT-TO-RIGHT SCAN, NOT TWO STRIPPING PASSES, and that is the
+# whole point. Two passes are unsound in EITHER order, because each comment
+# form may legally contain the other's delimiter:
+#
+#   line-comments first:  `/* https://example */` is truncated at the `//`,
+#                         leaving an unclosed `/*` the block pass cannot match.
+#   block-comments first: `// a note about /* this */` opens a block comment
+#                         that swallows to the next `*/` anywhere in the file.
+#
+# There is no ordering that fixes both, so ordering is removed as a concept: a
+# single scan takes whichever delimiter it reaches first and is in exactly one
+# state at a time. That also lets it recognise STRING LITERALS, so a `//` or a
+# `/*` inside a string is data and survives -- which the two-pass version got
+# wrong and this file previously documented as an accepted approximation.
+#
+# Handles: line comments, block comments, interpreted strings with escapes, raw
+# backtick strings, and rune literals. State persists across lines, so
+# multi-line block comments and raw strings are handled too.
 flatten_go() {
-  sed 's|//.*$||' "$1" 2>/dev/null \
+  awk '
+    BEGIN { st = "code" }
+    {
+      line = $0; out = ""; i = 1; n = length(line)
+      while (i <= n) {
+        c = substr(line, i, 1); two = substr(line, i, 2)
+        if (st == "code") {
+          if (two == "//") { break }                      # rest of the line is comment
+          if (two == "/*") { st = "block"; out = out " "; i += 2; continue }
+          if (c == "\"")   { st = "str";  out = out c; i++; continue }
+          if (c == "`")    { st = "raw";  out = out c; i++; continue }
+          if (c == "\x27") { st = "rune"; out = out c; i++; continue }
+          out = out c; i++
+        } else if (st == "block") {
+          if (two == "*/") { st = "code"; i += 2; continue }
+          i++
+        } else if (st == "str") {
+          if (c == "\\") { out = out substr(line, i, 2); i += 2; continue }
+          if (c == "\"") { st = "code" }
+          out = out c; i++
+        } else if (st == "raw") {
+          if (c == "`") { st = "code" }
+          out = out c; i++
+        } else {                                          # rune
+          if (c == "\\") { out = out substr(line, i, 2); i += 2; continue }
+          if (c == "\x27") { st = "code" }
+          out = out c; i++
+        }
+      }
+      print out
+    }
+  ' "$1" 2>/dev/null \
     | tr '\n' ' ' \
-    | tr -s ' \t' ' ' \
-    | sed -E 's|/\*[^*]*\*+([^/*][^*]*\*+)*/| |g'
+    | tr -s ' \t' ' '
 }
 
 VIOLATIONS=0

--- a/scripts/check-mcp-site-containment.sh
+++ b/scripts/check-mcp-site-containment.sh
@@ -245,6 +245,25 @@ MCP_DIR="$API_ROOT/$MCP_PKG_REL"
 # log can tell "the boundary is violated" from "this check no longer works".
 broken() { printf 'check-mcp-site-containment: GUARD BROKEN: %s\n' "$1" >&2; exit 2; }
 
+# Flatten a Go file to ONE whitespace-collapsed line with comments removed.
+#
+# Comments are stripped because they are legal between any two tokens, so a
+# block comment sitting between two parameters survives flattening and defeats
+# a pattern that admits only whitespace there. Line comments go first, per
+# line, before the join -- afterwards a `//` would swallow the rest of the file.
+#
+# THIS IS AN APPROXIMATION AND IT IS DOCUMENTED AS ONE: `//` inside a string
+# literal (a URL) is stripped as though it were a comment. That direction loses
+# text rather than inventing it, so it can only ever hide a call, never fabricate
+# one -- and see the blind-spot block: this whole layer is approximate by
+# construction.
+flatten_go() {
+  sed 's|//.*$||' "$1" 2>/dev/null \
+    | tr '\n' ' ' \
+    | tr -s ' \t' ' ' \
+    | sed -E 's|/\*[^*]*\*+([^/*][^*]*\*+)*/| |g'
+}
+
 VIOLATIONS=0
 violation() {
   VIOLATIONS=$((VIOLATIONS + 1))
@@ -640,7 +659,7 @@ TOOLARGS_SIG='\([ ]*[A-Za-z_][A-Za-z0-9_]*[ ]+context\.Context[ ]*,[ ]*[A-Za-z_]
 # declaration itself in registry.go. If it does not, the shape changed and the
 # rule is matching nothing -- which would report the compliant state.
 FLAT_REGISTRY="$TMPDIR_RUN/flat.registry"
-tr '\n' ' ' <"$MCP_DIR/registry.go" 2>/dev/null | tr -s ' \t' ' ' >"$FLAT_REGISTRY"
+flatten_go "$MCP_DIR/registry.go" >"$FLAT_REGISTRY"
 grep -qE "$TOOLARGS_SIG" "$FLAT_REGISTRY" 2>/dev/null \
   || broken "the toolInvoker signature shape no longer matches $MCP_PKG_REL/registry.go. Rule C's pattern is stale and would report zero tool-argument surfaces on any tree."
 
@@ -652,7 +671,7 @@ while IFS= read -r f; do
   # stream rather than compared against, because a conforming handler is
   # textually identical to the declaration once both are flattened, so any
   # equality test would discard the handler along with the type.
-  tr '\n' ' ' <"$f" 2>/dev/null | tr -s ' \t' ' ' \
+  flatten_go "$f" \
     | sed -E "s/type[ ]+toolInvoker[ ]+func[ ]*$TOOLARGS_SIG//g" >"$flat"
 
   # Every remaining occurrence of the shape, one per line. `_ json.RawMessage`
@@ -737,7 +756,18 @@ DBPATH_HITS="$TMPDIR_RUN/found.dbpath"
 # `tx.Query(reqCtx, ...)` a way round the rule -- the same mistake Rule C made
 # with `auth`. Measured against the real tree: this matches no non-test file in
 # package mcp outside repo.go, so the broader form costs no false positives.
-PGX_OPS_RE='\.(Query|QueryRow|Exec|SendBatch|CopyFrom)[ ]*\([ ]*[A-Za-z_][A-Za-z0-9_]*[ ]*,'
+# The first argument is matched as "not a string literal, and followed by a
+# comma", rather than as a bare identifier. `tx.Query(context.Background(), sql)`
+# is an ordinary pgx call whose first argument is a call expression, and the old
+# identifier-only form did not match it.
+#
+# It cannot simply drop the first-argument test: gin's `c.Query("response_type")`
+# is all over internal/mcp/handler.go and matches the bare method name. What
+# separates them is that a pgx call takes a context expression and then at least
+# one more argument, while the gin reader takes a single string literal -- so
+# "first argument does not start with a quote, and a comma follows it" admits
+# every pgx form and excludes the gin one. Measured on this tree.
+PGX_OPS_RE='\.(Query|QueryRow|Exec|SendBatch|CopyFrom)[ ]*\([ ]*[^",][^,]*,'
 PGXPOOL_RE='"github\.com/jackc/pgx/v5/pgxpool"'
 
 dbpath_mechanism() {
@@ -748,11 +778,23 @@ dbpath_mechanism() {
   # line-oriented grep does not match it -- which would drop the file from
   # DBPATH_HITS and report successful containment over a live database path.
   _flat="$TMPDIR_RUN/flat.dbpath"
-  tr '\n' ' ' <"$_f" 2>/dev/null | tr -s ' \t' ' ' >"$_flat"
+  flatten_go "$_f" >"$_flat"
   # The local name bound to the sqlc package in THIS file, alias or not.
-  _sqlc="$(sed -nE 's|^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)?[[:space:]]*"github\.com/mosamlife/wpmgr/apps/api/internal/db/sqlc".*|\1|p' "$_f" 2>/dev/null | head -1)"
+  # The local name bound to the sqlc package in THIS file: an alias, nothing
+  # (the package name), or `.` for a dot import -- which puts New into the
+  # file's own scope, so the call is spelled `New(tx)` with no qualifier at all
+  # and no amount of looking for a dot will find it.
+  # NOTE the `#` delimiter: the alternation below contains `|`, which silently
+  # terminates an `s|...|...|` expression and leaves this returning nothing --
+  # which read as "no sqlc import" and turned the whole mechanism off.
+  _sqlc="$(sed -nE 's#^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*|\.)?[[:space:]]*"github\.com/mosamlife/wpmgr/apps/api/internal/db/sqlc".*#\1#p' "$_f" 2>/dev/null | head -1)"
   [ -n "$_sqlc" ] || _sqlc="sqlc"
-  if grep -qE "(^|[^A-Za-z0-9_.])${_sqlc}\.New[ ]*\(" "$_f" 2>/dev/null; then
+  if [ "$_sqlc" = "." ]; then
+    if grep -qE "(^|[^A-Za-z0-9_.])New[ ]*\(" "$_flat" 2>/dev/null; then
+      printf 'builds its own sqlc.Queries via a DOT-IMPORTED New(\n'
+      return 0
+    fi
+  elif grep -qE "(^|[^A-Za-z0-9_.])${_sqlc}\.New[ ]*\(" "$_flat" 2>/dev/null; then
     printf 'builds its own %s.Queries via %s.New(\n' "$_sqlc" "$_sqlc"
     return 0
   fi

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -240,6 +240,25 @@ run_case "ok-jsonrpc-envelope-id-is-not-tool-args" 0 "Rule C  0 file(s)" "transp
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 rm -f "$TREE/apps/api/internal/mcp/transport.go"
 
+# THE OVER-FIRE THAT REDDENED main. Rule A reads a two-line window so it can
+# catch a call split after the receiver dot. English prose ends sentences with
+# a full stop, so a doc comment whose last line ends in "." sitting immediately
+# above a declaration beginning with the chokepoint name is
+# character-for-character the same shape -- and Rule A reported the declaration
+# on the Store interface as an unreviewed call site at "(file scope)". Rule A
+# now reads comment-stripped input. Over-firing is worse than missing: a guard
+# that reddens correct work gets switched off, and then it guards nothing.
+printf '%s\n' 'package mcp' \
+  'type Store interface {' \
+  '	// ResolveScopeSites takes a ScopedPrincipal rather than a tenant uuid so' \
+  '	// that the chokepoint can route on scope; see the method on Repo. A caller' \
+  '	// passing a deliberately org-scoped principal must justify it there.' \
+  '	ResolveScopeSites(ctx context.Context, principal db.ScopedPrincipal) ([]uuid.UUID, error)' \
+  '}' >"$TREE/apps/api/internal/mcp/iface.go"
+run_case "ok-doc-comment-period-is-not-a-split-call" 0 "check-mcp-site-containment: OK" "iface.go" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/iface.go"
+
 run_case "ok-doc-comments-are-not-methods" 0 "Rule B  6 uuid parameter(s)" "VIOLATION" -- \
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -396,6 +396,24 @@ run_case "bypass-direct-pgx-query-without-sqlc-new" 1 "executes SQL directly" - 
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 rm -f "$TREE/apps/api/internal/mcp/rawsql.go"
 
+# The same direct pgx call with the context argument on the next line -- what
+# gofmt does to a long one. A line-oriented PGX_OPS_RE did not match it, the
+# file was dropped from DBPATH_HITS, and the guard reported successful
+# containment over a live database path.
+printf '%s\n' 'package mcp' \
+  'import "github.com/jackc/pgx/v5"' \
+  'func (s *Service) rawSplit(ctx context.Context, tx pgx.Tx, siteID uuid.UUID) error {' \
+  '	row := tx.QueryRow(' \
+  '		ctx,' \
+  '		"SELECT id FROM sites WHERE id = $1",' \
+  '		siteID,' \
+  '	)' \
+  '	return row.Scan(&siteID)' \
+  '}' >"$TREE/apps/api/internal/mcp/rawsplit.go"
+run_case "bypass-direct-pgx-query-split-across-lines" 1 "executes SQL directly" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/rawsplit.go"
+
 # sqlc.New takes a DBTX. Handed a *pgxpool.Pool, the file never imports the
 # root pgx package, and the old OUTER grep skipped the constructor check
 # entirely.

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# scripts/check-mcp-site-containment_test.sh
+#
+# The regression suite for scripts/check-mcp-site-containment.sh.
+#
+# WHY THIS EXISTS. A guard nobody has watched fail is not known to guard
+# anything. ADR-061 A11 item 4 asks for a containment test that fails CI, and
+# "fails CI" is a claim about behaviour, so it is asserted here as behaviour:
+# every case below plants a real bypass in a fixture tree and asserts the exit
+# code and the message.
+#
+# THE THREE FAMILIES OF CASE, and the third is the one that gets skipped:
+#
+#   bypass-*   A real containment violation. Exit 1.
+#   broken-*   The guard's own input is missing, empty, moved or unparseable.
+#              Exit 2, never 0. This project's signature defect is announcing
+#              success over its own errors, and a containment check that
+#              silently matches zero files is exactly that shape, so each of
+#              those states is planted rather than reasoned about.
+#   ok-*       Honest work the guard must NOT redden. A guard that fails
+#              correct work gets switched off, and then it guards nothing.
+#
+# THE FIXTURE TREE IS HERMETIC. It needs no Go toolchain, no database and no
+# network: the mcp.Store interface is supplied through --store-doc in exactly
+# the format `go doc -u` emits, and the Go files are the few lines the guard's
+# control patterns read. That is deliberate — the suite must be runnable on a
+# machine where the real check cannot run, or it will not be run.
+#
+# RUN IT:
+#   make check-mcp-containment-test
+#   scripts/check-mcp-site-containment_test.sh            # everything
+#   scripts/check-mcp-site-containment_test.sh bypass     # only matching cases
+#
+# Point it at a different implementation to prove the suite is not vacuous
+# (reintroduce a hole in a copy, watch the suite go red):
+#   WPMGR_MCP_CONTAINMENT_GUARD=/tmp/guard-with-hole.sh \
+#     scripts/check-mcp-site-containment_test.sh
+#
+# PORTABILITY. bash 3.2 and POSIX tools; no mapfile, no associative arrays,
+# no sed -i, no grep -P.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${WPMGR_MCP_CONTAINMENT_GUARD:-$HERE/check-mcp-site-containment.sh}"
+FILTER="${1:-}"
+
+if [ ! -f "$GUARD" ]; then
+  printf 'check-mcp-site-containment_test: guard not found: %s\n' "$GUARD" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+WORK="$(mktemp -d)" || exit 2
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# --- fixtures ---------------------------------------------------------------
+
+# A minimal apps/api tree carrying exactly what the guard's control patterns
+# and Rules A, C and D read. $1 is the tree root; it is created fresh.
+make_tree() {
+  root="$1"
+  mcp="$root/apps/api/internal/mcp"
+  rm -rf "$root"
+  mkdir -p "$mcp"
+
+  printf '%s\n' \
+    'package mcp' \
+    '' \
+    'func (r *Repo) ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error) {' \
+    '	return nil, nil' \
+    '}' \
+    >"$mcp/repo.go"
+
+  printf '%s\n' \
+    'package mcp' \
+    '' \
+    'func NewSiteSet(ids []uuid.UUID) SiteSet {' \
+    '	return SiteSet{}' \
+    '}' \
+    >"$mcp/model.go"
+
+  printf '%s\n' \
+    'package mcp' \
+    '' \
+    'type toolInvoker func(ctx context.Context, svc *Service, auth AuthorizedRequest, args json.RawMessage) (string, error)' \
+    '' \
+    'var listSites = toolEntry{' \
+    '	invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, _ json.RawMessage) (string, error) {' \
+    '		return svc.ListSitesForModel(ctx, auth)' \
+    '	},' \
+    '}' \
+    >"$mcp/registry.go"
+
+  printf '%s\n' \
+    'package mcp' \
+    '' \
+    'func (s *Service) Authenticate(ctx context.Context) (AuthorizedRequest, error) {' \
+    '	ids, err := s.store.ResolveScopeSites(ctx, tok.TenantID, chk.SiteScopeMode, chk.ScopeTagIds, chk.ScopeSiteIds)' \
+    '	_ = err' \
+    '	return AuthorizedRequest{Sites: NewSiteSet(ids)}, nil' \
+    '}' \
+    >"$mcp/service.go"
+}
+
+# The mcp.Store interface in `go doc -u` format: a tab-indented method per
+# line, doc comments as `\t//`. Extra methods are appended from "$@".
+make_store_doc() {
+  out="$1"; shift
+  {
+    printf 'package mcp // import "github.com/mosamlife/wpmgr/apps/api/internal/mcp"\n'
+    printf '\n'
+    printf 'type Store interface {\n'
+    printf '\t// A doc comment, which must not be parsed as a method.\n'
+    printf '\tRegisterClient(ctx context.Context, arg sqlc.RegisterMCPOAuthClientParams) (int64, error)\n'
+    printf '\tReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.Row, error)\n'
+    printf '\tResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error)\n'
+    printf '\tListSitesForRead(ctx context.Context, tenantID uuid.UUID, limit int32) ([]sqlc.ListSitesRow, bool, error)\n'
+    for extra in "$@"; do printf '\t%s\n' "$extra"; done
+    printf '}\n'
+  } >"$out"
+}
+
+# The allowlist that makes the fixture tree above clean. Extra records from "$@".
+make_allow() {
+  out="$1"; shift
+  {
+    printf '# fixture allowlist\n'
+    printf 'CALL internal/mcp/service.go Authenticate   # resolves the stored grant scope\n'
+    printf 'PARAM ReCheckAuthorization.tenantID   # tenant of the resolved principal\n'
+    printf 'PARAM ReCheckAuthorization.tokenID    # token row id\n'
+    printf 'PARAM ResolveScopeSites.tenantID      # the chokepoint itself\n'
+    printf 'PARAM ResolveScopeSites.tagIDs        # chokepoint input\n'
+    printf 'PARAM ResolveScopeSites.siteIDs       # chokepoint input\n'
+    printf 'PARAM ListSitesForRead.tenantID       # tenant of the resolved principal\n'
+    for extra in "$@"; do printf '%s\n' "$extra"; done
+  } >"$out"
+}
+
+# --- harness ----------------------------------------------------------------
+
+# run_case <name> <expected-exit> <must-contain|-> <must-not-contain|-> -- <args...>
+run_case() {
+  name="$1"; want="$2"; needle="$3"; anti="$4"; shift 5   # shift past the '--'
+  case "$name" in
+    *"$FILTER"*) : ;;
+    *) return 0 ;;
+  esac
+
+  out="$WORK/out.$$"
+  # NEVER pipe the guard: a pipeline reports the LAST command's status, and the
+  # status is the entire assertion here.
+  "$GUARD" "$@" >"$out" 2>&1
+  got=$?
+
+  ok=1
+  [ "$got" = "$want" ] || ok=0
+  # `--` before the pattern: a needle that starts with a dash (this guard has
+  # `--store-doc` in one of its messages) is otherwise read by grep as an
+  # option, and the case fails for a reason that has nothing to do with the
+  # guard.
+  if [ "$needle" != "-" ] && ! grep -qF -- "$needle" "$out"; then ok=0; fi
+  if [ "$anti" != "-" ] && grep -qF -- "$anti" "$out"; then ok=0; fi
+
+  if [ "$ok" = 1 ]; then
+    PASS=$((PASS + 1))
+    printf 'ok   %-46s exit %s\n' "$name" "$got"
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %-46s exit %s (want %s)\n' "$name" "$got" "$want"
+    [ "$needle" = "-" ] || printf '       wanted output containing: %s\n' "$needle"
+    [ "$anti" = "-" ]   || printf '       wanted output WITHOUT:    %s\n' "$anti"
+    sed 's/^/       | /' "$out"
+  fi
+  rm -f "$out"
+}
+
+TREE="$WORK/tree"
+DOC="$WORK/store.doc"
+ALLOW="$WORK/allow.txt"
+
+# ============================================================================
+# ok-* : the compliant tree, and honest work that must not be reddened.
+# ============================================================================
+
+make_tree "$TREE"; make_store_doc "$DOC"; make_allow "$ALLOW"
+run_case "ok-clean-tree" 0 "check-mcp-site-containment: OK" "VIOLATION" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# A tool that DISCARDS its arguments is the compliant Phase 1 form. `_` is a
+# legal Go identifier, and the first version of Rule C matched it and reported
+# the one compliant tool in HEAD as a violation.
+run_case "ok-tool-discards-its-args" 0 "Rule C  0 file(s)" "registry.go binds" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# A new Store method that takes NO uuid is ordinary work and must pass with no
+# allowlist edit at all.
+make_store_doc "$DOC" 'CountGrants(ctx context.Context, since time.Time) (int64, error)'
+run_case "ok-new-store-method-without-uuid" 0 "check-mcp-site-containment: OK" "VIOLATION" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# Tests construct SiteSets from literal ids constantly. Reddening them would
+# get the guard switched off, so _test.go is excluded by design.
+make_store_doc "$DOC"
+printf '%s\n' 'package mcp' 'func TestX(t *testing.T) { _ = NewSiteSet([]uuid.UUID{uuid.New()}) }' \
+  >"$TREE/apps/api/internal/mcp/scope_test.go"
+run_case "ok-test-files-may-build-sitesets" 0 "check-mcp-site-containment: OK" "scope_test.go" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/scope_test.go"
+
+# A doc comment inside the interface must not be parsed as a method. The
+# fixture carries one; this asserts it produced no phantom parameter.
+run_case "ok-doc-comments-are-not-methods" 0 "Rule B  6 uuid parameter(s)" "VIOLATION" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# ============================================================================
+# bypass-* : real containment violations. Exit 1.
+# ============================================================================
+
+# THE CANONICAL BYPASS. A new read tool wants one site, so a Store method takes
+# the site id straight from the request. It never touches the chokepoint, so
+# the uuid is never resolved under `sites` RLS and a foreign site id is
+# accepted -- scope_site_ids is a uuid[] with no foreign key over its elements.
+make_store_doc "$DOC" 'GetSiteByID(ctx context.Context, tenantID, siteID uuid.UUID) (sqlc.Site, error)'
+run_case "bypass-store-method-takes-site-id" 1 "PARAM GetSiteByID.siteID" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# THE SAME BYPASS, WEARING A NAME NO PATTERN WOULD MATCH. This is why Rule B
+# requires an entry for EVERY uuid parameter rather than hunting for /site/i:
+# `id` is what a bypass is actually called when nobody is trying to hide it.
+make_store_doc "$DOC" 'GetSiteByID(ctx context.Context, tenantID, id uuid.UUID) (sqlc.Site, error)'
+run_case "bypass-site-id-named-id" 1 "PARAM GetSiteByID.id" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# A slice of site ids is the same bypass in bulk.
+make_store_doc "$DOC" 'ListUpdatesForSites(ctx context.Context, tenantID uuid.UUID, targets []uuid.UUID) ([]sqlc.Row, error)'
+run_case "bypass-store-method-takes-site-id-slice" 1 "PARAM ListUpdatesForSites.targets" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# A tool that starts reading its request arguments is where a client-chosen
+# site id can first enter. Rule C makes that moment red until reviewed.
+make_store_doc "$DOC"
+sed 's/_ json\.RawMessage/args json.RawMessage/' "$TREE/apps/api/internal/mcp/registry.go" >"$WORK/registry.new"
+cp "$WORK/registry.new" "$TREE/apps/api/internal/mcp/registry.go"
+run_case "bypass-tool-reads-request-arguments" 1 "internal/mcp/registry.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+make_tree "$TREE"
+
+# A second, unreviewed call to the chokepoint. Not every such call is a bug --
+# but every one of them is a place where something decides which sites a
+# principal may see, and A11.1 says that set of places is enumerated.
+printf '%s\n' 'package mcp' \
+  'func (s *Service) GetSiteForModel(ctx context.Context, req Req) error {' \
+  '	ids, _ := s.store.ResolveScopeSites(ctx, req.TenantID, "list", nil, req.SiteIDs)' \
+  '	_ = ids' \
+  '	return nil' \
+  '}' >"$TREE/apps/api/internal/mcp/tools_get_site.go"
+run_case "bypass-unreviewed-chokepoint-call" 1 "CALL internal/mcp/tools_get_site.go GetSiteForModel" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tools_get_site.go"
+
+# A SiteSet built from ids that were never resolved is a resolution that never
+# happened. NewSiteSet's own doc comment says so; this makes it enforceable.
+printf '%s\n' 'package mcp' \
+  'func (s *Service) authFast(req Req) AuthorizedRequest {' \
+  '	return AuthorizedRequest{Sites: NewSiteSet(req.SiteIDs)}' \
+  '}' >"$TREE/apps/api/internal/mcp/fastpath.go"
+run_case "bypass-siteset-from-unresolved-ids" 1 "CALL internal/mcp/fastpath.go authFast" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/fastpath.go"
+
+# A second database path inside package mcp, outside repo.go, is outside the
+# reach of Rule B. Rule D is the backstop.
+printf '%s\n' 'package mcp' \
+  'import "github.com/jackc/pgx/v5"' \
+  'func (s *Service) direct(tx pgx.Tx) { _ = sqlc.New(tx) }' \
+  >"$TREE/apps/api/internal/mcp/shortcut.go"
+run_case "bypass-second-database-path-in-package" 1 "builds its own sqlc.Queries" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/shortcut.go"
+
+# Both directions. An entry that matches nothing means the guard is watching a
+# surface that has moved, which is indistinguishable from watching nothing.
+make_allow "$ALLOW" 'CALL internal/mcp/gone.go VanishedFunc   # was here once'
+run_case "bypass-stale-allowlist-call-entry" 1 "stale allowlist entry: CALL internal/mcp/gone.go" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+make_allow "$ALLOW" 'PARAM DeletedMethod.tenantID   # method no longer exists'
+run_case "bypass-stale-allowlist-param-entry" 1 "stale allowlist entry: PARAM DeletedMethod.tenantID" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+make_allow "$ALLOW"
+
+# ============================================================================
+# broken-* : the guard's own input is missing, empty or moved. Exit 2, never 0.
+# ============================================================================
+
+run_case "broken-allowlist-missing" 2 "allowlist not found" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$WORK/nope.txt" --store-doc "$DOC"
+
+printf '# every entry commented out\n' >"$WORK/empty-allow.txt"
+run_case "broken-allowlist-emptied" 2 "contains no entries" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$WORK/empty-allow.txt" --store-doc "$DOC"
+
+make_allow "$WORK/badkind.txt" 'PARM Typo.tenantID   # kind is misspelled'
+run_case "broken-allowlist-unrecognised-kind" 2 "unrecognised allowlist kind" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$WORK/badkind.txt" --store-doc "$DOC"
+
+run_case "broken-store-doc-file-missing" 2 "--store-doc file does not exist" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$WORK/nope.doc"
+
+: >"$WORK/empty.doc"
+run_case "broken-store-doc-empty" 2 "produced NO OUTPUT" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$WORK/empty.doc"
+
+printf 'some other output entirely\n' >"$WORK/wrong.doc"
+run_case "broken-store-doc-interface-renamed" 2 "does not contain 'type Store interface'" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$WORK/wrong.doc"
+
+# The chokepoint gone from the interface is not "no site-scope surface".
+printf '%s\n' 'type Store interface {' '	ListTagIDs(ctx context.Context, tenantID uuid.UUID) ([]uuid.UUID, error)' '}' \
+  >"$WORK/nochoke.doc"
+run_case "broken-store-doc-lost-the-chokepoint" 2 "no longer declares ResolveScopeSites" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$WORK/nochoke.doc"
+
+# An interface the parser can see but whose method lines it cannot read. This
+# is the shape that would otherwise pass on ANY tree.
+printf '%s\n' 'type Store interface {' '  ResolveScopeSites(ctx context.Context) error' '}' \
+  >"$WORK/unparseable.doc"
+run_case "broken-store-doc-no-methods-parsed" 2 "parsed ZERO methods" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$WORK/unparseable.doc"
+
+# An interface that parses but yields no uuid parameters at all. HEAD has
+# several, so this is a parse failure wearing the shape of a clean surface --
+# the exact defect that would have made the whole of Rule B vacuous.
+printf '%s\n' 'type Store interface {' '	ResolveScopeSites(ctx context.Context, mode string) error' '}' \
+  >"$WORK/nouuid.doc"
+run_case "broken-store-doc-zero-uuid-parameters" 2 "found ZERO uuid parameters" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$WORK/nouuid.doc"
+
+run_case "broken-api-root-missing" 2 "api root does not exist" "containment: OK" -- \
+  --api-root "$WORK/no-such-tree" --allowlist "$ALLOW" --store-doc "$DOC"
+
+# The package moved. A file-path guard whose files have moved reports a clean
+# tree unless it checks, and this is that check.
+mv "$TREE/apps/api/internal/mcp" "$TREE/apps/api/internal/assistant"
+run_case "broken-mcp-package-moved" 2 "the mcp package is not at" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+mv "$TREE/apps/api/internal/assistant" "$TREE/apps/api/internal/mcp"
+
+# The chokepoint renamed in the source. Rules A and B are then measuring
+# nothing, which must not read as "nothing to report".
+sed 's/ResolveScopeSites/ResolveSitesForScope/' "$TREE/apps/api/internal/mcp/repo.go" >"$WORK/repo.new"
+cp "$WORK/repo.new" "$TREE/apps/api/internal/mcp/repo.go"
+run_case "broken-chokepoint-renamed-in-source" 2 "is not defined in internal/mcp/repo.go" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+make_tree "$TREE"
+
+# NewSiteSet renamed. Same reasoning: Rule A's second half goes silent.
+sed 's/func NewSiteSet(/func MakeSiteSet(/' "$TREE/apps/api/internal/mcp/model.go" >"$WORK/model.new"
+cp "$WORK/model.new" "$TREE/apps/api/internal/mcp/model.go"
+run_case "broken-siteset-ctor-renamed-in-source" 2 "is not defined in internal/mcp/model.go" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+make_tree "$TREE"
+
+# Rule C's subject gone. Its compliant state is ZERO matches, so without this
+# control an absent toolInvoker and a compliant one look identical.
+sed 's/^type toolInvoker func(/type toolRunner func(/' "$TREE/apps/api/internal/mcp/registry.go" >"$WORK/reg.new"
+cp "$WORK/reg.new" "$TREE/apps/api/internal/mcp/registry.go"
+run_case "broken-toolinvoker-declaration-gone" 2 "toolInvoker declaration is not in" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+make_tree "$TREE"
+
+# No non-test Go under the api root at all.
+mkdir -p "$WORK/hollow/apps/api/internal/mcp"
+cp "$TREE/apps/api/internal/mcp/repo.go"     "$WORK/hollow/apps/api/internal/mcp/repo_test.go"
+cp "$TREE/apps/api/internal/mcp/model.go"    "$WORK/hollow/apps/api/internal/mcp/model_test.go"
+run_case "broken-no-non-test-go-files" 2 "no non-test .go files" "containment: OK" -- \
+  --api-root "$WORK/hollow/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+
+run_case "broken-unknown-argument" 2 "unknown argument" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC" --wat
+
+# ============================================================================
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+[ "$PASS" -gt 0 ] || { printf 'check-mcp-site-containment_test: ZERO cases ran (filter %q matched nothing)\n' "$FILTER" >&2; exit 2; }
+exit 0

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -382,6 +382,69 @@ run_case "broken-no-non-test-go-files" 2 "no non-test .go files" "containment: O
 run_case "broken-unknown-argument" 2 "unknown argument" "containment: OK" -- \
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC" --wat
 
+# An option given no value used to make `shift 2` fail, leaving the same option
+# in $1 and spinning the while loop forever: a CI job that never finishes and
+# never reports.
+#
+# THE CASE FOR A HANG MUST NOT ITSELF HANG. run_case waits for the guard to
+# exit, so using it here would wedge the suite on a regression instead of
+# reporting one. This variant backgrounds the guard, polls a FIXED number of
+# times, and calls a still-running guard a failure -- the bounded form the
+# project rule asks for, and the only shape that can assert termination.
+run_case_bounded() {
+  name="$1"; want="$2"; needle="$3"; limit="$4"; shift 5
+  case "$name" in
+    *"$FILTER"*) : ;;
+    *) return 0 ;;
+  esac
+
+  out="$WORK/out.bounded.$$"
+  "$GUARD" "$@" >"$out" 2>&1 &
+  pid=$!
+  waited=0
+  while [ "$waited" -lt "$limit" ]; do
+    sleep 1
+    waited=$((waited + 1))
+    kill -0 "$pid" 2>/dev/null || break
+  done
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %-46s DID NOT TERMINATE within %ss\n' "$name" "$limit"
+    printf '       the argument loop is spinning: `shift 2` with no value left\n'
+    rm -f "$out"
+    return 0
+  fi
+
+  wait "$pid" 2>/dev/null
+  got=$?
+  ok=1
+  [ "$got" = "$want" ] || ok=0
+  if [ "$needle" != "-" ] && ! grep -qF -- "$needle" "$out"; then ok=0; fi
+
+  if [ "$ok" = 1 ]; then
+    PASS=$((PASS + 1))
+    printf 'ok   %-46s exit %s\n' "$name" "$got"
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %-46s exit %s (want %s)\n' "$name" "$got" "$want"
+    [ "$needle" = "-" ] || printf '       wanted output containing: %s\n' "$needle"
+    sed 's/^/       | /' "$out"
+  fi
+  rm -f "$out"
+}
+
+run_case_bounded "broken-api-root-without-value" 2 "--api-root requires a value" 8 -- \
+  --api-root
+
+run_case_bounded "broken-allowlist-without-value" 2 "--allowlist requires a value" 8 -- \
+  --api-root "$TREE/apps/api" --allowlist
+
+run_case_bounded "broken-store-doc-without-value" 2 "--store-doc requires a value" 8 -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc
+
 # ============================================================================
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -65,11 +65,20 @@ make_tree() {
   rm -rf "$root"
   mkdir -p "$mcp"
 
+  # repo.go must actually reach the database. Rule D's control asserts that the
+  # one file whose job that is still matches its patterns -- a fixture repo.go
+  # that touched nothing would let stale patterns pass the control, which is
+  # the failure the control exists to catch.
   printf '%s\n' \
     'package mcp' \
     '' \
+    'import (' \
+    '	"github.com/jackc/pgx/v5"' \
+    '	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"' \
+    ')' \
+    '' \
     'func (r *Repo) ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error) {' \
-    '	return nil, nil' \
+    '	return sqlc.New(tx).ResolveScope(ctx, tenantID)' \
     '}' \
     >"$mcp/repo.go"
 
@@ -371,6 +380,86 @@ printf '%s\n' 'package mcp' \
 run_case "bypass-second-database-path-in-package" 1 "builds its own sqlc.Queries" - -- \
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 rm -f "$TREE/apps/api/internal/mcp/shortcut.go"
+
+# ---- Rule D: the three ways round the old import-plus-literal test ----------
+
+# Executes SQL with no sqlc.New anywhere. The old inner test required that
+# literal, so this file passed and Rule D printed "no second database path"
+# over a second database path.
+printf '%s\n' 'package mcp' \
+  'import "github.com/jackc/pgx/v5"' \
+  'func (s *Service) rawRead(ctx context.Context, tx pgx.Tx, siteID uuid.UUID) error {' \
+  '	_, err := tx.Query(ctx, "SELECT id FROM sites WHERE id = $1", siteID)' \
+  '	return err' \
+  '}' >"$TREE/apps/api/internal/mcp/rawsql.go"
+run_case "bypass-direct-pgx-query-without-sqlc-new" 1 "executes SQL directly" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/rawsql.go"
+
+# sqlc.New takes a DBTX. Handed a *pgxpool.Pool, the file never imports the
+# root pgx package, and the old OUTER grep skipped the constructor check
+# entirely.
+printf '%s\n' 'package mcp' \
+  'import "github.com/jackc/pgx/v5/pgxpool"' \
+  'func (s *Service) poolPath(pool *pgxpool.Pool) {' \
+  '	_ = sqlc.New(pool)' \
+  '}' >"$TREE/apps/api/internal/mcp/poolpath.go"
+run_case "bypass-sqlc-new-with-pgxpool-dbtx" 1 "builds its own sqlc.Queries" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/poolpath.go"
+
+# The same constructor reached through an import alias. Keying on the literal
+# string "sqlc.New(" made renaming the import a way round the rule.
+printf '%s\n' 'package mcp' \
+  'import (' \
+  '	"github.com/jackc/pgx/v5"' \
+  '	q "github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"' \
+  ')' \
+  'func (s *Service) aliased(tx pgx.Tx) { _ = q.New(tx) }' \
+  >"$TREE/apps/api/internal/mcp/aliased.go"
+run_case "bypass-sqlc-new-via-import-alias" 1 "builds its own q.Queries" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/aliased.go"
+
+# A reviewed exception. The Store implementation is allowed to be split across
+# more than one file, and before DBPATH existed that was unrepresentable: the
+# only exception was the hard-coded name repo.go.
+printf '%s\n' 'package mcp' \
+  'import "github.com/jackc/pgx/v5"' \
+  'func getGrantTx(ctx context.Context, tx pgx.Tx, grantID uuid.UUID) error {' \
+  '	_ = sqlc.New(tx)' \
+  '	return nil' \
+  '}' >"$TREE/apps/api/internal/mcp/repo_status.go"
+make_allow "$ALLOW" 'DBPATH internal/mcp/repo_status.go   # Repo split across files; reached only from Repo.Snapshot inside RunTenantTx'
+run_case "ok-dbpath-reviewed-repo-split" 0 "check-mcp-site-containment: OK" "VIOLATION" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/repo_status.go"
+
+# Both directions, as for every other kind. A DBPATH entry whose file stopped
+# touching the database means the guard is holding a door open on a room that
+# has moved.
+run_case "bypass-stale-allowlist-dbpath-entry" 1 "stale allowlist entry: DBPATH internal/mcp/repo_status.go" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+make_allow "$ALLOW"
+
+# Rule D's own control. If repo.go -- the one file whose job database access is
+# -- stops matching, the patterns are stale and Rule D would report a clean
+# package whatever the package contained.
+cp "$TREE/apps/api/internal/mcp/repo.go" "$WORK/repo.orig"
+printf '%s\n' 'package mcp' \
+  'func (r *Repo) ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error) {' \
+  '	return nil, nil' \
+  '}' >"$TREE/apps/api/internal/mcp/repo.go"
+run_case "broken-rule-d-patterns-match-nothing-in-repo" 2 "Rule D's database-access patterns match nothing" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+cp "$WORK/repo.orig" "$TREE/apps/api/internal/mcp/repo.go"
+
+# A DBPATH entry is a real allowlist kind, not a typo that silently drops a
+# record from the comparison.
+make_allow "$ALLOW" 'DBPTH internal/mcp/typo.go   # misspelled kind'
+run_case "broken-allowlist-dbpath-kind-typo" 2 "unrecognised allowlist kind" "containment: OK" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+make_allow "$ALLOW"
 
 # Both directions. An entry that matches nothing means the guard is watching a
 # surface that has moved, which is indistinguishable from watching nothing.

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -211,6 +211,26 @@ rm -f "$TREE/apps/api/internal/mcp/scope_test.go"
 
 # A doc comment inside the interface must not be parsed as a method. The
 # fixture carries one; this asserts it produced no phantom parameter.
+# THE OVER-FIRE THAT WAS LIVE ON main. Rule C used to key on the literal
+# `auth AuthorizedRequest,` followed by a named json.RawMessage, and matched
+# transport.go's writeProtocolRefusal(c *gin.Context, auth AuthorizedRequest,
+# id json.RawMessage, neg Negotiation, phase string) -- where the RawMessage is
+# the JSON-RPC ENVELOPE ID being echoed back into an error response, not tool
+# arguments. The only convenient way to quiet that would have been
+# `TOOLARGS internal/mcp/transport.go`, and Rule C's granularity is the FILE,
+# so that entry would have switched the rule off for the one file that
+# actually dispatches tools. The rule now keys on the toolInvoker type
+# sequence, which this signature does not have.
+printf '%s\n' 'package mcp' \
+  'func (h *TransportHandler) writeProtocolRefusal(' \
+  '	c *gin.Context, auth AuthorizedRequest, id json.RawMessage, neg Negotiation, phase string,' \
+  ') {' \
+  '	_ = newErrorResponse(id, codeProtocolUnsupported, "", nil)' \
+  '}' >"$TREE/apps/api/internal/mcp/transport.go"
+run_case "ok-jsonrpc-envelope-id-is-not-tool-args" 0 "Rule C  0 file(s)" "transport.go binds" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/transport.go"
+
 run_case "ok-doc-comments-are-not-methods" 0 "Rule B  6 uuid parameter(s)" "VIOLATION" -- \
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 
@@ -269,6 +289,78 @@ printf '%s\n' 'package mcp' \
 run_case "bypass-siteset-from-unresolved-ids" 1 "CALL internal/mcp/fastpath.go authFast" - -- \
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 rm -f "$TREE/apps/api/internal/mcp/fastpath.go"
+
+# ---- Rules A and C must not be defeated by ordinary Go formatting ----------
+#
+# Every case below is VALID Go that gofmt is happy to leave alone, and every
+# one of them slipped past the first version of these rules. A containment
+# guard that a space defeats reports green while the property is unenforced,
+# which is worse than having no guard at all.
+
+# A space between the method name and its paren. Legal Go, and the old
+# `index($0, ".ResolveScopeSites(")` test saw nothing.
+printf '%s\n' 'package mcp' \
+  'func (s *Service) spacedCall(ctx context.Context, req Req) error {' \
+  '	ids, _ := s.store.ResolveScopeSites (ctx, req.TenantID, "list", nil, req.SiteIDs)' \
+  '	_ = ids' \
+  '	return nil' \
+  '}' >"$TREE/apps/api/internal/mcp/spaced.go"
+run_case "bypass-chokepoint-call-space-before-paren" 1 "CALL internal/mcp/spaced.go spacedCall" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/spaced.go"
+
+printf '%s\n' 'package mcp' \
+  'func (s *Service) spacedCtor(req Req) AuthorizedRequest {' \
+  '	return AuthorizedRequest{Sites: NewSiteSet (req.SiteIDs)}' \
+  '}' >"$TREE/apps/api/internal/mcp/spacedctor.go"
+run_case "bypass-siteset-ctor-space-before-paren" 1 "CALL internal/mcp/spacedctor.go spacedCtor" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/spacedctor.go"
+
+# The receiver dot at the end of one line, the call on the next. No single
+# line contains ".ResolveScopeSites(" -- the old line-oriented matcher was
+# blind to it, and the canonical calls elsewhere kept the extraction nonempty
+# so it never even reached GUARD BROKEN.
+printf '%s\n' 'package mcp' \
+  'func (s *Service) splitCall(ctx context.Context, req Req) error {' \
+  '	ids, _ := s.store.' \
+  '		ResolveScopeSites(ctx, req.TenantID, "list", nil, req.SiteIDs)' \
+  '	_ = ids' \
+  '	return nil' \
+  '}' >"$TREE/apps/api/internal/mcp/split.go"
+run_case "bypass-chokepoint-call-split-across-lines" 1 "CALL internal/mcp/split.go splitCall" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/split.go"
+
+# Rule C keyed on the parameter NAME `auth`. The name is the tool author's
+# choice, so renaming it produced a conforming toolInvoker that reads its
+# request arguments and was invisible to the guard.
+printf '%s\n' 'package mcp' \
+  'var renamed = toolEntry{' \
+  '	invoke: func(ctx context.Context, svc *Service, req AuthorizedRequest, args json.RawMessage) (string, error) {' \
+  '		return svc.Something(ctx, req, args)' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_renamed.go"
+run_case "bypass-tool-args-renamed-auth-parameter" 1 "internal/mcp/tool_renamed.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_renamed.go"
+
+# The same handler with the signature wrapped across lines, which is what
+# gofmt does to a long one.
+printf '%s\n' 'package mcp' \
+  'var wrapped = toolEntry{' \
+  '	invoke: func(' \
+  '		ctx context.Context,' \
+  '		svc *Service,' \
+  '		auth AuthorizedRequest,' \
+  '		args json.RawMessage,' \
+  '	) (string, error) {' \
+  '		return svc.Something(ctx, auth, args)' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_wrapped.go"
+run_case "bypass-tool-args-signature-wrapped" 1 "internal/mcp/tool_wrapped.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_wrapped.go"
 
 # A second database path inside package mcp, outside repo.go, is outside the
 # reach of Rule B. Rule D is the backstop.

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -419,6 +419,53 @@ run_case "bypass-tool-args-comment-between-parameters" 1 "internal/mcp/tool_comm
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 rm -f "$TREE/apps/api/internal/mcp/tool_commented.go"
 
+# EACH COMMENT FORM CAN CONTAIN THE OTHER'"'"'S DELIMITER, so a two-pass strip is
+# unsound in EITHER order. Stripping line comments first truncated this at the
+# `//` inside the URL and left an unclosed `/*` that the block pass could not
+# match; the residue stopped TOOLARGS_SIG matching and Rule C reported
+# containment. Stripping block comments first fails symmetrically on
+# `// /* text`. Only a single left-to-right scan is correct.
+printf '%s\n' 'package mcp' \
+  'var slashed = toolEntry{' \
+  '	invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, /* https://example */ args json.RawMessage) (string, error) {' \
+  '		return svc.Something(ctx, auth, args)' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_slashed.go"
+run_case "bypass-tool-args-block-comment-containing-slashes" 1 "internal/mcp/tool_slashed.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_slashed.go"
+
+# The mirror image: a line comment containing a block-comment opener. Stripping
+# block comments first would swallow from here to the next `*/` anywhere in the
+# file, silently eating real code.
+printf '%s\n' 'package mcp' \
+  '// a note about /* nested markers */ in this package' \
+  'var lineFirst = toolEntry{' \
+  '	invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, args json.RawMessage) (string, error) {' \
+  '		return svc.Something(ctx, auth, args)' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_linefirst.go"
+run_case "bypass-tool-args-line-comment-containing-block-opener" 1 "internal/mcp/tool_linefirst.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_linefirst.go"
+
+# MUST NOT REDDEN. A URL in an ordinary line comment, and a URL inside a STRING
+# LITERAL -- which is not a comment at all and must survive stripping intact.
+# The tool here uses the compliant discard, so the file must stay out of
+# FOUND_TOOLARGS and the tree must stay clean.
+printf '%s\n' 'package mcp' \
+  '// see https://example.com/docs for the protocol' \
+  'const endpoint = "https://example.com/mcp"' \
+  '/* a block comment mentioning https://example.com too */' \
+  'var discards = toolEntry{' \
+  '	invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, _ json.RawMessage) (string, error) {' \
+  '		return endpoint, nil' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_urls.go"
+run_case "ok-urls-in-comments-and-strings" 0 "Rule C  0 file(s)" "tool_urls.go binds" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_urls.go"
+
 # A DOT IMPORT puts New into the file's own scope, so the constructor is
 # spelled with no qualifier at all and no amount of looking for a dot finds it.
 printf '%s\n' 'package mcp' \

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -371,6 +371,42 @@ run_case "bypass-tool-args-signature-wrapped" 1 "internal/mcp/tool_wrapped.go bi
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 rm -f "$TREE/apps/api/internal/mcp/tool_wrapped.go"
 
+# NAMED RESULTS. `(out string, err error)` is the same Go type as
+# `(string, error)` and is assignable to toolInvoker, but the pattern admitted
+# a name on every PARAMETER and none on either RESULT. The handler was omitted
+# from FOUND_TOOLARGS and the guard reported successful containment over a live
+# request-input channel.
+printf '%s\n' 'package mcp' \
+  'var namedResults = toolEntry{' \
+  '	invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, args json.RawMessage) (out string, err error) {' \
+  '		out, err = svc.Something(ctx, auth, args)' \
+  '		return out, err' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_named_results.go"
+run_case "bypass-tool-args-named-results" 1 "internal/mcp/tool_named_results.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_named_results.go"
+
+# The same handler with named results AND the signature wrapped, so the result
+# list picks up gofmt's trailing comma on both halves at once.
+printf '%s\n' 'package mcp' \
+  'var namedWrapped = toolEntry{' \
+  '	invoke: func(' \
+  '		ctx context.Context,' \
+  '		svc *Service,' \
+  '		auth AuthorizedRequest,' \
+  '		args json.RawMessage,' \
+  '	) (' \
+  '		out string,' \
+  '		err error,' \
+  '	) {' \
+  '		return out, err' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_named_wrapped.go"
+run_case "bypass-tool-args-named-results-wrapped" 1 "internal/mcp/tool_named_wrapped.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_named_wrapped.go"
+
 # A second database path inside package mcp, outside repo.go, is outside the
 # reach of Rule B. Rule D is the backstop.
 printf '%s\n' 'package mcp' \

--- a/scripts/check-mcp-site-containment_test.sh
+++ b/scripts/check-mcp-site-containment_test.sh
@@ -407,6 +407,56 @@ run_case "bypass-tool-args-named-results-wrapped" 1 "internal/mcp/tool_named_wra
   --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
 rm -f "$TREE/apps/api/internal/mcp/tool_named_wrapped.go"
 
+# A comment is legal between any two tokens, so it survives flattening and a
+# pattern admitting only whitespace between parameters stops matching.
+printf '%s\n' 'package mcp' \
+  'var commented = toolEntry{' \
+  '	invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, /* the tool args */ args json.RawMessage) (string, error) {' \
+  '		return svc.Something(ctx, auth, args)' \
+  '	},' \
+  '}' >"$TREE/apps/api/internal/mcp/tool_commented.go"
+run_case "bypass-tool-args-comment-between-parameters" 1 "internal/mcp/tool_commented.go binds toolInvoker" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/tool_commented.go"
+
+# A DOT IMPORT puts New into the file's own scope, so the constructor is
+# spelled with no qualifier at all and no amount of looking for a dot finds it.
+printf '%s\n' 'package mcp' \
+  'import (' \
+  '	"github.com/jackc/pgx/v5"' \
+  '	. "github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"' \
+  ')' \
+  'func (s *Service) dotted(tx pgx.Tx) { _ = New(tx) }' \
+  >"$TREE/apps/api/internal/mcp/dotted.go"
+run_case "bypass-sqlc-new-via-dot-import" 1 "DOT-IMPORTED New(" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/dotted.go"
+
+# A pgx call whose first argument is an expression rather than a bare
+# identifier. The old pattern required an identifier and missed it.
+printf '%s\n' 'package mcp' \
+  'import "github.com/jackc/pgx/v5"' \
+  'func (s *Service) exprCtx(tx pgx.Tx, siteID uuid.UUID) error {' \
+  '	_, err := tx.Query(context.Background(), "SELECT id FROM sites WHERE id = $1", siteID)' \
+  '	return err' \
+  '}' >"$TREE/apps/api/internal/mcp/exprctx.go"
+run_case "bypass-direct-pgx-query-expression-context" 1 "executes SQL directly" - -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/exprctx.go"
+
+# MUST NOT REDDEN: gin's c.Query("name") is all over internal/mcp/handler.go and
+# shares the method name with pgx. A single string-literal argument is what
+# separates them, and Rule D must keep telling them apart.
+printf '%s\n' 'package mcp' \
+  'import "github.com/gin-gonic/gin"' \
+  'func (h *Handler) readParams(c *gin.Context) {' \
+  '	_ = c.Query("response_type")' \
+  '	_ = c.Query("client_id")' \
+  '}' >"$TREE/apps/api/internal/mcp/ginquery.go"
+run_case "ok-gin-context-query-is-not-a-database-path" 0 "check-mcp-site-containment: OK" "VIOLATION" -- \
+  --api-root "$TREE/apps/api" --allowlist "$ALLOW" --store-doc "$DOC"
+rm -f "$TREE/apps/api/internal/mcp/ginquery.go"
+
 # A second database path inside package mcp, outside repo.go, is outside the
 # reach of Rule B. Rule D is the backstop.
 printf '%s\n' 'package mcp' \


### PR DESCRIPTION
Closes the second of ADR-061 A11's two open auth-boundary gate items: the containment test.

## The requirement

A11 item 4: *no handler on this surface may take a site id from a request and pass it anywhere but the chokepoint.* The chokepoint is `mcp.Repo.ResolveScopeSites` (`apps/api/internal/mcp/repo.go:467`). It existed; nothing stopped the next handler going round it, which is why ADR-060's freeze clause still counts the item open.

## What this adds

- `scripts/check-mcp-site-containment.sh` — four rules over the surface, each reconciled against `infra/mcp-site-containment-allowlist.txt` in both directions.
- `scripts/check-mcp-site-containment_test.sh` — 30 cases, hermetic (fixture trees, no Go toolchain, no DB).
- `ci.yml`: both steps in the `go` job, self-test first, every PR, no path filter.
- `make check-mcp-containment` / `make check-mcp-containment-test`.

The rules: **A** chokepoint and `NewSiteSet` call sites; **B** every `uuid.UUID` parameter on the `mcp.Store` interface, read via `go doc` rather than grep, allowlisted by name — not only the ones spelled `site`, because `GetSiteByID(ctx, tenantID, id uuid.UUID)` is a bypass no `/site/i` pattern matches; **C** any file binding `toolInvoker`'s request `args`; **D** a backstop against a second database path inside package `mcp`.

Exit 2 is `GUARD BROKEN` and is distinct from exit 1. There is no exit code meaning "checked nothing, fine".

## Proofs

Red and green against the real tree, and a mutation test of the suite, are in the agent report accompanying this PR. Summary: a planted `GetSiteByID` + argument-reading tool gives exit 1 naming `repo.go:85` and `registry.go`; `git checkout --` restores and it is exit 0. Holing Rule B and re-running the suite reddens exactly the three Rule B cases.

## Blind spots, stated

Structural, not taint analysis — it proves every channel was reviewed, not that the review was right. Rule B's subject is the `Store` interface; Rule D is only a partial backstop. Rule C's granularity is the file. `_test.go` is excluded by design. Nothing here proves the chokepoint's SQL is correct — that is A11 item 6's integration proof, which this does not replace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI and Quality**
  * Added automated safeguards to keep MCP requests within approved site-containment rules.
  * Checks run on every pull request and push, detecting violations, outdated approvals, and invalid checks.
  * Expanded validation to identify unapproved database access paths and request-scope bypasses.

* **Developer Tools**
  * Added commands and regression tests for validating containment rules.
  * Added an auditable allowlist for tracking approved access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->