### PR TITLE
feat(mcp): write and return mcp_grants.setup_client (m128)

### DIFF
--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -268,11 +268,22 @@ RETURNING *;
 -- either gets 23502 rather than a live organisation-wide grant (Decision 1).
 -- The caller passes status explicitly -- 'active' -- rather than relying on the
 -- schema to assume it.
+-- setup_client (m128) IS THE OPERATOR'S CHOICE AT S29 STEP 2 and is passed
+-- explicitly, like status, rather than being left to the schema. It is NULLABLE
+-- with NO DEFAULT precisely so a caller that never asked -- any path that is
+-- not the step-2 wizard -- can pass NULL and mean "no operator choice was
+-- recorded". PASS NULL RATHER THAN 'generic' ON SUCH A PATH: 'generic' asserts
+-- the operator saw nine cards and chose "Other MCP client", which is a
+-- different fact and the one S29 step 9 distinguishes.
+--
+-- Do NOT derive it from client_name. That column is self-reported at
+-- `initialize`, is NULL until the client first connects, and inferring a
+-- choice from it manufactures a fact the operator never stated.
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, setup_client
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 )
 RETURNING *;
 

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5651,6 +5651,36 @@ CREATE TABLE mcp_grants (
     client_version              text        NULL,
     protocol_version            text        NULL,
     client_identity_recorded_at timestamptz NULL,
+    -- m128. THE OPERATOR'S CHOICE at S29 step 2, as a client-table.ts slug.
+    -- A FOURTH client fact, not a replacement for the three above: those are
+    -- self-reported by the client at `initialize`, this one is what a human
+    -- said the connection was for. They disagree legitimately and permanently
+    -- (set up for Claude Desktop, URL pasted into Cursor), so neither
+    -- overwrites the other and RecordConnect must never write this column.
+    --
+    -- NULL MEANS "NO OPERATOR CHOICE WAS RECORDED", and is NOT 'generic'.
+    -- 'generic' means an operator saw nine cards and chose "Other MCP client",
+    -- which the wireframe calls "a complete path, not a placeholder". S29 step
+    -- 9's never-connected state needs both facts and needs them apart.
+    --
+    -- NULLABLE WITH NO DEFAULT, deliberately unlike m127's capabilities and
+    -- expires_at: this column carries NO AUTHORITY, so there is no fail-open
+    -- for a NOT NULL to close, and a DEFAULT 'generic' would make every row
+    -- ever created assert a choice nobody made.
+    --
+    -- The CHECK pins SPELLING, not MEMBERSHIP. It does not enumerate the nine
+    -- clients: a new MCP client arrives on a vendor's cadence and should cost
+    -- one row in client-table.ts, not a migration applied inside main() at
+    -- boot. What it does buy is S31's filter -- `client is windsurf` then
+    -- "None of them was set up for Windsurf" is only true if equality is
+    -- trustworthy, so 'Windsurf' and 'windsurf ' are unrepresentable. An
+    -- unrecognised slug degrades at the render layer to the generic panel.
+    -- See m128 DECISION 3 for the full argument.
+    setup_client                text        NULL
+        CONSTRAINT mcp_grants_setup_client_shape_check
+        CHECK (setup_client IS NULL
+               OR (setup_client ~ '^[a-z0-9]+(-[a-z0-9]+)*$'
+                   AND length(setup_client) <= 64)),
     created_by_user_id          uuid        NULL,
     created_at   timestamptz NOT NULL DEFAULT now(),
     last_used_at timestamptz NULL,

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -188,11 +188,11 @@ const createMCPGrant = `-- name: CreateMCPGrant :one
 
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
-    client_id, created_by_user_id
+    client_id, created_by_user_id, setup_client
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 )
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, setup_client, created_by_user_id, created_at, last_used_at, revoked_at
 `
 
 type CreateMCPGrantParams struct {
@@ -204,6 +204,7 @@ type CreateMCPGrantParams struct {
 	ScopeSiteIds    []uuid.UUID `json:"scope_site_ids"`
 	ClientID        *string     `json:"client_id"`
 	CreatedByUserID pgtype.UUID `json:"created_by_user_id"`
+	SetupClient     *string     `json:"setup_client"`
 }
 
 // ===========================================================================
@@ -231,6 +232,17 @@ type CreateMCPGrantParams struct {
 // either gets 23502 rather than a live organisation-wide grant (Decision 1).
 // The caller passes status explicitly -- 'active' -- rather than relying on the
 // schema to assume it.
+// setup_client (m128) IS THE OPERATOR'S CHOICE AT S29 STEP 2 and is passed
+// explicitly, like status, rather than being left to the schema. It is NULLABLE
+// with NO DEFAULT precisely so a caller that never asked -- any path that is
+// not the step-2 wizard -- can pass NULL and mean "no operator choice was
+// recorded". PASS NULL RATHER THAN 'generic' ON SUCH A PATH: 'generic' asserts
+// the operator saw nine cards and chose "Other MCP client", which is a
+// different fact and the one S29 step 9 distinguishes.
+//
+// Do NOT derive it from client_name. That column is self-reported at
+// `initialize`, is NULL until the client first connects, and inferring a
+// choice from it manufactures a fact the operator never stated.
 func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error) {
 	row := q.db.QueryRow(ctx, createMCPGrant,
 		arg.TenantID,
@@ -241,6 +253,7 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		arg.ScopeSiteIds,
 		arg.ClientID,
 		arg.CreatedByUserID,
+		arg.SetupClient,
 	)
 	var i McpGrant
 	err := row.Scan(
@@ -256,6 +269,7 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		&i.ClientVersion,
 		&i.ProtocolVersion,
 		&i.ClientIdentityRecordedAt,
+		&i.SetupClient,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.LastUsedAt,
@@ -413,7 +427,7 @@ func (q *Queries) GetMCPConnectionTokenByHashForLookup(ctx context.Context, toke
 }
 
 const getMCPGrant = `-- name: GetMCPGrant :one
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, setup_client, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
 WHERE tenant_id = $1 AND id = $2
 `
 
@@ -441,6 +455,7 @@ func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGr
 		&i.ClientVersion,
 		&i.ProtocolVersion,
 		&i.ClientIdentityRecordedAt,
+		&i.SetupClient,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.LastUsedAt,
@@ -531,7 +546,7 @@ func (q *Queries) ListMCPConnectionTokensForGrant(ctx context.Context, arg ListM
 }
 
 const listMCPGrantsForOrg = `-- name: ListMCPGrantsForOrg :many
-SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
+SELECT id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, setup_client, created_by_user_id, created_at, last_used_at, revoked_at FROM mcp_grants
 WHERE tenant_id = $1
 ORDER BY created_at DESC, id DESC
 `
@@ -568,6 +583,7 @@ func (q *Queries) ListMCPGrantsForOrg(ctx context.Context, tenantID uuid.UUID) (
 			&i.ClientVersion,
 			&i.ProtocolVersion,
 			&i.ClientIdentityRecordedAt,
+			&i.SetupClient,
 			&i.CreatedByUserID,
 			&i.CreatedAt,
 			&i.LastUsedAt,
@@ -676,7 +692,7 @@ SET client_name                 = $3,
     protocol_version            = $5,
     client_identity_recorded_at = now()
 WHERE tenant_id = $1 AND id = $2
-RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, created_by_user_id, created_at, last_used_at, revoked_at
+RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, setup_client, created_by_user_id, created_at, last_used_at, revoked_at
 `
 
 type RecordMCPGrantClientIdentityInTenantTxParams struct {
@@ -719,6 +735,7 @@ func (q *Queries) RecordMCPGrantClientIdentityInTenantTx(ctx context.Context, ar
 		&i.ClientVersion,
 		&i.ProtocolVersion,
 		&i.ClientIdentityRecordedAt,
+		&i.SetupClient,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.LastUsedAt,

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -491,6 +491,7 @@ type McpGrant struct {
 	ClientVersion            *string            `json:"client_version"`
 	ProtocolVersion          *string            `json:"protocol_version"`
 	ClientIdentityRecordedAt pgtype.Timestamptz `json:"client_identity_recorded_at"`
+	SetupClient              *string            `json:"setup_client"`
 	CreatedByUserID          pgtype.UUID        `json:"created_by_user_id"`
 	CreatedAt                time.Time          `json:"created_at"`
 	LastUsedAt               pgtype.Timestamptz `json:"last_used_at"`

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -614,6 +614,17 @@ type Querier interface {
 	// either gets 23502 rather than a live organisation-wide grant (Decision 1).
 	// The caller passes status explicitly -- 'active' -- rather than relying on the
 	// schema to assume it.
+	// setup_client (m128) IS THE OPERATOR'S CHOICE AT S29 STEP 2 and is passed
+	// explicitly, like status, rather than being left to the schema. It is NULLABLE
+	// with NO DEFAULT precisely so a caller that never asked -- any path that is
+	// not the step-2 wizard -- can pass NULL and mean "no operator choice was
+	// recorded". PASS NULL RATHER THAN 'generic' ON SUCH A PATH: 'generic' asserts
+	// the operator saw nine cards and chose "Other MCP client", which is a
+	// different fact and the one S29 step 9 distinguishes.
+	//
+	// Do NOT derive it from client_name. That column is self-reported at
+	// `initialize`, is NULL until the client first connects, and inferring a
+	// choice from it manufactures a fact the operator never stated.
 	CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error)
 	// ---------------------------------------------------------------------------
 	// backup_manifest_entries

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -178,6 +178,26 @@ type connectionDTO struct {
 	ReportedClientName    *string `json:"reported_client_name"`
 	ReportedClientVersion *string `json:"reported_client_version"`
 
+	// THE OPERATOR'S choice at step 2 -- a different fact from the two above,
+	// which is why it does not share their `reported_` prefix. Follows this
+	// struct's rule: pointer, no `omitempty`, so `"setup_client": null` is said
+	// out loud rather than becoming a missing key the consumer has to guess at.
+	//
+	// null MEANS "NO OPERATOR CHOICE WAS RECORDED", NOT "generic". S31's filter
+	// must not gather null rows under the "Other MCP client" chip: the sentence
+	// it renders is "None of them was set up for Windsurf", and coercing an
+	// absence into a stated choice is the falsehood that filter exists to
+	// avoid.
+	//
+	// AN UNRECOGNISED SLUG IS A LEGITIMATE VALUE HERE, not an error and not a
+	// server bug. The server pins spelling only; the vocabulary lives in
+	// apps/web/src/features/ai-connections/client-table.ts, so a client added
+	// there after this row was written arrives as a string the frontend of the
+	// day may not know. Render an unknown id as the generic panel -- which the
+	// wireframes call "a complete path, not a placeholder" -- never as an
+	// error.
+	SetupClient *string `json:"setup_client"`
+
 	Protocol protocolReportDTO `json:"protocol"`
 
 	// null means NEVER USED. It is not omitted and it is never a zero date.
@@ -227,6 +247,21 @@ type mintConnectionRequestDTO struct {
 	// empty stored capability set is a connection that authenticates and can
 	// then reach no tool at all.
 	Capabilities []string `json:"capabilities"`
+
+	// SetupClient is the operator's step-2 choice, and it is a *string SO THAT
+	// OMITTED AND EMPTY STAY DIFFERENT ON THE WIRE.
+	//
+	// A plain string would decode both `{}` and `{"setup_client":""}` to "",
+	// collapsing "the caller never asked" into "the caller asked and got
+	// nothing" -- and the service would then have to guess which. As a pointer,
+	// omitted is nil (stored NULL, nobody asked) and "" is a present-but-empty
+	// value, which validateSetupClient REFUSES rather than quietly storing as
+	// NULL. A caller that sends the key has made a claim and gets an answer
+	// about it.
+	//
+	// OPTIONAL, and omitting it is a legitimate request, not a degraded one:
+	// the consent path never asks and neither need any other non-wizard caller.
+	SetupClient *string `json:"setup_client"`
 }
 
 // mintConnectionResponseDTO carries the plaintext EXACTLY ONCE.
@@ -322,7 +357,12 @@ func toConnectionDTO(c Connection) connectionDTO {
 		CreatedAt:             c.CreatedAt.UTC().Format(time.RFC3339Nano),
 		ReportedClientName:    c.ReportedClientName,
 		ReportedClientVersion: c.ReportedClientVersion,
-		Protocol:              proto,
+		// Passed through as-is, nil and all. No fallback to
+		// ReportedClientName: that would answer "what was this set up for" with
+		// the client's own self-report, which is the substitution m128
+		// DECISION 1 exists to refuse.
+		SetupClient: c.SetupClient,
+		Protocol:    proto,
 		LastUsedAt:            isoOrNil(c.LastUsedAt),
 		RevokedAt:             isoOrNil(c.RevokedAt),
 	}

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -272,6 +272,12 @@ func (h *Handler) mintConnection(c *gin.Context) {
 		Name:         body.Name,
 		SiteScope:    SiteScopeRequest{Mode: SiteScopeMode(body.SiteScopeMode), TagIDs: tagIDs, SiteIDs: siteIDs},
 		Capabilities: caps,
+		// Forwarded as the pointer it arrived as, so "omitted" survives the
+		// handler as nil rather than being flattened to "". The service
+		// validates its shape and refuses a malformed one; the handler does not
+		// second-guess it, for the same reason it does no authorization of its
+		// own -- a fourth opinion is a fourth thing that can drift.
+		SetupClient: body.SetupClient,
 	})
 	if err != nil {
 		httpx.Error(c, err)

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -136,6 +137,72 @@ const ErrCodeMintRateLimited = "mcp_mint_rate_limited"
 // still has the context to fix it.
 const ErrCodeUnknownScopeTag = "mcp_unknown_scope_tag"
 
+// ErrCodeInvalidSetupClient refuses a setup_client whose SPELLING could not be
+// compared reliably. It is never returned for a slug the server simply has not
+// heard of; see setupClientShape.
+const ErrCodeInvalidSetupClient = "mcp_invalid_setup_client"
+
+// setupClientShapeMaxLen mirrors the length half of m128's CHECK.
+const setupClientShapeMaxLen = 64
+
+// setupClientShape mirrors mcp_grants_setup_client_shape_check EXACTLY --
+// `^[a-z0-9]+(-[a-z0-9]+)*$` -- and deliberately encodes nothing else.
+//
+// WHY THE API VALIDATES SHAPE AND NOT MEMBERSHIP, which is the decision worth
+// arguing rather than asserting. The vocabulary is nine ids and it lives in
+// apps/web/src/features/ai-connections/client-table.ts, whose header states the
+// intended cost of a new client: "when a client changes, one row changes". Go
+// cannot import that file, so a closed server-side list would be a SECOND copy
+// of the vocabulary in a second language on a second release cadence -- and the
+// failure mode of a stale copy is the wizard rejecting, at the end of a ten-step
+// flow, a client its own UI is offering. m128 DECISION 3 refused a closed
+// database CHECK for precisely that reason, and re-adding the closure one layer
+// up in Go would defeat the migration while leaving its rationale in place.
+//
+// The three alternatives and why each loses: a generated Go constant from the
+// TS table couples the control-plane release to a frontend data edit, which is
+// the coupling DECISION 3 was written to remove; a config-driven allowlist moves
+// the same staleness into an env var nobody updates; validating nothing lets
+// 'Windsurf', 'windsurf ' and 'Windsurf (Desktop)' all land in the column, and
+// then S31 renders "None of them was set up for Windsurf" with a matching
+// connection sitting in the list -- an absence coerced into a confident answer,
+// this project's signature defect.
+//
+// So the server guarantees the ONE property the screens actually need, which is
+// that equality is trustworthy, and stays silent on which slugs exist. An
+// unrecognised id is a LEGITIMATE STORED STATE that degrades at the render layer
+// to the generic panel -- "a complete path, not a placeholder" in the
+// wireframe's own words -- not a 400.
+//
+// It mirrors the CHECK rather than relaxing it so the refusal is a 400 naming
+// the field, not a 23514 surfacing as a 500 from the INSERT. The database stays
+// the backstop; this is the diagnosis.
+var setupClientShape = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// validateSetupClient refuses a present-but-malformed value and accepts nil.
+//
+// nil is "the caller never asked" and is always valid -- the consent path and
+// every non-wizard caller are entitled to it. A PRESENT value is held to the
+// shape, INCLUDING the empty string: "" is a caller that sent the key and put
+// nothing in it, which is a malformed claim rather than an absent one, and
+// silently rewriting it to NULL would report success for a step-2 choice that
+// was never stored.
+//
+// No trimming, no lowercasing, no repair of any kind. Coercing " Windsurf " into
+// "windsurf" would accept a caller that is wrong about the vocabulary and hide
+// the bug at the only layer positioned to name it; the operator would then see
+// a stored value they never chose. Refuse and say which field.
+func validateSetupClient(v *string) error {
+	if v == nil {
+		return nil
+	}
+	if len(*v) > setupClientShapeMaxLen || !setupClientShape.MatchString(*v) {
+		return domain.Validation(ErrCodeInvalidSetupClient,
+			"setup_client must be a lowercase slug of letters, digits and single hyphens")
+	}
+	return nil
+}
+
 // ErrCodeUnknownScopeSite is the same refusal on the site axis. Same column
 // shape (uuid[], no foreign key), same silent-narrowing outcome, and it is
 // detected differently: a site id is verified by resolving it through the
@@ -182,6 +249,13 @@ type MintConnectionRequest struct {
 	// A non-empty list is NARROWED against the org ceiling, never widened past
 	// it -- CapabilitySet.NarrowTo refuses rather than intersects.
 	Capabilities []Capability
+
+	// SetupClient is the operator's step-2 choice, OPTIONAL, and nil means the
+	// caller never asked -- which is stored as NULL and NOT as "generic". See
+	// Connection.SetupClient for why those two are not interchangeable.
+	//
+	// Validated for SHAPE ONLY, never for membership: see validateSetupClient.
+	SetupClient *string
 }
 
 // MintedConnection is the response. Token is present exactly once, here.
@@ -262,6 +336,22 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	// least one site, and an absent mode is refused rather than read as 'all'.
 	// An empty allowlist is never a way to ask for every site.
 	if err := ValidateSiteScopeRequest(req.SiteScope); err != nil {
+		return MintedConnection{}, err
+	}
+
+	// validateSetupClient is the Go mirror of
+	// mcp_grants_setup_client_shape_check, and it belongs in THIS step for the
+	// reason the step's own comment gives: it is a pure function of the request
+	// body, it reads no database, and it discloses nothing. Running it before
+	// the charge means a malformed slug is answered "your setup_client is
+	// malformed" rather than "slow down".
+	//
+	// It is in the SERVICE and not only in the handler on purpose. The handler
+	// is one caller; the invariant that a stored setup_client is comparable by
+	// equality is a property of the column, so it is enforced at the layer
+	// every caller passes through. A handler-only check is one new call site
+	// away from a row S31's filter cannot match.
+	if err := validateSetupClient(req.SetupClient); err != nil {
 		return MintedConnection{}, err
 	}
 
@@ -363,6 +453,19 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 			// window yet, and inventing one nobody chose is the credential-terms
 			// defect that column refuses to default.
 			IdleExpireAfterDays: nil,
+
+			// m128. THE OPERATOR'S STEP-2 CHOICE, PASSED THROUGH UNCHANGED --
+			// nil included. This is the one path in the codebase that has a
+			// real answer for this column, because it is the one the wizard
+			// calls.
+			//
+			// nil here is a caller that did not ask, and it stores NULL. It is
+			// NOT rewritten to "generic": that would assert the operator saw
+			// nine cards and chose "Other MCP client", which is a different
+			// fact and the one S29 step 9 exists to distinguish. Already
+			// validated for shape in step 2; the database CHECK is the backstop
+			// behind that, not the diagnosis.
+			SetupClient: req.SetupClient,
 		},
 		func(grantID uuid.UUID) sqlc.CreateMCPConnectionTokenParams {
 			return sqlc.CreateMCPConnectionTokenParams{

--- a/apps/api/internal/mcp/model.go
+++ b/apps/api/internal/mcp/model.go
@@ -243,6 +243,26 @@ type Connection struct {
 	ReportedClientName    *string
 	ReportedClientVersion *string
 
+	// SetupClient is THE OPERATOR'S CHOICE at the wizard's step 2, written once
+	// at creation and never again. It is a fourth client fact, not a tidier
+	// spelling of the two above, and the distinction is the whole reason the
+	// column exists (m128 DECISION 1).
+	//
+	// nil MEANS "NO OPERATOR CHOICE WAS RECORDED" AND NOTHING ELSE. It does not
+	// mean "generic": "generic" is the operator actively choosing "Other MCP
+	// client" from the nine cards, which is a stated choice, and step 9 renders
+	// the two differently. Never substitute one for the other in either
+	// direction.
+	//
+	// IT MAY DISAGREE WITH ReportedClientName PERMANENTLY AND LEGITIMATELY --
+	// set up for Claude Desktop, URL pasted into Cursor -- and neither is the
+	// other's stale copy, so neither may overwrite the other. In particular
+	// RecordConnect writes the reported pair and MUST NOT write this. It is
+	// also the only one of the three that survives the never-connected case,
+	// where both reported columns are nil by definition and step 9 still has to
+	// say what the connection was set up for.
+	SetupClient *string
+
 	// Protocol is the four-state classification of the stored header.
 	Protocol ClientProtocol
 

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -685,6 +685,28 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			// So: NULL until Step 5's second control ships and supplies a
 			// chosen value. The prerequisite is now met; the input is not.
 			IdleExpireAfterDays: nil,
+
+			// m128. NULL, AND NULL IS THE ANSWER RATHER THAN 'generic'.
+			//
+			// THE CONSENT PATH NEVER ASKS. An OAuth grant is authorised by a
+			// consent screen that shows the client's own unverified claim about
+			// itself; it never puts the nine-card chooser in front of the
+			// operator, so no operator choice exists to record. NULL is the
+			// column's word for "nobody asked" and it is the truth here.
+			//
+			// 'generic' WOULD BE A LIE, not a harmless default. It asserts the
+			// operator saw nine cards and picked "Other MCP client", and S31's
+			// filter and S29 step 9 both read that as a stated choice: every
+			// OAuth connection would then answer a filter chip no operator ever
+			// selected. m128 DECISION 2(b) refuses the schema default for this
+			// reason, and a Go-side default would reintroduce it one layer up.
+			//
+			// Do NOT derive it from client.ClientName either. That is the
+			// client's self-report, m128 DECISION 2(c), and inferring a choice
+			// from it manufactures a fact the operator never stated -- and
+			// makes an inferred row indistinguishable from a chosen one at
+			// exactly the screen that exists to tell them apart.
+			SetupClient: nil,
 		},
 		func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
 			return sqlc.CreateMCPAuthorizationCodeParams{
@@ -1169,6 +1191,30 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 // The error is RETURNED, not logged and dropped. The caller refuses the
 // session on failure -- a connection the control plane could not attribute is
 // worse than a refused one.
+//
+// ============================================================================
+// IT MUST NEVER WRITE mcp_grants.setup_client. THIS IS LOAD-BEARING (m128).
+// ============================================================================
+//
+// The tidy-looking change is to notice that this function already writes the
+// client's name and to "keep setup_client in sync" from it. That destroys the
+// column. setup_client is THE OPERATOR'S CHOICE at wizard step 2; name and
+// version are THE CLIENT'S SELF-REPORT at initialize. They are different facts
+// about different actors and they DISAGREE LEGITIMATELY AND PERMANENTLY -- set
+// up for Claude Desktop, URL pasted into Cursor. Neither is the other's stale
+// copy, so neither may overwrite the other.
+//
+// The damage is not hypothetical and it is silent. S29 step 9's failure state
+// reads setup_client precisely when NOTHING HAS EVER CONNECTED, which is by
+// definition the state in which this function has never run and both reported
+// columns are NULL; and S31 filters on "was set up for", not "last connected
+// as". A sync here would overwrite the operator's stated choice with an
+// observation on first connect, and every screen would keep rendering, wrong.
+//
+// The write path for that column is CreateGrant/MintConnection, once, at
+// creation. There is no second one. TestRecordConnectLeavesSetupClientAlone
+// and the integration proof of the same name are what make removing this
+// paragraph go red rather than green.
 func (s *Service) RecordConnect(ctx context.Context, auth AuthorizedRequest, name, version string, protocolHeader *string) error {
 	if err := s.store.RecordClientIdentity(ctx, auth.TenantID, auth.GrantID, name, version, protocolHeader); err != nil {
 		return fmt.Errorf("record mcp connect: %w", err)
@@ -1563,6 +1609,11 @@ func connectionFromGrant(g sqlc.McpGrant) Connection {
 		CreatedAt:             g.CreatedAt,
 		ReportedClientName:    g.ClientName,
 		ReportedClientVersion: g.ClientVersion,
+		// The OPERATOR's choice, read straight off the row and never
+		// substituted from ClientName above. The two fields sit adjacent here
+		// on purpose: they answer different questions and either may be nil
+		// while the other is set. See Connection.SetupClient.
+		SetupClient: g.SetupClient,
 		Protocol: ClassifyStoredProtocol(
 			timestamptzTimeOrNil(g.ClientIdentityRecordedAt), g.ProtocolVersion),
 		LastUsedAt: timestamptzTimeOrNil(g.LastUsedAt),

--- a/apps/api/internal/mcp/setup_client_test.go
+++ b/apps/api/internal/mcp/setup_client_test.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+// These run in CI. The integration proofs in
+// apps/api/tests/mcp_m128_setup_client_integration_test.go do not -- the
+// integration package is excluded by name -- so the shape rule, which is the
+// half a reviewer is most likely to "simplify", is pinned here where a PR
+// actually runs it.
+
+// TestValidateSetupClientAcceptsNilAndRefusesEmpty pins the distinction the
+// *string exists for. nil is "the caller never asked" and is always valid; ""
+// is a caller that sent the key and put nothing in it, which is a malformed
+// claim. Rewriting "" to NULL would report success for a step-2 choice that was
+// never stored.
+func TestValidateSetupClientAcceptsNilAndRefusesEmpty(t *testing.T) {
+	if err := validateSetupClient(nil); err != nil {
+		t.Fatalf("nil setup_client refused (%v); the consent path and every "+
+			"non-wizard caller pass nil and are entitled to", err)
+	}
+	empty := ""
+	if err := validateSetupClient(&empty); err == nil {
+		t.Fatal("an empty setup_client was accepted. It would store as \"\", " +
+			"which is neither a choice nor NULL, and S31's filter would have a " +
+			"third state nobody designed for.")
+	}
+}
+
+// TestValidateSetupClientPinsShapeNotVocabulary is the decision this file
+// exists to defend. Both halves are asserted together because each is the
+// other's control: a server that refused every unknown slug would pass the
+// first half alone and break the wizard at step 2 for a client its own UI
+// offers, and a server that validated nothing would pass the second half alone
+// and let 'Windsurf' and 'windsurf ' both into a column S31 compares by
+// equality.
+func TestValidateSetupClientPinsShapeNotVocabulary(t *testing.T) {
+	// Every id in apps/web/src/features/ai-connections/client-table.ts, plus
+	// slugs no vocabulary knows. ALL must pass: the server pins spelling only.
+	valid := []string{
+		"claude-code", "claude-desktop", "chatgpt", "codex-cli", "cursor",
+		"vscode", "windsurf", "gemini-cli", "generic",
+		// Not in the table today, and deliberately accepted. A client added
+		// to that table must not require a control-plane migration or release.
+		"some-future-client", "a", "x9", "a-b-c-d",
+	}
+	for _, v := range valid {
+		v := v
+		if err := validateSetupClient(&v); err != nil {
+			t.Errorf("validateSetupClient(%q) = %v, want accepted. An "+
+				"unrecognised but well-formed slug is a legitimate stored "+
+				"state that renders as the generic panel, not an error.", v, err)
+		}
+	}
+
+	// Refused for SHAPE, so that equality on the stored column is trustworthy.
+	invalid := []string{
+		"Windsurf",       // upper case
+		"windsurf ",      // trailing space
+		" windsurf",      // leading space
+		"windsurf_beta",  // underscore
+		"windsurf--beta", // doubled hyphen
+		"-windsurf",      // leading hyphen
+		"windsurf-",      // trailing hyphen
+		"wind surf",      // inner space
+		"Windsurf (Devin Desktop)",
+		"windsurf\n",
+	}
+	for _, v := range invalid {
+		v := v
+		if err := validateSetupClient(&v); err == nil {
+			t.Errorf("validateSetupClient(%q) was ACCEPTED. Free spelling in "+
+				"this column makes S31 render \"None of them was set up for "+
+				"Windsurf\" while a matching connection sits in the list.", v)
+		}
+	}
+
+	// The length half of the CHECK, asserted at the boundary rather than near
+	// it: 64 passes, 65 does not.
+	at := make([]byte, setupClientShapeMaxLen)
+	for i := range at {
+		at[i] = 'a'
+	}
+	ok := string(at)
+	if err := validateSetupClient(&ok); err != nil {
+		t.Errorf("a %d-character slug was refused (%v); the CHECK allows it",
+			setupClientShapeMaxLen, err)
+	}
+	over := ok + "a"
+	if err := validateSetupClient(&over); err == nil {
+		t.Errorf("a %d-character slug was accepted; the CHECK would take 23514 "+
+			"at the INSERT and surface as a 5xx instead of a field-level 400",
+			len(over))
+	}
+}
+
+// TestSetupClientSurvivesTheDTOMappingUnchanged pins the read half. The mapper
+// must pass nil through as nil and must never substitute ReportedClientName:
+// answering "what was this set up for" with the client's own self-report is the
+// exact substitution m128 DECISION 1 refuses, and it is invisible in any test
+// that sets both fields to the same string.
+func TestSetupClientSurvivesTheDTOMappingUnchanged(t *testing.T) {
+	reported := "Cursor"
+	chosen := "claude-desktop"
+
+	got := toConnectionDTO(connectionFromGrant(sqlc.McpGrant{
+		Name:        "disagreeing facts",
+		Status:      "active",
+		ClientName:  &reported,
+		SetupClient: &chosen,
+	}))
+	if got.SetupClient == nil {
+		t.Fatal("setup_client was dropped by the DTO mapping")
+	}
+	if *got.SetupClient != chosen {
+		t.Fatalf("setup_client = %q, want %q; the mapper is substituting the "+
+			"client's self-report for the operator's choice", *got.SetupClient, chosen)
+	}
+	if got.ReportedClientName == nil || *got.ReportedClientName != reported {
+		t.Fatal("reported_client_name was dropped or overwritten; the two fields " +
+			"must travel independently")
+	}
+
+	// A grant with NO operator choice must serialise the field as null, never
+	// as the reported name and never as "generic".
+	none := toConnectionDTO(connectionFromGrant(sqlc.McpGrant{
+		Name:       "never asked, has connected",
+		Status:     "active",
+		ClientName: &reported,
+	}))
+	if none.SetupClient != nil {
+		t.Fatalf("a grant with no operator choice reported setup_client=%q. "+
+			"NULL means nobody asked; anything else invents a choice.",
+			*none.SetupClient)
+	}
+}

--- a/apps/api/migrations/20260830000000_m128_mcp_grant_setup_client.sql
+++ b/apps/api/migrations/20260830000000_m128_mcp_grant_setup_client.sql
@@ -1,0 +1,341 @@
+-- m128 - S29 step 2: record WHICH CLIENT THE OPERATOR SAID THIS CONNECTION WAS
+-- FOR, as a durable fact on the grant row.
+--
+-- This migration CORRECTS NOTHING. It edits no applied migration, it re-runs no
+-- earlier backfill, and there is NO CONVERGE PATH OWED: no database in any
+-- state needs a follow-up to reach the end state this file describes. A
+-- database that has not applied it has one fewer nullable column and every
+-- statement in the codebase still works, because the column is nullable with no
+-- default and nothing reads it yet. That is the whole of the m114/m115 question
+-- for this file, answered: no m129-shaped repair is owed.
+--
+-- ORDINAL. This is 20260830000000, above m127's 20260829000000, which was
+-- unmerged and in flight on branch worktree-agent-a354e37ca74442255 when this
+-- was written. Ordinal is APPLY order, not commit order (the m113/m114 lesson),
+-- and the two files are independent: m127 adds capabilities and two expiries,
+-- this one adds one client column, neither reads the other's columns and
+-- neither's backfill touches the other's rows. They commute. Applying this
+-- against a base without m127 is correct, and so is the reverse.
+--
+-- WHY IT EXISTS. The 2026-08-24 wireframes (Screen S29, step 2) make the client
+-- choice THE FORK of the whole wizard -- "steps 5, 6, 7 and 9 are computed from
+-- it" -- and say twice, in the frame captions, that it is "stored server-side,
+-- on the connection row [...] which is the whole reason the column exists".
+-- mcp_grants has nowhere to put it. It stores three client-ish things and NOT
+-- ONE OF THEM IS THE OPERATOR'S CHOICE:
+--
+--   client_id       - the OAuth registration id. NULL on the token path.
+--   client_name     - SELF-REPORTED by the client at `initialize`.
+--   client_version  - SELF-REPORTED, same source.
+--
+-- m124 DECISION 10 already labelled client_name and client_version
+-- "WHAT THE CLIENT REPORTED ABOUT ITSELF [...] observations". An observation is
+-- not a decision, and the two screens below need the decision specifically.
+--
+-- ===========================================================================
+-- DECISION 1: THIS IS A FOURTH CLIENT FACT, NOT A REPLACEMENT FOR THE OTHER
+--             THREE, AND THE SELF-REPORTED COLUMNS CANNOT STAND IN FOR IT
+-- ===========================================================================
+--
+-- The obvious cheap answer -- "read client_name, it already says Claude Code"
+-- -- is wrong on both screens that need this, and it is wrong in the exact case
+-- each screen exists to handle.
+--
+--   S29 STEP 9, STATE X: "Nothing has reached us from this connection." The
+--   frame's own hint says "The checks know this connection was set up for
+--   Claude Code, because that was stored on the connection row at step 2
+--   rather than in the browser you happened to use." That state is BY
+--   DEFINITION the state in which no `initialize` has ever arrived, so
+--   client_name IS NULL and client_identity_recorded_at IS NULL. The only
+--   surviving answer to "what was this set up for" is the operator's choice.
+--   A screen whose whole purpose is the never-connected case cannot be served
+--   by a column that is only written on connect.
+--
+--   S31, FILTER STATE E: "You have 4 connections. None of them was set up for
+--   Windsurf." Note the tense and the voice -- "was set up for", not "last
+--   connected as". The filter is over the operator's intent. Filtering on
+--   client_name would silently drop every connection that has not yet
+--   connected, and the screen would state a falsehood ("none of them") while a
+--   Windsurf connection sat in the list, unconnected. That is this project's
+--   signature defect -- an absence coerced into a confident answer -- rendered
+--   as reassuring copy.
+--
+-- The two facts also DISAGREE legitimately and permanently. An operator sets a
+-- connection up for Claude Desktop and pastes the URL into Cursor; both facts
+-- are then true and they differ. Neither is the other's stale copy, so neither
+-- may overwrite the other, and RecordConnect must NOT be extended to write this
+-- column. It is written once, at creation, by the wizard.
+--
+-- ===========================================================================
+-- DECISION 2: NULLABLE, NO DEFAULT, AND NOT BACKFILLED
+-- ===========================================================================
+--
+-- NULL MEANS "NO OPERATOR CHOICE WAS RECORDED". It means only that.
+--
+--   a. NULLABLE, DELIBERATELY THE OPPOSITE OF m127. m127 made capabilities and
+--      expires_at NOT NULL with no default and was right to: a caller that
+--      omits a capability set must get 23502 rather than an unrestricted
+--      connection, because THAT column carries AUTHORITY and its absence would
+--      be read as permission. THIS COLUMN CARRIES NO AUTHORITY AT ALL. It
+--      grants nothing, widens nothing, and is read by a setup panel and a
+--      filter. There is no fail-open to protect against, so there is nothing
+--      for a NOT NULL to buy -- and a great deal for it to cost: four branches
+--      open at the time of writing insert into mcp_grants, and a NOT NULL
+--      column with no default breaks every one of them at 23502 the moment
+--      this applies inside main() at boot, which is precisely what m127 had to
+--      manage with a backfill. Adding that hazard for a labelling column would
+--      be paying m127's price for none of m127's protection.
+--
+--   b. NO DEFAULT, AND THE ABSENCE OF THE DEFAULT IS LOAD-BEARING. A
+--      DEFAULT 'generic' would be the single worst value here. It would make
+--      every row ever created by a path that never asked -- and every row that
+--      exists today -- assert that an operator looked at nine cards and chose
+--      "Other MCP client". S31 would then report those connections under a
+--      filter the operator never selected, and step 9 would offer the generic
+--      setup panel while claiming the operator picked it. The default must be
+--      absent so that NULL survives to mean "nobody asked".
+--
+--   c. NOT BACKFILLED, AND NOT INFERRED FROM client_name. Every existing row
+--      keeps NULL. Deriving 'claude-code' from a self-reported client_name of
+--      "Claude Code" would MANUFACTURE A FACT THE OPERATOR NEVER STATED and
+--      write it into the column whose entire job is to hold what the operator
+--      stated. It would also destroy DECISION 1's distinction at the exact
+--      moment step 9 needs it: a row backfilled from client_name is
+--      indistinguishable from a row the operator chose, and step 9 exists to
+--      tell those apart. A grant whose operator choice is unknown stays
+--      unknown. This is not caution about a hard problem; the honest value is
+--      known and it is NULL.
+--
+-- Because there is no backfill and no NOT NULL to arm, this file has no step
+-- (0)/(1)/(2) shape at all. It is one ADD COLUMN and one CHECK.
+--
+-- ===========================================================================
+-- DECISION 3: THE VOCABULARY IS **OPEN**. THE SHAPE IS CLOSED.
+--             THIS IS DELIBERATELY NOT WHAT m127 DID, AND HERE IS WHY.
+-- ===========================================================================
+--
+-- THIS IS THE DECISION THIS MIGRATION EXISTS TO ARGUE, so it is argued rather
+-- than asserted. The precedent genuinely cuts both ways and the wrong read of
+-- it is the easy one: m127 closed its vocabulary by CHECK, m127 was right, so
+-- close this one too. That reasoning copies the mechanism and drops the reason.
+--
+-- WHAT m127'S CLOSED CHECK ACTUALLY BUYS. Its own DECISION 1(c) says it plainly:
+-- the CHECK exists so that "a write capability cannot reach this table until
+-- someone writes a migration naming it, which is a reviewed artefact", and
+-- m124 DECISION 1 had refused a capabilities column precisely because it
+-- "would create the place a write capability could appear without a migration
+-- and without a review". THE COUPLING TO A MIGRATION *IS* THE PRODUCT THERE.
+-- The toll is the point: it converts "add a string" into "pass a review".
+--
+-- THAT ARGUMENT DOES NOT TRANSFER, BECAUSE THERE IS NO PRIVILEGE HERE TO GATE.
+-- Ask what a maximally hostile value in each column does:
+--
+--   capabilities = 'mcp.sites.write'  ->  the connection gains an authority no
+--                                         operator granted. A security event.
+--   setup_client = 'wndsurf'          ->  a settings page renders the generic
+--                                         setup panel instead of the Windsurf
+--                                         one, and one filter chip misses one
+--                                         row. A cosmetic defect, fixable by
+--                                         editing the row.
+--
+-- A review gate is priced for the first row. Charging that price for the second
+-- buys no security whatsoever and bills a migration -- which applies inside
+-- main() at boot, on every install at once -- for a vendor's product launch.
+--
+-- AND THE CADENCES ARE GENUINELY DIFFERENT, WHICH IS THE OTHER HALF. A new
+-- capability is OUR decision: it exists only once we build a tool, so a
+-- migration is already being written and the CHECK edit is free. A new MCP
+-- client is SOMEBODY ELSE'S decision, announced on their schedule, and the
+-- work to support one is a row in
+-- apps/web/src/features/ai-connections/client-table.ts -- a frontend data
+-- table whose header comment already states the intended cost: "when a client
+-- changes, one row changes". A closed CHECK would silently amend that to "one
+-- row changes, and a control-plane migration ships, and every install runs it
+-- at boot". That is the wrong toll on the wrong lever.
+--
+-- WHAT HAPPENS WHEN A CLIENT THE VOCABULARY DOES NOT KNOW IS CHOSEN -- the
+-- question the brief requires this file to answer, and the one that decides it.
+-- Under a closed CHECK the INSERT fails 23514 and THE WIZARD BREAKS at step 2
+-- for a client the UI is offering. The failure lands on an operator, at the end
+-- of a ten-step flow, for a condition that is nobody's error. Under this
+-- migration the value stores, and an unrecognised slug DEGRADES AT THE RENDER
+-- LAYER to the generic panel -- which is not a fallback but, in the wireframe's
+-- own words for the "Other MCP client" card, "a complete path, not a
+-- placeholder", carrying "Fully supported" and drawn as one of "nine cards, one
+-- weight". The design already owns a first-class home for a client we do not
+-- have a row for. The schema does not need to invent a second, worse one out of
+-- an error code.
+--
+-- SO WHY A CHECK AT ALL. Because the two screens need ONE guarantee, and it is
+-- about FORM, not MEMBERSHIP. S31 renders `filter: client is windsurf` and then
+-- asserts "None of them was set up for Windsurf." That sentence is only true if
+-- equality is trustworthy. Free text lets 'Windsurf', 'windsurf ' and
+-- 'Windsurf (Devin Desktop)' all land in the column, and then the filter
+-- reports "none" while a matching connection sits in the list -- the same
+-- falsehood DECISION 1 rejected client_name for, reintroduced by the other
+-- door. So the constraint below pins the value to ONE CANONICAL SPELLING SHAPE
+-- -- lowercase, digits, single interior hyphens, non-empty, bounded -- and says
+-- nothing about which slugs exist.
+--
+-- THE RESULT IS THE ASYMMETRY THE PRODUCT ACTUALLY WANTS: a new client needs NO
+-- migration, and a MISSPELLED or MIS-CASED client is still unrepresentable.
+-- Membership is validated where the list lives (client-table.ts, which has a
+-- test) and where a bad value is a correctable form error rather than a 23514
+-- from the bottom of the stack.
+--
+-- THE PATTERN IS `^[a-z0-9]+(-[a-z0-9]+)*$`, VERIFIED AGAINST THE WHOLE LIST.
+-- All nine ids in client-table.ts match it and none fails:
+--
+--   printf '%s\n' claude-code claude-desktop chatgpt codex-cli cursor vscode \
+--     windsurf gemini-cli generic | grep -cE '^[a-z0-9]+(-[a-z0-9]+)*$'
+--     -> 9
+--   ...same list piped to grep -vE '<pattern>'  -> no output, exit 1
+--
+-- The ceiling is 64, the figure m120 and m127 both chose for a bounded text
+-- axis, and it is a property of the identifier rather than of any client.
+--
+-- WHAT WOULD CHANGE THIS DECISION. If a future capability, expiry or refusal is
+-- ever computed FROM setup_client -- if the client choice starts granting or
+-- withholding something rather than labelling it -- then it has become an
+-- authority column and m127's argument applies to it in full. It should then
+-- get a closed CHECK by a new migration. Written down here so that change is a
+-- decision someone makes, not a line someone crosses without noticing.
+--
+-- ===========================================================================
+-- DECISION 4: 'generic' IS A STORED VALUE AND IS NOT THE SAME AS NULL
+-- ===========================================================================
+--
+-- These are two different facts and the schema keeps them two:
+--
+--   setup_client IS NULL     - nobody asked. No operator ever saw step 2 for
+--                              this grant. Every row that exists today.
+--   setup_client = 'generic' - an operator SAW nine cards and CHOSE "Other MCP
+--                              client". A decision, as deliberate as choosing
+--                              Cursor.
+--
+-- Collapsing them would be tidier and it would break step 9 exactly as
+-- DECISION 2(b) describes. The distinction is why NULL is available at all
+-- despite 'generic' existing, and why 'generic' is required despite NULL
+-- existing. A reader tempted to remove one of the two states should read
+-- S29 step 9 state X first.
+--
+-- ===========================================================================
+-- DECISION 5: NAMED setup_client, BECAUSE THREE client_* COLUMNS ALREADY MEAN
+--             SOMETHING ELSE
+-- ===========================================================================
+--
+-- mcp_grants already has client_id, client_name and client_version, and every
+-- one of them is a fact about what connected rather than about what was chosen.
+-- A fourth column called client_choice or chosen_client_id would sit in that
+-- family and be misread as a variant of it -- and chosen_client_id in
+-- particular is one glance from client_id, which is an OAuth registration id
+-- and would be a genuinely dangerous confusion in a WHERE clause.
+--
+-- `setup_client` is lifted verbatim from the copy on both screens that read it:
+-- "this connection was set up for Claude Desktop" (S29 step 2) and "None of
+-- them was set up for Windsurf" (S31). The column is named after the sentence
+-- it exists to make true.
+--
+-- ===========================================================================
+-- DECISION 6: RLS IS INHERITED. NO POLICY. THE CROSS-TENANT LEDGER IS UNCHANGED
+-- ===========================================================================
+--
+-- THIS MIGRATION CREATES NO TABLE AND NO POLICY, so rule 2's site-scope
+-- checklist has nothing to attach to. m124 already put mcp_grants under ENABLE
+-- plus FORCE ROW LEVEL SECURITY with five policies -- the permissive
+-- mcp_grants_tenant_isolation and the four RESTRICTIVE
+-- mcp_grants_site_scope_{select,insert,update,delete}. RLS FILTERS ROWS, NOT
+-- COLUMNS, so a column added to a protected table is protected by the existing
+-- policies with no further statement, and a redundant policy here would be a
+-- second thing to keep in sync. This is m127 DECISION 5 for the same table and
+-- the same reason.
+--
+-- NO ROW IS OWED IN db/rls-cross-tenant-policies.txt. That ledger records
+-- policies granting access ACROSS tenants. This file adds no policy of any
+-- kind, and every existing policy on mcp_grants is tenant-isolated rather than
+-- cross-tenant, so the ledger gains no row and
+-- scripts/check-rls-cross-tenant.sh must stay green WITHOUT AN EDIT. A ledger
+-- diff accompanying this migration would be a defect, not a completion.
+--
+-- WHICH DISPATCH HELPER A CALLER MUST USE: db.RunTenantTx, unchanged and for
+-- m127 DECISION 5's reason. The four site_scope policies are RESTRICTIVE and
+-- each tests coalesce(current_setting('app.site_scope', true), '') <> 'on';
+-- RunTenantTx is the only thing that sets that GUC, and a call site choosing
+-- InTenantTx, InTenantTxAsUser or InScopedTenantTx leaves it unset, whereupon
+-- the coalesced empty string is not 'on', the RESTRICTIVE check passes, and the
+-- write proceeds with no error raised anywhere. A live privilege escalation of
+-- exactly that shape was fixed in this area on 2026-08-30. This column changes
+-- none of that and inherits all of it.
+--
+-- ===========================================================================
+-- DECISION 7: NO INDEX
+-- ===========================================================================
+--
+-- S31's filter is the only read that selects on this column, and it runs inside
+-- one organisation's connection list -- the wireframe's own example is "You
+-- have 4 connections". mcp_grants_tenant_idx already narrows to the tenant and
+-- the residual filter is applied to a handful of already-fetched rows. An index
+-- on setup_client would earn nothing on that path and would cost a write on
+-- every grant insert. Stated rather than left silent, so the absence reads as a
+-- decision.
+--
+-- ===========================================================================
+-- DECISION 8: GRANTS
+-- ===========================================================================
+--
+-- Nothing to add. m1's ALTER DEFAULT PRIVILEGES and m124's explicit
+-- GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_grants TO wpmgr_app are
+-- table-level and cover columns added later; there is no per-column grant in
+-- force on this table that a new column could fall outside of. Stated because
+-- "the new column is invisible to wpmgr_app" is a failure that looks like an
+-- RLS bug for a day.
+--
+-- EVERY STATEMENT BELOW IS IDEMPOTENT AND THE FILE IS RE-RUNNABLE.
+
+-- ---------------------------------------------------------------------------
+-- (1) The column. NULLABLE, NO DEFAULT. See DECISION 2 -- both properties are
+--     load-bearing and neither is an oversight.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."mcp_grants"
+    ADD COLUMN IF NOT EXISTS "setup_client" text NULL;
+
+COMMENT ON COLUMN "public"."mcp_grants"."setup_client" IS
+    'The AI client the operator chose at S29 step 2, as a client-table.ts slug. '
+    'NULL means no operator choice was recorded -- NOT "generic", which is the '
+    'distinct case of an operator actively choosing "Other MCP client". '
+    'Distinct from client_name/client_version, which are self-reported by the '
+    'client at initialize, and from client_id, which is an OAuth registration '
+    'id. Never written by RecordConnect. See m128 DECISIONS 1, 2 and 4.';
+
+-- ---------------------------------------------------------------------------
+-- (2) Shape, not vocabulary. See DECISION 3.
+--
+--     This CHECK deliberately does NOT enumerate the nine clients. It pins the
+--     spelling so S31's equality filter is trustworthy, and stays silent on
+--     which slugs exist so a new MCP client costs one row in client-table.ts
+--     rather than a migration applied inside main() at boot.
+--
+--     NULL passes: an unconstrained CHECK result of NULL is not a violation,
+--     and NULL is a legal value here. Stated explicitly because a reader
+--     checking that DECISION 2 survives this constraint should not have to
+--     recall PostgreSQL's three-valued CHECK semantics to be sure.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.mcp_grants'::regclass
+          AND conname  = 'mcp_grants_setup_client_shape_check'
+    ) THEN
+        ALTER TABLE "public"."mcp_grants"
+            ADD CONSTRAINT "mcp_grants_setup_client_shape_check"
+            CHECK (
+                "setup_client" IS NULL
+                OR ("setup_client" ~ '^[a-z0-9]+(-[a-z0-9]+)*$'
+                    AND length("setup_client") <= 64)
+            );
+    END IF;
+END;
+$$;

--- a/apps/api/tests/mcp_m127_m128_merge_roundtrip_integration_test.go
+++ b/apps/api/tests/mcp_m127_m128_merge_roundtrip_integration_test.go
@@ -1,0 +1,194 @@
+// m127 and m128 were built on separate branches and reconciled by merge. m128's
+// author predicted the two files commute -- neither reads the other's columns,
+// neither backfill touches the other's rows -- and the merge resolution kept
+// both sides of the CreateMCPGrant column list on that basis.
+//
+// THAT PREDICTION IS AN ASSERTION ABOUT A DATABASE, AND UNTIL SOMETHING EXECUTES
+// IT IT IS ONLY A CLAIM. These two tests execute it, as wpmgr_app, against the
+// real merged schema.
+//
+// WHY A DEDICATED PROOF RATHER THAN LEANING ON THE m127 SUITE. Dropping
+// setup_client from the merged INSERT compiles clean and leaves every existing
+// test green, because no Go caller populates the field yet:
+//
+//	grep -rn "SetupClient" apps/api --include="*.go" | grep -v "internal/db/sqlc/"
+//	  -> no matches
+//
+// So the compiler guards m127's half of the merge and nothing at all guards
+// m128's. This file is that missing guard. It drives the sqlc query directly
+// rather than Service.Approve precisely because the service layer does not yet
+// carry the column -- the query is the surface the merge changed, so the query
+// is the surface under test.
+//
+// THE NULLABILITY SPLIT IS THE POINT AND IT IS ASYMMETRIC ON PURPOSE.
+// capabilities and expires_at are NOT NULL, so an omitting caller gets 23502
+// rather than an unrestricted or never-expiring connection. setup_client is
+// NULLABLE, so an omitting caller gets NULL and every non-wizard insert path
+// keeps working. A merge that quietly flipped either direction would still
+// compile and still generate; only an executed INSERT can tell them apart.
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// mcpMergeCreateGrant inserts through RunTenantTx -- the ONLY helper that sets
+// app.site_scope, which the four RESTRICTIVE mcp_grants_site_scope_* policies
+// read. A test that picked InTenantTx here would leave the GUC unset, the
+// coalesced empty string would not equal 'on', the RESTRICTIVE check would pass
+// and the policies would be inert while this test stayed green. m127 DECISION 5
+// records a live privilege escalation of exactly that shape, fixed 2026-08-30.
+//
+// The role is asserted INSIDE this transaction, not around it, so the evidence
+// belongs to the connection that actually ran the INSERT.
+func mcpMergeCreateGrant(t *testing.T, pool interface {
+	RunTenantTx(context.Context, db.ScopedPrincipal, func(pgx.Tx) error) error
+}, tenantID uuid.UUID, arg sqlc.CreateMCPGrantParams, where string) sqlc.McpGrant {
+	t.Helper()
+	var out sqlc.McpGrant
+	principal := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+	err := pool.RunTenantTx(context.Background(), principal, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, where)
+		gr, err := sqlc.New(tx).CreateMCPGrant(context.Background(), arg)
+		if err != nil {
+			return err
+		}
+		out = gr
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("%s: CreateMCPGrant: %v", where, err)
+	}
+	return out
+}
+
+// TestMCPMergedGrantCarriesBothMigrationsColumnsAsAppRole supplies m127's three
+// columns AND m128's setup_client on one INSERT and asserts every value comes
+// back unchanged. This is the merge resolution's central claim: the two column
+// sets are independent and both land.
+func TestMCPMergedGrantCarriesBothMigrationsColumnsAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "mcp-merge-both-"+uuid.NewString()[:8])
+
+	idleDays := int32(45)
+	setupClient := "claude-desktop"
+	expires := time.Now().UTC().Add(30 * 24 * time.Hour).Truncate(time.Microsecond)
+
+	created := mcpMergeCreateGrant(t, pool, tenant, sqlc.CreateMCPGrantParams{
+		TenantID:      tenant,
+		Name:          "m127 and m128 together",
+		Status:        "active",
+		SiteScopeMode: "all",
+		// NOT NULL DEFAULT '{}' -- an empty slice, never nil. nil marshals to
+		// NULL and would take 23502 on a column that has a default, which reads
+		// as a merge defect and is not one.
+		ScopeTagIds:  []uuid.UUID{},
+		ScopeSiteIds: []uuid.UUID{},
+		// m127.
+		Capabilities:        []string{"mcp.sites.read"},
+		ExpiresAt:           expires,
+		IdleExpireAfterDays: &idleDays,
+		// m128.
+		SetupClient: &setupClient,
+	}, "RunTenantTx (both column sets)")
+
+	// m127: capabilities. The stored set is the authority; an empty array here
+	// would mean the merge dropped the value and reached no tool, and a longer
+	// one would mean it invented authority nobody granted.
+	if len(created.Capabilities) != 1 || created.Capabilities[0] != "mcp.sites.read" {
+		t.Fatalf("capabilities = %v, want exactly [mcp.sites.read]", created.Capabilities)
+	}
+
+	// m127: expires_at. Compared at microsecond resolution because that is what
+	// timestamptz stores; a wider tolerance would hide a column that came back
+	// from a different source than it went in on.
+	if got := created.ExpiresAt.UTC().Truncate(time.Microsecond); !got.Equal(expires) {
+		t.Fatalf("expires_at = %s, want %s", got, expires)
+	}
+
+	// m127: idle_expire_after_days, non-NULL on this row specifically so the
+	// NULL in the second test is known to be a real answer and not the only
+	// value this column can hold.
+	if created.IdleExpireAfterDays == nil {
+		t.Fatalf("idle_expire_after_days = NULL, want %d", idleDays)
+	}
+	if *created.IdleExpireAfterDays != idleDays {
+		t.Fatalf("idle_expire_after_days = %d, want %d", *created.IdleExpireAfterDays, idleDays)
+	}
+
+	// m128: setup_client. THIS IS THE ASSERTION NOTHING ELSE IN THE TREE MAKES.
+	if created.SetupClient == nil {
+		t.Fatalf("setup_client = NULL, want %q -- the merge dropped m128's column "+
+			"from the INSERT and no compiler or existing test would have said so",
+			setupClient)
+	}
+	if *created.SetupClient != setupClient {
+		t.Fatalf("setup_client = %q, want %q", *created.SetupClient, setupClient)
+	}
+
+	t.Logf("round-tripped capabilities=%v expires_at=%s idle_expire_after_days=%d setup_client=%q",
+		created.Capabilities, created.ExpiresAt.UTC().Format(time.RFC3339),
+		*created.IdleExpireAfterDays, *created.SetupClient)
+}
+
+// TestMCPMergedGrantOmittingSetupClientIsNullAsAppRole is the other half, and it
+// is what keeps every non-wizard insert path alive. m128's column is NULLABLE
+// WITH NO DEFAULT so a caller that never asked can pass NULL and mean "no
+// operator choice was recorded".
+//
+// NULL IS NOT 'generic'. 'generic' means an operator saw the client cards and
+// chose "Other MCP client", which is a different fact that S29 step 9
+// distinguishes. A DEFAULT 'generic' -- or a merge that added one -- would make
+// every row ever created assert a choice nobody made, so this test fails on any
+// non-NULL value rather than only on the wrong string.
+func TestMCPMergedGrantOmittingSetupClientIsNullAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "mcp-merge-null-"+uuid.NewString()[:8])
+
+	expires := time.Now().UTC().Add(90 * 24 * time.Hour).Truncate(time.Microsecond)
+
+	created := mcpMergeCreateGrant(t, pool, tenant, sqlc.CreateMCPGrantParams{
+		TenantID:      tenant,
+		Name:          "m127 only, no operator choice",
+		Status:        "active",
+		SiteScopeMode: "all",
+		ScopeTagIds:   []uuid.UUID{},
+		ScopeSiteIds:  []uuid.UUID{},
+		Capabilities:  []string{"mcp.sites.read"},
+		ExpiresAt:     expires,
+		// IdleExpireAfterDays and SetupClient both deliberately omitted. Both are
+		// nullable; leaving the fields zero is exactly what a caller that does
+		// not know about these columns does.
+	}, "RunTenantTx (setup_client omitted)")
+
+	if created.SetupClient != nil {
+		t.Fatalf("setup_client = %q on a caller that never supplied it, want NULL -- "+
+			"a non-NULL value here means a DEFAULT reached the column and every "+
+			"grant now asserts an operator choice nobody made", *created.SetupClient)
+	}
+	if created.IdleExpireAfterDays != nil {
+		t.Fatalf("idle_expire_after_days = %d, want NULL", *created.IdleExpireAfterDays)
+	}
+
+	// m127's NOT NULL columns still land on this path, which is what makes the
+	// two migrations independent rather than merely co-resident.
+	if len(created.Capabilities) != 1 || created.Capabilities[0] != "mcp.sites.read" {
+		t.Fatalf("capabilities = %v, want exactly [mcp.sites.read]", created.Capabilities)
+	}
+	if got := created.ExpiresAt.UTC().Truncate(time.Microsecond); !got.Equal(expires) {
+		t.Fatalf("expires_at = %s, want %s", got, expires)
+	}
+
+	t.Logf("omitted-path grant: setup_client=NULL idle_expire_after_days=NULL "+
+		"capabilities=%v expires_at=%s", created.Capabilities,
+		created.ExpiresAt.UTC().Format(time.RFC3339))
+}

--- a/apps/api/tests/mcp_m128_setup_client_integration_test.go
+++ b/apps/api/tests/mcp_m128_setup_client_integration_test.go
@@ -314,8 +314,20 @@ func TestMCPSetupClientRefusesShapeButAcceptsUnknownClientAsAppRole(t *testing.T
 	userID := seedUserRow(t, pool, "mcp-m128-shape-"+suffix+"@example.test")
 	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantID, userID))
 
-	// (a) MALFORMED IS A 400, not a 500 from a 23514 at the INSERT. The wizard
+	// (a) MALFORMED IS A 422, not a 5xx from a 23514 at the INSERT. The wizard
 	// must be able to point at the field.
+	//
+	// 422 AND NOT 400 BECAUSE THAT IS THE HOUSE MAPPING, not a choice this
+	// endpoint made: domain.HTTPStatus sends every KindValidation to
+	// StatusUnprocessableEntity (internal/domain/errors.go), which is what the
+	// blank-name and malformed-site-scope refusals on this same route already
+	// answer. Asserting 400 here would have pinned this one field to a status
+	// no other refusal on the endpoint uses -- the first draft did exactly
+	// that and this run is what corrected it.
+	//
+	// The status is asserted rather than "any 4xx" because 4xx-in-general
+	// includes 401 and 403, and a refusal that turned out to be an auth failure
+	// would satisfy a looser check while proving nothing about validation.
 	for _, bad := range []string{"Windsurf", "windsurf ", "windsurf_beta", "", "-lead", "trail-"} {
 		var ignored map[string]any
 		code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
@@ -323,8 +335,8 @@ func TestMCPSetupClientRefusesShapeButAcceptsUnknownClientAsAppRole(t *testing.T
 			"site_scope_mode": "all",
 			"setup_client":    bad,
 		}, nil, &ignored)
-		if code != http.StatusBadRequest {
-			t.Errorf("setup_client=%q answered %d, want 400. Anything else means "+
+		if code != http.StatusUnprocessableEntity {
+			t.Errorf("setup_client=%q answered %d, want 422. Anything else means "+
 				"either a malformed slug was STORED -- and S31's equality filter "+
 				"can no longer be trusted -- or the database CHECK surfaced as a "+
 				"5xx instead of a field-level refusal.", bad, code)

--- a/apps/api/tests/mcp_m128_setup_client_integration_test.go
+++ b/apps/api/tests/mcp_m128_setup_client_integration_test.go
@@ -1,0 +1,414 @@
+// m128's setup_client, proven end to end through the SAME DISPATCH PRODUCTION
+// USES -- the mounted POST /api/v1/mcp/connections and GET
+// /api/v1/mcp/connections routes, over mcp.Service and mcp.Repo, as wpmgr_app
+// with neither SUPERUSER nor BYPASSRLS.
+//
+// WHY THESE PROOFS AND NOT THE ONES NEXT DOOR.
+// mcp_m127_m128_merge_roundtrip_integration_test.go proves the COLUMN survives
+// the merge, and it drives sqlc.CreateMCPGrant directly because when it was
+// written no Go caller populated the field. That is now the wrong surface: the
+// question has moved from "does the column exist" to "does the request path
+// write it, and does every path that should not write it leave it alone". A
+// query-level proof cannot answer either -- it would stay green against a
+// handler that drops the field on the floor, which is precisely the shape of
+// GH #605, where a fully-wired read path sat over a column nothing ever
+// stamped and the list confidently reported "Never used" for every connection.
+//
+// SO EVERY WRITE HERE ENTERS THROUGH THE HTTP ROUTE AND EVERY READ COMES BACK
+// OFF THE WIRE. The DTO field, the service, the repo, the tx helper and the
+// RLS policies are all inside the loop. The one direct-SQL read in this file is
+// the tenant-isolation control, and it is inside InTenantTx for the same reason.
+package tests
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// setupClientMintResponse is the mint response, narrowed to what these proofs
+// read. The plaintext token is needed by the RecordConnect proof.
+type setupClientMintResponse struct {
+	GrantID string `json:"grant_id"`
+	Token   string `json:"token"`
+}
+
+// setupClientListResponse mirrors connectionListDTO, narrowed the same way.
+//
+// SetupClient IS A *string HERE ON PURPOSE, and it is the entire point of the
+// file. A plain string would decode both `"setup_client": null` and
+// `"setup_client": "generic"`-less-omitted into "", collapsing the two states
+// these tests exist to keep apart -- the test would then pass against exactly
+// the defect it is written to catch.
+type setupClientListResponse struct {
+	Connections []struct {
+		ID                 string  `json:"id"`
+		Name               string  `json:"name"`
+		SetupClient        *string `json:"setup_client"`
+		ReportedClientName *string `json:"reported_client_name"`
+	} `json:"connections"`
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 1 -- ROUND TRIP. Mint with a client id, read it back off the list.
+// ---------------------------------------------------------------------------
+
+func TestMCPSetupClientRoundTripsThroughTheMountedRoutesAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing and is asserted INSIDE a transaction the request
+	// path actually opens. Either privilege makes every RLS assertion below
+	// vacuous, and this file's tenant-isolation proof would pass while the
+	// policy was inert -- m112's exact failure.
+	if err := pool.InTenantTx(ctx, uuid.New(), func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (setup_client round trip)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-m128-rt-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-m128-rt-"+suffix+"@example.test")
+	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantID, userID))
+
+	var minted setupClientMintResponse
+	code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+		"name":            "round trip",
+		"site_scope_mode": "all",
+		"setup_client":    "claude-code",
+	}, nil, &minted)
+	if code != http.StatusCreated {
+		t.Fatalf("mint answered %d, want 201", code)
+	}
+
+	got := setupClientFor(t, eng, minted.GrantID)
+	if got == nil {
+		t.Fatal("setup_client came back NULL for a connection minted WITH " +
+			"\"claude-code\". The write path is not wired: this is GH #605's " +
+			"defect -- a read path over a column nothing stamps.")
+	}
+	if *got != "claude-code" {
+		t.Fatalf("setup_client = %q, want \"claude-code\"", *got)
+	}
+	t.Logf("PROOF 1 ok: minted with \"claude-code\", read back %q off the list route", *got)
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 -- NULL AND "generic" ARE DIFFERENT, ASSERTED BY VALUE.
+//
+// Both are legal stored states and they mean opposite things: NULL is "nobody
+// asked", "generic" is "the operator saw nine cards and chose Other MCP
+// client". S29 step 9 renders them differently and S31's filter gathers only
+// the second. Asserting merely that the omitted case is "not claude-code" would
+// pass against a service that defaulted it to "generic", which is the specific
+// wrong answer m128 DECISION 2(b) refuses a schema default to prevent -- so
+// BOTH are asserted by value, in one test, against one another.
+// ---------------------------------------------------------------------------
+
+func TestMCPSetupClientOmittedStoresNullNotGenericAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-m128-null-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-m128-null-"+suffix+"@example.test")
+	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantID, userID))
+
+	// (a) The key is ABSENT from the body -- not null, absent. This is the
+	// request every non-wizard caller sends.
+	var omitted setupClientMintResponse
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+		"name":            "no client chosen",
+		"site_scope_mode": "all",
+	}, nil, &omitted); code != http.StatusCreated {
+		t.Fatalf("mint without setup_client answered %d, want 201", code)
+	}
+
+	// (b) The operator actively chose "Other MCP client".
+	var chose setupClientMintResponse
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+		"name":            "other mcp client",
+		"site_scope_mode": "all",
+		"setup_client":    "generic",
+	}, nil, &chose); code != http.StatusCreated {
+		t.Fatalf("mint with generic answered %d, want 201", code)
+	}
+
+	gotOmitted := setupClientFor(t, eng, omitted.GrantID)
+	gotChose := setupClientFor(t, eng, chose.GrantID)
+
+	if gotOmitted != nil {
+		t.Fatalf("a mint that never mentioned setup_client stored %q. NULL is "+
+			"the only honest value: %q asserts the operator saw the nine-card "+
+			"chooser and made a choice they were never shown.",
+			*gotOmitted, *gotOmitted)
+	}
+	if gotChose == nil {
+		t.Fatal("an operator who explicitly chose \"generic\" got NULL back. " +
+			"The choice was discarded and step 9 can no longer tell that " +
+			"operator apart from one who was never asked.")
+	}
+	if *gotChose != "generic" {
+		t.Fatalf("explicit \"generic\" stored as %q", *gotChose)
+	}
+	t.Logf("PROOF 2 ok: omitted -> null, explicit choice -> %q; the two are distinct on the wire", *gotChose)
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 -- RecordConnect DOES NOT TOUCH setup_client.
+//
+// THE PROPERTY MOST LIKELY TO BE BROKEN LATER BY SOMEONE TIDYING. RecordConnect
+// already writes client_name and client_version, so "keep setup_client in sync
+// while we are here" is the natural-looking next edit, and it silently destroys
+// the column: the operator's stated choice is overwritten by the client's
+// self-report on first connect, and every screen keeps rendering, wrong.
+//
+// The two values are deliberately DIFFERENT and both non-empty -- set up for
+// Claude Desktop, connected as Cursor -- which is the legitimate permanent
+// disagreement m128 DECISION 1 describes. A test using the same string for
+// both would pass against an overwrite.
+// ---------------------------------------------------------------------------
+
+func TestMCPRecordConnectLeavesSetupClientAloneAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-m128-rc-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-m128-rc-"+suffix+"@example.test")
+	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantID, userID))
+
+	var minted setupClientMintResponse
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+		"name":            "set up for one, connected as another",
+		"site_scope_mode": "all",
+		"setup_client":    "claude-desktop",
+	}, nil, &minted); code != http.StatusCreated {
+		t.Fatalf("mint answered %d, want 201", code)
+	}
+
+	// CONTROL: it is "claude-desktop" BEFORE the connect. Without this the
+	// assertion after the connect proves nothing -- a column that was never
+	// written also reads "unchanged".
+	before := setupClientFor(t, eng, minted.GrantID)
+	if before == nil || *before != "claude-desktop" {
+		t.Fatalf("CONTROL: setup_client before connect = %v, want \"claude-desktop\"; "+
+			"nothing below can prove RecordConnect left it alone", derefOrNil(before))
+	}
+
+	// Connect, reporting a DIFFERENT client, through the real authenticate +
+	// RecordConnect pair the transport calls.
+	auth, err := svc.Authenticate(ctx, minted.Token)
+	if err != nil {
+		t.Fatalf("CONTROL: the freshly minted token does not authenticate, so "+
+			"RecordConnect never runs and this proof is vacuous: %v", err)
+	}
+	proto := "2025-06-18"
+	if err := svc.RecordConnect(ctx, auth, "Cursor", "1.4.2", &proto); err != nil {
+		t.Fatalf("RecordConnect: %v", err)
+	}
+
+	// CONTROL: RecordConnect actually wrote something. If it silently did
+	// nothing, "setup_client unchanged" would be true for the wrong reason.
+	after := connectionRowFor(t, eng, minted.GrantID)
+	if after.ReportedClientName == nil || *after.ReportedClientName != "Cursor" {
+		t.Fatalf("CONTROL: reported_client_name = %v after RecordConnect, want "+
+			"\"Cursor\"; RecordConnect did not write, so the assertion below "+
+			"would pass against an inert call", derefOrNil(after.ReportedClientName))
+	}
+
+	if after.SetupClient == nil {
+		t.Fatal("RecordConnect NULLED setup_client. The operator's step-2 " +
+			"choice is gone and step 9 can no longer say what this connection " +
+			"was set up for.")
+	}
+	if *after.SetupClient != "claude-desktop" {
+		t.Fatalf("RecordConnect OVERWROTE setup_client: %q -> %q. These are two "+
+			"different facts about two different actors -- the operator's "+
+			"choice and the client's self-report -- and they disagree "+
+			"legitimately. Neither may overwrite the other (m128 DECISION 1).",
+			"claude-desktop", *after.SetupClient)
+	}
+	t.Logf("PROOF 3 ok: connected as %q, setup_client still %q",
+		*after.ReportedClientName, *after.SetupClient)
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 4 -- TENANT ISOLATION ON THE NEW READ.
+//
+// setup_client is a new column on the connections list, so it is a new thing
+// that could leak. The list is read by an admin of tenant B and must not carry
+// tenant A's row at all -- the whole connection, not merely the column.
+// ---------------------------------------------------------------------------
+
+func TestMCPSetupClientListIsTenantIsolatedAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+	svc := mcp.NewService(mcp.NewRepo(pool))
+
+	suffixA := uuid.NewString()[:8]
+	tenantA := seedTenant(t, pool, "mcp-m128-a-"+suffixA)
+	userA := seedUserRow(t, pool, "mcp-m128-a-"+suffixA+"@example.test")
+	engA := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantA, userA))
+
+	suffixB := uuid.NewString()[:8]
+	tenantB := seedTenant(t, pool, "mcp-m128-b-"+suffixB)
+	userB := seedUserRow(t, pool, "mcp-m128-b-"+suffixB+"@example.test")
+	engB := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantB, userB))
+
+	var mintedA setupClientMintResponse
+	if code := mcpDoJSON(t, engA, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+		"name":            "tenant A windsurf",
+		"site_scope_mode": "all",
+		"setup_client":    "windsurf",
+	}, nil, &mintedA); code != http.StatusCreated {
+		t.Fatalf("tenant A mint answered %d, want 201", code)
+	}
+
+	// CONTROL: A can see its own row. Without this, B seeing nothing would be
+	// explained just as well by the list being broken for everyone.
+	if got := setupClientFor(t, engA, mintedA.GrantID); got == nil || *got != "windsurf" {
+		t.Fatalf("CONTROL: tenant A cannot read back its own setup_client (%v); "+
+			"the isolation assertion below would pass vacuously", derefOrNil(got))
+	}
+
+	var listB setupClientListResponse
+	if code := mcpDoJSON(t, engB, http.MethodGet, mcp.ConnectionsPath, nil, nil, &listB); code != http.StatusOK {
+		t.Fatalf("tenant B list answered %d, want 200", code)
+	}
+	for _, c := range listB.Connections {
+		if c.ID == mintedA.GrantID {
+			t.Fatalf("tenant B's connections list carries tenant A's grant %s "+
+				"(setup_client=%v). RLS did not scope the read.",
+				c.ID, derefOrNil(c.SetupClient))
+		}
+	}
+	t.Logf("PROOF 4 ok: tenant B's list holds %d connection(s), none of them tenant A's",
+		len(listB.Connections))
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 5 -- SHAPE IS REFUSED, AN UNKNOWN CLIENT IS NOT.
+//
+// The two halves belong in one test because each is the other's control. A
+// server that refused everything unknown would pass the first half alone, and
+// that is the failure m128 DECISION 3 argues against at length: the wizard
+// breaking at step 2, at the end of a ten-step flow, for a client its own UI is
+// offering. A server that validated nothing would pass the second half alone,
+// and then 'Windsurf' and 'windsurf ' both land in the column and S31's
+// equality filter says "none of them" while a matching row sits in the list.
+// ---------------------------------------------------------------------------
+
+func TestMCPSetupClientRefusesShapeButAcceptsUnknownClientAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-m128-shape-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-m128-shape-"+suffix+"@example.test")
+	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantID, userID))
+
+	// (a) MALFORMED IS A 400, not a 500 from a 23514 at the INSERT. The wizard
+	// must be able to point at the field.
+	for _, bad := range []string{"Windsurf", "windsurf ", "windsurf_beta", "", "-lead", "trail-"} {
+		var ignored map[string]any
+		code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+			"name":            "malformed " + bad,
+			"site_scope_mode": "all",
+			"setup_client":    bad,
+		}, nil, &ignored)
+		if code != http.StatusBadRequest {
+			t.Errorf("setup_client=%q answered %d, want 400. Anything else means "+
+				"either a malformed slug was STORED -- and S31's equality filter "+
+				"can no longer be trusted -- or the database CHECK surfaced as a "+
+				"5xx instead of a field-level refusal.", bad, code)
+		}
+	}
+
+	// (b) A WELL-FORMED SLUG THE SERVER HAS NEVER HEARD OF IS ACCEPTED AND
+	// STORED. This is a legitimate state, not an error: the vocabulary lives in
+	// the frontend's client-table.ts and a client added there must not need a
+	// control-plane release. It renders as the generic panel, which the
+	// wireframes call a complete path rather than a placeholder.
+	const unknown = "some-future-client"
+	var minted setupClientMintResponse
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+		"name":            "a client the server has never heard of",
+		"site_scope_mode": "all",
+		"setup_client":    unknown,
+	}, nil, &minted); code != http.StatusCreated {
+		t.Fatalf("a well-formed but unrecognised slug answered %d, want 201. The "+
+			"server must not hold a second copy of the nine-id vocabulary: a "+
+			"stale copy refuses, at step 2, a client the wizard is offering.", code)
+	}
+	got := setupClientFor(t, eng, minted.GrantID)
+	if got == nil || *got != unknown {
+		t.Fatalf("unrecognised slug stored as %v, want %q", derefOrNil(got), unknown)
+	}
+	t.Logf("PROOF 5 ok: malformed shapes refused 400; unrecognised %q stored intact", unknown)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// ginEngine names the mounted router these helpers drive. Spelled as a local
+// alias so the helper signatures read as "the production mount", not as a bare
+// third-party type.
+type ginEngine = *gin.Engine
+
+// setupClientFor reads one connection's setup_client back OFF THE LIST ROUTE,
+// returning nil for JSON null.
+func setupClientFor(t *testing.T, eng ginEngine, grantID string) *string {
+	t.Helper()
+	return connectionRowFor(t, eng, grantID).SetupClient
+}
+
+// connectionRow is one decoded row of the list response.
+type connectionRow struct {
+	ID                 string
+	SetupClient        *string
+	ReportedClientName *string
+}
+
+// connectionRowFor GETs the mounted list route and returns the named row. It
+// fails rather than returning a zero value when the row is missing: a missing
+// connection and a connection with a null column are different answers, and
+// collapsing them would let a caller read "null" from a list that never had the
+// row at all.
+func connectionRowFor(t *testing.T, eng ginEngine, grantID string) connectionRow {
+	t.Helper()
+	var list setupClientListResponse
+	if code := mcpDoJSON(t, eng, http.MethodGet, mcp.ConnectionsPath, nil, nil, &list); code != http.StatusOK {
+		t.Fatalf("list answered %d, want 200", code)
+	}
+	for _, c := range list.Connections {
+		if c.ID == grantID {
+			return connectionRow{
+				ID:                 c.ID,
+				SetupClient:        c.SetupClient,
+				ReportedClientName: c.ReportedClientName,
+			}
+		}
+	}
+	t.Fatalf("grant %s is absent from its own organisation's connections list "+
+		"(%d row(s) returned); nothing about its columns can be asserted",
+		grantID, len(list.Connections))
+	return connectionRow{}
+}
+
+// derefOrNil renders a *string for a failure message without panicking on nil,
+// so a failed assertion prints "<nil>" rather than crashing the run and hiding
+// every later proof in the file.
+func derefOrNil(s *string) any {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}


### PR DESCRIPTION
Wires `mcp_grants.setup_client` in Go. The column and its migration already existed on the reconciliation branch; nothing in Go wrote it.

```
git grep "SetupClient" -- 'apps/api/**/*.go' | grep -v internal/db/sqlc/   # before: nothing
```

A column with a fully-wired read path and no write path is GH #605's defect exactly — the connections list reported every connection "Never used" because `last_used_at` was never stamped. Unwired, `setup_client` would have had S31's filter truthfully answer *"None of them was set up for Windsurf"* for every client, Windsurf included.

## Can m128 land

**Yes.** The column is written on every path that should write it and left NULL on every path that should not.

| Path | What it writes | Why |
|---|---|---|
| `MintConnection` (wizard, `POST /api/v1/mcp/connections`) | the operator's choice, passed through unchanged, nil included | the only path that asks |
| `CreateGrant` (OAuth consent) | `nil` → NULL, explicitly | the consent screen never shows the nine-card chooser, so no operator choice exists to record |
| `RecordConnect` (client `initialize`) | **nothing** | different fact, different actor; see below |

There is exactly one write site and it runs once, at creation.

## Why `RecordConnect` must never touch it

The tidy-looking future edit is to notice `RecordConnect` already writes `client_name`/`client_version` and "keep `setup_client` in sync". That destroys the column. `setup_client` is the **operator's** choice; the other two are the **client's** self-report at `initialize`. They disagree legitimately and permanently — set up for Claude Desktop, URL pasted into Cursor — so neither may overwrite the other. S29 step 9 reads this column precisely when *nothing has ever connected*, which is by definition the state where both reported columns are NULL.

That property has a named integration proof and a long doc comment on `RecordConnect` itself, and the mutation sweep below confirms both go red when it is broken.

## NULL is not `'generic'`

NULL means *nobody asked*. `'generic'` means *the operator saw nine cards and chose "Other MCP client"*. Step 9 renders them differently and S31's filter gathers only the second. No layer substitutes one for the other — not the schema (m128 DECISION 2b refuses the default), not the service, not the DTO. The request field is `*string` rather than `string` so an omitted key and an empty one stay distinguishable on the wire.

## Validation: shape, not vocabulary

`validateSetupClient` mirrors `mcp_grants_setup_client_shape_check` (`^[a-z0-9]+(-[a-z0-9]+)*$`, ≤64) so a malformed slug is a field-level 422 rather than a 23514 surfacing as a 5xx. The database stays the backstop; this is the diagnosis.

It deliberately does **not** enumerate the nine ids. The vocabulary lives in `apps/web/src/features/ai-connections/client-table.ts`, Go cannot import it, and a second copy in a second language on a second release cadence fails by *rejecting* — at the end of a ten-step flow — a client the wizard itself is offering. m128 DECISION 3 refused a closed database CHECK for that reason; re-adding the closure one layer up in Go would defeat the migration while leaving its rationale in place. Validation lives in the service, not only the handler, so a future second caller cannot store a value S31's equality filter cannot match.

## What the frontend owes, in wire terms

Enough to start without reading this diff:

- **Field name:** `setup_client`, snake_case, on both the mint request and every connections-list row.
- **Mint request** (`POST /api/v1/mcp/connections`): **optional**. Omit the key entirely when the operator was not asked — do not send `""` and do not send `"generic"` as a stand-in. `""` is refused 422.
- **Accepted values:** any lowercase slug matching `^[a-z0-9]+(-[a-z0-9]+)*$`, max 64 chars. Send the `client-table.ts` id verbatim.
- **Rejected values:** anything else — `"Windsurf"`, `"windsurf "`, `"windsurf_beta"`, `""`, leading/trailing hyphens — answer **422** with code `mcp_invalid_setup_client`. Do not trim or lowercase client-side to sneak a value through; the server deliberately does not repair spelling, because a repaired value is one the operator never chose.
- **An id the API does not recognise is accepted and stored intact.** The API has no allowlist. A slug added to `client-table.ts` after a row was written comes back as a string this build may not know — render it as the generic panel, which the wireframes call "a complete path, not a placeholder", never as an error.
- **Read** (`GET /api/v1/mcp/connections`): `setup_client` is present on every row, pointer semantics, **no `omitempty`** — `"setup_client": null` is said out loud rather than becoming a missing key. `null` means *no operator choice was recorded*. Do not gather `null` rows under the "Other MCP client" chip, and do not fall back to `reported_client_name` to fill it.

`reported_client_name` / `reported_client_version` keep their existing meaning and are unaffected.

## Proof

Five integration proofs through the **same dispatch production uses** — the mounted POST and GET routes over `Service` and `Repo` — as `wpmgr_app`, with the role asserted *inside* a transaction the request path opens and printed with the evidence:

```
InTenantTx (setup_client round trip): current_user=wpmgr_app rolsuper=false rolbypassrls=false
```

1. round trip — mint `"claude-code"`, read it back off the list
2. omitted → NULL, explicit `"generic"` → `"generic"`, asserted **by value against each other**
3. `RecordConnect` leaves it alone — created `"claude-desktop"`, connected reporting `"Cursor"`, with controls that the value was right *before* the connect and that `RecordConnect` actually wrote `reported_client_name`, so "unchanged" cannot be true for the wrong reason
4. tenant isolation on the new read, with a control that tenant A can read its own row
5. malformed shapes refused; a well-formed **unknown** slug accepted and stored intact — one test, because each half is the other's control

Plus unit tests in `internal/mcp`, which **CI does run** (the integration package is excluded by name), pinning nil-vs-empty, all nine `client-table.ts` ids plus unknown slugs accepted, ten malformed spellings refused, the 64/65 length boundary, and that the DTO mapper never substitutes `reported_client_name` for `setup_client`.

### Mutation sweep

Each planted, run, reverted the moment it went red. Tree clean and no markers afterwards.

| Mutation | Result |
|---|---|
| drop the write | all five red — `setup_client came back NULL for a connection minted WITH "claude-code". The write path is not wired: this is GH #605's defect` |
| write `'generic'` where NULL belongs | one red — `a mint that never mentioned setup_client stored "generic". NULL is the only honest value` |
| let `RecordConnect` overwrite | one red — `RecordConnect OVERWROTE setup_client: "claude-desktop" -> "cursor" ... Neither may overwrite the other` |

The marker grep was proved able to return a match before its zero was trusted.

### A test that was wrong

The first draft asserted 400 for a malformed slug and the run answered 422 six times. 422 is correct: `domain.HTTPStatus` maps every `KindValidation` to `StatusUnprocessableEntity` (`internal/domain/errors.go:171`), which is already what the blank-name and bad-scope refusals on this same route return. Fixed in its own commit rather than folded in.

## Merge conflict: a path I do not own

`git merge origin/worktree-agent-a9ecaf6970a8d0f44` conflicted in three files, **all of them `database-engineer`'s**: `apps/api/db/query/mcp_connections.sql` and two files under `internal/db/sqlc/`. Flagging rather than burying it.

Every conflict hunk was **comment-only prose** — two revisions of the same paragraph about `idle_expire_after_days`. The `INSERT` column list auto-merged and already carried `setup_client`. I kept HEAD's revision (which records that `TouchMCPGrantInTenantTx` now *has* a caller) and appended the incoming `setup_client` paragraphs: they describe different columns and neither supersedes the other. The two `internal/db/sqlc` conflicts were the same paragraph copied into generated doc comments and were resolved by **regenerating with sqlc v1.31.1**, never hand-synced.

An in-progress merge cannot be handed to another worktree, which is why I resolved it here. It is worth `database-engineer`'s eyes on the merge commit regardless.

## Unblocks

#610 (the migration), #614 (the m128/m127 reconciliation), and #619 (m129's expiry ceiling, stacked behind it).

## Full integration run

`make test-integration` from the repo root, exit status **0**, no `-run` filter, so all 527 test functions in `apps/api/tests/*.go` ran, the five new proofs among them:

```
ok  github.com/mosamlife/wpmgr/apps/api/tests            844.149s
ok  github.com/mosamlife/wpmgr/apps/api/tests/contract     3.395s
ok  github.com/mosamlife/wpmgr/apps/api/tests/gh458        7.129s
ok  github.com/mosamlife/wpmgr/apps/api/tests/testinfra    2.353s
```

Counts from `grep -rhoE '^func Test[A-Za-z0-9_]+' apps/api/tests/*.go | wc -l`, run at the moment of writing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP connections now record the operator-selected setup client.
  * The selected client is displayed when viewing connection details and lists.
  * Setup client selection is optional; omitted choices remain distinct from “generic.”
* **Bug Fixes**
  * Invalid setup-client values are rejected with a clear validation error.
  * Recorded setup choices remain unchanged when a client later reports a different name.
* **Tests**
  * Added coverage for validation, persistence, API round trips, tenant isolation, and omitted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->