### PR TITLE
feat(mcp): widen the Go capability vocabulary to m131's eight, and decouple the default

### DIFF
--- a/apps/api/internal/mcp/capability_default_test.go
+++ b/apps/api/internal/mcp/capability_default_test.go
@@ -1,0 +1,278 @@
+// The three sets this package keeps separate, and the tests that keep them
+// separate.
+//
+//	capabilityVocabulary       what may be spelled at all      -- 8
+//	scopeCapabilities          what a scope confers, a CEILING -- 7
+//	DefaultGrantCapabilities   what an unasked grant receives  -- 1
+//
+// Before m131 all three held one member, so all three were the same list and
+// nothing in the tree could tell them apart. The identity was TRUE, and every
+// test that ranged over one of them would have passed just as well ranging over
+// either other. That is why these tests assert EXACT SETS BY VALUE rather than
+// membership or length: a proof written as "the default contains
+// mcp.sites.read" stays green against a default of all eight, which is the
+// exact widening this file exists to catch.
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// capsToStrings renders a capability list for comparison and for failure
+// messages, so a failure prints the sets rather than a bare count.
+func capsToStrings(caps []Capability) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, string(c))
+	}
+	return out
+}
+
+// sameCaps reports set-and-order equality against an expected literal.
+func sameCaps(got []Capability, want []Capability) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// THE TRAP TEST.
+// ---------------------------------------------------------------------------
+
+// TestDefaultGrantCapabilitiesIsThePresetNotTheVocabulary is the test that
+// would have caught the widening m131's closing note warns about, and it is the
+// reason this file exists.
+//
+// The failure it guards is not a bug anyone would write on purpose. It is
+// `func DefaultGrantCapabilities() []Capability { return AllCapabilities() }`
+// left untouched while capabilityVocabulary grows from one member to eight --
+// a one-line map edit, no compiler error, no existing test red, and every grant
+// minted afterwards silently carrying all eight capabilities including a
+// content group ADR-062 holds behind ship blockers.
+//
+// SO IT ASSERTS THE EXACT SET BY VALUE. `set.Allows(CapSitesRead)` would be
+// green against all eight. `len(set) > 0` would be green against all eight.
+// Only naming the whole expected list catches it.
+func TestDefaultGrantCapabilitiesIsThePresetNotTheVocabulary(t *testing.T) {
+	want := []Capability{CapSitesRead}
+
+	got := DefaultGrantCapabilities()
+	if !sameCaps(got, want) {
+		t.Fatalf("DefaultGrantCapabilities() = %v, want exactly %v.\n"+
+			"A grant minted with no explicit capability request receives this set "+
+			"verbatim (Service.Approve and Service.MintConnection), so anything "+
+			"wider here is authority stamped onto a credential whose operator was "+
+			"never shown it.",
+			capsToStrings(got), capsToStrings(want))
+	}
+
+	// THE SECOND HALF, AND THE ONE THAT NAMES THE WIDENING. The equality above
+	// pins today's value; this pins the RELATIONSHIP, so restoring
+	// `return AllCapabilities()` fails with a message that says what happened
+	// rather than only printing two differing lists.
+	if len(got) >= len(AllCapabilities()) {
+		t.Fatalf("DefaultGrantCapabilities() holds %d of the vocabulary's %d "+
+			"capabilities -- the default is the whole vocabulary again.\n"+
+			"default=%v\nvocabulary=%v\n"+
+			"DefaultGrantCapabilities() must not be AllCapabilities(). That identity "+
+			"was true and safe while the vocabulary held one member; against m131's "+
+			"eight it stamps every capability onto every newly minted grant, which "+
+			"is a credential widening delivered by a map edit.",
+			len(got), len(AllCapabilities()),
+			capsToStrings(got), capsToStrings(AllCapabilities()))
+	}
+
+	// The default must be REACHABLE, or every grant minted without an explicit
+	// request authenticates and then reaches nothing -- the half-working
+	// connection m127 DECISION 3 forbids. Checked against the ceiling, which is
+	// what Authenticate narrows the stored column against.
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	if err != nil {
+		t.Fatalf("OrgDefaultCapabilities(grantScopes()): %v", err)
+	}
+	if _, err := ceiling.NarrowTo(got); err != nil {
+		t.Fatalf("the default preset %v is not held by the organisation ceiling %v: %v.\n"+
+			"Every grant minted without an explicit request would store this set and "+
+			"then be refused by Authenticate on every request.",
+			capsToStrings(got), capsToStrings(ceiling.Sorted()), err)
+	}
+}
+
+// TestMintWithNoRequestedCapabilitiesGetsThePresetNotTheCeiling is the same
+// proof one function over, on the OTHER path that mints a grant.
+//
+// resolveMintCapabilities returned the CEILING for an empty request, which was
+// the default only while the ceiling held one member. Against a seven-member
+// ceiling that line is a second, independent copy of the same widening --
+// reached by the mint endpoint rather than by the consent screen, so a proof
+// aimed only at DefaultGrantCapabilities would miss it entirely.
+func TestMintWithNoRequestedCapabilitiesGetsThePresetNotTheCeiling(t *testing.T) {
+	// resolveMintCapabilities reads no Service field, so the zero value is the
+	// honest fixture rather than a stub standing in for one.
+	svc := &Service{}
+
+	set, err := svc.resolveMintCapabilities(nil)
+	if err != nil {
+		t.Fatalf("resolveMintCapabilities(nil): %v", err)
+	}
+	if !sameCaps(set.Sorted(), DefaultGrantCapabilities()) {
+		t.Fatalf("an empty capability request minted %v, want exactly %v.\n"+
+			"An operator who POSTs no capability list has chosen nothing, and the "+
+			"answer to 'nobody asked' is the preset, never the widest set the "+
+			"organisation ceiling allows.",
+			capsToStrings(set.Sorted()), capsToStrings(DefaultGrantCapabilities()))
+	}
+
+	// The ceiling is still reachable BY ASKING, which is the other half of the
+	// decision: this is a narrower default, not a narrower surface.
+	wider := []Capability{CapSitesRead, CapUptimeRead, CapBackupsRead}
+	asked, err := svc.resolveMintCapabilities(wider)
+	if err != nil {
+		t.Fatalf("resolveMintCapabilities(%v): %v -- an operator who explicitly asks "+
+			"for a seated, conferred capability must receive it", capsToStrings(wider), err)
+	}
+	if asked.Len() != len(wider) {
+		t.Fatalf("an explicit request for %v minted %v", capsToStrings(wider), capsToStrings(asked.Sorted()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The vocabulary and the ceiling, pinned by value.
+// ---------------------------------------------------------------------------
+
+// TestVocabularyIsM131sEight pins the Go half of the two-place closed set by
+// value. The DATABASE half is proved separately and against the live
+// constraint, by TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole in
+// apps/api/tests -- this one cannot see the database and does not pretend to.
+func TestVocabularyIsM131sEight(t *testing.T) {
+	want := []Capability{
+		CapActivityRead,
+		CapBackupsRead,
+		CapContentRead,
+		CapDiagnosticsRead,
+		CapPerformanceRead,
+		CapSecurityRead,
+		CapSitesRead,
+		CapUptimeRead,
+	}
+	if !sameCaps(AllCapabilities(), want) {
+		t.Fatalf("AllCapabilities() = %v, want exactly %v (m131's seated vocabulary, "+
+			"alphabetical, which is the order the constraint lists them in)",
+			capsToStrings(AllCapabilities()), capsToStrings(want))
+	}
+}
+
+// TestEveryCapabilityIsARead makes "this build seats no write capability" a
+// property that is checked rather than claimed. m131 DECISION 2 froze the
+// three-segment form specifically so this is a pattern test: the write side of
+// the design uses '.propose' and '.write', and the first member that does not
+// end in '.read' is the one that needs the write review.
+//
+// It also fails on an empty vocabulary, because a loop over an empty set passes
+// having checked nothing -- the exact shape this brief names as failure mode 3
+// on the database side.
+func TestEveryCapabilityIsARead(t *testing.T) {
+	all := AllCapabilities()
+	if len(all) == 0 {
+		t.Fatal("the vocabulary is empty, so this test ranged over nothing and " +
+			"would have reported a pass having checked no capability at all")
+	}
+	for _, c := range all {
+		if !strings.HasSuffix(string(c), ".read") {
+			t.Fatalf("capability %q does not end in '.read'.\n"+
+				"If this is the first write capability, it needs the review m124 "+
+				"DECISION 1 built the closed CHECK to force -- and it must not be "+
+				"conferred by ScopeRead, which is a read scope.", c)
+		}
+		if !strings.HasPrefix(string(c), "mcp.") {
+			t.Fatalf("capability %q does not carry the frozen 'mcp.' prefix. The "+
+				"wireframes' 'site.*' labels are the SCREEN's, not the stored "+
+				"string's; adopting one here strands every live grant.", c)
+		}
+	}
+	t.Logf("all %d seated capabilities carry the mcp. prefix and the .read suffix: %v",
+		len(all), capsToStrings(all))
+}
+
+// TestScopeReadConfersTheSevenReachableGroups pins the CEILING by value, and it
+// is deliberately not written as a comparison against AllCapabilities().
+//
+// `ScopeRead: AllCapabilities()` is the tempting spelling of this map and it
+// rebuilds the trap one function over: the first '.propose' capability seated
+// in the vocabulary would become conferred by the READ scope silently. The
+// literal below is the rule -- the read scope confers the read capabilities --
+// and a member that arrives in the vocabulary without arriving here goes red at
+// TestContentReadIsKnownButConferredByNoScope's sibling arm rather than being
+// conferred by default.
+func TestScopeReadConfersTheSevenReachableGroups(t *testing.T) {
+	want := []Capability{
+		CapActivityRead,
+		CapBackupsRead,
+		CapDiagnosticsRead,
+		CapPerformanceRead,
+		CapSecurityRead,
+		CapSitesRead,
+		CapUptimeRead,
+	}
+	set, err := OrgDefaultCapabilities([]Scope{ScopeRead})
+	if err != nil {
+		t.Fatalf("OrgDefaultCapabilities([mcp:read]): %v", err)
+	}
+	if !sameCaps(set.Sorted(), want) {
+		t.Fatalf("the mcp:read ceiling = %v, want exactly %v",
+			capsToStrings(set.Sorted()), capsToStrings(want))
+	}
+}
+
+// TestContentReadIsKnownButConferredByNoScope is the seated-and-unreachable
+// stance, held on the Go side, and it is the one asymmetry between the two
+// closed sets that is deliberate.
+//
+// m131 DECISION 3 seats mcp.content.read in the database while nothing can
+// grant it: no post or page table exists, no agent command returns post
+// content, and ADR-062 holds the content work behind ship blockers including a
+// plugin privacy disclosure. The database's version of "nothing writes it" is
+// that no INSERT names it; Go's version is that no SCOPE confers it, so
+// NarrowTo refuses it and no mint path can store it.
+//
+// The alternative -- putting it in the ceiling -- lets an operator mint a
+// connection holding a capability that reaches nothing today and reaches real
+// post content the day those tools land, with no second consent and no
+// disclosure. That is a widening arriving as a side effect of a registry edit,
+// which is the same shape as the default trap this file's first test guards.
+func TestContentReadIsKnownButConferredByNoScope(t *testing.T) {
+	// KNOWN: it must be in the vocabulary, because the database CHECK holds it
+	// and a name the database accepts and Go does not is refused at a different
+	// layer with a different error.
+	if !KnownCapability(CapContentRead) {
+		t.Fatalf("%q is not in capabilityVocabulary, but m131 seats it in "+
+			"mcp_grants_capabilities_vocabulary_check; the two closed sets must "+
+			"agree exactly", CapContentRead)
+	}
+
+	// NOT CONFERRED: no scope hands it out, so no grant can be minted holding it.
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	if err != nil {
+		t.Fatalf("OrgDefaultCapabilities(grantScopes()): %v", err)
+	}
+	if ceiling.Allows(CapContentRead) {
+		t.Fatalf("the organisation ceiling confers %q. Nothing serves it: the tool "+
+			"registry registers no tool requiring it, and ADR-062 holds the content "+
+			"work behind ship blockers. Confer it in the same diff that ships those "+
+			"tools, not before.", CapContentRead)
+	}
+
+	// AND THE REFUSAL IS LOUD, not a silent drop. An operator asking for it is
+	// told, by name, rather than handed a quietly smaller connection.
+	if _, err := ceiling.NarrowTo([]Capability{CapSitesRead, CapContentRead}); err == nil {
+		t.Fatalf("a mint request naming %q was accepted; it must be refused whole, "+
+			"not trimmed down to the capabilities the ceiling does hold", CapContentRead)
+	}
+}

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -242,10 +242,25 @@ type mintConnectionRequestDTO struct {
 	ScopeTagIDs   []string `json:"scope_tag_ids"`
 	ScopeSiteIDs  []string `json:"scope_site_ids"`
 
-	// Capabilities is OPTIONAL and an omitted list means the organisation
-	// default, never an empty set. See Service.resolveMintCapabilities: an
-	// empty stored capability set is a connection that authenticates and can
-	// then reach no tool at all.
+	// Capabilities is OPTIONAL, and THIS IS THE WIRE CONTRACT A CLIENT
+	// INTEGRATOR READS, so it states the answer rather than naming a function.
+	//
+	// AN OMITTED LIST MEANS THE DEFAULT PRESET: exactly ["mcp.sites.read"].
+	//
+	// IT DOES NOT MEAN AN EMPTY SET. An empty stored capability set is a
+	// connection that authenticates and can then reach no tool at all, which
+	// Authenticate refuses by name on every request.
+	//
+	// AND IT DOES NOT MEAN THE ORGANISATION CEILING, which is the wider
+	// seven-member set OrgDefaultCapabilities resolves. This comment said "the
+	// organisation default" until the capability vocabulary widened from one
+	// member to eight; the two were the same list then and are not now. A
+	// client that omits the field and expects the ceiling gets one capability,
+	// and must send the list explicitly to get more.
+	//
+	// See Service.resolveMintCapabilities. A non-empty list is narrowed against
+	// the ceiling and a capability the ceiling does not hold refuses the whole
+	// request rather than being dropped from it.
 	Capabilities []string `json:"capabilities"`
 
 	// SetupClient is the operator's step-2 choice, and it is a *string SO THAT

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -537,8 +537,8 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 // resolveMintCapabilities turns the operator's requested capability list into
 // the set that will be stored.
 //
-// AN EMPTY REQUEST MEANS THE ORGANISATION DEFAULT, NOT AN EMPTY SET, and the
-// difference is the whole function. mcp_grants.capabilities admits '{}' -- the
+// AN EMPTY REQUEST MEANS THE DEFAULT PRESET, NOT AN EMPTY SET AND NOT THE
+// CEILING, and the difference is the whole function. mcp_grants.capabilities admits '{}' -- the
 // shape CHECK passes it, because '{}' is the RESTRICTIVE value -- so an empty
 // set is perfectly storable, and Authenticate then refuses the connection by
 // name on every request ("this connection holds no capability, so it can reach
@@ -552,13 +552,29 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 // tomorrow), whereas an empty capability set is a connection that cannot
 // function at all. The two axes are not symmetric because their empty values
 // mean different things.
+//
+// THE ABSENT REQUEST TAKES DefaultGrantCapabilities(), NOT THE CEILING, AND THE
+// TWO STOPPED BEING THE SAME THING WHEN THE VOCABULARY WIDENED. `return
+// ceiling, nil` here was correct and safe for exactly as long as the ceiling
+// held one member; against a seven-member ceiling it is the SECOND COPY of the
+// widening m131's note warns about, one function over from
+// DefaultGrantCapabilities and reached by the mint endpoint rather than by the
+// consent screen. An operator who POSTs no capability list has chosen nothing,
+// and the answer to "nobody asked" is the preset, never the widest set
+// available. An operator who wants more asks for it on the line below, and
+// asking is choosing.
 func (s *Service) resolveMintCapabilities(requested []Capability) (CapabilitySet, error) {
 	ceiling, err := OrgDefaultCapabilities(grantScopes())
 	if err != nil {
 		return CapabilitySet{}, fmt.Errorf("resolve organisation capabilities: %w", err)
 	}
 	if len(requested) == 0 {
-		return ceiling, nil
+		// Still routed through NarrowTo rather than returned directly, so the
+		// preset is subject to the same ceiling every explicit request is. A
+		// preset that named a capability no scope confers would be a refusal
+		// here, loudly, rather than a stored set Authenticate refuses later on
+		// every request of a credential the operator is already holding.
+		return ceiling.NarrowTo(DefaultGrantCapabilities())
 	}
 	// NarrowTo REFUSES anything the ceiling does not hold rather than dropping
 	// it. Dropping would be fail-closed and still wrong: the operator would be

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -242,12 +242,22 @@ type MintConnectionRequest struct {
 	// do, is VERIFY the ids server-side -- see ErrCodeUnknownScopeTag.
 	SiteScope SiteScopeRequest
 
-	// Capabilities is the tool axis. EMPTY MEANS "the organisation default",
-	// not "none": an empty stored capability set is a connection that
-	// authenticates and then reaches no tool, which Authenticate refuses by
-	// name, so writing one here would mint a credential that can never work.
-	// A non-empty list is NARROWED against the org ceiling, never widened past
-	// it -- CapabilitySet.NarrowTo refuses rather than intersects.
+	// Capabilities is the tool axis. EMPTY MEANS THE DEFAULT PRESET --
+	// DefaultGrantCapabilities(), which is {mcp.sites.read} -- and it is
+	// neither "none" nor "the organisation ceiling".
+	//
+	// BOTH OF THOSE READINGS ARE WRONG AND THEY ARE WRONG IN OPPOSITE
+	// DIRECTIONS. "None" would store an empty set, and an empty stored
+	// capability set is a connection that authenticates and then reaches no
+	// tool, which Authenticate refuses by name -- a credential that can never
+	// work. "The organisation default" was this comment's own wording until the
+	// vocabulary widened, and it is the name of OrgDefaultCapabilities, the
+	// SEVEN-member ceiling; reading it that way now hands the widest available
+	// set to a caller who asked for nothing.
+	//
+	// A non-empty list is NARROWED against that ceiling, never widened past it
+	// -- CapabilitySet.NarrowTo refuses rather than intersects. So the ceiling
+	// is reachable BY ASKING, and only by asking.
 	Capabilities []Capability
 
 	// SetupClient is the operator's step-2 choice, OPTIONAL, and nil means the

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -44,17 +44,73 @@ const ErrCodeCapabilityWiderThanDefault = "mcp_capability_wider_than_default"
 // something this path enforces. See ToolPolicy.OperatorPermission.
 type Capability string
 
-// CapSitesRead is the only capability the Phase 1 surface has: read the fleet
-// inventory. The vocabulary is closed (capabilityVocabulary below) for the same
-// reason recognisedScopes is closed -- an unrecognised capability must be a
-// refusal, never a token quietly dropped from a set that is then honoured.
-const CapSitesRead Capability = "mcp.sites.read"
+// The v1 READ vocabulary, one constant per outcome group. m131 seated these
+// eight in mcp_grants_capabilities_vocabulary_check and its DECISION 1 is the
+// argument for each name and each boundary; it is not restated here, because a
+// second copy of that argument is a second thing that can drift.
+//
+// Three properties of the set that this file DOES have to hold:
+//
+//   - The `mcp.` prefix is FROZEN by CapSitesRead, not chosen. The wireframes
+//     render the operator-facing form as `site.*`; those are the SCREEN's
+//     labels and the picker may render whatever label it likes above these
+//     strings.
+//   - EVERY MEMBER ENDS IN `.read`, which is what makes "no write capability is
+//     reachable from this build" checkable by pattern rather than by claim.
+//     TestEveryCapabilityIsARead pins it.
+//   - The set is CLOSED, for the same reason recognisedScopes is closed: an
+//     unrecognised capability must be a refusal, never a token quietly dropped
+//     from a set that is then honoured.
+const (
+	// CapSitesRead is the fleet inventory, and the ONLY member any grant minted
+	// before this commit holds. It is also the only member the tool registry
+	// currently requires (registry.go).
+	CapSitesRead Capability = "mcp.sites.read"
+
+	CapUptimeRead      Capability = "mcp.uptime.read"
+	CapBackupsRead     Capability = "mcp.backups.read"
+	CapSecurityRead    Capability = "mcp.security.read"
+	CapActivityRead    Capability = "mcp.activity.read"
+	CapPerformanceRead Capability = "mcp.performance.read"
+	CapDiagnosticsRead Capability = "mcp.diagnostics.read"
+
+	// CapContentRead is SEATED AND DELIBERATELY UNREACHABLE. It is in the
+	// vocabulary because the database's CHECK holds it and the two sets must
+	// agree exactly (m131 DECISION 5), and it is in NO scope's capability list
+	// so no grant can be minted holding it. See scopeCapabilities.
+	CapContentRead Capability = "mcp.content.read"
+)
 
 // capabilityVocabulary is the CLOSED set of capabilities this surface knows.
 // A Capability outside it is not a weaker grant, it is an unknown one, and an
 // unknown grant is refused.
+//
+// IT IS THE GO HALF OF A SET THAT IS CLOSED IN TWO PLACES. The other half is
+// mcp_grants_capabilities_vocabulary_check, and the two must hold the same
+// eight names: a name the database accepts and this map does not is refused at
+// a different layer with a different error, and a name this map accepts and the
+// database does not is a 23514 at INSERT on a path an operator reached through
+// a wizard. TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole (in
+// apps/api/tests) reads the live constraint and asserts both directions.
+//
+// KNOWING a capability is not CONFERRING it and is not DEFAULTING to it. Those
+// are three separate sets and this is the widest of them:
+//
+//	capabilityVocabulary   -- what may be spelled at all           (8)
+//	scopeCapabilities      -- what a scope confers, the CEILING    (7)
+//	DefaultGrantCapabilities -- what an unasked grant receives     (1)
+//
+// Widening this map alone widens NOTHING a grant receives, and that separation
+// is the whole point of this commit. See DefaultGrantCapabilities.
 var capabilityVocabulary = map[Capability]struct{}{
-	CapSitesRead: {},
+	CapActivityRead:    {},
+	CapBackupsRead:     {},
+	CapContentRead:     {},
+	CapDiagnosticsRead: {},
+	CapPerformanceRead: {},
+	CapSecurityRead:    {},
+	CapSitesRead:       {},
+	CapUptimeRead:      {},
 }
 
 // KnownCapability reports whether c is in the vocabulary.
@@ -86,8 +142,37 @@ func AllCapabilities() []Capability {
 // nothing for it, and neither party is told. That is the same shape as a scope
 // token silently dropped from an otherwise-honoured request, which scope.go
 // already refuses. An unmapped scope is a misconfiguration and it says so.
+//
+// IT IS THE CEILING, AND IT IS WRITTEN OUT RATHER THAN DERIVED. `ScopeRead:
+// AllCapabilities()` would read as the obvious spelling and would rebuild, one
+// function over, exactly the coupling this commit exists to break: the first
+// `.propose` or `.write` capability seated in the vocabulary would become
+// conferred by the READ scope, silently, as a consequence of a map edit. The
+// rule this literal encodes is instead stated and checkable -- the read scope
+// confers the READ capabilities, and a member that does not end in `.read` is
+// not conferred by it until someone writes that line and defends it.
+//
+// CapContentRead IS ABSENT, AND THE ABSENCE IS THE DECISION. m131 DECISION 3
+// seats it in the database while nothing can grant it: no post or page table
+// exists, no agent command returns post content, and ADR-062 holds the content
+// work behind ship blockers including a plugin privacy disclosure. Go's
+// equivalent of the database's "nothing writes it" is "no scope confers it",
+// and this is that. Listing it here instead would let an operator mint a
+// connection holding a capability that reaches nothing today and then reaches
+// real post content the day those tools land -- a widening with no second
+// consent, arriving as a side effect of a registry edit. Adding it to this list
+// is a one-line change at the moment the content tools ship, in that diff,
+// under that review. TestContentReadIsKnownButConferredByNoScope pins it.
 var scopeCapabilities = map[Scope][]Capability{
-	ScopeRead: {CapSitesRead},
+	ScopeRead: {
+		CapActivityRead,
+		CapBackupsRead,
+		CapDiagnosticsRead,
+		CapPerformanceRead,
+		CapSecurityRead,
+		CapSitesRead,
+		CapUptimeRead,
+	},
 }
 
 // grantScopes returns the OAuth scopes a live grant holds.
@@ -111,20 +196,60 @@ func grantScopes() []Scope {
 }
 
 // DefaultGrantCapabilities is the capability set stamped onto mcp_grants.
-// capabilities when a NEW grant is created and the consent screen offered no
-// narrowing control.
+// capabilities when a NEW grant is created and NOBODY ASKED FOR A PARTICULAR
+// ONE -- the OAuth consent screen, which offers no narrowing control, and the
+// mint endpoint called with an empty Capabilities list.
 //
-// It is the vocabulary, which is also the org default while exactly one scope
-// is recognised. It is a FUNCTION and not a constant slice because a package
-// variable would be shared, mutable, and one append away from widening every
-// grant this surface has ever minted.
+// IT USED TO RETURN AllCapabilities() AND THAT IS THE TRAP m131 LEFT A WARNING
+// ABOUT. The identity was true and safe while the vocabulary held exactly one
+// member. The moment the map above widened to eight, that one line would have
+// stamped all eight onto every newly minted grant -- including groups whose
+// tools do not exist and a content group that is behind ADR-062's ship blockers
+// -- as a silent consequence of a map edit that nothing would have failed on.
+// A credential nobody chose the terms of is the precise failure m127 DECISION 1
+// and m124 DECISION 1 built the NOT NULL column and the closed CHECK to
+// prevent, and it would have arrived through the one door neither of them
+// watches.
+//
+// SO THE DEFAULT IS NOW AN EXPLICIT PRESET AND IT IS DELIBERATELY THE
+// NARROWEST ONE: the fleet inventory read, and nothing else.
+//
+// The argument for that value, rather than for the seven-member ceiling:
+//
+//  1. IT IS THE ONLY CAPABILITY THAT REACHES A TOOL. registry.go registers one
+//     tool and it requires CapSitesRead. Every other member of the ceiling
+//     names a group whose tools are not built, so defaulting to them would
+//     stamp authority that resolves to nothing -- and would then silently
+//     become real authority as each group's tools land, on grants whose
+//     operators consented before those tools existed.
+//  2. IT IS WHAT THE CONSENT SCREEN SAYS. Phase 1's screen describes reading
+//     the fleet inventory; a default wider than the screen's own words is a
+//     grant the operator did not read the terms of, whatever the terms were.
+//  3. IT MOVES NO EXISTING GRANT AND NO FUTURE ONE. Every grant this surface
+//     has ever minted holds exactly {mcp.sites.read}, and every grant minted
+//     after this commit without an explicit request holds exactly the same
+//     thing. This commit raises two ceilings and moves no floor, which is the
+//     same stance m131 DECISION 4 takes on the database side by refusing a
+//     backfill.
+//
+// THE CEILING IS STILL THE SEVEN. An operator who asks for a wider set gets it
+// (Service.MintConnection -> resolveMintCapabilities -> NarrowTo), because
+// asking is choosing. The default is what happens when nobody asked, and the
+// answer to "nobody asked" is never "everything".
+//
+// It is a FUNCTION and not a package-level slice because a package variable
+// would be shared, mutable, and one append away from widening every grant this
+// surface has ever minted. The literal is rebuilt on each call for the same
+// reason.
 //
 // This is where a chosen value replaces a defaulted one when Step 5's
 // capability control ships: the operator's selection arrives on
 // ApprovalRequest and is passed instead. It is deliberately NOT a database
 // DEFAULT -- see the column's NOT NULL and m127's reasoning about a credential
 // nobody chose the terms of.
-func DefaultGrantCapabilities() []Capability { return AllCapabilities() }
+func DefaultGrantCapabilities() []Capability {
+	return []Capability{CapSitesRead}
+}
 
 // capabilityNames renders capabilities for the text[] column.
 func capabilityNames(caps []Capability) []string {

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -967,6 +967,69 @@ func (h *TransportHandler) writeUnauthorized(c *gin.Context, err error) {
 
 	msg := "a valid bearer token is required"
 	code := ErrCodeInvalidGrant
+
+	// A CONFIGURATION REFUSAL IS 403 AND IT LEAVES THIS FUNCTION HERE.
+	//
+	// Service.Authenticate argues at length that an unresolvable capability set
+	// must be 403 rather than 401, and it returns exactly that. Without this
+	// arm the verdict was DISCARDED: a KindForbidden matched neither the
+	// KindUnauthorized branch below nor the not-a-domain-error branch, so it
+	// fell through to the 401 at the bottom of this function carrying the
+	// DEFAULT msg and code -- "a valid bearer token is required" and
+	// mcp_invalid_grant. The service's own code and message never reached the
+	// client, and the status said "your credential is bad" about a state where
+	// the credential is fine.
+	//
+	// That is not a cosmetic status-code error. It manufactures the precise
+	// loop the service comment exists to prevent: an MCP client that receives
+	// 401 re-runs the OAuth handshake, a handshake cannot change a stored
+	// capability set, so the client re-authenticates forever and the operator
+	// is sent to rotate a credential that was never the problem. The
+	// mcp.content.read refusal and the empty-capabilities refusal both land
+	// here.
+	//
+	// IT IS EVERY DOMAIN KIND EXCEPT KindUnauthorized, NOT KindForbidden ALONE,
+	// AND THAT IS THE WHOLE DIFFERENCE BETWEEN CATCHING THIS BUG AND HALF
+	// CATCHING IT. Authenticate produces the two capability refusals by
+	// DIFFERENT constructors: the empty-set refusal is domain.Forbidden, but
+	// the NarrowTo refusal -- the mcp.content.read arm -- is domain.Validation,
+	// %w-wrapped as "resolve grant capabilities: %w". A KindForbidden-only test
+	// would fix the first and leave the second falling through to the same 401
+	// with the same discarded code.
+	//
+	// So the split is by what the caller can DO about it, which is the only
+	// thing the status code is for. KindUnauthorized means "your credential is
+	// the problem", and re-authenticating is the remedy: 401. Every other
+	// domain kind reaching this function is a fact about the GRANT that a new
+	// credential cannot change: 403. Writing it as "not Unauthorized" rather
+	// than as a list of kinds also means a domain kind added later cannot
+	// silently inherit the wrong default, which is exactly how this defect
+	// existed.
+	//
+	// Matched on the UNWRAPPED chain: domain.AsDomain unwraps, so the %w above
+	// does not hide the kind.
+	//
+	// WWW-AUTHENTICATE IS CLEARED ON THIS PATH, DELIBERATELY, AND IT IS THE
+	// HALF THAT ACTUALLY STOPS THE LOOP. It is a CHALLENGE header: it tells the
+	// client which scheme to authenticate with and is an invitation to try
+	// again with a credential. RFC 7235 defines it as the 401 companion, and
+	// sending it alongside 403 is telling a client whose credential is valid to
+	// go and get another one -- which is the retry this arm exists to stop,
+	// re-invited by a header. So the status and the headers have to agree:
+	// nothing here says "authenticate again", because authenticating again
+	// cannot help. Gin's c.Header with an empty value deletes the header rather
+	// than writing a blank one, which is the same mechanism the 500 arm below
+	// already relies on.
+	if de, ok := domain.AsDomain(err); ok && de.Kind != domain.KindUnauthorized {
+		h.log.Warn("mcp connection refused by configuration, not by credential",
+			slog.String("code", de.Code), slog.Any("kind", de.Kind))
+		c.Header("WWW-Authenticate", "")
+		data, _ := json.Marshal(map[string]any{"code": de.Code})
+		c.JSON(http.StatusForbidden,
+			newErrorResponse(nil, codeInvalidRequest, de.Message, data))
+		return
+	}
+
 	if de, ok := domain.AsDomain(err); ok && de.Kind == domain.KindUnauthorized {
 		msg = de.Message
 		code = de.Code

--- a/apps/api/internal/mcp/transport_capability_refusal_test.go
+++ b/apps/api/internal/mcp/transport_capability_refusal_test.go
@@ -1,0 +1,198 @@
+// Service.Authenticate argues in capitals that a capability refusal must be
+// 403 and not 401, because an MCP client that receives 401 re-runs the OAuth
+// handshake, a handshake cannot change a stored capability set, so the client
+// loops and the operator is sent to rotate a credential that was never the
+// problem.
+//
+// THE SERVICE RETURNED THAT VERDICT AND THE TRANSPORT DISCARDED IT. A domain
+// error that was not KindUnauthorized matched neither branch in
+// writeUnauthorized and fell through to the 401 at the bottom carrying the
+// DEFAULT message and code -- "a valid bearer token is required" and
+// mcp_invalid_grant -- so the refusal's own code never reached the client and
+// the status reported a credential problem for a configuration state. The
+// transport produced precisely the loop the service comment exists to prevent.
+//
+// THESE ARE EXECUTED REQUESTS THROUGH THE MOUNTED ROUTER, not a code read and
+// not a direct call to writeUnauthorized. newTransportRouter calls
+// TransportHandler.Register with the shape server.go passes it, so what these
+// assert is the status line and body a client actually receives.
+//
+// THE TWO REFUSALS ARE BUILT BY DIFFERENT CONSTRUCTORS AND BOTH ARE TESTED.
+// The empty-set refusal is domain.Forbidden; the NarrowTo refusal -- the
+// mcp.content.read arm -- is domain.Validation, %w-wrapped. A fix tested only
+// against the first would leave the second falling through.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+// capabilityRefusalStore is liveGrantStore with the stored capability column
+// set to whatever the case under test needs. The column is the authority
+// Authenticate reads, so this is the one field that decides the outcome.
+func capabilityRefusalStore(caps []string) *fakeStore {
+	s := liveGrantStore(uuid.New())
+	s.recheck.GrantCapabilities = caps
+	return s
+}
+
+// infraFailStore makes the credential lookup fail with a NON-domain error --
+// the database being unreachable, not the token being wrong. It wraps rather
+// than extends fakeStore so no shared fixture changes shape for one test.
+type infraFailStore struct{ *fakeStore }
+
+func (s infraFailStore) LookupConnectionToken(context.Context, string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error) {
+	return sqlc.GetMCPConnectionTokenByHashForLookupRow{}, errors.New("database is unreachable")
+}
+
+// rpcErrorData reads the `data.code` the transport attaches, which is where the
+// domain code travels. Returns "" when absent, so a missing code is a visible
+// empty string rather than a panic.
+func rpcErrorData(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	if len(raw) == 0 {
+		return ""
+	}
+	var d struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &d); err != nil {
+		t.Fatalf("error data is not an object: %v (%s)", err, string(raw))
+	}
+	return d.Code
+}
+
+// TestTransport_CapabilityRefusalIs403WithItsOwnCode is the F1 proof.
+//
+// Both cases assert THREE things, and the mutation reddens on all three:
+// the status is 403 and not 401; the domain code survives rather than being
+// replaced by mcp_invalid_grant; and WWW-Authenticate is absent.
+//
+// THE HEADER IS PART OF THE FIX, NOT A DETAIL. WWW-Authenticate is a CHALLENGE
+// header -- it names the scheme and invites the client to try again with a
+// credential. RFC 7235 defines it as the 401 companion. Sending it with a 403
+// tells a client whose credential is valid to go and get another one, which is
+// the retry this arm exists to stop, re-invited by a header. The status and the
+// headers have to agree.
+func TestTransport_CapabilityRefusalIs403WithItsOwnCode(t *testing.T) {
+	cases := []struct {
+		name     string
+		caps     []string
+		wantCode string
+		why      string
+	}{
+		{
+			name:     "empty stored capability set",
+			caps:     []string{},
+			wantCode: ErrCodeCapabilityUnmapped,
+			why: "domain.Forbidden -- a grant whose capabilities column is '{}' " +
+				"authenticates and can reach no tool",
+		},
+		{
+			name:     "a stored capability no scope confers",
+			caps:     []string{string(CapContentRead)},
+			wantCode: ErrCodeCapabilityWiderThanDefault,
+			why: "domain.Validation, %w-wrapped by Authenticate as " +
+				"'resolve grant capabilities: %w' -- the NarrowTo refusal, which a " +
+				"KindForbidden-only fix would miss entirely",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newTransportRouter(t, capabilityRefusalStore(tc.caps))
+			w := post(t, r, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, nil)
+
+			if w.Code != http.StatusForbidden {
+				t.Errorf("HTTP %d, want 403 (%s).\n"+
+					"A 401 here tells the client its credential is bad when the "+
+					"credential is fine, and an MCP client answers 401 by re-running "+
+					"the OAuth handshake -- which cannot change a stored capability "+
+					"set. That is an infinite loop and an operator rotating the wrong "+
+					"thing.\nbody: %s", w.Code, tc.why, w.Body.String())
+			}
+
+			resp := decodeRPC(t, w)
+			if resp.Error == nil {
+				t.Fatalf("no JSON-RPC error object: %s", w.Body.String())
+			}
+			got := rpcErrorData(t, resp.Error.Data)
+			if got != tc.wantCode {
+				t.Errorf("error data.code = %q, want %q.\n"+
+					"The refusal's own code was discarded and replaced with the "+
+					"function's default, so the client is told nothing it can act on.\n"+
+					"message: %q", got, tc.wantCode, resp.Error.Message)
+			}
+			if resp.Error.Message == "a valid bearer token is required" {
+				t.Errorf("message is the default credential message, so the service's " +
+					"own explanation was discarded on the way out")
+			}
+
+			if h := w.Header().Get("WWW-Authenticate"); h != "" {
+				t.Errorf("WWW-Authenticate = %q on a 403; want it absent. It is a "+
+					"challenge header, and sending it here invites the retry this "+
+					"status exists to stop", h)
+			}
+			t.Logf("%s -> HTTP %d code=%q www-authenticate=%q",
+				tc.name, w.Code, got, w.Header().Get("WWW-Authenticate"))
+		})
+	}
+}
+
+// TestTransport_CredentialRefusalIsStill401WithAChallenge is the over-fire
+// half. A guard that reddens correct work gets switched off, so the 403 arm
+// must not swallow the case 401 is RIGHT for: a bearer that resolves to no live
+// token. Here re-authenticating IS the remedy, so the status invites it and the
+// challenge header belongs.
+func TestTransport_CredentialRefusalIsStill401WithAChallenge(t *testing.T) {
+	store := capabilityRefusalStore([]string{string(CapSitesRead)})
+	store.tokenOK = false // the bearer resolves to nothing
+	r := newTransportRouter(t, store)
+
+	w := post(t, r, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("HTTP %d on an unresolvable bearer, want 401 -- the 403 arm has "+
+			"over-fired and is now answering genuine credential failures with a "+
+			"status that tells the client not to retry.\nbody: %s",
+			w.Code, w.Body.String())
+	}
+	if h := w.Header().Get("WWW-Authenticate"); h == "" {
+		t.Error("WWW-Authenticate is absent on a 401; a client is not told how to " +
+			"authenticate")
+	}
+	t.Logf("unresolvable bearer -> HTTP %d www-authenticate=%q",
+		w.Code, w.Header().Get("WWW-Authenticate"))
+}
+
+// TestTransport_InfrastructureFailureIsStill500WithNoChallenge is the other
+// over-fire arm. An unreachable database is not an auth verdict at all: it must
+// stay 500, must not be reported as a refusal of any kind, and must not carry a
+// challenge header -- telling a caller to re-authenticate when the database is
+// down sends them to rotate a credential that was never the problem.
+func TestTransport_InfrastructureFailureIsStill500WithNoChallenge(t *testing.T) {
+	r := newTransportRouter(t, infraFailStore{capabilityRefusalStore([]string{string(CapSitesRead)})})
+
+	w := post(t, r, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("HTTP %d on an unreachable database, want 500.\nbody: %s",
+			w.Code, w.Body.String())
+	}
+	if h := w.Header().Get("WWW-Authenticate"); h != "" {
+		t.Errorf("WWW-Authenticate = %q on a 500; the infrastructure arm clears it "+
+			"precisely so a database outage is not read as a credential problem", h)
+	}
+	if body := w.Body.String(); strings.Contains(body, "database is unreachable") {
+		t.Errorf("the internal error leaked to the client: %s", body)
+	}
+	t.Logf("unreachable database -> HTTP %d www-authenticate=%q",
+		w.Code, w.Header().Get("WWW-Authenticate"))
+}

--- a/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
+++ b/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
@@ -267,6 +268,44 @@ func m131GrantWithBearer(
 	return bearer
 }
 
+// m131AssertRoleOnBothDispatches asserts, INSIDE the transactions the request
+// path actually opens, that this connection is wpmgr_app with neither SUPERUSER
+// nor BYPASSRLS -- and prints what it found, so the proof carries its own
+// evidence rather than asking the reader to trust it.
+//
+// TWO HELPERS BECAUSE THE THREE TESTS BELOW USE TWO DISPATCHES. The grant and
+// its token are inserted through RunTenantTx (repo.CreateGrantWithCode), and
+// Authenticate resolves the bearer through InMCPTokenLookupTx. Asserting only
+// one would leave the other unevidenced, and they are different helpers setting
+// different GUCs.
+//
+// WHY THIS IS NOT A FRESH CONNECTION. Both calls go through the SAME db.Pool
+// the test hands to mcp.NewRepo, using the SAME dispatch functions the path
+// under test uses, so current_user is read on a connection from the pool that
+// runs the INSERT and the lookup. Opening a connection of its own would prove
+// something about a database rather than about the transactions these tests
+// run in -- which is the mistake that left the m112 RLS policies inert while
+// every proof passed.
+func m131AssertRoleOnBothDispatches(t *testing.T, pool *db.Pool, tenantID uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	principal := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+	if err := pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "RunTenantTx (the grant insert dispatch)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open the grant-insert dispatch: %v", err)
+	}
+
+	if err := pool.InMCPTokenLookupTx(ctx, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InMCPTokenLookupTx (the Authenticate dispatch)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open the token-lookup dispatch: %v", err)
+	}
+}
+
 // TestExistingSitesReadGrantStillAuthenticatesAsAppRole is the no-regression
 // half, and it is the one that matters most: every grant this surface has ever
 // minted holds exactly {mcp.sites.read}. Widening a containment CHECK is
@@ -279,6 +318,10 @@ func TestExistingSitesReadGrantStillAuthenticatesAsAppRole(t *testing.T) {
 	tenant := seedTenant(t, pool, "m131-legacy-"+uuid.NewString()[:8])
 	repo := mcp.NewRepo(pool)
 	svc := mcp.NewService(repo)
+
+	// The role is load-bearing HERE: this test INSERTS a grant and
+	// AUTHENTICATES a bearer, and either privilege makes both vacuous.
+	m131AssertRoleOnBothDispatches(t, pool, tenant)
 
 	bearer := m131GrantWithBearer(t, repo, tenant, []string{"mcp.sites.read"})
 
@@ -315,6 +358,10 @@ func TestNewlySeatedCapabilityInsertsAndAuthenticatesAsAppRole(t *testing.T) {
 	tenant := seedTenant(t, pool, "m131-new-"+uuid.NewString()[:8])
 	repo := mcp.NewRepo(pool)
 	svc := mcp.NewService(repo)
+
+	// The role is load-bearing HERE: this test INSERTS a grant and
+	// AUTHENTICATES a bearer, and either privilege makes both vacuous.
+	m131AssertRoleOnBothDispatches(t, pool, tenant)
 
 	want := []string{"mcp.sites.read", "mcp.uptime.read"}
 	bearer := m131GrantWithBearer(t, repo, tenant, want)
@@ -357,6 +404,10 @@ func TestContentReadInsertsButDoesNotAuthenticateAsAppRole(t *testing.T) {
 	tenant := seedTenant(t, pool, "m131-content-"+uuid.NewString()[:8])
 	repo := mcp.NewRepo(pool)
 	svc := mcp.NewService(repo)
+
+	// The role is load-bearing HERE: this test INSERTS a grant and
+	// AUTHENTICATES a bearer, and either privilege makes both vacuous.
+	m131AssertRoleOnBothDispatches(t, pool, tenant)
 
 	// It INSERTS: the CHECK holds it, which is what m131 seated.
 	bearer := m131GrantWithBearer(t, repo, tenant,

--- a/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
+++ b/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
@@ -1,0 +1,369 @@
+// m131 widened mcp_grants_capabilities_vocabulary_check from one member to
+// eight; the commit that widened capabilityVocabulary in internal/mcp/policy.go
+// to match is the one this file proves.
+//
+// THE VOCABULARY IS NOW CLOSED IN TWO PLACES AND THAT IS WORSE THAN ONE OPEN
+// SET UNLESS SOMETHING EXECUTES THE COMPARISON. m131 DECISION 5 states the
+// hazard: a capability the database accepts and Go does not is refused at a
+// different layer with a different error, and a capability Go accepts and the
+// database does not is a 23514 at INSERT on a path an operator reached through
+// a wizard. Neither is visible to the compiler, to `go vet`, or to any unit
+// test -- the unit test in internal/mcp pins the Go set by value and has no
+// database in front of it.
+//
+// THE EXTRACTION IS m131 DECISION 5's, VERBATIM, AND NOT A REWRITE OF IT.
+// pg_get_constraintdef renders the STORED expression tree, so this reads what
+// the database actually enforces and cannot be fooled by editing the migration
+// file's text or its comments.
+//
+// THE THIRD FAILURE MODE IS THE ONE THAT LOOKS LIKE A PASS. Rename the
+// constraint and the extraction matches nothing: both difference arms come back
+// empty, and "no differences" reads as "the sets agree" while the check has
+// verified nothing at all. This file returns an explicit INDETERMINATE for that
+// case, before either difference is computed, exactly as the database half
+// does. A parity check that cannot find its subject must fail loudly.
+//
+// NOT BUILT AS A `1/0`-INSIDE-`CASE` GUARD. Postgres constant-folds the
+// division at plan time, so that shape raises division_by_zero on every run
+// including the passing ones. The guard here is a row count in Go.
+package tests
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// m131VocabularyExtraction is m131 DECISION 5's statement, used rather than
+// rewritten so the two halves of the proof read the constraint identically.
+const m131VocabularyExtraction = `
+	SELECT m[1] AS capability
+	  FROM pg_constraint c
+	  CROSS JOIN LATERAL regexp_matches(
+	           pg_get_constraintdef(c.oid), '''([^'']*)''::text', 'g') AS m
+	 WHERE c.conrelid = 'public.mcp_grants'::regclass
+	   AND c.conname  = 'mcp_grants_capabilities_vocabulary_check'`
+
+// TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole is the parity proof.
+//
+// ON THE ROLE, PLAINLY, BECAUSE THE BRIEF ASKS AND BECAUSE OVERCLAIMING HERE
+// WOULD BE WORSE THAN SAYING NOTHING: the role does NOT change this particular
+// answer. pg_constraint and pg_get_constraintdef are readable by every role,
+// carry no RLS, and a CHECK constraint is enforced identically against a
+// superuser and against wpmgr_app -- so this read would return the same eight
+// strings connected as anyone. The role is asserted and printed anyway for two
+// reasons that are real. First, it proves the constraint is visible in the
+// database the application actually connects to, rather than in some other one
+// a privileged fixture reached. Second, the sibling tests in this file INSERT
+// and AUTHENTICATE, where the role is entirely load-bearing -- m127 DECISION 5
+// records a live privilege escalation of exactly the shape a superuser fixture
+// hides -- and a file whose evidence is uniform is a file where nobody has to
+// work out which transaction was the honest one.
+func TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "m131-parity-"+uuid.NewString()[:8])
+
+	var inDB []string
+	// Through InTenantTx -- the production dispatch -- and not a connection this
+	// test opened. A test that dials its own connection proves something about a
+	// database, not about the one the request path reaches.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (vocabulary parity)")
+		rows, err := tx.Query(ctx, m131VocabularyExtraction)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var c string
+			if err := rows.Scan(&c); err != nil {
+				return err
+			}
+			inDB = append(inDB, c)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("read mcp_grants_capabilities_vocabulary_check: %v", err)
+	}
+
+	// FAILURE MODE 3, CHECKED FIRST AND BEFORE EITHER DIFFERENCE.
+	//
+	// Zero rows means the constraint was not found or its definition did not
+	// render as the expected literal list -- a rename, a drop, a schema change,
+	// or an extraction that no longer matches. Every arm below would then be
+	// empty and this test would report a pass having compared nothing against
+	// nothing. It is INDETERMINATE, not agreement, and it fails.
+	if len(inDB) == 0 {
+		t.Fatalf("INDETERMINATE: the extraction returned no rows, so this test "+
+			"compared nothing.\n"+
+			"Looked for constraint %q on public.mcp_grants.\n"+
+			"This is NOT 'the sets agree' -- both difference arms are empty because "+
+			"there is nothing to difference against. Either the constraint was "+
+			"renamed or dropped, or pg_get_constraintdef no longer renders the "+
+			"vocabulary as quoted ::text literals. Fix the extraction or the "+
+			"constraint; do not read this as a pass.",
+			"mcp_grants_capabilities_vocabulary_check")
+	}
+
+	sort.Strings(inDB)
+	inGo := make([]string, 0, len(mcp.AllCapabilities()))
+	for _, c := range mcp.AllCapabilities() {
+		inGo = append(inGo, string(c))
+	}
+	sort.Strings(inGo)
+
+	// A second empty-set guard, on the other side. AllCapabilities() ranges over
+	// capabilityVocabulary, so an emptied map would make the "in Go but not in
+	// the database" arm vacuously empty in the same way.
+	if len(inGo) == 0 {
+		t.Fatal("INDETERMINATE: mcp.AllCapabilities() is empty, so the Go half of " +
+			"this comparison contributed nothing")
+	}
+
+	dbSet := map[string]struct{}{}
+	for _, c := range inDB {
+		dbSet[c] = struct{}{}
+	}
+	goSet := map[string]struct{}{}
+	for _, c := range inGo {
+		goSet[c] = struct{}{}
+	}
+
+	// FAILURE MODE 1: Go holds a member the CHECK does not. This is the
+	// direction that produces a 23514 at INSERT, on a path an operator reached
+	// through a wizard, after the wizard already told them it would work.
+	var goOnly []string
+	for _, c := range inGo {
+		if _, ok := dbSet[c]; !ok {
+			goOnly = append(goOnly, c)
+		}
+	}
+
+	// FAILURE MODE 2: the CHECK holds a member Go does not. This one does not
+	// error at INSERT; it produces a name the database will happily store and
+	// that NewCapabilitySet then DROPS as unknown, so the grant authenticates
+	// holding less than its row says.
+	var dbOnly []string
+	for _, c := range inDB {
+		if _, ok := goSet[c]; !ok {
+			dbOnly = append(dbOnly, c)
+		}
+	}
+
+	if len(goOnly) > 0 || len(dbOnly) > 0 {
+		t.Fatalf("the two closed vocabularies disagree.\n"+
+			"  in Go but NOT in the CHECK: %v\n"+
+			"      -> a grant naming one of these takes 23514 at INSERT, on the "+
+			"wizard path, after the operator was shown it as available\n"+
+			"  in the CHECK but NOT in Go:  %v\n"+
+			"      -> the database stores it and NewCapabilitySet drops it as "+
+			"unknown, so the grant authenticates holding less than its row says\n"+
+			"  Go:       %v\n"+
+			"  database: %v\n"+
+			"Widening either set is a change to the other. The database half is a "+
+			"migration (database-engineer); the Go half is capabilityVocabulary in "+
+			"apps/api/internal/mcp/policy.go.",
+			goOnly, dbOnly, inGo, inDB)
+	}
+
+	t.Logf("vocabularies agree on %d capabilities, read from pg_get_constraintdef "+
+		"inside InTenantTx: %s", len(inDB), strings.Join(inDB, " "))
+}
+
+// m131GrantWithBearer mints a grant carrying an ARBITRARY capability list and a
+// live connection token for it, returning the plaintext bearer.
+//
+// It is s7GrantWithBearer's shape with the one hard-coded value lifted into a
+// parameter: that helper pins Capabilities to {mcp.sites.read}, which is
+// exactly the value the tests below have to vary. Everything still goes through
+// mcp.Repo -- CreateGrantWithCode is what the consent endpoint calls,
+// RedeemAuthorizationCode is what the token endpoint calls -- so no row here is
+// inserted by a statement this file wrote and no connection is opened by it.
+func m131GrantWithBearer(
+	t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, caps []string,
+) string {
+	t.Helper()
+	ctx := context.Background()
+
+	clientID := "m131-client-" + uuid.NewString()
+	secretHash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	affected, err := repo.RegisterClient(ctx, sqlc.RegisterMCPOAuthClientParams{
+		ClientID:                clientID,
+		ClientSecretHash:        &secretHash,
+		TokenEndpointAuthMethod: "client_secret_basic",
+		RedirectUris:            []string{"https://claude.ai/api/mcp/auth_callback"},
+	})
+	if err != nil || affected != 1 {
+		t.Fatalf("register client: affected=%d err=%v", affected, err)
+	}
+
+	codePlain := "m131-code-" + uuid.NewString()
+	codeSum := sha256.Sum256([]byte(codePlain))
+	approver := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+
+	grant, code, err := repo.CreateGrantWithCode(ctx, approver, sqlc.CreateMCPGrantParams{
+		TenantID:            tenantID,
+		Name:                "m131 grant",
+		Status:              "active",
+		SiteScopeMode:       "all",
+		ScopeTagIds:         []uuid.UUID{},
+		ScopeSiteIds:        []uuid.UUID{},
+		ClientID:            &clientID,
+		Capabilities:        caps,
+		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
+		IdleExpireAfterDays: nil,
+	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {
+		return sqlc.CreateMCPAuthorizationCodeParams{
+			TenantID:            tenantID,
+			GrantID:             grantID,
+			ClientID:            clientID,
+			CodeHash:            hex.EncodeToString(codeSum[:]),
+			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			CodeChallengeMethod: "S256",
+			RedirectUri:         "https://claude.ai/api/mcp/auth_callback",
+			ExpiresAt:           time.Now().UTC().Add(5 * time.Minute),
+		}
+	}, nil)
+	if err != nil {
+		t.Fatalf("create grant holding %v: %v -- if this is a 23514 the Go "+
+			"vocabulary is wider than the CHECK", caps, err)
+	}
+	if len(grant.Capabilities) != len(caps) {
+		t.Fatalf("stored capabilities = %v, want %v", grant.Capabilities, caps)
+	}
+
+	bearer := "m131-bearer-" + uuid.NewString()
+	bearerSum := sha256.Sum256([]byte(bearer))
+	if _, err := repo.RedeemAuthorizationCode(ctx, tenantID, code.ID,
+		sqlc.CreateMCPConnectionTokenParams{
+			TenantID:    tenantID,
+			GrantID:     grant.ID,
+			TokenPrefix: "m131tk",
+			TokenHash:   hex.EncodeToString(bearerSum[:]),
+			Status:      "active",
+		}); err != nil {
+		t.Fatalf("mint connection token: %v", err)
+	}
+	return bearer
+}
+
+// TestExistingSitesReadGrantStillAuthenticatesAsAppRole is the no-regression
+// half, and it is the one that matters most: every grant this surface has ever
+// minted holds exactly {mcp.sites.read}. Widening a containment CHECK is
+// monotone so the row still passes, but the GO side changed too -- the ceiling
+// grew from one member to seven and Authenticate narrows the stored column
+// against it -- and nothing about that is monotone by inspection.
+func TestExistingSitesReadGrantStillAuthenticatesAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "m131-legacy-"+uuid.NewString()[:8])
+	repo := mcp.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	bearer := m131GrantWithBearer(t, repo, tenant, []string{"mcp.sites.read"})
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("a pre-m131 grant holding {mcp.sites.read} no longer "+
+			"authenticates: %v", err)
+	}
+	if !auth.Capabilities.Allows(mcp.CapSitesRead) {
+		t.Fatalf("resolved capabilities = %v, want to hold %q",
+			auth.Capabilities.Sorted(), mcp.CapSitesRead)
+	}
+	// EXACTLY ONE. A wider resolved set would mean the widening reached an
+	// existing credential, which is the failure m131 DECISION 4 refuses a
+	// backfill to avoid and which this commit must not reintroduce in Go.
+	if auth.Capabilities.Len() != 1 {
+		t.Fatalf("a grant whose row holds exactly {mcp.sites.read} resolved to %v.\n"+
+			"The stored column is the authority and the ceiling only ever narrows "+
+			"it; a resolved set wider than the row is the widening this commit "+
+			"exists to prevent, arriving at read time instead of at write time.",
+			auth.Capabilities.Sorted())
+	}
+	t.Logf("legacy grant authenticated holding %v", auth.Capabilities.Sorted())
+}
+
+// TestNewlySeatedCapabilityInsertsAndAuthenticatesAsAppRole is the other half:
+// m131's point was that the tool registry can now widen with no further schema
+// work, and that claim is only true if a grant holding one of the seven newly
+// seated names both INSERTS (the CHECK accepts it) and AUTHENTICATES (the Go
+// ceiling confers it). Either one failing makes the migration a no-op.
+func TestNewlySeatedCapabilityInsertsAndAuthenticatesAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "m131-new-"+uuid.NewString()[:8])
+	repo := mcp.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	want := []string{"mcp.sites.read", "mcp.uptime.read"}
+	bearer := m131GrantWithBearer(t, repo, tenant, want)
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("a grant holding a newly seated capability does not "+
+			"authenticate: %v -- the row inserted, so this is the Go ceiling "+
+			"refusing what the database accepted", err)
+	}
+	if !auth.Capabilities.Allows(mcp.CapUptimeRead) {
+		t.Fatalf("resolved capabilities = %v, want to hold %q",
+			auth.Capabilities.Sorted(), mcp.CapUptimeRead)
+	}
+	if auth.Capabilities.Len() != len(want) {
+		t.Fatalf("resolved %v, want exactly %v", auth.Capabilities.Sorted(), want)
+	}
+	t.Logf("newly seated capability round-tripped: stored %v, resolved %v",
+		want, auth.Capabilities.Sorted())
+}
+
+// TestContentReadInsertsButDoesNotAuthenticateAsAppRole executes the one
+// deliberate asymmetry between the two closed sets, so that it is a proven
+// stance rather than a comment.
+//
+// m131 DECISION 3 seats mcp.content.read in the CHECK and calls it unreachable.
+// The database's version of "unreachable" is that no INSERT names it -- the
+// CHECK is a ceiling and a member no code writes affects no row -- so the
+// database will store it if asked. Go's version is stronger and is where the
+// stance is actually held: no scope confers it, so Authenticate's ceiling
+// refuses the whole stored set rather than trimming it.
+//
+// The refusal being WHOLE rather than a trim is the property under test. A trim
+// would authenticate the connection holding {mcp.sites.read} and tell nobody
+// that the row and the resolved set disagree, which is the silent-narrowing
+// failure NarrowTo is written to refuse.
+func TestContentReadInsertsButDoesNotAuthenticateAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "m131-content-"+uuid.NewString()[:8])
+	repo := mcp.NewRepo(pool)
+	svc := mcp.NewService(repo)
+
+	// It INSERTS: the CHECK holds it, which is what m131 seated.
+	bearer := m131GrantWithBearer(t, repo, tenant,
+		[]string{"mcp.content.read", "mcp.sites.read"})
+
+	// It does NOT authenticate: no scope confers it, so the ceiling refuses.
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err == nil {
+		t.Fatalf("a grant holding %q authenticated, resolving to %v.\n"+
+			"Nothing serves that capability -- no post or page table, no agent "+
+			"command returning post content, ADR-062 behind ship blockers -- and a "+
+			"connection that holds it today would gain real reach the day those "+
+			"tools land, with no second consent. Confer it in the diff that ships "+
+			"them.", "mcp.content.read", auth.Capabilities.Sorted())
+	}
+	t.Logf("a grant holding mcp.content.read inserted and was refused at "+
+		"Authenticate: %v", err)
+}

--- a/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
+++ b/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
@@ -45,6 +45,14 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
 
+// m131VocabularyConstraint is the name the extraction looks up and the name the
+// INDETERMINATE message prints. ONE constant, bound as $1 rather than
+// interpolated into the SQL, so the two can never disagree: a failure message
+// naming a constraint the query did not actually look for is a message that
+// sends the reader to the wrong place, and the whole point of the INDETERMINATE
+// arm is that the reader believes it.
+const m131VocabularyConstraint = "mcp_grants_capabilities_vocabulary_check"
+
 // m131VocabularyExtraction is m131 DECISION 5's statement, used rather than
 // rewritten so the two halves of the proof read the constraint identically.
 const m131VocabularyExtraction = `
@@ -53,7 +61,7 @@ const m131VocabularyExtraction = `
 	  CROSS JOIN LATERAL regexp_matches(
 	           pg_get_constraintdef(c.oid), '''([^'']*)''::text', 'g') AS m
 	 WHERE c.conrelid = 'public.mcp_grants'::regclass
-	   AND c.conname  = 'mcp_grants_capabilities_vocabulary_check'`
+	   AND c.conname  = $1`
 
 // TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole is the parity proof.
 //
@@ -81,7 +89,7 @@ func TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole(t *testing.T) {
 	// database, not about the one the request path reaches.
 	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
 		mcpAssertAndReportRole(t, tx, "InTenantTx (vocabulary parity)")
-		rows, err := tx.Query(ctx, m131VocabularyExtraction)
+		rows, err := tx.Query(ctx, m131VocabularyExtraction, m131VocabularyConstraint)
 		if err != nil {
 			return err
 		}
@@ -114,7 +122,7 @@ func TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole(t *testing.T) {
 			"renamed or dropped, or pg_get_constraintdef no longer renders the "+
 			"vocabulary as quoted ::text literals. Fix the extraction or the "+
 			"constraint; do not read this as a pass.",
-			"mcp_grants_capabilities_vocabulary_check")
+			m131VocabularyConstraint)
 	}
 
 	sort.Strings(inDB)


### PR DESCRIPTION
Stacked on `worktree-agent-a42dad999155add5a` (m131), which is merged into this branch and must land first or with it.

## What this does

m131 widened `mcp_grants_capabilities_vocabulary_check` from one member to eight. This widens `capabilityVocabulary` to match — and, in the same commit, breaks the identity m131's closing note warns about.

`DefaultGrantCapabilities()` returned `AllCapabilities()`. That was true and safe at one member. At eight it stamps every capability onto every newly minted grant, including a content group ADR-062 holds behind ship blockers, as a silent consequence of a map edit that nothing fails on.

What was one set is now three:

| set | answers | size |
|---|---|---|
| `capabilityVocabulary` | what may be spelled at all | 8 |
| `scopeCapabilities[ScopeRead]` | what a scope confers — the ceiling | 7 |
| `DefaultGrantCapabilities()` | what an unasked grant receives | 1 |

**The default is `{mcp.sites.read}`.** It is the only capability the tool registry can serve, it is what the Phase 1 consent screen describes, and it means every grant minted after this commit holds exactly what every grant minted before it holds. Two ceilings rise, no floor moves — the stance m131 DECISION 4 takes by refusing a backfill.

**The ceiling is a written-out literal, not `AllCapabilities()`.** Deriving it rebuilds the same coupling one function over: the first `.propose` capability seated in the vocabulary would become conferred by the READ scope as a side effect of a map edit.

**`mcp.content.read` is in the vocabulary and in no scope's list.** The database's version of m131 DECISION 3's "seated and unreachable" is that no INSERT names it; Go's is that no scope confers it. Listing it in the ceiling would let an operator mint a connection that reaches nothing today and real post content the day those tools land, with no second consent.

**`resolveMintCapabilities` carried the second copy of the trap** — an empty request returned the ceiling, which was the default only while the ceiling held one member.

## Proofs

Unit, `internal/mcp/capability_default_test.go`: the default by exact value and separately by relationship to the vocabulary; the mint path's empty request; every capability carries `mcp.`/`.read`; content known but conferred by nothing and refused whole rather than trimmed.

Integration, `tests/mcp_m131_capability_vocabulary_parity_test.go`, as `wpmgr_app` (`rolsuper=false rolbypassrls=false`, printed inside the transaction) through `InTenantTx`: parity against the live constraint using m131 DECISION 5's extraction verbatim, with the zero-row case reported as INDETERMINATE before either difference is computed; a legacy `{mcp.sites.read}` grant still authenticating to exactly one capability; a newly seated capability inserting and authenticating; and `mcp.content.read` inserting and being refused at `Authenticate`.

All four failure modes proven by mutation (default restored to `AllCapabilities()`; a Go member removed; a Go member added; the constraint renamed), each reverted immediately.