### PR TITLE
fix(mcp): fix mode literal so the org-ceiling S7 test actually runs

### DIFF
--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -515,7 +515,7 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 		t.Fatalf("create site: %v", err)
 	}
 
-	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "ceiling", []uuid.UUID{s1.ID})
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{s1.ID})
 
 	auth, err := svc.Authenticate(ctx, bearer)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole` passed `"ceiling"` as the grant's `site_scope_mode` at `apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go:518` — its own descriptive label, not a valid mode. `mcp_grants_site_scope_mode_check` only accepts `all`/`tags`/`list`, so the insert failed 23514 in setup and the test never once executed its body, on any commit since it was introduced (`49e8aff3`).
- Fixed the literal to `"list"`, matching all four sibling calls in the file.

## What running it revealed
Verified with the machine lock (`scripts/with-machine-lock.sh api-integration -- sh -c 'cd apps/api && go test -count=1 -run TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole -v -timeout 20m ./tests/...'`):

- The test now executes end to end as `wpmgr_app` and **passes**, and the assertions are real, not vacuous.
- Mutation-tested against the production logic it claims to guard (`internal/mcp/registry.go`), then reverted both times:
  - Forcing `withinOrgCeiling` to always return `true` (never drop a tool outside the org ceiling) reddens the test at the "IT IS NOT LISTED" assertion (`a capability outside the org ceiling was LISTED`).
  - Changing the ceiling refusal to return `ErrCodeCapabilityNotGranted` instead of `ErrCodeToolNotAvailable` reddens it at the disclosure-sameness assertion (`code = "mcp_capability_not_granted", want "mcp_tool_not_available"`).
- Both mutations restored; `git diff` on `internal/mcp/registry.go` is clean, and the test is green again.

So this is outcome (1): the test passes and its assertions genuinely catch the org-ceiling defect it names.

## Siblings checked
All four sibling tests in the same file (`TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole`, `TestS7GuessedToolNameIsRefusedForARealConnectionAsAppRole`, `TestS7UntickedCapabilityRefusesByNameAsAppRole`, `TestS7EmptySiteScopeRefusesByNameAsAppRole`) pass and log non-vacuous, value-specific results (resolved capability/site counts, exact domain error codes, positive controls before each refusal).

## Test plan
- [x] `cd apps/api && go build ./... && go vet ./...`
- [x] Ran the fixed test plus its four siblings under `scripts/with-machine-lock.sh api-integration`, all PASS, exit 0
- [x] Mutation-tested `withinOrgCeiling` and the ceiling-refusal error code, both went red on the correct assertion, then reverted to a clean diff