### PR TITLE
fix(mcp): correct stale InTenantTx query header claims after #649

### DIFF
--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -464,14 +464,21 @@ RETURNING *;
 -- ===========================================================================
 
 -- name: CreateMCPConnectionToken :one
--- Runs InTenantTx from RedeemAuthorizationCode's token exchange, and inside a
--- tenant transaction chosen by the principal's scope, via db.Pool.RunTenantTx,
--- from CreateGrantWithCode and CreateGrantWithToken -- NOT a fixed InTenantTx
--- on those two paths. mcp_connection_tokens carries a RESTRICTIVE
--- `_site_scope_insert` policy keyed on app.site_scope; only the scoped
--- dispatch, via InScopedTenantTx, sets that GUC, so a caller minting a token
--- alongside a grant must go through RunTenantTx or the policy sits inert for a
--- site-constrained principal. token_hash is lower-case hex SHA-256 (Decision 4, the
+-- Has two callers, on two different dispatches. RedeemAuthorizationCode runs
+-- it under literal InTenantTx -- the tenant is already known, from the code
+-- just consumed, and no principal is in scope at that point to dispatch on.
+-- CreateGrantWithToken runs it inside a tenant transaction chosen by the
+-- principal's scope, via db.Pool.RunTenantTx, NOT a fixed InTenantTx, because
+-- this is the path that mints the FIRST token alongside a new grant.
+-- CreateGrantWithCode is NOT a caller of this query -- it mints a code, via
+-- CreateMCPAuthorizationCode, and never a token.
+--
+-- mcp_connection_tokens carries a RESTRICTIVE `_site_scope_insert` policy
+-- keyed on app.site_scope; only the scoped dispatch, via InScopedTenantTx,
+-- sets that GUC, so CreateGrantWithToken minting a token for a site-scoped
+-- principal must go through RunTenantTx or the policy sits inert.
+--
+-- token_hash is lower-case hex SHA-256 (Decision 4, the
 -- internal/apikey/apikey.go:102 construction); the plaintext is returned to
 -- the operator once, here, and there is no column to read it back from.
 --

--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -320,14 +320,22 @@ INSERT INTO mcp_grants (
 RETURNING *;
 
 -- name: GetMCPGrant :one
--- Runs InTenantTx. tenant_id is in the WHERE as well as in the RLS policy --
--- the house convention, defense in depth -- so a grant id from another
--- organisation returns no rows rather than a row.
+-- Runs inside a tenant transaction chosen by the principal's scope: its one
+-- caller, ConnectionStatusSnapshot, dispatches through db.Pool.RunTenantTx,
+-- not a fixed InTenantTx. mcp_grants carries RESTRICTIVE `_site_scope`
+-- policies keyed on app.site_scope, and only the scoped dispatch -- via
+-- InScopedTenantTx -- sets that GUC; a caller that picked InTenantTx directly
+-- would read this row with those policies inert. tenant_id is in the WHERE as
+-- well as in the RLS policy -- the house convention, defense in depth -- so a
+-- grant id from another organisation returns no rows rather than a row.
 SELECT * FROM mcp_grants
 WHERE tenant_id = $1 AND id = $2;
 
 -- name: ListMCPGrantsForOrg :many
--- Runs InTenantTx. Refused outright for a site-scoped session by
+-- Runs inside a tenant transaction chosen by the principal's scope: its
+-- caller, ListGrants, dispatches through db.Pool.RunTenantTx, not a fixed
+-- InTenantTx, precisely so that dispatch can reach InScopedTenantTx and set
+-- app.site_scope. Refused outright for a site-scoped session by
 -- mcp_grants_site_scope_select (PR #569 finding F1): scope_site_ids enumerates
 -- every site the organisation has granted MCP access to, and RLS filters rows,
 -- not columns, so total refusal is the only shape that closes it.
@@ -342,8 +350,12 @@ WHERE tenant_id = $1
 ORDER BY created_at DESC, id DESC;
 
 -- name: RevokeMCPGrantWithTokensInTenantTx :one
--- Runs InTenantTx. ONE STATEMENT, BOTH TABLES, BECAUSE A GRANT AND ITS TOKENS
--- MUST NOT BE REVOKED SEPARATELY.
+-- Runs inside a tenant transaction chosen by the principal's scope: its
+-- caller, RevokeGrantWithTokens, dispatches through db.Pool.RunTenantTx, not a
+-- fixed InTenantTx, so that a site-constrained principal reaches
+-- InScopedTenantTx and mcp_grants' RESTRICTIVE `_site_scope` policies engage
+-- rather than sitting inert. ONE STATEMENT, BOTH TABLES, BECAUSE A GRANT AND
+-- ITS TOKENS MUST NOT BE REVOKED SEPARATELY.
 --
 -- A security review of this stack proved the two are currently independent --
 -- it observed `grant_status revoked / token_status active` -- and a live token
@@ -452,7 +464,14 @@ RETURNING *;
 -- ===========================================================================
 
 -- name: CreateMCPConnectionToken :one
--- Runs InTenantTx. token_hash is lower-case hex SHA-256 (Decision 4, the
+-- Runs InTenantTx from RedeemAuthorizationCode's token exchange, and inside a
+-- tenant transaction chosen by the principal's scope, via db.Pool.RunTenantTx,
+-- from CreateGrantWithCode and CreateGrantWithToken -- NOT a fixed InTenantTx
+-- on those two paths. mcp_connection_tokens carries a RESTRICTIVE
+-- `_site_scope_insert` policy keyed on app.site_scope; only the scoped
+-- dispatch, via InScopedTenantTx, sets that GUC, so a caller minting a token
+-- alongside a grant must go through RunTenantTx or the policy sits inert for a
+-- site-constrained principal. token_hash is lower-case hex SHA-256 (Decision 4, the
 -- internal/apikey/apikey.go:102 construction); the plaintext is returned to
 -- the operator once, here, and there is no column to read it back from.
 --
@@ -683,15 +702,24 @@ RETURNING *;
 -- ===========================================================================
 
 -- name: ResolveMCPGrantScopeSitesInTenantTx :many
--- MUST RUN INSIDE InTenantTx, AND THAT IS A CORRECTNESS REQUIREMENT RATHER
--- THAN A CONVENTION. scope_site_ids is a uuid[] and PostgreSQL has no foreign
--- key over array elements, so the column ACCEPTS ANY UUID -- including a site
--- id belonging to another organisation, or one that never existed. No CHECK
--- can refuse that; the constraint needed is a cross-table membership test.
--- This query IS that test: joining through `sites` under tenant isolation
--- silently drops every id that is not this tenant's. Resolve outside a tenant
--- transaction, or against a cached site list, and a foreign UUID survives all
--- the way to the read.
+-- MUST RUN INSIDE A TENANT TRANSACTION CHOSEN BY THE PRINCIPAL'S SCOPE, AND
+-- THAT IS A CORRECTNESS REQUIREMENT RATHER THAN A CONVENTION. Since #649
+-- (ADR-061 A11 item 2) the caller is db.Pool.RunTenantTx, which dispatches on
+-- db.ScopedPrincipal to InScopedTenantTx, InTenantTxAsUser or InTenantTx --
+-- NOT a fixed InTenantTx call. The dispatch is not incidental: InScopedTenantTx
+-- is the only one of the three that sets app.site_scope, and sites_site_scope
+-- (m19) -- the RESTRICTIVE policy this query's join through `sites` passes
+-- through -- is inert without it. A caller that ran plain InTenantTx here would
+-- leave a site-constrained principal's scope unenforced.
+--
+-- Separately, and for the reason below: scope_site_ids is a uuid[] and
+-- PostgreSQL has no foreign key over array elements, so the column ACCEPTS ANY
+-- UUID -- including a site id belonging to another organisation, or one that
+-- never existed. No CHECK can refuse that; the constraint needed is a
+-- cross-table membership test. This query IS that test: joining through
+-- `sites` under tenant isolation silently drops every id that is not this
+-- tenant's. Resolve outside a tenant transaction, or against a cached site
+-- list, and a foreign UUID survives all the way to the read.
 --
 -- ONE QUERY, BECAUSE ITEM 2 SAYS ONE AUDITED CHOKEPOINT. Three per-mode
 -- queries would be three places for the empty-set mistake to be made.

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -149,14 +149,21 @@ type CreateMCPConnectionTokenParams struct {
 // ===========================================================================
 // mcp_connection_tokens -- the headless bearer path, and rotation
 // ===========================================================================
-// Runs InTenantTx from RedeemAuthorizationCode's token exchange, and inside a
-// tenant transaction chosen by the principal's scope, via db.Pool.RunTenantTx,
-// from CreateGrantWithCode and CreateGrantWithToken -- NOT a fixed InTenantTx
-// on those two paths. mcp_connection_tokens carries a RESTRICTIVE
-// `_site_scope_insert` policy keyed on app.site_scope; only the scoped
-// dispatch, via InScopedTenantTx, sets that GUC, so a caller minting a token
-// alongside a grant must go through RunTenantTx or the policy sits inert for a
-// site-constrained principal. token_hash is lower-case hex SHA-256 (Decision 4, the
+// Has two callers, on two different dispatches. RedeemAuthorizationCode runs
+// it under literal InTenantTx -- the tenant is already known, from the code
+// just consumed, and no principal is in scope at that point to dispatch on.
+// CreateGrantWithToken runs it inside a tenant transaction chosen by the
+// principal's scope, via db.Pool.RunTenantTx, NOT a fixed InTenantTx, because
+// this is the path that mints the FIRST token alongside a new grant.
+// CreateGrantWithCode is NOT a caller of this query -- it mints a code, via
+// CreateMCPAuthorizationCode, and never a token.
+//
+// mcp_connection_tokens carries a RESTRICTIVE `_site_scope_insert` policy
+// keyed on app.site_scope; only the scoped dispatch, via InScopedTenantTx,
+// sets that GUC, so CreateGrantWithToken minting a token for a site-scoped
+// principal must go through RunTenantTx or the policy sits inert.
+//
+// token_hash is lower-case hex SHA-256 (Decision 4, the
 // internal/apikey/apikey.go:102 construction); the plaintext is returned to
 // the operator once, here, and there is no column to read it back from.
 //

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -149,7 +149,14 @@ type CreateMCPConnectionTokenParams struct {
 // ===========================================================================
 // mcp_connection_tokens -- the headless bearer path, and rotation
 // ===========================================================================
-// Runs InTenantTx. token_hash is lower-case hex SHA-256 (Decision 4, the
+// Runs InTenantTx from RedeemAuthorizationCode's token exchange, and inside a
+// tenant transaction chosen by the principal's scope, via db.Pool.RunTenantTx,
+// from CreateGrantWithCode and CreateGrantWithToken -- NOT a fixed InTenantTx
+// on those two paths. mcp_connection_tokens carries a RESTRICTIVE
+// `_site_scope_insert` policy keyed on app.site_scope; only the scoped
+// dispatch, via InScopedTenantTx, sets that GUC, so a caller minting a token
+// alongside a grant must go through RunTenantTx or the policy sits inert for a
+// site-constrained principal. token_hash is lower-case hex SHA-256 (Decision 4, the
 // internal/apikey/apikey.go:102 construction); the plaintext is returned to
 // the operator once, here, and there is no column to read it back from.
 //
@@ -477,9 +484,14 @@ type GetMCPGrantParams struct {
 	ID       uuid.UUID `json:"id"`
 }
 
-// Runs InTenantTx. tenant_id is in the WHERE as well as in the RLS policy --
-// the house convention, defense in depth -- so a grant id from another
-// organisation returns no rows rather than a row.
+// Runs inside a tenant transaction chosen by the principal's scope: its one
+// caller, ConnectionStatusSnapshot, dispatches through db.Pool.RunTenantTx,
+// not a fixed InTenantTx. mcp_grants carries RESTRICTIVE `_site_scope`
+// policies keyed on app.site_scope, and only the scoped dispatch -- via
+// InScopedTenantTx -- sets that GUC; a caller that picked InTenantTx directly
+// would read this row with those policies inert. tenant_id is in the WHERE as
+// well as in the RLS policy -- the house convention, defense in depth -- so a
+// grant id from another organisation returns no rows rather than a row.
 func (q *Queries) GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGrant, error) {
 	row := q.db.QueryRow(ctx, getMCPGrant, arg.TenantID, arg.ID)
 	var i McpGrant
@@ -595,7 +607,10 @@ WHERE tenant_id = $1
 ORDER BY created_at DESC, id DESC
 `
 
-// Runs InTenantTx. Refused outright for a site-scoped session by
+// Runs inside a tenant transaction chosen by the principal's scope: its
+// caller, ListGrants, dispatches through db.Pool.RunTenantTx, not a fixed
+// InTenantTx, precisely so that dispatch can reach InScopedTenantTx and set
+// app.site_scope. Refused outright for a site-scoped session by
 // mcp_grants_site_scope_select (PR #569 finding F1): scope_site_ids enumerates
 // every site the organisation has granted MCP access to, and RLS filters rows,
 // not columns, so total refusal is the only shape that closes it.
@@ -1093,15 +1108,24 @@ type ResolveMCPGrantScopeSitesInTenantTxParams struct {
 // ===========================================================================
 // Site-scope resolution -- "WHAT S6b MUST DO" item 2
 // ===========================================================================
-// MUST RUN INSIDE InTenantTx, AND THAT IS A CORRECTNESS REQUIREMENT RATHER
-// THAN A CONVENTION. scope_site_ids is a uuid[] and PostgreSQL has no foreign
-// key over array elements, so the column ACCEPTS ANY UUID -- including a site
-// id belonging to another organisation, or one that never existed. No CHECK
-// can refuse that; the constraint needed is a cross-table membership test.
-// This query IS that test: joining through `sites` under tenant isolation
-// silently drops every id that is not this tenant's. Resolve outside a tenant
-// transaction, or against a cached site list, and a foreign UUID survives all
-// the way to the read.
+// MUST RUN INSIDE A TENANT TRANSACTION CHOSEN BY THE PRINCIPAL'S SCOPE, AND
+// THAT IS A CORRECTNESS REQUIREMENT RATHER THAN A CONVENTION. Since #649
+// (ADR-061 A11 item 2) the caller is db.Pool.RunTenantTx, which dispatches on
+// db.ScopedPrincipal to InScopedTenantTx, InTenantTxAsUser or InTenantTx --
+// NOT a fixed InTenantTx call. The dispatch is not incidental: InScopedTenantTx
+// is the only one of the three that sets app.site_scope, and sites_site_scope
+// (m19) -- the RESTRICTIVE policy this query's join through `sites` passes
+// through -- is inert without it. A caller that ran plain InTenantTx here would
+// leave a site-constrained principal's scope unenforced.
+//
+// Separately, and for the reason below: scope_site_ids is a uuid[] and
+// PostgreSQL has no foreign key over array elements, so the column ACCEPTS ANY
+// UUID -- including a site id belonging to another organisation, or one that
+// never existed. No CHECK can refuse that; the constraint needed is a
+// cross-table membership test. This query IS that test: joining through
+// `sites` under tenant isolation silently drops every id that is not this
+// tenant's. Resolve outside a tenant transaction, or against a cached site
+// list, and a foreign UUID survives all the way to the read.
 //
 // ONE QUERY, BECAUSE ITEM 2 SAYS ONE AUDITED CHOKEPOINT. Three per-mode
 // queries would be three places for the empty-set mistake to be made.
@@ -1230,8 +1254,12 @@ type RevokeMCPGrantWithTokensInTenantTxRow struct {
 	TokensRevoked int64 `json:"tokens_revoked"`
 }
 
-// Runs InTenantTx. ONE STATEMENT, BOTH TABLES, BECAUSE A GRANT AND ITS TOKENS
-// MUST NOT BE REVOKED SEPARATELY.
+// Runs inside a tenant transaction chosen by the principal's scope: its
+// caller, RevokeGrantWithTokens, dispatches through db.Pool.RunTenantTx, not a
+// fixed InTenantTx, so that a site-constrained principal reaches
+// InScopedTenantTx and mcp_grants' RESTRICTIVE `_site_scope` policies engage
+// rather than sitting inert. ONE STATEMENT, BOTH TABLES, BECAUSE A GRANT AND
+// ITS TOKENS MUST NOT BE REVOKED SEPARATELY.
 //
 // A security review of this stack proved the two are currently independent --
 // it observed `grant_status revoked / token_status active` -- and a live token

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -578,7 +578,14 @@ type Querier interface {
 	// ===========================================================================
 	// mcp_connection_tokens -- the headless bearer path, and rotation
 	// ===========================================================================
-	// Runs InTenantTx. token_hash is lower-case hex SHA-256 (Decision 4, the
+	// Runs InTenantTx from RedeemAuthorizationCode's token exchange, and inside a
+	// tenant transaction chosen by the principal's scope, via db.Pool.RunTenantTx,
+	// from CreateGrantWithCode and CreateGrantWithToken -- NOT a fixed InTenantTx
+	// on those two paths. mcp_connection_tokens carries a RESTRICTIVE
+	// `_site_scope_insert` policy keyed on app.site_scope; only the scoped
+	// dispatch, via InScopedTenantTx, sets that GUC, so a caller minting a token
+	// alongside a grant must go through RunTenantTx or the policy sits inert for a
+	// site-constrained principal. token_hash is lower-case hex SHA-256 (Decision 4, the
 	// internal/apikey/apikey.go:102 construction); the plaintext is returned to
 	// the operator once, here, and there is no column to read it back from.
 	//
@@ -1447,9 +1454,14 @@ type Querier interface {
 	// than a *bool -- see the note on GetMCPAuthorizationCodeByHashForLookup. A
 	// nil-pointer liveness verdict is the fail-open shape this column closes.
 	GetMCPConnectionTokenByHashForLookup(ctx context.Context, tokenHash string) (GetMCPConnectionTokenByHashForLookupRow, error)
-	// Runs InTenantTx. tenant_id is in the WHERE as well as in the RLS policy --
-	// the house convention, defense in depth -- so a grant id from another
-	// organisation returns no rows rather than a row.
+	// Runs inside a tenant transaction chosen by the principal's scope: its one
+	// caller, ConnectionStatusSnapshot, dispatches through db.Pool.RunTenantTx,
+	// not a fixed InTenantTx. mcp_grants carries RESTRICTIVE `_site_scope`
+	// policies keyed on app.site_scope, and only the scoped dispatch -- via
+	// InScopedTenantTx -- sets that GUC; a caller that picked InTenantTx directly
+	// would read this row with those policies inert. tenant_id is in the WHERE as
+	// well as in the RLS policy -- the house convention, defense in depth -- so a
+	// grant id from another organisation returns no rows rather than a row.
 	GetMCPGrant(ctx context.Context, arg GetMCPGrantParams) (McpGrant, error)
 	// REQUIRES app.mcp_client_lookup = 'on'. Serves both the authorize endpoint
 	// (resolve the client before rendering consent) and the token endpoint
@@ -2456,7 +2468,10 @@ type Querier interface {
 	// are -- last_used_at and revoked_at are the record. Never selects token_hash
 	// for display; it is returned because the row is, and must not be rendered.
 	ListMCPConnectionTokensForGrant(ctx context.Context, arg ListMCPConnectionTokensForGrantParams) ([]McpConnectionToken, error)
-	// Runs InTenantTx. Refused outright for a site-scoped session by
+	// Runs inside a tenant transaction chosen by the principal's scope: its
+	// caller, ListGrants, dispatches through db.Pool.RunTenantTx, not a fixed
+	// InTenantTx, precisely so that dispatch can reach InScopedTenantTx and set
+	// app.site_scope. Refused outright for a site-scoped session by
 	// mcp_grants_site_scope_select (PR #569 finding F1): scope_site_ids enumerates
 	// every site the organisation has granted MCP access to, and RLS filters rows,
 	// not columns, so total refusal is the only shape that closes it.
@@ -3386,15 +3401,24 @@ type Querier interface {
 	// ===========================================================================
 	// Site-scope resolution -- "WHAT S6b MUST DO" item 2
 	// ===========================================================================
-	// MUST RUN INSIDE InTenantTx, AND THAT IS A CORRECTNESS REQUIREMENT RATHER
-	// THAN A CONVENTION. scope_site_ids is a uuid[] and PostgreSQL has no foreign
-	// key over array elements, so the column ACCEPTS ANY UUID -- including a site
-	// id belonging to another organisation, or one that never existed. No CHECK
-	// can refuse that; the constraint needed is a cross-table membership test.
-	// This query IS that test: joining through `sites` under tenant isolation
-	// silently drops every id that is not this tenant's. Resolve outside a tenant
-	// transaction, or against a cached site list, and a foreign UUID survives all
-	// the way to the read.
+	// MUST RUN INSIDE A TENANT TRANSACTION CHOSEN BY THE PRINCIPAL'S SCOPE, AND
+	// THAT IS A CORRECTNESS REQUIREMENT RATHER THAN A CONVENTION. Since #649
+	// (ADR-061 A11 item 2) the caller is db.Pool.RunTenantTx, which dispatches on
+	// db.ScopedPrincipal to InScopedTenantTx, InTenantTxAsUser or InTenantTx --
+	// NOT a fixed InTenantTx call. The dispatch is not incidental: InScopedTenantTx
+	// is the only one of the three that sets app.site_scope, and sites_site_scope
+	// (m19) -- the RESTRICTIVE policy this query's join through `sites` passes
+	// through -- is inert without it. A caller that ran plain InTenantTx here would
+	// leave a site-constrained principal's scope unenforced.
+	//
+	// Separately, and for the reason below: scope_site_ids is a uuid[] and
+	// PostgreSQL has no foreign key over array elements, so the column ACCEPTS ANY
+	// UUID -- including a site id belonging to another organisation, or one that
+	// never existed. No CHECK can refuse that; the constraint needed is a
+	// cross-table membership test. This query IS that test: joining through
+	// `sites` under tenant isolation silently drops every id that is not this
+	// tenant's. Resolve outside a tenant transaction, or against a cached site
+	// list, and a foreign UUID survives all the way to the read.
 	//
 	// ONE QUERY, BECAUSE ITEM 2 SAYS ONE AUDITED CHOKEPOINT. Three per-mode
 	// queries would be three places for the empty-set mistake to be made.
@@ -3451,8 +3475,12 @@ type Querier interface {
 	// revoked_at is set with status to satisfy
 	// mcp_connection_tokens_revoked_at_matches_status_check.
 	RevokeMCPConnectionTokenInTenantTx(ctx context.Context, arg RevokeMCPConnectionTokenInTenantTxParams) (McpConnectionToken, error)
-	// Runs InTenantTx. ONE STATEMENT, BOTH TABLES, BECAUSE A GRANT AND ITS TOKENS
-	// MUST NOT BE REVOKED SEPARATELY.
+	// Runs inside a tenant transaction chosen by the principal's scope: its
+	// caller, RevokeGrantWithTokens, dispatches through db.Pool.RunTenantTx, not a
+	// fixed InTenantTx, so that a site-constrained principal reaches
+	// InScopedTenantTx and mcp_grants' RESTRICTIVE `_site_scope` policies engage
+	// rather than sitting inert. ONE STATEMENT, BOTH TABLES, BECAUSE A GRANT AND
+	// ITS TOKENS MUST NOT BE REVOKED SEPARATELY.
 	//
 	// A security review of this stack proved the two are currently independent --
 	// it observed `grant_status revoked / token_status active` -- and a live token

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -578,14 +578,21 @@ type Querier interface {
 	// ===========================================================================
 	// mcp_connection_tokens -- the headless bearer path, and rotation
 	// ===========================================================================
-	// Runs InTenantTx from RedeemAuthorizationCode's token exchange, and inside a
-	// tenant transaction chosen by the principal's scope, via db.Pool.RunTenantTx,
-	// from CreateGrantWithCode and CreateGrantWithToken -- NOT a fixed InTenantTx
-	// on those two paths. mcp_connection_tokens carries a RESTRICTIVE
-	// `_site_scope_insert` policy keyed on app.site_scope; only the scoped
-	// dispatch, via InScopedTenantTx, sets that GUC, so a caller minting a token
-	// alongside a grant must go through RunTenantTx or the policy sits inert for a
-	// site-constrained principal. token_hash is lower-case hex SHA-256 (Decision 4, the
+	// Has two callers, on two different dispatches. RedeemAuthorizationCode runs
+	// it under literal InTenantTx -- the tenant is already known, from the code
+	// just consumed, and no principal is in scope at that point to dispatch on.
+	// CreateGrantWithToken runs it inside a tenant transaction chosen by the
+	// principal's scope, via db.Pool.RunTenantTx, NOT a fixed InTenantTx, because
+	// this is the path that mints the FIRST token alongside a new grant.
+	// CreateGrantWithCode is NOT a caller of this query -- it mints a code, via
+	// CreateMCPAuthorizationCode, and never a token.
+	//
+	// mcp_connection_tokens carries a RESTRICTIVE `_site_scope_insert` policy
+	// keyed on app.site_scope; only the scoped dispatch, via InScopedTenantTx,
+	// sets that GUC, so CreateGrantWithToken minting a token for a site-scoped
+	// principal must go through RunTenantTx or the policy sits inert.
+	//
+	// token_hash is lower-case hex SHA-256 (Decision 4, the
 	// internal/apikey/apikey.go:102 construction); the plaintext is returned to
 	// the operator once, here, and there is no column to read it back from.
 	//


### PR DESCRIPTION
## Summary

- `ResolveMCPGrantScopeSitesInTenantTx`'s header said the query **MUST RUN INSIDE InTenantTx**. That stopped being true when #649 moved `ResolveScopeSites` (`apps/api/internal/mcp/repo.go`) onto `db.Pool.RunTenantTx`, which dispatches to `InScopedTenantTx`, `InTenantTxAsUser` or `InTenantTx` based on the caller's principal. `InTenantTx` never sets `app.site_scope`, so a caller that followed the old header literally would leave `sites_site_scope` (m19) inert.
- Three more headers in the same file made the identical blanket "Runs InTenantTx" claim while their actual Go callers already dispatch through `RunTenantTx`: `GetMCPGrant` (via `ConnectionStatusSnapshot`), `ListMCPGrantsForOrg` (via `ListGrants`), `RevokeMCPGrantWithTokensInTenantTx` (via `RevokeGrantWithTokens`). All three read/write `mcp_grants`, which carries RESTRICTIVE `_site_scope` policies keyed on `app.site_scope`.
- `CreateMCPConnectionToken` carried the same claim. `mcp_connection_tokens` has its own RESTRICTIVE `mcp_connection_tokens_site_scope_insert` policy, and this query is invoked both via literal `InTenantTx` (`RedeemAuthorizationCode`) and via `RunTenantTx` (`CreateGrantWithCode`, `CreateGrantWithToken`), so it gets the same correction.

## Not changed, and why

- `CreateMCPAuthorizationCode`'s "Runs InTenantTx" header is imprecise about the exact helper name too, but `mcp_authorization_codes` has only a `_site_scope_select` policy, no insert-time site-scope check (`grep -n "CREATE POLICY" apps/api/migrations/20260826000000_m124_mcp_connection_surface.sql | grep mcp_authorization_codes`), so nothing is inert either way. Left as-is to keep this change to provably wrong claims.
- `ListMCPConnectionTokensForGrant` and `RevokeMCPConnectionTokenInTenantTx` have no Go caller yet (`grep -rn` over `apps/api/internal/mcp/*.go` returns nothing), so their headers aren't false today, only worth a second look when they're wired up.
- `RecordMCPGrantClientIdentityInTenantTx`, `TouchMCPGrantInTenantTx`/`TouchMCPConnectionTokenInTenantTx`, `ReCheckMCPRequestAuthorizationInTenantTx`: all still called via literal `InTenantTx` today — headers accurate, untouched.

## Two applied-migration findings (not fixed — reporting per the immutability rule)

Two migration headers make the same now-stale claim about `ResolveScopeSites`, and both are already applied/merged (immutable per `.claude/rules/db-migrations.md`):

- `apps/api/migrations/20260826000000_m124_mcp_connection_surface.sql:526` — "THE RESOLUTION MUST RUN INSIDE InTenantTx, and that is a correctness requirement rather than a convention."
- `apps/api/migrations/20260903000000_m132_assistant_read_site_scope_rls.sql:56-60` — "The assistant's own scope resolution does NOT currently route through the scoped helper. ResolveScopeSites (...repo.go:494) runs under r.pool.InTenantTx and takes a uuid.UUID rather than a principal... That signature change is ADR-061 A11 item 2 and is Wave 1.3; it is deliberately NOT in this file."

Both were true when written and are false since #649 landed. Per the standing rule, an applied migration is never edited — a correction would be a new ordinal, and that's a judgement call for whoever owns the next migration in this area, not a comment fix. Flagging for a ruling rather than acting on it.

## sqlc

Comment-only changes to `db/query/*.sql` DO change sqlc output: sqlc carries the header block preceding `-- name: ...` verbatim into the generated method's Go doc comment (confirmed by inspecting the pre-existing generated file before regenerating). Regenerated with the resolved binary:

```
$ command -v sqlc
/Users/mosamgor/go/bin/sqlc
$ grep -h 'sqlc v' apps/api/internal/db/sqlc/*.go | sort -u
//   sqlc v1.31.1
$ sqlc generate   # matches the stamped version
```

`git diff --stat -- apps/api/internal/db/sqlc/` shows only `mcp_connections.sql.go` and `querier.go` touched, and every changed line in both is a `//` comment — no struct, signature, or embedded SQL string changed.

## Test plan

- [x] `go build ./...` — clean (one pre-existing linker alignment warning on `cmd/media-encoder`, unrelated)
- [x] `go vet ./...` — clean
- [x] `go test ./internal/...` — all packages pass, including `internal/mcp` (12.4s)
- [ ] `make test-integration` — not run; this is a comment/doc-generation-only change with no behavioral, query-text, or RLS-policy change, so nothing here regresses tenancy or scope proofs. Flagging per the DoD rather than silently skipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation for MCP connection and grant operations to clarify tenant transaction and site-scope enforcement behavior.
  * Added context explaining how site-restricted access policies are applied.
  * No functional behavior, query results, or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->