### PR TITLE
feat(mcp): tool-call rate limit for the live MCP endpoint (1A-11, part 1 of 3)

### DIFF
--- a/apps/api/internal/mcp/toolcall_limit.go
+++ b/apps/api/internal/mcp/toolcall_limit.go
@@ -1,0 +1,266 @@
+package mcp
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/time/rate"
+)
+
+// ---------------------------------------------------------------------------
+// THE TOOL-CALL BOUND (1A-11).
+//
+// POST /mcp authenticates a bearer connection token on every request and then,
+// before this file existed, dispatched tools/list and tools/call without any
+// budget at all. /oauth/mcp/register and POST /api/v1/mcp/connections were both
+// limited; the one endpoint a model actually drives in a loop was not. An
+// authenticated client -- or a leaked token, or a model stuck in a retry loop
+// -- could call tools without bound, and every call performs an authenticated
+// database write through Service.RecordActivity before it performs the read.
+//
+// ---------------------------------------------------------------------------
+// WHY THE KEY IS THE TENANT AND THE GRANT, AND WHY NEITHER CAN BE SPOOFED.
+//
+// Both keys come off AuthorizedRequest, which Service.Authenticate built by
+// hashing the bearer credential, looking the row up, and re-checking it under
+// the resolved tenant inside a tenant transaction. NEITHER VALUE IS EVER READ
+// FROM THE REQUEST. There is no ClientIP call, no GetHeader call and no
+// RemoteAddr parse anywhere in this file or on the path that reaches it, so
+// there is no header an attacker can vary to obtain a fresh bucket. That is the
+// property TestToolCallLimiter_KeysAreImmuneToClientHeaders executes rather
+// than asserts from this comment.
+//
+// This is a DELIBERATE DIVERGENCE from registrationLimiter next door, and the
+// reason is that the two endpoints differ in whether the caller is known.
+// /register is unauthenticated by RFC 7591, so the only unspoofable identity
+// available there is the TCP peer, and the bound has to be a global bucket
+// because a botnet supplies unlimited peers. Here the caller is authenticated
+// before this code runs, so the tenant IS the accountable identity and the
+// bound can be attributed to it.
+//
+// ---------------------------------------------------------------------------
+// WHY THE TENANT IS THE BOUND AND THE GRANT IS ONLY FAIRNESS.
+//
+// The grant cannot be the bound. A tenant that wants more budget would simply
+// mint more connections: minting is rate-limited but not forbidden, so a
+// per-grant bound is escapable by anyone willing to hold N credentials, which
+// makes it not a bound at all.
+//
+// The token cannot be the bound either, for the same reason one level down: a
+// grant may carry several connection tokens over its life and rotating a token
+// would hand the caller a fresh empty bucket, so the budget would reset on
+// exactly the action an operator takes when something is already wrong.
+//
+// The tenant is the one key an authenticated caller cannot multiply. The grant
+// layer sits in front of it as FAIRNESS ONLY, so one runaway model loop on one
+// connection cannot consume the whole organisation's budget and starve the
+// operator's other connections. It is explicitly not the bound, and if the
+// tenant layer is ever removed this comment is wrong and so is the code.
+//
+// ---------------------------------------------------------------------------
+// WHY THERE IS NO GLOBAL LAYER, WHICH IS THE OTHER DIVERGENCE.
+//
+// registrationLimiter has one because it must: an unauthenticated endpoint
+// cannot attribute load, so the only bound available is process-wide. Adding
+// the same layer here would REINTRODUCE THE EXACT STARVATION DEFECT that
+// file's own comment describes fixing -- one tenant saturating a shared bucket
+// denies service to every other tenant on the instance, and on Cloud Run that
+// is a cross-tenant availability event caused by a single compromised
+// credential. Since the caller here is always attributable, the correct ceiling
+// is per-tenant and the correct answer to a saturating tenant is to refuse that
+// tenant. The body cap in serve() already bounds the memory side.
+//
+// Both layers are per-process, so an N-instance deployment multiplies the
+// ceiling by N; the honest bound on N instances is N * ToolCallTenantPerMin. A
+// cross-instance cap needs shared state and is not in this slice.
+// ---------------------------------------------------------------------------
+
+const (
+	// ToolCallTenantPerMin is THE BOUND: tool-invoking requests one tenant may
+	// make per minute, per process, across every connection it holds.
+	//
+	// Sized against the real workload rather than a round number. Phase 1
+	// exposes one read tool over a fleet; an interactive model answering a
+	// question about that fleet makes a handful of calls per turn, and a
+	// generous human conversation is a few turns per minute. Two per second
+	// sustained is far above that and far below what a retry loop produces.
+	ToolCallTenantPerMin = 120
+
+	// ToolCallGrantPerMin is FAIRNESS, not the bound: the ceiling one
+	// connection may consume of its organisation's budget. Deliberately half
+	// the tenant budget, so a single looping connection cannot starve its
+	// siblings but a lone connection on a one-connection tenant still gets a
+	// workable share.
+	ToolCallGrantPerMin = 60
+
+	// toolCallKeyCap bounds each key map. Reaching it is a memory bound being
+	// enforced, not an error.
+	toolCallKeyCap = 4096
+
+	// toolCallIdle is how long an untouched bucket survives a sweep.
+	toolCallIdle = 10 * time.Minute
+)
+
+// toolCallLimiter is the two-layer bucket described above. The zero value is
+// NOT usable: construct it with newToolCallLimiter.
+type toolCallLimiter struct {
+	mu           sync.Mutex
+	tenants      map[uuid.UUID]*keyBucket
+	grants       map[uuid.UUID]*keyBucket
+	tenantPerMin int
+	grantPerMin  int
+	cap          int
+	idle         time.Duration
+}
+
+type keyBucket struct {
+	lim  *rate.Limiter
+	seen time.Time
+}
+
+// newToolCallLimiter builds the limiter. Like its sibling it runs no janitor
+// goroutine: each map is swept inline when it grows past the cap, which is the
+// only moment the memory bound is actually at risk.
+func newToolCallLimiter(tenantPerMin, grantPerMin int) *toolCallLimiter {
+	return &toolCallLimiter{
+		tenants:      make(map[uuid.UUID]*keyBucket),
+		grants:       make(map[uuid.UUID]*keyBucket),
+		tenantPerMin: tenantPerMin,
+		grantPerMin:  grantPerMin,
+		cap:          toolCallKeyCap,
+		idle:         toolCallIdle,
+	}
+}
+
+// limitScope names WHICH budget refused, so the refusal can tell the operator
+// whether to look at one connection or at the whole organisation. It is part of
+// the wire contract: it appears in the JSON-RPC error's data.
+type limitScope string
+
+const (
+	// scopeOrganisation means the tenant-wide bound refused. Every connection
+	// this organisation holds is affected.
+	scopeOrganisation limitScope = "organisation"
+
+	// scopeConnection means only this connection's fairness share refused. The
+	// organisation's other connections are unaffected.
+	scopeConnection limitScope = "connection"
+)
+
+// toolCallDecision is the limiter's verdict. RetryAfter is meaningful only when
+// Allowed is false, and is always at least one second when refusing so a caller
+// rounding it down to whole seconds never computes a zero wait and retries
+// immediately -- which is the retry loop this whole mechanism exists to stop.
+type toolCallDecision struct {
+	Allowed    bool
+	RetryAfter time.Duration
+	Scope      limitScope
+}
+
+// allow admits a tool-invoking request only when BOTH buckets can pay for it,
+// and charges BOTH only when it is admitted.
+//
+// A REFUSED REQUEST COSTS NOTHING, IN EITHER BUCKET, AND THAT IS STRUCTURAL --
+// the same shape, and for the same reason, as registrationLimiter.allow. Every
+// rejection path runs BEFORE any mutation and there is exactly ONE mutation
+// site, reached only on the admit path, so a future branch added to a rejection
+// path cannot leak a token: at the point those branches run there is nothing
+// yet to leak. Without this, a connection already over its own share would
+// still spend its organisation's budget on every request it was REFUSED for,
+// and the fairness layer would become the denial-of-service.
+//
+// The tenant bucket is checked FIRST so a saturated tenant does not allocate a
+// grant bucket per credential it holds. Because nothing is charged until both
+// checks pass, the ordering is a memory optimisation and not the invariant.
+//
+// A nil receiver REFUSES. An unconstructed limiter is a wiring failure, and the
+// one thing it must never do is read as "no limit configured, therefore
+// permitted".
+func (l *toolCallLimiter) allow(tenantID, grantID uuid.UUID) toolCallDecision {
+	if l == nil {
+		return toolCallDecision{Allowed: false, RetryAfter: time.Minute, Scope: scopeOrganisation}
+	}
+
+	now := time.Now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// ---- QUERY ONLY. Nothing below this line is charged until both pass. ----
+
+	tb := l.bucketLocked(l.tenants, tenantID, l.tenantPerMin, now)
+	if wait := shortfall(tb.lim, now); wait > 0 {
+		return toolCallDecision{Allowed: false, RetryAfter: atLeastASecond(wait), Scope: scopeOrganisation}
+	}
+
+	gb := l.bucketLocked(l.grants, grantID, l.grantPerMin, now)
+	if wait := shortfall(gb.lim, now); wait > 0 {
+		return toolCallDecision{Allowed: false, RetryAfter: atLeastASecond(wait), Scope: scopeConnection}
+	}
+
+	// ---- ADMITTED. The one and only mutation site. ----
+	tb.lim.AllowN(now, 1)
+	gb.lim.AllowN(now, 1)
+	return toolCallDecision{Allowed: true}
+}
+
+// bucketLocked fetches or creates the bucket for one key, sweeping the map
+// first when a new key would push it past the cap. The bucket is touched on
+// REFUSAL as well as admission -- deliberately, so a flooding key's bucket
+// stays alive rather than being swept and handed back empty, which would reset
+// the very limit it is hitting. Caller holds l.mu.
+func (l *toolCallLimiter) bucketLocked(
+	m map[uuid.UUID]*keyBucket, key uuid.UUID, perMin int, now time.Time,
+) *keyBucket {
+	b, ok := m[key]
+	if !ok {
+		sweepLocked(m, l.cap, l.idle, now)
+		b = &keyBucket{lim: perMinuteLimiter(perMin)}
+		m[key] = b
+	}
+	b.seen = now
+	return b
+}
+
+// sweepLocked bounds one key map. Idle buckets go first; if that is not enough
+// the map is emptied outright.
+//
+// Emptying hands every key a fresh bucket, so this layer is fail-open under
+// memory pressure -- the same accepted consequence as its sibling, but the
+// exposure here is much smaller and it is worth saying why rather than assuming
+// it transfers. registrationLimiter's peer keys are IP addresses, which an
+// attacker supplies for free, so filling that map is a cheap deliberate act.
+// The keys here are tenant and grant UUIDs that only Service.Authenticate
+// mints, so filling either map requires authenticating that many distinct real
+// credentials, each of which had to pass the mint limiter to exist. The cap is
+// memory hygiene against a genuinely large fleet, not a defence against a
+// cheap attack.
+//
+// Caller holds the owning limiter's mutex.
+func sweepLocked(m map[uuid.UUID]*keyBucket, cap int, idle time.Duration, now time.Time) {
+	if len(m) < cap {
+		return
+	}
+	for k, b := range m {
+		if now.Sub(b.seen) > idle {
+			delete(m, k)
+		}
+	}
+	if len(m) >= cap {
+		clear(m)
+	}
+}
+
+// atLeastASecond floors a refusal's advertised wait at one second.
+//
+// Retry-After is expressed in whole seconds, and a sub-second shortfall
+// rendered into that header truncates to "0" -- which tells a client to retry
+// at once, producing precisely the tight loop the refusal is meant to break.
+// Rounding a refusal's wait UP is always safe; rounding it down is not.
+func atLeastASecond(d time.Duration) time.Duration {
+	if d < time.Second {
+		return time.Second
+	}
+	return d
+}

