### PR TITLE
release: 0.61.151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ### Security
 
-- Every table the assistant surface can read now carries the same restrictive site-scope policy already enforced elsewhere in the schema: 22 policies added across 22 tables that previously had no database-level opinion of their own about which site a scoped grant could reach (m132).
-- The chokepoint the assistant surface uses to resolve which sites a connection may reach now routes on the caller's authenticated principal rather than a bare tenant id, so the site-scope policies above actually engage instead of being satisfied by any grant in the tenant.
+- Every table the assistant surface can read now carries the same restrictive site-scope policy already enforced elsewhere in the schema: 22 policies added across 22 tables that previously had no database-level opinion of their own about which site a scoped grant could reach (m132). These protect every path that runs with a site-constrained principal, which is the ordinary way a site-scoped collaborator reaches this data.
+- The chokepoint the assistant surface uses to resolve which sites a connection may reach now takes the caller's authenticated principal rather than a bare tenant id, so it is capable of engaging the site-scope policies above wherever that principal is site-constrained. On the assistant's own read path it is not: resolving a grant's site allowlist is deliberately done with a tenant-scoped principal, because the allowlist cannot be used to scope the query that produces it. The assistant surface's site scoping there is enforced by the resolved allowlist in application code, not by this database policy.
 
 ## [0.61.150] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.151] - 2026-09-01
