### PR TITLE
docs(adr): accept ADR-062 and ADR-064, with 062's open items as ship blockers

### DIFF
--- a/docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md
+++ b/docs/adr/ADR-062-assistant-surface-phase-2-content-operations.md
@@ -1,12 +1,30 @@
 # ADR-062 — Assistant surface, Phase 2: governed fleet content operations
 
-**Status:** Proposed · **Date:** 2026-08-27
+**Status:** Accepted (2026-08-31), amended the same day by [A1](#amendments-2026-08-31); checklist items 3, 4, 9 and 10 stay open and are now ship blockers · **Date:** 2026-08-27
 **Supersedes/relates:** Revisits ADR-061 Decision 7 (site generation conceded) directly, and its acceptance supersedes that decision's concession framing for the content-editing and page-generation capabilities scoped below — see [Consequences](#consequences). Relates to ADR-061 as Accepted (Decision 1's siting and signed-command channel, Decision 2's out-of-band approval state machine, Decision 3's control-plane-derived approval facts and quarantined-note contract, Decision 4's application-layer site scoping with database-level scoping named as its own deferred decision, Decision 5's capability-by-registry-absence model, Decision 6's flat tool set and its roughly-25-entry facade threshold) and ADR-060 (this work sits at position 5, Differentiation, in that ADR's precedence order, and does not outbid open earlier-position work for engineering time).
 
