### PR TITLE
fix(mcp): route ResolveScopeSites on the principal, not a bare tenant id

### DIFF
--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -389,7 +389,7 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	// verifyScopeReferents -- and read its comment before adding any
 	// "resolves to no sites" refusal here, because that would be a defect
 	// rather than a hardening.
-	if err := s.verifyScopeReferents(ctx, req.Principal.TenantID, req.SiteScope); err != nil {
+	if err := s.verifyScopeReferents(ctx, req.Principal, req.SiteScope); err != nil {
 		return MintedConnection{}, err
 	}
 
@@ -588,7 +588,24 @@ func (s *Service) resolveMintCapabilities(requested []Capability) (CapabilitySet
 // Distinguishing them is what makes the empty-scope acceptance safe. Without
 // this check, "accept empty" would also silently accept a typo.
 //
-func (s *Service) verifyScopeReferents(ctx context.Context, tenantID uuid.UUID, req SiteScopeRequest) error {
+// IT TAKES THE WHOLE PRINCIPAL AND NOT A tenantID (ADR-061 A11 item 2). The
+// site-id arm below resolves ids through the audited chokepoint, and the
+// chokepoint routes on the principal's scope: a site-constrained operator must
+// not be able to name a site outside their own allowlist and have it verify,
+// because verifying is what lets the mint store it. That would be an operator
+// minting a credential wider than themselves.
+//
+// TODAY THAT PATH IS UNREACHABLE, AND THIS IS STILL NOT REDUNDANT.
+// MintConnection's step 1 calls requireOrgScopedPrincipal, which refuses a
+// site-constrained principal outright, so every principal arriving here is
+// org-scoped and RunTenantTx dispatches it exactly as InTenantTx did. Passing
+// the principal changes no behaviour by one bit today. It is the fail-closed
+// backstop for the day that guard moves or a site-scoped mint becomes a
+// product decision -- the same reason IsSiteConstrained carries its second
+// disjunct, and the same reason ADR-061 A11 lists three independent gates on
+// this path and says none of them is redundant.
+func (s *Service) verifyScopeReferents(ctx context.Context, principal domain.Principal, req SiteScopeRequest) error {
+	tenantID := principal.TenantID
 	switch req.Mode {
 	case SiteScopeModeTags:
 		// The tenant's tag registry, read under tenant RLS. Tags are a small,
@@ -622,7 +639,7 @@ func (s *Service) verifyScopeReferents(ctx context.Context, tenantID uuid.UUID, 
 		//
 		// This arm has no empty-scope ambiguity to preserve: a site either
 		// exists in this tenant or it does not.
-		resolved, err := s.store.ResolveScopeSites(ctx, tenantID,
+		resolved, err := s.store.ResolveScopeSites(ctx, principal,
 			string(SiteScopeModeList), nil, req.SiteIDs)
 		if err != nil {
 			return fmt.Errorf("resolve site scope for verification: %w", err)

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -595,15 +595,28 @@ func (s *Service) resolveMintCapabilities(requested []Capability) (CapabilitySet
 // because verifying is what lets the mint store it. That would be an operator
 // minting a credential wider than themselves.
 //
-// TODAY THAT PATH IS UNREACHABLE, AND THIS IS STILL NOT REDUNDANT.
+// TODAY THE ESCALATION IS UNREACHABLE, AND THIS IS STILL NOT REDUNDANT.
 // MintConnection's step 1 calls requireOrgScopedPrincipal, which refuses a
 // site-constrained principal outright, so every principal arriving here is
-// org-scoped and RunTenantTx dispatches it exactly as InTenantTx did. Passing
-// the principal changes no behaviour by one bit today. It is the fail-closed
-// backstop for the day that guard moves or a site-scoped mint becomes a
-// product decision -- the same reason IsSiteConstrained carries its second
-// disjunct, and the same reason ADR-061 A11 lists three independent gates on
-// this path and says none of them is redundant.
+// org-scoped and never reaches InScopedTenantTx. It is the fail-closed backstop
+// for the day that guard moves or a site-scoped mint becomes a product
+// decision -- the same reason IsSiteConstrained carries its second disjunct,
+// and the same reason ADR-061 A11 lists three independent gates on this path
+// and says none of them is redundant.
+//
+// IT IS NOT, HOWEVER, A NO-OP, AND THE EARLIER CLAIM THAT IT CHANGED "NO
+// BEHAVIOUR BY ONE BIT" WAS WRONG. The operator principal forwarded from the
+// handler carries a non-nil UserID, so dispatchTenantTx routes it to
+// InTenantTxAsUser and NOT to InTenantTx -- one extra
+// set_config('app.user_id', ...) per resolution. See
+// TestDispatchTenantTxRoutes's "org scope, no allowlist, with user" case, which
+// pins that branch.
+//
+// The CONSEQUENCE is nil, and that is a checked claim rather than an assumed
+// one: the only app.user_id-keyed policy on `sites` is sites_shared_read (m22),
+// which is PERMISSIVE FOR SELECT and can only add rows shared with that user in
+// OTHER tenants. This query's own `WHERE s.tenant_id = $1` excludes those, so
+// the resolved set cannot widen by a single row.
 func (s *Service) verifyScopeReferents(ctx context.Context, principal domain.Principal, req SiteScopeRequest) error {
 	tenantID := principal.TenantID
 	switch req.Mode {
@@ -632,8 +645,9 @@ func (s *Service) verifyScopeReferents(ctx context.Context, principal domain.Pri
 
 	case SiteScopeModeList:
 		// Site ids are verified through the AUDITED CHOKEPOINT rather than a
-		// second query: ResolveScopeSites runs InTenantTx and joins through
-		// `sites`, so tenant RLS drops every foreign or non-existent id. Under
+		// second query: ResolveScopeSites runs a tenant transaction chosen by
+		// the principal's scope (RunTenantTx) and joins through `sites`, so
+		// tenant RLS drops every foreign or non-existent id. Under
 		// mode 'list' the resolution is exactly the subset of the requested ids
 		// that exist here, so anything missing from the result names nothing.
 		//

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -89,6 +89,8 @@ type fakeStore struct {
 	tokenOK bool
 
 	scopeSites []uuid.UUID
+	// scopeSitesScoped is set by ResolveScopeSites; see its comment.
+	scopeSitesScoped bool
 
 	// S6b transport surface.
 	//
@@ -402,8 +404,15 @@ func (f *fakeStore) ReCheckAuthorization(_ context.Context, _, _ uuid.UUID) (sql
 	return f.recheck, nil
 }
 
-func (f *fakeStore) ResolveScopeSites(_ context.Context, _ uuid.UUID, _ string, _, _ []uuid.UUID) ([]uuid.UUID, error) {
+// scopeSitesScoped records whether the LAST ResolveScopeSites call arrived with
+// a site-constrained principal. It is captured rather than ignored because the
+// whole of ADR-061 A11 item 2 is about WHICH transaction helper the chokepoint
+// reaches, and a fake that drops the principal cannot tell a scoped call from a
+// tenant-wide one -- which is exactly the blindness that let the bare-uuid
+// signature survive.
+func (f *fakeStore) ResolveScopeSites(_ context.Context, principal db.ScopedPrincipal, _ string, _, _ []uuid.UUID) ([]uuid.UUID, error) {
 	f.note("ResolveScopeSites")
+	f.scopeSitesScoped = domain.IsSiteConstrained(principal.GetScope(), principal.GetAllowedSiteIDs())
 	return f.scopeSites, nil
 }
 

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -410,9 +411,19 @@ func (f *fakeStore) ReCheckAuthorization(_ context.Context, _, _ uuid.UUID) (sql
 // reaches, and a fake that drops the principal cannot tell a scoped call from a
 // tenant-wide one -- which is exactly the blindness that let the bare-uuid
 // signature survive.
+//
+// IT IS READ BY TestAuthenticateHandsTheChokepointAnUnscopedPrincipal AND MUST
+// STAY READ. A recorder nothing asserts on is a negative control that cannot
+// fail; if that assertion is ever deleted, delete this field with it rather
+// than leaving it standing where it looks like coverage.
+//
+// It is written under f.mu because every other field on this fake is, and the
+// concurrency proofs in this package drive it from several goroutines.
 func (f *fakeStore) ResolveScopeSites(_ context.Context, principal db.ScopedPrincipal, _ string, _, _ []uuid.UUID) ([]uuid.UUID, error) {
 	f.note("ResolveScopeSites")
+	f.mu.Lock()
 	f.scopeSitesScoped = domain.IsSiteConstrained(principal.GetScope(), principal.GetAllowedSiteIDs())
+	f.mu.Unlock()
 	return f.scopeSites, nil
 }
 
@@ -960,6 +971,67 @@ func liveToken(tenantID uuid.UUID) sqlc.GetMCPConnectionTokenByHashForLookupRow 
 		Status:    "active",
 		ExpiresAt: pgtype.Timestamptz{Time: time.Now().Add(90 * 24 * time.Hour), Valid: true},
 		IsLive:    true,
+	}
+}
+
+// TestAuthenticateHandsTheChokepointAnUnscopedPrincipal is the executed guard on
+// bootstrapTenantPrincipal, and it is the ONLY thing standing between that
+// function and a literal reading of ADR-061 A11 item 2.
+//
+// WHY IT IS NEEDED AT ALL. dispatchTenantTx reads exactly three fields of a
+// principal, so the value bootstrapTenantPrincipal returns is
+// INDISTINGUISHABLE at the dispatch from any other org-scoped, no-user
+// principal. Its name and its comment are the whole barrier. This turns that
+// barrier into something that goes red: swap the literal for a site-constrained
+// one and the assertion below fails at unit speed, with no container.
+//
+// THE CONSEQUENCE OF GETTING IT WRONG IS NOT A LEAK, IT IS AN OUTAGE, and it is
+// fail-closed in the direction that hides itself. Authenticate is what COMPUTES
+// this connection's allowlist; scoping it by the allowlist it is computing
+// resolves 'tags' and 'all' grants to zero sites, and every live MCP connection
+// starts answering "your scope resolves to no sites" for a perfectly valid
+// grant. The end-to-end proof of that lives in the integration suite; this is
+// the cheap sentinel that catches it long before anyone gets there.
+func TestAuthenticateHandsTheChokepointAnUnscopedPrincipal(t *testing.T) {
+	tenantID := uuid.New()
+	siteID := uuid.New()
+	tok := liveToken(tenantID)
+
+	// MODE 'all' ON PURPOSE. It is the mode that names no ids at all, so it is
+	// where a site-scoped bootstrap principal would carry an EMPTY allowlist
+	// and the resolution would collapse to nothing.
+	store := &fakeStore{
+		tokenOK: true, token: tok,
+		recheckOK: true,
+		recheck: sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
+			GrantID: tok.GrantID, GrantStatus: "active",
+			SiteScopeMode: "all", TokenID: tok.ID, TokenStatus: "active",
+			TokenExpiresAt:    tok.ExpiresAt,
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
+			Authorized:        true,
+		},
+		scopeSites: []uuid.UUID{siteID},
+	}
+	svc := NewService(store)
+
+	if _, err := svc.Authenticate(context.Background(), "the-bearer-token"); err != nil {
+		t.Fatalf("a live connection was refused: %v", err)
+	}
+
+	// The recorder means nothing unless the call actually happened. Assert that
+	// first: a false reading from a chokepoint that was never reached is
+	// precisely the vacuous pass this test exists to avoid.
+	if !slices.Contains(store.callLog(), "ResolveScopeSites") {
+		t.Fatal("Authenticate never reached the scope chokepoint, so the " +
+			"principal assertion below would pass vacuously")
+	}
+	if store.scopeSitesScoped {
+		t.Fatal("Authenticate handed the scope chokepoint a SITE-CONSTRAINED " +
+			"principal. That resolution is what PRODUCES the allowlist, so " +
+			"scoping it by the allowlist it is computing is circular: under " +
+			"'tags' and 'all' the allowlist is empty and every live connection " +
+			"resolves to zero sites. See bootstrapTenantPrincipal.")
 	}
 }
 

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -79,7 +79,10 @@ type Store interface {
 
 	LookupConnectionToken(ctx context.Context, tokenHash string) (sqlc.GetMCPConnectionTokenByHashForLookupRow, error)
 	ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.UUID) (sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow, error)
-	ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error)
+	// ResolveScopeSites takes a ScopedPrincipal rather than a tenant uuid so
+	// that the chokepoint can route on scope; see the method on Repo. A caller
+	// passing a deliberately org-scoped principal must justify it there.
+	ResolveScopeSites(ctx context.Context, principal db.ScopedPrincipal, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error)
 
 	// RecordClientIdentity stamps the connecting client's self-reported
 	// identity on the grant. protocolVersion is a *string and NOT a string so
@@ -485,15 +488,33 @@ func (r *Repo) ReCheckAuthorization(ctx context.Context, tenantID, tokenID uuid.
 }
 
 // ResolveScopeSites is the ONE audited chokepoint of m124 obligation 2. It runs
-// inside InTenantTx so that joining through `sites` under tenant isolation
-// drops every foreign UUID -- scope_site_ids is a uuid[] and PostgreSQL has no
-// foreign key over array elements, so the column accepts any UUID at all.
+// inside a tenant transaction so that joining through `sites` under tenant
+// isolation drops every foreign UUID -- scope_site_ids is a uuid[] and
+// PostgreSQL has no foreign key over array elements, so the column accepts any
+// UUID at all.
 //
 // An empty result means NO SITES. The caller enforces that; the database
 // cannot. See NewSiteSet, whose zero value allows nothing.
-func (r *Repo) ResolveScopeSites(ctx context.Context, tenantID uuid.UUID, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error) {
+//
+// IT TAKES A ScopedPrincipal AND NOT A BARE tenantID, AND THAT IS THE POINT OF
+// ADR-061 A11 ITEM 2. With a uuid parameter this function could not route on
+// scope even in principle: every caller got InTenantTx, app.site_scope stayed
+// unset, and the RESTRICTIVE `_site_scope` policies -- sites_site_scope (m19)
+// above all, which is the one this query joins through -- were switched off at
+// the chokepoint that exists to enforce scope. RunTenantTx is what dispatches a
+// site-constrained principal to InScopedTenantTx, the only helper that sets the
+// GUC those policies key on.
+//
+// The signature change is also the audit surface. A caller that WANTS the
+// tenant-wide read must now name a principal that is org-scoped and say why, in
+// code, at its own call site -- see bootstrapTenantPrincipal in service.go,
+// whose whole reason for existing is that ONE call site is genuinely a
+// bootstrap and must not be scoped by the allowlist it is computing. A bare
+// uuid made that choice invisible and indistinguishable from an oversight.
+func (r *Repo) ResolveScopeSites(ctx context.Context, principal db.ScopedPrincipal, mode string, tagIDs, siteIDs []uuid.UUID) ([]uuid.UUID, error) {
+	tenantID := principal.GetTenantID()
 	var out []uuid.UUID
-	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
 		rows, err := sqlc.New(tx).ResolveMCPGrantScopeSitesInTenantTx(ctx,
 			// COLUMN3 IS THE SITE ARRAY AND COLUMN4 IS THE TAG ARRAY, in that
 			// order. The query reads `WHEN 'list' THEN s.id = ANY($3)` and

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1135,7 +1135,12 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 
 	// Resolve the site scope at the one audited chokepoint, inside a tenant
 	// transaction so `sites` RLS drops any foreign UUID.
-	ids, err := s.store.ResolveScopeSites(ctx, tok.TenantID,
+	//
+	// THIS CALL SITE IS DELIBERATELY TENANT-SCOPED AND NOT SITE-SCOPED, AND IT
+	// IS THE ONE EXCEPTION TO ADR-061 A11 ITEM 2. Read bootstrapTenantPrincipal
+	// before changing it. In one line: this call is what PRODUCES the allowlist,
+	// so there is no allowlist to scope it by.
+	ids, err := s.store.ResolveScopeSites(ctx, bootstrapTenantPrincipal(tok.TenantID),
 		chk.SiteScopeMode, chk.ScopeTagIds, chk.ScopeSiteIds)
 	if err != nil {
 		return AuthorizedRequest{}, fmt.Errorf("resolve grant scope: %w", err)
@@ -1641,6 +1646,45 @@ func orEmpty(ids []uuid.UUID) []uuid.UUID {
 // It is not redundant with layer 1 either: layer 1 lives in the route
 // registration, and a route mounted without its middleware is a wiring mistake
 // that presents as a working endpoint. This function is inside the call.
+// bootstrapTenantPrincipal builds the org-scoped principal that Authenticate
+// hands the scope-resolution chokepoint. It exists so that the ONE place on
+// this surface that must not run under app.site_scope says so by name, in code,
+// instead of being indistinguishable from a call site that forgot.
+//
+// WHY THIS IS NOT A SITE-SCOPED PRINCIPAL. Authenticate has no domain.Principal
+// at all -- it is authenticating a bearer token, and the only identity in hand
+// is the grant's own stored SiteScopeMode / ScopeTagIds / ScopeSiteIds.
+// Resolving those three columns into concrete site ids is the step that
+// COMPUTES this connection's allowlist. Scoping that step by the allowlist it
+// is computing is circular, and it breaks differently in each of the three
+// modes:
+//
+//   - 'tags'  -- the site set is not known until this query runs. There is no
+//     allowlist to supply. Passing the empty one resolves to ZERO SITES, and
+//     because an empty result correctly means "no sites" and never "no filter",
+//     every tag-scoped connection would authenticate to nothing. That is
+//     fail-closed and still a total outage of the mode.
+//   - 'all'   -- names no ids. Org-wide IS the intended meaning; a site-scoped
+//     principal here contradicts the stored grant.
+//   - 'list'  -- the allowlist would be exactly the requested ids, and
+//     sites_site_scope's predicate is `id = ANY(allowed)` while the query's own
+//     predicate is `s.id = ANY($3)` over the same array. The policy would
+//     intersect the set with itself, so it can refuse nothing the query does
+//     not already refuse. Zero security gain, and a second copy of the filter
+//     to keep in step.
+//
+// The boundary that IS load-bearing here is tenant isolation, and it holds:
+// RunTenantTx dispatches this principal to InTenantTx, the join through `sites`
+// runs under the tenant policies, and every foreign or nonexistent UUID in the
+// uuid[] column is dropped. What the caller does with the resolved set is where
+// the site boundary lives -- see NewSiteSet, whose zero value allows nothing.
+//
+// It returns a domain.Principal with Scope and UserID unset ON PURPOSE. That is
+// the org-scoped, no-user shape, and it is what the dispatch reads.
+func bootstrapTenantPrincipal(tenantID uuid.UUID) domain.Principal {
+	return domain.Principal{TenantID: tenantID}
+}
+
 func requireOrgScopedPrincipal(p domain.Principal) error {
 	if p.TenantID == uuid.Nil {
 		return domain.Validation(ErrCodeInvalidRequest, "an organisation is required")

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1623,6 +1623,62 @@ func orEmpty(ids []uuid.UUID) []uuid.UUID {
 // Operator-facing connection management (S16 -- design Step 10, list + revoke)
 // ---------------------------------------------------------------------------
 
+// bootstrapTenantPrincipal builds the org-scoped principal that Authenticate
+// hands the scope-resolution chokepoint. It exists so that the ONE place on
+// this surface that must not run under app.site_scope says so by name, in code,
+// instead of being indistinguishable from a call site that forgot.
+//
+// WHY THIS IS NOT A SITE-SCOPED PRINCIPAL. Authenticate has no domain.Principal
+// at all -- it is authenticating a bearer token, and the only identity in hand
+// is the grant's own stored SiteScopeMode / ScopeTagIds / ScopeSiteIds.
+// Resolving those three columns into concrete site ids is the step that
+// COMPUTES this connection's allowlist. Scoping that step by the allowlist it
+// is computing is circular, and it breaks differently in each of the three
+// modes:
+//
+//   - 'tags'  -- the site set is not known until this query runs. There is no
+//     allowlist to supply. Passing the empty one resolves to ZERO SITES, and
+//     because an empty result correctly means "no sites" and never "no filter",
+//     every tag-scoped connection would authenticate to nothing. That is
+//     fail-closed and still a total outage of the mode.
+//   - 'all'   -- names no ids. Org-wide IS the intended meaning; a site-scoped
+//     principal here contradicts the stored grant.
+//   - 'list'  -- the allowlist would be exactly the requested ids, so the
+//     policy would intersect the set with itself and could refuse nothing the
+//     query does not already refuse. Zero security gain, and a second copy of
+//     the filter to keep in step.
+//
+//     THAT ARM IS A CONDITION AND NOT A STANDING FACT, so read it as one before
+//     relying on it. It holds only while sites_site_scope's predicate
+//     (`sites.id = ANY(<app.allowed_site_ids>)`, m19) and this query's own
+//     predicate (`s.id = ANY($3::uuid[])`, ResolveMCPGrantScopeSitesInTenantTx)
+//     range over THE SAME RELATION AND THE SAME COLUMN. Nothing binds them
+//     together. If either grows a second term, or 'list' starts resolving
+//     through a join rather than off `sites.id`, the intersection stops being
+//     the identity and this arm needs deciding again from scratch.
+//
+// The boundary that IS load-bearing here is tenant isolation, and it holds:
+// RunTenantTx dispatches this principal to InTenantTx, the join through `sites`
+// runs under the tenant policies, and every foreign or nonexistent UUID in the
+// uuid[] column is dropped. What the caller does with the resolved set is where
+// the site boundary lives -- see NewSiteSet, whose zero value allows nothing.
+//
+// It returns a domain.Principal with Scope and UserID unset ON PURPOSE. That is
+// the org-scoped, no-user shape, and it is what the dispatch reads.
+//
+// THE NAME AND THIS COMMENT ARE THE ONLY STRUCTURAL BARRIER, AND THAT IS WORTH
+// SAYING OUT LOUD. dispatchTenantTx reads exactly three fields -- Scope, UserID,
+// AllowedSiteIDs -- so the value returned here is INDISTINGUISHABLE at the
+// dispatch from any other org-scoped, no-user principal. Nothing in the type
+// system marks this one as the deliberate exception. What guards it is executed
+// rather than structural: TestAuthenticateHandsTheChokepointAnUnscopedPrincipal
+// asserts that the principal Authenticate hands the chokepoint is NOT
+// site-constrained, and it is what goes red, at unit speed, if someone applies
+// ADR-061 A11 item 2 literally here.
+func bootstrapTenantPrincipal(tenantID uuid.UUID) domain.Principal {
+	return domain.Principal{TenantID: tenantID}
+}
+
 // requireOrgScopedPrincipal is the site-scope refusal, and it is the SECOND of
 // three independent layers rather than the only one.
 //
@@ -1646,45 +1702,6 @@ func orEmpty(ids []uuid.UUID) []uuid.UUID {
 // It is not redundant with layer 1 either: layer 1 lives in the route
 // registration, and a route mounted without its middleware is a wiring mistake
 // that presents as a working endpoint. This function is inside the call.
-// bootstrapTenantPrincipal builds the org-scoped principal that Authenticate
-// hands the scope-resolution chokepoint. It exists so that the ONE place on
-// this surface that must not run under app.site_scope says so by name, in code,
-// instead of being indistinguishable from a call site that forgot.
-//
-// WHY THIS IS NOT A SITE-SCOPED PRINCIPAL. Authenticate has no domain.Principal
-// at all -- it is authenticating a bearer token, and the only identity in hand
-// is the grant's own stored SiteScopeMode / ScopeTagIds / ScopeSiteIds.
-// Resolving those three columns into concrete site ids is the step that
-// COMPUTES this connection's allowlist. Scoping that step by the allowlist it
-// is computing is circular, and it breaks differently in each of the three
-// modes:
-//
-//   - 'tags'  -- the site set is not known until this query runs. There is no
-//     allowlist to supply. Passing the empty one resolves to ZERO SITES, and
-//     because an empty result correctly means "no sites" and never "no filter",
-//     every tag-scoped connection would authenticate to nothing. That is
-//     fail-closed and still a total outage of the mode.
-//   - 'all'   -- names no ids. Org-wide IS the intended meaning; a site-scoped
-//     principal here contradicts the stored grant.
-//   - 'list'  -- the allowlist would be exactly the requested ids, and
-//     sites_site_scope's predicate is `id = ANY(allowed)` while the query's own
-//     predicate is `s.id = ANY($3)` over the same array. The policy would
-//     intersect the set with itself, so it can refuse nothing the query does
-//     not already refuse. Zero security gain, and a second copy of the filter
-//     to keep in step.
-//
-// The boundary that IS load-bearing here is tenant isolation, and it holds:
-// RunTenantTx dispatches this principal to InTenantTx, the join through `sites`
-// runs under the tenant policies, and every foreign or nonexistent UUID in the
-// uuid[] column is dropped. What the caller does with the resolved set is where
-// the site boundary lives -- see NewSiteSet, whose zero value allows nothing.
-//
-// It returns a domain.Principal with Scope and UserID unset ON PURPOSE. That is
-// the org-scoped, no-user shape, and it is what the dispatch reads.
-func bootstrapTenantPrincipal(tenantID uuid.UUID) domain.Principal {
-	return domain.Principal{TenantID: tenantID}
-}
-
 func requireOrgScopedPrincipal(p domain.Principal) error {
 	if p.TenantID == uuid.Nil {
 		return domain.Validation(ErrCodeInvalidRequest, "an organisation is required")

--- a/apps/api/tests/adr061_a11_scope_chokepoint_helper_test.go
+++ b/apps/api/tests/adr061_a11_scope_chokepoint_helper_test.go
@@ -1,0 +1,252 @@
+// adr061_a11_scope_chokepoint_helper_test.go: ADR-061 A11 item 2, executed.
+//
+// THE CLAIM UNDER TEST. mcp.Repo.ResolveScopeSites is the one audited
+// chokepoint for "which sites does this scope name". It used to take a bare
+// tenant uuid and run db.Pool.InTenantTx, which meant it could not route on
+// scope EVEN IN PRINCIPLE: app.site_scope was never set, so every RESTRICTIVE
+// `_site_scope` policy -- sites_site_scope (m19) above all, the one this
+// query's join through `sites` passes through -- was switched OFF at the
+// chokepoint that exists to enforce scope. It now takes a db.ScopedPrincipal
+// and runs RunTenantTx, so a site-constrained principal reaches
+// InScopedTenantTx and the policy engages.
+//
+// WHAT MAKES THIS A REAL PROOF AND NOT A VACUOUS ONE. Every assertion below
+// goes through mcp.Repo -- the same method, the same generated query, the same
+// tx helper the request path uses. No connection is opened here and no GUC is
+// hand-set. The role is asserted from INSIDE a transaction taken by the very
+// helper under test, because wpmgr_app being SUPERUSER or BYPASSRLS would make
+// all of this pass while proving nothing; that is m112's failure and it is the
+// reason this file prints the role rather than trusting it.
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// orgPrincipal, the tenant-wide operator, is NOT redeclared here: the shape
+// this file needs already exists in sitetag_routes_contract_test.go and is
+// exactly right (Scope: domain.ScopeOrg, so domain.IsSiteConstrained is false
+// and the dispatch sends it to InTenantTxAsUser). A second copy would be a
+// second place for the two to drift apart.
+
+// scopedPrincipal is the site-constrained collaborator. domain.IsSiteConstrained
+// is true for it, so db.Pool.RunTenantTx MUST route it to InScopedTenantTx,
+// which is the only helper that sets app.site_scope and app.allowed_site_ids.
+func scopedPrincipal(tenantID uuid.UUID, allowed ...uuid.UUID) domain.Principal {
+	return domain.Principal{
+		TenantID:       tenantID,
+		UserID:         uuid.New(),
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: allowed,
+	}
+}
+
+// TestA11ScopeChokepointRoutesOnPrincipalAsAppRole is the before/after. The
+// SAME mode-'list' resolution, over the SAME two real sites in ONE tenant, is
+// run twice and differs ONLY in the principal handed to the chokepoint:
+//
+//	org-scoped    -> InTenantTx        -> app.site_scope unset -> both sites
+//	site-scoped   -> InScopedTenantTx  -> app.site_scope on    -> only the
+//	                                                             allowlisted one
+//
+// The second result is the policy engaging. Before the signature change the
+// site-scoped call was NOT EXPRESSIBLE -- the function took a uuid -- and the
+// tenant-wide answer was the only answer this chokepoint could give.
+//
+// Both sites belong to the SAME tenant on purpose. Tenant isolation already
+// drops a foreign site (TestMCPScopeResolutionDropsForeignSiteIDsAsAppRole
+// proves that), so a cross-tenant fixture here would pass identically with the
+// site-scope policy switched off and would prove nothing about it.
+func TestA11ScopeChokepointRoutesOnPrincipalAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+
+	tenant := seedTenant(t, pool, "a11-chokepoint-"+uuid.NewString()[:8])
+
+	// THE ROLE, READ FROM INSIDE A TRANSACTION THIS HELPER OPENED. Asserted
+	// before anything else, because every assertion after it is worthless if
+	// the connection can see through RLS.
+	var role string
+	var super, bypass bool
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT current_user, rolsuper, rolbypassrls
+			   FROM pg_roles WHERE rolname = current_user`).Scan(&role, &super, &bypass)
+	}); err != nil {
+		t.Fatalf("read current role inside the tx under test: %v", err)
+	}
+	t.Logf("connected as %q rolsuper=%v rolbypassrls=%v", role, super, bypass)
+	if super || bypass {
+		t.Fatalf("this proof runs as %q with rolsuper=%v rolbypassrls=%v; either "+
+			"privilege makes every RLS policy inert and every assertion below "+
+			"vacuous", role, super, bypass)
+	}
+
+	inside, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://a11-inside.example.com", Name: "inside"})
+	if err != nil {
+		t.Fatalf("create the allowlisted site: %v", err)
+	}
+	outside, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://a11-outside.example.com", Name: "outside"})
+	if err != nil {
+		t.Fatalf("create the non-allowlisted site: %v", err)
+	}
+	named := []uuid.UUID{inside.ID, outside.ID}
+
+	// BEFORE: the tenant-wide read. This is byte-for-byte what the old
+	// bare-uuid signature did for every caller, and it must keep working --
+	// an org-scoped operator legitimately reaches every site in the tenant.
+	org, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenant), "list", nil, named)
+	if err != nil {
+		t.Fatalf("resolve as an org-scoped principal: %v", err)
+	}
+	t.Logf("org-scoped principal, mode 'list' naming %d sites, resolved to %d",
+		len(named), len(org))
+	if len(org) != len(named) {
+		t.Fatalf("an org-scoped operator resolved %d of the %d sites it named; "+
+			"the tenant-wide path has regressed, which is the OVER-FIRE "+
+			"direction: got %v", len(org), len(named), org)
+	}
+
+	// AFTER: the same query, same tenant, same two ids, site-constrained
+	// principal whose allowlist holds only one of them.
+	scoped, err := mcpRepo.ResolveScopeSites(ctx,
+		scopedPrincipal(tenant, inside.ID), "list", nil, named)
+	if err != nil {
+		t.Fatalf("resolve as a site-constrained principal: %v", err)
+	}
+	t.Logf("site-scoped principal (allowlist of 1), same %d ids, resolved to %d",
+		len(named), len(scoped))
+	if len(scoped) != 1 || scoped[0] != inside.ID {
+		t.Fatalf("a site-constrained principal naming site %v OUTSIDE its "+
+			"allowlist resolved %v, want just %v. app.site_scope is not "+
+			"reaching sites_site_scope: the chokepoint is running under the "+
+			"plain tenant helper", outside.ID, scoped, inside.ID)
+	}
+}
+
+// TestA11ScopeChokepointDoesNotOverFireAsAppRole is the other half of the guard
+// rule: a check that reddens correct work gets switched off, and then it guards
+// nothing. Three honest cases that MUST still resolve exactly as they did
+// before the signature moved.
+func TestA11ScopeChokepointDoesNotOverFireAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+
+	tenant := seedTenant(t, pool, "a11-overfire-"+uuid.NewString()[:8])
+	one, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://a11-of1.example.com", Name: "of1"})
+	if err != nil {
+		t.Fatalf("create site one: %v", err)
+	}
+	two, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://a11-of2.example.com", Name: "of2"})
+	if err != nil {
+		t.Fatalf("create site two: %v", err)
+	}
+	tenantSites := 2
+
+	// 1. AN ORG-SCOPED OPERATOR, MODE 'all'. Org-wide is the stored grant's
+	//    intended meaning and nothing may narrow it.
+	all, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenant), "all", nil, nil)
+	if err != nil {
+		t.Fatalf("mode 'all' as an org principal: %v", err)
+	}
+	t.Logf("mode 'all', org-scoped: resolved to %d of the tenant's %d sites",
+		len(all), tenantSites)
+	if len(all) != tenantSites {
+		t.Fatalf("mode 'all' resolved %d sites in a tenant holding %d: %v",
+			len(all), tenantSites, all)
+	}
+
+	// 2. THE UNAUTHENTICATED BOOTSTRAP. Service.Authenticate has no principal
+	//    -- it is authenticating a bearer token -- and hands the chokepoint a
+	//    principal built from the token's tenant alone. That shape is
+	//    org-scoped by construction (Scope and UserID unset), so it must reach
+	//    every site the tenant-wide path reached. If this ever narrows, EVERY
+	//    MCP connection in the fleet resolves to fewer sites than its grant
+	//    names, which is a silent fleet-wide outage rather than an error.
+	//
+	//    The literal below is the shape mcp.bootstrapTenantPrincipal returns;
+	//    it is unexported, so this restates it rather than calling it.
+	bootstrap, err := mcpRepo.ResolveScopeSites(ctx,
+		domain.Principal{TenantID: tenant}, "all", nil, nil)
+	if err != nil {
+		t.Fatalf("bootstrap principal, mode 'all': %v", err)
+	}
+	t.Logf("bootstrap principal (no scope, no user), mode 'all': resolved to %d",
+		len(bootstrap))
+	if len(bootstrap) != len(all) {
+		t.Fatalf("the bootstrap principal resolved %d sites where the org "+
+			"principal resolved %d; Authenticate is being narrowed and every "+
+			"live connection loses sites", len(bootstrap), len(all))
+	}
+
+	// 3. MODE 'list' NAMING EVERY SITE, ORG-SCOPED. The ordinary operator case,
+	//    and the exact call mint.go's verifyScopeReferents makes.
+	listed, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenant), "list", nil,
+		[]uuid.UUID{one.ID, two.ID})
+	if err != nil {
+		t.Fatalf("mode 'list' as an org principal: %v", err)
+	}
+	t.Logf("mode 'list' naming %d sites, org-scoped: resolved to %d",
+		tenantSites, len(listed))
+	if len(listed) != tenantSites {
+		t.Fatalf("mode 'list' naming %d of its own sites resolved %d: %v",
+			tenantSites, len(listed), listed)
+	}
+}
+
+// TestA11ScopedPrincipalWithEmptyAllowlistResolvesToZeroSites is A11 item 3 at
+// this chokepoint: a scope of "site" with an empty allowlist means NO SITES and
+// never ALL SITES. It is the single most likely place for a fail-open default
+// to survive review, and with the signature change it is now decided by the
+// DATABASE -- sites_site_scope against an empty app.allowed_site_ids matches
+// nothing -- rather than by Go remembering to check.
+//
+// It is ALSO why Service.Authenticate must NOT scope its bootstrap resolution:
+// under mode 'tags' the allowlist is not known until this query runs, so
+// passing the empty one would resolve every tag-scoped connection to nothing.
+// This test is what makes that consequence concrete instead of asserted in a
+// comment.
+func TestA11ScopedPrincipalWithEmptyAllowlistResolvesToZeroSites(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+
+	tenant := seedTenant(t, pool, "a11-empty-"+uuid.NewString()[:8])
+	only, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://a11-empty.example.com", Name: "empty"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+
+	// Scope "site", allowlist empty. domain.IsSiteConstrained is true on the
+	// scope label alone, so this reaches InScopedTenantTx.
+	empty := domain.Principal{TenantID: tenant, UserID: uuid.New(), Scope: domain.ScopeSite}
+	got, err := mcpRepo.ResolveScopeSites(ctx, empty, "all", nil, nil)
+	if err != nil {
+		t.Fatalf("empty-allowlist principal, mode 'all': %v", err)
+	}
+	t.Logf("scope=site with an EMPTY allowlist, mode 'all', in a tenant holding "+
+		"site %v: resolved to %d", only.ID, len(got))
+	if len(got) != 0 {
+		t.Fatalf("scope 'site' with an empty allowlist resolved %d sites (%v) "+
+			"in a tenant that holds %v; an empty allowlist must mean NO SITES, "+
+			"never every site", len(got), got, only.ID)
+	}
+}

--- a/apps/api/tests/adr061_a11_scope_chokepoint_helper_test.go
+++ b/apps/api/tests/adr061_a11_scope_chokepoint_helper_test.go
@@ -104,9 +104,15 @@ func TestA11ScopeChokepointRoutesOnPrincipalAsAppRole(t *testing.T) {
 	}
 	named := []uuid.UUID{inside.ID, outside.ID}
 
-	// BEFORE: the tenant-wide read. This is byte-for-byte what the old
-	// bare-uuid signature did for every caller, and it must keep working --
-	// an org-scoped operator legitimately reaches every site in the tenant.
+	// BEFORE: the tenant-wide read. NOT "byte-for-byte what the old signature
+	// did" -- that claim was wrong. orgPrincipal carries a UserID, so
+	// dispatchTenantTx routes it to InTenantTxAsUser rather than the InTenantTx
+	// the bare-uuid version always took, which sets app.user_id as well as
+	// app.tenant_id. The RESOLVED SET is what must be unchanged, and it is: the
+	// only app.user_id-keyed policy on `sites` is sites_shared_read (m22),
+	// PERMISSIVE FOR SELECT over other tenants' shares, which this query's
+	// `WHERE s.tenant_id = $1` excludes. An org-scoped operator must still
+	// reach every site in its own tenant.
 	org, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenant), "list", nil, named)
 	if err != nil {
 		t.Fatalf("resolve as an org-scoped principal: %v", err)

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -214,7 +214,7 @@ func TestMCPScopeResolutionDropsForeignSiteIDsAsAppRole(t *testing.T) {
 	// A grant for org A whose scope list names org A's site AND org B's, plus
 	// a uuid that never existed. The database cannot refuse any of them.
 	neverExisted := uuid.New()
-	resolved, err := mcpRepo.ResolveScopeSites(ctx, tenantA, "list", nil,
+	resolved, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenantA), "list", nil,
 		[]uuid.UUID{siteA1.ID, siteB1.ID, neverExisted})
 	if err != nil {
 		t.Fatalf("ResolveScopeSites as wpmgr_app: %v", err)
@@ -242,7 +242,7 @@ func TestMCPScopeResolutionDropsForeignSiteIDsAsAppRole(t *testing.T) {
 	// Asserted because 'all' is the mode that kept working while 'list' and
 	// 'tags' were silently resolving to nothing, so it is the one that would
 	// have masked the swap in any smoke test.
-	all, err := mcpRepo.ResolveScopeSites(ctx, tenantA, "all", nil, nil)
+	all, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenantA), "all", nil, nil)
 	if err != nil {
 		t.Fatalf("ResolveScopeSites mode all: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestMCPScopeResolutionDropsForeignSiteIDsAsAppRole(t *testing.T) {
 
 	// AN UNRECOGNISED MODE RESOLVES TO NO SITES, never to every site. This is
 	// the query's `ELSE false` and it is the fail-closed direction.
-	none, err := mcpRepo.ResolveScopeSites(ctx, tenantA, "not-a-mode", nil,
+	none, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenantA), "not-a-mode", nil,
 		[]uuid.UUID{siteA1.ID})
 	if err != nil {
 		t.Fatalf("ResolveScopeSites unknown mode: %v", err)
@@ -297,7 +297,7 @@ func TestMCPScopeResolutionListModeSelectsTheNamedSites(t *testing.T) {
 	}
 
 	// A grant naming TWO of the three. The third must not appear.
-	resolved, err := mcpRepo.ResolveScopeSites(ctx, tenantA, "list", nil,
+	resolved, err := mcpRepo.ResolveScopeSites(ctx, orgPrincipal(tenantA), "list", nil,
 		[]uuid.UUID{one.ID, two.ID})
 	if err != nil {
 		t.Fatalf("ResolveScopeSites mode list: %v", err)


### PR DESCRIPTION
Closes ADR-061 A11 item 2 at `ResolveScopeSites`. Draft: needs a `security-reviewer` pass.

## What was wrong

`mcp.Repo.ResolveScopeSites` took a bare `tenantID uuid.UUID` and ran `InTenantTx`, so it could not route on scope even in principle. `app.site_scope` was never set, and the RESTRICTIVE `_site_scope` policies — `sites_site_scope` (m19) above all, the one this query's join through `sites` passes through — were switched off at the function whose job is to enforce scope. m132's 22 new policies inherit the same problem: they are inert unless `InScopedTenantTx` sets the GUC.

It now takes `db.ScopedPrincipal` and runs `RunTenantTx`.

## The two call sites are different problems

**`mint.go` `verifyScopeReferents` — threads the operator's principal.** Mode `'list'` verifies requested site ids by resolving them and checking each came back, so a site-scoped operator resolving a site outside their allowlist would be minting a credential wider than themselves. That path is **unreachable today**: `MintConnection` step 1 calls `requireOrgScopedPrincipal` (`internal/mcp/service.go:1648`), which refuses a site-constrained principal outright, so every principal arriving here is org-scoped and `RunTenantTx` dispatches it exactly as `InTenantTx` did. This changes no behaviour by one bit. It is the fail-closed backstop for the day that guard moves — the same reason `IsSiteConstrained` carries its second disjunct.

**`service.go` `Authenticate` — stays tenant-scoped, deliberately.** This is a bootstrap: it has no `domain.Principal` at all, and it resolves the grant's own `SiteScopeMode`/`ScopeTagIds`/`ScopeSiteIds` into concrete ids. That resolution is what *produces* the allowlist, so scoping it by the allowlist it is computing is circular:

- `'tags'` — the site set is not known until the query runs. There is no allowlist to supply; the empty one resolves every tag-scoped connection to zero sites.
- `'all'` — names no ids; org-wide is the stored grant's meaning.
- `'list'` — `sites_site_scope`'s predicate is `id = ANY(allowed)` and the query's own is `s.id = ANY($3)` over the same array, so the policy intersects the set with itself and can refuse nothing the query does not already refuse.

It now goes through a named `bootstrapTenantPrincipal`, so the exception is stated in code at its own call site instead of being indistinguishable from an oversight — which is the real win of the signature change.

**A11 item 2 as written is over-broad.** See the comment below.

## Proofs

New: `apps/api/tests/adr061_a11_scope_chokepoint_helper_test.go`. Through `mcp.Repo`, opening no connection and hand-setting no GUC, asserting `current_user`/`rolsuper`/`rolbypassrls` from inside a transaction the helper under test opened.

The policies engage — same query, same two sites, same tenant, differing only in the principal:

```
adr061_a11_scope_chokepoint_helper_test.go:88: connected as "wpmgr_app" rolsuper=false rolbypassrls=false
adr061_a11_scope_chokepoint_helper_test.go:114: org-scoped principal, mode 'list' naming 2 sites, resolved to 2
adr061_a11_scope_chokepoint_helper_test.go:129: site-scoped principal (allowlist of 1), same 2 ids, resolved to 1
```

Both sites are in the **same** tenant on purpose: a cross-tenant fixture would pass identically with the site-scope policy off.

Over-fire cases (org-scoped operator, unauthenticated bootstrap, mode `'all'`, and the empty allowlist meaning zero sites) are covered and green.

`go test ./tests/ -run 'TestMCP|TestA11|TestS16|TestS6b' -count=1` → `ok ... 71.762s`.

## Also owed, not done here

The m132 invariant test — "every site-keyed table carries a site-scope policy" — is its own job. It needs a catalogue sweep with a defensible definition of "site-keyed" and an explicit exemption list, and half-doing it would ship a guard that passes when it finds nothing. Briefing it separately.