+
+### Added
+
+- A per-tenant switch that turns the assistant surface off entirely, independent of any single connection's grant (m130).
+- The read capability vocabulary a grant can hold widened from one member to the full v1 set (m131). The default a newly created grant receives is unchanged, so nothing already issued gains a capability it was not explicitly given.
+- Tool calls on the live MCP endpoint now carry a per-connection and a per-tenant rate limit. A refusal names both the sustained rate and the burst allowance it is enforcing, rather than leaving a client to find the ceiling by trial and error.
+- Connections now record the client the operator said they were setting the connection up for, distinct from the client name and version the connection later negotiates on its own, and return it alongside the grant.
+- A grant's expiry can no longer be set more than one year past its creation. Nothing today asks for more than 90 days, so this closes an open-ended bound ahead of the caller that will.
+
+### Fixed
+
+- A capability refusal on the assistant surface now answers 403 with its own error code, naming the capability that was required and the ones the grant actually holds, instead of falling through to a generic 401 that told the client to re-authenticate. Re-authenticating could never have changed the answer, because the refusal was about the grant and not the credential. **Client-visible behaviour change**: anything integrating against the assistant surface that treated 401 as "renew and retry" needs to treat 403 as terminal instead.
+
+### Security
+
+- Every table the assistant surface can read now carries the same restrictive site-scope policy already enforced elsewhere in the schema: 22 policies added across 22 tables that previously had no database-level opinion of their own about which site a scoped grant could reach (m132).
+- The chokepoint the assistant surface uses to resolve which sites a connection may reach now routes on the caller's authenticated principal rather than a bare tenant id, so the site-scope policies above actually engage instead of being satisfied by any grant in the tenant.
+
 ## [0.61.150] - 2026-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.150**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.151**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.150
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.150
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.150
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.151
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.151
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.151
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.150   # omit to track :latest
+export WPMGR_VERSION=v0.61.151   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,46 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.151",
+    date: "2026-09-01",
+    summary:
+      "Every table the assistant surface can read now carries a database-level site-scope policy, a capability refusal answers 403 instead of falling back to a generic 401, and a per-tenant kill switch and a tool-call rate limit round out the release.",
+    items: [
+      {
+        tag: "Security",
+        text: "Every table the assistant surface can read now carries the same restrictive site-scope policy already enforced elsewhere in the schema: 22 policies added across 22 tables that previously had no database-level opinion of their own about which site a scoped grant could reach.",
+      },
+      {
+        tag: "Security",
+        text: "The chokepoint the assistant surface uses to resolve which sites a connection may reach now routes on the caller's authenticated principal rather than a bare tenant id, so the site-scope policies above actually engage instead of being satisfied by any grant in the tenant.",
+      },
+      {
+        tag: "Fixed",
+        text: "A capability refusal on the assistant surface now answers 403 with its own error code, naming the capability that was required and the ones the grant actually holds, instead of falling through to a generic 401 that told the client to re-authenticate. Client-visible behaviour change: anything integrating against the assistant surface that treated 401 as \"renew and retry\" needs to treat 403 as terminal instead.",
+      },
+      {
+        tag: "Added",
+        text: "A per-tenant switch that turns the assistant surface off entirely, independent of any single connection's grant.",
+      },
+      {
+        tag: "Added",
+        text: "The read capability vocabulary a grant can hold widened from one member to the full v1 set. The default a newly created grant receives is unchanged, so nothing already issued gains a capability it was not explicitly given.",
+      },
+      {
+        tag: "Added",
+        text: "Tool calls on the live MCP endpoint now carry a per-connection and a per-tenant rate limit. A refusal names both the sustained rate and the burst allowance it is enforcing, rather than leaving a client to find the ceiling by trial and error.",
+      },
+      {
+        tag: "Added",
+        text: "Connections now record the client the operator said they were setting the connection up for, distinct from the client name and version the connection later negotiates on its own, and return it alongside the grant.",
+      },
+      {
+        tag: "Added",
+        text: "A grant's expiry can no longer be set more than one year past its creation, closing an open-ended bound ahead of the caller that will need it.",
+      },
+    ],
+  },
+  {
     version: "0.61.150",
     date: "2026-08-31",
     summary:

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -57,11 +57,11 @@ const RELEASES: ChangeEntry[] = [
     items: [
       {
         tag: "Security",
-        text: "Every table the assistant surface can read now carries the same restrictive site-scope policy already enforced elsewhere in the schema: 22 policies added across 22 tables that previously had no database-level opinion of their own about which site a scoped grant could reach.",
+        text: "Every table the assistant surface can read now carries the same restrictive site-scope policy already enforced elsewhere in the schema: 22 policies added across 22 tables that previously had no database-level opinion of their own about which site a scoped grant could reach. These protect every path that runs with a site-constrained principal, which is the ordinary way a site-scoped collaborator reaches this data.",
       },
       {
         tag: "Security",
-        text: "The chokepoint the assistant surface uses to resolve which sites a connection may reach now routes on the caller's authenticated principal rather than a bare tenant id, so the site-scope policies above actually engage instead of being satisfied by any grant in the tenant.",
+        text: "The chokepoint the assistant surface uses to resolve which sites a connection may reach now takes the caller's authenticated principal rather than a bare tenant id, so it is capable of engaging the site-scope policies above wherever that principal is site-constrained. On the assistant's own read path it is not: resolving a grant's site allowlist is deliberately done with a tenant-scoped principal, because the allowlist cannot be used to scope the query that produces it. The assistant surface's site scoping there is enforced by the resolved allowlist in application code, not by this database policy.",
       },
       {
         tag: "Fixed",

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.150   # omit to track :latest
+export WPMGR_VERSION=v0.61.151   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.150
+  version: 0.61.151
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
Control-plane only. The agent plugin did not change, so every agent version surface stays at 0.61.147 and the marketing hero badge does not move.

## What is in it

Five migrations, m128 to m132. The two an operator needs to know about:

- **m132 adds 22 restrictive site-scope policies across 22 tables.** Every table the assistant surface can read now carries the same database-level site-scope opinion the rest of the schema already enforced.
- **A capability refusal answers 403 instead of 401.** This is a client-visible behaviour change. Anything treating 401 as "renew and retry" against the assistant surface must treat 403 as terminal, because re-authenticating could never change a refusal that is about the grant rather than the credential.

The rest is in the changelog entry.

## Verification

A full integration run against `4da49240`, under the machine lock:

```
ok  github.com/mosamlife/wpmgr/apps/api/tests            887.247s
ok  github.com/mosamlife/wpmgr/apps/api/tests/contract     2.836s
ok  github.com/mosamlife/wpmgr/apps/api/tests/gh458        7.669s
ok  github.com/mosamlife/wpmgr/apps/api/tests/testinfra    3.112s
```

0 occurrences of FAIL, no panic, no `[no tests to run]`, no build failure. That package is outside `ci.yml`, so this is the run that covers the RLS and tenancy proofs those five migrations touch.

The diff from `4da49240` to the release base is comment-only: 0 non-comment changed lines in both `apps/api/internal/db/sqlc/` and `apps/api/db/query/`, so the baseline holds for this release.

Worth noting for the record: that package was red before this batch. `TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole` had never once passed since it was written, and `ci.yml` does not run the package, so nobody knew. Fixed in #648, cause written up in #647. This is the first clean run of it.

## Not done here, deliberately

**No tag.** The tag is the last step, after deploy and after QA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a tenant-level switch to disable the assistant surface.
  - Expanded read capabilities to the complete v1 vocabulary.
  - Added per-connection and per-tenant MCP tool-call rate limits.
  - Connections now record their configured client.
  - Grant expiry is limited to a maximum of one year.

- **Bug Fixes**
  - Capability refusals now return HTTP 403 with specific error details.

- **Security**
  - Added site-scope protections across supported data areas.
  - Improved site resolution using the authenticated caller.

- **Documentation**
  - Updated release, installation, image, and API version references to 0.61.151.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->