### PR TITLE
feat(mcp): audit every refusal on the assistant surface (ADR-061 A10)

### DIFF
--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -406,6 +406,53 @@ const (
 	// operator_permission (the dashboard authority the tool call mirrors) and
 	// tool.
 	ActionMCPToolCalled = "mcp.tool.called"
+	// ActionMCPToolDenied is the REFUSAL counterpart of ActionMCPToolCalled,
+	// under the same <action>.denied convention as
+	// ActionSiteFilesSensitiveDenied. It is recorded by
+	// internal/mcp.Service.RecordToolDenied whenever the tools/call gate
+	// (mcp.AuthorizeTool) refuses a named tool, and it is the surface's own
+	// evidence that the boundary held.
+	//
+	// THIS ROW IS NOT A RECORD OF AN ACTION; IT IS THE RECORD THAT NO ACTION
+	// HAPPENED, which is a different and stronger claim. ActionMCPToolCalled
+	// can be reconstructed after the fact from the effect it describes -- the
+	// data was read, something changed, there is a second trace. A refusal
+	// leaves NO other trace anywhere in the system by construction, so if this
+	// row is missing there is nothing to fall back on and "the boundary was
+	// never tested" is indistinguishable from "the boundary was tested and we
+	// lost the record".
+	//
+	// Actor kinds match ActionMCPToolCalled exactly and for the same reason:
+	// ActorAssistant over the mcp_grants id, never the human who granted
+	// access, because the fact an operator wants is WHICH CONNECTION was
+	// refused. TargetType is "mcp_tool" and TargetID is the name AS THE CALLER
+	// SPELLED IT -- an unregistered name is the whole content of a probe, and
+	// normalising it away would erase the evidence. Metadata carries
+	// refusal_reason (the operator-facing classification the wire deliberately
+	// blurs), grant_name, held_capabilities and scoped_sites.
+	//
+	// ON FAILURE THE APPEND IS LOGGED, NOT PROPAGATED, and the caller's refusal
+	// is unchanged. See TransportHandler.auditGap for the full argument; the
+	// short form is that "fail closed" has no meaning for an operation that is
+	// already a denial, and its only available implementation would tell the
+	// denied caller when this log is down.
+	ActionMCPToolDenied = "mcp.tool.denied"
+	// ActionMCPProtocolDenied is recorded when an AUTHENTICATED MCP request is
+	// refused at protocol negotiation -- a revision below the compatibility
+	// floor, or one this server does not speak. Same actor kinds as
+	// ActionMCPToolDenied. TargetType is "mcp_protocol" and TargetID is the
+	// revision string the client asked for.
+	//
+	// It earns a row separate from ActionMCPToolDenied because it answers a
+	// different question. A run of these from one grant is a client that cannot
+	// talk to this server at all, which looks identical to an idle connection
+	// in every other record the surface keeps: no tool is named, so
+	// ActionMCPToolDenied never fires, and last_used_at moves, so the grant
+	// does not look abandoned either. Metadata carries refusal_reason
+	// (below_floor / unsupported), the phase it was caught in (header or
+	// initialize_params), and the floor and target it was measured against, so
+	// a row stays interpretable after those constants move.
+	ActionMCPProtocolDenied = "mcp.protocol.denied"
 )
 
 // ActorFor resolves the (ActorType, ActorID) pair for whichever credential

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1211,10 +1211,12 @@ func (s *Service) RecordActivity(ctx context.Context, auth AuthorizedRequest) er
 
 // RecordToolCall appends the ActionMCPToolCalled audit row for one
 // successfully executed tool call. The caller (TransportHandler.callTool)
-// invokes this AFTER entry.invoke returns without error -- a refused call
-// never reaches a tenant's data, and is already visible in the operator log
-// TransportHandler writes at refusal time (h.log.WarnContext), so it earns no
-// row here.
+// invokes this AFTER entry.invoke returns without error. A REFUSED call is
+// recorded separately, by RecordToolDenied, under ActionMCPToolDenied: until
+// ADR-061 A10 was addressed this comment claimed a refusal earned no row
+// because it "never reaches a tenant's data and is already in the operator
+// log", and both halves of that were true while the conclusion was not -- see
+// the argument on RecordToolDenied.
 //
 // ActorType is ActorAssistant, the one actor kind in this whole log that
 // attributes the row to the MODEL rather than to the human who granted it
