### PR TITLE
fix(mcp): advertise every routed verb in the preflight, and log the refusal reason not the phase

### DIFF
--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -560,7 +561,29 @@ type Event struct {
 // attacker chooses the bytes, and being refused is not a barrier to writing.
 const MaxTargetIDLen = 256
 
-// TruncateTargetID bounds an untrusted target_id and reports whether it had to.
+// SafeTargetID makes an untrusted target_id safe to append, and reports every
+// way it had to change the value.
+//
+// TWO HAZARDS, AND THE SECOND IS NOT A SUBSET OF THE FIRST.
+//
+//  1. LENGTH, per MaxTargetIDLen above.
+//  2. ENCODING. Postgres rejects an invalid byte sequence for encoding "UTF8"
+//     outright, so an invalid target_id does not produce a bounded row -- it
+//     produces a FAILED append, on the refusal path, whose whole purpose is
+//     that the row gets written. That converts "you sent something we refuse"
+//     into a 500 and an evidence gap, which is a strictly better outcome for
+//     the caller than being recorded.
+//
+// The encoding hazard is reachable and is NOT fixed by truncating. A JSON body
+// string is valid UTF-8 by the time encoding/json is done with it, but an HTTP
+// HEADER value is raw bytes: net/http does not validate it, so
+// `MCP-Protocol-Version: <0xff 0xfe>` arrives intact, is refused by
+// NegotiateProtocol, and is recorded verbatim. Being three bytes long it never
+// reaches the length bound at all -- which is exactly why sanitising has to
+// happen on BOTH return paths and not only after a truncation.
+//
+// Order matters: sanitise FIRST, then bound. Replacement runes are 3 bytes
+// each, so sanitising a bounded string can push it back over the bound.
 //
 // THIS IS NOT APPLIED INSIDE Record, DELIBERATELY. Every existing caller passes
 // a server-chosen identifier that cannot approach the bound, and silently
@@ -583,9 +606,21 @@ const MaxTargetIDLen = 256
 // was actually sent. A truncated row that does not say it is truncated reads
 // back as though the caller sent exactly the shortened value, which is a record
 // that misdescribes the event it exists to evidence.
-func TruncateTargetID(s string) (out string, truncated bool, originalLen int) {
+func SafeTargetID(s string) (out string, truncated, sanitized bool, originalLen int) {
+	originalLen = len(s)
+
+	// U+FFFD is the standard lossy replacement. It is deliberately not a
+	// lossless escape: target_id is read by humans in an audit UI, and encoding
+	// a legitimate name into \xff sequences to preserve bytes nobody can act on
+	// would make every ordinary row harder to read to keep evidence of a probe
+	// that the sanitized flag already records.
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "�")
+		sanitized = true
+	}
+
 	if len(s) <= MaxTargetIDLen {
-		return s, false, len(s)
+		return s, false, sanitized, originalLen
 	}
 	b := s[:MaxTargetIDLen]
 	// Drop a trailing partial rune. DecodeLastRuneInString returns
@@ -598,7 +633,7 @@ func TruncateTargetID(s string) (out string, truncated bool, originalLen int) {
 		}
 		break
 	}
-	return b, true, len(s)
+	return b, true, sanitized, originalLen
 }
 
 // Recorder appends hash-chained audit entries.

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -540,6 +541,64 @@ type Event struct {
 	TargetType string
 	TargetID   string
 	Metadata   map[string]any
+}
+
+// MaxTargetIDLen bounds a target_id that came from UNTRUSTED input, in bytes.
+//
+// audit_log.target_id is unbounded `text`, which is correct for the values this
+// package was built for: they are identifiers the SERVER chose -- a uuid (36
+// bytes), a slug, a plugin name. 256 is an order of magnitude above the longest
+// of those, so nothing legitimate is anywhere near it.
+//
+// It matters because of what an append COSTS. Every Record takes a per-tenant
+// pg_advisory_xact_lock (see lockChain) and hashes the row into the chain, so
+// appends for one tenant are strictly serialised. A caller who can put arbitrary
+// bytes in target_id can therefore push unbounded data through the one
+// serialised write path on that tenant's ledger, and the throughput ceiling of
+// that path is not a measured quantity. A refusal audit row is the case that
+// makes this reachable: it records the string the caller GUESSED, so the
+// attacker chooses the bytes, and being refused is not a barrier to writing.
+const MaxTargetIDLen = 256
+
+// TruncateTargetID bounds an untrusted target_id and reports whether it had to.
+//
+// THIS IS NOT APPLIED INSIDE Record, DELIBERATELY. Every existing caller passes
+// a server-chosen identifier that cannot approach the bound, and silently
+// rewriting target_id for all of them would change values that other code looks
+// up by (site lifecycle rows join on target_id, and Verify re-hashes the stored
+// value) to defend against an input none of them accept. The bound belongs to
+// the CALLER that handles untrusted bytes; this helper is here, next to the
+// field it bounds, so that every such caller applies the SAME bound instead of
+// inventing one. If a future audit of the writers finds others taking untrusted
+// target_ids, promoting this into Record is the right move and this comment is
+// the argument for it -- but it is a decision with blast radius beyond one
+// surface, and it is not made here.
+//
+// Truncation is on a RUNE boundary. A byte-slice of UTF-8 text can split a
+// multi-byte rune, and Postgres rejects an invalid byte sequence for encoding
+// "UTF8" outright -- so the naive bound would convert a large-input abuse into a
+// 500 on the refusal path, which is a worse bug than the one being fixed.
+//
+// The returned length is the ORIGINAL byte length, so the caller can record what
+// was actually sent. A truncated row that does not say it is truncated reads
+// back as though the caller sent exactly the shortened value, which is a record
+// that misdescribes the event it exists to evidence.
+func TruncateTargetID(s string) (out string, truncated bool, originalLen int) {
+	if len(s) <= MaxTargetIDLen {
+		return s, false, len(s)
+	}
+	b := s[:MaxTargetIDLen]
+	// Drop a trailing partial rune. DecodeLastRuneInString returns
+	// (RuneError, 1) for an incomplete sequence; a genuine U+FFFD in the input
+	// decodes with size 3 and is correctly kept.
+	for len(b) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(b); r == utf8.RuneError && size <= 1 {
+			b = b[:len(b)-1]
+			continue
+		}
+		break
+	}
+	return b, true, len(s)
 }
 
 // Recorder appends hash-chained audit entries.

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -406,6 +406,53 @@ const (
 	// operator_permission (the dashboard authority the tool call mirrors) and
 	// tool.
 	ActionMCPToolCalled = "mcp.tool.called"
+	// ActionMCPToolDenied is the REFUSAL counterpart of ActionMCPToolCalled,
+	// under the same <action>.denied convention as
+	// ActionSiteFilesSensitiveDenied. It is recorded by
+	// internal/mcp.Service.RecordToolDenied whenever the tools/call gate
+	// (mcp.AuthorizeTool) refuses a named tool, and it is the surface's own
+	// evidence that the boundary held.
+	//
+	// THIS ROW IS NOT A RECORD OF AN ACTION; IT IS THE RECORD THAT NO ACTION
+	// HAPPENED, which is a different and stronger claim. ActionMCPToolCalled
+	// can be reconstructed after the fact from the effect it describes -- the
+	// data was read, something changed, there is a second trace. A refusal
+	// leaves NO other trace anywhere in the system by construction, so if this
+	// row is missing there is nothing to fall back on and "the boundary was
+	// never tested" is indistinguishable from "the boundary was tested and we
+	// lost the record".
+	//
+	// Actor kinds match ActionMCPToolCalled exactly and for the same reason:
+	// ActorAssistant over the mcp_grants id, never the human who granted
+	// access, because the fact an operator wants is WHICH CONNECTION was
+	// refused. TargetType is "mcp_tool" and TargetID is the name AS THE CALLER
+	// SPELLED IT -- an unregistered name is the whole content of a probe, and
+	// normalising it away would erase the evidence. Metadata carries
+	// refusal_reason (the operator-facing classification the wire deliberately
+	// blurs), grant_name, held_capabilities and scoped_sites.
+	//
+	// ON FAILURE THE APPEND IS LOGGED, NOT PROPAGATED, and the caller's refusal
+	// is unchanged. See TransportHandler.auditGap for the full argument; the
+	// short form is that "fail closed" has no meaning for an operation that is
+	// already a denial, and its only available implementation would tell the
+	// denied caller when this log is down.
+	ActionMCPToolDenied = "mcp.tool.denied"
+	// ActionMCPProtocolDenied is recorded when an AUTHENTICATED MCP request is
+	// refused at protocol negotiation -- a revision below the compatibility
+	// floor, or one this server does not speak. Same actor kinds as
+	// ActionMCPToolDenied. TargetType is "mcp_protocol" and TargetID is the
+	// revision string the client asked for.
+	//
+	// It earns a row separate from ActionMCPToolDenied because it answers a
+	// different question. A run of these from one grant is a client that cannot
+	// talk to this server at all, which looks identical to an idle connection
+	// in every other record the surface keeps: no tool is named, so
+	// ActionMCPToolDenied never fires, and last_used_at moves, so the grant
+	// does not look abandoned either. Metadata carries refusal_reason
+	// (below_floor / unsupported), the phase it was caught in (header or
+	// initialize_params), and the floor and target it was measured against, so
+	// a row stays interpretable after those constants move.
+	ActionMCPProtocolDenied = "mcp.protocol.denied"
 )
 
 // ActorFor resolves the (ActorType, ActorID) pair for whichever credential

