### PR TITLE
fix(mcp): tell the consent screen the truth about grant lifetime

### DIFF
--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -61,6 +61,18 @@ type consentResponseDTO struct {
 	State                string   `json:"state"`
 	CodeChallenge        string   `json:"code_challenge"`
 	CodeChallengeMethod  string   `json:"code_challenge_method"`
+
+	// GrantLifetimeDays is how long the grant this screen consents to will
+	// live, and it is here because the screen cannot state a lifetime it is
+	// not given.
+	//
+	// Until this field existed the consent screen told the user the connection
+	// "does not expire on its own", which stopped being true when m127 made
+	// mcp_grants.expires_at NOT NULL and CreateGrant began stamping every row
+	// with grantAbsoluteTTL. The dashboard had no way to say otherwise: adding
+	// 90 days client-side would have been the same falsehood with a shorter
+	// shelf life, since the term is a server constant the dashboard cannot see.
+	GrantLifetimeDays int `json:"grant_lifetime_days"`
 }
 
 func toConsentResponse(c ConsentContext) consentResponseDTO {
@@ -83,6 +95,9 @@ func toConsentResponse(c ConsentContext) consentResponseDTO {
 		State:               c.State,
 		CodeChallenge:       c.CodeChallenge,
 		CodeChallengeMethod: c.CodeChallengeMethod,
+		// Read from the same constant CreateGrant stamps expires_at from, not
+		// from a second copy of the number. See grantLifetimeDays.
+		GrantLifetimeDays: grantLifetimeDays(),
 	}
 }
 

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -47,6 +47,22 @@ const (
 	grantAbsoluteTTL = 90 * 24 * time.Hour
 )
 