@@ -1246,6 +1248,111 @@ func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, to
 		Metadata: map[string]any{
 			"grant_name":          auth.GrantName,
 			"operator_permission": operatorPermission,
+		},
+	})
+	return err
+}
+
+// RecordToolDenied appends the ActionMCPToolDenied audit row for one REFUSED
+// tools/call. The caller (TransportHandler.callTool) invokes it on the
+// AuthorizeTool refusal branch, alongside the operator log line and before the
+// wire answer is chosen.
+//
+// WHY A REFUSAL EARNS A ROW WHEN THE OLD COMMENT ON RecordToolCall SAID IT DID
+// NOT. That comment argued a refusal "never reached a tenant's data, and is
+// already covered by the WarnContext log at the refusal site", and both halves
+// are true and neither is sufficient. Never reaching the data is exactly what
+// has to be PROVEN rather than assumed -- it is the boundary's own claim about
+// itself -- and an slog line is not the artifact that proves it: it is not
+// hash-chained, not tenant-scoped, not readable through the audit endpoint a
+// customer's auditor is given, and it is subject to a retention the log
+// pipeline chooses. "Who was denied what" was therefore answerable only by an
+// operator with production log access, which is the wrong audience and the
+// wrong durability for the record that a security boundary functioned.
+//
+// The actor pair is ActorAssistant over auth.GrantID, identical to
+// RecordToolCall's, so a single query on actor_id returns everything one
+// connection did AND everything it was refused -- which is the shape an
+// investigation actually wants, and it is why this is not modelled as a
+// separate actor kind.
+//
+// reason is the OPERATOR-FACING refusalReason, deliberately the value the wire
+// blurs: the whole disclosure decision on AuthorizeTool is that "no such tool"
+// and "not yours" are indistinguishable to the CALLER, and it holds only
+// because the operator gets the precise reason somewhere else. This row is now
+// that somewhere else. Taking the typed refusalReason rather than a string is
+// what stops a caller composing a reason by hand and drifting from the log line
+// two lines above it.
+//
+// BEST-EFFORT, and that is a deliberate divergence from ADR-061 A10's
+// fail-closed language rather than an oversight. See TransportHandler.auditGap.
+func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, toolName string, reason refusalReason) error {
+	// NOTE: a Service with no recorder records NOTHING and reports no error,
+	// the same as RecordToolCall. That is the unit-test configuration (see the
+	// audit field doc); in production WithAudit has always been called, and a
+	// request path reached without it is a wiring bug whose finding is "this
+	// deploy is unattributable", not "make this quieter".
+	if s.audit == nil {
+		return nil
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:  auth.TenantID,
+		ActorType: audit.ActorAssistant,
+		ActorID:   auth.GrantID.String(),
+		Action:    audit.ActionMCPToolDenied,
+		// The name AS SPELLED BY THE CALLER, not a registry name: on the
+		// unregistered branch there is no registry entry, and the string the
+		// caller guessed is the entire content of the evidence.
+		TargetType: "mcp_tool",
+		TargetID:   toolName,
+		Metadata: map[string]any{
+			"grant_name":        auth.GrantName,
+			"refusal_reason":    string(reason),
+			"held_capabilities": auth.Capabilities.Len(),
+			"scoped_sites":      auth.Sites.Len(),
+		},
+	})
+	return err
+}
+
+// RecordProtocolDenied appends the ActionMCPProtocolDenied audit row for an
+// authenticated request refused at revision negotiation.
+//
+// It is called from TransportHandler.writeProtocolRefusal, which is the ONE
+// function both refusal sites go through (the per-request header in serve, and
+// the initialize params). Putting the append there rather than at the two call
+// sites is what makes "every protocol refusal is recorded" structurally true
+// instead of true by convention -- a third refusal site added later inherits it.
+//
+// phase names which of the two negotiations refused, because they mean
+// different things operationally: a params refusal is a client that cannot
+// connect at all, a header refusal is a client that connected and then sent
+// something else, and only the second can indicate a proxy rewriting headers.
+func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedRequest, neg Negotiation, phase string) error {
+	if s.audit == nil {
+		return nil
+	}
+	reason := "unsupported"
+	if neg.Outcome == NegotiationBelowFloor {
+		reason = "below_floor"
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:   auth.TenantID,
+		ActorType:  audit.ActorAssistant,
+		ActorID:    auth.GrantID.String(),
+		Action:     audit.ActionMCPProtocolDenied,
+		TargetType: "mcp_protocol",
+		TargetID:   neg.Raw,
+		Metadata: map[string]any{
+			"grant_name":     auth.GrantName,
+			"refusal_reason": reason,
+			"phase":          phase,
+			// Recorded per row rather than left to be looked up: these are
+			// compile-time constants that WILL move, and a row that says only
+			// "2024-11-05 was refused" stops being interpretable the moment
+			// they do.
+			"floor":  ProtocolFloor,
+			"target": ProtocolTarget,
 		},
 	})
 	return err

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
@@ -234,7 +235,7 @@ func (h *TransportHandler) serve(c *gin.Context) {
 	)
 
 	if neg.Refused() {
-		h.writeProtocolRefusal(c, nil, neg)
+		h.writeProtocolRefusal(c, auth, nil, neg, "header")
 		return
 	}
 
