### PR TITLE
feat(db): m130 per-tenant assistant enablement flag and kill switch

### DIFF
--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -566,6 +566,16 @@ SELECT
         AND COALESCE(g.last_used_at, g.created_at)
             + make_interval(days => g.idle_expire_after_days) <= now(),
         true)::boolean AS grant_idle_expired,
+    -- The two tenant-level reasons (m130), so a refusal names its own cause
+    -- instead of presenting as a mysterious auth error. No COALESCE is needed
+    -- or wanted on these three: IS NULL and IS NOT NULL never return NULL, and
+    -- the tenant row is always present because the join is an inner join on a
+    -- table with no RLS. The reason string is a diagnostic for the operator
+    -- console and MUST NOT be returned to the MCP client -- it is an internal
+    -- incident note, not a protocol-visible error message.
+    (tn.assistant_enabled_at IS NULL)::boolean  AS tenant_assistant_disabled,
+    (tn.assistant_paused_at IS NOT NULL)::boolean AS tenant_assistant_paused,
+    tn.assistant_paused_reason                  AS tenant_assistant_paused_reason,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
@@ -593,11 +603,32 @@ SELECT
         -- NULL: an actively used connection must never idle-expire.
         AND (g.idle_expire_after_days IS NULL
              OR COALESCE(g.last_used_at, g.created_at)
-                + make_interval(days => g.idle_expire_after_days) > now()),
+                + make_interval(days => g.idle_expire_after_days) > now())
+        -- TENANT ENABLEMENT (m130 DECISION 4). NULL means the organisation has
+        -- never turned the assistant on, which is OFF. This is the restrictive
+        -- direction of NULL and it is the OPPOSITE of the line below it -- the
+        -- two tenant columns are not symmetric and must not be folded into one
+        -- helper. Existing tenants were backfilled by m130 step (1), so no live
+        -- connection changed behaviour when that file applied.
+        AND tn.assistant_enabled_at IS NOT NULL
+        -- THE KILL SWITCH (m130 DECISION 3). NULL means not paused, which is
+        -- RUNNING -- the permissive direction, and the reason every existing
+        -- row keeps working untouched. Because this verdict is recomputed on
+        -- EVERY REQUEST, engaging the switch refuses the very next request on
+        -- an already-issued, otherwise perfectly valid connection. That is the
+        -- requirement: a switch that only blocks new grants while existing
+        -- tokens keep reading is not a kill switch. Do not cache this.
+        AND tn.assistant_paused_at IS NULL,
         false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id
+-- INNER JOIN, and it is safe as an inner join ONLY because tenants has no RLS
+-- (m130 DECISION 1/3). No policy can filter this row away, the foreign key on
+-- t.tenant_id guarantees it exists, and t.tenant_id is already a bound
+-- parameter, so this is a primary-key probe and costs no extra round trip.
+JOIN tenants tn
+    ON tn.id = t.tenant_id
 WHERE t.tenant_id = $1 AND t.id = $2;
 
 -- name: ListMCPConnectionTokensForGrant :many

--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -604,13 +604,18 @@ SELECT
         AND (g.idle_expire_after_days IS NULL
              OR COALESCE(g.last_used_at, g.created_at)
                 + make_interval(days => g.idle_expire_after_days) > now())
-        -- TENANT ENABLEMENT (m130 DECISION 4). NULL means the organisation has
-        -- never turned the assistant on, which is OFF. This is the restrictive
-        -- direction of NULL and it is the OPPOSITE of the line below it -- the
-        -- two tenant columns are not symmetric and must not be folded into one
-        -- helper. Existing tenants were backfilled by m130 step (1), so no live
-        -- connection changed behaviour when that file applied.
-        AND tn.assistant_enabled_at IS NOT NULL
+        -- TENANT ENABLEMENT IS DELIBERATELY *NOT* IN THIS PREDICATE YET, AND
+        -- THE OMISSION IS LOAD-BEARING. See m130 DECISION 5. Adding
+        -- `AND tn.assistant_enabled_at IS NOT NULL` here is a ONE-LINE CHANGE
+        -- THAT MUST NOT BE MADE UNTIL A GO PATH WRITES THAT COLUMN: a tenant
+        -- created after m130 applied has it NULL, so the line refuses every
+        -- connection that tenant will ever make. That was executed, not
+        -- reasoned about -- it refused a live bearer in
+        -- TestMCPActivityStampLandsAsAppRole with
+        -- "this connection has been revoked or has expired". The column is
+        -- inert by construction until the enable control exists, which is the
+        -- m127 DECISION 4 shape.
+        --
         -- THE KILL SWITCH (m130 DECISION 3). NULL means not paused, which is
         -- RUNNING -- the permissive direction, and the reason every existing
         -- row keeps working untouched. Because this verdict is recomputed on

--- a/apps/api/db/query/tenants.sql
+++ b/apps/api/db/query/tenants.sql
@@ -112,3 +112,110 @@ WHERE id = @tenant_id AND deleted_at IS NOT NULL AND purge_started_at IS NULL;
 -- on an org an owner already confirmed deleting.
 -- name: AdminPurgeTenant :one
 SELECT admin_purge_tenant(@tenant_id) AS purged;
+
+-- ===========================================================================
+-- M130 — the assistant / MCP surface's per-tenant enablement flag and kill
+-- switch. Four statements, deliberately NOT two: enabling and pausing are
+-- different facts with different lifecycles (m130 DECISION 2), so releasing
+-- the kill switch after an incident cannot accidentally enable a surface an
+-- owner had deliberately turned off.
+--
+-- ENFORCEMENT DOES NOT LIVE HERE. All four of these are WRITE paths for the
+-- operator console. The read that matters runs on every request inside
+-- ReCheckMCPRequestAuthorizationInTenantTx, which joins tenants and folds both
+-- columns into the single `authorized` verdict. Do not add a second read of
+-- these columns on the request path and do not cache them: a cached kill
+-- switch is not a kill switch.
+-- ===========================================================================
+
+-- GetTenantAssistantState is the operator console's read. NOT the request
+-- path — the request path reads these columns through the verdict, never here.
+-- :one and no RLS on tenants, so the tenant_id filter in the WHERE clause is
+-- the ONLY thing scoping this row; a caller that drops it reads another
+-- organisation's state.
+-- name: GetTenantAssistantState :one
+SELECT id,
+       assistant_enabled_at,
+       assistant_paused_at,
+       assistant_paused_reason
+FROM tenants
+WHERE id = @tenant_id AND deleted_at IS NULL;
+
+-- EnableTenantAssistant turns the surface on for an organisation. This is a
+-- CONFIGURATION change, made in daylight by an owner, and it is not the kill
+-- switch's inverse — it deliberately does NOT touch assistant_paused_at, so
+-- enabling a paused organisation leaves it paused and the operator must
+-- release the switch as a separate, visible act.
+--
+-- assistant_enabled_at IS NULL in the WHERE clause makes this idempotent and
+-- preserves the ORIGINAL enablement timestamp: re-enabling an already-enabled
+-- org affects 0 rows rather than rewriting when the decision was made.
+-- :execrows so the caller can tell "already enabled" from "no such tenant".
+-- name: EnableTenantAssistant :execrows
+UPDATE tenants
+SET assistant_enabled_at = now(),
+    updated_at = now()
+WHERE id = @tenant_id
+  AND deleted_at IS NULL
+  AND assistant_enabled_at IS NULL;
+
+-- DisableTenantAssistant turns the surface off. Also a configuration change.
+-- It is NOT the kill switch and must not be offered as one in the UI: it is
+-- the durable "this organisation does not use the assistant" decision, whereas
+-- the kill switch is the incident action. Both refuse requests through the
+-- same verdict, so the effect on traffic is immediate either way; the
+-- difference is what the record says afterwards and what the release action
+-- restores.
+--
+-- Grants are left untouched on purpose (m130 DECISION 4c): disabling must not
+-- destroy the connection history that documents what the surface did, and an
+-- owner re-enabling later must get their connections back unchanged.
+-- name: DisableTenantAssistant :execrows
+UPDATE tenants
+SET assistant_enabled_at = NULL,
+    updated_at = now()
+WHERE id = @tenant_id
+  AND deleted_at IS NULL
+  AND assistant_enabled_at IS NOT NULL;
+
+-- EngageTenantAssistantKillSwitch is the 3am control. ONE UPDATE, ONE ROW, no
+-- INSERT and no row that has to exist first — that is what makes a one-click
+-- control possible and is a reason the state lives on tenants (m130 DECISION
+-- 1c). Every in-flight connection for this organisation is refused on its NEXT
+-- request, because the verdict is recomputed per request.
+--
+-- No assistant_paused_at IS NULL guard: re-engaging an already-paused
+-- organisation refreshes the timestamp and the reason, which is what an
+-- operator escalating an ongoing incident wants. Idempotent in effect.
+--
+-- The reason is required to be present and non-blank by
+-- tenants_assistant_paused_reason_check when it is not NULL; pass NULL for
+-- "no reason given" rather than a string of zero length, which the constraint
+-- refuses.
+-- name: EngageTenantAssistantKillSwitch :execrows
+UPDATE tenants
+SET assistant_paused_at = now(),
+    assistant_paused_reason = @reason,
+    updated_at = now()
+WHERE id = @tenant_id AND deleted_at IS NULL;
+
+-- ReleaseTenantAssistantKillSwitch clears the pause after an incident.
+--
+-- IT CLEARS THE REASON IN THE SAME STATEMENT, and it must: the reason is part
+-- of the pause, tenants_assistant_paused_reason_check refuses a reason without
+-- a pause, and clearing only assistant_paused_at would violate that constraint
+-- and fail — loudly, which is the correct direction, but the caller should
+-- never have to discover it.
+--
+-- IT DOES NOT TOUCH assistant_enabled_at. That is the whole point of two
+-- columns (m130 DECISION 2): an organisation that was deliberately off before
+-- the incident is still off after it, and releasing the switch never enables
+-- a surface nobody chose to enable.
+-- name: ReleaseTenantAssistantKillSwitch :execrows
+UPDATE tenants
+SET assistant_paused_at = NULL,
+    assistant_paused_reason = NULL,
+    updated_at = now()
+WHERE id = @tenant_id
+  AND deleted_at IS NULL
+  AND assistant_paused_at IS NOT NULL;

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -179,6 +179,26 @@ CREATE TABLE tenants (
     cancel_at_period_end     boolean     NOT NULL DEFAULT false,
     deleted_at               timestamptz,
     purge_started_at         timestamptz,
+    -- M130 — the assistant / MCP surface's per-tenant enablement flag and kill
+    -- switch. Two columns, not one tri-state, because releasing the kill
+    -- switch after an incident must not enable a surface that was deliberately
+    -- off. NULL means a DIFFERENT thing on each: assistant_enabled_at IS NULL
+    -- means never enabled (off), assistant_paused_at IS NULL means not paused
+    -- (running). Both join the `authorized` verdict in
+    -- ReCheckMCPRequestAuthorizationInTenantTx, so the switch stops in-flight
+    -- requests on the next request rather than only blocking new grants.
+    --
+    -- These live on tenants, and NOT in a settings table, because tenants has
+    -- no RLS: a kill switch read on the authentication path from behind a
+    -- policy can be filtered to NULL and read as "not paused", which is an
+    -- inert kill switch. See m130 DECISION 1.
+    assistant_enabled_at     timestamptz,
+    assistant_paused_at      timestamptz,
+    assistant_paused_reason  text
+        CHECK (assistant_paused_reason IS NULL
+               OR (assistant_paused_at IS NOT NULL
+                   AND length(btrim(assistant_paused_reason)) > 0
+                   AND length(assistant_paused_reason) <= 500)),
     created_at               timestamptz NOT NULL DEFAULT now(),
     updated_at               timestamptz NOT NULL DEFAULT now()
 );

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -184,9 +184,14 @@ CREATE TABLE tenants (
     -- switch after an incident must not enable a surface that was deliberately
     -- off. NULL means a DIFFERENT thing on each: assistant_enabled_at IS NULL
     -- means never enabled (off), assistant_paused_at IS NULL means not paused
-    -- (running). Both join the `authorized` verdict in
-    -- ReCheckMCPRequestAuthorizationInTenantTx, so the switch stops in-flight
-    -- requests on the next request rather than only blocking new grants.
+    -- (running).
+    --
+    -- ONLY assistant_paused_at IS IN THE `authorized` VERDICT in
+    -- ReCheckMCPRequestAuthorizationInTenantTx, so the kill switch stops
+    -- in-flight requests on the next request rather than only blocking new
+    -- grants. assistant_enabled_at is NOT in the verdict and nothing reads it
+    -- yet: a tenant created after m130 has it NULL, so gating on it would
+    -- refuse every new signup. See m130 DECISION 5 before wiring it.
     --
     -- These live on tenants, and NOT in a settings table, because tenants has
     -- no RLS: a kill switch read on the authentication path from behind a

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -672,6 +672,16 @@ SELECT
         AND COALESCE(g.last_used_at, g.created_at)
             + make_interval(days => g.idle_expire_after_days) <= now(),
         true)::boolean AS grant_idle_expired,