+// grantLifetimeDays is grantAbsoluteTTL in whole days, and it is the ONLY
+// lifetime figure the consent screen is given.
+//
+// A TERM AND NOT A DATE, because at consent time no grant exists. expires_at is
+// stamped at approval from s.now(), which is later than the moment this
+// response was built by however long the human spends reading the screen, so a
+// timestamp computed here would be a date the row never holds. The term is
+// exact at both moments: approve it and it expires this many days later.
+//
+// DERIVED, NEVER RETYPED. The screen's sentence and the column's value now have
+// one source, so a change to grantAbsoluteTTL cannot leave the consent copy
+// stating the old term.
+func grantLifetimeDays() int {
+	return int(grantAbsoluteTTL / (24 * time.Hour))
+}
+
 // Error codes. These are domain codes; the OAuth wire errors are mapped from
 // them in dto.go so that RFC 6749 section 5.2 naming lives at the edge.
 const (

--- a/apps/web/src/features/mcp-consent/consent-context.test.ts
+++ b/apps/web/src/features/mcp-consent/consent-context.test.ts
@@ -21,6 +21,7 @@ const VALID = {
   redirect_uri: "https://attacker.example/oauth/callback",
   redirect_host: "attacker.example",
   scopes: [SCOPE_READ],
+  grant_lifetime_days: 90,
   state: "xyz",
   code_challenge: "abc",
   code_challenge_method: "S256",
@@ -77,6 +78,28 @@ describe("parseConsentContext — unverified identity", () => {
       .toEqual({ stated: false });
     const { client_name_unverified: _omitted, ...noName } = VALID;
     expect(parseConsentContext(noName).clientNameUnverified).toEqual({ stated: false });
+  });
+
+  it("refuses a payload with no grant lifetime rather than assuming one", () => {
+    // The screen has to say how long the authorisation lasts. A missing term
+    // is an unrenderable screen, not a screen that quietly falls back to the
+    // term this file last knew about. Same fail-closed direction as
+    // redirect_host above.
+    const { grant_lifetime_days: _omitted, ...noTerm } = VALID;
+    expect(() => parseConsentContext(noTerm)).toThrow();
+  });
+
+  it("refuses a grant lifetime that is not a positive whole number of days", () => {
+    expect(() => parseConsentContext({ ...VALID, grant_lifetime_days: 0 })).toThrow();
+    expect(() => parseConsentContext({ ...VALID, grant_lifetime_days: -30 })).toThrow();
+    expect(() => parseConsentContext({ ...VALID, grant_lifetime_days: 90.5 })).toThrow();
+    expect(() => parseConsentContext({ ...VALID, grant_lifetime_days: "90" })).toThrow();
+  });
+
+  it("carries the server's term through unchanged", () => {
+    expect(parseConsentContext({ ...VALID, grant_lifetime_days: 365 }).grantLifetimeDays).toBe(
+      365,
+    );
   });
 
   it("never coerces an absent optional into a plausible value", () => {

--- a/apps/web/src/features/mcp-consent/consent-context.ts
+++ b/apps/web/src/features/mcp-consent/consent-context.ts
@@ -80,6 +80,23 @@ export const consentWireSchema = z.object({
   state: z.string().optional(),
   code_challenge: z.string().optional(),
   code_challenge_method: z.string().optional(),
+
+  // REQUIRED, for the same reason redirect_host is.
+  //
+  // The screen has to tell the user how long they are authorising this for.
+  // The term is a server constant (grantAbsoluteTTL in
+  // apps/api/internal/mcp/service.go), stamped onto mcp_grants.expires_at at
+  // approval and enforced on every later request by the `g.expires_at > now()`
+  // arm of the authentication lookup (apps/api/db/query/mcp_connections.sql:561).
+  // The dashboard cannot derive it and must not assume it: hard-coding 90 here
+  // would restate a number only the server owns, and it would go quietly wrong
+  // the day the server's value changes.
+  //
+  // So an absent term is an unrenderable screen, not a screen with a default.
+  // A positive integer of days is the only parseable value: 0 would describe a
+  // grant that expires the moment it is created, which the schema refuses
+  // outright (mcp_grants_expires_at_after_created_check).
+  grant_lifetime_days: z.number().int().positive(),
 });
 
 export type ConsentWire = z.infer<typeof consentWireSchema>;
@@ -153,6 +170,15 @@ export interface ConsentContext {
   readonly state: string | null;
   readonly codeChallenge: string | null;
   readonly codeChallengeMethod: string | null;
+
+  /**
+   * Whole days from approval to automatic expiry, supplied by the server.
+   *
+   * Not nullable and not optional: every grant this screen can create expires,
+   * so there is no "no expiry" case for a caller to render. See the wire
+   * schema's note for why the dashboard is told this rather than computing it.
+   */
+  readonly grantLifetimeDays: number;
 }
 
 function orNull(raw: string | undefined): string | null {
@@ -180,6 +206,7 @@ export function parseConsentContext(raw: unknown): ConsentContext {
     state: orNull(wire.state),
     codeChallenge: orNull(wire.code_challenge),
     codeChallengeMethod: orNull(wire.code_challenge_method),
+    grantLifetimeDays: wire.grant_lifetime_days,
   };
 }
 

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -5,6 +5,7 @@ import { renderWithProviders } from "@/test/render";
 
 import { ConsentScreen, type ConsentScreenProps } from "./consent-screen";
 import { parseConsentContext, SCOPE_READ } from "./consent-context";
+import { bannedWordHits } from "./site-enforcement";
 import type { ScopedSite } from "./site-scope";
 
 // The rendered half of m124 obligation 7 and of the empty-scope rule.
@@ -27,6 +28,7 @@ const ATTACKER = parseConsentContext({
   redirect_uri: "https://claude-desktop-oauth.example.net/cb",
   redirect_host: "claude-desktop-oauth.example.net",
   scopes: [SCOPE_READ],
+  grant_lifetime_days: 90,
   state: "s",
   code_challenge: "cc",
   code_challenge_method: "S256",
@@ -100,6 +102,7 @@ describe("ConsentScreen — the self-declared name is never presented as verifie
       redirect_uri: "https://x.example/cb",
       redirect_host: "x.example",
       scopes: [SCOPE_READ],
+      grant_lifetime_days: 90,
     });
     renderWithProviders(<ConsentScreen {...props({ consent: nameless })} />);
     expect(screen.getByTestId("consent-client-name-absent").textContent).toMatch(
@@ -125,16 +128,94 @@ describe("ConsentScreen — what it can do and what it cannot", () => {
       redirect_uri: "https://x.example/cb",
       redirect_host: "x.example",
       scopes: [SCOPE_READ, "mcp:write"],
+      grant_lifetime_days: 90,
     });
     renderWithProviders(<ConsentScreen {...props({ consent: odd })} />);
     expect(screen.getByTestId("consent-unrecognised-scope")).toBeTruthy();
     expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(true);
   });
 
-  it("tells the user the grant lasts until revoked and where to revoke it", () => {
+  it("tells the user where to revoke it", () => {
     renderWithProviders(<ConsentScreen {...props()} />);
-    expect(screen.getByText(/does not expire on its own/i)).toBeTruthy();
     expect(screen.getByText(/AI connections/i)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The lifetime sentence
+// ---------------------------------------------------------------------------
+//
+// THIS SCREEN SHIPPED A FALSE ONE. It said the connection "does not expire on
+// its own", over a comment asserting mcp_grants had no expires_at column. m127
+// made that column NOT NULL and CreateGrant stamps every grant with
+// grantAbsoluteTTL, so the sentence was untrue at the exact moment a person
+// decides how long to authorise an assistant for. It was predicted in writing
+// before it shipped, which is why the tests below assert the replacement BY
+// VALUE and pin the retired wording as a thing that must never render again.
+//
+// Rendered through the real router and a real QueryClient (withRouter: true),
+// because a copy assertion that only ever sees a bare component is one mount
+// away from being about something the user does not get.
+describe("ConsentScreen — the lifetime it states is the one the server stamps", () => {
+  it("states the term in days, from the payload, not from a constant in this file", async () => {
+    const shortTerm = parseConsentContext({
+      client_id: "c_short",
+      identity_verified: false,
+      redirect_uri: "https://x.example/cb",
+      redirect_host: "x.example",
+      scopes: [SCOPE_READ],
+      // NOT 90. If the screen ever hard-codes the term, or recomputes it from
+      // its own idea of the default, this is the assertion that catches it.
+      grant_lifetime_days: 30,
+    });
+    renderWithProviders(<ConsentScreen {...props({ consent: shortTerm })} />, {
+      withRouter: true,
+    });
+    const expiry = await screen.findByTestId("consent-duration-expiry");
+    expect(expiry.textContent).toBe(
+      "This connection expires on its own 30 days after you approve it. Once it expires the " +
+        "client is refused at its next request and reads nothing further. Getting it working " +
+        "again means coming back to this screen and approving a new connection.",
+    );
+  });
+
+  it("never tells the user the connection does not expire", async () => {
+    renderWithProviders(<ConsentScreen {...props()} />, { withRouter: true });
+    const duration = (await screen.findByTestId("consent-duration-expiry")).closest("section");
+    expect(duration).not.toBeNull();
+    const text = duration!.textContent ?? "";
+
+    // The retired sentence and its two companions, each pinned as an exact
+    // substring. A future edit that restores any of them reddens here.
+    expect(text).not.toContain("does not expire on its own");
+    expect(text).not.toContain("It lasts until you revoke it");
+    expect(text).not.toContain("short-lived and renews itself");
+
+    // And the claim in its general form, however it might be reworded. The
+    // grant expires, so no phrasing of "no expiry" belongs on this screen.
+    expect(text).not.toMatch(/does not expire|never expires|no expiry|until you revoke it/i);
+
+    // The truthful half of the old copy survives: revocation still works and
+    // is immediate.
+    expect(text).toContain("You can end it sooner in Settings, under AI connections");
+    expect(text).toContain("takes effect immediately");
+  });
+
+  it("says nothing about idle expiry, which is not in force", async () => {
+    // mcp_grants.idle_expire_after_days exists but CreateGrant writes NULL
+    // (apps/api/internal/mcp/service.go, IdleExpireAfterDays: nil) and NULL
+    // means never idle-expire. A caveat about a control that is not running
+    // would be noise on a screen whose whole job is candour.
+    renderWithProviders(<ConsentScreen {...props()} />, { withRouter: true });
+    const duration = (await screen.findByTestId("consent-duration-expiry")).closest("section");
+    const text = duration!.textContent ?? "";
+    expect(text).not.toMatch(/idle|inactiv|unused|if you stop using/i);
+  });
+
+  it("keeps the duration copy clear of the words that overclaim", async () => {
+    renderWithProviders(<ConsentScreen {...props()} />, { withRouter: true });
+    const duration = (await screen.findByTestId("consent-duration-expiry")).closest("section");
+    expect(bannedWordHits(duration!.textContent ?? "")).toEqual([]);
   });
 });
 

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -452,14 +452,30 @@ function SiteScopeBlock({
 /**
  * Duration and revocation.
  *
- * NO DATE IS SHOWN, because there is no expiry to show. mcp_grants (m124, lines
- * 608-648) has a `status` of 'active' or 'revoked' and NO expires_at column,
- * and consentResponseDTO carries no lifetime field. Rendering a date here would
- * be inventing one, and rendering the word "never" as a lifetime would be
- * dressing an absent field as a decision. The truthful statement is the one
- * below: it lasts until it is revoked.
+ * A TERM IN DAYS, FROM THE SERVER, AND NOT A DATE THIS FILE COMPUTES.
+ * `grantLifetimeDays` is `grantAbsoluteTTL` (apps/api/internal/mcp/service.go)
+ * carried on the consent payload. Every grant is stamped with
+ * `mcp_grants.expires_at` at approval, the column is NOT NULL with no default
+ * (m127 decision 2), and the authentication lookup gates on
+ * `g.expires_at > now()` (apps/api/db/query/mcp_connections.sql:561), so
+ * expiry is a fact about the connection and not a background intention.
+ *
+ * Two things are deliberately absent. The first is a calendar date: no grant
+ * exists while this screen is open, the stamp happens at approval, and a date
+ * rendered here would be earlier than the one the row actually gets. The
+ * second is idle expiry: `mcp_grants.idle_expire_after_days` exists but
+ * CreateGrant writes NULL and NULL means never idle-expire, so no unused
+ * connection is closed for being unused today. Describing a control that is
+ * not running would be its own untrue sentence.
+ *
+ * Until 2026-08-31 this block said the connection "does not expire on its own",
+ * over a comment asserting mcp_grants had no expires_at column. The column
+ * landed in m127 and the sentence did not follow it, so the screen spent that
+ * window telling people a 90 day authorisation was open-ended at the moment
+ * they decided to grant it. The regression test asserts the replacement by
+ * value.
  */
-function DurationBlock() {
+function DurationBlock({ lifetimeDays }: { readonly lifetimeDays: number }) {
   return (
     <section
       aria-labelledby="consent-duration-heading"
@@ -468,15 +484,18 @@ function DurationBlock() {
       <h2 id="consent-duration-heading" className="text-sm font-medium">
         How long this lasts, and how to stop it
       </h2>
-      <p className="mt-2 text-sm text-[var(--color-muted-foreground)]">
-        This connection does not expire on its own. It lasts until you revoke it. The key the
-        client holds is short-lived and renews itself, so the connection keeps working until
-        you end it.
+      <p
+        data-testid="consent-duration-expiry"
+        className="mt-2 text-sm text-[var(--color-muted-foreground)]"
+      >
+        This connection expires on its own {lifetimeDays} days after you approve it. Once it
+        expires the client is refused at its next request and reads nothing further. Getting it
+        working again means coming back to this screen and approving a new connection.
       </p>
       <p className="mt-2 text-sm text-[var(--color-muted-foreground)]">
-        You end it in {REVOKE_LOCATION}. Every request this connection makes is checked against
-        that setting, so revoking stops it at its next request rather than whenever its current
-        key would have expired.
+        You can end it sooner in {REVOKE_LOCATION}, and that takes effect immediately. Every
+        request this connection makes is checked against that setting, so revoking stops it at
+        its next request rather than waiting for the {lifetimeDays} days to run out.
       </p>
     </section>
   );
@@ -648,7 +667,7 @@ export function ConsentScreen({
           )
         }
       />
-      <DurationBlock />
+      <DurationBlock lifetimeDays={consent.grantLifetimeDays} />
 
       <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4">
         <Label htmlFor="consent-name">Name this connection</Label>

--- a/apps/web/src/features/mcp-consent/denial.test.ts
+++ b/apps/web/src/features/mcp-consent/denial.test.ts
@@ -19,6 +19,7 @@ function ctx(over: Record<string, unknown> = {}) {
     redirect_uri: "https://client.example/oauth/cb",
     redirect_host: "client.example",
     scopes: [SCOPE_READ],
+    grant_lifetime_days: 90,
     state: "opaque-csrf-token",
     ...over,
   });

--- a/apps/web/src/routes/_authed/-connect.ai.test.tsx
+++ b/apps/web/src/routes/_authed/-connect.ai.test.tsx
@@ -135,6 +135,7 @@ const CONSENT = parseConsentContext({
   redirect_uri: "https://client.example/cb",
   redirect_host: "client.example",
   scopes: [SCOPE_READ],
+  grant_lifetime_days: 90,
   state: "opaque-csrf-token",
 });
 


### PR DESCRIPTION
## The defect

The live consent screen told users a fixed-term authorisation was open-ended, at the exact moment they decided whether to grant an assistant read access to their fleet.

`apps/web/src/features/mcp-consent/consent-screen.tsx:471` rendered:

> This connection does not expire on its own. It lasts until you revoke it. The key the client holds is short-lived and renews itself, so the connection keeps working until you end it.

The comment above it justified that by asserting `mcp_grants` has "NO expires_at column".

Both were false:

- `apps/api/db/schema.sql:5698` - `expires_at timestamptz NOT NULL`, no default (m127 decision 2).
- `apps/api/internal/mcp/service.go:47` - `grantAbsoluteTTL = 90 * 24 * time.Hour`, stamped at `service.go:653` by the same `CreateGrant` path this screen consents to.
- `apps/api/db/query/mcp_connections.sql:561` - `AND g.expires_at > now()` in the authentication lookup, so the expiry is enforced on every later request and not merely recorded.

The third sentence was false in its own right: `connectionTokenTTL` is also 90 days (`service.go:29`), so the key the client holds is not short-lived and does not renew itself.

## Why this needed an API field

`consentResponseDTO` carried no lifetime field, so the screen could not have stated the term. Computing it client-side would have restated a number only the server owns, and would have gone quietly wrong the day that number changed.

`GrantLifetimeDays int \`json:"grant_lifetime_days"\`` is now on the DTO, derived from `grantAbsoluteTTL` by `grantLifetimeDays()` rather than typed a second time.

**A term in days, not a date.** No grant exists while the screen is open; `expires_at` is stamped at approval from `s.now()`. A timestamp rendered at consent time would be earlier than the one the row actually gets. The term is exact at both moments.

**Idle expiry is not mentioned.** `mcp_grants.idle_expire_after_days` exists, but `CreateGrant` writes NULL (`service.go:671`) and NULL means never idle-expire. Nothing asks the operator for a window yet, so no connection is closed for being unused. A caveat about a control that is not running would be its own untrue sentence.

## The copy

> This connection expires on its own 90 days after you approve it. Once it expires the client is refused at its next request and reads nothing further. Getting it working again means coming back to this screen and approving a new connection.

> You can end it sooner in Settings, under AI connections, and that takes effect immediately. Every request this connection makes is checked against that setting, so revoking stops it at its next request rather than waiting for the 90 days to run out.

The revocation half of the old copy was true and survives. Checked against `ENFORCEMENT_BANNED_WORDS` by a test that reads the rendered DOM, not the source strings.

## Deploy order is load-bearing

`grant_lifetime_days` is **required** in the wire schema, matching how `redirect_host` is required: a payload with no term is an unrenderable screen rather than one that falls back to a default. This is the fail-closed direction that file already commits to, and it means **api deploys before web**. Web ahead of api makes every consent load fail its parse and refuse approval.

## Routing note for the reviewer

The DTO change is Go, under `backend-architect`'s path in the routing table. It was written here on the dispatching brief's explicit instruction that the field was in scope. It is additive and read-only (a response field derived from an existing constant; no auth logic, no query change, no migration), but it is on the MCP authorization surface and should get a `security-reviewer` pass before merge.

## Gates

| command | exit |
|---|---|
| `pnpm -C apps/web typecheck` | 0 |
| `pnpm -C apps/web lint` | 0 (0 errors, 10 pre-existing warnings) |
| `pnpm -C apps/web test` | 0 (166 files, 2110 tests passed) |
| `pnpm -C apps/web build` | 0 (`routeTree.gen.ts` unchanged, no new routes) |
| `go build ./...` | 0 |
| `go test ./internal/mcp/...` | 0 |

## Mutation sweep

- **M1** restored the retired sentence. Red, exit 1, two tests named it: `expected 'This connection does not expire on it...' to be 'This connection expires on its own 30...'` and `expected ... not to contain 'does not expire on its own'`.
- **M2** hard-coded `90` in place of `{lifetimeDays}`. Red, exit 1: `expected '...on its own 90...' to be '...on its own 30...'`.
- **M3** made the wire field `.optional().default(90)`. Red, exit 1: `refuses a payload with no grant lifetime rather than assuming one`.

All reverted. `git grep "MUTATION M" -- apps/web` exits 1 with no output; `git diff --stat` is empty.

## Finding, unrelated to this change

`impeccable detect` (2.1.9) fails open and reports nothing useful on TSX here. `impeccable detect /tmp/definitely-not-a-dir-xyz` prints `Warning: cannot access ...` and **exits 0**; a planted `style={{ color: "#ff0000" }}` in this file produced `[]` and exit 0 as well. The DoD's design-lint step passes vacuously for this file type, so its exit 0 above is reported as what it is rather than as evidence of a clean scan.