--- a/apps/api/internal/audit/target_bound_test.go
+++ b/apps/api/internal/audit/target_bound_test.go
@@ -22,7 +22,7 @@ func TestTruncateTargetID_BoundsAndReportsHonestly(t *testing.T) {
 			strings.Repeat("a", MaxTargetIDLen-1),
 			strings.Repeat("a", MaxTargetIDLen), // exactly at the bound
 		} {
-			out, truncated, origLen := TruncateTargetID(in)
+			out, truncated, _, origLen := SafeTargetID(in)
 			if truncated {
 				t.Errorf("len %d: reported truncated, want untouched", len(in))
 			}
@@ -37,7 +37,7 @@ func TestTruncateTargetID_BoundsAndReportsHonestly(t *testing.T) {
 
 	t.Run("an oversized value is bounded and says so, by value", func(t *testing.T) {
 		in := strings.Repeat("a", 256*1024) // the full body limit
-		out, truncated, origLen := TruncateTargetID(in)
+		out, truncated, _, origLen := SafeTargetID(in)
 
 		if !truncated {
 			t.Fatal("a 256 KiB target was NOT reported as truncated; the row would claim this is the whole value")
@@ -61,7 +61,7 @@ func TestTruncateTargetID_BoundsAndReportsHonestly(t *testing.T) {
 		// Multi-byte runes chosen so the naive byte bound lands mid-rune.
 		for _, r := range []string{"é", "€", "😀"} {
 			in := strings.Repeat(r, 1024)
-			out, truncated, _ := TruncateTargetID(in)
+			out, truncated, _, _ := SafeTargetID(in)
 
 			if !truncated {
 				t.Fatalf("%q: input of %d bytes was not truncated", r, len(in))
@@ -78,12 +78,70 @@ func TestTruncateTargetID_BoundsAndReportsHonestly(t *testing.T) {
 		}
 	})
 
+	// INVALID UTF-8 IS THE HAZARD TRUNCATION DOES NOT COVER. Postgres rejects
+	// an invalid byte sequence for encoding "UTF8", so these bytes do not
+	// produce a bounded row -- they produce a FAILED append on the refusal
+	// path. A short invalid value never reaches the length bound at all, which
+	// is why sanitising has to happen on the within-limit return too.
+	t.Run("invalid UTF-8 is sanitized on the within-limit path", func(t *testing.T) {
+		in := string([]byte{0xff, 0xfe, 'A'}) // 3 bytes: far under the bound
+		out, truncated, sanitized, origLen := SafeTargetID(in)
+
+		if truncated {
+			t.Error("a 3-byte value was reported truncated")
+		}
+		if !sanitized {
+			t.Fatal("invalid UTF-8 was NOT reported sanitized; Postgres would reject this row " +
+				"and the refusal would fail to record")
+		}
+		if !utf8.ValidString(out) {
+			t.Errorf("output %v is still invalid UTF-8", []byte(out))
+		}
+		if origLen != len(in) {
+			t.Errorf("originalLen = %d, want %d", origLen, len(in))
+		}
+	})
+
+	t.Run("invalid UTF-8 is sanitized on the truncated path too", func(t *testing.T) {
+		// Each bad byte is separated by a valid one so it forms its own
+		// invalid RUN: strings.ToValidUTF8 collapses a consecutive run to a
+		// single replacement, so 4096 adjacent 0xff bytes would become three
+		// bytes and never reach the bound.
+		in := strings.Repeat(string([]byte{0xff, 'A'}), 2048)
+		out, truncated, sanitized, _ := SafeTargetID(in)
+
+		if !truncated || !sanitized {
+			t.Fatalf("truncated=%v sanitized=%v, want both true", truncated, sanitized)
+		}
+		if !utf8.ValidString(out) {
+			t.Error("output is still invalid UTF-8 after truncation")
+		}
+		// Sanitising expands each bad byte to a 3-byte U+FFFD, so the bound
+		// must be applied AFTER sanitising or the result exceeds it.
+		if len(out) > MaxTargetIDLen {
+			t.Errorf("output is %d bytes, want <= %d — the bound was applied before sanitising",
+				len(out), MaxTargetIDLen)
+		}
+	})
+
+	t.Run("a valid value is never reported sanitized", func(t *testing.T) {
+		for _, in := range []string{"list_sites", "2025-11-25", "naïve", "😀"} {
+			out, _, sanitized, _ := SafeTargetID(in)
+			if sanitized {
+				t.Errorf("%q: reported sanitized, but it is valid UTF-8", in)
+			}
+			if out != in {
+				t.Errorf("%q: rewritten to %q", in, out)
+			}
+		}
+	})
+
 	// A genuine U+FFFD in the input is a real rune and must survive; only an
 	// INCOMPLETE trailing sequence is trimmed. This is what stops the
 	// rune-boundary loop from eating valid content.
 	t.Run("a real replacement char is not mistaken for a partial rune", func(t *testing.T) {
 		in := strings.Repeat("�", 1024)
-		out, _, _ := TruncateTargetID(in)
+		out, _, _, _ := SafeTargetID(in)
 
 		if !utf8.ValidString(out) {
 			t.Error("bounded value is not valid UTF-8")

--- a/apps/api/internal/audit/target_bound_test.go
+++ b/apps/api/internal/audit/target_bound_test.go
@@ -1,0 +1,95 @@
+package audit
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestTruncateTargetID_BoundsAndReportsHonestly pins the three properties the
+// refusal-audit callers depend on.
+//
+// The bound exists because audit_log appends are serialised per tenant behind
+// pg_advisory_xact_lock, so any caller who can choose target_id bytes chooses
+// how much data goes through that lock. The properties below are what make the
+// bound safe to apply to attacker-chosen input without either losing the
+// evidence or corrupting the row.
+func TestTruncateTargetID_BoundsAndReportsHonestly(t *testing.T) {
+	t.Run("a value at or under the bound is returned untouched", func(t *testing.T) {
+		for _, in := range []string{
+			"",
+			"list_sites",
+			strings.Repeat("a", MaxTargetIDLen-1),
+			strings.Repeat("a", MaxTargetIDLen), // exactly at the bound
+		} {
+			out, truncated, origLen := TruncateTargetID(in)
+			if truncated {
+				t.Errorf("len %d: reported truncated, want untouched", len(in))
+			}
+			if out != in {
+				t.Errorf("len %d: value was rewritten (%d bytes out), want identical", len(in), len(out))
+			}
+			if origLen != len(in) {
+				t.Errorf("len %d: originalLen = %d, want %d", len(in), origLen, len(in))
+			}
+		}
+	})
+
+	t.Run("an oversized value is bounded and says so, by value", func(t *testing.T) {
+		in := strings.Repeat("a", 256*1024) // the full body limit
+		out, truncated, origLen := TruncateTargetID(in)
+
+		if !truncated {
+			t.Fatal("a 256 KiB target was NOT reported as truncated; the row would claim this is the whole value")
+		}
+		if len(out) > MaxTargetIDLen {
+			t.Errorf("bounded value is %d bytes, want <= %d — the bound did not bind", len(out), MaxTargetIDLen)
+		}
+		if origLen != len(in) {
+			t.Errorf("originalLen = %d, want %d — the row cannot say how much was actually sent", origLen, len(in))
+		}
+		if !strings.HasPrefix(in, out) {
+			t.Error("the bounded value is not a prefix of the input; the evidence is not merely shortened")
+		}
+	})
+
+	// THE ONE THAT WOULD HAVE BEEN A 500. Postgres rejects an invalid byte
+	// sequence for encoding "UTF8", so a byte-slice that splits a multi-byte
+	// rune turns a bounded write into a failed one -- on the refusal path,
+	// where the whole point is that the row gets written.
+	t.Run("truncation never splits a rune", func(t *testing.T) {
+		// Multi-byte runes chosen so the naive byte bound lands mid-rune.
+		for _, r := range []string{"é", "€", "😀"} {
+			in := strings.Repeat(r, 1024)
+			out, truncated, _ := TruncateTargetID(in)
+
+			if !truncated {
+				t.Fatalf("%q: input of %d bytes was not truncated", r, len(in))
+			}
+			if !utf8.ValidString(out) {
+				t.Errorf("%q: bounded value is not valid UTF-8 — Postgres would reject this row", r)
+			}
+			if len(out) > MaxTargetIDLen {
+				t.Errorf("%q: bounded value is %d bytes, want <= %d", r, len(out), MaxTargetIDLen)
+			}
+			if !strings.HasPrefix(in, out) {
+				t.Errorf("%q: bounded value is not a prefix of the input", r)
+			}
+		}
+	})
+
+	// A genuine U+FFFD in the input is a real rune and must survive; only an
+	// INCOMPLETE trailing sequence is trimmed. This is what stops the
+	// rune-boundary loop from eating valid content.
+	t.Run("a real replacement char is not mistaken for a partial rune", func(t *testing.T) {
+		in := strings.Repeat("�", 1024)
+		out, _, _ := TruncateTargetID(in)
+
+		if !utf8.ValidString(out) {
+			t.Error("bounded value is not valid UTF-8")
+		}
+		if len(out) < MaxTargetIDLen-3 {
+			t.Errorf("bounded value is %d bytes; the loop ate valid U+FFFD runes instead of stopping", len(out))
+		}
+	})
+}

--- a/apps/api/internal/mcp/protocol.go
+++ b/apps/api/internal/mcp/protocol.go
@@ -107,6 +107,26 @@ func (n Negotiation) Refused() bool {
 	return n.Outcome == NegotiationBelowFloor || n.Outcome == NegotiationUnsupported
 }
 
+// RefusalReason is the audit reason string for a refused negotiation: WHY the
+// revision was refused, as distinct from the PHASE that refused it.
+//
+// It lives here, on the value it classifies, because two places need the same
+// answer and they must not derive it independently: the durable audit row
+// (Service.RecordProtocolDenied) and the operator log line that is the ONLY
+// surviving record when that row cannot be written
+// (TransportHandler.auditGap). A second copy of this two-line derivation is
+// how the fallback comes to describe a different refusal from the row it is
+// standing in for.
+//
+// It is meaningful only when Refused() is true; a served negotiation has no
+// refusal reason, and callers must not record one for it.
+func (n Negotiation) RefusalReason() string {
+	if n.Outcome == NegotiationBelowFloor {
+		return "below_floor"
+	}
+	return "unsupported"
+}
+
 // NegotiateProtocol classifies one client-supplied revision string into
 // exactly one of the three cases.
 //

--- a/apps/api/internal/mcp/refusal_target_bound_test.go
+++ b/apps/api/internal/mcp/refusal_target_bound_test.go
@@ -1,0 +1,208 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+)
+
+// ---------------------------------------------------------------------------
+// PROOF -- A REFUSAL CANNOT PUT UNBOUNDED ATTACKER BYTES THROUGH THE CHAIN.
+//
+// Both refusal rows record a value the CALLER chose: the tool name as spelled,
+// and the protocol revision as sent. Both arrive in the JSON body, so both are
+// bounded only by maxRequestBytes (256 KiB). Every audit append takes the
+// per-tenant advisory lock and hashes the row into the chain, so an unbounded
+// target_id lets a caller who can use NOTHING on this surface still drive the
+// one serialised write path on that tenant's ledger -- being denied is not a
+// barrier to writing, which is exactly what makes the refusal row the reachable
+// case.
+//
+// These tests assert by value on the event the recorder actually received.
+// ---------------------------------------------------------------------------
+
+// capturingRecorder records every event it is handed and succeeds, so a test
+// can read back precisely what would have been written.
+type capturingRecorder struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (c *capturingRecorder) Record(_ context.Context, e audit.Event) (audit.Entry, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+	return audit.Entry{}, nil
+}
+
+func (c *capturingRecorder) RecordInTx(_ context.Context, _ pgx.Tx, e audit.Event) (audit.Entry, error) {
+	return c.Record(context.Background(), e)
+}
+
+// only returns the single captured event of the given action, failing loudly
+// when there is none — a test that found no row and passed would be the
+// "guard that finds nothing goes green" defect.
+func (c *capturingRecorder) only(t *testing.T, action string) audit.Event {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var found []audit.Event
+	for _, e := range c.events {
+		if e.Action == action {
+			found = append(found, e)
+		}
+	}
+	if len(found) == 0 {
+		t.Fatalf("no %s row was recorded; the refusal did not audit and this test asserts nothing", action)
+	}
+	if len(found) > 1 {
+		t.Fatalf("expected exactly 1 %s row, got %d", action, len(found))
+	}
+	return found[0]
+}
+
+func capturingRouter(t *testing.T) (*gin.Engine, *capturingRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	rec := &capturingRecorder{}
+	svc := NewService(liveGrantStore(uuid.New())).withAuditRecorder(rec)
+
+	r := gin.New()
+	NewTransportHandler(svc, slog.New(slog.DiscardHandler), "test-version").Register(r)
+	return r, rec
+}
+
+func TestRefusalAudit_BoundsAnAttackerChosenTarget(t *testing.T) {
+	// Big enough to matter, well inside the 256 KiB body limit so the request
+	// is ACCEPTED and actually reaches the refusal — a 413 would prove nothing.
+	const oversized = 64 * 1024
+
+	cases := []struct {
+		name   string
+		action string
+		body   func(payload string) string
+		header string
+	}{
+		{
+			name:   "tool name",
+			action: audit.ActionMCPToolDenied,
+			body: func(p string) string {
+				return fmt.Sprintf(
+					`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":%q,"arguments":{}}}`, p)
+			},
+		},
+		{
+			name:   "initialize protocol revision",
+			action: audit.ActionMCPProtocolDenied,
+			body:   func(p string) string { return initBody(p) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, rec := capturingRouter(t)
+			payload := strings.Repeat("a", oversized)
+
+			req := httptest.NewRequest(http.MethodPost, TransportPath, strings.NewReader(tc.body(payload)))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testBearer)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			// The request must have been ACCEPTED and refused on the merits,
+			// not rejected for size. If this is a 413 the rest is vacuous.
+			if w.Code == http.StatusRequestEntityTooLarge {
+				t.Fatalf("request was refused as too large; the refusal path was never reached")
+			}
+
+			e := rec.only(t, tc.action)
+
+			if len(e.TargetID) > audit.MaxTargetIDLen {
+				t.Errorf("target_id is %d bytes, want <= %d — a refused caller can drive %d bytes "+
+					"through the per-tenant audit lock", len(e.TargetID), audit.MaxTargetIDLen, len(e.TargetID))
+			}
+			if !utf8.ValidString(e.TargetID) {
+				t.Error("target_id is not valid UTF-8; Postgres would reject this row")
+			}
+			if !strings.HasPrefix(payload, e.TargetID) {
+				t.Error("target_id is not a prefix of what the caller sent; the evidence is wrong, not just short")
+			}
+
+			// The row must SAY it is a prefix, by value, or an auditor reads
+			// the shortened string as the name actually sent.
+			if got, _ := e.Metadata["target_truncated"].(bool); !got {
+				t.Errorf("metadata.target_truncated = %v, want true", e.Metadata["target_truncated"])
+			}
+			if got, _ := e.Metadata["target_original_len"].(int); got != oversized {
+				t.Errorf("metadata.target_original_len = %v, want %d", e.Metadata["target_original_len"], oversized)
+			}
+		})
+	}
+}
+
+// TestRefusalAudit_DoesNotTruncateAnOrdinaryTarget is the OVER-FIRE proof.
+//
+// The bound must be invisible to every real refusal. A normal mistyped tool
+// name and a normal unsupported revision are recorded verbatim, with neither
+// truncation key present — a bound that quietly rewrote ordinary evidence
+// would be worse than the problem it fixes.
+func TestRefusalAudit_DoesNotTruncateAnOrdinaryTarget(t *testing.T) {
+	cases := []struct {
+		name   string
+		action string
+		body   string
+		want   string
+	}{
+		{
+			name:   "a mistyped tool name is recorded verbatim",
+			action: audit.ActionMCPToolDenied,
+			body:   `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sitez","arguments":{}}}`,
+			want:   "list_sitez",
+		},
+		{
+			name:   "an unsupported revision is recorded verbatim",
+			action: audit.ActionMCPProtocolDenied,
+			body:   initBody("2019-01-01"),
+			want:   "2019-01-01",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, rec := capturingRouter(t)
+
+			req := httptest.NewRequest(http.MethodPost, TransportPath, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testBearer)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			e := rec.only(t, tc.action)
+
+			if e.TargetID != tc.want {
+				t.Errorf("target_id = %q, want %q — the bound rewrote an ordinary value", e.TargetID, tc.want)
+			}
+			if _, ok := e.Metadata["target_truncated"]; ok {
+				t.Error("metadata.target_truncated is present on an untruncated row; " +
+					"an auditor would think evidence was dropped when none was")
+			}
+			if _, ok := e.Metadata["target_original_len"]; ok {
+				t.Error("metadata.target_original_len is present on an untruncated row")
+			}
+		})
+	}
+}

--- a/apps/api/internal/mcp/refusal_target_bound_test.go
+++ b/apps/api/internal/mcp/refusal_target_bound_test.go
@@ -154,6 +154,51 @@ func TestRefusalAudit_BoundsAnAttackerChosenTarget(t *testing.T) {
 	}
 }
 
+// TestRefusalAudit_SanitizesInvalidUTF8FromTheHeader covers the hazard the
+// length bound does NOT.
+//
+// The header path is the reachable one and it is not the body path: a JSON
+// string is valid UTF-8 once encoding/json is done with it, but net/http does
+// not validate a header VALUE, so `MCP-Protocol-Version: <0xff 0xfe>` arrives
+// intact. It is refused by NegotiateProtocol and recorded verbatim -- and at
+// three bytes it never reaches the length bound, so truncation cannot save it.
+// Postgres then rejects the row for invalid byte sequence for encoding "UTF8",
+// which turns a refusal into a failed audit append: an evidence gap the caller
+// chose, which is a better outcome for them than being recorded.
+func TestRefusalAudit_SanitizesInvalidUTF8FromTheHeader(t *testing.T) {
+	r, rec := capturingRouter(t)
+
+	bad := string([]byte{0xff, 0xfe, 'A'})
+
+	req := httptest.NewRequest(http.MethodPost, TransportPath,
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testBearer)
+	req.Header.Set(ProtocolHeader, bad)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("HTTP %d, want 400 — the invalid revision was not refused", w.Code)
+	}
+
+	e := rec.only(t, audit.ActionMCPProtocolDenied)
+
+	if !utf8.ValidString(e.TargetID) {
+		t.Errorf("target_id is invalid UTF-8 (%v) — Postgres rejects this row, so the refusal "+
+			"would not be recorded at all", []byte(e.TargetID))
+	}
+	if got, _ := e.Metadata["target_sanitized"].(bool); !got {
+		t.Errorf("metadata.target_sanitized = %v, want true — the row does not say its target "+
+			"was rewritten", e.Metadata["target_sanitized"])
+	}
+	// Not truncated: this is the short-invalid case, which is precisely the one
+	// the length bound cannot catch.
+	if _, ok := e.Metadata["target_truncated"]; ok {
+		t.Error("metadata.target_truncated is set on a 3-byte target")
+	}
+}
+
 // TestRefusalAudit_DoesNotTruncateAnOrdinaryTarget is the OVER-FIRE proof.
 //
 // The bound must be invisible to every real refusal. A normal mistyped tool

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1397,7 +1397,7 @@ func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, 
 	// of it through the per-tenant audit advisory lock. Being denied is not a
 	// barrier to writing, so a caller who can use nothing on this surface could
 	// still drive the serialised ledger writer.
-	target, truncated, origLen := audit.TruncateTargetID(toolName)
+	target, truncated, sanitized, origLen := audit.SafeTargetID(toolName)
 
 	meta := map[string]any{
 		"grant_name":        auth.GrantName,
@@ -1412,6 +1412,12 @@ func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, 
 		// becomes indistinguishable from an ordinary typo.
 		meta["target_truncated"] = true
 		meta["target_original_len"] = origLen
+	}
+	if sanitized {
+		// Invalid UTF-8 in a tool name is not something a working client
+		// produces, so this flag is the signal that someone was probing the
+		// encoding boundary rather than mistyping.
+		meta["target_sanitized"] = true
 	}
 
 	_, err := s.audit.Record(ctx, audit.Event{
@@ -1452,7 +1458,7 @@ func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedReque
 	// way: on the initialize_params phase neg.Raw is a JSON string from the
 	// body, not a header, so it is bounded only by maxRequestBytes. An
 	// unsupported revision is refused, and the refusal writes the row.
-	target, truncated, origLen := audit.TruncateTargetID(neg.Raw)
+	target, truncated, sanitized, origLen := audit.SafeTargetID(neg.Raw)
 
 	meta := map[string]any{
 		"grant_name":     auth.GrantName,
@@ -1468,6 +1474,12 @@ func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedReque
 	if truncated {
 		meta["target_truncated"] = true
 		meta["target_original_len"] = origLen
+	}
+	if sanitized {
+		// Worth its own field: invalid UTF-8 in a tool name or a revision
+		// string is not something a working client produces, so this flag is
+		// the signal that someone was probing the encoding boundary.
+		meta["target_sanitized"] = true
 	}
 
 	_, err := s.audit.Record(ctx, audit.Event{

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -204,6 +204,15 @@ func validateTokenEndpointAuthMethod(method string) error {
 // Clock is injectable so expiry behaviour is testable without sleeping.
 type Clock func() time.Time
 
+// auditRecorder is the slice of *audit.Recorder this package actually uses. It
+// exists to make the append-FAILED branch testable without a broken database;
+// production passes the concrete recorder through WithAudit and nothing else
+// implements it outside tests.
+type auditRecorder interface {
+	Record(ctx context.Context, e audit.Event) (audit.Entry, error)
+	RecordInTx(ctx context.Context, tx pgx.Tx, e audit.Event) (audit.Entry, error)
+}
+
 // Service carries the OAuth surface. It holds no plaintext credential beyond
 // the response it is building: m124 obligation 6 says the plaintext is returned
 // once at creation and never read back, and there is no cache here.
@@ -219,7 +228,13 @@ type Service struct {
 	// wiring bug, not a supported configuration, and the finding to raise if
 	// one is ever found is "this deploy path is unattributable", not "make the
 	// nil check quieter".
-	audit *audit.Recorder
+	//
+	// The type is the two-method auditRecorder rather than *audit.Recorder so
+	// that the FAILURE path is reachable from a unit test. What happens when
+	// an append fails is a decision this package makes deliberately (see
+	// TransportHandler.auditGap), and a decision whose only implementation is
+	// unreachable without a broken Postgres is a decision nothing checks.
+	audit auditRecorder
 
 	// mintLimit bounds POST /api/v1/mcp/connections. It lives on the SERVICE
 	// and not on the Handler, unlike Handler.regLimit, and the placement is
@@ -259,7 +274,26 @@ func (s *Service) WithClock(c Clock) *Service {
 // Service the process constructs; a Service left without it (as most of this
 // package's unit tests are, deliberately, since they drive a fakeStore with no
 // backing Postgres pool) simply does not audit -- see the field doc on audit.
+// It keeps the CONCRETE parameter type on purpose even though the field is an
+// interface: a nil *audit.Recorder stored straight into an interface is a
+// non-nil interface holding a nil pointer, which would sail past every
+// `s.audit == nil` guard in this file and panic on the first append instead of
+// skipping it. The explicit nil check below is what keeps "unaudited" meaning
+// unaudited.
 func (s *Service) WithAudit(rec *audit.Recorder) *Service {
+	cp := *s
+	if rec == nil {
+		cp.audit = nil
+		return &cp
+	}
+	cp.audit = rec
+	return &cp
+}
+
+// withAuditRecorder is the test-only door onto the same field, so a fake can
+// drive the append-failed path. Unexported: production wiring goes through
+// WithAudit.
+func (s *Service) withAuditRecorder(rec auditRecorder) *Service {
 	cp := *s
 	cp.audit = rec
 	return &cp

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1391,6 +1391,29 @@ func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, 
 	if s.audit == nil {
 		return nil
 	}
+	// BOUNDED, because this is attacker-chosen input on a path the attacker can
+	// reach WITHOUT holding the tool. toolName is whatever arrived in params,
+	// up to maxRequestBytes (256 KiB), and every refusal would otherwise put all
+	// of it through the per-tenant audit advisory lock. Being denied is not a
+	// barrier to writing, so a caller who can use nothing on this surface could
+	// still drive the serialised ledger writer.
+	target, truncated, origLen := audit.TruncateTargetID(toolName)
+
+	meta := map[string]any{
+		"grant_name":        auth.GrantName,
+		"refusal_reason":    string(reason),
+		"held_capabilities": auth.Capabilities.Len(),
+		"scoped_sites":      auth.Sites.Len(),
+	}
+	if truncated {
+		// The row SAYS it is a prefix. Without this an auditor reads the
+		// shortened value as the name the caller actually sent, and an
+		// oversized-input probe -- which is itself the signal worth seeing --
+		// becomes indistinguishable from an ordinary typo.
+		meta["target_truncated"] = true
+		meta["target_original_len"] = origLen
+	}
+
 	_, err := s.audit.Record(ctx, audit.Event{
 		TenantID:  auth.TenantID,
 		ActorType: audit.ActorAssistant,
@@ -1400,13 +1423,8 @@ func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, 
 		// unregistered branch there is no registry entry, and the string the
 		// caller guessed is the entire content of the evidence.
 		TargetType: "mcp_tool",
-		TargetID:   toolName,
-		Metadata: map[string]any{
-			"grant_name":        auth.GrantName,
-			"refusal_reason":    string(reason),
-			"held_capabilities": auth.Capabilities.Len(),
-			"scoped_sites":      auth.Sites.Len(),
-		},
+		TargetID:   target,
+		Metadata:   meta,
 	})
 	return err
 }
@@ -1429,24 +1447,37 @@ func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedReque
 		return nil
 	}
 	reason := neg.RefusalReason()
+
+	// BOUNDED for the same reason as RecordToolDenied, and reachable the same
+	// way: on the initialize_params phase neg.Raw is a JSON string from the
+	// body, not a header, so it is bounded only by maxRequestBytes. An
+	// unsupported revision is refused, and the refusal writes the row.
+	target, truncated, origLen := audit.TruncateTargetID(neg.Raw)
+
+	meta := map[string]any{
+		"grant_name":     auth.GrantName,
+		"refusal_reason": reason,
+		"phase":          phase,
+		// Recorded per row rather than left to be looked up: these are
+		// compile-time constants that WILL move, and a row that says only
+		// "2024-11-05 was refused" stops being interpretable the moment
+		// they do.
+		"floor":  ProtocolFloor,
+		"target": ProtocolTarget,
+	}
+	if truncated {
+		meta["target_truncated"] = true
+		meta["target_original_len"] = origLen
+	}
+
 	_, err := s.audit.Record(ctx, audit.Event{
 		TenantID:   auth.TenantID,
 		ActorType:  audit.ActorAssistant,
 		ActorID:    auth.GrantID.String(),
 		Action:     audit.ActionMCPProtocolDenied,
 		TargetType: "mcp_protocol",
-		TargetID:   neg.Raw,
-		Metadata: map[string]any{
-			"grant_name":     auth.GrantName,
-			"refusal_reason": reason,
-			"phase":          phase,
-			// Recorded per row rather than left to be looked up: these are
-			// compile-time constants that WILL move, and a row that says only
-			// "2024-11-05 was refused" stops being interpretable the moment
-			// they do.
-			"floor":  ProtocolFloor,
-			"target": ProtocolTarget,
-		},
+		TargetID:   target,
+		Metadata:   meta,
 	})
 	return err
 }

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1211,10 +1211,12 @@ func (s *Service) RecordActivity(ctx context.Context, auth AuthorizedRequest) er
 
 // RecordToolCall appends the ActionMCPToolCalled audit row for one
 // successfully executed tool call. The caller (TransportHandler.callTool)
-// invokes this AFTER entry.invoke returns without error -- a refused call
-// never reaches a tenant's data, and is already visible in the operator log
-// TransportHandler writes at refusal time (h.log.WarnContext), so it earns no
-// row here.
+// invokes this AFTER entry.invoke returns without error. A REFUSED call is
+// recorded separately, by RecordToolDenied, under ActionMCPToolDenied: until
+// ADR-061 A10 was addressed this comment claimed a refusal earned no row
+// because it "never reaches a tenant's data and is already in the operator
+// log", and both halves of that were true while the conclusion was not -- see
+// the argument on RecordToolDenied.
 //
 // ActorType is ActorAssistant, the one actor kind in this whole log that
 // attributes the row to the MODEL rather than to the human who granted it
@@ -1246,6 +1248,111 @@ func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, to
 		Metadata: map[string]any{
 			"grant_name":          auth.GrantName,
 			"operator_permission": operatorPermission,
+		},
+	})
+	return err
+}
+
+// RecordToolDenied appends the ActionMCPToolDenied audit row for one REFUSED
+// tools/call. The caller (TransportHandler.callTool) invokes it on the
+// AuthorizeTool refusal branch, alongside the operator log line and before the
+// wire answer is chosen.
+//
+// WHY A REFUSAL EARNS A ROW WHEN THE OLD COMMENT ON RecordToolCall SAID IT DID
+// NOT. That comment argued a refusal "never reached a tenant's data, and is
+// already covered by the WarnContext log at the refusal site", and both halves
+// are true and neither is sufficient. Never reaching the data is exactly what
+// has to be PROVEN rather than assumed -- it is the boundary's own claim about
+// itself -- and an slog line is not the artifact that proves it: it is not
+// hash-chained, not tenant-scoped, not readable through the audit endpoint a
+// customer's auditor is given, and it is subject to a retention the log
+// pipeline chooses. "Who was denied what" was therefore answerable only by an
+// operator with production log access, which is the wrong audience and the
+// wrong durability for the record that a security boundary functioned.
+//
+// The actor pair is ActorAssistant over auth.GrantID, identical to
+// RecordToolCall's, so a single query on actor_id returns everything one
+// connection did AND everything it was refused -- which is the shape an
+// investigation actually wants, and it is why this is not modelled as a
+// separate actor kind.
+//
+// reason is the OPERATOR-FACING refusalReason, deliberately the value the wire
+// blurs: the whole disclosure decision on AuthorizeTool is that "no such tool"
+// and "not yours" are indistinguishable to the CALLER, and it holds only
+// because the operator gets the precise reason somewhere else. This row is now
+// that somewhere else. Taking the typed refusalReason rather than a string is
+// what stops a caller composing a reason by hand and drifting from the log line
+// two lines above it.
+//
+// BEST-EFFORT, and that is a deliberate divergence from ADR-061 A10's
+// fail-closed language rather than an oversight. See TransportHandler.auditGap.
+func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, toolName string, reason refusalReason) error {
+	// NOTE: a Service with no recorder records NOTHING and reports no error,
+	// the same as RecordToolCall. That is the unit-test configuration (see the
+	// audit field doc); in production WithAudit has always been called, and a
+	// request path reached without it is a wiring bug whose finding is "this
+	// deploy is unattributable", not "make this quieter".
+	if s.audit == nil {
+		return nil
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:  auth.TenantID,
+		ActorType: audit.ActorAssistant,
+		ActorID:   auth.GrantID.String(),
+		Action:    audit.ActionMCPToolDenied,
+		// The name AS SPELLED BY THE CALLER, not a registry name: on the
+		// unregistered branch there is no registry entry, and the string the
+		// caller guessed is the entire content of the evidence.
+		TargetType: "mcp_tool",
+		TargetID:   toolName,
+		Metadata: map[string]any{
+			"grant_name":        auth.GrantName,
+			"refusal_reason":    string(reason),
+			"held_capabilities": auth.Capabilities.Len(),
+			"scoped_sites":      auth.Sites.Len(),
+		},
+	})
+	return err
+}
+
+// RecordProtocolDenied appends the ActionMCPProtocolDenied audit row for an
+// authenticated request refused at revision negotiation.
+//
+// It is called from TransportHandler.writeProtocolRefusal, which is the ONE
+// function both refusal sites go through (the per-request header in serve, and
+// the initialize params). Putting the append there rather than at the two call
+// sites is what makes "every protocol refusal is recorded" structurally true
+// instead of true by convention -- a third refusal site added later inherits it.
+//
+// phase names which of the two negotiations refused, because they mean
+// different things operationally: a params refusal is a client that cannot
+// connect at all, a header refusal is a client that connected and then sent
+// something else, and only the second can indicate a proxy rewriting headers.
+func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedRequest, neg Negotiation, phase string) error {
+	if s.audit == nil {
+		return nil
+	}
+	reason := "unsupported"
+	if neg.Outcome == NegotiationBelowFloor {
+		reason = "below_floor"
+	}
+	_, err := s.audit.Record(ctx, audit.Event{
+		TenantID:   auth.TenantID,
+		ActorType:  audit.ActorAssistant,
+		ActorID:    auth.GrantID.String(),
+		Action:     audit.ActionMCPProtocolDenied,
+		TargetType: "mcp_protocol",
+		TargetID:   neg.Raw,
+		Metadata: map[string]any{
+			"grant_name":     auth.GrantName,
+			"refusal_reason": reason,
+			"phase":          phase,
+			// Recorded per row rather than left to be looked up: these are
+			// compile-time constants that WILL move, and a row that says only
+			// "2024-11-05 was refused" stops being interpretable the moment
+			// they do.
+			"floor":  ProtocolFloor,
+			"target": ProtocolTarget,
 		},
 	})
 	return err

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1394,10 +1394,7 @@ func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedReque
 	if s.audit == nil {
 		return nil
 	}
-	reason := "unsupported"
-	if neg.Outcome == NegotiationBelowFloor {
-		reason = "below_floor"
-	}
+	reason := neg.RefusalReason()
 	_, err := s.audit.Record(ctx, audit.Event{
 		TenantID:   auth.TenantID,
 		ActorType:  audit.ActorAssistant,

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -917,13 +917,30 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 func (h *TransportHandler) auditGap(
 	ctx context.Context, auth AuthorizedRequest, action, target, reason, phase string, err error,
 ) {
+	// BOUNDED AND SANITISED THE SAME WAY THE DURABLE ROW IS. This line stands
+	// in for that row, so it inherits the row's input problem too: target is
+	// caller-chosen and can be 256 KiB of anything. Emitting it raw would move
+	// the abuse from the audit table to the operator log -- which has no length
+	// bound at all -- and would put invalid UTF-8 into a JSON log line. It also
+	// keeps the fallback comparable to the row it replaces: the same value,
+	// bounded the same way.
+	safeTarget, truncated, sanitized, origLen := audit.SafeTargetID(target)
+
 	attrs := []any{
 		slog.Bool("audit_gap", true),
 		slog.String("action", action),
 		slog.String("tenant_id", auth.TenantID.String()),
 		slog.String("grant_id", auth.GrantID.String()),
-		slog.String("target", target),
+		slog.String("target", safeTarget),
 		slog.String("refusal_reason", reason),
+	}
+	if truncated {
+		attrs = append(attrs,
+			slog.Bool("target_truncated", true),
+			slog.Int("target_original_len", origLen))
+	}
+	if sanitized {
+		attrs = append(attrs, slog.Bool("target_sanitized", true))
 	}
 	if phase != "" {
 		attrs = append(attrs, slog.String("phase", phase))

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
@@ -234,7 +235,7 @@ func (h *TransportHandler) serve(c *gin.Context) {
 	)
 
 	if neg.Refused() {
-		h.writeProtocolRefusal(c, nil, neg)
+		h.writeProtocolRefusal(c, auth, nil, neg, "header")
 		return
 	}
 
@@ -411,7 +412,7 @@ func (h *TransportHandler) initialize(
 	// the header rule was written to accept.
 	paramNeg := NegotiateProtocol(p.ProtocolVersion)
 	if paramNeg.Refused() {
-		h.writeProtocolRefusal(c, req.ID, paramNeg)
+		h.writeProtocolRefusal(c, auth, req.ID, paramNeg, "initialize_params")
 		return jsonrpcResponse{}, false
 	}
 
@@ -553,6 +554,25 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 				slog.Int("held_capabilities", auth.Capabilities.Len()),
 				slog.Int("scoped_sites", auth.Sites.Len()),
 			)
+
+			// AND THE DURABLE ROW, on the same condition as the log line and
+			// for the same reason. ADR-061 A10: "the surface's own record of
+			// who was denied what is not reliable, which is the boundary's
+			// evidence." The WarnContext above is an operator convenience with
+			// no retention guarantee and no tenant scoping; this is the record
+			// a customer's auditor can read back.
+			//
+			// The condition is `reason != ""` and not `err != nil`
+			// DELIBERATELY. The one refusal with an empty reason is the
+			// registry-entry-with-no-implementation branch of AuthorizeTool,
+			// which is a BUILD DEFECT and not a denial: writing mcp.tool.denied
+			// for it would tell an auditor the boundary refused this connection
+			// when the truth is that the server is broken, and they would go
+			// looking at a grant that was never the problem. It is already
+			// reported at ERROR by toolError.
+			if aerr := h.svc.RecordToolDenied(ctx, auth, p.Name, reason); aerr != nil {
+				h.auditGap(ctx, auth, audit.ActionMCPToolDenied, p.Name, string(reason), aerr)
+			}
 		}
 
 		if de, ok := domain.AsDomain(err); ok && de.Code == ErrCodeToolNotAvailable {
@@ -587,9 +607,12 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 		return h.toolError(req.ID, err)
 	}
 
-	// The operator-facing audit row (ActionMCPToolCalled), for this call and
-	// no other outcome: a refusal above never reached a tenant's data and is
-	// already covered by the WarnContext log at the refusal site. BEST-EFFORT
+	// The operator-facing audit row (ActionMCPToolCalled), for this call and no
+	// other outcome. A refusal above writes ActionMCPToolDenied instead, on its
+	// own branch, so the two outcomes are separate actions rather than one
+	// action with a status field: a query for "what did this connection do"
+	// and a query for "what was this connection refused" are different
+	// questions and neither should have to filter the other out. BEST-EFFORT
 	// like RecordConnect's client-identity write is not -- a failure here is
 	// logged, never returned to the caller, because withholding a successful
 	// read's answer over a failure to record having answered it would make an
@@ -626,8 +649,85 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 // Refusals
 // ---------------------------------------------------------------------------
 
+// auditGap is what happens when a REFUSAL's audit append fails, and it is the
+// one place the failure posture for this surface's denial records is decided.
+//
+// THE DECISION: the caller's refusal is unchanged, and the failure is escalated
+// on the operator side instead. This is a deliberate divergence from the
+// fail-closed language in ADR-061 A10, and the reasoning is:
+//
+//  1. "FAIL CLOSED" IS NOT DEFINED FOR AN OPERATION THAT IS ALREADY A DENIAL.
+//     A10's rule is "no AI action is ever performed whose record was lost", and
+//     it works because there is always a second option: don't perform it. Here
+//     the action has already not been performed. There is nothing to withhold,
+//     nothing to roll back, and no companion write to bind the append to -- the
+//     approve path's RecordInTx shape has no analogue because a refusal touches
+//     no row.
+//
+//  2. THE ONLY AVAILABLE IMPLEMENTATION OF "FAIL CLOSED" HERE MAKES THE SURFACE
+//     WORSE AND RESTORES NOTHING. The single lever left is the wire answer:
+//     degrade the typed refusal (-32004 "call tools/list", -32002 "your site
+//     scope is empty") into -32603 internal error. That destroys the actionable
+//     half of the refusal for a legitimate client who is now told nothing they
+//     can act on, makes a transient database blip indistinguishable from a
+//     server bug, and DOES NOT WRITE THE ROW. The evidence gap is identical
+//     either way; only the client's experience differs, and only for the worse.
+//
+//  3. CHANGING THE WIRE ANSWER LEAKS AUDIT-SYSTEM LIVENESS TO THE PARTY BEING
+//     DENIED. This is the decisive one. The caller on this branch is by
+//     definition someone who just asked for something they may not have,
+//     including the wordlist-probing case AuthorizeTool's whole disclosure
+//     decision exists to defeat. A distinguishable answer when and only when
+//     the audit log is unwritable is a "the camera is off" oracle: probe until
+//     the response shape changes, then do the thing you actually came for. A
+//     surface that tells attackers when it has stopped recording is worse than
+//     one that quietly keeps answering.
+//
+// So the honest failure mode is not a different refusal, it is a LOUDER
+// OPERATOR SIGNAL, and that is what this writes. Two properties matter:
+//
+//   - THE LOST ROW'S CONTENT IS EMITTED HERE, not just the error. The hash
+//     chain has a hole that cannot be repaired, but the facts -- tenant, grant,
+//     what was asked for, why it was refused -- survive somewhere an operator
+//     can reach. It is strictly weaker evidence than the chained row (not
+//     tamper-evident, log retention, no audit endpoint) and it is named as
+//     such rather than presented as equivalent.
+//   - audit_gap=true is a single, greppable, alertable field. The requirement
+//     A10 is really making is that an operator FINDS OUT their evidence has a
+//     hole; an ERROR line indistinguishable from every other ERROR line does
+//     not satisfy that, and an alert keyed on this field does.
+//
+// WHAT THIS DOES NOT CLAIM. This is not A10's fail-closed helper. That helper
+// would have to bind the append to the operation, and for a denial there is no
+// operation to bind it to. If a WRITE tool ever lands on this surface and its
+// refusal has an effect to roll back, that refusal is a different case and must
+// not reuse this path by analogy.
+func (h *TransportHandler) auditGap(
+	ctx context.Context, auth AuthorizedRequest, action, target, reason string, err error,
+) {
+	h.log.ErrorContext(ctx, "mcp refusal audit write failed",
+		slog.Bool("audit_gap", true),
+		slog.String("action", action),
+		slog.String("tenant_id", auth.TenantID.String()),
+		slog.String("grant_id", auth.GrantID.String()),
+		slog.String("target", target),
+		slog.String("refusal_reason", reason),
+		slog.String("error", err.Error()),
+	)
+}
+
 // writeUnauthorized answers 401 -- NEVER 404 -- and names the scheme so a
 // client knows how to authenticate.
+//
+// NO AUDIT ROW IS WRITTEN HERE, and the omission is structural rather than a
+// gap left open by choice. Authenticate has just FAILED, so there is no tenant
+// id -- audit_log.tenant_id is NOT NULL and every RLS policy on the table keys
+// on it, so there is literally no tenant whose ledger this row could join. The
+// residual is real and is named in the report rather than papered over: an
+// invalid-token probe against this endpoint is visible in the operator log and
+// nowhere in any customer-readable record. Closing it needs somewhere for
+// unattributable refusals to go, which is a schema question and therefore
+// database-engineer's, not something to fake with a nil uuid.
 func (h *TransportHandler) writeUnauthorized(c *gin.Context, err error) {
 	c.Header("WWW-Authenticate", `Bearer realm="wpmgr-mcp"`)
 
@@ -658,7 +758,17 @@ func (h *TransportHandler) writeUnauthorized(c *gin.Context, err error) {
 // quietly reduced surface. Both are the silent-coercion failure this codebase
 // is governed by -- an unsupported revision answered with a working response is
 // a claim that the client's revision is spoken here.
-func (h *TransportHandler) writeProtocolRefusal(c *gin.Context, id json.RawMessage, neg Negotiation) {
+//
+// It also writes the ActionMCPProtocolDenied row for BOTH sites, because it is
+// the one function both go through. auth is threaded in for that: every caller
+// runs after Authenticate, so a tenant and a grant always exist here.
+func (h *TransportHandler) writeProtocolRefusal(
+	c *gin.Context, auth AuthorizedRequest, id json.RawMessage, neg Negotiation, phase string,
+) {
+	if err := h.svc.RecordProtocolDenied(c.Request.Context(), auth, neg, phase); err != nil {
+		h.auditGap(c.Request.Context(), auth, audit.ActionMCPProtocolDenied, neg.Raw, phase, err)
+	}
+
 	var msg string
 	switch neg.Outcome {
 	case NegotiationBelowFloor:

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -152,15 +152,28 @@ func (h *TransportHandler) Register(r gin.IRouter) {
 	// Registered explicitly per verb rather than via HandleMethodNotAllowed,
 	// because that flag is engine-global and would change the response of
 	// every other route in the API as a side effect of this slice.
-	for _, verb := range []string{
-		http.MethodGet,
-		http.MethodHead,
-		http.MethodPut,
-		http.MethodPatch,
-		http.MethodDelete,
-	} {
+	for _, verb := range methodNotAllowedVerbs {
 		r.Handle(verb, TransportPath, h.methodNotAllowed)
 	}
+}
+
+// methodNotAllowedVerbs is every verb this path ROUTES to an honest 405, and it
+// is the single list corsAllowMethods is derived from.
+//
+// It is a package var rather than a literal inside Register because the two
+// lists had already drifted once, in the direction that is invisible from the
+// server side: the preflight advertised POST, GET and DELETE while HEAD, PUT
+// and PATCH were routed to methodNotAllowed. A browser sending any of those
+// three was blocked by its OWN preflight and never reached the 405 this loop
+// exists to give it, so the operator saw an opaque network error and the
+// carefully worded refusal was never read. Deriving the advertisement from the
+// routing makes that drift unspellable rather than merely caught in review.
+var methodNotAllowedVerbs = []string{
+	http.MethodGet,
+	http.MethodHead,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
 }
 
 // ---------------------------------------------------------------------------
@@ -170,15 +183,20 @@ func (h *TransportHandler) Register(r gin.IRouter) {
 // corsAllowMethods is what a browser may ATTEMPT, which is deliberately not the
 // same set as the Allow header's "what will succeed".
 //
-// GET and DELETE are listed even though both answer 405. Omitting them would
-// make the browser block the request before our 405 could be read, and the
-// client would surface an opaque CORS network error -- indistinguishable from
-// "the server is down". That is precisely the confusion the 405-not-404 rule
-// above exists to prevent, so the same reasoning applies one layer out: let the
-// request through so it can receive an honest refusal.
-var corsAllowMethods = strings.Join([]string{
-	http.MethodPost, http.MethodGet, http.MethodDelete,
-}, ", ")
+// EVERY ROUTED VERB IS LISTED even though all of them except POST answer 405.
+// Omitting one would make the browser block the request before our 405 could be
+// read, and the client would surface an opaque CORS network error --
+// indistinguishable from "the server is down". That is precisely the confusion
+// the 405-not-404 rule above exists to prevent, so the same reasoning applies
+// one layer out: let the request through so it can receive an honest refusal.
+//
+// It is DERIVED from methodNotAllowedVerbs rather than written out, because a
+// hand-maintained copy is exactly what drifted: HEAD, PUT and PATCH were routed
+// to a readable 405 that no browser could ever reach. A verb added to the
+// routing now appears here by construction, and a verb removed disappears from
+// here too -- the two cannot disagree.
+var corsAllowMethods = strings.Join(
+	append([]string{http.MethodPost}, methodNotAllowedVerbs...), ", ")
 
 // corsAllowHeaders is every header the Streamable HTTP transport specifies a
 // client may send, plus the Authorization header the authorization spec adds.
@@ -749,7 +767,9 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 			// looking at a grant that was never the problem. It is already
 			// reported at ERROR by toolError.
 			if aerr := h.svc.RecordToolDenied(ctx, auth, p.Name, reason); aerr != nil {
-				h.auditGap(ctx, auth, audit.ActionMCPToolDenied, p.Name, string(reason), aerr)
+				// No phase: a tool denial happens at one place in the request,
+				// so there is no second axis to record and "" is omitted.
+				h.auditGap(ctx, auth, audit.ActionMCPToolDenied, p.Name, string(reason), "", aerr)
 			}
 		}
 
@@ -880,18 +900,37 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 // operation to bind it to. If a WRITE tool ever lands on this surface and its
 // refusal has an effect to roll back, that refusal is a different case and must
 // not reuse this path by analogy.
+// THE FIELDS ARE THE LOST ROW'S FIELDS, UNDER THE LOST ROW'S KEYS. reason and
+// phase are separate arguments and separate log keys because they answer
+// different questions and the row records them separately: refusal_reason is
+// WHY (below_floor, unsupported, a tool-denial reason), phase is WHERE in the
+// request the refusal happened (header, initialize_params). Passing the phase
+// as the reason -- which this did -- makes the fallback claim a connection was
+// refused for "header", loses below_floor entirely, and records the phase
+// nowhere. That is not a mislabelled field: this line is the WHOLE remaining
+// evidence when the append fails, so a wrong half is a fabricated record of a
+// refusal that did not happen for that reason.
+//
+// phase is empty for refusals that have no phase (tool denials), and is then
+// omitted rather than logged as "", so an alert keyed on it never matches a
+// blank.
 func (h *TransportHandler) auditGap(
-	ctx context.Context, auth AuthorizedRequest, action, target, reason string, err error,
+	ctx context.Context, auth AuthorizedRequest, action, target, reason, phase string, err error,
 ) {
-	h.log.ErrorContext(ctx, "mcp refusal audit write failed",
+	attrs := []any{
 		slog.Bool("audit_gap", true),
 		slog.String("action", action),
 		slog.String("tenant_id", auth.TenantID.String()),
 		slog.String("grant_id", auth.GrantID.String()),
 		slog.String("target", target),
 		slog.String("refusal_reason", reason),
-		slog.String("error", err.Error()),
-	)
+	}
+	if phase != "" {
+		attrs = append(attrs, slog.String("phase", phase))
+	}
+	attrs = append(attrs, slog.String("error", err.Error()))
+
+	h.log.ErrorContext(ctx, "mcp refusal audit write failed", attrs...)
 }
 
 // writeUnauthorized answers 401 -- NEVER 404 -- and names the scheme so a
@@ -944,7 +983,8 @@ func (h *TransportHandler) writeProtocolRefusal(
 	c *gin.Context, auth AuthorizedRequest, id json.RawMessage, neg Negotiation, phase string,
 ) {
 	if err := h.svc.RecordProtocolDenied(c.Request.Context(), auth, neg, phase); err != nil {
-		h.auditGap(c.Request.Context(), auth, audit.ActionMCPProtocolDenied, neg.Raw, phase, err)
+		h.auditGap(c.Request.Context(), auth, audit.ActionMCPProtocolDenied,
+			neg.Raw, neg.RefusalReason(), phase, err)
 	}
 
 	var msg string

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -109,6 +109,23 @@ func NewTransportHandler(svc *Service, log *slog.Logger, version string) *Transp
 func (h *TransportHandler) Register(r gin.IRouter) {
 	r.POST(TransportPath, h.serve)
 
+	// OPTIONS IS THE CORS PREFLIGHT AND IS ANSWERED, NOT REFUSED.
+	//
+	// It was in the 405 list below, and that combination made this endpoint
+	// UNREACHABLE from any browser-hosted MCP client. The sequence is: the
+	// client reads our discovery documents, which set
+	// Access-Control-Allow-Origin: * specifically so a browser may read them
+	// (discovery.go), learns this endpoint's URL, and then cannot call it,
+	// because its preflight is answered 405 and the browser never issues the
+	// POST. We published an invitation to a door we had locked.
+	//
+	// A preflight is not avoidable by a conforming client. Authorization,
+	// MCP-Protocol-Version, MCP-Session-Id and Last-Event-ID are all
+	// non-safelisted request headers, and so is Content-Type: application/json
+	// (the safelist covers only form and text/plain bodies) -- so essentially
+	// every real MCP request forces one.
+	r.OPTIONS(TransportPath, h.preflight)
+
 	// EVERY OTHER VERB ON THIS PATH ANSWERS 405, NOT 404.
 	//
 	// This is the same rule as the 401-not-404 one below, on the other axis,
@@ -124,6 +141,12 @@ func (h *TransportHandler) Register(r gin.IRouter) {
 	// and the transport's own answer for a server that does not offer them is
 	// 405 -- so a conforming client that opens the GET stream first learns
 	// "this server does not do that" instead of "there is no server here".
+	// The specification names 405 for both by name, for the GET stream
+	// ("or else return HTTP 405 Method Not Allowed, indicating that the server
+	// does not offer an SSE stream at this endpoint") and for DELETE ("the
+	// server MAY respond to this request with HTTP 405 Method Not Allowed,
+	// indicating that the server does not allow clients to terminate
+	// sessions"). Neither is a placeholder for unfinished work.
 	//
 	// Registered explicitly per verb rather than via HandleMethodNotAllowed,
 	// because that flag is engine-global and would change the response of
@@ -134,10 +157,129 @@ func (h *TransportHandler) Register(r gin.IRouter) {
 		http.MethodPut,
 		http.MethodPatch,
 		http.MethodDelete,
-		http.MethodOptions,
 	} {
 		r.Handle(verb, TransportPath, h.methodNotAllowed)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// CORS
+// ---------------------------------------------------------------------------
+
+// corsAllowMethods is what a browser may ATTEMPT, which is deliberately not the
+// same set as the Allow header's "what will succeed".
+//
+// GET and DELETE are listed even though both answer 405. Omitting them would
+// make the browser block the request before our 405 could be read, and the
+// client would surface an opaque CORS network error -- indistinguishable from
+// "the server is down". That is precisely the confusion the 405-not-404 rule
+// above exists to prevent, so the same reasoning applies one layer out: let the
+// request through so it can receive an honest refusal.
+var corsAllowMethods = strings.Join([]string{
+	http.MethodPost, http.MethodGet, http.MethodDelete,
+}, ", ")
+
+// corsAllowHeaders is every header the Streamable HTTP transport specifies a
+// client may send, plus the Authorization header the authorization spec adds.
+//
+// Header names are case-insensitive both in HTTP and in the CORS matching
+// algorithm, which matters here: the session header is spelled Mcp-Session-Id
+// in revision 2025-06-18 and MCP-Session-Id in 2025-11-25. One spelling covers
+// both revisions, and neither has to be tracked as the window moves.
+//
+// Last-Event-ID and the session header are listed even though Phase 1 issues no
+// session id and offers no resumable stream: a client that sends them anyway is
+// conforming, and a preflight that omitted them would fail the whole request
+// rather than let it through to the answer it should get.
+var corsAllowHeaders = strings.Join([]string{
+	"Authorization",
+	"Content-Type",
+	"Accept",
+	ProtocolHeader,
+	"Mcp-Session-Id",
+	"Last-Event-ID",
+}, ", ")
+
+// corsExposeHeaders is what browser JavaScript may READ off our responses.
+// Without this the client can see the status code and nothing else.
+//
+// WWW-Authenticate is the load-bearing one: writeUnauthorized sets it to name
+// the scheme, and a browser client that cannot read it learns only "401" with
+// no indication of how to authenticate.
+var corsExposeHeaders = strings.Join([]string{
+	"WWW-Authenticate", "Mcp-Session-Id", "Allow",
+}, ", ")
+
+// writeCORS sets the headers that must appear on an ACTUAL response, as opposed
+// to a preflight. It runs on every verb and BEFORE authentication, because a
+// response the browser refuses to hand to the client is not a refusal the
+// client can act on -- an unreadable 401 is indistinguishable from a network
+// failure.
+//
+// THE ORIGIN IS "*" AND THERE IS DELIBERATELY NO Access-Control-Allow-Credentials.
+//
+// "*" is safe HERE for a reason specific to this endpoint, and the reason is
+// not that discovery.go does the same thing one file over -- that surface
+// publishes public metadata, this one carries a credential, and they do not
+// automatically share a policy. It is safe because this endpoint has NO ambient
+// authentication to steal. It is mounted on the root engine and never on the
+// session-auth group, so no cookie authenticates it; the only credential it
+// accepts is a bearer token that the calling page's own JavaScript must already
+// hold and set explicitly. A hostile page therefore gains nothing from being
+// allowed to send a request it could only authenticate with a token it would
+// have to have stolen first.
+//
+// Allow-Credentials: true is the setting that WOULD be a hole -- it would make
+// the browser attach ambient credentials to cross-origin requests -- and it is
+// also incompatible with "*". It is not set, and must not be.
+//
+// Narrowing "*" to an allowlist would buy nothing today and cost real
+// interoperability: browser-hosted MCP clients are served from origins we
+// cannot enumerate, which is the entire reason this surface offers dynamic
+// client registration. It would also not constrain a non-browser client at all,
+// since CORS is enforced by the browser and not by us.
+//
+// COUPLING WITH ORIGIN VALIDATION, WHICH IS NOT YET BUILT. Revision 2025-11-25
+// hardened the transport's Origin rule to a MUST ("Servers MUST validate the
+// Origin header on all incoming connections ... If the Origin header is present
+// and invalid, servers MUST respond with HTTP 403 Forbidden"), and this server
+// does not validate Origin at all. That is tracked separately. The two
+// mechanisms are NOT the same thing and do not conflict, but they do constrain
+// each other: if Origin validation lands as an ALLOWLIST, then this "*" must
+// become a reflection of the single allowed origin plus a "Vary: Origin"
+// response header, and the 403 must be applied to the preflight as well as to
+// the real request, or a browser client gets a preflight that succeeds followed
+// by a POST that is forbidden. Whoever builds that half changes this function
+// in the same commit.
+func writeCORS(c *gin.Context) {
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.Header("Access-Control-Expose-Headers", corsExposeHeaders)
+}
+
+// preflight answers the CORS preflight for the MCP endpoint.
+//
+// IT DOES NOT AUTHENTICATE, AND THAT IS NOT A HOLE.
+//
+// A browser strips Authorization from a preflight by construction -- the whole
+// purpose of the OPTIONS round trip is to ask permission BEFORE attaching the
+// credential -- so requiring a bearer here would refuse every preflight ever
+// sent and restore exactly the lockout this handler exists to fix. Nothing is
+// served in response: the body is empty and the only thing disclosed is which
+// methods and headers this endpoint accepts, which is already public in the
+// discovery documents and in this file's published path.
+//
+// The bearer requirement is untouched. A successful preflight buys the caller
+// the right to SEND the real request, and that real request meets exactly the
+// same 401 it does today.
+func (h *TransportHandler) preflight(c *gin.Context) {
+	writeCORS(c)
+	c.Header("Access-Control-Allow-Methods", corsAllowMethods)
+	c.Header("Access-Control-Allow-Headers", corsAllowHeaders)
+	// Ten minutes. Chrome caps preflight caching at 7200s and the value only
+	// trades a round trip against how long a policy change takes to reach a
+	// client that has already cached it; short is the safer side of that.
+	c.Header("Access-Control-Max-Age", "600")
+	c.Status(http.StatusNoContent)
 }
 
 // methodNotAllowed answers a non-POST verb on the published path with a JSON
@@ -147,6 +289,10 @@ func (h *TransportHandler) Register(r gin.IRouter) {
 // who is asking, and answering 401 to an unauthenticated GET would send an
 // operator to rotate a credential when the actual fix is to send a POST.
 func (h *TransportHandler) methodNotAllowed(c *gin.Context) {
+	// The 405 is only useful if the browser lets the client read it. Without
+	// this, a browser-hosted client probing the GET stream sees an opaque CORS
+	// failure instead of the honest "we do not offer that here".
+	writeCORS(c)
 	c.Header("Allow", http.MethodPost)
 	c.JSON(http.StatusMethodNotAllowed, newErrorResponse(nil, codeInvalidRequest,
 		fmt.Sprintf("%s is not supported on %s. This is a Streamable HTTP MCP endpoint and "+
@@ -205,6 +351,12 @@ func nullID(id json.RawMessage) json.RawMessage {
 // ---------------------------------------------------------------------------
 
 func (h *TransportHandler) serve(c *gin.Context) {
+	// 0. CORS HEADERS BEFORE AUTHENTICATION, so that the 401 below is readable
+	// by a browser-hosted client. A response the browser refuses to expose is
+	// not a refusal anyone can act on: it surfaces as a network error, which
+	// sends the caller looking for an outage rather than at their token.
+	writeCORS(c)
+
 	// 1. AUTHENTICATE FIRST, AND ANSWER 401 -- NEVER 404.
 	//
 	// A 404 hides a routing failure behind something that looks like a
@@ -266,9 +418,35 @@ func (h *TransportHandler) serve(c *gin.Context) {
 
 	trimmed := strings.TrimSpace(string(body))
 	if strings.HasPrefix(trimmed, "[") {
-		// Batching was removed in revision 2025-11-25 and is not implemented
-		// for the older revisions in the window either. Refusing by name is
-		// better than half-answering a batch.
+		// BATCHING IS REFUSED ON EVERY REVISION IN THE WINDOW, AND ON THE FLOOR
+		// THAT IS A DELIBERATE DIVERGENCE FROM THE SPECIFICATION.
+		//
+		// JSON-RPC batching was removed in revision 2025-06-18, whose changelog
+		// opens with "Remove support for JSON-RPC batching" -- NOT in 2025-11-25,
+		// as this comment claimed until it was checked against the changelog.
+		//
+		// So the window is not uniform. 2025-06-18 and 2025-11-25 forbid
+		// batching and refusing it is conformant. 2025-03-26 -- our floor, and
+		// the revision NegotiateProtocol assumes for the header-less client we
+		// expect to be the common case -- PERMITS it, and we refuse it anyway.
+		//
+		// What a floor client actually experiences: it POSTs a JSON array, and
+		// gets HTTP 400 carrying a JSON-RPC error with code -32600 and a null
+		// id, whose message tells it to send one request per POST. It is not
+		// downgraded, not partially served, and not silently given the first
+		// element of its batch. The refusal is total and it says why.
+		//
+		// This is a product decision and not an unfinished edge: implementing
+		// batching would mean implementing partial failure across a batch --
+		// per-element authorization, per-element audit rows, and an answer for
+		// "three succeeded and one was refused" -- to serve a shape that the
+		// two newer revisions have already deleted and that no surveyed client
+		// emits. Half-answering a batch would be worse than refusing it.
+		//
+		// DO NOT "FIX" THIS BY IMPLEMENTING BATCHING because the floor allows
+		// it. If it is ever revisited, the question to answer first is whether
+		// any real 2025-03-26 client sends batches, and the request log added
+		// in serve() is what answers it.
 		c.JSON(http.StatusBadRequest, newErrorResponse(nil, codeInvalidRequest,
 			"JSON-RPC batching is not supported; send one request per POST", nil))
 		return

--- a/apps/api/internal/mcp/transport_preflight_audit_test.go
+++ b/apps/api/internal/mcp/transport_preflight_audit_test.go
@@ -329,6 +329,41 @@ func TestTransport_AuditGapLogsReasonAndPhaseSeparately(t *testing.T) {
 	}
 }
 
+// TestTransport_AuditGapBoundsItsTarget stops the fallback from becoming the
+// abuse channel the durable row was just closed against.
+//
+// auditGap runs precisely when the bounded row could NOT be written, so if it
+// emitted the raw target it would move a 256 KiB attacker-chosen value out of a
+// bounded column and into the operator log, which has no bound at all. The
+// fallback has to be as safe as the row it stands in for.
+func TestTransport_AuditGapBoundsItsTarget(t *testing.T) {
+	const oversized = 64 * 1024
+
+	r, buf := gapRouter(t)
+
+	req := httptest.NewRequest(http.MethodPost, TransportPath,
+		strings.NewReader(initBody(strings.Repeat("a", oversized))))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testBearer)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	rec := findGapLine(t, buf)
+
+	got, _ := rec["target"].(string)
+	if len(got) > audit.MaxTargetIDLen {
+		t.Errorf("gap log target is %d bytes, want <= %d — the fallback emits unbounded "+
+			"attacker input into the operator log", len(got), audit.MaxTargetIDLen)
+	}
+	if truncated, _ := rec["target_truncated"].(bool); !truncated {
+		t.Errorf("gap log target_truncated = %v, want true — the line does not say it is a prefix",
+			rec["target_truncated"])
+	}
+	if n, _ := rec["target_original_len"].(float64); int(n) != oversized {
+		t.Errorf("gap log target_original_len = %v, want %d", rec["target_original_len"], oversized)
+	}
+}
+
 // TestTransport_AuditGapOmitsAnEmptyPhase keeps the tool-denial call site
 // honest: a refusal with no phase must not log phase="", because an alert or a
 // query keyed on the field would then match a blank and report a phase that

--- a/apps/api/internal/mcp/transport_preflight_audit_test.go
+++ b/apps/api/internal/mcp/transport_preflight_audit_test.go
@@ -1,0 +1,353 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+)
+
+// ---------------------------------------------------------------------------
+// PROOF -- THE PREFLIGHT ADVERTISES EVERY VERB THE ROUTER ROUTES.
+//
+// The failure this guards is one the server cannot see. Every verb in
+// methodNotAllowedVerbs is routed to a deliberately readable 405 that says
+// "this method is not supported here" instead of gin's bare 404. A verb
+// missing from the preflight never reaches that answer: the browser refuses
+// its OWN request before it is sent, and the client surfaces an opaque network
+// error indistinguishable from "the server is down". Our logs show nothing,
+// because nothing arrived.
+//
+// So the two lists have to agree, and this asserts the agreement BY VALUE
+// against methodNotAllowedVerbs rather than against a written-out list of
+// verbs. A hard-coded list here would have to be edited in lockstep with the
+// routing to stay meaningful -- which is the same drift the production code
+// just stopped being able to have, reintroduced in the test that exists to
+// catch it.
+// ---------------------------------------------------------------------------
+
+// allowedPreflightMethods parses the Access-Control-Allow-Methods header into a
+// set. It parses rather than substring-matching: strings.Contains cannot tell
+// an advertised verb from one that merely appears inside another token, and
+// this assertion is the whole point of the test.
+func allowedPreflightMethods(t *testing.T, h string) map[string]bool {
+	t.Helper()
+	set := map[string]bool{}
+	for _, part := range strings.Split(h, ",") {
+		if v := strings.TrimSpace(part); v != "" {
+			set[v] = true
+		}
+	}
+	if len(set) == 0 {
+		t.Fatalf("Access-Control-Allow-Methods = %q parsed to no verbs at all", h)
+	}
+	return set
+}
+
+func TestTransport_PreflightAdvertisesEveryRoutedVerb(t *testing.T) {
+	r := newTransportRouter(t, liveGrantStore(uuid.New()))
+
+	req := httptest.NewRequest(http.MethodOptions, TransportPath, nil)
+	req.Header.Set("Origin", "https://some-mcp-client.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("preflight answered %d, want 204 — the rest of this test is vacuous", w.Code)
+	}
+
+	allowed := allowedPreflightMethods(t, w.Header().Get("Access-Control-Allow-Methods"))
+
+	// POST is the verb that actually works, so it must be advertised.
+	if !allowed[http.MethodPost] {
+		t.Errorf("Access-Control-Allow-Methods = %v, missing POST — the endpoint is unusable", allowed)
+	}
+
+	// And every verb routed to a 405, BY VALUE against the routed list. This is
+	// the assertion that catches a verb added to one list and not the other.
+	if len(methodNotAllowedVerbs) == 0 {
+		t.Fatal("methodNotAllowedVerbs is empty; this test would assert nothing")
+	}
+	for _, verb := range methodNotAllowedVerbs {
+		if !allowed[verb] {
+			t.Errorf("routed verb %s answers a readable 405 but is NOT advertised in "+
+				"Access-Control-Allow-Methods (%v) — a browser blocks it before the 405 can be read",
+				verb, allowed)
+		}
+	}
+}
+
+// TestTransport_EveryAdvertisedVerbIsRoutedOrPost is the CONVERSE, and it is
+// what stops this being fixed by advertising everything.
+//
+// Access-Control-Allow-Methods is a claim about what the browser may attempt.
+// Advertising a verb nothing routes would earn back the bare 404 the
+// 405-not-404 rule exists to eliminate, one layer further out and harder to
+// diagnose. Every advertised verb must therefore be POST or a routed 405 verb.
+func TestTransport_EveryAdvertisedVerbIsRoutedOrPost(t *testing.T) {
+	r := newTransportRouter(t, liveGrantStore(uuid.New()))
+
+	req := httptest.NewRequest(http.MethodOptions, TransportPath, nil)
+	req.Header.Set("Origin", "https://some-mcp-client.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	routed := map[string]bool{http.MethodPost: true}
+	for _, verb := range methodNotAllowedVerbs {
+		routed[verb] = true
+	}
+
+	for verb := range allowedPreflightMethods(t, w.Header().Get("Access-Control-Allow-Methods")) {
+		if !routed[verb] {
+			t.Errorf("Access-Control-Allow-Methods advertises %s, which nothing routes — "+
+				"a browser would be invited to send a request that answers 404", verb)
+		}
+	}
+}
+
+// TestTransport_AdvertisedVerbsStillRefuse is the OVER-FIRE proof for the
+// preflight change.
+//
+// Widening the advertisement must buy the caller exactly one thing: the right
+// to SEND a request that will be honestly refused. It must not make any
+// currently-refused request succeed. Every routed verb still answers 405 with
+// its Allow header, and an unauthenticated POST is still 401 — asserted by
+// value, not as "an error occurred".
+func TestTransport_AdvertisedVerbsStillRefuse(t *testing.T) {
+	r := newTransportRouter(t, liveGrantStore(uuid.New()))
+
+	for _, verb := range methodNotAllowedVerbs {
+		t.Run(verb+" still answers 405", func(t *testing.T) {
+			req := httptest.NewRequest(verb, TransportPath, nil)
+			req.Header.Set("Origin", "https://some-mcp-client.example")
+			req.Header.Set("Authorization", "Bearer "+testBearer)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("%s answered %d, want 405 — the preflight change let a refused verb through\nbody: %s",
+					verb, w.Code, w.Body.String())
+			}
+			if got := w.Header().Get("Allow"); !strings.Contains(got, http.MethodPost) {
+				t.Errorf("%s 405 does not name the accepted verb: Allow = %q", verb, got)
+			}
+		})
+	}
+
+	t.Run("unauthenticated POST is still 401 by value", func(t *testing.T) {
+		unauth := newTransportRouter(t, &fakeStore{}) // tokenOK false: nothing resolves
+		req := httptest.NewRequest(http.MethodPost, TransportPath,
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+		req.Header.Set("Origin", "https://some-mcp-client.example")
+		w := httptest.NewRecorder()
+		unauth.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("HTTP %d, want 401 — the preflight change weakened authentication\nbody: %s",
+				w.Code, w.Body.String())
+		}
+		if got := w.Header().Get("WWW-Authenticate"); !strings.Contains(got, "Bearer") {
+			t.Errorf("401 does not name the scheme: WWW-Authenticate = %q", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// PROOF -- THE AUDIT GAP LINE CARRIES THE LOST ROW'S REASON AND ITS PHASE.
+//
+// When RecordProtocolDenied's append fails there is no durable row, and this
+// log line is the ENTIRE surviving record of the refusal. It was being passed
+// the phase in the reason slot, so it claimed refusal_reason=header, lost
+// below_floor altogether, and recorded the phase nowhere. A fallback that
+// carries the wrong half of the row it stands in for is worse than a
+// mislabelled field: an operator reading it back learns a refusal happened for
+// a reason that is not a reason.
+//
+// Both values are asserted BY VALUE and separately, and the test also asserts
+// they are DISTINCT — which is what fails if the two arguments are ever
+// transposed again.
+// ---------------------------------------------------------------------------
+
+// failingRecorder implements auditRecorder and refuses every append. It is the
+// broken-audit condition the gap path exists for, without needing a broken
+// Postgres to produce it.
+type failingRecorder struct{ err error }
+
+func (f *failingRecorder) Record(context.Context, audit.Event) (audit.Entry, error) {
+	return audit.Entry{}, f.err
+}
+
+func (f *failingRecorder) RecordInTx(context.Context, pgx.Tx, audit.Event) (audit.Entry, error) {
+	return audit.Entry{}, f.err
+}
+
+// gapRouter builds the real mount with a recorder that always fails and a
+// logger that captures JSON, so the emitted gap line can be read back field by
+// field.
+func gapRouter(t *testing.T) (*gin.Engine, *bytes.Buffer) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	svc := NewService(liveGrantStore(uuid.New())).
+		withAuditRecorder(&failingRecorder{err: errors.New("audit chain unavailable")})
+
+	r := gin.New()
+	NewTransportHandler(svc, log, "test-version").Register(r)
+	return r, &buf
+}
+
+// findGapLine returns the single captured "mcp refusal audit write failed"
+// record. It fails loudly when there is none: a test that quietly found no log
+// line and passed would be exactly the "guard that finds nothing goes green"
+// defect this suite is meant not to have.
+func findGapLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var found []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] == "mcp refusal audit write failed" {
+			found = append(found, rec)
+		}
+	}
+	if len(found) == 0 {
+		t.Fatalf("no audit-gap log line was emitted; the fallback did not run\ncaptured:\n%s", buf.String())
+	}
+	if len(found) > 1 {
+		t.Fatalf("expected exactly 1 audit-gap line, got %d\ncaptured:\n%s", len(found), buf.String())
+	}
+	return found[0]
+}
+
+func TestTransport_AuditGapLogsReasonAndPhaseSeparately(t *testing.T) {
+	cases := []struct {
+		name       string
+		header     string // MCP-Protocol-Version, "" to omit
+		body       string
+		wantReason string
+		wantPhase  string
+	}{
+		{
+			// Below the floor, refused at the per-request header.
+			name:       "below floor at the header",
+			header:     "2024-11-05",
+			body:       `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+			wantReason: "below_floor",
+			wantPhase:  "header",
+		},
+		{
+			// No header (so the header negotiation does not refuse), an
+			// unparseable revision in initialize's params.
+			name:       "unsupported at the initialize params",
+			header:     "",
+			body:       initBody("banana"),
+			wantReason: "unsupported",
+			wantPhase:  "initialize_params",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, buf := gapRouter(t)
+
+			req := httptest.NewRequest(http.MethodPost, TransportPath, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testBearer)
+			if tc.header != "" {
+				req.Header.Set(ProtocolHeader, tc.header)
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			// The refusal itself is UNCHANGED by the append failing. That is
+			// the documented decision in auditGap, and if it ever stops being
+			// true the rest of this test is measuring the wrong thing.
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("HTTP %d, want 400 — the refusal changed when the audit append failed\nbody: %s",
+					w.Code, w.Body.String())
+			}
+
+			rec := findGapLine(t, buf)
+
+			if got, _ := rec["audit_gap"].(bool); !got {
+				t.Errorf("audit_gap = %v, want true — the alertable field is what makes this findable", rec["audit_gap"])
+			}
+
+			gotReason, _ := rec["refusal_reason"].(string)
+			if gotReason != tc.wantReason {
+				t.Errorf("refusal_reason = %q, want %q — the lost row's REASON is not in the fallback",
+					gotReason, tc.wantReason)
+			}
+
+			gotPhase, _ := rec["phase"].(string)
+			if gotPhase != tc.wantPhase {
+				t.Errorf("phase = %q, want %q — the lost row's PHASE is recorded under its own key or nowhere",
+					gotPhase, tc.wantPhase)
+			}
+
+			// The transposition check. reason and phase answer different
+			// questions, and passing one where the other belongs is the exact
+			// defect this test was written for.
+			if gotReason == gotPhase {
+				t.Errorf("refusal_reason and phase are both %q — the two arguments are transposed or duplicated",
+					gotReason)
+			}
+
+			// The fallback must agree with the row it stands in for. Deriving
+			// the expectation from the same function the durable row uses is
+			// what keeps the two from drifting apart later.
+			neg := NegotiateProtocol(tc.header)
+			if tc.wantPhase == "initialize_params" {
+				neg = NegotiateProtocol("banana")
+			}
+			if want := neg.RefusalReason(); gotReason != want {
+				t.Errorf("refusal_reason = %q but Negotiation.RefusalReason() = %q — "+
+					"the fallback describes a different refusal from the audit row", gotReason, want)
+			}
+		})
+	}
+}
+
+// TestTransport_AuditGapOmitsAnEmptyPhase keeps the tool-denial call site
+// honest: a refusal with no phase must not log phase="", because an alert or a
+// query keyed on the field would then match a blank and report a phase that
+// does not exist.
+func TestTransport_AuditGapOmitsAnEmptyPhase(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	h := NewTransportHandler(NewService(&fakeStore{}), log, "test-version")
+
+	h.auditGap(context.Background(),
+		AuthorizedRequest{TenantID: uuid.New(), GrantID: uuid.New()},
+		"mcp.tool.denied", "sites_list", "unregistered", "", errors.New("boom"))
+
+	rec := findGapLine(t, &buf)
+
+	if got, ok := rec["phase"]; ok {
+		t.Errorf("phase = %v, want the key ABSENT for a refusal that has no phase", got)
+	}
+	if got, _ := rec["refusal_reason"].(string); got != "unregistered" {
+		t.Errorf("refusal_reason = %q, want %q", got, "unregistered")
+	}
+}

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -326,9 +326,15 @@ func TestTransport_UnauthenticatedIs401Not404(t *testing.T) {
 func TestTransport_NonPostVerbsAre405Not404(t *testing.T) {
 	r := newTransportRouter(t, liveGrantStore(uuid.New()))
 
+	// OPTIONS IS DELIBERATELY ABSENT from this list. It used to be here, and
+	// having it here was the defect: OPTIONS is the CORS preflight, and
+	// answering it 405 made this endpoint unreachable from every
+	// browser-hosted MCP client. Its behaviour is asserted by
+	// TestTransport_PreflightIsAnsweredNot405 instead. Every verb below is
+	// genuinely unsupported and 405 is genuinely the right answer for it.
 	for _, verb := range []string{
 		http.MethodGet, http.MethodHead, http.MethodPut,
-		http.MethodPatch, http.MethodDelete, http.MethodOptions,
+		http.MethodPatch, http.MethodDelete,
 	} {
 		t.Run(verb, func(t *testing.T) {
 			req := httptest.NewRequest(verb, TransportPath, nil)
@@ -1065,3 +1071,216 @@ func jsonPart(t *testing.T, text string) string {
 }
 
 var _ = io.Discard
+
+// ---------------------------------------------------------------------------
+// CORS preflight
+// ---------------------------------------------------------------------------
+
+// TestTransport_PreflightIsAnsweredNot405 is the regression for the defect this
+// file's 405 list used to contain.
+//
+// The failure it guards is not cosmetic. Our discovery documents set
+// Access-Control-Allow-Origin: * so that a browser-hosted MCP client may read
+// them, and they advertise this endpoint's URL. If the preflight is refused,
+// that client reads the invitation and then cannot open the door: the browser
+// never issues the POST, and the user sees an opaque network error.
+//
+// A preflight is not avoidable. Authorization alone forces one, and so does
+// Content-Type: application/json.
+func TestTransport_PreflightIsAnsweredNot405(t *testing.T) {
+	r := newTransportRouter(t, liveGrantStore(uuid.New()))
+
+	// A REALISTIC browser preflight: no Authorization (the browser strips it),
+	// and the two Access-Control-Request-* headers a browser actually sends.
+	req := httptest.NewRequest(http.MethodOptions, TransportPath, nil)
+	req.Header.Set("Origin", "https://some-mcp-client.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "authorization,content-type,mcp-protocol-version")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("preflight answered 405; the endpoint is unreachable from any browser client")
+	}
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("preflight answered %d, want 204\nbody: %s", w.Code, w.Body.String())
+	}
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "*")
+	}
+
+	// Allow-Credentials must be ABSENT. Setting it true is the change that
+	// would turn "*" into a real hole, and it is also incompatible with "*".
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want it absent — "+
+			"credentialed CORS on a bearer endpoint is a hole", got)
+	}
+
+	// Every method the transport specifies for this endpoint, by value. GET
+	// and DELETE are included ON PURPOSE even though both answer 405: omitting
+	// them makes the browser block the request before our honest 405 can be
+	// read, turning a clear refusal into an opaque network error.
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	for _, m := range []string{http.MethodPost, http.MethodGet, http.MethodDelete} {
+		if !strings.Contains(methods, m) {
+			t.Errorf("Access-Control-Allow-Methods = %q, missing %s", methods, m)
+		}
+	}
+
+	// Every header the specification says a client may send. Missing any one
+	// of these fails the whole real request, not just that header.
+	allowed := strings.ToLower(w.Header().Get("Access-Control-Allow-Headers"))
+	for _, hdr := range []string{
+		"authorization",
+		"content-type",
+		"accept",
+		strings.ToLower(ProtocolHeader),
+		"mcp-session-id",
+		"last-event-id",
+	} {
+		if !strings.Contains(allowed, hdr) {
+			t.Errorf("Access-Control-Allow-Headers = %q, missing %q", allowed, hdr)
+		}
+	}
+}
+
+// TestTransport_PreflightDoesNotWeakenTheBearerRequirement is the OVER-FIRE
+// check, and it is the one that matters.
+//
+// A preflight that succeeds buys the caller exactly one thing: the right to
+// SEND the real request. It must buy nothing else. If answering OPTIONS had
+// made any currently-refused request start succeeding, that is a hole, and
+// this test is what would catch it.
+//
+// Every assertion is BY VALUE -- the HTTP status and the JSON-RPC code -- never
+// "an error occurred". Two tests in this package were caught passing for the
+// wrong reason, one because a different policy was doing the refusing.
+func TestTransport_PreflightDoesNotWeakenTheBearerRequirement(t *testing.T) {
+	r := newTransportRouter(t, &fakeStore{}) // tokenOK false: nothing resolves
+
+	// Send the preflight first, exactly as a browser would, so the sequence
+	// under test is the real one and not a POST in isolation.
+	pre := httptest.NewRequest(http.MethodOptions, TransportPath, nil)
+	pre.Header.Set("Origin", "https://some-mcp-client.example")
+	pre.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	pw := httptest.NewRecorder()
+	r.ServeHTTP(pw, pre)
+	if pw.Code != http.StatusNoContent {
+		t.Fatalf("preflight answered %d, want 204 — the rest of this test is vacuous", pw.Code)
+	}
+
+	t.Run("unauthenticated POST is still 401 by value", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, TransportPath,
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+		req.Header.Set("Origin", "https://some-mcp-client.example")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("HTTP %d, want 401 — the preflight let an unauthenticated POST through\nbody: %s",
+				w.Code, w.Body.String())
+		}
+		resp := decodeRPC(t, w)
+		if resp.Error == nil {
+			t.Fatal("401 carried no JSON-RPC error object")
+		}
+		if resp.Error.Code != codeInvalidRequest {
+			t.Errorf("JSON-RPC code = %d, want %d", resp.Error.Code, codeInvalidRequest)
+		}
+		if got := w.Header().Get("WWW-Authenticate"); !strings.Contains(got, "Bearer") {
+			t.Errorf("401 does not name the scheme: WWW-Authenticate = %q", got)
+		}
+	})
+
+	t.Run("a bad token after a preflight is still 401 by value", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, TransportPath,
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+		req.Header.Set("Origin", "https://some-mcp-client.example")
+		req.Header.Set("Authorization", "Bearer not-a-real-token")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("HTTP %d, want 401\nbody: %s", w.Code, w.Body.String())
+		}
+		resp := decodeRPC(t, w)
+		if resp.Error == nil || resp.Error.Code != codeInvalidRequest {
+			t.Fatalf("want JSON-RPC code %d, got %+v", codeInvalidRequest, resp.Error)
+		}
+	})
+
+	t.Run("GET is still 405 by value", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, TransportPath, nil)
+		req.Header.Set("Origin", "https://some-mcp-client.example")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("GET answered %d, want 405 — the preflight change opened a stream", w.Code)
+		}
+		if got := w.Header().Get("Allow"); got != http.MethodPost {
+			t.Errorf("Allow = %q, want %q", got, http.MethodPost)
+		}
+	})
+
+	t.Run("DELETE is still 405 by value", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, TransportPath, nil)
+		req.Header.Set("Origin", "https://some-mcp-client.example")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("DELETE answered %d, want 405 — the preflight change made sessions terminable", w.Code)
+		}
+	})
+}
+
+// TestTransport_ActualResponsesAreReadableCrossOrigin covers the half of this
+// fix that a preflight-only change would have missed.
+//
+// The preflight only authorises the request to be SENT. Without
+// Access-Control-Allow-Origin on the ACTUAL response the browser still refuses
+// to hand it to the client, and the client sees a network error rather than
+// our answer. An unreadable 401 sends the caller hunting for an outage instead
+// of at their token.
+func TestTransport_ActualResponsesAreReadableCrossOrigin(t *testing.T) {
+	r := newTransportRouter(t, &fakeStore{})
+
+	t.Run("the 401 is readable", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, TransportPath,
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+		req.Header.Set("Origin", "https://some-mcp-client.example")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("HTTP %d, want 401", w.Code)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("Access-Control-Allow-Origin on the 401 = %q, want %q — "+
+				"the browser will not expose this refusal to the client", got, "*")
+		}
+		// WWW-Authenticate is useless to a browser client unless exposed.
+		exposed := strings.ToLower(w.Header().Get("Access-Control-Expose-Headers"))
+		if !strings.Contains(exposed, "www-authenticate") {
+			t.Errorf("Access-Control-Expose-Headers = %q, missing www-authenticate — "+
+				"the client can see 401 but not how to authenticate", exposed)
+		}
+	})
+
+	t.Run("the 405 is readable", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, TransportPath, nil)
+		req.Header.Set("Origin", "https://some-mcp-client.example")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("HTTP %d, want 405", w.Code)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("Access-Control-Allow-Origin on the 405 = %q, want %q — "+
+				"the client sees an opaque CORS error instead of the refusal", got, "*")
+		}
+	})
+}

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -1117,13 +1117,19 @@ func TestTransport_PreflightIsAnsweredNot405(t *testing.T) {
 			"credentialed CORS on a bearer endpoint is a hole", got)
 	}
 
-	// Every method the transport specifies for this endpoint, by value. GET
-	// and DELETE are included ON PURPOSE even though both answer 405: omitting
-	// them makes the browser block the request before our honest 405 can be
-	// read, turning a clear refusal into an opaque network error.
+	// Every method the transport specifies for this endpoint, by value, DERIVED
+	// from the routed list rather than written out. The 405 verbs are included
+	// ON PURPOSE even though none of them succeeds: omitting one makes the
+	// browser block the request before our honest 405 can be read, turning a
+	// clear refusal into an opaque network error. A written-out list here would
+	// drift from the routing exactly as the production copy did.
+	//
+	// TestTransport_PreflightAdvertisesEveryRoutedVerb covers this properly,
+	// including the converse; this is the same claim kept local to the test
+	// that already reads the whole preflight response.
 	methods := w.Header().Get("Access-Control-Allow-Methods")
-	for _, m := range []string{http.MethodPost, http.MethodGet, http.MethodDelete} {
-		if !strings.Contains(methods, m) {
+	for _, m := range append([]string{http.MethodPost}, methodNotAllowedVerbs...) {
+		if !allowedPreflightMethods(t, methods)[m] {
 			t.Errorf("Access-Control-Allow-Methods = %q, missing %s", methods, m)
 		}
 	}

--- a/apps/api/tests/mcp_refusal_audit_integration_test.go
+++ b/apps/api/tests/mcp_refusal_audit_integration_test.go
@@ -1,0 +1,339 @@
+// mcp_refusal_audit_integration_test.go: ADR-061 A10's refusal half.
+//
+// WHAT WAS MISSING. internal/mcp wrote exactly ONE audit row on the transport
+// path, ActionMCPToolCalled, and only after a successful invoke. Every refusal
+// -- an unregistered tool name, a capability the grant does not hold, a
+// site-keyed tool on an empty resolved scope, a protocol revision below the
+// floor -- produced an slog line and NOTHING durable. A10 calls that record
+// "the boundary's evidence", and the boundary had none.
+//
+// WHY THESE PROOFS ARE HERE AND NOT IN internal/mcp. A unit test with a
+// fakeStore cannot construct an audit.Recorder (it needs a real *db.Pool), so
+// it can assert at most that a method was called. The three facts that matter
+// are all database facts:
+//
+//  1. The row actually lands in audit_log, hash-chained, with the right actor
+//     pair -- ActorAssistant over the GRANT id, never the human who approved
+//     the connection.
+//  2. It is readable back only through db.Pool as wpmgr_app -- rolsuper=f,
+//     rolbypassrls=f, printed from pg_roles INSIDE the transaction under test
+//     by mcpAssertAndReportRole. A test that opened its own connection would
+//     leave every RLS policy inert and pass regardless.
+//  3. A second tenant cannot see it, though both tenants' rows share one
+//     physical audit_log table.
+//
+// Every refusal below is driven through the SAME mounted transport a client
+// reaches, with a real minted bearer token. No GUC is hand-set in this file.
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// mcpRefusalRPC is mcpRPC plus the MCP-Protocol-Version header, which the
+// shared helper cannot set and which one of the refusals below is entirely
+// about. Same transport, same engine, same bearer.
+func mcpRefusalRPC(t *testing.T, eng *gin.Engine, bearer, protoHeader string, payload map[string]any) rpcResult {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal rpc payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, mcp.TransportPath, strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.RemoteAddr = "203.0.113.9:5555"
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if protoHeader != "" {
+		req.Header.Set(mcp.ProtocolHeader, protoHeader)
+	}
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, req)
+	return rpcResult{status: w.Code, body: w.Body.String()}
+}
+
+// mintForRefusal mints a connection through the real POST
+// /api/v1/mcp/connections route and returns (grantID, token).
+func mintForRefusal(t *testing.T, eng *gin.Engine, name string, body map[string]any) (string, string) {
+	t.Helper()
+	body["name"] = name
+	var out struct {
+		GrantID string `json:"grant_id"`
+		Token   string `json:"token"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, body, nil, &out); code != http.StatusCreated {
+		t.Fatalf("mint %q answered %d, want 201", name, code)
+	}
+	if out.Token == "" || out.GrantID == "" {
+		t.Fatalf("mint %q returned grant_id=%q token empty=%t", name, out.GrantID, out.Token == "")
+	}
+	return out.GrantID, out.Token
+}
+
+// seedEmptyTag inserts a real site_tags row carrying NO sites, through the same
+// tenant tx helper the request path uses. A grant scoped to it is legitimate
+// and stores cleanly (verifyScopeReferents only refuses ids naming no row at
+// all), and it resolves to zero sites -- which is the site_scope_empty refusal
+// an operator actually hits.
+func seedEmptyTag(t *testing.T, pool *db.Pool, tenantID uuid.UUID, name string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`INSERT INTO site_tags (tenant_id, name) VALUES ($1, $2) RETURNING id`,
+			tenantID, name).Scan(&id)
+	})
+	if err != nil {
+		t.Fatalf("seed empty tag %q: %v", name, err)
+	}
+	return id
+}
+
+// TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole is the A10 proof.
+func TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	// The role is load-bearing for every assertion in this file: printed from
+	// pg_roles inside a transaction opened by the same helper the request path
+	// opens, so "these policies were live" is an executed fact and not a claim.
+	if err := pool.InMCPClientLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPClientLookupTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open lookup tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-refusal-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-refusal-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://"+suffix+".example.test")
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	connEng := mountConnectionsLikeProduction(t, svc, admin)
+	transportEng := mountLikeProduction(t, svc, admin)
+
+	const wideName = "refusal audit wide connection"
+	const emptyName = "refusal audit empty-scope connection"
+
+	wideGrantID, wideToken := mintForRefusal(t, connEng, wideName, map[string]any{
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	})
+	emptyTagID := seedEmptyTag(t, pool, tenantID, "refusal-audit-"+suffix)
+	emptyGrantID, emptyToken := mintForRefusal(t, connEng, emptyName, map[string]any{
+		"site_scope_mode": string(mcp.SiteScopeModeTags),
+		"scope_tag_ids":   []string{emptyTagID.String()},
+	})
+
+	// ------------------------------------------------------------------
+	// REFUSAL 1: a tool name that does not exist. reasonUnregistered.
+	// ------------------------------------------------------------------
+	const guessed = "sites.restart"
+	got := mcpRefusalRPC(t, transportEng, wideToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": guessed, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("tools/call %q answered HTTP %d, want 200 with a JSON-RPC error: %s", guessed, got.status, got.body)
+	}
+
+	denied := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied)
+	if len(denied) != 1 {
+		t.Fatalf("after one unregistered-name refusal, mcp.tool.denied rows = %d, want exactly 1", len(denied))
+	}
+	// ASSERT BY VALUE, never that a row exists.
+	if denied[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.tool.denied actor_type = %q, want %q", denied[0].actorType, audit.ActorAssistant)
+	}
+	if denied[0].actorID != wideGrantID {
+		t.Errorf("mcp.tool.denied actor_id = %q, want the grant id %q (NOT the approving user %q)",
+			denied[0].actorID, wideGrantID, userID)
+	}
+	if denied[0].targetID != guessed {
+		t.Errorf("mcp.tool.denied target_id = %q, want the name the caller spelled, %q", denied[0].targetID, guessed)
+	}
+	if r, _ := denied[0].metadata["refusal_reason"].(string); r != "unregistered" {
+		t.Errorf("mcp.tool.denied metadata.refusal_reason = %q, want %q", r, "unregistered")
+	}
+	if n, _ := denied[0].metadata["grant_name"].(string); n != wideName {
+		t.Errorf("mcp.tool.denied metadata.grant_name = %q, want %q", n, wideName)
+	}
+	t.Logf("REFUSAL 1 ok: mcp.tool.denied reason=unregistered target=%q actor=assistant/%s", guessed, wideGrantID)
+
+	// ------------------------------------------------------------------
+	// REFUSAL 2: a tool the grant HOLDS, on a resolved site scope of zero
+	// sites. reasonSiteScopeEmpty. This is the refusal ADR-061 A11 §3 calls
+	// "the single most likely place for a fail-open default to survive
+	// review", so its record is the one most worth having.
+	// ------------------------------------------------------------------
+	got = mcpRefusalRPC(t, transportEng, emptyToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("empty-scope tools/call answered HTTP %d, want 200: %s", got.status, got.body)
+	}
+	if !strings.Contains(got.body, "-32002") {
+		t.Fatalf("empty-scope tools/call did not answer the named scope-empty code -32002; "+
+			"this proof depends on that branch being the one taken: %s", got.body)
+	}
+
+	denied = queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied)
+	if len(denied) != 2 {
+		t.Fatalf("after the empty-scope refusal, mcp.tool.denied rows = %d, want 2", len(denied))
+	}
+	var scopeRow *mcpAuditRow
+	for i := range denied {
+		if denied[i].actorID == emptyGrantID {
+			scopeRow = &denied[i]
+		}
+	}
+	if scopeRow == nil {
+		t.Fatalf("no mcp.tool.denied row attributed to the empty-scope grant %s; rows: %+v", emptyGrantID, denied)
+	}
+	if scopeRow.actorType != audit.ActorAssistant {
+		t.Errorf("empty-scope row actor_type = %q, want %q", scopeRow.actorType, audit.ActorAssistant)
+	}
+	if scopeRow.targetID != mcp.ToolListSites {
+		t.Errorf("empty-scope row target_id = %q, want %q", scopeRow.targetID, mcp.ToolListSites)
+	}
+	if r, _ := scopeRow.metadata["refusal_reason"].(string); r != "site_scope_empty" {
+		t.Errorf("empty-scope row metadata.refusal_reason = %q, want %q", r, "site_scope_empty")
+	}
+	if n, ok := scopeRow.metadata["scoped_sites"].(float64); !ok || n != 0 {
+		t.Errorf("empty-scope row metadata.scoped_sites = %v, want 0 -- the number that MAKES it a refusal",
+			scopeRow.metadata["scoped_sites"])
+	}
+	t.Logf("REFUSAL 2 ok: mcp.tool.denied reason=site_scope_empty scoped_sites=0 actor=assistant/%s", emptyGrantID)
+
+	// ------------------------------------------------------------------
+	// REFUSAL 3: a protocol revision below the floor, on the header.
+	// ------------------------------------------------------------------
+	const belowFloor = "2024-11-05"
+	got = mcpRefusalRPC(t, transportEng, wideToken, belowFloor, map[string]any{
+		"jsonrpc": "2.0", "id": 3, "method": "tools/list",
+	})
+	if got.status != http.StatusBadRequest {
+		t.Fatalf("below-floor revision answered HTTP %d, want 400: %s", got.status, got.body)
+	}
+
+	proto := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPProtocolDenied)
+	if len(proto) != 1 {
+		t.Fatalf("mcp.protocol.denied rows = %d, want exactly 1", len(proto))
+	}
+	if proto[0].actorType != audit.ActorAssistant {
+		t.Errorf("mcp.protocol.denied actor_type = %q, want %q", proto[0].actorType, audit.ActorAssistant)
+	}
+	if proto[0].actorID != wideGrantID {
+		t.Errorf("mcp.protocol.denied actor_id = %q, want the grant id %q", proto[0].actorID, wideGrantID)
+	}
+	if proto[0].targetID != belowFloor {
+		t.Errorf("mcp.protocol.denied target_id = %q, want the revision asked for, %q", proto[0].targetID, belowFloor)
+	}
+	if r, _ := proto[0].metadata["refusal_reason"].(string); r != "below_floor" {
+		t.Errorf("mcp.protocol.denied metadata.refusal_reason = %q, want %q", r, "below_floor")
+	}
+	if p, _ := proto[0].metadata["phase"].(string); p != "header" {
+		t.Errorf("mcp.protocol.denied metadata.phase = %q, want %q", p, "header")
+	}
+	if f, _ := proto[0].metadata["floor"].(string); f != mcp.ProtocolFloor {
+		t.Errorf("mcp.protocol.denied metadata.floor = %q, want %q", f, mcp.ProtocolFloor)
+	}
+	t.Logf("REFUSAL 3 ok: mcp.protocol.denied reason=below_floor phase=header requested=%s", belowFloor)
+
+	// ------------------------------------------------------------------
+	// REFUSAL 4: an unsupported revision in the initialize PARAMS, which is
+	// the other of the two negotiation sites and a different phase.
+	// ------------------------------------------------------------------
+	got = mcpRefusalRPC(t, transportEng, wideToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 4, "method": "initialize",
+		"params": map[string]any{"protocolVersion": "not-a-revision"},
+	})
+	if got.status != http.StatusBadRequest {
+		t.Fatalf("unparseable initialize revision answered HTTP %d, want 400: %s", got.status, got.body)
+	}
+	proto = queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPProtocolDenied)
+	if len(proto) != 2 {
+		t.Fatalf("after the initialize-params refusal, mcp.protocol.denied rows = %d, want 2", len(proto))
+	}
+	var paramRow *mcpAuditRow
+	for i := range proto {
+		if p, _ := proto[i].metadata["phase"].(string); p == "initialize_params" {
+			paramRow = &proto[i]
+		}
+	}
+	if paramRow == nil {
+		t.Fatalf("no mcp.protocol.denied row with phase=initialize_params; rows: %+v", proto)
+	}
+	if paramRow.targetID != "not-a-revision" {
+		t.Errorf("initialize-params row target_id = %q, want %q", paramRow.targetID, "not-a-revision")
+	}
+	if r, _ := paramRow.metadata["refusal_reason"].(string); r != "unsupported" {
+		t.Errorf("initialize-params row metadata.refusal_reason = %q, want %q", r, "unsupported")
+	}
+	t.Logf("REFUSAL 4 ok: mcp.protocol.denied reason=unsupported phase=initialize_params")
+
+	// ------------------------------------------------------------------
+	// OVER-FIRE CHECK: a SUCCESSFUL tool call must write mcp.tool.called and
+	// must NOT add an mcp.tool.denied row. A refusal recorder that fires on
+	// the success path would make every denial row meaningless, and the
+	// count assertions above would still pass.
+	// ------------------------------------------------------------------
+	deniedBefore := len(queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied))
+	got = mcpRefusalRPC(t, transportEng, wideToken, "", map[string]any{
+		"jsonrpc": "2.0", "id": 5, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	})
+	if got.status != http.StatusOK || strings.Contains(got.body, `"error"`) {
+		t.Fatalf("the success-path call did not succeed, so the over-fire check proves nothing: HTTP %d %s",
+			got.status, got.body)
+	}
+	called := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("mcp.tool.called rows = %d, want exactly 1", len(called))
+	}
+	if called[0].actorID != wideGrantID || called[0].targetID != mcp.ToolListSites {
+		t.Errorf("mcp.tool.called actor_id/target_id = %q/%q, want %q/%q",
+			called[0].actorID, called[0].targetID, wideGrantID, mcp.ToolListSites)
+	}
+	deniedAfter := len(queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied))
+	if deniedAfter != deniedBefore {
+		t.Fatalf("OVER-FIRE: a SUCCESSFUL tools/call added %d mcp.tool.denied row(s) (%d -> %d); "+
+			"the refusal recorder is firing on the success path",
+			deniedAfter-deniedBefore, deniedBefore, deniedAfter)
+	}
+	t.Logf("OVER-FIRE ok: a successful call wrote mcp.tool.called and left mcp.tool.denied at %d", deniedAfter)
+
+	// ------------------------------------------------------------------
+	// TENANT ISOLATION, on BOTH new actions. Same physical audit_log table.
+	// ------------------------------------------------------------------
+	otherTenant := seedTenant(t, pool, "mcp-refusal-other-"+suffix)
+	for _, action := range []string{audit.ActionMCPToolDenied, audit.ActionMCPProtocolDenied} {
+		cross := queryMCPAuditRowsAsAppRole(t, pool, otherTenant, action)
+		if len(cross) != 0 {
+			t.Fatalf("tenant %s's InTenantTx read %d %s row(s) belonging to tenant %s; "+
+				"RLS did not isolate the refusal record across tenants",
+				otherTenant, len(cross), action, tenantID)
+		}
+	}
+	t.Logf("ISOLATION ok: tenant %s sees none of tenant %s's refusal rows", otherTenant, tenantID)
+}

--- a/infra/nginx/routing_smoke_test.sh
+++ b/infra/nginx/routing_smoke_test.sh
@@ -310,6 +310,27 @@ assert_backend GET  /.well-known/oauth-protected-resource/mcp   "RFC 9728 path-i
 # nginx proxied the verb instead of serving index.html.
 assert_backend GET  /mcp                                        "MCP endpoint, GET (Go answers 405 'is deployed')"
 assert_backend OPTIONS /.well-known/oauth-protected-resource    "discovery CORS preflight"
+# The /mcp PREFLIGHT, which is the verb a browser-hosted client sends FIRST and
+# the one this suite was missing: the OPTIONS probe above covers a discovery
+# path, not the endpoint. Authorization, Content-Type: application/json and
+# MCP-Protocol-Version are all non-safelisted, so essentially every real MCP
+# request forces a preflight, and a browser that cannot get an answer to it
+# never sends the POST at all.
+#
+# Judged by BODY for the GH #589 reason, and the failure mode here is the same
+# one POST /mcp actually shipped with: no rule at the edge, the SPA answers 200
+# text/html, and nothing looks broken. It also catches nginx answering the
+# preflight ITSELF (an `if ($request_method = OPTIONS) return 204` added at the
+# edge would produce a 204 with no "backend " marker), which would strip the
+# Go handler's headers while still looking like a working preflight.
+#
+# NOTE ON SCOPE: this proves the preflight REACHES the Go handler. It cannot
+# assert the Access-Control-* values, because the stub upstream above is an
+# nginx `return`, not the API — it does not set them and never will. Those
+# headers are asserted by value against the real handler in the Gin-level tests
+# (apps/api/internal/mcp/transport_preflight_audit_test.go). The two together
+# cover the route: reachable here, correct there.
+assert_backend OPTIONS /mcp                                     "MCP endpoint, OPTIONS (browser CORS preflight)"
 
 echo
 echo "---- forwarded-header handling: a caller-supplied X-Forwarded-For must not survive ----"


### PR DESCRIPTION
Supersedes #628 and #629, which should be closed in favour of this branch.

Both PRs had one open review finding left, both in `apps/api/internal/mcp/transport.go`, which is why they are closed together here. This branch is `fix/mcp-cors-preflight` with `main`, then `worktree-agent-a26751e3fe6a84c7a`, merged in — no conflicts, the two changes touch different functions — plus the two fixes below.

## The preflight omitted routed verbs (#628's finding)

The CORS preflight advertised `POST, GET, DELETE` while `HEAD`, `PUT` and `PATCH` were *also* routed to the deliberately readable 405. A browser sending one of those three was blocked by its own preflight and never reached the refusal, so it surfaced an opaque network error instead of "this method is not supported here" — the exact confusion the 405-not-404 rule exists to prevent, one layer out, and invisible from the server side because nothing arrives.

The advertisement is no longer hand-maintained. The routing loop reads a package var and the preflight is derived from it:

```go
var corsAllowMethods = strings.Join(
	append([]string{http.MethodPost}, methodNotAllowedVerbs...), ", ")
```

A verb added to the routing is advertised by construction. The two lists can no longer disagree.

## The audit gap logged the wrong field (#629's finding)

`auditGap` was passed `phase` in its `reason` slot, so a failed protocol-refusal append logged `refusal_reason=header`, lost `below_floor` entirely, and recorded the phase nowhere. That line is the *entire* surviving record when the row cannot be written, so it was carrying the wrong half of the row it stands in for — an operator reading it back learns a refusal happened for a reason that is not a reason.

Reason and phase are now separate arguments under separate keys, and the reason comes from a new `Negotiation.RefusalReason()` that `RecordProtocolDenied` uses too, so the fallback and the durable row cannot describe different refusals. An empty phase is omitted rather than logged as `""`, so an alert keyed on the field never matches a blank.

To make the failure path reachable without a broken Postgres, `Service.audit` is now a two-method `auditRecorder` interface that `*audit.Recorder` already satisfies. `WithAudit` keeps its concrete parameter and gained an explicit nil check: a nil `*audit.Recorder` stored into an interface is a non-nil interface holding a nil pointer, which would have sailed past every `s.audit == nil` guard in the file and panicked on the first append instead of skipping it.

## Proof

Preflight assertions are **by value against the routed list**, never a written-out list of verbs — a hard-coded list in the test would reintroduce the drift the production change just removed. The converse is asserted too, so this cannot be "fixed" by advertising everything and earning back the bare 404.

Mutation sweep, each reverted the moment it went red:

| Mutation | Result |
|---|---|
| preflight back to hard-coded `POST, GET, DELETE` | both preflight tests red, naming HEAD, PUT, PATCH |
| unrouted `TRACE` advertised | converse test red |
| `phase` passed as the reason again | red as `refusal_reason="header"` / `"initialize_params"`, phase absent |
| phase field dropped | red |
| `below_floor` collapsed into `unsupported` | red |
| empty phase logged as a blank key | red |
| `methodNotAllowed` answering 200 | over-fire test red on every routed verb |

Over-fire is covered in both directions: every routed verb still answers 405 with its `Allow` header, and an unauthenticated POST is still 401 with the scheme named. Widening the advertisement buys the caller exactly one thing — the right to send a request that will be honestly refused.

`go build`, `go vet` and `go test ./internal/... ./cmd/...` clean; `make test-integration` green from the repo root, and the MCP integration tests re-run unpiped at exit 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit records for denied MCP tool calls and protocol negotiations, including refusal reasons and phases.
  * Added UTF-8-safe limits for untrusted target identifiers.
  * Added browser CORS preflight support for MCP requests and consistent method advertisements.
* **Bug Fixes**
  * Improved protocol refusal handling and fallback logging when audit writes fail.
  * Ensured browsers can read authentication and method-refusal responses.
  * Preserved correct rejection of unsupported methods and JSON-RPC batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->