+    -- The two tenant-level reasons (m130), so a refusal names its own cause
+    -- instead of presenting as a mysterious auth error. No COALESCE is needed
+    -- or wanted on these three: IS NULL and IS NOT NULL never return NULL, and
+    -- the tenant row is always present because the join is an inner join on a
+    -- table with no RLS. The reason string is a diagnostic for the operator
+    -- console and MUST NOT be returned to the MCP client -- it is an internal
+    -- incident note, not a protocol-visible error message.
+    (tn.assistant_enabled_at IS NULL)::boolean  AS tenant_assistant_disabled,
+    (tn.assistant_paused_at IS NOT NULL)::boolean AS tenant_assistant_paused,
+    tn.assistant_paused_reason                  AS tenant_assistant_paused_reason,
     -- COALESCE(..., false)::boolean so this generates as a plain bool and not
     -- a *bool. This is the single column the whole MCP request
     -- boundary turns on; handing it back as a pointer with an absent case is
@@ -699,11 +709,28 @@ SELECT
         -- NULL: an actively used connection must never idle-expire.
         AND (g.idle_expire_after_days IS NULL
              OR COALESCE(g.last_used_at, g.created_at)
-                + make_interval(days => g.idle_expire_after_days) > now()),
+                + make_interval(days => g.idle_expire_after_days) > now())
+        -- TENANT ENABLEMENT (m130 DECISION 4). NULL means the organisation has
+        -- never turned the assistant on, which is OFF. This is the restrictive
+        -- direction of NULL and it is the OPPOSITE of the line below it -- the
+        -- two tenant columns are not symmetric and must not be folded into one
+        -- helper. Existing tenants were backfilled by m130 step (1), so no live
+        -- connection changed behaviour when that file applied.
+        AND tn.assistant_enabled_at IS NOT NULL
+        -- THE KILL SWITCH (m130 DECISION 3). NULL means not paused, which is
+        -- RUNNING -- the permissive direction, and the reason every existing
+        -- row keeps working untouched. Because this verdict is recomputed on
+        -- EVERY REQUEST, engaging the switch refuses the very next request on
+        -- an already-issued, otherwise perfectly valid connection. That is the
+        -- requirement: a switch that only blocks new grants while existing
+        -- tokens keep reading is not a kill switch. Do not cache this.
+        AND tn.assistant_paused_at IS NULL,
         false)::boolean AS authorized
 FROM mcp_connection_tokens t
 JOIN mcp_grants g
     ON g.id = t.grant_id AND g.tenant_id = t.tenant_id
+JOIN tenants tn
+    ON tn.id = t.tenant_id
 WHERE t.tenant_id = $1 AND t.id = $2
 `
 
@@ -713,24 +740,27 @@ type ReCheckMCPRequestAuthorizationInTenantTxParams struct {
 }
 
 type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
-	GrantID                  uuid.UUID          `json:"grant_id"`
-	GrantName                string             `json:"grant_name"`
-	GrantStatus              string             `json:"grant_status"`
-	SiteScopeMode            string             `json:"site_scope_mode"`
-	ScopeTagIds              []uuid.UUID        `json:"scope_tag_ids"`
-	ScopeSiteIds             []uuid.UUID        `json:"scope_site_ids"`
-	ClientID                 *string            `json:"client_id"`
-	GrantCapabilities        []string           `json:"grant_capabilities"`
-	GrantExpiresAt           time.Time          `json:"grant_expires_at"`
-	GrantIdleExpireAfterDays *int32             `json:"grant_idle_expire_after_days"`
-	GrantLastUsedAt          pgtype.Timestamptz `json:"grant_last_used_at"`
-	TokenID                  uuid.UUID          `json:"token_id"`
-	TokenPrefix              string             `json:"token_prefix"`
-	TokenStatus              string             `json:"token_status"`
-	TokenExpiresAt           pgtype.Timestamptz `json:"token_expires_at"`
-	GrantAbsoluteExpired     bool               `json:"grant_absolute_expired"`
-	GrantIdleExpired         bool               `json:"grant_idle_expired"`
-	Authorized               bool               `json:"authorized"`
+	GrantID                     uuid.UUID          `json:"grant_id"`
+	GrantName                   string             `json:"grant_name"`
+	GrantStatus                 string             `json:"grant_status"`
+	SiteScopeMode               string             `json:"site_scope_mode"`
+	ScopeTagIds                 []uuid.UUID        `json:"scope_tag_ids"`
+	ScopeSiteIds                []uuid.UUID        `json:"scope_site_ids"`
+	ClientID                    *string            `json:"client_id"`
+	GrantCapabilities           []string           `json:"grant_capabilities"`
+	GrantExpiresAt              time.Time          `json:"grant_expires_at"`
+	GrantIdleExpireAfterDays    *int32             `json:"grant_idle_expire_after_days"`
+	GrantLastUsedAt             pgtype.Timestamptz `json:"grant_last_used_at"`
+	TokenID                     uuid.UUID          `json:"token_id"`
+	TokenPrefix                 string             `json:"token_prefix"`
+	TokenStatus                 string             `json:"token_status"`
+	TokenExpiresAt              pgtype.Timestamptz `json:"token_expires_at"`
+	GrantAbsoluteExpired        bool               `json:"grant_absolute_expired"`
+	GrantIdleExpired            bool               `json:"grant_idle_expired"`
+	TenantAssistantDisabled     bool               `json:"tenant_assistant_disabled"`
+	TenantAssistantPaused       bool               `json:"tenant_assistant_paused"`
+	TenantAssistantPausedReason *string            `json:"tenant_assistant_paused_reason"`
+	Authorized                  bool               `json:"authorized"`
 }
 
 // Runs InTenantTx with the tenant the lookup above established. STEP 2 OF 2,
@@ -768,6 +798,10 @@ type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
 // and the SAME transaction as the verdict it was authorized under (S7's exit
 // gate: discovery never grants what the registry does not hold, and it cannot
 // hold what this row does not carry).
+// INNER JOIN, and it is safe as an inner join ONLY because tenants has no RLS
+// (m130 DECISION 1/3). No policy can filter this row away, the foreign key on
+// t.tenant_id guarantees it exists, and t.tenant_id is already a bound
+// parameter, so this is a primary-key probe and costs no extra round trip.
 func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error) {
 	row := q.db.QueryRow(ctx, reCheckMCPRequestAuthorizationInTenantTx, arg.TenantID, arg.ID)
 	var i ReCheckMCPRequestAuthorizationInTenantTxRow
@@ -789,6 +823,9 @@ func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, 
 		&i.TokenExpiresAt,
 		&i.GrantAbsoluteExpired,
 		&i.GrantIdleExpired,
+		&i.TenantAssistantDisabled,
+		&i.TenantAssistantPaused,
+		&i.TenantAssistantPausedReason,
 		&i.Authorized,
 	)
 	return i, err

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -710,13 +710,18 @@ SELECT
         AND (g.idle_expire_after_days IS NULL
              OR COALESCE(g.last_used_at, g.created_at)
                 + make_interval(days => g.idle_expire_after_days) > now())
-        -- TENANT ENABLEMENT (m130 DECISION 4). NULL means the organisation has
-        -- never turned the assistant on, which is OFF. This is the restrictive
-        -- direction of NULL and it is the OPPOSITE of the line below it -- the
-        -- two tenant columns are not symmetric and must not be folded into one
-        -- helper. Existing tenants were backfilled by m130 step (1), so no live
-        -- connection changed behaviour when that file applied.
-        AND tn.assistant_enabled_at IS NOT NULL
+        -- TENANT ENABLEMENT IS DELIBERATELY *NOT* IN THIS PREDICATE YET, AND
+        -- THE OMISSION IS LOAD-BEARING. See m130 DECISION 5. Adding
+        -- ` + "`" + `AND tn.assistant_enabled_at IS NOT NULL` + "`" + ` here is a ONE-LINE CHANGE
+        -- THAT MUST NOT BE MADE UNTIL A GO PATH WRITES THAT COLUMN: a tenant
+        -- created after m130 applied has it NULL, so the line refuses every
+        -- connection that tenant will ever make. That was executed, not
+        -- reasoned about -- it refused a live bearer in
+        -- TestMCPActivityStampLandsAsAppRole with
+        -- "this connection has been revoked or has expired". The column is
+        -- inert by construction until the enable control exists, which is the
+        -- m127 DECISION 4 shape.
+        --
         -- THE KILL SWITCH (m130 DECISION 3). NULL means not paused, which is
         -- RUNNING -- the permissive direction, and the reason every existing
         -- row keeps working untouched. Because this verdict is recomputed on

--- a/apps/api/internal/db/sqlc/models.go
+++ b/apps/api/internal/db/sqlc/models.go
@@ -1276,6 +1276,9 @@ type Tenant struct {
 	CancelAtPeriodEnd      bool               `json:"cancel_at_period_end"`
 	DeletedAt              pgtype.Timestamptz `json:"deleted_at"`
 	PurgeStartedAt         pgtype.Timestamptz `json:"purge_started_at"`
+	AssistantEnabledAt     pgtype.Timestamptz `json:"assistant_enabled_at"`
+	AssistantPausedAt      pgtype.Timestamptz `json:"assistant_paused_at"`
+	AssistantPausedReason  *string            `json:"assistant_paused_reason"`
 	CreatedAt              time.Time          `json:"created_at"`
 	UpdatedAt              time.Time          `json:"updated_at"`
 }

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -849,6 +849,44 @@ type Querier interface {
 	DeleteWebAuthnCredential(ctx context.Context, arg DeleteWebAuthnCredentialParams) (int64, error)
 	// Remove the registration session after FinishRegistration (or on failure).
 	DeleteWebAuthnRegistrationSession(ctx context.Context, id uuid.UUID) error
+	// DisableTenantAssistant turns the surface off. Also a configuration change.
+	// It is NOT the kill switch and must not be offered as one in the UI: it is
+	// the durable "this organisation does not use the assistant" decision, whereas
+	// the kill switch is the incident action. Both refuse requests through the
+	// same verdict, so the effect on traffic is immediate either way; the
+	// difference is what the record says afterwards and what the release action
+	// restores.
+	//
+	// Grants are left untouched on purpose (m130 DECISION 4c): disabling must not
+	// destroy the connection history that documents what the surface did, and an
+	// owner re-enabling later must get their connections back unchanged.
+	DisableTenantAssistant(ctx context.Context, tenantID uuid.UUID) (int64, error)
+	// EnableTenantAssistant turns the surface on for an organisation. This is a
+	// CONFIGURATION change, made in daylight by an owner, and it is not the kill
+	// switch's inverse — it deliberately does NOT touch assistant_paused_at, so
+	// enabling a paused organisation leaves it paused and the operator must
+	// release the switch as a separate, visible act.
+	//
+	// assistant_enabled_at IS NULL in the WHERE clause makes this idempotent and
+	// preserves the ORIGINAL enablement timestamp: re-enabling an already-enabled
+	// org affects 0 rows rather than rewriting when the decision was made.
+	// :execrows so the caller can tell "already enabled" from "no such tenant".
+	EnableTenantAssistant(ctx context.Context, tenantID uuid.UUID) (int64, error)
+	// EngageTenantAssistantKillSwitch is the 3am control. ONE UPDATE, ONE ROW, no
+	// INSERT and no row that has to exist first — that is what makes a one-click
+	// control possible and is a reason the state lives on tenants (m130 DECISION
+	// 1c). Every in-flight connection for this organisation is refused on its NEXT
+	// request, because the verdict is recomputed per request.
+	//
+	// No assistant_paused_at IS NULL guard: re-engaging an already-paused
+	// organisation refreshes the timestamp and the reason, which is what an
+	// operator escalating an ongoing incident wants. Idempotent in effect.
+	//
+	// The reason is required to be present and non-blank by
+	// tenants_assistant_paused_reason_check when it is not NULL; pass NULL for
+	// "no reason given" rather than a string of zero length, which the constraint
+	// refuses.
+	EngageTenantAssistantKillSwitch(ctx context.Context, arg EngageTenantAssistantKillSwitchParams) (int64, error)
 	// site_object_reclaim (m113 / GH #402): the durable record of object-storage
 	// work that outlives a site delete.
 	//
@@ -1717,6 +1755,26 @@ type Querier interface {
 	// of sites the operator asked to hear about, so a "3/8 -> 1/6" step reads
 	// correctly to a human even though no site's health moved.
 	GetTenantAppAlertRatio(ctx context.Context, tenantID uuid.UUID) (GetTenantAppAlertRatioRow, error)
+	// ===========================================================================
+	// M130 — the assistant / MCP surface's per-tenant enablement flag and kill
+	// switch. Four statements, deliberately NOT two: enabling and pausing are
+	// different facts with different lifecycles (m130 DECISION 2), so releasing
+	// the kill switch after an incident cannot accidentally enable a surface an
+	// owner had deliberately turned off.
+	//
+	// ENFORCEMENT DOES NOT LIVE HERE. All four of these are WRITE paths for the
+	// operator console. The read that matters runs on every request inside
+	// ReCheckMCPRequestAuthorizationInTenantTx, which joins tenants and folds both
+	// columns into the single `authorized` verdict. Do not add a second read of
+	// these columns on the request path and do not cache them: a cached kill
+	// switch is not a kill switch.
+	// ===========================================================================
+	// GetTenantAssistantState is the operator console's read. NOT the request
+	// path — the request path reads these columns through the verdict, never here.
+	// :one and no RLS on tenants, so the tenant_id filter in the WHERE clause is
+	// the ONLY thing scoping this row; a caller that drops it reads another
+	// organisation's state.
+	GetTenantAssistantState(ctx context.Context, tenantID uuid.UUID) (GetTenantAssistantStateRow, error)
 	// Returns the M16 Phase A billing/plan fields used by internal/billing's
 	// entitlement resolution. tenants carries no RLS (see schema.sql); every
 	// caller already holds a tenant_id it is entitled to query — either the
@@ -3123,6 +3181,10 @@ type Querier interface {
 	// and the SAME transaction as the verdict it was authorized under (S7's exit
 	// gate: discovery never grants what the registry does not hold, and it cannot
 	// hold what this row does not carry).
+	// INNER JOIN, and it is safe as an inner join ONLY because tenants has no RLS
+	// (m130 DECISION 1/3). No policy can filter this row away, the foreign key on
+	// t.tenant_id guarantees it exists, and t.tenant_id is already a bound
+	// parameter, so this is a primary-key probe and costs no extra round trip.
 	ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, arg ReCheckMCPRequestAuthorizationInTenantTxParams) (ReCheckMCPRequestAuthorizationInTenantTxRow, error)
 	RecolorTag(ctx context.Context, arg RecolorTagParams) (SiteTag, error)
 	// Runs InTenantTx. Decision 10: there are TWO distinguishable absences in the
@@ -3272,6 +3334,19 @@ type Querier interface {
 	// carrying a secret and a confidential client without one both fail here with
 	// 23514 rather than reaching a Go comparison against NULL (Decision 11).
 	RegisterMCPOAuthClient(ctx context.Context, arg RegisterMCPOAuthClientParams) (int64, error)
+	// ReleaseTenantAssistantKillSwitch clears the pause after an incident.
+	//
+	// IT CLEARS THE REASON IN THE SAME STATEMENT, and it must: the reason is part
+	// of the pause, tenants_assistant_paused_reason_check refuses a reason without
+	// a pause, and clearing only assistant_paused_at would violate that constraint
+	// and fail — loudly, which is the correct direction, but the caller should
+	// never have to discover it.
+	//
+	// IT DOES NOT TOUCH assistant_enabled_at. That is the whole point of two
+	// columns (m130 DECISION 2): an organisation that was deliberately off before
+	// the incident is still off after it, and releasing the switch never enables
+	// a surface nobody chose to enable.
+	ReleaseTenantAssistantKillSwitch(ctx context.Context, tenantID uuid.UUID) (int64, error)
 	RemovePairingCodeTagName(ctx context.Context, arg RemovePairingCodeTagNameParams) error
 	RemoveSiteTagName(ctx context.Context, arg RemoveSiteTagNameParams) error
 	// May fail with unique_violation (23505) when @name collides with another

--- a/apps/api/internal/db/sqlc/tenants.sql.go
+++ b/apps/api/internal/db/sqlc/tenants.sql.go
@@ -32,7 +32,7 @@ func (q *Queries) AdminPurgeTenant(ctx context.Context, tenantID uuid.UUID) (boo
 const createTenant = `-- name: CreateTenant :one
 INSERT INTO tenants (name, slug)
 VALUES ($1, $2)
-RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, created_at, updated_at
+RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, assistant_enabled_at, assistant_paused_at, assistant_paused_reason, created_at, updated_at
 `
 
 type CreateTenantParams struct {
@@ -61,14 +61,107 @@ func (q *Queries) CreateTenant(ctx context.Context, arg CreateTenantParams) (Ten
 		&i.CancelAtPeriodEnd,
 		&i.DeletedAt,
 		&i.PurgeStartedAt,
+		&i.AssistantEnabledAt,
+		&i.AssistantPausedAt,
+		&i.AssistantPausedReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
 	return i, err
 }
 
+const disableTenantAssistant = `-- name: DisableTenantAssistant :execrows
+UPDATE tenants
+SET assistant_enabled_at = NULL,
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+  AND assistant_enabled_at IS NOT NULL
+`
+
+// DisableTenantAssistant turns the surface off. Also a configuration change.
+// It is NOT the kill switch and must not be offered as one in the UI: it is
+// the durable "this organisation does not use the assistant" decision, whereas
+// the kill switch is the incident action. Both refuse requests through the
+// same verdict, so the effect on traffic is immediate either way; the
+// difference is what the record says afterwards and what the release action
+// restores.
+//
+// Grants are left untouched on purpose (m130 DECISION 4c): disabling must not
+// destroy the connection history that documents what the surface did, and an
+// owner re-enabling later must get their connections back unchanged.
+func (q *Queries) DisableTenantAssistant(ctx context.Context, tenantID uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, disableTenantAssistant, tenantID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const enableTenantAssistant = `-- name: EnableTenantAssistant :execrows
+UPDATE tenants
+SET assistant_enabled_at = now(),
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+  AND assistant_enabled_at IS NULL
+`
+
+// EnableTenantAssistant turns the surface on for an organisation. This is a
+// CONFIGURATION change, made in daylight by an owner, and it is not the kill
+// switch's inverse — it deliberately does NOT touch assistant_paused_at, so
+// enabling a paused organisation leaves it paused and the operator must
+// release the switch as a separate, visible act.
+//
+// assistant_enabled_at IS NULL in the WHERE clause makes this idempotent and
+// preserves the ORIGINAL enablement timestamp: re-enabling an already-enabled
+// org affects 0 rows rather than rewriting when the decision was made.
+// :execrows so the caller can tell "already enabled" from "no such tenant".
+func (q *Queries) EnableTenantAssistant(ctx context.Context, tenantID uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, enableTenantAssistant, tenantID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const engageTenantAssistantKillSwitch = `-- name: EngageTenantAssistantKillSwitch :execrows
+UPDATE tenants
+SET assistant_paused_at = now(),
+    assistant_paused_reason = $1,
+    updated_at = now()
+WHERE id = $2 AND deleted_at IS NULL
+`
+
+type EngageTenantAssistantKillSwitchParams struct {
+	Reason   *string   `json:"reason"`
+	TenantID uuid.UUID `json:"tenant_id"`
+}
+
+// EngageTenantAssistantKillSwitch is the 3am control. ONE UPDATE, ONE ROW, no
+// INSERT and no row that has to exist first — that is what makes a one-click
+// control possible and is a reason the state lives on tenants (m130 DECISION
+// 1c). Every in-flight connection for this organisation is refused on its NEXT
+// request, because the verdict is recomputed per request.
+//
+// No assistant_paused_at IS NULL guard: re-engaging an already-paused
+// organisation refreshes the timestamp and the reason, which is what an
+// operator escalating an ongoing incident wants. Idempotent in effect.
+//
+// The reason is required to be present and non-blank by
+// tenants_assistant_paused_reason_check when it is not NULL; pass NULL for
+// "no reason given" rather than a string of zero length, which the constraint
+// refuses.
+func (q *Queries) EngageTenantAssistantKillSwitch(ctx context.Context, arg EngageTenantAssistantKillSwitchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, engageTenantAssistantKillSwitch, arg.Reason, arg.TenantID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getTenant = `-- name: GetTenant :one
-SELECT id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, created_at, updated_at FROM tenants
+SELECT id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, assistant_enabled_at, assistant_paused_at, assistant_paused_reason, created_at, updated_at FROM tenants
 WHERE id = $1
 `
 
@@ -93,8 +186,59 @@ func (q *Queries) GetTenant(ctx context.Context, id uuid.UUID) (Tenant, error) {
 		&i.CancelAtPeriodEnd,
 		&i.DeletedAt,
 		&i.PurgeStartedAt,
+		&i.AssistantEnabledAt,
+		&i.AssistantPausedAt,
+		&i.AssistantPausedReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getTenantAssistantState = `-- name: GetTenantAssistantState :one
+
+SELECT id,
+       assistant_enabled_at,
+       assistant_paused_at,
+       assistant_paused_reason
+FROM tenants
+WHERE id = $1 AND deleted_at IS NULL
+`
+
+type GetTenantAssistantStateRow struct {
+	ID                    uuid.UUID          `json:"id"`
+	AssistantEnabledAt    pgtype.Timestamptz `json:"assistant_enabled_at"`
+	AssistantPausedAt     pgtype.Timestamptz `json:"assistant_paused_at"`
+	AssistantPausedReason *string            `json:"assistant_paused_reason"`
+}
+
+// ===========================================================================
+// M130 — the assistant / MCP surface's per-tenant enablement flag and kill
+// switch. Four statements, deliberately NOT two: enabling and pausing are
+// different facts with different lifecycles (m130 DECISION 2), so releasing
+// the kill switch after an incident cannot accidentally enable a surface an
+// owner had deliberately turned off.
+//
+// ENFORCEMENT DOES NOT LIVE HERE. All four of these are WRITE paths for the
+// operator console. The read that matters runs on every request inside
+// ReCheckMCPRequestAuthorizationInTenantTx, which joins tenants and folds both
+// columns into the single `authorized` verdict. Do not add a second read of
+// these columns on the request path and do not cache them: a cached kill
+// switch is not a kill switch.
+// ===========================================================================
+// GetTenantAssistantState is the operator console's read. NOT the request
+// path — the request path reads these columns through the verdict, never here.
+// :one and no RLS on tenants, so the tenant_id filter in the WHERE clause is
+// the ONLY thing scoping this row; a caller that drops it reads another
+// organisation's state.
+func (q *Queries) GetTenantAssistantState(ctx context.Context, tenantID uuid.UUID) (GetTenantAssistantStateRow, error) {
+	row := q.db.QueryRow(ctx, getTenantAssistantState, tenantID)
+	var i GetTenantAssistantStateRow
+	err := row.Scan(
+		&i.ID,
+		&i.AssistantEnabledAt,
+		&i.AssistantPausedAt,
+		&i.AssistantPausedReason,
 	)
 	return i, err
 }
@@ -187,7 +331,7 @@ func (q *Queries) ListOrgsForUser(ctx context.Context, userID uuid.UUID) ([]List
 }
 
 const listTenants = `-- name: ListTenants :many