@@ -411,7 +412,7 @@ func (h *TransportHandler) initialize(
 	// the header rule was written to accept.
 	paramNeg := NegotiateProtocol(p.ProtocolVersion)
 	if paramNeg.Refused() {
-		h.writeProtocolRefusal(c, req.ID, paramNeg)
+		h.writeProtocolRefusal(c, auth, req.ID, paramNeg, "initialize_params")
 		return jsonrpcResponse{}, false
 	}
 
@@ -553,6 +554,25 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 				slog.Int("held_capabilities", auth.Capabilities.Len()),
 				slog.Int("scoped_sites", auth.Sites.Len()),
 			)
+
+			// AND THE DURABLE ROW, on the same condition as the log line and
+			// for the same reason. ADR-061 A10: "the surface's own record of
+			// who was denied what is not reliable, which is the boundary's
+			// evidence." The WarnContext above is an operator convenience with
+			// no retention guarantee and no tenant scoping; this is the record
+			// a customer's auditor can read back.
+			//
+			// The condition is `reason != ""` and not `err != nil`
+			// DELIBERATELY. The one refusal with an empty reason is the
+			// registry-entry-with-no-implementation branch of AuthorizeTool,
+			// which is a BUILD DEFECT and not a denial: writing mcp.tool.denied
+			// for it would tell an auditor the boundary refused this connection
+			// when the truth is that the server is broken, and they would go
+			// looking at a grant that was never the problem. It is already
+			// reported at ERROR by toolError.
+			if aerr := h.svc.RecordToolDenied(ctx, auth, p.Name, reason); aerr != nil {
+				h.auditGap(ctx, auth, audit.ActionMCPToolDenied, p.Name, string(reason), aerr)
+			}
 		}
 
 		if de, ok := domain.AsDomain(err); ok && de.Code == ErrCodeToolNotAvailable {
@@ -587,9 +607,12 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 		return h.toolError(req.ID, err)
 	}
 
-	// The operator-facing audit row (ActionMCPToolCalled), for this call and
-	// no other outcome: a refusal above never reached a tenant's data and is
-	// already covered by the WarnContext log at the refusal site. BEST-EFFORT
+	// The operator-facing audit row (ActionMCPToolCalled), for this call and no
+	// other outcome. A refusal above writes ActionMCPToolDenied instead, on its
+	// own branch, so the two outcomes are separate actions rather than one
+	// action with a status field: a query for "what did this connection do"
+	// and a query for "what was this connection refused" are different
+	// questions and neither should have to filter the other out. BEST-EFFORT
 	// like RecordConnect's client-identity write is not -- a failure here is
 	// logged, never returned to the caller, because withholding a successful
 	// read's answer over a failure to record having answered it would make an
@@ -626,8 +649,85 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 // Refusals
 // ---------------------------------------------------------------------------
 
