### PR TITLE
release: 0.61.150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.150] - 2026-08-31
+
+### Fixed
+
+- The consent screen now states the truth about how long a connection lasts. It previously said "This connection does not expire on its own. It lasts until you revoke it," and that the key a client holds is short-lived and renews itself. Every grant is stamped with a 90-day absolute expiry, enforced in the authentication lookup, and the connection token carries the same lifetime. The screen now states the term it is actually consenting to, supplied by the API rather than computed in the browser.
+
+### Changed
+
+- Agent worktrees are now excluded from the Cloud Build upload, so a build no longer uploads the repository once for every live worktree.
+- ADR-062 and ADR-064 are now Accepted. ADR-062 is accepted with four checklist items open, converted from acceptance criteria to ship blockers, so no content-write code ships until each closes.
+
 ## [0.61.149] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.149**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.150**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.149
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.149
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.149
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.150
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.150
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.150
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.149   # omit to track :latest
+export WPMGR_VERSION=v0.61.150   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,18 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.150",
+    date: "2026-08-31",
+    summary:
+      "The MCP consent screen now states the truth about how long a connection lasts, instead of claiming it never expires on its own.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The consent screen now states the truth about how long a connection lasts. It previously said the connection does not expire on its own and that the key a client holds is short-lived and renews itself. Every grant carries a 90-day absolute expiry, enforced by the control plane, and the screen now shows the term it is actually consenting to instead of a claim computed in the browser.",
+      },
+    ],
+  },
+  {
     version: "0.61.149",
     date: "2026-08-30",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.149   # omit to track :latest
+export WPMGR_VERSION=v0.61.150   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.149
+  version: 0.61.150
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. The agent plugin stays at 0.61.147; only the
control-plane version surfaces move to 0.61.150.

- **Fixed:** the MCP consent screen now states the truth about how long a
  connection lasts. It previously said the connection does not expire on its
  own and that the key a client holds renews itself; every grant carries a
  90-day absolute expiry (enforced in the authentication lookup), and the
  screen now shows the term it is actually consenting to, supplied by the API.
- **Build:** agent worktrees are excluded from the Cloud Build upload.
- **Governance:** ADR-062 and ADR-064 are Accepted (ADR-062 with four
  checklist items converted from acceptance criteria to ship blockers).

Version surfaces bumped to 0.61.150: `CHANGELOG.md`, `README.md` (status line,
three `ghcr.io` pull tags, `WPMGR_VERSION` export), `docs/install.md`
(`WPMGR_VERSION` export), `packages/openapi/openapi.yaml` (`info.version`),
and the marketing `/changelog` page. The marketing hero badge and the agent
plugin (`apps/agent/wpmgr-agent.php`, `apps/agent/readme.txt`) are untouched
at 0.61.147, since this release does not change the agent.

## Test plan

- [x] `make check-versions-test` — 76 passed, 0 failed, exit 0
- [x] `make check-versions` — exit 0, all surfaces consistent, agent badge
      correctly frozen at 0.61.147
- [x] Docs vocabulary check (competitor names), copied verbatim from
      `ci.yml` in this session — no hits, exit 0
- [x] `node apps/marketing/scripts/check-copy.mjs` — passed, 390 files, no
      em/en dashes or competitor names
- [x] Grepped for stray `0.61.149` (none outside CHANGELOG history) and
      confirmed `0.61.147` is untouched everywhere in `apps/agent/**` and the
      marketing hero badge
- [x] Changelog entry dated `2026-08-31`, matching `date -u +%F`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the MCP consent screen to accurately explain that connections expire after 90 days.

- **Documentation**
  - Added release notes for version 0.61.150.
  - Updated installation guidance and prebuilt container references to version 0.61.150.
  - Updated the public API specification to reflect the latest release version.
  - Documented Cloud Build upload improvements and accepted architecture decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->