-**This ADR is Proposed and it blocks Phase 2.** No content-write code ships in
-`apps/agent` or in the control plane until it is Accepted. The items in
-[The acceptance checklist](#the-acceptance-checklist) are what has to close
-first.
+**Amended 2026-08-31. Read [Amendments](#amendments-2026-08-31) before
+concluding that anything below has been lifted.** The status above changed;
+no decision text in this document is rewritten. One amendment, A1, records
+that this ADR is Accepted with four checklist items still open, and converts
+those four from acceptance criteria into ship blockers.
+
+*The paragraph immediately below is the gate as this ADR originally set it
+for itself. Its wording is unchanged, and it is quoted here rather than
+deleted because the record of what was originally required matters. What it
+means now is defined in A1, not here.*
+
+> **This ADR is Proposed and it blocks Phase 2.** No content-write code ships in
+> `apps/agent` or in the control plane until it is Accepted. The items in
+> [The acceptance checklist](#the-acceptance-checklist) are what has to close
+> first.
+
+**As amended, the operative rule is this.** No content-write code ships in
+`apps/agent` or in the control plane until checklist items 3, 4, 9 and 10 each
+close on their own terms. The gate moved from document approval to code
+shipping. It was not removed, it was not lifted, and it is not weaker: the
+same four items block the same code, and the only thing that changed is which
+event they block. **Item 4 in particular is unconditional**, and A1 says why.
 
 ---
 
@@ -211,6 +229,14 @@ recorded where the affected method lives rather than here in the abstract:
 Elementor.
 
 ## The acceptance checklist
+
+*Amended 2026-08-31. This list is unchanged and no box has been ticked. The
+sentence below, that every `[ ]` is a reason this ADR is still Proposed,
+recorded the acceptance procedure this document set for itself. The ADR is
+now Accepted with items 3, 4, 9 and 10 open, and those four are ship blockers
+under [A1](#amendments-2026-08-31). The boxes stay `[ ]` because the items are
+genuinely open; ticking them to match the status would be a lie, and an
+Accepted ADR with four visibly open items is the honest record.*
 
 `[x]` means the decision is recorded in this ADR; `[ ]` means it is not, and
 every `[ ]` is a reason this ADR is still Proposed. The count below is never
@@ -1106,6 +1132,13 @@ handler is written, not discovered after a double-apply incident.
 
 ## Why this is still Proposed
 
+*Amended 2026-08-31. This section is kept as written, including its heading,
+and the five reasons below are not withdrawn: each names something that is
+still open. What changed is what they block, per
+[A1](#amendments-2026-08-31). Point 1 is the one the amendment answers
+directly, and A1 records why its reasoning did not survive contact with the
+work it was gating.*
+
 1. **Its own gate is what would lift.** Accepting this ADR releases the
    sentence at the top — *no content-write code ships until it is
    Accepted*. That sentence should be released when the work is ready to
@@ -1247,3 +1280,104 @@ permanent open marks.
   changed timestamp does not trigger a rollback.
 - `make test-integration` run locally before merge, since content proposals
   carry site scoping and `ci.yml` does not run that package.
+
+---
+
+## Amendments (2026-08-31)
+
+This ADR set itself an acceptance procedure: every `[ ]` on
+[The acceptance checklist](#the-acceptance-checklist) was a reason it stayed
+Proposed, and it would become Accepted when they closed. Four did not close,
+and on 2026-08-31 the owner accepted the ADR anyway, deliberately and on the
+record, by moving those four rather than by waiting for them or ticking them.
+
+**This is a departure from this document's own procedure, and it is recorded
+as one rather than smoothed over.** No decision text above is rewritten, no
+box is ticked, and the gating paragraph near the top keeps its original
+wording so the record of what was originally required survives.
+
+### A1: Accepted with items 3, 4, 9 and 10 open, and those four become ship blockers
+
+**The decision.** ADR-062 is Accepted as of 2026-08-31 by explicit owner
+decision, with checklist items 3, 4, 9 and 10 open. They stay open, marked
+`[ ]`, and they are quoted here as the checklist states them, not paraphrased
+into something easier:
+
+- **Item 3.** "Own or delegate, per integration, with verify-and-rollback as
+  a shared platform primitive rather than a per-integration one." The rule is
+  recorded; the per-integration table that applies it is not fully written,
+  and cannot be for the builders behind the first two until the first-wave
+  machinery is proved once.
+- **Item 4.** "Snapshot before every destructive write, mandatory,
+  fail-closed, at the platform layer." Open because no fail-closed snapshot
+  mechanism for content rows exists. The file-write staging precedent is
+  fail-open by its own documentation, so it cannot be extended unchanged.
+- **Item 9.** "Dynamic-data binding as the primary write-reduction strategy."
+  Recorded as a design goal; the binding operation itself is unscoped and
+  lands with the first builder, so it cannot close ahead of that work.
+- **Item 10.** "How the tool surface accommodates content", bounded by
+  ADR-061 Decision 6's roughly-25-entry facade-revisit threshold rather than
+  a number invented here. The checklist calls this one **open by
+  construction**: the threshold is measured against a live `tools/list`,
+  which does not exist until the Phase 1 surface is serving traffic.
+
+**What the four items now are.** They convert from acceptance criteria into
+**ship blockers**. No content-write code ships in `apps/agent` or in the
+control plane until each of the four closes on its own terms. The gate has
+moved from document approval to code shipping. It has not been removed, it
+has not been lifted, and it is not weaker: the same four items block the same
+code, and the only thing that changed is which event they stand in front of.
+Accepting this ADR buys the right to design Phase 2, not the right to ship
+any part of it.
+
+**Item 4 is unconditional, and it is the one to read twice.** A mandatory,
+fail-closed, platform-layer snapshot taken before every destructive write
+**does not exist in this system today, in any form**. Nothing partial
+substitutes for it, the fail-open file-write staging mechanism least of all.
+No content-write capability ships without it, not behind a flag, not for one
+builder, not as a pilot on a single site, and not with the snapshot taken by
+an integration instead of by the platform. This is the safety net under
+everything Phase 2 does, and an acceptance that left it ambiguous would be
+worse than no acceptance at all.
+
+**Why the change was made.** The previous shape was circular. Items 3, 9 and
+10 each close only by doing design, scoping or measurement work that the
+gating paragraph forbade starting, because that paragraph blocked Phase 2
+work while the items were open, and the items could not close without it.
+Item 10 is the sharpest case and is why this could not be waited out: it is
+open by construction, measured against a live `tools/list` that does not
+exist yet, and it may never close on its own terms at all. **An acceptance
+criterion that cannot be satisfied is not a gate, it is a stall**, and a
+document held Proposed by one stops functioning as a decision record while
+the work it governs gets planned somewhere else, unrecorded. Moving the four
+to the shipping boundary keeps every one of them binding while letting the
+work that closes them begin.
+
+**What this unblocks.** Design, scoping and schema work for Phase 2: the
+per-integration own/delegate table, the fail-closed snapshot mechanism's
+design and its planted-failure proof, the binding operation's scoping, the
+proposal and staging schema, and the pre-development tasks under
+[The fleet-inventory query gates order](#the-fleet-inventory-query-gates-order-never-the-framework).
+
+**What this does not unblock.** Shipping any content write. Every entry under
+[What has to exist before any Phase 2 content code is written](#consequences)
+stands unchanged, including the service-principal attack-test suite, the
+`verify()` primitive with its planted-failure proof, the injection-fencing
+sanitizers, and the `security-reviewer` and `database-engineer` passes.
+
+**What this amendment does not touch.** It is scoped to this ADR's own
+acceptance procedure and nothing else.
+
+- **ADR-060's freeze clause is untouched.** This amendment does not close it,
+  weaken it, comment on it, or claim anything about whether Phase 2 trips it.
+  That clause remains ADR-060's one absolute prohibition, and it is read
+  through ADR-060's own Amendment A1, which this document does not amend.
+- **ADR-061's A10 (audit is fail-closed for this surface) and A11 (site
+  scoping is in v1, as an application-layer chokepoint, and it must be built
+  rather than assumed) are separate and still open.** Accepting ADR-062 does
+  not close either, does not weaken either, and says nothing about either.
+  Both remain exactly as ADR-061 leaves them.
+
+If this amendment is ever read as having touched any of those three, that
+reading is wrong: the only thing moved here is the boundary that four of
+this document's own checklist items stand at.

--- a/docs/adr/ADR-064-governed-site-org-context.md
+++ b/docs/adr/ADR-064-governed-site-org-context.md
@@ -845,9 +845,19 @@ ad hoc, document by document, by whichever ADR needs the exemption next.
 This document proceeds on the reading above for its own purposes, but does
 not treat that reading as binding on any future ADR; a later document
 claiming the same exemption should point at an ADR-060 amendment, not at
-this paragraph. **That amendment does not exist yet, and until it does this
-document can be merged and read as Proposed but cannot move to Accepted**
-— see Open questions, below.
+this paragraph. **That amendment now exists.** [ADR-060's Amendments
+(2026-08-27)](./ADR-060-phase-order-safety-before-capability.md#amendments-2026-08-27),
+its A1, "Defining 'externally-reachable surface' for the freeze clause,"
+defines the term this section had to interpret on its own, and ADR-060's own
+status line now reads "Accepted (amended 2026-08-27)." A1 reaches the same
+conclusion independently, naming this document by name: a dozen routes added
+for a caller class an existing, already-authenticated perimeter already
+admits, under an authentication requirement this ADR adds no new mechanism
+for, is not a new surface (ADR-060's Amendments section, "Contrast ADR-064").
+This section's reading was therefore correct, and is no longer this
+document's own unbound interpretation — it is what a superseding ADR-060
+amendment settles. **The gate is met.** This ADR moves to Accepted on that
+basis, not on a restatement of the argument above.
 
 This ADR's vocabulary leans on ADR-061 Decision 3, correctly attributed:
 that decision draws the line between control-plane-derived facts, which
@@ -994,20 +1004,23 @@ explicitly rather than drift into it unannounced.
 ## Open questions
 
 Named and owned, rather than answered with an invented mechanism this
-document has not earned the right to assert. None of the questions below
-blocks merging this ADR as Proposed; all of them block it moving to
-**Accepted**.
+document has not earned the right to assert. This ADR is accepted with
+questions 2 through 4 below still open, the same posture ADR-062 took the
+same day with its own four open items — acceptance records the decisions
+made, not a claim that every question this document raised has an answer.
 
-1. **What "surface" means for ADR-060's freeze clause.** Relationship,
-   above, argues Decision 13's routes are not gated by ADR-060's freeze
-   clause, but states plainly that this is this document's interpretation
-   of a term ADR-060 leaves undefined, not a settled reading, and that a
-   reading meant to bind later ADRs belongs in a superseding ADR-060
-   amendment, not in this one. That amendment does not exist yet.
-   **Owner:** whoever holds ADR-060 next (its author or a designated
-   successor). **Resolution:** a change to ADR-060, not to this document —
-   this ADR does not re-argue the point further and is not the place to
-   settle it.
+1. **Resolved. What "surface" means for ADR-060's freeze clause.**
+   Relationship, above, argued Decision 13's routes are not gated by
+   ADR-060's freeze clause, but stated plainly that this was this document's
+   own interpretation of a term ADR-060 left undefined, not a settled
+   reading, and that a reading meant to bind later ADRs belonged in a
+   superseding ADR-060 amendment, not in this one. **That amendment now
+   exists** — [ADR-060 Amendment A1](./ADR-060-phase-order-safety-before-capability.md#amendments-2026-08-27),
+   accepted 2026-08-27, defines "externally-reachable surface" for the
+   freeze clause and reaches, independently and by name, the same
+   conclusion this section argued. **Owner:** closed; ADR-060 held this
+   question. **Resolution:** landed in ADR-060 Amendment A1, cited above and
+   in Relationship.
 2. **Concurrency control on `PATCH` (Decision 13).** `PATCH` applies a
    partial field set onto the latest version's snapshot. Two concurrent
    `PATCH` calls touching disjoint fields can both read version N and both

--- a/docs/adr/ADR-064-governed-site-org-context.md
+++ b/docs/adr/ADR-064-governed-site-org-context.md
@@ -22,23 +22,35 @@ running today" are different claims — the two inherited layers are decided,
 not deployed.)
 
 **Accepted 2026-08-31 by owner decision.** This ADR set itself no acceptance
-checklist, and carries none: `grep -cE '^\s*-?\s*\[ \]'` against this file
-returns zero. That is the honest reason its acceptance is clean rather than
-conditional, and it is worth stating plainly, because the companion decision
+checklist, and carries none: `grep -cE '^[[:space:]]*-?[[:space:]]*\[[ xX]\]'`
+against this file, which matches a checkbox in any state rather than only an
+unchecked one, still returns zero. That is the honest reason its acceptance
+is clean rather than conditional, and it is worth stating plainly, because
+the companion decision
 taken on the same day (ADR-062, accepted with four items open, see its
 [Amendment A1](./ADR-062-assistant-surface-phase-2-content-operations.md#amendments-2026-08-31))
 is not clean in that way and should not be read as the same kind of event.
 
 Acceptance here makes the record match reality rather than authorising new
-work: the governed-context subsystem specified below is already built, wired
-and shipped. Its tables land in migrations `m122_governed_context` and
+work: the governed-context subsystem specified below is built, wired, and
+reachable in production, not merely inferred from a CHANGELOG entry. Its
+tables land in migrations `m122_governed_context` and
 `m123_org_context_write_scope`; its handler is mounted as `GovContextH` in
 `apps/api/internal/server/server.go`; its screens live under
-`apps/web/src/features/context/`; and `CHANGELOG.md` records the whole of it
-shipping in 0.61.147. What was missing was the decision record, not the
-implementation. **This does not extend to the two layers inherited from
-ADR-061**, which remain decided rather than deployed exactly as the paragraph
-above says.
+`apps/web/src/features/context/`; `CHANGELOG.md` records the whole of it
+shipping in 0.61.147; and, checked directly this session, an unauthenticated
+`GET` against the deployed `/api/v1/sites/{siteId}/context` and
+`/api/v1/sites/{siteId}/context/effective` routes returns `401`
+`application/json` rather than the `404 text/plain` an absent route would
+give, confirming both are mounted and live. **What remains open is not the
+implementation but three of this ADR's own decisions: Decision 7's
+fail-closed audit append does not exist yet, Decision 11's per-response-nonce
+injection fencing does not exist yet, and Decision 12's site-transfer
+mechanism does not exist anywhere in this codebase.** Acceptance records the
+decisions, including those three still-open ones, not a claim that every
+mechanism they describe is built. This also does not extend to the two
+layers inherited from ADR-061, which remain decided rather than deployed
+exactly as the paragraph above says.
 
 ---
 

--- a/docs/adr/ADR-064-governed-site-org-context.md
+++ b/docs/adr/ADR-064-governed-site-org-context.md
@@ -1,6 +1,6 @@
 # ADR-064 — Governed per-site and organisation context
 
-**Status:** Proposed · **Date:** 2026-08-27
+**Status:** Accepted (2026-08-31) · **Date:** 2026-08-27
 **Supersedes/relates:** ADR-060 (argued, under an interpretation of its
 undefined term "surface" rather than a settled reading, as not gated by its
 freeze clause — see Relationship, below, including the flag that this
@@ -20,6 +20,25 @@ its accepted design and five of which this ADR is the first record of. (As
 Decision 7 and Decision 11 below note, "ADR-061 specified it" and "it is
 running today" are different claims — the two inherited layers are decided,
 not deployed.)
+
+**Accepted 2026-08-31 by owner decision.** This ADR set itself no acceptance
+checklist, and carries none: `grep -cE '^\s*-?\s*\[ \]'` against this file
+returns zero. That is the honest reason its acceptance is clean rather than
+conditional, and it is worth stating plainly, because the companion decision
+taken on the same day (ADR-062, accepted with four items open, see its
+[Amendment A1](./ADR-062-assistant-surface-phase-2-content-operations.md#amendments-2026-08-31))
+is not clean in that way and should not be read as the same kind of event.
+
+Acceptance here makes the record match reality rather than authorising new
+work: the governed-context subsystem specified below is already built, wired
+and shipped. Its tables land in migrations `m122_governed_context` and
+`m123_org_context_write_scope`; its handler is mounted as `GovContextH` in
+`apps/api/internal/server/server.go`; its screens live under
+`apps/web/src/features/context/`; and `CHANGELOG.md` records the whole of it
+shipping in 0.61.147. What was missing was the decision record, not the
+implementation. **This does not extend to the two layers inherited from
+ADR-061**, which remain decided rather than deployed exactly as the paragraph
+above says.
 
 ---
 

--- a/docs/adr/ADR-064-governed-site-org-context.md
+++ b/docs/adr/ADR-064-governed-site-org-context.md
@@ -42,15 +42,22 @@ shipping in 0.61.147; and, checked directly this session, an unauthenticated
 `GET` against the deployed `/api/v1/sites/{siteId}/context` and
 `/api/v1/sites/{siteId}/context/effective` routes returns `401`
 `application/json` rather than the `404 text/plain` an absent route would
-give, confirming both are mounted and live. **What remains open is not the
-implementation but three of this ADR's own decisions: Decision 7's
-fail-closed audit append does not exist yet, Decision 11's per-response-nonce
-injection fencing does not exist yet, and Decision 12's site-transfer
-mechanism does not exist anywhere in this codebase.** Acceptance records the
-decisions, including those three still-open ones, not a claim that every
-mechanism they describe is built. This also does not extend to the two
-layers inherited from ADR-061, which remain decided rather than deployed
-exactly as the paragraph above says.
+give, confirming both are mounted and live. **Decision 7's fail-closed audit
+append is also built and wired, not open**: `RecordInTx`
+(`apps/api/internal/audit/audit.go:653`) is called from inside the same
+transaction as the version write at
+`apps/api/internal/govcontext/service.go:152,207,350,416` (org patch, org
+restore, site patch, site restore), and its error is returned up through
+`CreateOrgVersion`/`CreateSiteVersion`'s transaction callback
+(`apps/api/internal/govcontext/repo.go:287,466`), which aborts the whole
+transaction, so a failed append takes the version row with it exactly as
+Decision 7 requires. **What remains open is two of this ADR's own
+decisions: Decision 11's per-response-nonce injection fencing does not exist
+yet, and Decision 12's site-transfer mechanism does not exist anywhere in
+this codebase.** Acceptance records the decisions, including those two
+still-open ones, not a claim that every mechanism they describe is built.
+This also does not extend to the two layers inherited from ADR-061, which
+remain decided rather than deployed exactly as the paragraph above says.
 
 ---
 
@@ -624,10 +631,13 @@ routes — called directly, before the transfer completes, while
 export tool the Export paragraph above names as conditional on ever being
 built, because pointing at that tool specifically would overclaim a
 mechanism this codebase does not confirm exists. Decision 13's routes are
-at least a real, specified part of this ADR's own build — they do not exist
-yet because nothing in this Proposed ADR does, but "what has to exist
-before this ships" below already requires them for reasons independent of
-transfer.
+built and mounted, not merely specified: `GET .../context/versions`, the
+item and diff routes, and `POST .../restore` are registered on the same
+router group as `/context` and `/context/effective`
+(`apps/api/internal/govcontext/handler.go:49-55`), the two routes the
+acceptance note above confirms are live in production. What has no route to
+call it, because it does not exist, is the transfer mechanism itself,
+covered next.
 
 **The harder truth checked directly rather than assumed: no mechanism for
 moving a site to a different organisation exists anywhere in this
@@ -939,65 +949,77 @@ explicitly rather than drift into it unannounced.
   layer with the least standing to complain about it — an accepted
   trade-off, not an oversight.
 
-**What has to exist before this ships.**
+**What this ADR requires, checked against the codebase this session, item by
+item, rather than assumed shipped or assumed missing.**
 
-- One resolution function that both the model-facing context assembly and
-  the effective-context preview call — not two implementations of the same
-  seven-layer walk.
-- Version, author, and provenance columns on both context tables, with
-  `UPDATE`/`DELETE` revoked from the application role at the privilege
-  level, the same way the audit log already enforces append-only.
-- The `context.*` capabilities added to the existing registry, with a
-  registry test asserting no assistant-kind principal can ever be granted a
-  context-write capability — the same test shape ADR-061 Decision 5 already
-  uses for capabilities an assistant must never reach.
-- Planted-failure proofs, each pasted with its command and its before/after
-  output: a save shaped like a credential is rejected, and the rejection is
-  asserted not to contain the matched text; a site-level edit that would
-  remove an organisation-set restriction is rejected, and the prior version
-  is asserted unchanged; a forced audit-append failure is asserted to leave
-  no new context version committed; a tool call that a resolved restriction
-  forbids is refused at dispatch even when the fenced context the model was
-  handed contained no hint of the restriction's wording (Decision 4); after
-  a simulated site transfer, a principal in the destination organisation can
-  list only post-transfer versions, the first post-transfer version's
-  `diff` renders as a baseline rather than a computed comparison against
-  its sealed, source-stamped predecessor, and any restore of a
-  pre-transfer version id is refused for every caller, source organisation
-  included (Decision 12); two concurrent runs against the same site,
-  supplied with different layer-6 session inputs, resolve to different
-  effective context and neither run's session content appears in the
-  other's result or in the cached layers either one reads (Decision 2 and
-  Decision 8).
-- `make test-integration` coverage of tenant scoping on both new tables,
-  run before merge — context is exactly the shape of tenant-scoped data
-  ADR-061 Decision 4 already found this codebase gets wrong by default when
-  it is not checked.
-- **A restrictive site-scope policy on both context tables, not only tenant
-  isolation**, delivered as part of the deferred migration ADR-061 Decision
-  4 named and this ADR extends to include them (see Relationship, above).
-  Tenant isolation alone would let any principal scoped to the tenant read
-  or resolve another site's context; the restrictive policy is what confines
-  a read to the sites a principal can actually see.
-- **The injection-fencing mechanism itself**, per Decision 11 — the two
-  sanitizers ADR-061 lists under its own "What has to exist before v1 ships"
-  (ADR-061:544,548-550). This ADR's quarantine in Decision 11 has nothing to
-  run against until that mechanism is built.
-- **A fail-closed audit-append path**, per Decision 7 — `Record()` in
-  `apps/api/internal/audit/audit.go` is best-effort today
-  (`apps/api/internal/audit/audit.go:498-500`), and no fail-closed variant
-  exists for this ADR's transaction or for ADR-061's approval path either.
-- **A site-to-organisation transfer mechanism, which this ADR depends on
-  but does not build.** Verified this pass: no query in
-  `apps/api/db/query/sites.sql` reassigns a site's organisation, no file
-  under `apps/api/internal/site/` or `apps/api/internal/org/` implements
-  one, and no other ADR or `CHANGELOG.md` entry describes one. Decision
-  12's transfer rules (clear the site layer, stamp and seal history, treat
-  a stamp-boundary version as a diff baseline per Decision 5, refuse a
-  cross-boundary `restore`) are a contract for whatever eventually calls
-  them, not a hook into something already running — they have nothing to
-  run against, and are untestable end to end, until a real transfer
-  mechanism exists and invokes them.
+- **Built.** One resolution function, not two implementations of the same
+  seven-layer walk: `Resolver.Resolve` (`apps/api/internal/govcontext/resolver.go:70`)
+  is the only caller of the seven-layer walk in this codebase. The
+  effective-context preview calls it directly with `session=nil`
+  (`apps/api/internal/govcontext/service.go:471`). Nothing yet calls it with
+  a live session, because the model-facing assembly path that would supply
+  one does not exist; that is the ADR-061-deployment gap the acceptance note
+  above already names, not a second implementation of this walk.
+- **Built.** Version, author, and provenance columns exist on both context
+  tables, and `UPDATE`, `DELETE`, and `TRUNCATE` are revoked from the
+  application role on both
+  (`apps/api/migrations/20260824000000_m122_governed_context.sql:836,837`).
+- **Partly built.** `context.org.write` and `context.site.write` are
+  registered permissions, mapped only to `RoleAdmin` and `RoleOperator`
+  respectively (`apps/api/internal/authz/role.go:214,224,287,289`). No test
+  in the codebase references either permission constant (checked this
+  session, no hit under `apps/api/internal/**/*_test.go`), so the registry
+  test this item asks for, asserting no assistant-kind principal can ever be
+  granted a context-write capability, does not exist yet.
+- **Partly built.** Of the five planted-failure proofs, three exist and
+  pass: the widen rejection
+  (`TestADR064S4_PatchSiteContext_WideningOrgPolicy_RefusedAndNothingCommitted`,
+  `apps/api/tests/adr064_s4_govcontext_integration_test.go:64`), the
+  credential-shaped rejection with no echo
+  (`TestDetectSecret_NeverEchoesTheMatch`,
+  `apps/api/internal/govcontext/secretscan_test.go:65`), and the forced
+  audit-append failure, for both org and site
+  (`TestADR064S4_CreateOrgVersion_AuditFailureAbortsTheWholeWrite` and
+  `TestADR064S4_CreateSiteVersion_AuditFailureAbortsTheWholeWrite`, same
+  file, lines 169 and 471). Two do not exist, and cannot yet, because each
+  needs a mechanism this list already records as missing: a
+  tool-call-refusal-at-dispatch proof (Decision 4) has no live dispatch path
+  to run against, and a site-transfer simulation proof (Decision 12) has no
+  transfer mechanism to run against. A concurrent-session-isolation proof
+  was not found either; the nearest test,
+  `TestEffectiveContextPreview_NoSessionContent`
+  (`apps/api/internal/govcontext/preview_test.go:98`), proves the preview
+  carries no session content, which is a different claim from two live
+  sessions staying isolated from each other.
+- **Built.** `make test-integration` coverage of tenant scoping exists for
+  both tables in `apps/api/tests/adr064_governed_context_rls_integration_test.go`,
+  for example `TestADR064_TenantIsolation_AnotherOrgSeesNoContext` (line 273)
+  and `TestADR064_TenantIsolation_AnotherOrgCannotAuthorContext` (line 299).
+- **Built.** A restrictive site-scope policy, not only tenant isolation,
+  exists on both tables:
+  `org_context_versions_site_scope_insert` is `AS RESTRICTIVE FOR INSERT`
+  (`apps/api/migrations/20260824000000_m122_governed_context.sql:656`), and
+  the site table carries an `AS RESTRICTIVE FOR ALL` policy on `site_id`
+  (same file, line 805).
+- **Not built.** The injection-fencing mechanism itself, per Decision 11.
+  Unchanged since this ADR was written: the per-response-nonce sanitizers
+  ADR-061 lists under its own "What has to exist before v1 ships"
+  (ADR-061:544,548-550) do not exist, so this ADR's quarantine in Decision
+  11 has nothing to run against.
+- **Built.** A fail-closed audit-append path, per Decision 7. See the
+  acceptance note above for the file:line evidence. This bullet stays only
+  so the list reads complete, not because the mechanism is missing.
+- **Not built.** A site-to-organisation transfer mechanism, which this ADR
+  depends on but does not build. Re-checked this session: no query in
+  `apps/api/db/query/sites.sql` reassigns a site's organisation (zero hits
+  for an organisation-id column in that file), no file under
+  `apps/api/internal/site/` or `apps/api/internal/org/` implements one, and
+  no other ADR or `CHANGELOG.md` entry describes one. Decision 12's transfer
+  rules (clear the site layer, stamp and seal history, treat a
+  stamp-boundary version as a diff baseline per Decision 5, refuse a
+  cross-boundary `restore`) remain a contract for whatever eventually calls
+  them, not a hook into something already running, and are untestable end
+  to end until a real transfer mechanism exists and invokes them.
 
 ---
 
@@ -1052,8 +1074,9 @@ made, not a claim that every question this document raised has an answer.
    whether that mechanism should block on, prompt for, or simply document
    the loss of ordinary access to pre-transfer history. **Owner:**
    whoever eventually builds site-to-organisation transfer, unassigned
-   today; that build is itself a prerequisite this ADR depends on and
-   does not provide (see "What has to exist before this ships").
+   today; that build is itself a prerequisite this ADR depends on and does
+   not provide (see "What this ADR requires," in Consequences, above, which
+   confirms this one is still not built).
 4. **Nothing bounds the size of a stored context row.** Decision 9 caps
    each layer's contribution and the resolved whole in bytes, but
    specifies *truncation at resolution* — at a field or record boundary,

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,9 +43,9 @@ each file (see "Status line formats" below — the tree is not normalized).
 | 059 | Site-User Authentication Policy (2FA + Password Policy) | Accepted — 2026-06-20 | 2026-06-20 | [ADR-059-site-user-auth-policy.md](./ADR-059-site-user-auth-policy.md) |
 | 060 | Phase order: safety and truth before capability | Accepted (amended 2026-08-27) | 2026-08-18 | [ADR-060-phase-order-safety-before-capability.md](./ADR-060-phase-order-safety-before-capability.md) |
 | 061 | Assistant surface, Phase 1: control-plane server and out-of-band approval | Accepted (amended 2026-08-23 and 2026-08-24) | 2026-08-22 | [ADR-061-assistant-surface-phase-1.md](./ADR-061-assistant-surface-phase-1.md) |
-| 062 | Assistant surface, Phase 2: governed fleet content operations | Proposed | 2026-08-27 | [ADR-062-assistant-surface-phase-2-content-operations.md](./ADR-062-assistant-surface-phase-2-content-operations.md) |
+| 062 | Assistant surface, Phase 2: governed fleet content operations | Accepted (2026-08-31, amended the same day by A1); items 3, 4, 9 and 10 open as ship blockers | 2026-08-27 | [ADR-062-assistant-surface-phase-2-content-operations.md](./ADR-062-assistant-surface-phase-2-content-operations.md) |
 | 063 | Repository licensing, and the rules for third-party reuse | Accepted | 2026-08-24 | [ADR-063-licensing-and-third-party-reuse.md](./ADR-063-licensing-and-third-party-reuse.md) |
-| 064 | Governed per-site and organisation context | Proposed | 2026-08-27 | [ADR-064-governed-site-org-context.md](./ADR-064-governed-site-org-context.md) |
+| 064 | Governed per-site and organisation context | Accepted (2026-08-31) | 2026-08-27 | [ADR-064-governed-site-org-context.md](./ADR-064-governed-site-org-context.md) |
 
 Not part of the numbering: [`font-subsetting-phase2-plan.md`](./font-subsetting-phase2-plan.md)
 is a build plan, not a decision record. It lives in this directory because it


### PR DESCRIPTION
Records the owner decision of 2026-08-31. `docs/adr/` only: no code, no other document.

## ADR-064: Accepted outright

Status Proposed to Accepted (2026-08-31). It set itself no acceptance checklist (`grep -cE '^\s*-?\s*\[ \]'` returns 0), which is the honest reason this half is clean. A short dated note records that acceptance makes the record match reality rather than authorising new work: the governed-context subsystem is already built, wired and shipped. Verified in this branch, not inherited:

- migrations `20260824000000_m122_governed_context.sql` and `20260825000000_m123_org_context_write_scope.sql` present
- `GovContextH *govcontext.Handler` mounted in `apps/api/internal/server/server.go`, commented as ADR-064 slice S4
- screens under `apps/web/src/features/context/`
- `CHANGELOG.md` records it shipping in 0.61.147

The two layers inherited from ADR-061 stay decided rather than deployed, exactly as ADR-064 already says.

## ADR-062: Accepted with four items open, as ship blockers

Status Proposed to Accepted (2026-08-31), plus `Amendment A1`, written in the register of ADR-060 Amendment A1 (define, do not loosen; leave the original text standing).

Items 3, 4, 9 and 10 stay open and stay `[ ]`. **No box is ticked.** They convert from acceptance criteria into **ship blockers**: no content-write code ships in `apps/agent` or in the control plane until each closes on its own terms. The gate moved from document approval to code shipping. It was not removed and it is not weaker.

**Item 4 is unconditional** and A1 says so plainly: a mandatory, fail-closed, platform-layer snapshot before every destructive write does not exist in this system in any form today, and no content-write capability ships without it.

Why the change was made: the previous shape blocked the design and scoping work needed to close the items, which is circular. Item 10 is open by construction and may never close on its own terms, and an acceptance criterion that cannot be satisfied is not a gate, it is a stall.

Unblocked: design, scoping and schema work for Phase 2. Not unblocked: shipping any content write.

The original gating paragraph is **quoted, not deleted**, with a dated note around it, so the record of what was originally required survives. Same treatment at `The acceptance checklist` and `Why this is still Proposed`.

## Explicitly not touched

ADR-060's freeze clause, and ADR-061's A10 (audit is fail-closed for this surface) and A11 (site scoping is in v1, as an application-layer chokepoint). All separate, all still open, none closed, weakened or commented on. A1 says this in its own text.

## Gates run on this branch

- Docs vocabulary check, copied out of `ci.yml` this turn: no output, `grep` exit status 1, so no banned term anywhere under `docs/` or root markdown. The ADR-055 exclusion never came into play because there were no hits at all.
- `node apps/marketing/scripts/check-copy.mjs`: exit 0, 390 files.
- `make check-versions-test`: 76 passed, 0 failed.
- `make check-versions`: version surfaces consistent. No version surface is touched by this change, correctly, since this is a governance change and not a release.
- No em dashes or en dashes in any added line: `git diff -U0 -- docs/adr/ | grep '^+' | grep -E "—|–"` returns nothing.
- Open items after the change: `grep -cE '^- \[ \] \*\*[0-9]+\.'` returns 4, and they are 3, 4, 9 and 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated ADR-062 to Accepted, clarifying that four outstanding checklist items remain ship blockers for content-write functionality.
  - Updated ADR-064 to Accepted, documenting that governed context is already built and shipped.
  - Revised the ADR index to reflect the new statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->