### PR TITLE
ci: print the integration test count instead of hard-coding it

### DIFF
--- a/.github/workflows/api-integration.yml
+++ b/.github/workflows/api-integration.yml
@@ -6,8 +6,8 @@ name: api-integration
 #
 # ci.yml's Go job excludes `/apps/api/tests` from `go test` and its comment said
 # those tests "belong in a separate lane". That lane did not exist. From the day
-# the exclusion landed until this file, 343 tests were compile-checked by Vet
-# and never executed by anything. (Vet, not Build: ci.yml's Build step excludes
+# the exclusion landed until this file, every test in this package was
+# compile-checked by Vet and never executed by anything. (Vet, not Build: ci.yml's Build step excludes
 # this package too, because every file in it is a _test.go file and `go build`
 # errors on a package with no buildable non-test files. Vet compiles the test
 # files, so it is the only thing standing between this package and bit rot.)
@@ -27,8 +27,10 @@ name: api-integration
 # schema as a non-superuser. Both halves are needed. Neither is redundant: the
 # repo half fails when the dispatch stops setting app.site_scope, the policy
 # half fails when the policy stops refusing. This lane covers the policy half,
-# plus the other ~320 container tests in the package (billing, backups, audit
-# chain, uptime, tenant isolation, social identity).
+# plus the rest of the package's container tests (billing, backups, audit
+# chain, uptime, tenant isolation, social identity) — see the "Count
+# integration test functions" step below for the live total, not a number
+# frozen in this comment.
 #
 # COST AND RISK, stated so the next person can revisit this knowingly.
 # Cost: one ubuntu-latest runner for the wall time reported in the PR that added
@@ -43,8 +45,11 @@ name: api-integration
 on:
   # MANUAL ONLY, and that is a deliberate cost decision, not an oversight.
   #
-  # This lane takes about 18 minutes on a GitHub runner: 344 tests, most of
-  # which stand up their own ephemeral Postgres. On a PR that is 18 minutes of
+  # This lane takes about 18 minutes on a GitHub runner, most of the package's
+  # tests standing up their own ephemeral Postgres (the "Count integration test
+  # functions" step and the Summary step below print the live test total and
+  # the actual wall time on every run — this estimate is only for why the lane
+  # is manual, not a claim to keep re-counting). On a PR that is 18 minutes of
   # waiting before anyone can merge anything, which is too high a toll to pay on
   # every change while the project runs on the standard runners. The tests are
   # run locally instead (`make test-integration`), which is how they have always
@@ -222,13 +227,38 @@ jobs:
             docker pull --quiet "$img"
           done
 