+// auditGap is what happens when a REFUSAL's audit append fails, and it is the
+// one place the failure posture for this surface's denial records is decided.
+//
+// THE DECISION: the caller's refusal is unchanged, and the failure is escalated
+// on the operator side instead. This is a deliberate divergence from the
+// fail-closed language in ADR-061 A10, and the reasoning is:
+//
+//  1. "FAIL CLOSED" IS NOT DEFINED FOR AN OPERATION THAT IS ALREADY A DENIAL.
+//     A10's rule is "no AI action is ever performed whose record was lost", and
+//     it works because there is always a second option: don't perform it. Here
+//     the action has already not been performed. There is nothing to withhold,
+//     nothing to roll back, and no companion write to bind the append to -- the
+//     approve path's RecordInTx shape has no analogue because a refusal touches
+//     no row.
+//
+//  2. THE ONLY AVAILABLE IMPLEMENTATION OF "FAIL CLOSED" HERE MAKES THE SURFACE
+//     WORSE AND RESTORES NOTHING. The single lever left is the wire answer:
+//     degrade the typed refusal (-32004 "call tools/list", -32002 "your site
+//     scope is empty") into -32603 internal error. That destroys the actionable
+//     half of the refusal for a legitimate client who is now told nothing they
+//     can act on, makes a transient database blip indistinguishable from a
+//     server bug, and DOES NOT WRITE THE ROW. The evidence gap is identical
+//     either way; only the client's experience differs, and only for the worse.
+//
+//  3. CHANGING THE WIRE ANSWER LEAKS AUDIT-SYSTEM LIVENESS TO THE PARTY BEING
+//     DENIED. This is the decisive one. The caller on this branch is by
+//     definition someone who just asked for something they may not have,
+//     including the wordlist-probing case AuthorizeTool's whole disclosure
+//     decision exists to defeat. A distinguishable answer when and only when
+//     the audit log is unwritable is a "the camera is off" oracle: probe until
+//     the response shape changes, then do the thing you actually came for. A
+//     surface that tells attackers when it has stopped recording is worse than
+//     one that quietly keeps answering.
+//
+// So the honest failure mode is not a different refusal, it is a LOUDER
+// OPERATOR SIGNAL, and that is what this writes. Two properties matter:
+//
+//   - THE LOST ROW'S CONTENT IS EMITTED HERE, not just the error. The hash
+//     chain has a hole that cannot be repaired, but the facts -- tenant, grant,
+//     what was asked for, why it was refused -- survive somewhere an operator
+//     can reach. It is strictly weaker evidence than the chained row (not
+//     tamper-evident, log retention, no audit endpoint) and it is named as
+//     such rather than presented as equivalent.
+//   - audit_gap=true is a single, greppable, alertable field. The requirement
+//     A10 is really making is that an operator FINDS OUT their evidence has a
+//     hole; an ERROR line indistinguishable from every other ERROR line does
+//     not satisfy that, and an alert keyed on this field does.
+//
+// WHAT THIS DOES NOT CLAIM. This is not A10's fail-closed helper. That helper
+// would have to bind the append to the operation, and for a denial there is no
+// operation to bind it to. If a WRITE tool ever lands on this surface and its
+// refusal has an effect to roll back, that refusal is a different case and must
+// not reuse this path by analogy.
+func (h *TransportHandler) auditGap(
+	ctx context.Context, auth AuthorizedRequest, action, target, reason string, err error,
+) {
+	h.log.ErrorContext(ctx, "mcp refusal audit write failed",
+		slog.Bool("audit_gap", true),
+		slog.String("action", action),
+		slog.String("tenant_id", auth.TenantID.String()),
+		slog.String("grant_id", auth.GrantID.String()),
+		slog.String("target", target),
+		slog.String("refusal_reason", reason),
+		slog.String("error", err.Error()),
+	)
+}
+
 // writeUnauthorized answers 401 -- NEVER 404 -- and names the scheme so a
 // client knows how to authenticate.