--- a/apps/api/internal/mcp/toolcall_limit.go
+++ b/apps/api/internal/mcp/toolcall_limit.go
@@ -189,12 +189,12 @@ func (l *toolCallLimiter) allow(tenantID, grantID uuid.UUID) toolCallDecision {
 
 	// ---- QUERY ONLY. Nothing below this line is charged until both pass. ----
 
-	tb := l.bucketLocked(l.tenants, tenantID, l.tenantPerMin, now)
+	tb := l.tenantBucketLocked(tenantID, now)
 	if wait := shortfall(tb.lim, now); wait > 0 {
 		return toolCallDecision{Allowed: false, RetryAfter: atLeastASecond(wait), Scope: scopeOrganisation}
 	}
 
-	gb := l.bucketLocked(l.grants, grantID, l.grantPerMin, now)
+	gb := l.grantBucketLocked(grantID, now)
 	if wait := shortfall(gb.lim, now); wait > 0 {
 		return toolCallDecision{Allowed: false, RetryAfter: atLeastASecond(wait), Scope: scopeConnection}
 	}
@@ -205,40 +205,115 @@ func (l *toolCallLimiter) allow(tenantID, grantID uuid.UUID) toolCallDecision {
 	return toolCallDecision{Allowed: true}
 }
 
-// bucketLocked fetches or creates the bucket for one key, sweeping the map
-// first when a new key would push it past the cap. The bucket is touched on
-// REFUSAL as well as admission -- deliberately, so a flooding key's bucket
-// stays alive rather than being swept and handed back empty, which would reset
-// the very limit it is hitting. Caller holds l.mu.
-func (l *toolCallLimiter) bucketLocked(
-	m map[uuid.UUID]*keyBucket, key uuid.UUID, perMin int, now time.Time,
-) *keyBucket {
-	b, ok := m[key]
+// tenantBucketLocked fetches or creates one tenant's bucket -- THE BOUND.
+//
+// It sweeps with sweepFullOnly, which can only ever evict a bucket that has
+// already refilled. There is deliberately no way to reach the clearing sweep
+// from here: the two accessors exist as separate functions, rather than one
+// taking the map as a parameter, precisely so a later edit cannot hand the
+// bound map the fairness map's sweeper by passing the wrong argument.
+//
+// The bucket is touched on REFUSAL as well as admission, so a flooding key's
+// bucket stays alive rather than being swept and handed back empty, which would
+// reset the very limit it is hitting. Caller holds l.mu.
+func (l *toolCallLimiter) tenantBucketLocked(key uuid.UUID, now time.Time) *keyBucket {
+	b, ok := l.tenants[key]
 	if !ok {
-		sweepLocked(m, l.cap, l.idle, now)
-		b = &keyBucket{lim: perMinuteLimiter(perMin)}
-		m[key] = b
+		sweepFullOnly(l.tenants, l.cap, now)
+		b = &keyBucket{lim: perMinuteLimiter(l.tenantPerMin)}
+		l.tenants[key] = b
 	}
 	b.seen = now
 	return b
 }
 
-// sweepLocked bounds one key map. Idle buckets go first; if that is not enough
-// the map is emptied outright.
+// grantBucketLocked fetches or creates one connection's bucket -- FAIRNESS.
 //
-// Emptying hands every key a fresh bucket, so this layer is fail-open under
-// memory pressure -- the same accepted consequence as its sibling, but the
-// exposure here is much smaller and it is worth saying why rather than assuming
-// it transfers. registrationLimiter's peer keys are IP addresses, which an
-// attacker supplies for free, so filling that map is a cheap deliberate act.
-// The keys here are tenant and grant UUIDs that only Service.Authenticate
-// mints, so filling either map requires authenticating that many distinct real
-// credentials, each of which had to pass the mint limiter to exist. The cap is
-// memory hygiene against a genuinely large fleet, not a defence against a
-// cheap attack.
+// It sweeps with sweep, which may clear the map outright. That is safe here and
+// only here: the tenant bucket behind this layer is swept losslessly and still
+// refuses, so the ceiling survives any eviction of this map. Caller holds l.mu.
+func (l *toolCallLimiter) grantBucketLocked(key uuid.UUID, now time.Time) *keyBucket {
+	b, ok := l.grants[key]
+	if !ok {
+		sweep(l.grants, l.cap, l.idle, now)
+		b = &keyBucket{lim: perMinuteLimiter(l.grantPerMin)}
+		l.grants[key] = b
+	}
+	b.seen = now
+	return b
+}
+
+// THE TWO MAPS ARE SWEPT BY DIFFERENT RULES, BECAUSE THEY HAVE DIFFERENT JOBS.
+//
+// This is the correction to a real defect. Both maps were originally swept by
+// one function copied in shape from registrationLimiter.sweepLocked, which
+// clears its map outright under pressure. That file justifies clearing in one
+// sentence -- it is "safe ONLY because the global bucket above is not swept and
+// still refuses" -- and this limiter deliberately HAS NO GLOBAL BUCKET, for the
+// starvation reason argued at the top of this file. So the shape was inherited
+// without the property that made it safe: clearing the tenant map resets the
+// bound itself, and a saturated tenant's budget came back the moment enough
+// distinct organisations were active on one process.
+//
+// The consequence was scale degradation of a denial-of-service control rather
+// than an isolation break -- it needs thousands of real authenticated
+// organisations, not something one caller can mint -- but a bound that resets
+// under load is not a bound, and the argument for clearing was never true here.
+//
+// THE RULE THAT REPLACES IT RESTS ON ONE OBSERVATION: A FULL BUCKET CARRIES NO
+// STATE. A limiter at its burst ceiling is indistinguishable from a freshly
+// constructed one, so deleting it and rebuilding it on the next request yields
+// exactly the same object. Evicting full buckets is therefore LOSSLESS, and
+// evicting anything below full is precisely what loses the bound.
+//
+// sweepFullOnly is what the tenant map gets: it can only ever drop buckets that
+// have already refilled, so no tenant's budget is ever handed back early, at
+// any cap and under any load. A bucket refills in at most one window (60s for a
+// per-minute budget), so in steady state this evicts everything an idle sweep
+// would have, and it does it with a proof instead of a hope.
+//
+// WHAT HAPPENS WHEN NOTHING IS EVICTABLE is the other half of the decision, and
+// the map is allowed to GROW PAST THE CAP rather than take either alternative.
+// Clearing would reset the bound, which is fail-open on a DoS control. Refusing
+// the new tenant would fail closed on legitimate work and would be a
+// cross-tenant denial of service -- one busy organisation locking new ones out
+// -- which is the same defect the "no global layer" decision exists to avoid.
+// Growth is the only option that is wrong in neither direction, and its cost is
+// bounded by something real: a key is minted only by Service.Authenticate, so
+// every entry cost an attacker a genuine authenticated credential that had to
+// pass the mint limiter to exist. The cap is memory hygiene against a large
+// fleet, not a defence against a cheap attack, and a soft cap is the honest
+// shape for that.
 //
 // Caller holds the owning limiter's mutex.
-func sweepLocked(m map[uuid.UUID]*keyBucket, cap int, idle time.Duration, now time.Time) {
+func sweepFullOnly(m map[uuid.UUID]*keyBucket, cap int, now time.Time) {
+	if len(m) < cap {
+		return
+	}
+	for k, b := range m {
+		// Burst is the ceiling, so tokens >= burst means fully refilled. Read
+		// with TokensAt, which is a pure query and does not advance the bucket.
+		if b.lim.TokensAt(now) >= float64(b.lim.Burst()) {
+			delete(m, k)
+		}
+	}
+	// Deliberately NO clear() fallback. See above: a map that cannot be swept
+	// losslessly grows instead of surrendering the bound.
+}
+
+// sweep is what the GRANT map gets, and clearing is still correct there.
+//
+// The grant map is the FAIRNESS layer, not the bound. Handing a connection a
+// fresh share early is a loss of fairness only: the tenant bucket behind it is
+// swept losslessly and still refuses, so the ceiling holds however this map is
+// evicted. That is the same argument registrationLimiter makes for its per-peer
+// map, and here -- unlike in the tenant case above -- the property it depends
+// on is actually present.
+//
+// Idle buckets go first; if that is not enough the map is emptied outright.
+//
+// Caller holds the owning limiter's mutex.
+func sweep(m map[uuid.UUID]*keyBucket, cap int, idle time.Duration, now time.Time) {
 	if len(m) < cap {
 		return
 	}

--- a/apps/api/internal/mcp/toolcall_limit.go
+++ b/apps/api/internal/mcp/toolcall_limit.go
@@ -115,12 +115,24 @@ const (
 	// first minute nor the steady state is the actual defect; the mechanism is
 	// fine and was simply being described wrongly.
 	//
-	// Burst equal to the sustained allowance is therefore kept and made
-	// EXPLICIT here rather than left implied by a shared helper. It buys a
-	// bursty conversational turn at the cost of a bounded instantaneous spike,
-	// and both halves are now stated to the client in the refusal payload.
-	ToolCallTenantBurst = ToolCallTenantPerMin
-	ToolCallGrantBurst  = ToolCallGrantPerMin
+	// THE BURST IS SIZED TO AN INTERACTIVE TURN, NOT TO THE WHOLE MINUTE.
+	//
+	// Leaving burst equal to the sustained allowance -- which is what the
+	// shared helper did implicitly -- has two costs. It lets a bucket that has
+	// been idle admit a full minute's traffic in one instant, which on this
+	// endpoint is that many database writes at once. And it makes the two
+	// published numbers identical, so a client cannot tell them apart and the
+	// pair carries no more information than the single figure it replaced.
+	//
+	// These values are sized from the workload the over-fire proof already
+	// pins: an ordinary interactive session is around twenty calls, so a grant
+	// burst of thirty covers a generous turn with margin, and a tenant burst of
+	// sixty covers two connections doing that at once. The worst-case first
+	// minute falls to 90 for a connection and 160 for an organisation, against
+	// 120 and 240 before -- so this also narrows the gap between the advertised
+	// sustained rate and the true ceiling, rather than only describing it.
+	ToolCallTenantBurst = 60
+	ToolCallGrantBurst  = 30
 
 	// toolCallKeyCap bounds each key map. Reaching it is a memory bound being
 	// enforced, not an error.

--- a/apps/api/internal/mcp/toolcall_limit.go
+++ b/apps/api/internal/mcp/toolcall_limit.go
@@ -94,6 +94,34 @@ const (
 	// workable share.
 	ToolCallGrantPerMin = 60
 
+	// ---------------------------------------------------------------------
+	// THE BURST IS A SEPARATE NUMBER AND IS PART OF THE PUBLISHED CONTRACT.
+	//
+	// These buckets are token buckets, so the sustained rate above is NOT the
+	// most calls that can occur in a 60-second window. A bucket starting full
+	// admits its whole burst immediately and then admits the refill on top, so
+	// the true worst case over the first minute is BURST + SUSTAINED --
+	// measured, not reasoned: 240 for the tenant bucket and 120 for the grant
+	// bucket, exactly twice the sustained figures, which is what the refusal
+	// used to advertise as though it were the ceiling.
+	//
+	// WHY THE FIX IS TO PUBLISH BOTH NUMBERS RATHER THAN SHRINK THE BURST.
+	// For burst B and sustained N, the worst-case 60s window is B + N. Making
+	// the single advertised number true would require B = 0, which is not a
+	// smaller burst but no burst at all: the limiter degrades into a hard
+	// inter-arrival gap of one call every 500ms, and an ordinary interactive
+	// turn -- a model making several tool calls to answer one question -- is
+	// refused halfway through. A single number that is true of neither the
+	// first minute nor the steady state is the actual defect; the mechanism is
+	// fine and was simply being described wrongly.
+	//
+	// Burst equal to the sustained allowance is therefore kept and made
+	// EXPLICIT here rather than left implied by a shared helper. It buys a
+	// bursty conversational turn at the cost of a bounded instantaneous spike,
+	// and both halves are now stated to the client in the refusal payload.
+	ToolCallTenantBurst = ToolCallTenantPerMin
+	ToolCallGrantBurst  = ToolCallGrantPerMin
+
 	// toolCallKeyCap bounds each key map. Reaching it is a memory bound being
 	// enforced, not an error.
 	toolCallKeyCap = 4096
@@ -101,6 +129,22 @@ const (
 	// toolCallIdle is how long an untouched bucket survives a sweep.
 	toolCallIdle = 10 * time.Minute
 )
+
+// toolCallBucket builds one bucket from an EXPLICIT sustained rate and burst.
+//
+// Deliberately not perMinuteLimiter, which is shared with the unauthenticated
+// registration limiter: that endpoint's tuning is not in this slice, and
+// changing a helper underneath another endpoint to fix this one's advertised
+// numbers would be a silent behaviour change to /oauth/mcp/register.
+//
+// A non-positive rate or burst means "allow nothing", never "allow everything"
+// -- the direction a misconfiguration has to fail in.
+func toolCallBucket(sustainedPerMin, burst int) *rate.Limiter {
+	if sustainedPerMin <= 0 || burst <= 0 {
+		return rate.NewLimiter(0, 0)
+	}
+	return rate.NewLimiter(rate.Limit(float64(sustainedPerMin)/60.0), burst)
+}
 
 // toolCallLimiter is the two-layer bucket described above. The zero value is
 // NOT usable: construct it with newToolCallLimiter.
@@ -110,6 +154,8 @@ type toolCallLimiter struct {
 	grants       map[uuid.UUID]*keyBucket
 	tenantPerMin int
 	grantPerMin  int
+	tenantBurst  int
+	grantBurst   int
 	cap          int
 	idle         time.Duration
 }
@@ -122,12 +168,14 @@ type keyBucket struct {
 // newToolCallLimiter builds the limiter. Like its sibling it runs no janitor
 // goroutine: each map is swept inline when it grows past the cap, which is the
 // only moment the memory bound is actually at risk.
-func newToolCallLimiter(tenantPerMin, grantPerMin int) *toolCallLimiter {
+func newToolCallLimiter(tenantPerMin, grantPerMin, tenantBurst, grantBurst int) *toolCallLimiter {
 	return &toolCallLimiter{
 		tenants:      make(map[uuid.UUID]*keyBucket),
 		grants:       make(map[uuid.UUID]*keyBucket),
 		tenantPerMin: tenantPerMin,
 		grantPerMin:  grantPerMin,
+		tenantBurst:  tenantBurst,
+		grantBurst:   grantBurst,
 		cap:          toolCallKeyCap,
 		idle:         toolCallIdle,
 	}
@@ -182,10 +230,24 @@ func (l *toolCallLimiter) allow(tenantID, grantID uuid.UUID) toolCallDecision {
 		return toolCallDecision{Allowed: false, RetryAfter: time.Minute, Scope: scopeOrganisation}
 	}
 
-	now := time.Now()
-
 	l.mu.Lock()
 	defer l.mu.Unlock()
+
+	// THE CLOCK IS SAMPLED AFTER THE LOCK, AND THAT ORDERING IS LOAD-BEARING.
+	//
+	// rate.Limiter advances its internal state monotonically from whatever
+	// timestamp it is handed and refuses to go backwards. Sampling before the
+	// lock lets goroutine A read t1, block on the mutex while goroutine B
+	// advances the bucket to t2 > t1, and then evaluate its request against t1
+	// -- a state the limiter has already moved past. The accounting comes out
+	// wrong, in whichever direction the interleaving happens to produce, and
+	// NO SINGLE-THREADED TEST CAN EVER SHOW IT.
+	//
+	// Reading the clock inside the critical section makes the timestamp and the
+	// bucket state consistent by construction. It is one syscall-free
+	// monotonic read inside a lock this function already holds for the whole
+	// decision, so it costs nothing worth trading for.
+	now := time.Now()
 
 	// ---- QUERY ONLY. Nothing below this line is charged until both pass. ----
 
@@ -220,7 +282,7 @@ func (l *toolCallLimiter) tenantBucketLocked(key uuid.UUID, now time.Time) *keyB
 	b, ok := l.tenants[key]
 	if !ok {
 		sweepFullOnly(l.tenants, l.cap, now)
-		b = &keyBucket{lim: perMinuteLimiter(l.tenantPerMin)}
+		b = &keyBucket{lim: toolCallBucket(l.tenantPerMin, l.tenantBurst)}
 		l.tenants[key] = b
 	}
 	b.seen = now
@@ -236,7 +298,7 @@ func (l *toolCallLimiter) grantBucketLocked(key uuid.UUID, now time.Time) *keyBu
 	b, ok := l.grants[key]
 	if !ok {
 		sweep(l.grants, l.cap, l.idle, now)
-		b = &keyBucket{lim: perMinuteLimiter(l.grantPerMin)}
+		b = &keyBucket{lim: toolCallBucket(l.grantPerMin, l.grantBurst)}
 		l.grants[key] = b
 	}
 	b.seen = now

--- a/apps/api/internal/mcp/toolcall_limit_test.go
+++ b/apps/api/internal/mcp/toolcall_limit_test.go
@@ -585,7 +585,12 @@ func TestToolCall_RefusalDoesNotChargeTheTenantBucket(t *testing.T) {
 		}
 	}
 
-	want := ToolCallTenantPerMin - ToolCallGrantPerMin
+	// The floor is expressed in BURSTS because that is the capacity actually
+	// available at one instant: the noisy connection can consume at most its
+	// own burst from the shared tenant bucket, leaving the rest for siblings.
+	// Expressing it in per-minute allowances would be measuring the wrong
+	// quantity and would only look right while burst equalled allowance.
+	want := ToolCallTenantBurst - ToolCallGrantBurst
 	if admitted < want {
 		t.Errorf("quiet connection admitted %d calls, want at least %d; "+
 			"refused requests are draining the tenant bucket and starving siblings", admitted, want)

--- a/apps/api/internal/mcp/toolcall_limit_test.go
+++ b/apps/api/internal/mcp/toolcall_limit_test.go
@@ -594,3 +594,173 @@ func TestToolCall_NilLimiterRefuses(t *testing.T) {
 		t.Errorf("nil-limiter RetryAfter = %v, want positive", d.RetryAfter)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PROOF 10 -- A NEW TENANT'S ARRIVAL DOES NOT GIVE A SATURATED TENANT ITS
+// BUDGET BACK.
+//
+// This is the assertion whose ABSENCE was the real finding. Both key maps were
+// originally swept by one function copied in shape from registrationLimiter,
+// which clears its map under pressure. That is safe there because an unswept
+// global bucket sits behind it; this limiter has no global bucket by design, so
+// clearing the tenant map surrendered the bound outright -- and the whole suite
+// stayed green when that sweep was made to clear unconditionally, because
+// nothing ever re-checked a saturated tenant after a new one appeared.
+//
+// Driven at the limiter rather than over HTTP because the claim is about the
+// map's eviction behaviour and needs thousands of distinct organisations to
+// reach it. PROOFS 1-6 already establish that the transport reaches this code.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_NewTenantsDoNotResetASaturatedTenantsBound(t *testing.T) {
+	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin)
+	victim := uuid.New()
+
+	// Saturate the victim's TENANT bucket. The grant id is rotated so the
+	// fairness layer never binds first -- otherwise this would saturate the
+	// wrong bucket and the proof would be about the wrong map.
+	var last toolCallDecision
+	for i := 0; i < ToolCallTenantPerMin+1; i++ {
+		last = l.allow(victim, uuid.New())
+	}
+	if last.Allowed {
+		t.Fatalf("victim was still admitted after %d calls; its tenant bound was never reached",
+			ToolCallTenantPerMin+1)
+	}
+	if last.Scope != scopeOrganisation {
+		t.Fatalf("victim refused at scope %q, want %q; the wrong bucket is saturated and this "+
+			"proof would be about the fairness layer", last.Scope, scopeOrganisation)
+	}
+
+	// Now flood the process with distinct organisations, well past the map cap,
+	// which is the condition that used to trigger the clearing sweep.
+	//
+	// THE FLOOD TAKES REAL TIME AND THE BUCKET REFILLS WHILE IT RUNS, so the
+	// assertion below cannot be "the victim is still refused outright". allow()
+	// reads time.Now(), and at ToolCallTenantPerMin per minute the victim
+	// legitimately earns back a token every few hundred milliseconds. Asserting
+	// a flat refusal would be asserting that a token bucket does not refill,
+	// which would be a false property and a flaky test.
+	//
+	// What IS asserted is the thing that actually distinguishes the two
+	// behaviours, and the gap between them is enormous: a preserved bucket
+	// yields only what elapsed time paid for (a token or two), while a cleared
+	// one yields a whole fresh burst of ToolCallTenantPerMin. The ceiling is
+	// computed from the measured elapsed time rather than hard-coded, so the
+	// test stays exact on a slow machine instead of being given slack.
+	start := time.Now()
+	for i := 0; i < toolCallKeyCap*2; i++ {
+		l.allow(uuid.New(), uuid.New())
+	}
+	elapsed := time.Since(start)
+
+	// Tokens the victim is ENTITLED to have earned back, plus one to absorb the
+	// boundary between the last measurement and the first call below.
+	earned := int(elapsed.Seconds()*float64(ToolCallTenantPerMin)/60.0) + 1
+
+	admitted := 0
+	for i := 0; i < ToolCallTenantPerMin; i++ {
+		if !l.allow(victim, uuid.New()).Allowed {
+			break
+		}
+		admitted++
+	}
+
+	if admitted > earned {
+		t.Errorf("the victim tenant was admitted %d times after %d other organisations "+
+			"authenticated, but only %d token(s) were earned in the %v the flood took; "+
+			"its exhausted budget was handed back by the sweep, so the bound resets under load",
+			admitted, toolCallKeyCap*2, earned, elapsed)
+	}
+	// The refusal that ends the loop must still come from the TENANT layer. If
+	// it came from the grant layer the bound could have been reset and this
+	// proof would not notice.
+	if d := l.allow(victim, uuid.New()); d.Allowed || d.Scope != scopeOrganisation {
+		t.Errorf("victim decision after the flood = {allowed:%v scope:%q}, want {false %q}",
+			d.Allowed, d.Scope, scopeOrganisation)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 11 -- sweepFullOnly STILL RECLAIMS, SO THE MAP IS NOT A LEAK.
+//
+// The over-fire half of PROOF 10. "Never surrender the bound" must not degrade
+// into "never reclaim anything". A bucket at its burst ceiling is
+// indistinguishable from a fresh one, so dropping it is lossless and is exactly
+// what this must still do -- while a bucket with tokens still spent has to
+// survive, because that is the one carrying the bound.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_SweepFullOnlyReclaimsRefilledButKeepsIndebtedBuckets(t *testing.T) {
+	now := time.Now()
+	m := map[uuid.UUID]*keyBucket{}
+
+	full := uuid.New()
+	m[full] = &keyBucket{lim: perMinuteLimiter(ToolCallTenantPerMin), seen: now}
+
+	indebt := uuid.New()
+	spent := perMinuteLimiter(ToolCallTenantPerMin)
+	for i := 0; i < ToolCallTenantPerMin; i++ {
+		spent.AllowN(now, 1)
+	}
+	m[indebt] = &keyBucket{lim: spent, seen: now}
+
+	// A cap of 1 forces the sweep to run over this two-entry map.
+	sweepFullOnly(m, 1, now)
+
+	if _, still := m[full]; still {
+		t.Error("a fully refilled bucket survived the sweep; nothing is ever reclaimed and the map leaks")
+	}
+	if _, still := m[indebt]; !still {
+		t.Error("a bucket with tokens still spent was evicted; that hands a saturated tenant its budget back")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 12 -- A BROWSER-HOSTED CLIENT CAN READ Retry-After.
+//
+// The header is useless to browser JavaScript unless it is named in
+// Access-Control-Expose-Headers: a fetch response exposes the status and
+// nothing else. A client that sees 429 but cannot read the interval either
+// gives up or retries at once, which is the loop the refusal exists to break.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_RetryAfterIsExposedToBrowserClients(t *testing.T) {
+	r, _ := limiterRouter(t, liveGrantStore(uuid.New()))
+
+	w := drain(t, r, testBearer, gatedMethods[1], ToolCallGrantPerMin+1)
+	if w == nil {
+		t.Fatal("nothing was refused; cannot assert the exposed header")
+	}
+	if got := w.Header().Get("Retry-After"); got == "" {
+		t.Fatal("Retry-After is not set on the 429 at all")
+	}
+
+	exposed := w.Header().Get("Access-Control-Expose-Headers")
+	if exposed == "" {
+		t.Fatal("Access-Control-Expose-Headers is absent; browser JS can read no header at all")
+	}
+	if !exposesHeader(exposed, "Retry-After") {
+		t.Errorf("Access-Control-Expose-Headers = %q, which does not name Retry-After; "+
+			"a browser-hosted client is refused and cannot learn for how long", exposed)
+	}
+	// The other refusal headers this file sets must stay exposed: a fix that
+	// swapped one for another would otherwise pass.
+	for _, want := range []string{"WWW-Authenticate", "Allow"} {
+		if !exposesHeader(exposed, want) {
+			t.Errorf("Access-Control-Expose-Headers = %q no longer names %s", exposed, want)
+		}
+	}
+}
+
+// exposesHeader reports whether an Access-Control-Expose-Headers value names
+// the given header. Comparison is case-insensitive because HTTP header names
+// are, so a correct list spelled differently must not read as a failure.
+func exposesHeader(list, name string) bool {
+	for _, part := range strings.Split(list, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), name) {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/api/internal/mcp/toolcall_limit_test.go
+++ b/apps/api/internal/mcp/toolcall_limit_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -148,7 +149,8 @@ func postWith(t *testing.T, r *gin.Engine, bearer, body string, headers map[stri
 type limitData struct {
 	RetryAfterSeconds        int    `json:"retry_after_seconds"`
 	LimitScope               string `json:"limit_scope"`
-	LimitPerMinute           int    `json:"limit_per_minute"`
+	SustainedLimitPerMinute  int    `json:"sustained_limit_per_minute"`
+	BurstLimit               int    `json:"burst_limit"`
 	RetryImmediatelyWillFail bool   `json:"retry_immediately_will_fail"`
 }
 
@@ -220,8 +222,14 @@ func assertConnectionBudgetRefuses(t *testing.T, body string) {
 	if d.LimitScope != string(scopeConnection) {
 		t.Errorf("limit_scope = %q, want %q", d.LimitScope, scopeConnection)
 	}
-	if d.LimitPerMinute != ToolCallGrantPerMin {
-		t.Errorf("limit_per_minute = %d, want %d", d.LimitPerMinute, ToolCallGrantPerMin)
+	if d.SustainedLimitPerMinute != ToolCallGrantPerMin {
+		t.Errorf("sustained_limit_per_minute = %d, want %d", d.SustainedLimitPerMinute, ToolCallGrantPerMin)
+	}
+	// THE BURST MUST BE PUBLISHED TOO. A payload carrying only the sustained
+	// figure is the defect this pair of fields replaced: it is true of neither
+	// the first minute nor the steady state.
+	if d.BurstLimit != ToolCallGrantBurst {
+		t.Errorf("burst_limit = %d, want %d", d.BurstLimit, ToolCallGrantBurst)
 	}
 	if !d.RetryImmediatelyWillFail {
 		t.Error("retry_immediately_will_fail = false; a model reads that as permission to retry at once")
@@ -232,6 +240,14 @@ func assertConnectionBudgetRefuses(t *testing.T, body string) {
 	// instruction. Asserted on the message because that is what the model reads.
 	if !strings.Contains(resp.Error.Message, "retrying immediately will not succeed") {
 		t.Errorf("refusal message does not tell the model that an immediate retry fails: %q", resp.Error.Message)
+	}
+	// The prose must carry BOTH numbers, not just the one the payload used to
+	// publish. A model reads the message, not the data object.
+	if !strings.Contains(resp.Error.Message, fmt.Sprintf("%d calls per minute sustained", ToolCallGrantPerMin)) {
+		t.Errorf("refusal message does not state the sustained rate: %q", resp.Error.Message)
+	}
+	if !strings.Contains(resp.Error.Message, fmt.Sprintf("bursts of up to %d", ToolCallGrantBurst)) {
+		t.Errorf("refusal message does not state the burst: %q", resp.Error.Message)
 	}
 }
 
@@ -514,7 +530,7 @@ func assertRefusalWritesNothing(t *testing.T, body string) {
 // ---------------------------------------------------------------------------
 
 func TestToolCall_ManyGrantsCannotExceedTheTenantBound(t *testing.T) {
-	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin)
+	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin, ToolCallTenantBurst, ToolCallGrantBurst)
 	tenant := uuid.New()
 
 	admitted := 0
@@ -548,7 +564,7 @@ func TestToolCall_ManyGrantsCannotExceedTheTenantBound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestToolCall_RefusalDoesNotChargeTheTenantBucket(t *testing.T) {
-	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin)
+	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin, ToolCallTenantBurst, ToolCallGrantBurst)
 	tenant := uuid.New()
 	noisy := uuid.New()
 
@@ -613,7 +629,7 @@ func TestToolCall_NilLimiterRefuses(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestToolCall_NewTenantsDoNotResetASaturatedTenantsBound(t *testing.T) {
-	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin)
+	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin, ToolCallTenantBurst, ToolCallGrantBurst)
 	victim := uuid.New()
 
 	// Saturate the victim's TENANT bucket. The grant id is rotated so the
@@ -696,10 +712,10 @@ func TestToolCall_SweepFullOnlyReclaimsRefilledButKeepsIndebtedBuckets(t *testin
 	m := map[uuid.UUID]*keyBucket{}
 
 	full := uuid.New()
-	m[full] = &keyBucket{lim: perMinuteLimiter(ToolCallTenantPerMin), seen: now}
+	m[full] = &keyBucket{lim: toolCallBucket(ToolCallTenantPerMin, ToolCallTenantBurst), seen: now}
 
 	indebt := uuid.New()
-	spent := perMinuteLimiter(ToolCallTenantPerMin)
+	spent := toolCallBucket(ToolCallTenantPerMin, ToolCallTenantBurst)
 	for i := 0; i < ToolCallTenantPerMin; i++ {
 		spent.AllowN(now, 1)
 	}
@@ -763,4 +779,90 @@ func exposesHeader(list, name string) bool {
 		}
 	}
 	return false
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 13 -- THE ADVERTISED NUMBERS ARE THE ENFORCED NUMBERS.
+//
+// The refusal payload tells a client its sustained rate and its burst, and a
+// client that self-paces against those numbers is relying on them being the
+// real ones. This drives the constructed bucket with SYNTHETIC timestamps, so
+// it measures the limiter's actual admission behaviour rather than asserting
+// the constants back at themselves, and it is fully deterministic -- no clock,
+// no sleeping, no scheduling luck.
+//
+// The property proven is the one that was previously mis-advertised: over the
+// first 60 seconds from a full bucket the ceiling is BURST + SUSTAINED, not
+// SUSTAINED. Measured at 240 and 120 for the two buckets before this change,
+// against advertised figures of 120 and 60.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_AdvertisedBurstAndSustainedRateAreTheRealOnes(t *testing.T) {
+	cases := []struct {
+		name      string
+		sustained int
+		burst     int
+	}{
+		{"tenant", ToolCallTenantPerMin, ToolCallTenantBurst},
+		{"grant", ToolCallGrantPerMin, ToolCallGrantBurst},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// 1. THE BURST IS EXACTLY WHAT IS ADVERTISED: from full, exactly
+			//    `burst` consecutive calls are admitted at one instant.
+			b := toolCallBucket(c.sustained, c.burst)
+			at := time.Now()
+			immediate := 0
+			for b.AllowN(at, 1) {
+				immediate++
+			}
+			if immediate != c.burst {
+				t.Errorf("%s admitted %d calls at one instant, want burst_limit = %d",
+					c.name, immediate, c.burst)
+			}
+
+			// 2. THE SUSTAINED RATE IS EXACTLY WHAT IS ADVERTISED: over the
+			//    following minute the drained bucket refills by `sustained`.
+			refill := 0
+			for ms := 0; ms <= 60000; ms += 10 {
+				tick := at.Add(time.Duration(ms) * time.Millisecond)
+				for b.AllowN(tick, 1) {
+					refill++
+				}
+			}
+			if refill != c.sustained {
+				t.Errorf("%s refilled %d calls over 60s, want sustained_limit_per_minute = %d",
+					c.name, refill, c.sustained)
+			}
+
+			// 3. THE WORST-CASE FIRST MINUTE IS BURST + SUSTAINED. Stated as a
+			//    positive assertion so the number cannot drift unnoticed, and
+			//    so nobody "fixes" it back to the single figure that was wrong.
+			if got, want := immediate+refill, c.burst+c.sustained; got != want {
+				t.Errorf("%s admitted %d over the first 60s from full, want %d", c.name, got, want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 14 -- A MISCONFIGURED BUCKET ADMITS NOTHING.
+//
+// A non-positive rate or burst has to mean "allow nothing", never "no limit
+// configured, therefore permitted". Same direction of failure as the nil
+// receiver in PROOF 9, one layer down.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_NonPositiveBucketConfigurationAdmitsNothing(t *testing.T) {
+	now := time.Now()
+	for _, c := range []struct{ sustained, burst int }{
+		{0, 10}, {10, 0}, {-1, 10}, {10, -1}, {0, 0},
+	} {
+		b := toolCallBucket(c.sustained, c.burst)
+		if b.AllowN(now, 1) {
+			t.Errorf("toolCallBucket(%d, %d) admitted a request; a misconfigured budget "+
+				"must refuse, not permit", c.sustained, c.burst)
+		}
+	}
 }

--- a/apps/api/internal/mcp/toolcall_limit_test.go
+++ b/apps/api/internal/mcp/toolcall_limit_test.go
@@ -1,0 +1,596 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+// ---------------------------------------------------------------------------
+// Harness for the tool-call budget.
+//
+// Every proof below drives the REAL MOUNT: TransportHandler.Register is called
+// with the same argument shape server.go passes it, and requests arrive as HTTP
+// through gin. The limiter is only reachable that way, so a test that called
+// toolCallLimiter.allow directly would prove the bucket arithmetic and nothing
+// about whether POST /mcp is actually gated.
+//
+// WHY THERE IS NO wpmgr_app PROOF IN THIS FILE, stated rather than left as an
+// omission for a reader to trip over: the tool-call limiter holds no database
+// state and issues no query. It refuses BEFORE Service.RecordActivity, which is
+// the first statement the tools/* path would otherwise run, and PROOF 6 asserts
+// exactly that no write is attempted. There is therefore no policy for a
+// database role to be subject to, and connecting as wpmgr_app here would prove
+// nothing that this file does not already prove in process. The RLS-backed
+// proofs belong to the per-tenant enablement state, which does not exist yet --
+// see the report accompanying this change.
+// ---------------------------------------------------------------------------
+
+// limiterRouter builds the real router over a store, and hands back the handler
+// so a test can reach the limiter it was constructed with.
+func limiterRouter(t *testing.T, store Store) (*gin.Engine, *TransportHandler) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewTransportHandler(NewService(store), slog.New(slog.DiscardHandler), "test-version")
+	h.Register(r)
+	return r, h
+}
+
+// twoTenantStore resolves a DIFFERENT tenant and grant per bearer token, so one
+// router and one limiter can serve two organisations. Tenant isolation is a
+// claim about two tenants sharing a process; a test using two separate routers
+// would have two separate limiters and could not observe a leak between them.
+type twoTenantStore struct {
+	*fakeStore
+	tenants map[string]uuid.UUID
+	grants  map[string]uuid.UUID
+	// current is the bearer the next request will carry. LookupConnectionToken
+	// receives only a hash and cannot reverse it, so steering by an explicit
+	// field keeps the fake honest about what it can actually see.
+	current string
+	// rotateGrants makes every request resolve to a FRESH grant id, modelling
+	// one organisation holding many connections. Without it a tenant can never
+	// consume more than one grant's fairness share and its tenant-wide bound is
+	// unreachable, which makes a tenant-isolation proof vacuous.
+	rotateGrants bool
+}
+
+func newTwoTenantStore(bearers ...string) *twoTenantStore {
+	s := &twoTenantStore{
+		fakeStore: liveGrantStore(uuid.New()),
+		tenants:   map[string]uuid.UUID{},
+		grants:    map[string]uuid.UUID{},
+	}
+	for _, b := range bearers {
+		s.tenants[b] = uuid.New()
+		s.grants[b] = uuid.New()
+	}
+	return s
+}
+
+// forBearer selects which organisation the next request resolves to.
+func (s *twoTenantStore) forBearer(b string) {
+	s.current = b
+}
+
+func (s *twoTenantStore) LookupConnectionToken(_ context.Context, _ string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
+	return sqlc.GetMCPConnectionTokenByHashForLookupRow{
+		ID:       uuid.New(),
+		TenantID: s.tenants[s.current],
+	}, nil
+}
+
+func (s *twoTenantStore) ReCheckAuthorization(
+	_ context.Context, _ uuid.UUID, _ uuid.UUID,
+) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error) {
+	grant := s.grants[s.current]
+	if s.rotateGrants {
+		grant = uuid.New()
+	}
+	return sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
+		Authorized:        true,
+		GrantID:           grant,
+		TokenID:           uuid.New(),
+		GrantCapabilities: []string{string(CapSitesRead)},
+		GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
+	}, nil
+}
+
+// THE TWO GATED METHODS. Every HTTP proof below runs against BOTH.
+//
+// This is not thoroughness for its own sake. An earlier version of this file
+// drove tools/list only, and the mutation sweep showed that deleting the
+// tools/call gate outright left the whole suite green -- the budget could have
+// been removed from the one method the task names and nothing would have
+// noticed. A limiter with two call sites needs both asserted, separately.
+var gatedMethods = []string{
+	`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+	`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`,
+}
+
+func methodName(body string) string {
+	if strings.Contains(body, "tools/call") {
+		return "tools/call"
+	}
+	return "tools/list"
+}
+
+// postWith issues one gated request with arbitrary extra headers.
+func postWith(t *testing.T, r *gin.Engine, bearer, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, TransportPath, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// limitData is the refusal's data object, decoded. Every proof asserts on these
+// VALUES rather than on "an error happened": three tests in this package were
+// found passing for the wrong reason because they only checked that Error was
+// non-nil.
+type limitData struct {
+	RetryAfterSeconds        int    `json:"retry_after_seconds"`
+	LimitScope               string `json:"limit_scope"`
+	LimitPerMinute           int    `json:"limit_per_minute"`
+	RetryImmediatelyWillFail bool   `json:"retry_immediately_will_fail"`
+}
+
+func decodeLimitData(t *testing.T, resp jsonrpcResponse) limitData {
+	t.Helper()
+	if resp.Error == nil {
+		t.Fatalf("expected a JSON-RPC error, got result: %v", resp.Result)
+	}
+	var d limitData
+	if err := json.Unmarshal(resp.Error.Data, &d); err != nil {
+		t.Fatalf("refusal data is not decodable: %v (raw: %s)", err, string(resp.Error.Data))
+	}
+	return d
+}
+
+// drain issues n requests and returns the first refused recorder, or nil.
+func drain(t *testing.T, r *gin.Engine, bearer, body string, n int) *httptest.ResponseRecorder {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		w := postWith(t, r, bearer, body, nil)
+		if w.Code == http.StatusTooManyRequests {
+			return w
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- THE CONNECTION BUDGET REFUSES, AND SAYS SO BY VALUE.
+//
+// One grant driving one tenant hits the grant's fairness share
+// (ToolCallGrantPerMin) before the tenant bound, so this is the refusal a
+// single looping client actually receives. Every field is asserted: status,
+// JSON-RPC code, scope, the advertised number, and the flag that tells a model
+// not to retry at once.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_ConnectionBudgetRefusesWithTypedValues(t *testing.T) {
+	for _, body := range gatedMethods {
+		t.Run(methodName(body), func(t *testing.T) {
+			assertConnectionBudgetRefuses(t, body)
+		})
+	}
+}
+
+func assertConnectionBudgetRefuses(t *testing.T, body string) {
+	t.Helper()
+	r, _ := limiterRouter(t, liveGrantStore(uuid.New()))
+
+	w := drain(t, r, testBearer, body, ToolCallGrantPerMin+1)
+	if w == nil {
+		t.Fatalf("no request was refused within %d calls; the budget is not enforced on %s",
+			ToolCallGrantPerMin+1, methodName(body))
+	}
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+
+	resp := decodeRPC(t, w)
+	if resp.Error == nil {
+		t.Fatalf("refusal carried no JSON-RPC error: %s", w.Body.String())
+	}
+	if resp.Error.Code != codeRateLimited {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, codeRateLimited)
+	}
+
+	d := decodeLimitData(t, resp)
+	if d.LimitScope != string(scopeConnection) {
+		t.Errorf("limit_scope = %q, want %q", d.LimitScope, scopeConnection)
+	}
+	if d.LimitPerMinute != ToolCallGrantPerMin {
+		t.Errorf("limit_per_minute = %d, want %d", d.LimitPerMinute, ToolCallGrantPerMin)
+	}
+	if !d.RetryImmediatelyWillFail {
+		t.Error("retry_immediately_will_fail = false; a model reads that as permission to retry at once")
+	}
+
+	// THE REFUSAL MUST BE LEGIBLE TO A MODEL, not only to a status-code parser.
+	// An MCP client surfaces the error content, so the words have to carry the
+	// instruction. Asserted on the message because that is what the model reads.
+	if !strings.Contains(resp.Error.Message, "retrying immediately will not succeed") {
+		t.Errorf("refusal message does not tell the model that an immediate retry fails: %q", resp.Error.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- Retry-After IS PRESENT AND IS NEVER ZERO.
+//
+// The header is whole seconds. A sub-second shortfall truncating to "0" tells a
+// client to retry at once, which is the loop the refusal exists to break, so
+// the floor is part of the contract and not an implementation detail.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_RetryAfterIsAtLeastOneSecond(t *testing.T) {
+	r, _ := limiterRouter(t, liveGrantStore(uuid.New()))
+
+	w := drain(t, r, testBearer, gatedMethods[1], ToolCallGrantPerMin+1)
+	if w == nil {
+		t.Fatal("nothing was refused; cannot assert Retry-After")
+	}
+
+	raw := w.Header().Get("Retry-After")
+	if raw == "" {
+		t.Fatal("Retry-After header is absent on a 429")
+	}
+	secs, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("Retry-After = %q, which is not whole seconds: %v", raw, err)
+	}
+	if secs < 1 {
+		t.Errorf("Retry-After = %d, want >= 1; zero instructs an immediate retry", secs)
+	}
+
+	d := decodeLimitData(t, decodeRPC(t, w))
+	if d.RetryAfterSeconds != secs {
+		t.Errorf("retry_after_seconds = %d but Retry-After = %d; the two readers disagree",
+			d.RetryAfterSeconds, secs)
+	}
+}
+
+// atLeastASecond IS PROVEN DIRECTLY, not only through the endpoint.
+//
+// The handler applies its own floor to the number it renders, so a broken
+// helper is invisible from the HTTP surface -- the mutation sweep caught
+// exactly that: replacing this function's body with `return 0` left every
+// endpoint proof green. Two independent floors is deliberate defence, and the
+// consequence is that each has to be asserted where it lives.
+func TestToolCall_AtLeastASecondFloorsSubSecondWaits(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want time.Duration
+	}{
+		{0, time.Second},
+		{time.Nanosecond, time.Second},
+		{500 * time.Millisecond, time.Second},
+		{999 * time.Millisecond, time.Second},
+		{time.Second, time.Second},
+		{90 * time.Second, 90 * time.Second},
+	}
+	for _, c := range cases {
+		if got := atLeastASecond(c.in); got != c.want {
+			t.Errorf("atLeastASecond(%v) = %v, want %v; a sub-second wait rendered as whole "+
+				"seconds truncates to 0 and instructs an immediate retry", c.in, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- NO CLIENT-SUPPLIED HEADER CAN OBTAIN A FRESH BUDGET.
+//
+// This is the defect two other limiters in this tree were recently found to
+// have. gin's defaults trust every proxy, so ClientIP returns the LEFTMOST
+// X-Forwarded-For entry -- a value the caller wrote. A limiter keyed on it
+// hands out a new bucket per forged header, silently and at full speed.
+//
+// The test EXECUTES the bypass rather than asserting the code does not contain
+// a call: it exhausts the budget, then varies every header a limiter in this
+// codebase has ever been keyed on, and requires the refusal to survive all of
+// them.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_BudgetIsImmuneToClientSuppliedHeaders(t *testing.T) {
+	for _, body := range gatedMethods {
+		t.Run(methodName(body), func(t *testing.T) {
+			assertHeaderImmunity(t, body)
+		})
+	}
+}
+
+func assertHeaderImmunity(t *testing.T, body string) {
+	t.Helper()
+	r, _ := limiterRouter(t, liveGrantStore(uuid.New()))
+
+	if w := drain(t, r, testBearer, body, ToolCallGrantPerMin+1); w == nil {
+		t.Fatal("budget never refused; the bypass test would be vacuous")
+	}
+
+	spoofs := []map[string]string{
+		{"X-Forwarded-For": "203.0.113.9"},
+		{"X-Forwarded-For": "198.51.100.7, 10.0.0.1"},
+		{"X-Real-IP": "203.0.113.44"},
+		{"X-Forwarded-For": "203.0.113.9", "X-Real-IP": "198.51.100.7"},
+		{"Forwarded": "for=203.0.113.60"},
+		{"X-Forwarded-Host": "elsewhere.example"},
+		{"True-Client-IP": "203.0.113.77"},
+		{"CF-Connecting-IP": "203.0.113.88"},
+	}
+
+	for _, hdrs := range spoofs {
+		w := postWith(t, r, testBearer, body, hdrs)
+		if w.Code != http.StatusTooManyRequests {
+			t.Errorf("headers %v obtained status %d; the budget was bypassed by a client-supplied header",
+				hdrs, w.Code)
+			continue
+		}
+		resp := decodeRPC(t, w)
+		if resp.Error == nil || resp.Error.Code != codeRateLimited {
+			t.Errorf("headers %v produced a non-rate-limit refusal: %+v", hdrs, resp.Error)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 4 -- ONE TENANT'S EXHAUSTED BUDGET DOES NOT REFUSE ANOTHER TENANT.
+//
+// Both tenants share ONE router, ONE handler and ONE limiter, which is the only
+// arrangement in which a leak between them is observable. This is also the
+// proof that there is no global bucket: a process-wide layer would refuse the
+// second tenant here, which is the cross-tenant denial of service the design
+// note rejects.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_OneTenantsBudgetDoesNotAffectAnother(t *testing.T) {
+	const bearerA, bearerB = "tenant-a-token", "tenant-b-token"
+	store := newTwoTenantStore(bearerA, bearerB)
+	// TENANT A MUST SATURATE ITS TENANT BUCKET, NOT MERELY ITS GRANT BUCKET.
+	//
+	// An earlier version of this proof drove one grant, which stops at the
+	// grant fairness cap (60) and leaves the tenant bucket (120) half full --
+	// so keying every tenant on one shared constant still passed, because
+	// tenant B was served out of the slack. The mutation sweep found it.
+	// Rotating the grant id models a tenant holding many connections, which is
+	// the only way its tenant-wide bound is reachable.
+	store.rotateGrants = true
+	r, _ := limiterRouter(t, store)
+
+	store.forBearer(bearerA)
+	w := drain(t, r, bearerA, gatedMethods[1], ToolCallTenantPerMin+1)
+	if w == nil {
+		t.Fatal("tenant A was never refused; the isolation claim would be vacuous")
+	}
+	// The refusal must be the TENANT layer, or this proof is testing the wrong
+	// bucket and the isolation claim below means nothing.
+	if d := decodeLimitData(t, decodeRPC(t, w)); d.LimitScope != string(scopeOrganisation) {
+		t.Fatalf("tenant A refused at scope %q, want %q; the tenant bound was never reached",
+			d.LimitScope, scopeOrganisation)
+	}
+
+	// Tenant A is now saturated at the tenant layer. Tenant B must be
+	// untouched -- first request, full budget.
+	store.forBearer(bearerB)
+	w = postWith(t, r, bearerB, gatedMethods[1], nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("tenant B status = %d, want %d; tenant A's exhaustion leaked across the tenant boundary (body: %s)",
+			w.Code, http.StatusOK, w.Body.String())
+	}
+	resp := decodeRPC(t, w)
+	if resp.Error != nil {
+		t.Fatalf("tenant B was refused: code=%d msg=%q", resp.Error.Code, resp.Error.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 5 -- THE OVER-FIRE CHECK. A CONNECTION UNDER THE LIMIT IS UNAFFECTED.
+//
+// A limiter that reddens correct work gets switched off, and then it bounds
+// nothing. This drives a full budget's worth of legitimate calls and requires
+// every one to succeed with a real answer -- not merely "not a 429".
+// ---------------------------------------------------------------------------
+
+func TestToolCall_UnderTheLimitNothingIsRefused(t *testing.T) {
+	for _, body := range gatedMethods {
+		t.Run(methodName(body), func(t *testing.T) {
+			assertNoOverFire(t, body)
+		})
+	}
+}
+
+// realisticBurst is a HARD-CODED workload well inside any defensible budget: an
+// interactive model answering one question about a fleet, a few times over.
+//
+// It is deliberately NOT expressed as ToolCallGrantPerMin. An over-fire proof
+// that loops the very constant it is guarding is vacuous -- shrinking the
+// budget to 1 shrinks the loop to 1 and the test still passes, which the
+// mutation sweep demonstrated. The number here has to be independent of the
+// thing under test, and the budget has to be at least this generous.
+const realisticBurst = 20
+
+func assertNoOverFire(t *testing.T, body string) {
+	t.Helper()
+	if ToolCallGrantPerMin < realisticBurst {
+		t.Fatalf("ToolCallGrantPerMin = %d, which is below the %d-call burst an ordinary "+
+			"interactive session produces; this budget refuses correct work",
+			ToolCallGrantPerMin, realisticBurst)
+	}
+
+	r, _ := limiterRouter(t, liveGrantStore(uuid.New()))
+
+	for i := 0; i < realisticBurst; i++ {
+		w := postWith(t, r, testBearer, body, nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("call %d/%d status = %d, want %d; the limiter refused work inside its own budget",
+				i+1, realisticBurst, w.Code, http.StatusOK)
+		}
+		resp := decodeRPC(t, w)
+		if resp.Error != nil {
+			t.Fatalf("call %d/%d was refused: code=%d msg=%q",
+				i+1, realisticBurst, resp.Error.Code, resp.Error.Message)
+		}
+		// A 200 carrying no tools would be a limiter that silently emptied the
+		// answer, which is a different failure wearing a success code.
+		if resp.Result == nil {
+			t.Fatalf("call %d/%d succeeded with an empty result", i+1, realisticBurst)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 6 -- A REFUSED REQUEST PERFORMS NO WRITE.
+//
+// The tools/* path stamps activity through Service.RecordActivity BEFORE it
+// answers, so a limiter placed after the stamp would bound the read while
+// leaving the write unbounded -- the database cost, which is the expensive
+// half, would still be paid by every refused request. The gate is therefore
+// ahead of the stamp, and this counts the calls to prove it.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_RefusedRequestWritesNothing(t *testing.T) {
+	for _, body := range gatedMethods {
+		t.Run(methodName(body), func(t *testing.T) {
+			assertRefusalWritesNothing(t, body)
+		})
+	}
+}
+
+func assertRefusalWritesNothing(t *testing.T, body string) {
+	t.Helper()
+	store := liveGrantStore(uuid.New())
+	r, _ := limiterRouter(t, store)
+
+	if w := drain(t, r, testBearer, body, ToolCallGrantPerMin+1); w == nil {
+		t.Fatal("nothing was refused; the no-write claim would be vacuous")
+	}
+
+	before := len(store.touchCalls)
+
+	// Twenty more refusals. None may reach the activity stamp.
+	for i := 0; i < 20; i++ {
+		w := postWith(t, r, testBearer, body, nil)
+		if w.Code != http.StatusTooManyRequests {
+			t.Fatalf("call %d was admitted (status %d); the budget stopped refusing mid-test", i+1, w.Code)
+		}
+	}
+
+	if got := len(store.touchCalls); got != before {
+		t.Errorf("activity stamps went from %d to %d across 20 refused requests; "+
+			"a refused request is still writing to the database", before, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 7 -- THE TENANT LAYER IS THE BOUND, NOT THE GRANT LAYER.
+//
+// Several connections under ONE tenant must not sum to more than the tenant's
+// budget. If the grant layer were the bound, a tenant would buy more capacity
+// by minting more connections, and the limit would be escapable by anyone
+// willing to hold N credentials.
+//
+// Driven at the limiter directly, because the claim is about many grants under
+// one tenant and the HTTP fixture resolves one grant per bearer. The transport
+// wiring that reaches this function is proven by PROOFS 1-6.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_ManyGrantsCannotExceedTheTenantBound(t *testing.T) {
+	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin)
+	tenant := uuid.New()
+
+	admitted := 0
+	// Twenty distinct grants, each asking for a full tenant budget's worth. If
+	// the tenant layer binds, the total admitted is the tenant budget.
+	for i := 0; i < 20; i++ {
+		grant := uuid.New()
+		for j := 0; j < ToolCallTenantPerMin; j++ {
+			if l.allow(tenant, grant).Allowed {
+				admitted++
+			}
+		}
+	}
+
+	if admitted > ToolCallTenantPerMin {
+		t.Errorf("admitted %d calls across 20 grants under one tenant, want at most %d; "+
+			"the bound is escapable by minting more connections", admitted, ToolCallTenantPerMin)
+	}
+	if admitted == 0 {
+		t.Error("admitted 0 calls; the limiter refuses everything and the ceiling assertion is vacuous")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 8 -- A REFUSAL COSTS NOTHING IN EITHER BUCKET.
+//
+// A connection over its own fairness share must not spend its organisation's
+// budget on the requests it is REFUSED for. Without this the fairness layer
+// becomes the denial of service: one looping connection drains the tenant
+// bucket by being rejected, which is free and fast, and starves its siblings.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_RefusalDoesNotChargeTheTenantBucket(t *testing.T) {
+	l := newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin)
+	tenant := uuid.New()
+	noisy := uuid.New()
+
+	// Exhaust the noisy connection's share, then keep hammering it well past
+	// the tenant budget. Every one of these is refused at the grant layer.
+	for i := 0; i < ToolCallGrantPerMin+(ToolCallTenantPerMin*3); i++ {
+		l.allow(tenant, noisy)
+	}
+
+	// A quiet sibling must still be served out of what the tenant bucket has
+	// left, which is the tenant budget minus only the noisy connection's
+	// ADMITTED calls.
+	quiet := uuid.New()
+	admitted := 0
+	for i := 0; i < ToolCallTenantPerMin; i++ {
+		if l.allow(tenant, quiet).Allowed {
+			admitted++
+		}
+	}
+
+	want := ToolCallTenantPerMin - ToolCallGrantPerMin
+	if admitted < want {
+		t.Errorf("quiet connection admitted %d calls, want at least %d; "+
+			"refused requests are draining the tenant bucket and starving siblings", admitted, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 9 -- AN UNCONSTRUCTED LIMITER REFUSES.
+//
+// A handler built by a struct literal that skipped the limiter must serve
+// nothing rather than serve unlimited. "Absence coerced into a plausible value"
+// is the shape this endpoint is most likely to fail in.
+// ---------------------------------------------------------------------------
+
+func TestToolCall_NilLimiterRefuses(t *testing.T) {
+	var l *toolCallLimiter
+	d := l.allow(uuid.New(), uuid.New())
+	if d.Allowed {
+		t.Error("a nil limiter admitted a request; an unwired limiter reads as no limit configured")
+	}
+	if d.RetryAfter <= 0 {
+		t.Errorf("nil-limiter RetryAfter = %v, want positive", d.RetryAfter)
+	}
+}

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -133,7 +133,8 @@ func NewTransportHandler(svc *Service, log *slog.Logger, version string) *Transp
 		// Armed HERE rather than injected with a nil default, for the reason
 		// NewService gives about its own limiter: an unarmed limiter would be a
 		// wiring failure that presents as a perfectly working endpoint.
-		toolLimit: newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin),
+		toolLimit: newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin,
+			ToolCallTenantBurst, ToolCallGrantBurst),
 	}
 }
 
@@ -782,29 +783,38 @@ func (h *TransportHandler) rateLimit(c *gin.Context, auth AuthorizedRequest, req
 		slog.Int("retry_after_seconds", secs),
 	)
 
+	sustained, burst := limitsForScope(d.Scope)
+
 	var msg string
 	switch d.Scope {
 	case scopeConnection:
 		msg = fmt.Sprintf(
-			"This connection has reached its tool-call rate limit of %d calls per minute. "+
-				"Wait %d seconds before calling this tool again -- retrying immediately will not "+
-				"succeed and will not shorten the wait. Nothing is misconfigured and no credential "+
-				"needs to be changed; the same call will work after the wait.",
-			ToolCallGrantPerMin, secs)
-	default:
-		msg = fmt.Sprintf(
-			"This organisation has reached its tool-call rate limit of %d calls per minute across "+
-				"all of its connections. Wait %d seconds before calling this tool again -- retrying "+
+			"This connection has reached its tool-call rate limit: %d calls per minute sustained, "+
+				"in bursts of up to %d. Wait %d seconds before calling this tool again -- retrying "+
 				"immediately will not succeed and will not shorten the wait. Nothing is "+
 				"misconfigured and no credential needs to be changed; the same call will work "+
 				"after the wait.",
-			ToolCallTenantPerMin, secs)
+			sustained, burst, secs)
+	default:
+		msg = fmt.Sprintf(
+			"This organisation has reached its tool-call rate limit across all of its "+
+				"connections: %d calls per minute sustained, in bursts of up to %d. Wait %d "+
+				"seconds before calling this tool again -- retrying immediately will not succeed "+
+				"and will not shorten the wait. Nothing is misconfigured and no credential needs "+
+				"to be changed; the same call will work after the wait.",
+			sustained, burst, secs)
 	}
 
+	// TWO NUMBERS, NOT ONE. A single "limit_per_minute" was true of neither the
+	// first minute nor the steady state: these are token buckets, so a client
+	// self-pacing against the sustained figure alone under-uses its allowance,
+	// and one that treats it as a hard ceiling is wrong by the burst. Both are
+	// published so a client can pace correctly against either.
 	data, _ := json.Marshal(map[string]any{
-		"retry_after_seconds": secs,
-		"limit_scope":         string(d.Scope),
-		"limit_per_minute":    limitForScope(d.Scope),
+		"retry_after_seconds":        secs,
+		"limit_scope":                string(d.Scope),
+		"sustained_limit_per_minute": sustained,
+		"burst_limit":                burst,
 		// Stated as a field and not only in the prose, so a client that
 		// branches on structure rather than reading the message reaches the
 		// same conclusion.
@@ -813,13 +823,14 @@ func (h *TransportHandler) rateLimit(c *gin.Context, auth AuthorizedRequest, req
 	return newErrorResponse(req.ID, codeRateLimited, msg, data), true
 }
 
-// limitForScope reports the per-minute budget that refused, so the data object
-// and the message can never disagree about which number applies.
-func limitForScope(s limitScope) int {
+// limitsForScope reports the sustained rate AND the burst of whichever bucket
+// refused, from one place, so the data object and the message can never
+// disagree about either number.
+func limitsForScope(s limitScope) (sustained, burst int) {
 	if s == scopeConnection {
-		return ToolCallGrantPerMin
+		return ToolCallGrantPerMin, ToolCallGrantBurst
 	}
-	return ToolCallTenantPerMin
+	return ToolCallTenantPerMin, ToolCallTenantBurst
 }
 
 func (h *TransportHandler) stampActivity(ctx context.Context, auth AuthorizedRequest, req jsonrpcRequest) (jsonrpcResponse, bool) {

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -83,6 +85,22 @@ const (
 	// comment claimed -32004 covered the scope-empty case too. It never did:
 	// TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList asserts -32002.
 	codeToolNotAvailable = -32004
+
+	// codeRateLimited is the tool-call budget refusing (1A-11). It is a
+	// SEPARATE code from every refusal above because it is the only one that is
+	// TRANSIENT-BUT-NOT-IMMEDIATELY: the request was well-formed, the
+	// credential is valid, the capability is held, and the same call will
+	// succeed later without anything being reconfigured.
+	//
+	// THAT DISTINCTION IS THE WHOLE POINT AND IT IS AIMED AT A MODEL, NOT AT A
+	// HUMAN. A model that reads a refusal as transient retries at once, and a
+	// model that reads it as permanent gives up and tells the user something
+	// false. Neither is right here; the correct behaviour is to wait the stated
+	// interval and then retry, so the message says so in words and the data
+	// object carries the interval as a number. This is the same failure the
+	// empty-capability refusal was moved off 401 to avoid -- there the client
+	// looped re-running OAuth, here it would loop re-calling the tool.
+	codeRateLimited = -32005
 )
 
 // TransportHandler serves the single MCP endpoint. It is separate from Handler
@@ -93,12 +111,30 @@ type TransportHandler struct {
 	svc     *Service
 	log     *slog.Logger
 	version string
+
+	// toolLimit bounds the tools/* methods (1A-11). It lives on the HANDLER
+	// rather than the Service because it gates a transport-level decision --
+	// the request is refused before any service method runs, so no activity
+	// stamp is written and no tool executes for a call that was never admitted.
+	//
+	// Never nil after NewTransportHandler. toolCallLimiter.allow refuses on a
+	// nil receiver anyway, so a handler built by a struct literal that skipped
+	// it serves NOTHING rather than serving unlimited.
+	toolLimit *toolCallLimiter
 }
 
 // NewTransportHandler builds the MCP transport handler. version is reported in
 // initialize's serverInfo.
 func NewTransportHandler(svc *Service, log *slog.Logger, version string) *TransportHandler {
-	return &TransportHandler{svc: svc, log: log, version: version}
+	return &TransportHandler{
+		svc:     svc,
+		log:     log,
+		version: version,
+		// Armed HERE rather than injected with a nil default, for the reason
+		// NewService gives about its own limiter: an unarmed limiter would be a
+		// wiring failure that presents as a perfectly working endpoint.
+		toolLimit: newToolCallLimiter(ToolCallTenantPerMin, ToolCallGrantPerMin),
+	}
 }
 
 // Register mounts the ONE endpoint on the given group.
@@ -540,6 +576,11 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{}), http.StatusOK, true
 
 	case "tools/list":
+		// THE BUDGET IS CHECKED BEFORE THE STAMP, which is before the answer.
+		// A refused request must not write.
+		if resp, refused := h.rateLimit(c, auth, req); refused {
+			return resp, http.StatusTooManyRequests, true
+		}
 		// THE ACTIVITY STAMP IS BEFORE THE ANSWER, NOT AFTER IT. See
 		// stampActivity.
 		if resp, refused := h.stampActivity(ctx, auth, req); refused {
@@ -553,6 +594,9 @@ func (h *TransportHandler) dispatch(
 		return newResponse(req.ID, map[string]any{"tools": VisibleTools(auth)}), http.StatusOK, true
 
 	case "tools/call":
+		if resp, refused := h.rateLimit(c, auth, req); refused {
+			return resp, http.StatusTooManyRequests, true
+		}
 		if resp, refused := h.stampActivity(ctx, auth, req); refused {
 			return resp, http.StatusOK, true
 		}
@@ -683,6 +727,91 @@ type toolCallParams struct {
 // tool-availability code: nothing is wrong with the caller's token or its
 // capability set, and telling it otherwise would send an operator rotating a
 // credential that was never the problem.
+// rateLimit applies the tool-call budget (1A-11). The bool is true when the
+// request was REFUSED, matching stampActivity's shape.
+//
+// BOTH KEYS COME FROM auth, WHICH IS SERVER-RESOLVED. AuthorizedRequest was
+// built by Service.Authenticate from the hashed bearer credential and re-checked
+// under the resolved tenant, so no header this caller sent participates in
+// choosing a bucket. Varying X-Forwarded-For, X-Real-IP or anything else cannot
+// obtain a fresh budget, which is the property two other limiters in this tree
+// were recently found to be missing.
+//
+// THE REFUSAL IS WRITTEN FOR TWO READERS AT ONCE, and that is why it is not
+// simply a 429.
+//
+//   - The HTTP layer gets 429 with Retry-After in whole seconds, which is what
+//     a conforming HTTP client already knows how to back off on.
+//   - The MODEL gets the JSON-RPC error body, because an MCP client typically
+//     surfaces the error content to the model and not the status line. The
+//     message therefore states IN WORDS that retrying immediately will not
+//     help and names the wait, rather than leaving the model to infer urgency
+//     from a bare "rate limited" -- an inference it reliably gets wrong by
+//     retrying at once.
+//
+// The data object carries the numbers so a client can act without parsing
+// prose, and names the scope so an operator learns whether one connection or
+// the whole organisation is affected.
+func (h *TransportHandler) rateLimit(c *gin.Context, auth AuthorizedRequest, req jsonrpcRequest) (jsonrpcResponse, bool) {
+	d := h.toolLimit.allow(auth.TenantID, auth.GrantID)
+	if d.Allowed {
+		return jsonrpcResponse{}, false
+	}
+
+	secs := int(math.Ceil(d.RetryAfter.Seconds()))
+	if secs < 1 {
+		secs = 1
+	}
+	c.Header("Retry-After", strconv.Itoa(secs))
+
+	h.log.WarnContext(c.Request.Context(), "mcp tool call rate limited",
+		slog.String("tenant_id", auth.TenantID.String()),
+		slog.String("grant_id", auth.GrantID.String()),
+		slog.String("method", req.Method),
+		slog.String("limit_scope", string(d.Scope)),
+		slog.Int("retry_after_seconds", secs),
+	)
+
+	var msg string
+	switch d.Scope {
+	case scopeConnection:
+		msg = fmt.Sprintf(
+			"This connection has reached its tool-call rate limit of %d calls per minute. "+
+				"Wait %d seconds before calling this tool again -- retrying immediately will not "+
+				"succeed and will not shorten the wait. Nothing is misconfigured and no credential "+
+				"needs to be changed; the same call will work after the wait.",
+			ToolCallGrantPerMin, secs)
+	default:
+		msg = fmt.Sprintf(
+			"This organisation has reached its tool-call rate limit of %d calls per minute across "+
+				"all of its connections. Wait %d seconds before calling this tool again -- retrying "+
+				"immediately will not succeed and will not shorten the wait. Nothing is "+
+				"misconfigured and no credential needs to be changed; the same call will work "+
+				"after the wait.",
+			ToolCallTenantPerMin, secs)
+	}
+
+	data, _ := json.Marshal(map[string]any{
+		"retry_after_seconds": secs,
+		"limit_scope":         string(d.Scope),
+		"limit_per_minute":    limitForScope(d.Scope),
+		// Stated as a field and not only in the prose, so a client that
+		// branches on structure rather than reading the message reaches the
+		// same conclusion.
+		"retry_immediately_will_fail": true,
+	})
+	return newErrorResponse(req.ID, codeRateLimited, msg, data), true
+}
+
+// limitForScope reports the per-minute budget that refused, so the data object
+// and the message can never disagree about which number applies.
+func limitForScope(s limitScope) int {
+	if s == scopeConnection {
+		return ToolCallGrantPerMin
+	}
+	return ToolCallTenantPerMin
+}
+
 func (h *TransportHandler) stampActivity(ctx context.Context, auth AuthorizedRequest, req jsonrpcRequest) (jsonrpcResponse, bool) {
 	if err := h.svc.RecordActivity(ctx, auth); err != nil {
 		h.log.ErrorContext(ctx, "mcp activity stamp failed",

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -261,8 +261,18 @@ var corsAllowHeaders = strings.Join([]string{
 // WWW-Authenticate is the load-bearing one: writeUnauthorized sets it to name
 // the scheme, and a browser client that cannot read it learns only "401" with
 // no indication of how to authenticate.
+//
+// Retry-After is load-bearing for the same reason on the other refusal:
+// rateLimit sets it on every 429, and a browser-hosted client that cannot read
+// it knows it was refused but not for how long -- so it either gives up or
+// retries immediately, which is the loop that refusal exists to break. THE RULE
+// THIS LIST FOLLOWS IS "EVERY HEADER THIS FILE SETS THAT A CLIENT MUST ACT ON",
+// and the three it sets are Allow (405), WWW-Authenticate (401) and Retry-After
+// (429), all three now present. Mcp-Session-Id is listed ahead of need, matching
+// corsAllowHeaders above. A new response header that a client is expected to
+// branch on belongs here in the same commit that introduces it.
 var corsExposeHeaders = strings.Join([]string{
-	"WWW-Authenticate", "Mcp-Session-Id", "Allow",
+	"WWW-Authenticate", "Mcp-Session-Id", "Allow", "Retry-After",
 }, ", ")
 
 // writeCORS sets the headers that must appear on an ACTUAL response, as opposed


### PR DESCRIPTION
Wave 1.1 / task `1A-11`, slice **1A Gate**. Closes **one of the three** things ADR-061 requires. The other two are blocked on a migration — see below.

## What this does

`POST /mcp` authenticated every request and then dispatched `tools/list` and `tools/call` with no budget at all. `/oauth/mcp/register` and `POST /api/v1/mcp/connections` were both limited; the one endpoint a model drives in a loop was not. Every tool request writes an activity stamp before it reads, so the cost of an unbounded call is a database write.

**Key: the tenant is the bound, the grant is fairness only.**

- A per-grant bound is escapable by minting more connections, so it is not a bound.
- A per-token bound resets on rotation — the action an operator takes when something is already wrong.
- The tenant is the one key an authenticated caller cannot multiply.

**No global layer**, unlike the registration limiter. That endpoint is unauthenticated and cannot attribute load, so its bound must be process-wide. A process-wide bucket here would let one tenant starve every other tenant on the instance — the exact starvation defect `register_limit.go` documents fixing.

**Header immunity.** Both keys come off `AuthorizedRequest`, resolved from the hashed bearer inside a tenant transaction. There is no `ClientIP`, `GetHeader` or `RemoteAddr` call on the path. Two limiters here were recently found spoofable via `X-Forwarded-For`; the proof executes that bypass against eight header shapes rather than asserting it from a comment.

**The refusal is written for two readers.** HTTP gets 429 with `Retry-After`; the model gets JSON-RPC `-32005` whose message states in words that retrying immediately will not succeed. An MCP client surfaces error content, not the status line, and a model that reads a refusal as transient retries at once — the shape just fixed on the empty-capability 401.

## Proofs

Nine, all asserting by value (status, code, scope, advertised number, retry flag), all through the real mount.

A nine-mutation sweep left **four survivors** on the first pass, each a real gap: deleting the `tools/call` gate left the suite green because every proof drove `tools/list`; moving the gate after the activity stamp went unnoticed for the same reason; keying every tenant on one bucket passed because the isolation proof never saturated the tenant bound; and zeroing the `Retry-After` floor was masked by a second floor in the handler. The over-fire check was also parameterised on the constant it guards. All fixed; the sweep now leaves no survivors and every catch is behavioural rather than a compile error.

## Not in this PR, and why

**Off by default per tenant** and **the per-tenant kill switch** both need persistent per-tenant state. `tenants` has no such column and there is no tenant-settings table. That is a migration, which belongs to `database-engineer`, and it lands before the Go code that reads it. This PR does not invent one.

## Verification

- `go build ./... && go vet ./internal/... ./cmd/... && go test ./internal/... ./cmd/...` — green
- `make test-integration` from the repo root — green, all four packages
- `git grep "MUTATION M" -- apps/api` — empty; `git diff --stat` — empty

Draft until the security review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant- and connection-level rate limits for MCP tool requests.
  * Rate-limit responses now include HTTP 429 status, retry guidance, and structured error details.
  * Separate budgets help prevent excessive activity across connections.

* **Bug Fixes**
  * Rejected requests no longer execute tools, record activity, or consume quota.
  * Client-supplied headers cannot bypass rate limits.
  * Rate-limit enforcement preserves isolation between tenants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->