+      # The workflow comments used to hard-code this package's test count, and
+      # that literal drifted twice (see the "TWO GENERATIONS" comment below)
+      # without anyone noticing, because nothing recomputed it. Print it
+      # instead, every run, so a stale literal in a comment can never again be
+      # mistaken for a current fact. `set -euo pipefail` means a moved or
+      # emptied tests/ directory fails this step loudly rather than printing 0.
+      - name: Count integration test functions
+        run: |
+          set -euo pipefail
+          total=$(grep -rhoE '^func Test[A-Za-z0-9_]+' tests/*.go | wc -l | tr -d '[:space:]')
+          cgo_files=$(grep -l 'go:build cgo' tests/*.go || true)
+          if [ -n "$cgo_files" ]; then
+            cgo_only=$(grep -hoE '^func Test[A-Za-z0-9_]+' $cgo_files | wc -l | tr -d '[:space:]')
+            cgo_names=$(grep -hoE '^func Test[A-Za-z0-9_]+' $cgo_files | sed 's/^func //' | paste -sd, -)
+          else
+            cgo_only=0
+            cgo_names="(none)"
+          fi
+          runnable=$(( total - cgo_only ))
+          echo "apps/api/tests: $total test functions total"
+          echo "apps/api/tests: $runnable run in this lane under CGO_ENABLED=0"
+          echo "apps/api/tests: $cgo_only excluded by a //go:build cgo tag: $cgo_names"
+
       # GOWORK=off and CGO_ENABLED=0 mirror ci.yml's Go job and the production
       # main-API image. One honest consequence: tests/media_encode_integration_test.go
       # carries a `//go:build cgo` tag, so it is excluded here exactly as it is
-      # excluded everywhere else today. 343 of the package's 344 test functions
-      # run. Covering that last one means building lilliput's CGO codecs, which
-      # is what infra/Dockerfile.media-encoder exists for, and dragging that
-      # toolchain in here would trade a real flake risk for one test.
+      # excluded everywhere else today. Every test function in the package runs
+      # except that file's TestMediaEncodeWorker_EndToEnd (see the "Count
+      # integration test functions" step above for the live totals). Covering
+      # that one means building lilliput's CGO codecs, which is what
+      # infra/Dockerfile.media-encoder exists for, and dragging that toolchain
+      # in here would trade a real flake risk for one test.
       #
       # -count=1 defeats the build cache so a green tick always means the tests
       # ran, never that Go replayed a cached result.
@@ -256,13 +286,18 @@ jobs:
       # as a sign of trouble; read its elapsed number against the ceiling.
       #
       # THAT RANGE IS A HISTORICAL SAMPLE, not a live maximum, and it is stated
-      # without a run count on purpose. The whole reason this file exists is
-      # that ci.yml carried a hand-counted "262" that had drifted to 344 while
-      # nobody noticed, so a comment here that has to be re-counted after every
-      # run would repeat the same mistake. A later run landing outside this
-      # range falsifies nothing. Every run prints its own wall time (see the
-      # Summary step): read that for anything current, and treat this range as
-      # the reason the ceiling is 45m rather than as a live measurement.
+      # without a run count on purpose. TWO GENERATIONS OF THE SAME MISTAKE:
+      # ci.yml once carried a hand-counted test total that drifted silently for
+      # a long time before anyone noticed, and the comment that replaced it
+      # with a fresh hand-count drifted again, by even more, before the next
+      # person noticed. The lesson is not "recount it" — a fixed literal in a
+      # comment is never re-checked, so any hard-coded count here would repeat
+      # the same mistake a third time. That is why the count is now a step
+      # ("Count integration test functions" above) instead of a sentence. A
+      # later run landing outside this timing range falsifies nothing. Every
+      # run prints its own wall time (see the Summary step): read that for
+      # anything current, and treat this range as the reason the ceiling is
+      # 45m rather than as a live measurement.
       #
       # TWO DIFFERENT NUMBERS, AND THEY DO NOT CONTRADICT EACH OTHER. The
       # figures above are what `go test` reports for the package, which is
@@ -310,9 +345,9 @@ jobs:
       # t.Skipf("skipping: cannot start ... container (docker unavailable?)")
       # when it cannot reach a daemon. It SKIPS, it does not fail. So a runner
       # image that one day ships without Docker, or a daemon that dies mid-job,
-      # produces 343 skips, `ok`, exit 0 and a green tick, and this lane would go
-      # on protecting nothing while looking like it protects everything. Green
-      # has to mean the tests ran.
+      # produces an all-skip `ok`, exit 0 and a green tick, and this lane would
+      # go on protecting nothing while looking like it protects everything.
+      # Green has to mean the tests ran.
       #
       # Three layers, weakest to strongest:
       #   1. no test may have skipped for the docker-unavailable reason (today
@@ -336,9 +371,11 @@ jobs:
 
           passed=$(grep -cE '^--- PASS: ' "$log" || true)
           echo "passing tests: $passed"
-          # 343 run today. The floor leaves headroom for tests being renamed or
-          # retired without becoming a maintenance tax, while still being far
-          # above anything a mass-skip could produce.
+          # The floor sits well below the live total (see the "Count
+          # integration test functions" step earlier in this job for today's
+          # number), so tests can be renamed or retired without this becoming
+          # a maintenance tax, while still landing far above anything a
+          # mass-skip could produce.
           if [ "$passed" -lt 320 ]; then
             echo "::error::only $passed tests passed, expected at least 320; the package did not really run"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,16 +72,19 @@ jobs:
           CGO_ENABLED: "0"
         # Also exclude apps/api/tests here: those are container-based integration
         # tests (testcontainers: postgres, redis, minio, clickhouse) that belong
-        # in a separate lane, not the fast unit CI. 344 test functions live
-        # there, 343 of which run under CGO_ENABLED=0 (one is //go:build cgo),
-        # and most stand up their own ephemeral Postgres, so the cost, not any
-        # missing Docker daemon, is why they sit out this lane.
+        # in a separate lane, not the fast unit CI. Nearly all of that package's
+        # test functions run under CGO_ENABLED=0 (one is excluded by a
+        # //go:build cgo tag), and most stand up their own ephemeral Postgres,
+        # so the cost, not any missing Docker daemon, is why they sit out this
+        # lane.
         #
         # THE SEPARATE LANE IS .github/workflows/api-integration.yml, and it is
         # MANUAL ONLY. It runs the package for real, but only when somebody
         # dispatches it: about 18 minutes on a standard runner is too long to
-        # wait on every PR until a faster one is available. Its triggers are
-        # written and commented out, ready to uncomment.
+        # wait on every PR until a faster one is available. Its "Count
+        # integration test functions" step prints the live total on every run;
+        # this file does not restate it. Its triggers are written and commented
+        # out, ready to uncomment.
         #
         # SO NOTHING IN CI EXECUTES THESE TESTS TODAY. That includes the m112
         # site-scope RLS proofs, the ones that stop a collaborator invited to a


### PR DESCRIPTION
## Summary
- `api-integration.yml` and `ci.yml` carried a hand-counted "344 tests" (and 343/262/~320 derivatives of it) across six comment sites. It's drifted twice now: `grep -rhoE '^func Test[A-Za-z0-9_]+' apps/api/tests/*.go | wc -l` currently returns 531.
- Added a `Count integration test functions` step to `api-integration.yml` that computes and prints the total, the runnable count under `CGO_ENABLED=0`, and the name(s) of any `//go:build cgo`-excluded test, every run. `set -euo pipefail` makes it fail loud (not print 0) if `apps/api/tests` is ever moved or emptied.
- Rewrote the six comment sites to stop stating a literal: they now either point at the new step for the live number, or restate the underlying fact without a number (e.g. "343 of 344 test functions run" -> "every test function runs except `TestMediaEncodeWorker_EndToEnd`").
- Did not touch `CLAUDE.md` or `.claude/agents/devops-engineer.md`, which quote the stale "344" figure as a worked example — per instruction, that's the owner's file to update now that the workflows no longer carry the number.

## Proof
Green case (real run of the new step's logic):
```
apps/api/tests: 531 test functions total
apps/api/tests: 530 run in this lane under CGO_ENABLED=0
apps/api/tests: 1 excluded by a //go:build cgo tag: TestMediaEncodeWorker_EndToEnd
exit=0
```
Red case (`apps/api/tests` moved aside):
```
grep: tests/*.go: No such file or directory
exit=2
```
Restored and re-ran: back to the green output above, exit 0.

## Test plan
- [x] Both workflow files parse as valid YAML (`ruby -ryaml`)
- [x] `grep -n "343\|344\|262\|~320" .github/workflows/*.yml` returns nothing
- [x] New step's logic proven to fire (red) and not over-fire (green), pasted above
- [ ] CI (`ci.yml`) runs green on this PR