-SELECT id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, created_at, updated_at FROM tenants
+SELECT id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, assistant_enabled_at, assistant_paused_at, assistant_paused_reason, created_at, updated_at FROM tenants
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
@@ -224,6 +368,9 @@ func (q *Queries) ListTenants(ctx context.Context, arg ListTenantsParams) ([]Ten
 			&i.CancelAtPeriodEnd,
 			&i.DeletedAt,
 			&i.PurgeStartedAt,
+			&i.AssistantEnabledAt,
+			&i.AssistantPausedAt,
+			&i.AssistantPausedReason,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -292,7 +439,7 @@ func (q *Queries) ListTenantsForUser(ctx context.Context, arg ListTenantsForUser
 }
 
 const listTenantsPendingPurge = `-- name: ListTenantsPendingPurge :many
-SELECT id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, created_at, updated_at FROM tenants
+SELECT id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, assistant_enabled_at, assistant_paused_at, assistant_paused_reason, created_at, updated_at FROM tenants
 WHERE deleted_at IS NOT NULL AND deleted_at < $1
 ORDER BY deleted_at ASC
 `
@@ -329,6 +476,9 @@ func (q *Queries) ListTenantsPendingPurge(ctx context.Context, cutoff pgtype.Tim
 			&i.CancelAtPeriodEnd,
 			&i.DeletedAt,
 			&i.PurgeStartedAt,
+			&i.AssistantEnabledAt,
+			&i.AssistantPausedAt,
+			&i.AssistantPausedReason,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -362,11 +512,41 @@ func (q *Queries) MarkPurgeStarted(ctx context.Context, tenantID uuid.UUID) (int
 	return result.RowsAffected(), nil
 }
 
+const releaseTenantAssistantKillSwitch = `-- name: ReleaseTenantAssistantKillSwitch :execrows
+UPDATE tenants
+SET assistant_paused_at = NULL,
+    assistant_paused_reason = NULL,
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+  AND assistant_paused_at IS NOT NULL
+`
+
+// ReleaseTenantAssistantKillSwitch clears the pause after an incident.
+//
+// IT CLEARS THE REASON IN THE SAME STATEMENT, and it must: the reason is part
+// of the pause, tenants_assistant_paused_reason_check refuses a reason without
+// a pause, and clearing only assistant_paused_at would violate that constraint
+// and fail — loudly, which is the correct direction, but the caller should
+// never have to discover it.
+//
+// IT DOES NOT TOUCH assistant_enabled_at. That is the whole point of two
+// columns (m130 DECISION 2): an organisation that was deliberately off before
+// the incident is still off after it, and releasing the switch never enables
+// a surface nobody chose to enable.
+func (q *Queries) ReleaseTenantAssistantKillSwitch(ctx context.Context, tenantID uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, releaseTenantAssistantKillSwitch, tenantID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const restoreTenant = `-- name: RestoreTenant :one
 UPDATE tenants
 SET deleted_at = NULL
 WHERE id = $1 AND deleted_at IS NOT NULL AND purge_started_at IS NULL
-RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, created_at, updated_at
+RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, assistant_enabled_at, assistant_paused_at, assistant_paused_reason, created_at, updated_at
 `
 
 // RestoreTenant clears deleted_at within the grace window (GH #152 undelete).
@@ -398,6 +578,9 @@ func (q *Queries) RestoreTenant(ctx context.Context, tenantID uuid.UUID) (Tenant
 		&i.CancelAtPeriodEnd,
 		&i.DeletedAt,
 		&i.PurgeStartedAt,
+		&i.AssistantEnabledAt,
+		&i.AssistantPausedAt,
+		&i.AssistantPausedReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -408,7 +591,7 @@ const softDeleteTenant = `-- name: SoftDeleteTenant :one
 UPDATE tenants
 SET deleted_at = now()
 WHERE id = $1 AND deleted_at IS NULL
-RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, created_at, updated_at
+RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, assistant_enabled_at, assistant_paused_at, assistant_paused_reason, created_at, updated_at
 `
 
 // SoftDeleteTenant sets deleted_at (GH #152 Lane B — populated org). The read-
@@ -438,6 +621,9 @@ func (q *Queries) SoftDeleteTenant(ctx context.Context, tenantID uuid.UUID) (Ten
 		&i.CancelAtPeriodEnd,
 		&i.DeletedAt,
 		&i.PurgeStartedAt,
+		&i.AssistantEnabledAt,
+		&i.AssistantPausedAt,
+		&i.AssistantPausedReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -448,7 +634,7 @@ const updateTenantName = `-- name: UpdateTenantName :one
 UPDATE tenants
 SET name = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, created_at, updated_at
+RETURNING id, name, slug, plan, plan_status, plan_overrides, grace_until, billing_provider, provider_customer_id, provider_subscription_id, current_period_end, comp_reason, suspended_at, suspended_reason, cancel_at_period_end, deleted_at, purge_started_at, assistant_enabled_at, assistant_paused_at, assistant_paused_reason, created_at, updated_at
 `
 
 type UpdateTenantNameParams struct {
@@ -479,6 +665,9 @@ func (q *Queries) UpdateTenantName(ctx context.Context, arg UpdateTenantNamePara
 		&i.CancelAtPeriodEnd,
 		&i.DeletedAt,
 		&i.PurgeStartedAt,
+		&i.AssistantEnabledAt,
+		&i.AssistantPausedAt,
+		&i.AssistantPausedReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/apps/api/migrations/20260901000000_m130_tenant_assistant_kill_switch.sql
+++ b/apps/api/migrations/20260901000000_m130_tenant_assistant_kill_switch.sql
@@ -1,0 +1,414 @@
+-- m130 - ADR-061 pre-v1 checklist: the PER-TENANT ENABLEMENT FLAG and the
+-- PER-TENANT KILL SWITCH for the assistant / MCP surface. Roadmap task 1A-11,
+-- slice 1A Gate, data-phase Phase 1.
+--
+-- This migration CORRECTS NOTHING. It edits no applied migration, it re-runs no
+-- earlier backfill, and no database needs converging onto it beyond the
+-- one-time backfill in step (1), which is described in DECISION 6. There is no
+-- m114/m115-shaped follow-up owed.
+--
+-- WHY IT EXISTS. The MCP transport is LIVE IN PRODUCTION and has no off
+-- switch. ADR-061's pre-v1 checklist requires two separate things that this
+-- schema cannot express today:
+--
+--     "Off by default at the tenant level, and a connection whose site
+--      allowlist starts empty [...]"
+--     "A per-tenant kill switch reachable in one click [...]"
+--
+-- A backend agent built the tool-call rate limiter (the checklist's third item)
+-- and correctly stopped at these two, because both need persistent per-tenant
+-- state that does not exist:
+--
+--     grep -nE "CREATE TABLE.*tenant_settings|CREATE TABLE.*org_settings" \
+--         apps/api/db/schema.sql
+--       -> no matches
+--
+-- and the tenants table carries no enablement, assistant, mcp, kill or paused
+-- column. This file adds that state and joins it to the verdict that already
+-- runs on every request.
+--
+-- ===========================================================================
+-- DECISION 1: THE STATE LIVES ON `tenants`, NOT IN A NEW TABLE, AND THE
+--             REASON IS THAT `tenants` HAS NO ROW LEVEL SECURITY
+-- ===========================================================================
+--
+-- This is the load-bearing decision in the file and it is a security decision,
+-- not an ergonomic one.
+--
+-- 184 tables in this schema are under RLS:
+--
+--     grep -rhoE 'ALTER TABLE [^ ]+ ENABLE ROW LEVEL SECURITY' \
+--         apps/api/migrations/*.sql apps/api/db/schema.sql | sort -u | grep -c .
+--       -> 184
+--
+-- `tenants` IS NOT ONE OF THEM:
+--
+--     grep -rniE 'ALTER TABLE.*tenants.* (ENABLE|FORCE) ROW LEVEL SECURITY' \
+--         apps/api/migrations/*.sql apps/api/db/schema.sql
+--       -> no matches
+--
+-- THAT ABSENCE IS WHY THE KILL SWITCH BELONGS HERE. A kill switch is read on
+-- the authentication path, inside a tenant transaction, and it must be read
+-- correctly there under every dispatch helper. Put it in a new RLS-protected
+-- table and it acquires a failure mode it cannot have on `tenants`: if a
+-- policy filters the settings row out of the join -- because a call site chose
+-- InTenantTx over RunTenantTx and never set app.site_scope, or because a
+-- RESTRICTIVE policy is added later without this read in mind -- the LEFT JOIN
+-- yields NULL, NULL reads as "not paused", AND THE KILL SWITCH IS SILENTLY
+-- INERT. That is precisely the shape m127 DECISION 5 records as a live
+-- privilege escalation fixed on 2026-08-30: a policy that tests a GUC is inert
+-- on any path that does not set it.
+--
+-- An inert kill switch is worse than no kill switch, because an operator at
+-- 3am believes the surface is stopped. On `tenants` the row is reachable by
+-- primary key with no policy able to hide it, so the switch cannot be made
+-- inert by anything short of deleting the tenant.
+--
+-- THREE FURTHER REASONS, ALL SECONDARY TO THAT ONE:
+--
+--   a. `tenants` IS ALREADY THE HOME OF PER-TENANT OPERATOR STATE OF EXACTLY
+--      THIS KIND. It carries suspended_at, suspended_reason, plan_status
+--      (whose vocabulary already includes a paused value) and grace_until.
+--      The columns below are the same fact-shape as suspended_at/
+--      suspended_reason and are deliberately named and typed to match, so an
+--      operator reading the row sees one consistent idiom and not two.
+--
+--   b. NO EXTRA ROUND TRIP AND NO NEW INDEX. The verdict query joins
+--      tenants on its PRIMARY KEY, which is an index probe on a row the
+--      planner reaches once. See DECISION 3.
+--
+--   c. ONE CLICK IS ONE UPDATE ON ONE ROW. The brief requires the shape to
+--      allow a one-click control later. Engaging the switch is a single
+--      UPDATE tenants SET assistant_paused_at = now(), assistant_paused_reason
+--      = $2 WHERE id = $1. Releasing it is the mirror image. No row has to be
+--      created first, which is the trap a settings table sets: a one-click
+--      control whose first click is an INSERT is a control that can fail with
+--      a unique violation during an incident.
+--
+-- A SETTINGS TABLE IS THE RIGHT ANSWER LATER AND IS NOT REFUSED FOREVER. When
+-- the assistant grows a dozen per-tenant knobs that are NOT read on the
+-- authentication path, they belong in their own table. These two are read on
+-- the authentication path, which is the whole reason they are here.
+--
+-- ===========================================================================
+-- DECISION 2: TWO COLUMNS, NOT ONE COLUMN WITH THREE STATES, BECAUSE THEY ARE
+--             TWO DIFFERENT FACTS WITH TWO DIFFERENT LIFECYCLES
+-- ===========================================================================
+--
+-- A single tri-state column (off / on / paused) was considered and REJECTED.
+-- It collapses a CONFIGURATION fact and an INCIDENT fact into one cell, and
+-- the collapse has a concrete failure:
+--
+--   AN OPERATOR RELEASING THE KILL SWITCH AFTER AN INCIDENT WOULD HAVE TO
+--   CHOOSE WHAT TO WRITE BACK. With one column, "un-pause" means "write on",
+--   and if the tenant had deliberately never enabled the surface, un-pausing
+--   TURNS IT ON. The incident response silently reverses a configuration
+--   decision nobody revisited. With two columns, releasing the switch clears
+--   assistant_paused_at and touches nothing else; a tenant that was off stays
+--   off, and that is not a thing the operator has to remember.
+--
+-- The audit story differs the same way and that is the second reason. Enabling
+-- the surface is a configuration change made deliberately, in daylight, by an
+-- owner. Engaging the kill switch is an incident action taken at speed, and it
+-- wants a reason string attached to it. One of those facts wants a reason
+-- column and the other does not, which is itself evidence they are two facts.
+--
+-- BOTH ARE `timestamptz NULL`, NOT `boolean`, MATCHING suspended_at.
+--     A timestamp carries WHEN, which is exactly the audit information the two
+--     lifecycles above are asking for, and it costs nothing over a boolean. A
+--     boolean answers "is it off" and destroys "since when", which is the
+--     first question asked about an incident action and the second question
+--     asked about a configuration one. suspended_at on this same table already
+--     made this choice.
+--
+--     NULL is a real, meaningful value on BOTH columns and means a DIFFERENT
+--     thing on each -- the m127 DECISION 2 property, restated because it is
+--     the thing a reader gets backwards:
+--
+--       assistant_enabled_at  NULL  =>  NEVER ENABLED. The surface is off.
+--       assistant_paused_at   NULL  =>  NOT PAUSED. The switch is released.
+--
+--     One NULL is restrictive and one NULL is permissive. They are NOT
+--     symmetric and must not be refactored into a shared helper that treats
+--     them as the same predicate.
+--
+-- ===========================================================================
+-- DECISION 3: BOTH FACTS JOIN THE EXISTING `authorized` VERDICT. NO SECOND
+--             QUERY, NO CACHE.
+-- ===========================================================================
+--
+-- ReCheckMCPRequestAuthorizationInTenantTx already runs on EVERY REQUEST and
+-- already returns `authorized` as the whole verdict in one column, "computed
+-- here so that no caller reassembles it". m127 DECISION 3 folded both grant
+-- expiries into that same predicate rather than adding a read a caller could
+-- forget. This migration does the same with both tenant facts, in its
+-- companion change to db/query/mcp_connections.sql.
+--
+-- THE KILL SWITCH THEREFORE STOPS IN-FLIGHT REQUESTS, WHICH IS THE ENTIRE
+-- POINT AND IS THE PART A NAIVE IMPLEMENTATION GETS WRONG. A switch that only
+-- blocks the creation of new grants leaves every already-issued connection
+-- token reading data for as long as it lives. The brief states the standard
+-- plainly: a switch that blocks new connections while existing tokens keep
+-- reading is not the control anyone wants at 3am. Because the verdict is
+-- recomputed per request, engaging the switch refuses THE VERY NEXT REQUEST on
+-- an existing, otherwise perfectly valid connection.
+--
+-- A CACHED KILL SWITCH IS NOT A KILL SWITCH, AND NO CACHE IS PROPOSED HERE.
+-- The cost of not caching is one join to `tenants` on its primary key, on a
+-- query that already does two primary-key probes. There is no new index
+-- because there is no new scan: the tenant row is reached by
+-- tenants.id = t.tenant_id, and t.tenant_id is already a bound parameter of
+-- this query, so the planner has a single-row lookup and nothing to search.
+-- The per-request cost is zero extra round trips.
+--
+-- THE JOIN IS AN INNER JOIN AND THAT IS SAFE HERE ONLY BECAUSE OF DECISION 1.
+-- An inner join that matches no row returns no row at all, and the Go caller
+-- reads a no-row result as a refusal. On a table with RLS that would be a
+-- latent fleet outage waiting for a policy change. On `tenants`, which has no
+-- RLS, the only way the join matches nothing is that the tenant does not
+-- exist -- in which case refusing is correct. The foreign key from
+-- mcp_connection_tokens.tenant_id guarantees the row is there.
+--
+-- ===========================================================================
+-- DECISION 4: ENABLEMENT EARNS AN EXPLICIT COLUMN EVEN THOUGH GRANT EXISTENCE
+--             ALREADY IMPLIES IT. THE ARGUMENT, SINCE IT WAS CHALLENGED.
+-- ===========================================================================
+--
+-- A previous agent established, correctly, that a tenant which has never
+-- turned the assistant on already serves nothing: authentication requires a
+-- bearer resolving to a connection token joined to a grant, so with no grant
+-- there is no token and the request is 401. A plain boolean would therefore
+-- DUPLICATE a fact the data already carries. That objection is right about the
+-- boolean and wrong about the column, for three reasons.
+--
+--   a. IT COLLAPSES TWO AXES ADR-061 KEEPS SEPARATE. The checklist asks for
+--      "off by default at the tenant level" AND "a connection whose site
+--      allowlist starts empty" as two distinct requirements. Deriving tenant
+--      enablement from grant existence means the tenant-level gate IS the
+--      connection-level gate: there is no tenant gate at all. Creating a
+--      connection would both enable the org and configure the connection, in
+--      one action, by whoever can create connections. An owner cannot say
+--      "this organisation does not use the assistant" in a way that survives
+--      a member opening the wizard.
+--
+--   b. THE TWO CAN NOW DIVERGE IN BOTH DIRECTIONS, WHICH IS THE TEST OF
+--      WHETHER A COLUMN IS REDUNDANT. Off-while-grants-exist is the case the
+--      brief names and it is real: an owner offboarding the surface without
+--      destroying the connection history that documents what it did. The
+--      mirror case is real too: enabling an organisation BEFORE any grant
+--      exists, so the wizard's first run is a configuration step and not
+--      simultaneously an authorisation decision. Neither is expressible by
+--      counting grants.
+--
+--   c. REVOCATION AND DISABLEMENT ARE DIFFERENT RECORDS. Deriving enablement
+--      from grants means turning the org off requires revoking every grant,
+--      which destroys the operator's ability to turn it back on unchanged.
+--      This is the same reasoning m127 used to keep revocation distinct from a
+--      backdated expiry: two mechanisms, kept distinct, so each stays honest.
+--
+-- WHAT IT IS NOT. It is not a kill switch, and DECISION 2 is why. It is not a
+-- licence tier and carries no plan semantics; plan and plan_status on this
+-- same table answer that question and this column must never be read as a
+-- billing signal.
+--
+-- ===========================================================================
+-- DECISION 5: THE ORDERING CONSTRAINT THIS PLACES ON backend-architect, WHICH
+--             IS HARD, AND WHICH IS THE MOST DANGEROUS THING IN THIS FILE
+-- ===========================================================================
+--
+-- WRITTEN DOWN RATHER THAN LEFT TO BE DISCOVERED, in the manner of m127
+-- DECISION 4.
+--
+-- After this migration, assistant_enabled_at IS PART OF THE VERDICT. Existing
+-- tenants are backfilled (DECISION 6) and are unaffected. But A TENANT CREATED
+-- AFTER THIS FILE APPLIES HAS assistant_enabled_at IS NULL, therefore IS OFF,
+-- and every request on any connection it creates will be refused until
+-- something writes that column.
+--
+-- THAT IS THE CORRECT AND INTENDED DIRECTION -- it is literally what "off by
+-- default at the tenant level" means, and the surface is a pre-v1 pilot with
+-- agreed kill criteria, not a generally available feature. A new tenant unable
+-- to use an unlaunched pilot surface is not an outage. A new tenant silently
+-- opted INTO it would be the defect.
+--
+-- BUT IT MEANS THE ENABLE CONTROL IS A PREREQUISITE OF ONBOARDING, NOT A
+-- FOLLOW-UP TO IT. Until backend-architect ships a path that sets
+-- assistant_enabled_at, the connection wizard will complete successfully for a
+-- new tenant and then every subsequent request will 401, with the cause
+-- visible only in the tenant_assistant_disabled diagnostic column added below.
+-- The diagnostic exists so that failure names itself instead of presenting as
+-- a mysterious auth error.
+--
+-- NO SWEEP JOB IS REQUIRED FOR ENFORCEMENT, on either column. Both are
+-- evaluated at read time against the row, so the switch takes effect at the
+-- instant it is written whether or not any background worker ran, and a worker
+-- that fails to run can never extend a credential or un-pause a surface.
+--
+-- ===========================================================================
+-- DECISION 6: THE BACKFILL PRESERVES TODAY'S EFFECTIVE AUTHORITY EXACTLY AND
+--             IS NOT A PERMISSIVE DEFAULT
+-- ===========================================================================
+--
+-- The brief's hardest constraint: this ships to a live surface, and a
+-- migration that silently switches every tenant off is an outage. m127
+-- DECISION 6 is the pattern and this follows it exactly.
+--
+-- NEITHER COLUMN CARRIES A DEFAULT CLAUSE. A DEFAULT and a one-time backfill
+-- are not the same thing. Step (1) sets a value on rows that already exist;
+-- every future INSERT is unaffected because both columns are NULLABLE. That is
+-- what makes constraint 1 -- every existing insert and read path keeps working
+-- -- true by construction rather than by assertion: m127's NOT NULL columns
+-- reddened ten integration tests, and NOTHING HERE IS NOT NULL.
+--
+--   assistant_enabled_at -> now(), FOR EVERY TENANT THAT HAS ANY mcp_grants
+--     ROW AT ALL.
+--
+--     THIS GRANTS NOTHING NEW. A tenant with a grant is a tenant already
+--     serving the assistant surface today; writing the column down records
+--     what the running system already permits. A tenant with no grant serves
+--     nothing today and is left NULL, so it loses nothing either. Every live
+--     connection in the fleet keeps working with precisely the authority it
+--     has now.
+--
+--     `EXISTS (SELECT 1 FROM mcp_grants ...)` WITH NO STATUS FILTER, AND THAT
+--     BREADTH IS DELIBERATE. Filtering to status = 'active' would leave a
+--     tenant whose only grant is currently revoked marked as never-enabled,
+--     and the next connection it creates would be refused -- an org that used
+--     the surface last week discovering it is off, caused by a migration
+--     rather than by a decision. Any tenant that has ever created a connection
+--     has demonstrably opted in.
+--
+--     ROLLING BACK IS AN OPERATOR ACTION, NOT A MIGRATION. If an org should
+--     not have been enabled, an operator sets the column to NULL. The backfill
+--     deliberately errs toward preserving service.
+--
+--   assistant_paused_at -> LEFT NULL ON EVERY ROW. Nothing to backfill. The
+--     kill switch starts released everywhere, which is today's behaviour
+--     exactly. THIS IS THE COLUMN THAT COULD CAUSE THE FLEET-WIDE OUTAGE IF IT
+--     WERE BACKFILLED OR DEFAULTED TO ANYTHING NON-NULL, and it is neither.
+--
+--   assistant_paused_reason -> LEFT NULL. Meaningless without a pause.
+--
+-- EVERY STATEMENT BELOW IS IDEMPOTENT AND THE FILE IS RE-RUNNABLE. The
+-- backfill is guarded by IS NULL, so a second application updates zero rows
+-- and cannot re-enable an organisation an operator has since turned off. That
+-- guard is the m110/m111 lesson: a backfill that can overwrite an operator
+-- decision is the thing that needs the repair migration.
+--
+-- ===========================================================================
+-- DECISION 7: RLS, POLICIES, AND WHAT IS DELIBERATELY NOT ADDED
+-- ===========================================================================
+--
+-- THIS MIGRATION CREATES NO TABLE AND NO POLICY, AND ADDS NO RLS.
+--
+-- WHICH POLICIES WERE ADDED: none.
+-- WHICH POLICIES WERE DELIBERATELY NOT ADDED, AND WHY:
+--
+--   NO tenants_tenant_isolation, NO tenants_agent, NO RESTRICTIVE
+--   tenants_site_scope. The standing rule that a new SITE-KEYED table gets the
+--   full site-scope policy set does not reach this migration, for two
+--   independent reasons: this migration creates no table, and `tenants` is not
+--   site-keyed -- it has no site_id and is the tenant axis itself, the table
+--   every other table's tenant_id points AT. Adding RLS to `tenants` would be
+--   a schema-wide change to the tenancy substrate, would break every join that
+--   currently reads it outside a tenant transaction (billing sweeps, the purge
+--   worker, the cross-tenant reconcilers), and is emphatically not a thing to
+--   do inside a kill-switch migration. It is also, per DECISION 1, the exact
+--   property that makes the switch reliable.
+--
+--   RLS filters ROWS, not columns, so on a table with no RLS a new column
+--   inherits no policy because there is none to inherit. Stated rather than
+--   left silent.
+--
+-- NO ROW IS OWED IN db/rls-cross-tenant-policies.txt. That ledger records
+-- policies that grant access ACROSS tenants. This migration adds no policy of
+-- any kind, so the ledger is unchanged and check-rls-cross-tenant.sh must stay
+-- green without an edit.
+--
+-- ===========================================================================
+-- DECISION 8: GRANTS
+-- ===========================================================================
+--
+-- Nothing to add. m1's ALTER DEFAULT PRIVILEGES is table-level and covers
+-- columns added later; PostgreSQL has no per-column grant in force on
+-- `tenants` that a new column could fall outside of. Stated rather than left
+-- silent, because "the new column is invisible to wpmgr_app" is the kind of
+-- failure that looks like an RLS bug for a day -- and on this table, where
+-- there is no RLS to blame, for longer.
+
+-- ---------------------------------------------------------------------------
+-- (0) Columns. All three NULLABLE with NO DEFAULT, so every existing INSERT
+--     that does not mention them keeps working unchanged. See DECISION 6.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "public"."tenants"
+    ADD COLUMN IF NOT EXISTS "assistant_enabled_at" timestamptz;
+
+ALTER TABLE "public"."tenants"
+    ADD COLUMN IF NOT EXISTS "assistant_paused_at" timestamptz;
+
+ALTER TABLE "public"."tenants"
+    ADD COLUMN IF NOT EXISTS "assistant_paused_reason" text;
+
+-- ---------------------------------------------------------------------------
+-- (1) Backfill. WHERE ... IS NULL makes this a no-op on a second run and
+--     protects a decision an operator has already made. See DECISION 6.
+--
+--     Only assistant_enabled_at is backfilled. The kill switch and its reason
+--     stay NULL on every row, which is today's behaviour exactly.
+-- ---------------------------------------------------------------------------
+
+UPDATE "public"."tenants" AS tn
+   SET "assistant_enabled_at" = now()
+ WHERE tn."assistant_enabled_at" IS NULL
+   AND EXISTS (
+        SELECT 1
+          FROM "public"."mcp_grants" g
+         WHERE g."tenant_id" = tn."id"
+   );
+
+-- ---------------------------------------------------------------------------
+-- (2) Constraints. Each guarded by a pg_constraint probe so the file re-runs.
+--     No NOT NULL is armed anywhere in this file, by design.
+-- ---------------------------------------------------------------------------
+
+-- A pause reason cannot exist without a pause. The reason is part of the
+-- incident action, so releasing the switch clears both in one UPDATE and a
+-- stale reason cannot outlive the pause it described. The reason is also
+-- refused when it is a string of zero length: a control that records why the
+-- surface was stopped and stores nothing is worse than one that stores NULL,
+-- because NULL is honestly absent and a string of zero length reads as an
+-- answer. (Written in words rather than as a quoted literal: issue #597 -- a
+-- doubled single quote inside a comment is rewritten by sqlc into a non-ASCII
+-- character in one generated file and not the other.)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.tenants'::regclass
+          AND conname  = 'tenants_assistant_paused_reason_check'
+    ) THEN
+        ALTER TABLE "public"."tenants"
+            ADD CONSTRAINT "tenants_assistant_paused_reason_check"
+            CHECK (
+                "assistant_paused_reason" IS NULL
+                OR ("assistant_paused_at" IS NOT NULL
+                    AND length(btrim("assistant_paused_reason")) > 0
+                    AND length("assistant_paused_reason") <= 500)
+            );
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- (3) Indexes.
+--
+-- NONE, AND THAT IS CHECKED RATHER THAN ASSUMED. The verdict query reaches
+-- this row by tenants.id, which is the PRIMARY KEY, from a value that is
+-- already a bound parameter of that query. There is no scan to accelerate.
+--
+-- An index on assistant_paused_at was considered for an operator dashboard
+-- listing paused tenants; that is a rare, small, admin-side query over a table
+-- with one row per organisation, and an index that earns nothing on the hot
+-- path and little off it is a thing to keep in sync for no return.
+-- ---------------------------------------------------------------------------

--- a/apps/api/migrations/20260901000000_m130_tenant_assistant_kill_switch.sql
+++ b/apps/api/migrations/20260901000000_m130_tenant_assistant_kill_switch.sql
@@ -212,32 +212,65 @@
 -- billing signal.
 --
 -- ===========================================================================
--- DECISION 5: THE ORDERING CONSTRAINT THIS PLACES ON backend-architect, WHICH
---             IS HARD, AND WHICH IS THE MOST DANGEROUS THING IN THIS FILE
+-- DECISION 5: THE KILL SWITCH JOINS THE VERDICT NOW. ENABLEMENT DOES NOT, AND
+--             IS INERT BY CONSTRUCTION UNTIL GO WRITES IT.
+--
+--             THIS IS THE MOST DANGEROUS THING IN THIS FILE AND IT IS WRITTEN
+--             DOWN RATHER THAN LEFT TO BE DISCOVERED, in the manner of m127
+--             DECISION 4.
 -- ===========================================================================
 --
--- WRITTEN DOWN RATHER THAN LEFT TO BE DISCOVERED, in the manner of m127
--- DECISION 4.
+-- THE TWO COLUMNS ARE NOT WIRED AT THE SAME TIME, ON PURPOSE.
 --
--- After this migration, assistant_enabled_at IS PART OF THE VERDICT. Existing
--- tenants are backfilled (DECISION 6) and are unaffected. But A TENANT CREATED
--- AFTER THIS FILE APPLIES HAS assistant_enabled_at IS NULL, therefore IS OFF,
--- and every request on any connection it creates will be refused until
--- something writes that column.
+--   assistant_paused_at  -> IN THE VERDICT, IN THIS MIGRATION.
+--     Safe by construction: it is NULL on every existing row and NULL means
+--     "running", so applying this file changes no behaviour anywhere. It needs
+--     no Go code to be CORRECT on the read path -- only to be REACHABLE on the
+--     write path -- so the enforcement half ships now and the console catches
+--     up. This is the urgent item: the surface is live with no off switch.
 --
--- THAT IS THE CORRECT AND INTENDED DIRECTION -- it is literally what "off by
--- default at the tenant level" means, and the surface is a pre-v1 pilot with
--- agreed kill criteria, not a generally available feature. A new tenant unable
--- to use an unlaunched pilot surface is not an outage. A new tenant silently
--- opted INTO it would be the defect.
+--   assistant_enabled_at -> NOT IN THE VERDICT. NOTHING READS IT YET.
 --
--- BUT IT MEANS THE ENABLE CONTROL IS A PREREQUISITE OF ONBOARDING, NOT A
--- FOLLOW-UP TO IT. Until backend-architect ships a path that sets
--- assistant_enabled_at, the connection wizard will complete successfully for a
--- new tenant and then every subsequent request will 401, with the cause
--- visible only in the tenant_assistant_disabled diagnostic column added below.
--- The diagnostic exists so that failure names itself instead of presenting as
--- a mysterious auth error.
+-- WHY ENABLEMENT IS HELD BACK, AND IT IS NOT TIMIDITY -- IT WAS EXECUTED.
+-- The predicate `AND tn.assistant_enabled_at IS NOT NULL` was written into
+-- ReCheckMCPRequestAuthorizationInTenantTx and the integration suite was run
+-- against it as wpmgr_app:
+--
+--   go test ./tests/ -run 'TestMCPActivityStampLandsAsAppRole' -count=1
+--     mcp_grant_expiry_activity_integration_test.go:238:
+--       current_user=wpmgr_app rolsuper=false rolbypassrls=false
+--     mcp_grant_expiry_activity_integration_test.go:260:
+--       Authenticate with a live bearer: this connection has been revoked or
+--       has expired
+--     FAIL
+--
+-- THE BACKFILL CANNOT REACH A TENANT THAT DOES NOT EXIST YET. Step (1) enables
+-- every tenant holding a grant TODAY, but a tenant created AFTER this file
+-- applies has assistant_enabled_at IS NULL, so that one line refuses every
+-- connection it will ever make. In the suite that is a red test. IN
+-- PRODUCTION IT IS EVERY NEW SIGNUP: the connection wizard completes, a token
+-- is minted, and every request 401s with nothing naming the cause.
+--
+-- That is the exact defect shape this project keeps repeating -- m127's NOT
+-- NULL columns reddened ten integration tests -- and shipping it because "off
+-- by default is what the ADR says" would be following the letter of ADR-061
+-- into an outage. OFF BY DEFAULT IS STILL THE GOAL AND THE COLUMN STILL
+-- ENCODES IT. What is not yet true is that anything can turn it ON, and a gate
+-- with no key is not a gate, it is a wall.
+--
+-- THE ORDERING CONSTRAINT THIS PLACES ON backend-architect IS HARD, and it is
+-- a TWO-PART CHANGE THAT MUST SHIP TOGETHER, never one half of it:
+--
+--   1. A Go path that writes assistant_enabled_at (EnableTenantAssistant in
+--      db/query/tenants.sql is generated and waiting), reachable from the
+--      console, AND called wherever a tenant legitimately opts in.
+--   2. ONLY THEN, a follow-up migration adding the one line to the verdict --
+--      a NEW ORDINAL, never an edit to this file or to m130's applied form.
+--
+-- Until step 1 exists, assistant_enabled_at is a record of intent that costs
+-- nothing and refuses nothing. The diagnostic column tenant_assistant_disabled
+-- is returned by the verdict query from day one so that when step 2 lands, the
+-- refusal names itself instead of presenting as a mysterious auth error.
 --
 -- NO SWEEP JOB IS REQUIRED FOR ENFORCEMENT, on either column. Both are
 -- evaluated at read time against the row, so the switch takes effect at the

--- a/apps/api/migrations/20260901000000_m130_tenant_assistant_kill_switch.sql
+++ b/apps/api/migrations/20260901000000_m130_tenant_assistant_kill_switch.sql
@@ -3,9 +3,14 @@
 -- slice 1A Gate, data-phase Phase 1.
 --
 -- This migration CORRECTS NOTHING. It edits no applied migration, it re-runs no
--- earlier backfill, and no database needs converging onto it beyond the
--- one-time backfill in step (1), which is described in DECISION 6. There is no
--- m114/m115-shaped follow-up owed.
+-- earlier backfill, it contains no backfill of its own (DECISION 6), and no
+-- database in any state needs converging onto it. There is no m114/m115-shaped
+-- repair owed.
+--
+-- A FOLLOW-UP IS OWED, AND IT IS NOT A REPAIR. DECISION 5 holds
+-- assistant_enabled_at out of the authorization verdict on purpose; wiring it
+-- is a later, deliberate change with its own ordinal, and DECISION 6 states
+-- the backfill that change must carry.
 --
 -- WHY IT EXISTS. The MCP transport is LIVE IN PRODUCTION and has no off
 -- switch. ADR-061's pre-v1 checklist requires two separate things that this
@@ -244,10 +249,12 @@
 --       has expired
 --     FAIL
 --
--- THE BACKFILL CANNOT REACH A TENANT THAT DOES NOT EXIST YET. Step (1) enables
--- every tenant holding a grant TODAY, but a tenant created AFTER this file
--- applies has assistant_enabled_at IS NULL, so that one line refuses every
--- connection it will ever make. In the suite that is a red test. IN
+-- NO BACKFILL CAN REACH A TENANT THAT DOES NOT EXIST YET. Even the backfill
+-- this file originally carried -- since deleted, DECISION 6 -- enabled only
+-- tenants holding a grant AT APPLY TIME. A tenant created AFTER this file
+-- applies has assistant_enabled_at IS NULL either way, so that one line
+-- refuses every connection it will ever make. In the suite that is a red
+-- test. IN
 -- PRODUCTION IT IS EVERY NEW SIGNUP: the connection wizard completes, a token
 -- is minted, and every request 401s with nothing naming the cause.
 --
@@ -278,55 +285,75 @@
 -- that fails to run can never extend a credential or un-pause a surface.
 --
 -- ===========================================================================
--- DECISION 6: THE BACKFILL PRESERVES TODAY'S EFFECTIVE AUTHORITY EXACTLY AND
---             IS NOT A PERMISSIVE DEFAULT
+-- DECISION 6: THERE IS NO BACKFILL, BECAUSE THE ONE THIS FILE ORIGINALLY HAD
+--             DID NO WORK -- AND IT WAS 90% OF THE LOCK WINDOW
 -- ===========================================================================
 --
--- The brief's hardest constraint: this ships to a live surface, and a
--- migration that silently switches every tenant off is an outage. m127
--- DECISION 6 is the pattern and this follows it exactly.
+-- THIS FILE ORIGINALLY BACKFILLED assistant_enabled_at = now() FOR EVERY
+-- TENANT HOLDING ANY mcp_grants ROW. That statement has been DELETED, and it
+-- was deleted rather than batched. Both halves of that need arguing.
 --
--- NEITHER COLUMN CARRIES A DEFAULT CLAUSE. A DEFAULT and a one-time backfill
--- are not the same thing. Step (1) sets a value on rows that already exist;
--- every future INSERT is unaffected because both columns are NULLABLE. That is
--- what makes constraint 1 -- every existing insert and read path keeps working
--- -- true by construction rather than by assertion: m127's NOT NULL columns
--- reddened ten integration tests, and NOTHING HERE IS NOT NULL.
+-- WHY IT DOES NO WORK. Two independent reasons, either sufficient:
 --
---   assistant_enabled_at -> now(), FOR EVERY TENANT THAT HAS ANY mcp_grants
---     ROW AT ALL.
+--   a. NOTHING READS THE COLUMN. DECISION 5 holds assistant_enabled_at out of
+--      the verdict, and no other query references it. A backfill whose result
+--      is read by nothing changes no behaviour anywhere.
 --
---     THIS GRANTS NOTHING NEW. A tenant with a grant is a tenant already
---     serving the assistant surface today; writing the column down records
---     what the running system already permits. A tenant with no grant serves
---     nothing today and is left NULL, so it loses nothing either. Every live
---     connection in the fleet keeps working with precisely the authority it
---     has now.
+--   b. IT IS SUPERSEDED BY CONSTRUCTION, NOT MERELY UNUSED TODAY. The
+--      follow-up migration that puts enablement into the verdict MUST BACKFILL
+--      AT ITS OWN APPLY TIME REGARDLESS OF WHAT THIS FILE DID, because every
+--      tenant created BETWEEN this file and that one would otherwise hold NULL
+--      and be refused. So this file's backfill is not an early start on that
+--      work; it is the same work, computed against a strictly staler snapshot,
+--      and entirely overwritten in scope by the correct one. Doing it here and
+--      again there is doing it once, later.
 --
---     `EXISTS (SELECT 1 FROM mcp_grants ...)` WITH NO STATUS FILTER, AND THAT
---     BREADTH IS DELIBERATE. Filtering to status = 'active' would leave a
---     tenant whose only grant is currently revoked marked as never-enabled,
---     and the next connection it creates would be refused -- an org that used
---     the surface last week discovering it is off, caused by a migration
---     rather than by a decision. Any tenant that has ever created a connection
---     has demonstrably opted in.
+-- THAT IS AN INSTRUCTION TO WHOEVER WRITES THE FOLLOW-UP, AND IT IS THE ONE
+-- THING IN THIS FILE THAT CAN STILL CAUSE AN OUTAGE IF IT IS MISSED:
+-- THE FOLLOW-UP MIGRATION MUST BACKFILL assistant_enabled_at IN THE SAME FILE
+-- THAT ADDS THE PREDICATE TO THE VERDICT. Adding the predicate without the
+-- backfill refuses every existing connection in the fleet at boot. The
+-- backfill it needs is the statement deleted from step (1) of this file:
 --
---     ROLLING BACK IS AN OPERATOR ACTION, NOT A MIGRATION. If an org should
---     not have been enabled, an operator sets the column to NULL. The backfill
---     deliberately errs toward preserving service.
+--   UPDATE tenants AS tn SET assistant_enabled_at = now()
+--    WHERE tn.assistant_enabled_at IS NULL
+--      AND EXISTS (SELECT 1 FROM mcp_grants g WHERE g.tenant_id = tn.id);
 --
---   assistant_paused_at -> LEFT NULL ON EVERY ROW. Nothing to backfill. The
---     kill switch starts released everywhere, which is today's behaviour
---     exactly. THIS IS THE COLUMN THAT COULD CAUSE THE FLEET-WIDE OUTAGE IF IT
---     WERE BACKFILLED OR DEFAULTED TO ANYTHING NON-NULL, and it is neither.
+--   `EXISTS` WITH NO STATUS FILTER, AND THAT BREADTH IS DELIBERATE. Filtering
+--   to status = 'active' would leave a tenant whose only grant is currently
+--   revoked marked never-enabled, and its next connection would be refused --
+--   an org that used the surface last week discovering it is off, caused by a
+--   migration rather than by a decision. Any tenant that has ever created a
+--   connection has demonstrably opted in. Guard it `WHERE ... IS NULL` so a
+--   re-run cannot overwrite an operator decision; that guard is the m110/m111
+--   lesson.
 --
---   assistant_paused_reason -> LEFT NULL. Meaningless without a pause.
+-- WHY DELETING IT MATTERS RATHER THAN BEING A TIDY-UP. See DECISION 9: that
+-- one statement was ~90% of the time this migration holds ACCESS EXCLUSIVE on
+-- `tenants`, and it was the only part that wrote rows, generated WAL and
+-- bloated the table.
 --
--- EVERY STATEMENT BELOW IS IDEMPOTENT AND THE FILE IS RE-RUNNABLE. The
--- backfill is guarded by IS NULL, so a second application updates zero rows
--- and cannot re-enable an organisation an operator has since turned off. That
--- guard is the m110/m111 lesson: a backfill that can overwrite an operator
--- decision is the thing that needs the repair migration.
+-- WHAT REMAINS TRUE WITH NO BACKFILL AT ALL:
+--
+--   NO COLUMN CARRIES A DEFAULT AND NO COLUMN IS NOT NULL. Every existing row
+--   keeps NULL in all three, and NULL is a legal, meaningful value in each.
+--   Every existing INSERT that does not mention them keeps working. That is
+--   what makes constraint 1 -- every existing insert and read path keeps
+--   working -- true BY CONSTRUCTION rather than by assertion: m127's NOT NULL
+--   columns reddened ten integration tests, and NOTHING HERE IS NOT NULL.
+--
+--   assistant_paused_at IS NULL ON EVERY ROW, WHICH IS TODAY'S BEHAVIOUR
+--   EXACTLY. This is the column that would cause a fleet-wide outage if it
+--   were backfilled or defaulted to anything non-NULL, and it is neither. The
+--   kill switch starts released everywhere.
+--
+--   assistant_enabled_at IS NULL ON EVERY ROW, AND THAT IS SAFE ONLY BECAUSE
+--   NOTHING READS IT. If that ever stops being true without the backfill
+--   above, it is an outage. DECISION 5 is the same warning from the other
+--   side.
+--
+-- THE FILE REMAINS FULLY IDEMPOTENT AND RE-RUNNABLE: every statement is either
+-- ADD COLUMN IF NOT EXISTS or guarded by a pg_constraint probe.
 --
 -- ===========================================================================
 -- DECISION 7: RLS, POLICIES, AND WHAT IS DELIBERATELY NOT ADDED
@@ -369,9 +396,93 @@
 -- failure that looks like an RLS bug for a day -- and on this table, where
 -- there is no RLS to blame, for longer.
 
+-- ===========================================================================
+-- DECISION 9: THE LOCK WINDOW ON `tenants`, MEASURED, AND WHY `NOT VALID` IS
+--             NOT THE FIX HERE EVEN THOUGH IT USUALLY IS
+-- ===========================================================================
+--
+-- WHY THIS TABLE DESERVES THE PARAGRAPH. internal/db/migrate.go applies each
+-- file inside pgx.BeginFunc -- ONE TRANSACTION FOR THE WHOLE FILE (applyOne,
+-- migrate.go:96-98) -- from inside main() at boot, while other instances are
+-- still serving. So EVERY LOCK THIS FILE TAKES IS HELD UNTIL THE FILE COMMITS,
+-- and ACCESS EXCLUSIVE on `tenants` blocks essentially every request in the
+-- product rather than one feature. The window must not scale with customer
+-- count. "Fast on a laptop" is not the property being claimed.
+--
+-- MEASURED, NOT REASONED ABOUT. PostgreSQL 16.15, throwaway container, the
+-- statements below run in one transaction exactly as applyOne runs them, at
+-- two table sizes so the SHAPE is visible and not just a number:
+--
+--                              200,000 tenants     800,000 tenants
+--   ADD COLUMN x3 (nullable)          0.9 ms              0.65 ms
+--   UPDATE backfill (deleted)       152.6 ms            302.9 ms
+--   ADD CONSTRAINT (check)           10.4 ms             34.6 ms
+--   ---------------------------------------------------------------
+--   total, as first written         164 ms              338 ms
+--   total, as it now stands          11 ms               35 ms
+--
+-- WHAT EACH LINE IS PROPORTIONAL TO:
+--
+--   ADD COLUMN IS FLAT AND IS NOT THE PROBLEM. A nullable column with no
+--   DEFAULT is metadata-only on PostgreSQL 11+; it records an attmissingval
+--   and does not rewrite the table. The measurement confirms it: 4x the rows
+--   changed the time not at all. This is why the three ALTERs are left exactly
+--   as they are.
+--
+--   THE BACKFILL WAS THE WHOLE PROBLEM. ~93% of the original window, the only
+--   statement writing rows, and growing with tenant count. DECISION 6 DELETES
+--   IT rather than batching it, because it did no work -- batching would have
+--   preserved a cost while merely spreading it, and the honest fix for work
+--   that need not happen is not to do it.
+--
+--   THE CHECK SCAN REMAINS AND GROWS WITH TENANT COUNT. It is now the entire
+--   window: ~35 ms at 800k tenants, and it is a read-only sequential scan --
+--   no writes, no WAL, no bloat. It is cheaper than a bare scan of the table
+--   because all three columns were added in this same transaction, so every
+--   row carries the missing-value NULL and the constraint short-circuits on
+--   its first disjunct. Measured against pre-existing columns in their own
+--   transaction the same constraint costs 53 ms at 200k rather than 10 ms,
+--   which is the honest ceiling if that fast path is ever lost.
+--
+-- WHY `NOT VALID` + `VALIDATE CONSTRAINT` IS NOT USED, AND THIS IS A DIFFERENT
+-- ARGUMENT FROM m129's.
+--
+--   m129 DECISION 3 rejected NOT VALID because it "buys a skipped table scan
+--   and costs a permanent two-class table in which old rows are exempt from a
+--   SECURITY bound with nothing scheduled to ever VALIDATE them". That
+--   objection is about leaving a constraint PERMANENTLY unvalidated, and it
+--   would NOT apply to NOT VALID immediately followed by VALIDATE in the same
+--   file -- that pair ends in the identical validated state. So m129's reason
+--   alone does not settle this one, and the lock profile really could have
+--   changed the answer.
+--
+--   IT IS REJECTED HERE FOR A STRONGER AND MORE SPECIFIC REASON: UNDER THIS
+--   MIGRATION RUNNER THE PAIR IS INERT. VALIDATE CONSTRAINT takes the weaker
+--   SHARE UPDATE EXCLUSIVE lock, which is the entire benefit -- but a lock is
+--   only weak if nothing stronger is already held, and applyOne has already
+--   taken ACCESS EXCLUSIVE on this table via the ADD COLUMNs in the SAME
+--   TRANSACTION and holds it until COMMIT. A transaction cannot weaken its own
+--   lock. The split buys a lower lock level that nobody can observe, and pays
+--   for it with a constraint that is briefly invalid and a reader who must
+--   work out why. NOT VALID helps only when the two halves are in SEPARATE
+--   transactions, which internal/db/migrate.go cannot express.
+--
+--   AND THE PRIZE IS ~35 ms. Even granting the split worked, it would remove a
+--   35 ms read-only scan at 800k tenants. The measurement is what makes this a
+--   decision rather than a preference: it was worth checking, and having
+--   checked, the constraint is added VALIDATED, in one statement.
+--
+-- IF THIS TABLE EVER NEEDS A GENUINELY LONG DDL, the fix is not NOT VALID; it
+-- is a runner that can apply a file outside a single transaction. That is a
+-- change to migrate.go and is out of scope here, and it is the right place to
+-- start if a future migration on `tenants` cannot be made cheap in place.
+
 -- ---------------------------------------------------------------------------
 -- (0) Columns. All three NULLABLE with NO DEFAULT, so every existing INSERT
 --     that does not mention them keeps working unchanged. See DECISION 6.
+--
+--     METADATA-ONLY ON PG 11+: no table rewrite, and measured flat across a
+--     4x change in row count. See DECISION 9.
 -- ---------------------------------------------------------------------------
 
 ALTER TABLE "public"."tenants"
@@ -384,21 +495,10 @@ ALTER TABLE "public"."tenants"
     ADD COLUMN IF NOT EXISTS "assistant_paused_reason" text;
 
 -- ---------------------------------------------------------------------------
--- (1) Backfill. WHERE ... IS NULL makes this a no-op on a second run and
---     protects a decision an operator has already made. See DECISION 6.
---
---     Only assistant_enabled_at is backfilled. The kill switch and its reason
---     stay NULL on every row, which is today's behaviour exactly.
+-- (1) NO BACKFILL. THE STATEMENT THAT WAS HERE HAS BEEN DELETED, NOT BATCHED.
+--     See DECISION 6. Every column stays NULL on every existing row, which is
+--     today's behaviour exactly, and the lock window below stays flat.
 -- ---------------------------------------------------------------------------
-
-UPDATE "public"."tenants" AS tn
-   SET "assistant_enabled_at" = now()
- WHERE tn."assistant_enabled_at" IS NULL
-   AND EXISTS (
-        SELECT 1
-          FROM "public"."mcp_grants" g
-         WHERE g."tenant_id" = tn."id"
-   );
 
 -- ---------------------------------------------------------------------------
 -- (2) Constraints. Each guarded by a pg_constraint probe so the file re-runs.

--- a/apps/api/tests/mcp_m130_kill_switch_integration_test.go
+++ b/apps/api/tests/mcp_m130_kill_switch_integration_test.go
@@ -1,0 +1,278 @@
+// mcp_m130_kill_switch_integration_test.go: m130's per-tenant kill switch,
+// executed against the REAL schema as wpmgr_app.
+//
+// WHY THIS FILE EXISTS. The MCP transport shipped live with no off switch.
+// m130 adds one and folds it into the `authorized` verdict that already runs on
+// every request. The claim that makes it a KILL SWITCH rather than a
+// registration gate is not decidable by reading the SQL:
+//
+//	engaging it must refuse the VERY NEXT REQUEST on a connection that was
+//	already issued, already authenticated, and is otherwise perfectly valid.
+//
+// A switch that only blocks new grants while existing tokens keep reading is
+// not the control anyone wants at 3am, and the difference between the two is
+// invisible in a schema diff. So it is executed here, through mcp.Service --
+// the same method the transport calls, the same generated query, the same tx
+// helpers. No connection is opened by this file and no GUC is hand-set.
+//
+// THE ROLE IS LOAD-BEARING AND IS ASSERTED INSIDE THE TRANSACTION UNDER TEST.
+// wpmgr_app is NOSUPERUSER NOBYPASSRLS; either privilege would make an RLS
+// proof pass vacuously, which is exactly how m112's proofs were green while
+// every policy was inert.
+//
+// FOUR THINGS ARE IN QUESTION, and the first is not optional. Without it the
+// other three prove only that a broken query refuses everything:
+//
+//  1. BASELINE. A tenant with NO explicit assistant state -- both m130 columns
+//     NULL, which is every tenant in the fleet the moment m130 applies --
+//     authenticates exactly as it does today. This is m130's central safety
+//     claim and the one that would be an outage if it were false.
+//
+//  2. ENGAGED. The same bearer, on the same grant, is refused once the switch
+//     is on. Nothing about the grant or the token changed.
+//
+//  3. RELEASED. The same bearer works again. A switch that cannot be released
+//     is a deletion, not a switch, and an incident that ends with a permanently
+//     dead surface is not a resolved incident.
+//
+//  4. ISOLATION. One organisation's switch does not touch another's. The two
+//     tenants are exercised in the same test with live bearers on both, so a
+//     predicate that ignored tenant_id -- or a switch stored somewhere global
+//     -- fails here rather than in production during someone else's incident.
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// m130Engage turns the kill switch on for one tenant, through the generated
+// query and pool.InTenantTx -- never through a connection this file opened.
+// The role is re-asserted inside the write transaction, because a write that
+// only succeeds as superuser proves nothing about the operator console.
+func m130Engage(t *testing.T, pool interface {
+	InTenantTx(context.Context, uuid.UUID, func(pgx.Tx) error) error
+}, tenantID uuid.UUID, reason string) {
+	t.Helper()
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (EngageTenantAssistantKillSwitch)")
+		rows, err := sqlc.New(tx).EngageTenantAssistantKillSwitch(context.Background(),
+			sqlc.EngageTenantAssistantKillSwitchParams{
+				TenantID: tenantID,
+				Reason:   &reason,
+			})
+		if err != nil {
+			return err
+		}
+		if rows != 1 {
+			t.Fatalf("EngageTenantAssistantKillSwitch affected %d rows, want 1", rows)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("engage kill switch for %s: %v", tenantID, err)
+	}
+}
+
+// m130Release turns it back off. Clears the reason in the same statement --
+// tenants_assistant_paused_reason_check refuses a reason without a pause, so a
+// release that cleared only the timestamp would fail loudly here.
+func m130Release(t *testing.T, pool interface {
+	InTenantTx(context.Context, uuid.UUID, func(pgx.Tx) error) error
+}, tenantID uuid.UUID) {
+	t.Helper()
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (ReleaseTenantAssistantKillSwitch)")
+		rows, err := sqlc.New(tx).ReleaseTenantAssistantKillSwitch(context.Background(), tenantID)
+		if err != nil {
+			return err
+		}
+		if rows != 1 {
+			t.Fatalf("ReleaseTenantAssistantKillSwitch affected %d rows, want 1", rows)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("release kill switch for %s: %v", tenantID, err)
+	}
+}
+
+// m130State reads the columns back through the generated operator-console
+// query, so the test observes what the console will observe.
+func m130State(t *testing.T, pool interface {
+	InTenantTx(context.Context, uuid.UUID, func(pgx.Tx) error) error
+}, tenantID uuid.UUID) sqlc.GetTenantAssistantStateRow {
+	t.Helper()
+	var out sqlc.GetTenantAssistantStateRow
+	err := pool.InTenantTx(context.Background(), tenantID, func(tx pgx.Tx) error {
+		var err error
+		out, err = sqlc.New(tx).GetTenantAssistantState(context.Background(), tenantID)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("read assistant state for %s: %v", tenantID, err)
+	}
+	return out
+}
+
+func TestMCPKillSwitchStopsInFlightConnectionsAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	repo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	tenantA := seedTenant(t, pool, "m130-a-"+uuid.NewString()[:8])
+	tenantB := seedTenant(t, pool, "m130-b-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenantA, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (verdict path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	siteA, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenantA, URL: "https://m130-a.example.com", Name: "m130-alpha"})
+	if err != nil {
+		t.Fatalf("create site A: %v", err)
+	}
+	siteB, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenantB, URL: "https://m130-b.example.com", Name: "m130-bravo"})
+	if err != nil {
+		t.Fatalf("create site B: %v", err)
+	}
+
+	grantA, bearerA := s7GrantWithBearer(t, repo, tenantA, "list", []uuid.UUID{siteA.ID})
+	_, bearerB := s7GrantWithBearer(t, repo, tenantB, "list", []uuid.UUID{siteB.ID})
+
+	// ---------------------------------------------------------------------
+	// 1. BASELINE. Neither tenant has any explicit assistant state. This is
+	//    the state of every tenant in the fleet the instant m130 applies, and
+	//    it must behave exactly as today.
+	// ---------------------------------------------------------------------
+	stateA := m130State(t, pool, tenantA)
+	if stateA.AssistantPausedAt.Valid {
+		t.Fatalf("assistant_paused_at = %v on a fresh tenant, want NULL -- m130 "+
+			"must not pause anything by applying", stateA.AssistantPausedAt)
+	}
+	if stateA.AssistantPausedReason != nil {
+		t.Fatalf("assistant_paused_reason = %v on a fresh tenant, want NULL",
+			*stateA.AssistantPausedReason)
+	}
+
+	if _, err := svc.Authenticate(ctx, bearerA); err != nil {
+		t.Fatalf("BASELINE FAILED: Authenticate refused a tenant with no explicit "+
+			"assistant state: %v. m130 changed the behaviour of an untouched "+
+			"tenant, which is the outage this migration must not cause.", err)
+	}
+	if _, err := svc.Authenticate(ctx, bearerB); err != nil {
+		t.Fatalf("BASELINE FAILED for tenant B: %v", err)
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. ENGAGED. Nothing about grantA or its token changes -- the grant is
+	//    still active, still unexpired, still fully capable. Only the tenant
+	//    row moved, and the next request on the ALREADY-ISSUED bearer must be
+	//    refused. That is what makes this a kill switch.
+	// ---------------------------------------------------------------------
+	m130Engage(t, pool, tenantA, "m130 integration proof: simulated incident")
+
+	engaged := m130State(t, pool, tenantA)
+	if !engaged.AssistantPausedAt.Valid {
+		t.Fatal("assistant_paused_at is NULL after engaging the kill switch")
+	}
+	if engaged.AssistantPausedReason == nil {
+		t.Fatal("assistant_paused_reason is NULL after engaging with a reason")
+	}
+
+	if _, err := svc.Authenticate(ctx, bearerA); err == nil {
+		t.Fatalf("KILL SWITCH DID NOT FIRE: Authenticate ADMITTED grant %s on an "+
+			"organisation whose kill switch is engaged. An operator who engaged "+
+			"this switch during an incident believes the surface is stopped and "+
+			"it is still reading.", grantA.ID)
+	}
+
+	// ---------------------------------------------------------------------
+	// 4. ISOLATION, asserted while A is still paused. Tenant B never touched
+	//    its switch and must be entirely unaffected. A predicate that dropped
+	//    tenant_id, or state stored anywhere global, fails here.
+	// ---------------------------------------------------------------------
+	if _, err := svc.Authenticate(ctx, bearerB); err != nil {
+		t.Fatalf("CROSS-TENANT LEAK: tenant A's kill switch refused tenant B: %v. "+
+			"One organisation's incident action must never stop another's "+
+			"surface.", err)
+	}
+	stateB := m130State(t, pool, tenantB)
+	if stateB.AssistantPausedAt.Valid {
+		t.Fatalf("tenant B's assistant_paused_at = %v after only tenant A was "+
+			"paused, want NULL", stateB.AssistantPausedAt)
+	}
+
+	// ---------------------------------------------------------------------
+	// 3. RELEASED. The same bearer works again, unchanged. A switch that
+	//    cannot be released is a deletion.
+	// ---------------------------------------------------------------------
+	m130Release(t, pool, tenantA)
+
+	released := m130State(t, pool, tenantA)
+	if released.AssistantPausedAt.Valid {
+		t.Fatalf("assistant_paused_at = %v after release, want NULL",
+			released.AssistantPausedAt)
+	}
+	if released.AssistantPausedReason != nil {
+		t.Fatalf("assistant_paused_reason survived the release as %q; the reason "+
+			"is part of the pause and must not outlive it",
+			*released.AssistantPausedReason)
+	}
+
+	if _, err := svc.Authenticate(ctx, bearerA); err != nil {
+		t.Fatalf("Authenticate still refuses after the kill switch was released: "+
+			"%v. The switch is a deletion, not a switch.", err)
+	}
+}
+
+// TestMCPKillSwitchReleaseDoesNotEnableADisabledTenantAsAppRole is m130
+// DECISION 2 executed: the reason the two facts are two columns.
+//
+// An organisation that was deliberately never enabled, then paused during an
+// incident, then un-paused, must STILL BE NOT-ENABLED afterwards. With a single
+// tri-state column "un-pause" means "write on", so the incident response
+// silently reverses a configuration decision nobody revisited. This test is the
+// one that fails if anyone ever collapses the two columns into one.
+func TestMCPKillSwitchReleaseDoesNotEnableADisabledTenantAsAppRole(t *testing.T) {
+	pool := startPostgres(t)
+
+	tenant := seedTenant(t, pool, "m130-cfg-"+uuid.NewString()[:8])
+
+	// A fresh tenant has never been enabled: assistant_enabled_at IS NULL.
+	before := m130State(t, pool, tenant)
+	if before.AssistantEnabledAt.Valid {
+		t.Fatalf("assistant_enabled_at = %v on a fresh tenant, want NULL -- "+
+			"off by default at the tenant level is ADR-061's requirement",
+			before.AssistantEnabledAt)
+	}
+
+	m130Engage(t, pool, tenant, "m130 integration proof: pause a disabled org")
+	m130Release(t, pool, tenant)
+
+	after := m130State(t, pool, tenant)
+	if after.AssistantEnabledAt.Valid {
+		t.Fatalf("RELEASING THE KILL SWITCH ENABLED THE SURFACE: "+
+			"assistant_enabled_at went from NULL to %v across an "+
+			"engage/release cycle. Incident response must never reverse a "+
+			"configuration decision. This is why m130 uses two columns and "+
+			"not one tri-state.", after.AssistantEnabledAt)
+	}
+	if after.AssistantPausedAt.Valid {
+		t.Fatalf("assistant_paused_at = %v after release, want NULL",
+			after.AssistantPausedAt)
+	}
+}


### PR DESCRIPTION
Adds the per-tenant state ADR-061's pre-v1 checklist needs for the assistant/MCP surface (roadmap 1A-11), and folds the kill switch into the per-request authorization verdict.

## What lands

Three nullable columns on `tenants`, no DEFAULT, **no NOT NULL anywhere, and no backfill**:

- `assistant_enabled_at` — NULL means never enabled (off). Configuration.
- `assistant_paused_at` — NULL means not paused (running). The kill switch.
- `assistant_paused_reason` — the incident note, constrained to require a pause.

Only `assistant_paused_at` is in the verdict. See the last two sections.

## Three decisions worth reviewing

**State lives on `tenants`, not a settings table, and it is a security choice.** 184 tables here are under RLS; `tenants` is not one of them. A kill switch read on the authentication path from behind a policy can be filtered to NULL, read as "not paused", and be silently inert — the shape of the escalation fixed on 2026-08-30. On `tenants` no policy can hide the row, so the switch cannot be made inert. Secondary: one click is one UPDATE on one row, with no INSERT that could fail mid-incident.

**Two columns, not one tri-state.** With one column, un-pausing means writing "on", so incident response silently reverses a configuration decision nobody revisited. With two, releasing the switch clears only the pause. `TestMCPKillSwitchReleaseDoesNotEnableADisabledTenantAsAppRole` is the test that fails if anyone ever collapses them.

**It stops in-flight requests.** The verdict is recomputed per request, so engaging the switch refuses the very next request on an already-issued bearer. No cache — a cached kill switch is not a kill switch. Cost is one primary-key probe on a value already bound in the query; no new index.

## Existing tenants are unaffected

All three columns stay NULL on every existing row, and NULL is a legal, meaningful value in each. Every existing INSERT that does not mention them keeps working. Constraint 1 — every existing insert and read path keeps working — is true **by construction**, not by assertion: m127's NOT NULL columns reddened ten integration tests, and nothing here is NOT NULL.

`assistant_paused_at` NULL everywhere means the kill switch starts released fleet-wide, which is today's behaviour exactly.

## Lock profile on `tenants` (Greptile finding, addressed)

`applyOne` wraps each file in one transaction (`internal/db/migrate.go:96-98`), so every lock is held to COMMIT, at boot, on a table the whole product joins. Measured on PG 16.15 in one transaction at two sizes:

|                          | 200k tenants | 800k tenants |
|--------------------------|--------------|--------------|
| `ADD COLUMN` x3 (nullable) | 0.9 ms | 0.65 ms |
| `UPDATE` backfill | 152.6 ms | 302.9 ms |
| `ADD CONSTRAINT` | 10.4 ms | 34.6 ms |
| **total, as first written** | **164 ms** | **338 ms** |
| **total, as it now stands** | **11 ms** | **35 ms** |

`ADD COLUMN` nullable with no default is metadata-only on PG 11+ and measured flat across 4x rows. The backfill was 93% of the window and the only statement writing rows; it is **deleted, not batched**, because it did no work — nothing reads the column, and the follow-up must backfill at its own apply time regardless. `NOT VALID` + `VALIDATE` is rejected because it is *inert* under a single-transaction runner, not for m129's reason. Full argument in m130 DECISION 9.

Remaining window: a read-only scan, no writes, no WAL, no bloat, ~35 ms per 800k tenants.

## Enablement is deliberately NOT in the verdict yet

Gating on `assistant_enabled_at` was written, run, and **backed out on evidence**. No backfill can reach a tenant that does not exist yet, so any tenant created after m130 has it NULL and every connection it makes is refused:

```
go test ./tests/ -run TestMCPActivityStampLandsAsAppRole -count=1
  current_user=wpmgr_app rolsuper=false rolbypassrls=false
  Authenticate with a live bearer: this connection has been revoked or has expired
  FAIL
```

In the suite that is a red test; in production it is every new signup. The column stays and still encodes off-by-default, but nothing reads it until a Go path can write it — the m127 DECISION 4 shape. Wiring it is a **two-part change that must ship together**: the enable control first, then a NEW ordinal adding the one line to the verdict **plus the backfill DECISION 6 spells out**. Never an edit to m130.

## Proofs

All as `wpmgr_app`, `rolsuper=false rolbypassrls=false` printed from `pg_roles` inside the transaction under test, through `mcp.Service` and `pool.InTenantTx` — no connection opened by the test, no GUC hand-set.

- Baseline unchanged, engaged refuses an already-issued bearer, released restores, one tenant's switch does not touch another's, and releasing a pause never enables a surface that was deliberately off.
- Mutation sweep, re-run against the edited migration: removing the switch from the verdict makes the engaged case stop refusing; dropping the tenant filter from engage trips the row-count assertion. Both reverted; `git grep 'MUTATION M' -- apps/api` exits 1 and `git diff --quiet` exits 0.
- `scripts/check-rls-cross-tenant_test.sh` 54 passed 0 failed, then `scripts/check-rls-cross-tenant.sh` green on its own throwaway container (`WPMGR_RLS_DATABASE_URL` unset): 139 migrations applied, 105 cross-tenant policies against 105 ledger rows, 0 errors. No ledger row is owed — this migration adds no policy.
- `make test-integration` from the repo root.

sqlc v1.31.1 (`/Users/mosamgor/go/bin/sqlc`) regenerated, never hand-edited; `git diff --quiet -- internal/db/sqlc/` exits 0 after the lock fix, which is comment-only SQL plus the deleted statement.