+//
+// NO AUDIT ROW IS WRITTEN HERE, and the omission is structural rather than a
+// gap left open by choice. Authenticate has just FAILED, so there is no tenant
+// id -- audit_log.tenant_id is NOT NULL and every RLS policy on the table keys
+// on it, so there is literally no tenant whose ledger this row could join. The
+// residual is real and is named in the report rather than papered over: an
+// invalid-token probe against this endpoint is visible in the operator log and
+// nowhere in any customer-readable record. Closing it needs somewhere for
+// unattributable refusals to go, which is a schema question and therefore
+// database-engineer's, not something to fake with a nil uuid.
 func (h *TransportHandler) writeUnauthorized(c *gin.Context, err error) {
 	c.Header("WWW-Authenticate", `Bearer realm="wpmgr-mcp"`)
 
@@ -658,7 +758,17 @@ func (h *TransportHandler) writeUnauthorized(c *gin.Context, err error) {
 // quietly reduced surface. Both are the silent-coercion failure this codebase
 // is governed by -- an unsupported revision answered with a working response is
 // a claim that the client's revision is spoken here.
-func (h *TransportHandler) writeProtocolRefusal(c *gin.Context, id json.RawMessage, neg Negotiation) {
+//
+// It also writes the ActionMCPProtocolDenied row for BOTH sites, because it is
+// the one function both go through. auth is threaded in for that: every caller
+// runs after Authenticate, so a tenant and a grant always exist here.
+func (h *TransportHandler) writeProtocolRefusal(
+	c *gin.Context, auth AuthorizedRequest, id json.RawMessage, neg Negotiation, phase string,
+) {
+	if err := h.svc.RecordProtocolDenied(c.Request.Context(), auth, neg, phase); err != nil {
+		h.auditGap(c.Request.Context(), auth, audit.ActionMCPProtocolDenied, neg.Raw, phase, err)
+	}
+
 	var msg string
 	switch neg.Outcome {
 	case NegotiationBelowFloor:

--- a/apps/api/tests/mcp_refusal_audit_integration_test.go
+++ b/apps/api/tests/mcp_refusal_audit_integration_test.go
@@ -1,0 +1,339 @@
+// mcp_refusal_audit_integration_test.go: ADR-061 A10's refusal half.
+//
+// WHAT WAS MISSING. internal/mcp wrote exactly ONE audit row on the transport
+// path, ActionMCPToolCalled, and only after a successful invoke. Every refusal
+// -- an unregistered tool name, a capability the grant does not hold, a
+// site-keyed tool on an empty resolved scope, a protocol revision below the
+// floor -- produced an slog line and NOTHING durable. A10 calls that record
+// "the boundary's evidence", and the boundary had none.
+//
+// WHY THESE PROOFS ARE HERE AND NOT IN internal/mcp. A unit test with a
+// fakeStore cannot construct an audit.Recorder (it needs a real *db.Pool), so
+// it can assert at most that a method was called. The three facts that matter
+// are all database facts:
+//
+//  1. The row actually lands in audit_log, hash-chained, with the right actor
+//     pair -- ActorAssistant over the GRANT id, never the human who approved
+//     the connection.
+//  2. It is readable back only through db.Pool as wpmgr_app -- rolsuper=f,
+//     rolbypassrls=f, printed from pg_roles INSIDE the transaction under test
+//     by mcpAssertAndReportRole. A test that opened its own connection would
+//     leave every RLS policy inert and pass regardless.
+//  3. A second tenant cannot see it, though both tenants' rows share one
+//     physical audit_log table.
+//
+// Every refusal below is driven through the SAME mounted transport a client
+// reaches, with a real minted bearer token. No GUC is hand-set in this file.
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpRefusalRPC is mcpRPC plus the MCP-Protocol-Version header, which the
+// shared helper cannot set and which one of the refusals below is entirely
+// about. Same transport, same engine, same bearer.
+func mcpRefusalRPC(t *testing.T, eng *gin.Engine, bearer, protoHeader string, payload map[string]any) rpcResult {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal rpc payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, mcp.TransportPath, strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.RemoteAddr = "203.0.113.9:5555"
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if protoHeader != "" {
+		req.Header.Set(mcp.ProtocolHeader, protoHeader)
+	}
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+	return rpcResult{status: w.Code, body: w.Body.String()}
+}
+
+// mintForRefusal mints a connection through the real POST
+// /api/v1/mcp/connections route and returns (grantID, token).
+func mintForRefusal(t *testing.T, eng *gin.Engine, name string, body map[string]any) (string, string) {
+	t.Helper()
+	body["name"] = name
+	var out struct {
+		GrantID string `json:"grant_id"`
+		Token   string `json:"token"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, body, nil, &out); code != http.StatusCreated {
+		t.Fatalf("mint %q answered %d, want 201", name, code)
+	}
+	if out.Token == "" || out.GrantID == "" {
+		t.Fatalf("mint %q returned grant_id=%q token empty=%t", name, out.GrantID, out.Token == "")
+	}
+	return out.GrantID, out.Token
+}
+
+// seedEmptyTag inserts a real site_tags row carrying NO sites, through the same
+// tenant tx helper the request path uses. A grant scoped to it is legitimate
+// and stores cleanly (verifyScopeReferents only refuses ids naming no row at
+// all), and it resolves to zero sites -- which is the site_scope_empty refusal
+// an operator actually hits.
+func seedEmptyTag(t *testing.T, pool *db.Pool, tenantID uuid.UUID, name string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`INSERT INTO site_tags (tenant_id, name) VALUES ($1, $2) RETURNING id`,
+			tenantID, name).Scan(&id)
+	})
+	if err != nil {
+		t.Fatalf("seed empty tag %q: %v", name, err)
+	}
+	return id
+}
+
+// TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole is the A10 proof.
+func TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion in this file: printed from
+	// pg_roles inside a transaction opened by the same helper the request path
+	// opens, so "these policies were live" is an executed fact and not a claim.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-refusal-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-refusal-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://"+suffix+".example.test")
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	connEng := mountConnectionsLikeProduction(t, svc, admin)
+	transportEng := mountLikeProduction(t, svc, admin)
+
+	const wideName = "refusal audit wide connection"
+	const emptyName = "refusal audit empty-scope connection"
+
+	wideGrantID, wideToken := mintForRefusal(t, connEng, wideName, map[string]any{
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	})
+	emptyTagID := seedEmptyTag(t, pool, tenantID, "refusal-audit-"+suffix)
+	emptyGrantID, emptyToken := mintForRefusal(t, connEng, emptyName, map[string]any{
+		"site_scope_mode": string(mcp.SiteScopeModeTags),
+		"scope_tag_ids":   []string{emptyTagID.String()},
+	})
+
+	// ------------------------------------------------------------------
+	// REFUSAL 1: a tool name that does not exist. reasonUnregistered.
+	// ------------------------------------------------------------------
+	const guessed = "sites.restart"
+	got := mcpRefusalRPC(t, transportEng, wideToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": guessed, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("tools/call %q answered HTTP %d, want 200 with a JSON-RPC error: %s", guessed, got.status, got.body)
+	}
+
+	denied := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied)
+	if len(denied) != 1 {
+		t.Fatalf("after one unregistered-name refusal, mcp.tool.denied rows = %d, want exactly 1", len(denied))
+	}
+	// ASSERT BY VALUE, never that a row exists.
+	if denied[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.tool.denied actor_type = %q, want %q", denied[0].actorType, audit.ActorAssistant)
+	}
+	if denied[0].actorID != wideGrantID {
+		t.Errorf("mcp.tool.denied actor_id = %q, want the grant id %q (NOT the approving user %q)",
+			denied[0].actorID, wideGrantID, userID)
+	}
+	if denied[0].targetID != guessed {
+		t.Errorf("mcp.tool.denied target_id = %q, want the name the caller spelled, %q", denied[0].targetID, guessed)
+	}
+	if r, _ := denied[0].metadata["refusal_reason"].(string); r != "unregistered" {
+		t.Errorf("mcp.tool.denied metadata.refusal_reason = %q, want %q", r, "unregistered")
+	}
+	if n, _ := denied[0].metadata["grant_name"].(string); n != wideName {
+		t.Errorf("mcp.tool.denied metadata.grant_name = %q, want %q", n, wideName)
+	}
+	t.Logf("REFUSAL 1 ok: mcp.tool.denied reason=unregistered target=%q actor=assistant/%s", guessed, wideGrantID)
+
+	// ------------------------------------------------------------------
+	// REFUSAL 2: a tool the grant HOLDS, on a resolved site scope of zero
+	// sites. reasonSiteScopeEmpty. This is the refusal ADR-061 A11 §3 calls
+	// "the single most likely place for a fail-open default to survive
+	// review", so its record is the one most worth having.
+	// ------------------------------------------------------------------
+	got = mcpRefusalRPC(t, transportEng, emptyToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("empty-scope tools/call answered HTTP %d, want 200: %s", got.status, got.body)
+	}
+	if !strings.Contains(got.body, "-32002") {
+		t.Fatalf("empty-scope tools/call did not answer the named scope-empty code -32002; "+
+			"this proof depends on that branch being the one taken: %s", got.body)
+	}
+
+	denied = queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied)
+	if len(denied) != 2 {
+		t.Fatalf("after the empty-scope refusal, mcp.tool.denied rows = %d, want 2", len(denied))
+	}
+	var scopeRow *mcpAuditRow
+	for i := range denied {
+		if denied[i].actorID == emptyGrantID {
+			scopeRow = &denied[i]
+		}
+	}
+	if scopeRow == nil {
+		t.Fatalf("no mcp.tool.denied row attributed to the empty-scope grant %s; rows: %+v", emptyGrantID, denied)
+	}
+	if scopeRow.actorType != audit.ActorAssistant {
+		t.Errorf("empty-scope row actor_type = %q, want %q", scopeRow.actorType, audit.ActorAssistant)
+	}
+	if scopeRow.targetID != mcp.ToolListSites {
+		t.Errorf("empty-scope row target_id = %q, want %q", scopeRow.targetID, mcp.ToolListSites)
+	}
+	if r, _ := scopeRow.metadata["refusal_reason"].(string); r != "site_scope_empty" {
+		t.Errorf("empty-scope row metadata.refusal_reason = %q, want %q", r, "site_scope_empty")
+	}
+	if n, ok := scopeRow.metadata["scoped_sites"].(float64); !ok || n != 0 {
+		t.Errorf("empty-scope row metadata.scoped_sites = %v, want 0 -- the number that MAKES it a refusal",
+			scopeRow.metadata["scoped_sites"])
+	}
+	t.Logf("REFUSAL 2 ok: mcp.tool.denied reason=site_scope_empty scoped_sites=0 actor=assistant/%s", emptyGrantID)
+
+	// ------------------------------------------------------------------
+	// REFUSAL 3: a protocol revision below the floor, on the header.
+	// ------------------------------------------------------------------
+	const belowFloor = "2024-11-05"
+	got = mcpRefusalRPC(t, transportEng, wideToken, belowFloor, map[string]any{
+		"jsonrpc": "2.0", "id": 3, "method": "tools/list",
+	})
+	if got.status != http.StatusBadRequest {
+		t.Fatalf("below-floor revision answered HTTP %d, want 400: %s", got.status, got.body)
+	}
+
+	proto := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPProtocolDenied)
+	if len(proto) != 1 {
+		t.Fatalf("mcp.protocol.denied rows = %d, want exactly 1", len(proto))
+	}
+	if proto[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.protocol.denied actor_type = %q, want %q", proto[0].actorType, audit.ActorAssistant)
+	}
+	if proto[0].actorID != wideGrantID {
+		t.Errorf("mcp.protocol.denied actor_id = %q, want the grant id %q", proto[0].actorID, wideGrantID)
+	}
+	if proto[0].targetID != belowFloor {
+		t.Errorf("mcp.protocol.denied target_id = %q, want the revision asked for, %q", proto[0].targetID, belowFloor)
+	}
+	if r, _ := proto[0].metadata["refusal_reason"].(string); r != "below_floor" {
+		t.Errorf("mcp.protocol.denied metadata.refusal_reason = %q, want %q", r, "below_floor")
+	}
+	if p, _ := proto[0].metadata["phase"].(string); p != "header" {
+		t.Errorf("mcp.protocol.denied metadata.phase = %q, want %q", p, "header")
+	}
+	if f, _ := proto[0].metadata["floor"].(string); f != mcp.ProtocolFloor {
+		t.Errorf("mcp.protocol.denied metadata.floor = %q, want %q", f, mcp.ProtocolFloor)
+	}
+	t.Logf("REFUSAL 3 ok: mcp.protocol.denied reason=below_floor phase=header requested=%s", belowFloor)
+
+	// ------------------------------------------------------------------
+	// REFUSAL 4: an unsupported revision in the initialize PARAMS, which is
+	// the other of the two negotiation sites and a different phase.
+	// ------------------------------------------------------------------
+	got = mcpRefusalRPC(t, transportEng, wideToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 4, "method": "initialize",
+		"params": map[string]any{"protocolVersion": "not-a-revision"},
+	})
+	if got.status != http.StatusBadRequest {
+		t.Fatalf("unparseable initialize revision answered HTTP %d, want 400: %s", got.status, got.body)
+	}
+	proto = queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPProtocolDenied)
+	if len(proto) != 2 {
+		t.Fatalf("after the initialize-params refusal, mcp.protocol.denied rows = %d, want 2", len(proto))
+	}
+	var paramRow *mcpAuditRow
+	for i := range proto {
+		if p, _ := proto[i].metadata["phase"].(string); p == "initialize_params" {
+			paramRow = &proto[i]
+		}
+	}
+	if paramRow == nil {
+		t.Fatalf("no mcp.protocol.denied row with phase=initialize_params; rows: %+v", proto)
+	}
+	if paramRow.targetID != "not-a-revision" {
+		t.Errorf("initialize-params row target_id = %q, want %q", paramRow.targetID, "not-a-revision")
+	}
+	if r, _ := paramRow.metadata["refusal_reason"].(string); r != "unsupported" {
+		t.Errorf("initialize-params row metadata.refusal_reason = %q, want %q", r, "unsupported")
+	}
+	t.Logf("REFUSAL 4 ok: mcp.protocol.denied reason=unsupported phase=initialize_params")
+
+	// ------------------------------------------------------------------
+	// OVER-FIRE CHECK: a SUCCESSFUL tool call must write mcp.tool.called and
+	// must NOT add an mcp.tool.denied row. A refusal recorder that fires on
+	// the success path would make every denial row meaningless, and the
+	// count assertions above would still pass.
+	// ------------------------------------------------------------------
+	deniedBefore := len(queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied))
+	got = mcpRefusalRPC(t, transportEng, wideToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 5, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK || strings.Contains(got.body, `"error"`) {
+		t.Fatalf("the success-path call did not succeed, so the over-fire check proves nothing: HTTP %d %s",
+			got.status, got.body)
+	}
+	called := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("mcp.tool.called rows = %d, want exactly 1", len(called))
+	}
+	if called[0].actorID != wideGrantID || called[0].targetID != mcp.ToolListSites {
+		t.Errorf("mcp.tool.called actor_id/target_id = %q/%q, want %q/%q",
+			called[0].actorID, called[0].targetID, wideGrantID, mcp.ToolListSites)
+	}
+	deniedAfter := len(queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied))
+	if deniedAfter != deniedBefore {
+		t.Fatalf("OVER-FIRE: a SUCCESSFUL tools/call added %d mcp.tool.denied row(s) (%d -> %d); "+
+			"the refusal recorder is firing on the success path",
+			deniedAfter-deniedBefore, deniedBefore, deniedAfter)
+	}
+	t.Logf("OVER-FIRE ok: a successful call wrote mcp.tool.called and left mcp.tool.denied at %d", deniedAfter)
+
+	// ------------------------------------------------------------------
+	// TENANT ISOLATION, on BOTH new actions. Same physical audit_log table.
+	// ------------------------------------------------------------------
+	otherTenant := seedTenant(t, pool, "mcp-refusal-other-"+suffix)
+	for _, action := range []string{audit.ActionMCPToolDenied, audit.ActionMCPProtocolDenied} {
+		cross := queryMCPAuditRowsAsAppRole(t, pool, otherTenant, action)
+		if len(cross) != 0 {
+			t.Fatalf("tenant %s's InTenantTx read %d %s row(s) belonging to tenant %s; "+
+				"RLS did not isolate the refusal record across tenants",
+				otherTenant, len(cross), action, tenantID)
+		}
+	}
+	t.Logf("ISOLATION ok: tenant %s sees none of tenant %s's refusal rows", otherTenant, tenantID)
+}


### PR DESCRIPTION
Closes the refusal half of ADR-061 A10: the MCP surface recorded a successful tool call and nothing else, so every refusal left no durable record of who was denied what.

## What changed

- `audit.ActionMCPToolDenied` (`mcp.tool.denied`) and `audit.ActionMCPProtocolDenied` (`mcp.protocol.denied`), under the same `<action>.denied` convention as `ActionSiteFilesSensitiveDenied`.
- `Service.RecordToolDenied` on the `AuthorizeTool` refusal branch, and `Service.RecordProtocolDenied` from `writeProtocolRefusal` — the one function both negotiation refusal sites go through, so a third site added later inherits the row.
- Both reuse the `ActorAssistant` / grant-id pair `RecordToolCall` already uses. No second resolver.

## Failure posture — a reasoned divergence from A10, argued in full on `TransportHandler.auditGap`

The caller's refusal is unchanged; the audit failure is escalated to a greppable `audit_gap=true` operator line carrying the lost row's content. Reasons:

1. "Fail closed" is undefined for an operation that is already a denial — there is nothing to withhold and no companion write to bind the append to.
2. Its only available implementation degrades a typed refusal (-32004 / -32002) to -32603 and still does not write the row. The evidence gap is identical; only the client's experience is worse.
3. A wire answer that changes only when the audit log is unwritable hands the denied caller — including the wordlist prober `AuthorizeTool`'s disclosure decision exists to defeat — an oracle for exactly when the surface stopped recording.

## Not claimed

This is **not** A10's fail-closed helper, and this PR does not close A10 as the ADR states it. See the agent report for the residuals.

## Proof status

The integration proof is queued behind the machine-wide `api-integration` lock; the mutation sweep has not run yet. Draft until both are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable audit records for refused MCP tool calls.
  * Added audit records for protocol negotiation refusals, including unsupported and below-minimum revisions.
  * Preserved normal protocol responses when audit recording encounters an issue, while improving operator visibility.

* **Tests**
  * Added integration coverage for refusal auditing, successful calls, hash-chained records, and tenant isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->