### PR TITLE
fix(mcp): audit is fail-closed on the assistant surface, reads included

### DIFF
--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -769,6 +769,34 @@ func (r *Recorder) Record(ctx context.Context, e Event) (Entry, error) {
 	return out, err
 }
 
+// RecordOrFail appends an audit entry in its own transaction and returns only
+// once that entry is COMMITTED. Mechanically it is Record; the difference is
+// the contract, and the contract is the point.
+//
+// Record's doc tells its callers to log and continue. That instruction is
+// correct for the rest of the product and fatal for the assistant surface, and
+// a posture that exists only as a sentence in a doc comment is not a posture --
+// it is a suggestion the next caller reads as optional. RecordOrFail carries
+// the opposite instruction, and exists so that a package which must never fail
+// open can hold a field type whose method set DOES NOT CONTAIN Record. See
+// internal/mcp's auditRecorder: reaching the fail-open helper from there is a
+// compile error, not a review comment.
+//
+// THE CALLER MUST PROPAGATE THE ERROR, and "propagate" means the operation the
+// entry describes does not reach the client. A caller that logs this error and
+// answers anyway has the fail-open behaviour back with a fail-closed name on
+// it, which is worse than Record because the name now vouches for it.
+//
+// USE RecordInTx INSTEAD WHENEVER THERE IS A COMPANION WRITE. This helper
+// commits its own transaction, so it cannot roll anything back; it is the right
+// shape only where the effect being recorded is a DISCLOSURE rather than a row
+// (a read answered to a client, a refusal returned to a caller), and the caller
+// withholds that disclosure when this returns non-nil. The moment the recorded
+// operation writes a row, the append belongs in that row's transaction.
+func (r *Recorder) RecordOrFail(ctx context.Context, e Event) (Entry, error) {
+	return r.Record(ctx, e)
+}
+
 // RecordInTx appends an audit entry inside the CALLER's already-open
 // transaction, instead of opening its own. It is the fail-closed counterpart
 // to Record, required by ADR-064 Decision 7 (and, on paper, ADR-061 Decision

--- a/apps/api/internal/mcp/approve_test.go
+++ b/apps/api/internal/mcp/approve_test.go
@@ -130,7 +130,7 @@ func TestApprove_RefusesAClientThatWasNeverRegistered(t *testing.T) {
 // path, so the fix cannot regress into comparing the body against itself.
 func TestApprove_ResolvesTheClientBeforeMinting(t *testing.T) {
 	store := approvalStore()
-	if _, err := NewService(store).Approve(context.Background(), validApproval()); err != nil {
+	if _, err := auditedService(store).Approve(context.Background(), validApproval()); err != nil {
 		t.Fatalf("a legitimate approval was refused: %v", err)
 	}
 
@@ -246,7 +246,7 @@ func TestApprove_RefusesAnIncoherentOrEmptySiteScope(t *testing.T) {
 // RESOLVED client id rather than the body's copy.
 func TestApprove_ValidApprovalMintsAndRecordsTheResolvedClient(t *testing.T) {
 	store := approvalStore()
-	got, err := NewService(store).Approve(context.Background(), validApproval())
+	got, err := auditedService(store).Approve(context.Background(), validApproval())
 	if err != nil {
 		t.Fatalf("a legitimate approval was refused: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestApprove_RefusesASiteScopedApprover(t *testing.T) {
 // policy; it can prove the principal arrived.
 func TestApprove_HandsTheWholePrincipalToTheStore(t *testing.T) {
 	store := approvalStore()
-	svc := NewService(store)
+	svc := auditedService(store)
 
 	req := validApproval()
 	if _, err := svc.Approve(context.Background(), req); err != nil {

--- a/apps/api/internal/mcp/audit_fail_closed_test.go
+++ b/apps/api/internal/mcp/audit_fail_closed_test.go
@@ -1,0 +1,192 @@
+package mcp
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+// ---------------------------------------------------------------------------
+// ADR-061 A10, fail-closed: no tool answer is served whose audit record was
+// lost.
+//
+// WHAT THESE PIN, AND WHY THE ASSERTION IS ABOUT THE BODY RATHER THAN THE CODE.
+// The property is not "an unrecordable call returns an error" -- that would
+// still hold if the handler serialised the tool's text and then bolted an error
+// field beside it, and it would hold under a future refactor that answers the
+// client first and records in a defer. The property is that the DATA THE READ
+// RETURNED does not reach the client, so every test below asserts on the
+// absence of the site names from the response bytes. A test that only checked
+// the JSON-RPC code would go green on a surface that leaks the answer inside
+// the failure.
+//
+// The recorder is a fake rather than a broken Postgres because that is the only
+// way the failure branch is reachable at unit speed; the same property is
+// re-proven against a real database, as the wpmgr_app role, in the integration
+// package.
+// ---------------------------------------------------------------------------
+
+// failClosedStore is a live grant over two sites with distinctive names, so a
+// leak of the tool's answer into an error response is greppable.
+func failClosedStore(t *testing.T) (*fakeStore, uuid.UUID) {
+	t.Helper()
+	allowed := uuid.New()
+	store := liveGrantStore(allowed)
+	collected := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	row := siteRow(failClosedSiteName, &collected)
+	row.ID = allowed
+	store.sites = []sqlc.ListSitesRow{row}
+	return store, allowed
+}
+
+// The name is deliberately not a substring of any JSON key, error message or
+// protocol constant, so `strings.Contains` over the whole body is a sound leak
+// check rather than one that trips over the envelope.
+const failClosedSiteName = "zzz-canary-site"
+
+// routerWithRecorder mounts the real route over a store with the given
+// recorder, so a test can swap a failing recorder for a working one without
+// changing anything else about the request.
+func routerWithRecorder(t *testing.T, store Store, rec auditRecorder) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	svc := NewService(store)
+	if rec != nil {
+		svc = svc.withAuditRecorder(rec)
+	}
+	NewTransportHandler(svc, slog.New(slog.DiscardHandler), "test-version").Register(r)
+	return r
+}
+
+const toolCallBody = `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`
+
+// TestToolCall_AnswerIsWithheldWhenTheAuditAppendFails is the red-first half:
+// the append fails, and the tool's answer must not reach the client.
+func TestToolCall_AnswerIsWithheldWhenTheAuditAppendFails(t *testing.T) {
+	store, _ := failClosedStore(t)
+	r := routerWithRecorder(t, store, &failingRecorder{err: errors.New("audit chain unavailable")})
+
+	w := post(t, r, toolCallBody, nil)
+	body := w.Body.String()
+
+	// THE LOAD-BEARING ASSERTION. The read ran -- the store returned the row --
+	// and the answer was discarded because the row recording it could not be
+	// committed.
+	if strings.Contains(body, failClosedSiteName) {
+		t.Fatalf("the tool's answer was served despite an audit append that failed; "+
+			"this is the fail-open behaviour A10 forbids\nbody: %s", body)
+	}
+
+	resp := decodeRPC(t, w)
+	if resp.Error == nil {
+		t.Fatalf("an unrecordable tool call returned a result: %s", body)
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Errorf("error code = %d, want %d (internal) — an unrecordable call must not be "+
+			"reported as the caller's fault", resp.Error.Code, codeInternalError)
+	}
+	// The wire must not say WHICH failure this was: that is a poll on whether
+	// the audit system is up. See toolError's ErrCodeAuditUnavailable branch.
+	for _, leak := range []string{"audit", ErrCodeAuditUnavailable} {
+		if strings.Contains(strings.ToLower(body), strings.ToLower(leak)) {
+			t.Errorf("the response names the audit system (%q), handing a caller a "+
+				"liveness oracle\nbody: %s", leak, body)
+		}
+	}
+}
+
+// TestToolCall_HealthyAuditStillAnswersAndWritesExactlyOneRow is the restore
+// half, and the over-fire check: the same request, the same store, a recorder
+// that works. The answer comes back AND exactly one mcp.tool.called row is
+// written -- not zero (the fail-closed change did not quietly stop recording)
+// and not two (the record is not written on both sides of the gate).
+func TestToolCall_HealthyAuditStillAnswersAndWritesExactlyOneRow(t *testing.T) {
+	store, _ := failClosedStore(t)
+	rec := &capturingRecorder{}
+	r := routerWithRecorder(t, store, rec)
+
+	w := post(t, r, toolCallBody, nil)
+	body := w.Body.String()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("HTTP %d on a healthy audit path: %s", w.Code, body)
+	}
+	if !strings.Contains(body, failClosedSiteName) {
+		t.Fatalf("the tool's answer is missing on a healthy audit path: %s", body)
+	}
+
+	// only() fails loudly when there is no row, so "recorded nothing" cannot
+	// pass as "recorded correctly".
+	e := rec.only(t, audit.ActionMCPToolCalled)
+	if e.TargetID != ToolListSites {
+		t.Errorf("recorded target = %q, want %q", e.TargetID, ToolListSites)
+	}
+}
+
+// TestToolCall_ARecorderlessServiceRefusesRatherThanServing pins item 3: a
+// Service built without WithAudit cannot record, so it cannot answer.
+//
+// This used to be a SUPPORTED configuration -- the audit field's doc called it
+// "simply does not audit" and every unit test in this package relied on it --
+// and it is the exact shape of this codebase's signature defect: a surface that
+// presents as working while the guarantee it advertises is switched off. A
+// wiring mistake now fails at the first request instead of at the first audit.
+func TestToolCall_ARecorderlessServiceRefusesRatherThanServing(t *testing.T) {
+	store, _ := failClosedStore(t)
+	r := routerWithRecorder(t, store, nil) // no WithAudit, no fake: nil recorder
+
+	w := post(t, r, toolCallBody, nil)
+	body := w.Body.String()
+
+	if strings.Contains(body, failClosedSiteName) {
+		t.Fatalf("an UNAUDITED service served a tool answer; every call it handles would "+
+			"be an AI action with no record\nbody: %s", body)
+	}
+	resp := decodeRPC(t, w)
+	if resp.Error == nil {
+		t.Fatalf("an unaudited service returned a result: %s", body)
+	}
+	if resp.Error.Code != codeInternalError {
+		t.Errorf("error code = %d, want %d (internal)", resp.Error.Code, codeInternalError)
+	}
+}
+
+// TestRecordToolCall_PropagatesTheAppendFailure keeps the service-level
+// contract separate from the transport's use of it. If this returned nil on a
+// failed append, callTool's gate would be unreachable and every test above
+// would still pass for the wrong reason.
+func TestRecordToolCall_PropagatesTheAppendFailure(t *testing.T) {
+	boom := errors.New("audit chain unavailable")
+	svc := NewService(&fakeStore{}).withAuditRecorder(&failingRecorder{err: boom})
+
+	auth := authWith(CapabilitySet{}, uuid.New())
+	err := svc.RecordToolCall(t.Context(), auth, ToolListSites, "read")
+	if err == nil {
+		t.Fatal("RecordToolCall swallowed a failed append; the fail-closed gate above it " +
+			"can never fire")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("error = %v, want it to wrap the append failure", err)
+	}
+}
+
+// TestRecordToolCall_RecorderlessIsAnErrorNotASkip is the service-level half of
+// item 3, for the same reason as the test above.
+func TestRecordToolCall_RecorderlessIsAnErrorNotASkip(t *testing.T) {
+	svc := NewService(&fakeStore{})
+
+	auth := authWith(CapabilitySet{}, uuid.New())
+	if err := svc.RecordToolCall(t.Context(), auth, ToolListSites, "read"); err == nil {
+		t.Fatal("a Service with no recorder reported success for a row it did not write")
+	}
+}

--- a/apps/api/internal/mcp/audit_fail_closed_test.go
+++ b/apps/api/internal/mcp/audit_fail_closed_test.go
@@ -53,6 +53,16 @@ func failClosedStore(t *testing.T) (*fakeStore, uuid.UUID) {
 // check rather than one that trips over the envelope.
 const failClosedSiteName = "zzz-canary-site"
 
+// auditedService is NewService plus the recorder production always wires. It
+// exists because "no recorder" stopped being a supported configuration: an
+// unaudited Service refuses to approve, mint, revoke or serve a tool call, so a
+// test that builds one is testing a shape that never ships. Tests which are
+// ABOUT the unaudited case call NewService directly and assert the refusal --
+// see TestToolCall_ARecorderlessServiceRefusesRatherThanServing.
+func auditedService(store Store) *Service {
+	return NewService(store).withAuditRecorder(&capturingRecorder{})
+}
+
 // routerWithRecorder mounts the real route over a store with the given
 // recorder, so a test can swap a failing recorder for a working one without
 // changing anything else about the request.

--- a/apps/api/internal/mcp/audit_fail_closed_test.go
+++ b/apps/api/internal/mcp/audit_fail_closed_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -198,5 +200,67 @@ func TestRecordToolCall_RecorderlessIsAnErrorNotASkip(t *testing.T) {
 	auth := authWith(CapabilitySet{}, uuid.New())
 	if err := svc.RecordToolCall(t.Context(), auth, ToolListSites, "read"); err == nil {
 		t.Fatal("a Service with no recorder reported success for a row it did not write")
+	}
+}
+
+// TestMint_RESTWireDoesNotCarryTheAuditMessage answers, by execution, what the
+// REST surface does with an audit append that fails inside RecordInTx.
+//
+// THE THREE RecordInTx SITES DO NOT GO THROUGH auditFailure. Approve
+// (service.go), RevokeConnection (service.go) and MintConnection (mint.go)
+// return the recorder's own error under fmt.Errorf("...%w"), so what reaches
+// httpx.Error is internal/audit's own typed domain error -- audit_insert_failed,
+// audit_lock_failed, and the rest -- not this package's
+// ErrCodeAuditUnavailable. domain.AsDomain uses errors.As, so the %w wrapper is
+// transparent and the audit error IS what the mapping sees.
+//
+// That is the same starting position as the JSON-RPC leak, and this test exists
+// because the two mappings do NOT behave the same way and the difference is the
+// entire answer to the question. httpx.Error suppresses de.Message for
+// domain.KindInternal, which every audit error is; it copies de.Code
+// unconditionally. So the human-readable "failed to append audit entry" cannot
+// reach a REST client, and the machine-readable code can.
+//
+// The assertion is written as "the message must not appear" rather than "the
+// body must equal X" on purpose: the code being visible is a judged, accepted
+// outcome (see the report on finding #4) and pinning the whole envelope would
+// turn a deliberate decision into a tripwire that fires when someone revisits
+// it. The message leaking is not judged -- it is the defect -- so that is what
+// is pinned.
+func TestMint_RESTWireDoesNotCarryTheAuditMessage(t *testing.T) {
+	// The REAL shape internal/audit returns from a refused INSERT: a typed
+	// domain error of Kind internal. errors.New would take a different branch
+	// in httpx.Error and prove nothing about the case that actually happens --
+	// which is precisely how the -32602 defect survived the unit suite.
+	realAppendFailure := domain.Internal("audit_insert_failed", "failed to append audit entry")
+
+	tenant := uuid.New()
+	gin.SetMode(gin.TestMode)
+	eng := gin.New()
+	g := eng.Group(APIV1Prefix)
+	g.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), orgPrincipal(tenant)))
+		c.Next()
+	})
+	svc := NewService(&fakeStore{}).withAuditRecorder(&failingRecorder{err: realAppendFailure})
+	NewHandler(svc).RegisterConnections(g)
+
+	var h http.Handler = eng
+	status, body := postMint(t, h, map[string]any{"name": "audit-leak-probe", "site_scope_mode": "all"})
+
+	raw, _ := json.Marshal(body)
+	t.Logf("REST mint with a failing audit append: HTTP %d body=%s", status, raw)
+
+	if status == http.StatusCreated {
+		t.Fatal("the mint SUCCEEDED while its audit append failed; the RecordInTx " +
+			"callback is not propagating and the credential exists unrecorded")
+	}
+	if strings.Contains(string(raw), "failed to append audit entry") {
+		t.Errorf("the audit system's own message reached the REST wire: %s", raw)
+	}
+	if msg, _ := body["message"].(string); msg != "internal server error" {
+		t.Errorf("message = %q, want the generic %q — httpx.Error's KindInternal "+
+			"guard is what suppresses the audit detail, and this pins it",
+			msg, "internal server error")
 	}
 }

--- a/apps/api/internal/mcp/connections_test.go
+++ b/apps/api/internal/mcp/connections_test.go
@@ -77,7 +77,7 @@ func TestListConnectionsFailureIsNeverAnEmptyList(t *testing.T) {
 	tenantID := uuid.New()
 	boom := errors.New("connection refused: the database is down")
 	store := &fakeStore{grantsErr: boom}
-	svc := NewService(store)
+	svc := auditedService(store)
 
 	got, err := svc.ListConnections(context.Background(), orgPrincipal(tenantID))
 	if err == nil {
@@ -151,7 +151,7 @@ func TestSiteScopedPrincipalIsRefusedAndNeverReachesTheStore(t *testing.T) {
 
 	t.Run("list", func(t *testing.T) {
 		store := &fakeStore{}
-		svc := NewService(store)
+		svc := auditedService(store)
 
 		got, err := svc.ListConnections(context.Background(), siteScopedPrincipal(tenantID))
 		if err == nil {
@@ -179,7 +179,7 @@ func TestSiteScopedPrincipalIsRefusedAndNeverReachesTheStore(t *testing.T) {
 
 	t.Run("revoke", func(t *testing.T) {
 		store := &fakeStore{}
-		svc := NewService(store)
+		svc := auditedService(store)
 
 		_, err := svc.RevokeConnection(context.Background(),
 			siteScopedPrincipal(tenantID), uuid.New())
@@ -204,7 +204,7 @@ func TestStoreReceivesThePrincipalSoRunTenantTxCanDispatch(t *testing.T) {
 	tenantID := uuid.New()
 	p := orgPrincipal(tenantID)
 	store := &fakeStore{}
-	svc := NewService(store)
+	svc := auditedService(store)
 
 	if _, err := svc.ListConnections(context.Background(), p); err != nil {
 		t.Fatalf("list: %v", err)
@@ -554,7 +554,7 @@ func TestListIncludesRevokedGrantsAndReportsStoredStatus(t *testing.T) {
 			RevokedAt: tsAt(revokedAt), LastUsedAt: tsAt(revokedAt),
 		},
 	}}
-	svc := NewService(store)
+	svc := auditedService(store)
 
 	got, err := svc.ListConnections(context.Background(), orgPrincipal(uuid.New()))
 	if err != nil {
@@ -667,6 +667,6 @@ func newConnectionsRouter(t *testing.T, store Store, p domain.Principal) *gin.En
 		c.Request = c.Request.WithContext(domain.WithPrincipal(c.Request.Context(), p))
 		c.Next()
 	})
-	NewHandler(NewService(store)).RegisterConnections(g)
+	NewHandler(auditedService(store)).RegisterConnections(g)
 	return eng
 }

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -496,8 +496,14 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 		// there is no audit row for a grant that does not exist -- and,
 		// equally, no grant without the row that explains it.
 		func(tx pgx.Tx, gr sqlc.McpGrant) error {
-			if s.audit == nil {
-				return nil
+			// A10 names approval, and a headless mint IS the approval on this
+			// route: it hands out fleet access with no browser step in front of
+			// it. An unaudited Service therefore mints nothing. The error
+			// propagates into the caller's transaction and rolls back both
+			// inserts, so there is never a live credential whose creation is
+			// unrecorded. See Service.requireRecorder.
+			if err := s.requireRecorder(); err != nil {
+				return err
 			}
 			// THE ACTOR IS WHICHEVER CREDENTIAL AUTHENTICATED, resolved by
 			// audit.ActorFor rather than hardcoded. This is the headless path,

--- a/apps/api/internal/mcp/mint_test.go
+++ b/apps/api/internal/mcp/mint_test.go
@@ -53,7 +53,17 @@ func postMint(t *testing.T, h http.Handler, body map[string]any) (int, map[strin
 	return rec.Code, out
 }
 
-func mintService(store Store) *Service { return NewService(store) }
+// mintService builds the Service the mint tests drive, WITH A RECORDER.
+//
+// The recorder is production wiring, not scenery: a mint is an approval, so an
+// unaudited Service now refuses to mint at all (Service.requireRecorder, the
+// callback in mint.go rolls the whole transaction back). These tests used to
+// rely on the unaudited configuration, which was never a state production could
+// be in -- cmd/wpmgr/main.go has always called WithAudit -- so testing against
+// it was testing a shape nothing shipped.
+func mintService(store Store) *Service {
+	return NewService(store).withAuditRecorder(&capturingRecorder{})
+}
 
 // ---------------------------------------------------------------------------
 // PROOF 1 -- A SITE-SCOPED COLLABORATOR IS REFUSED, AND THE REFUSAL IS SAYABLE.

--- a/apps/api/internal/mcp/refusal_target_bound_test.go
+++ b/apps/api/internal/mcp/refusal_target_bound_test.go
@@ -40,7 +40,7 @@ type capturingRecorder struct {
 	events []audit.Event
 }
 
-func (c *capturingRecorder) Record(_ context.Context, e audit.Event) (audit.Entry, error) {
+func (c *capturingRecorder) RecordOrFail(_ context.Context, e audit.Event) (audit.Entry, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.events = append(c.events, e)
@@ -48,7 +48,7 @@ func (c *capturingRecorder) Record(_ context.Context, e audit.Event) (audit.Entr
 }
 
 func (c *capturingRecorder) RecordInTx(_ context.Context, _ pgx.Tx, e audit.Event) (audit.Entry, error) {
-	return c.Record(context.Background(), e)
+	return c.RecordOrFail(context.Background(), e)
 }
 
 // only returns the single captured event of the given action, failing loudly

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -837,8 +837,17 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 		// this append fails, the whole approval rolls back and there is no
 		// mcp.grant.created row for a grant that does not exist.
 		func(tx pgx.Tx, gr sqlc.McpGrant) error {
-			if s.audit == nil {
-				return nil
+			// A10 NAMES APPROVAL, so an unaudited Service may not approve. The
+			// error propagates out of this callback into the caller's
+			// transaction, which rolls the grant and the code back with it:
+			// there is no half-state where the credential exists and the row
+			// explaining it does not. This used to `return nil`, which created
+			// the fleet-access grant and skipped its record -- the most
+			// consequential row this system writes, dropped on a wiring
+			// mistake nobody would notice until an auditor asked who let the
+			// assistant in.
+			if err := s.requireRecorder(); err != nil {
+				return err
 			}
 			// THE ACTOR IS WHICHEVER CREDENTIAL AUTHENTICATED, resolved by
 			// audit.ActorFor rather than hardcoded.
@@ -1925,8 +1934,18 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 		// being attributed, not merely a state transition. It never runs
 		// alongside pgx.ErrNoRows -- see onRevoked's doc on the interface.
 		func(tx pgx.Tx, row sqlc.RevokeMCPGrantWithTokensInTenantTxRow) error {
-			if s.audit == nil {
-				return nil
+			// Closed for the same reason as Approve and the headless mint, and
+			// closed DELIBERATELY even though A10's list does not spell out
+			// "revocation": leaving the one sibling open is how the whole
+			// posture gets read as an inconsistency and tidied back to `return
+			// nil` later. A revocation is also the row an operator most needs
+			// after an incident -- "when did we cut this connection off" -- and
+			// it is the one place where failing closed leaves the credential
+			// live, so the refusal must be loud rather than quiet. It is: the
+			// rollback keeps the grant active and the request errors, instead
+			// of reporting a revocation that did not happen.
+			if err := s.requireRecorder(); err != nil {
+				return err
 			}
 			// THE ACTOR IS WHICHEVER CREDENTIAL AUTHENTICATED, resolved by
 			// audit.ActorFor rather than hardcoded.

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -367,6 +367,36 @@ func (s *Service) requireRecorder() error {
 	return nil
 }
 
+// auditFailure normalises anything the audit package returns into
+// ErrCodeAuditUnavailable, preserving the original as the cause.
+//
+// THIS EXISTS BECAUSE A REAL APPEND FAILURE DOES NOT LOOK LIKE A FAKE ONE, and
+// the difference was live for one commit. internal/audit returns TYPED domain
+// errors of its own -- audit_insert_failed, audit_prev_failed,
+// audit_marshal_failed, audit_canonical_failed -- so a genuine failure arrived
+// here as a domain error with a code this package's wire mapping had never
+// heard of. TransportHandler.toolError then fell through to its default branch
+// and answered -32602 INVALID PARAMS carrying de.Message verbatim: the caller
+// was told their parameters were wrong, and told "failed to append audit entry"
+// in plain English. That is the liveness oracle stated outright rather than
+// merely inferable, and it is the caller blamed for a server fault.
+//
+// The unit tests could not see it. A fake recorder returns errors.New, which is
+// NOT a domain error, so it took toolError's non-domain branch and produced the
+// correct generic answer. Only a real append failing for a real reason -- INSERT
+// revoked on audit_log for the app role -- produced the defect, which is the
+// whole argument for that proof existing.
+//
+// Every audit call on this surface goes through here, so a new error code added
+// inside internal/audit later cannot reintroduce the fallthrough.
+func auditFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	return domain.Internal(ErrCodeAuditUnavailable,
+		"this connection cannot be served because its audit trail cannot be written").WithCause(err)
+}
+
 // withAuditRecorder is the test-only door onto the same field, so a fake can
 // drive the append-failed path. Unexported: production wiring goes through
 // WithAudit.
@@ -1504,7 +1534,7 @@ func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, to
 			"operator_permission": operatorPermission,
 		},
 	})
-	return err
+	return auditFailure(err)
 }
 
 // RecordToolDenied appends the ActionMCPToolDenied audit row for one REFUSED
@@ -1591,7 +1621,7 @@ func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, 
 		TargetID:   target,
 		Metadata:   meta,
 	})
-	return err
+	return auditFailure(err)
 }
 
 // RecordProtocolDenied appends the ActionMCPProtocolDenied audit row for an
@@ -1654,7 +1684,7 @@ func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedReque
 		TargetID:   target,
 		Metadata:   meta,
 	})
-	return err
+	return auditFailure(err)
 }
 
 // ListSitesForModel is the one Phase 1 read tool. It returns the rendered tool

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1976,6 +1976,18 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 			// live, so the refusal must be loud rather than quiet. It is: the
 			// rollback keeps the grant active and the request errors, instead
 			// of reporting a revocation that did not happen.
+			//
+			// "SO A COMPROMISED CONNECTION CANNOT BE CUT OFF DURING A DATABASE
+			// DEGRADATION" IS THE OBVIOUS OBJECTION, AND IT DOES NOT HOLD.
+			// There is no window in which the connection is live and
+			// unrevokeable, because the same unwritable audit log that blocks
+			// this revoke also blocks every tool call the connection could
+			// make: callTool records BEFORE it serialises the answer (see
+			// transport.go) and withholds the answer when the append fails. The
+			// two capabilities fail together and recover together. What an
+			// operator loses is the ability to change the grant's STATE while
+			// the ledger is down; what they do not lose is containment, which
+			// is the thing the revoke was for.
 			if err := s.requireRecorder(); err != nil {
 				return err
 			}

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -107,6 +107,21 @@ const (
 	// for "the resource owner refused", and 403 rather than 401: re-presenting
 	// the same credential will not help.
 	ErrCodeAccessDenied = "mcp_access_denied"
+
+	// ErrCodeAuditUnavailable is the refusal for a request this surface could
+	// not RECORD -- either the append failed, or the Service was built with no
+	// recorder at all. It is not a permission decision and it is not the
+	// caller's fault; it exists so that "we could not write the record" is a
+	// distinguishable, greppable outcome in the operator log rather than being
+	// folded into a generic internal error nobody can alert on.
+	//
+	// It never reaches the wire with this spelling. TransportHandler.toolError
+	// maps it to the JSON-RPC internal code, deliberately indistinguishable
+	// from any other server-side failure: telling the caller WHICH failure this
+	// was would hand a probing client a direct read on whether the audit system
+	// is currently up. See TransportHandler.auditGap on the residual that
+	// remains even so.
+	ErrCodeAuditUnavailable = "mcp_audit_unavailable"
 )
 
 // The OAuth vocabulary this server implements, named once.
@@ -204,12 +219,28 @@ func validateTokenEndpointAuthMethod(method string) error {
 // Clock is injectable so expiry behaviour is testable without sleeping.
 type Clock func() time.Time
 
-// auditRecorder is the slice of *audit.Recorder this package actually uses. It
-// exists to make the append-FAILED branch testable without a broken database;
-// production passes the concrete recorder through WithAudit and nothing else
-// implements it outside tests.
+// auditRecorder is the slice of *audit.Recorder this package may use, and the
+// omission is the load-bearing part: audit.Recorder.Record -- the FAIL-OPEN
+// helper, whose doc tells callers to log the error and carry on -- is not in
+// this method set, so `s.audit.Record(...)` does not compile anywhere in this
+// package.
+//
+// That is ADR-061 A10's first bullet implemented as a type rather than as a
+// convention: "the fail-closed helper becomes the only audit path this surface
+// may use. A surface that can reach the fail-open helper will eventually reach
+// it." A grep guard would catch the same mistake one CI run later and only for
+// the spellings it anticipated; a method set catches it in the editor, for
+// every spelling, including the one a future refactor invents. The two members
+// below are both fail-closed by contract: RecordOrFail for a disclosure with no
+// companion row (a read answered, a refusal returned), RecordInTx for an append
+// that must live or die with the write beside it.
+//
+// It stays an interface rather than *audit.Recorder for a second reason: it
+// makes the append-FAILED branch reachable from a unit test without a broken
+// database, and what happens when an append fails is now the whole behaviour
+// under test on this surface.
 type auditRecorder interface {
-	Record(ctx context.Context, e audit.Event) (audit.Entry, error)
+	RecordOrFail(ctx context.Context, e audit.Event) (audit.Entry, error)
 	RecordInTx(ctx context.Context, tx pgx.Tx, e audit.Event) (audit.Entry, error)
 }
 
@@ -219,21 +250,43 @@ type auditRecorder interface {
 type Service struct {
 	store Store
 	now   Clock
-	// audit is nil unless WithAudit is called. Every audit write in this
-	// package guards on it being nil first -- see Approve, RevokeConnection,
-	// and RecordToolCall -- so a Service built by the many unit tests in this
-	// package (fakeStore, no real Postgres pool to back an audit.Recorder)
-	// keeps working unaudited. Production wiring (cmd/wpmgr/main.go) always
-	// calls WithAudit; a Service that reaches a request path without it is a
-	// wiring bug, not a supported configuration, and the finding to raise if
-	// one is ever found is "this deploy path is unattributable", not "make the
-	// nil check quieter".
+	// audit is nil unless WithAudit is called, and ON THE LIVE ASSISTANT
+	// SURFACE A NIL RECORDER NOW REFUSES rather than serving unaudited. See
+	// requireRecorder: RecordToolCall, RecordToolDenied and
+	// RecordProtocolDenied return ErrCodeAuditUnavailable when this is nil, and
+	// their callers withhold the answer.
 	//
-	// The type is the two-method auditRecorder rather than *audit.Recorder so
-	// that the FAILURE path is reachable from a unit test. What happens when
-	// an append fails is a decision this package makes deliberately (see
-	// TransportHandler.auditGap), and a decision whose only implementation is
-	// unreachable without a broken Postgres is a decision nothing checks.
+	// This reverses what the old text called a supported configuration. It said
+	// a Service without a recorder "keeps working unaudited", that production
+	// always calls WithAudit, and that a request path reached without one is a
+	// wiring bug whose finding is "this deploy is unattributable". Every clause
+	// of that is still true and the conclusion was still wrong: an unaudited
+	// assistant surface that presents as a working one is precisely the state
+	// ADR-061 A10 exists to make impossible, and leaving it reachable meant the
+	// wiring bug's symptom was a fleet answering questions with no record that
+	// it did. A misconfiguration must fail where it is made, not silently
+	// produce the one outcome the surface promises cannot happen.
+	//
+	// The type is the two-method auditRecorder rather than *audit.Recorder for
+	// two reasons, and the first is now the more important: audit.Recorder's
+	// FAIL-OPEN Record is not in that method set, so this package cannot reach
+	// it (see auditRecorder). The second is that it makes the append-FAILED
+	// branch reachable from a unit test without a broken Postgres, and that
+	// branch is now the behaviour this surface is judged on.
+	//
+	// THE BATCHING RULE, which ADR-061 A10 requires be written down rather than
+	// left to be inferred: READS ON THIS SURFACE ARE NOT BATCHED AND NOT
+	// SAMPLED. One tools/call produces exactly one audit row, synchronously,
+	// before the answer is served. A10 permits batching for volume and requires
+	// that any such rule be stated with a retention; the rule here is that
+	// there is no such rule, and the volume assumption that makes it safe is
+	// ToolCallTenantPerMin (see toolcall_limit.go) -- the per-tenant tool-call
+	// ceiling this endpoint already enforces, which is the upper bound on rows
+	// per tenant per minute this surface can generate. Retention is the
+	// audit_log table's own; this surface neither shortens it nor keeps a
+	// second copy. Sampling would have to be re-argued from scratch if that
+	// ceiling ever rises, because a sampled read log cannot answer "which sites
+	// did this connection read" -- it can only answer "some of them".
 	audit auditRecorder
 
 	// mintLimit bounds POST /api/v1/mcp/connections. It lives on the SERVICE
@@ -288,6 +341,30 @@ func (s *Service) WithAudit(rec *audit.Recorder) *Service {
 	}
 	cp.audit = rec
 	return &cp
+}
+
+// requireRecorder is the guard every live-surface audit write opens with, and
+// the reason it is a shared function rather than three copies of `if s.audit ==
+// nil` is that the three copies previously disagreed with the surface's own
+// promise and each other's comments.
+//
+// A NIL RECORDER IS A REFUSAL, NOT A QUIET SKIP. A Service built without
+// WithAudit cannot record anything, so under ADR-061 A10 it cannot answer
+// anything either: every tools/call it serves would be an AI action with no
+// record, which is the exact outcome the surface promises is impossible. The
+// misconfiguration is loud at the first request instead of silent until an
+// auditor asks a question nobody can answer.
+//
+// It returns an error rather than panicking because this is a request path (a
+// panic here would take the process down on a wiring mistake that only affects
+// one surface), and domain.Internal rather than a Forbidden because the caller
+// did nothing wrong -- the deploy did.
+func (s *Service) requireRecorder() error {
+	if s.audit == nil {
+		return domain.Internal(ErrCodeAuditUnavailable,
+			"this connection cannot be served because its audit trail cannot be written")
+	}
+	return nil
 }
 
 // withAuditRecorder is the test-only door onto the same field, so a fake can
@@ -1358,18 +1435,55 @@ func (s *Service) RecordActivity(ctx context.Context, auth AuthorizedRequest) er
 // registry entry AuthorizeTool already resolved -- see the OperatorPermission
 // doc on ToolPolicy for why that field lands here.
 //
-// BEST-EFFORT, deliberately unlike Approve/RevokeConnection's RecordInTx:
-// there is no companion write in the same transaction to roll back alongside a
-// failed append (a tool call in this phase is a read), so failing the whole
-// tool call because its own audit trail could not be appended would let a
-// purely observational feature take down the read path it exists to observe.
-// The error is returned so the caller can log it, never to be treated as a
-// reason to withhold the tool's answer.
+// FAIL-CLOSED. This comment used to argue the reverse -- that a tool call in
+// this phase is a read, that a read has no companion write to roll back, and
+// that failing the call over its own audit append would let an observational
+// feature take down the path it observes -- and the argument is retired rather
+// than softened. ADR-061 A10 says reads are included, because "which sites a
+// connection read, and when" is the record a customer needs when they ask what
+// the assistant saw, and an owner ruling on 2026-09-01 settled it: completeness
+// over availability, on this surface, deliberately.
+//
+// The throughput half of the old argument was measured and does not hold: the
+// per-tenant chain lock costs nothing detectable next to the transaction it
+// wraps, and one tenant's sustained append rate is orders of magnitude above
+// the ToolCallTenantPerMin ceiling that already bounds this endpoint. The
+// figures are laptop single-sample runs and are deliberately not quoted here or
+// anywhere else; they retire an objection, they are not a published number.
+//
+// The honest residual is AVAILABILITY, not throughput. A Postgres that cannot
+// take this append now fails the read instead of serving it unlogged. That is
+// the trade the ruling made with its eyes open.
+//
+// WHERE THE APPEND SITS RELATIVE TO THE READ, and why not the two alternatives:
+//
+//   - CHOSEN: after entry.invoke, before the answer is serialised. TransportHandler
+//     .callTool propagates a non-nil return by discarding the text it is holding
+//     and answering with an error instead. The property A10 asks for is that no
+//     AI action is performed whose record was lost, and for a read the ACTION IS
+//     THE DISCLOSURE -- data that never leaves the process was never seen. So
+//     binding the record to the disclosure is the faithful reading, and this is
+//     the point where the disclosure has not happened yet.
+//   - REJECTED, record before invoke: would put a mcp.tool.called row in the
+//     ledger for a call that then failed and answered nothing. That is not a
+//     safer direction, it is a ledger that claims reads which did not happen,
+//     and an auditor cannot tell those rows from the real ones.
+//   - REJECTED, one transaction shared by the read and the append: strictly the
+//     strongest shape and the one A10's "same transaction" language describes,
+//     but it buys nothing HERE and costs a pgx.Tx threaded through the Store
+//     interface and every tool implementation. A read writes no row, so there is
+//     nothing for the transaction to roll back; all it would add is that the
+//     append commits before the answer, which the ordering above already gives.
+//     THIS STOPS BEING TRUE THE MOMENT A WRITE TOOL LANDS: a tool that changes
+//     a row must use RecordInTx inside that row's transaction, and must not
+//     reuse this shape by analogy.
+//
+// NOT BATCHED, NOT SAMPLED -- see the batching rule on the Service audit field.
 func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, toolName string, operatorPermission string) error {
-	if s.audit == nil {
-		return nil
+	if err := s.requireRecorder(); err != nil {
+		return err
 	}
-	_, err := s.audit.Record(ctx, audit.Event{
+	_, err := s.audit.RecordOrFail(ctx, audit.Event{
 		TenantID:   auth.TenantID,
 		ActorType:  audit.ActorAssistant,
 		ActorID:    auth.GrantID.String(),
@@ -1415,16 +1529,17 @@ func (s *Service) RecordToolCall(ctx context.Context, auth AuthorizedRequest, to
 // what stops a caller composing a reason by hand and drifting from the log line
 // two lines above it.
 //
-// BEST-EFFORT, and that is a deliberate divergence from ADR-061 A10's
-// fail-closed language rather than an oversight. See TransportHandler.auditGap.
+// FAIL-CLOSED, reversing the divergence this comment used to defend. See
+// TransportHandler.auditGap for what the old posture argued, what survived the
+// reversal (the operator-side gap line still fires, as evidence of last resort)
+// and the ONE residual the reversal creates -- a caller being denied can now
+// distinguish "refused" from "refused and unrecordable", which is a liveness
+// oracle on the audit system. That residual is named there, was weighed against
+// a refusal that no ledger records, and is the reason this change goes to
+// security review rather than straight to merge.
 func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, toolName string, reason refusalReason) error {
-	// NOTE: a Service with no recorder records NOTHING and reports no error,
-	// the same as RecordToolCall. That is the unit-test configuration (see the
-	// audit field doc); in production WithAudit has always been called, and a
-	// request path reached without it is a wiring bug whose finding is "this
-	// deploy is unattributable", not "make this quieter".
-	if s.audit == nil {
-		return nil
+	if err := s.requireRecorder(); err != nil {
+		return err
 	}
 	// BOUNDED, because this is attacker-chosen input on a path the attacker can
 	// reach WITHOUT holding the tool. toolName is whatever arrived in params,
@@ -1455,7 +1570,7 @@ func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, 
 		meta["target_sanitized"] = true
 	}
 
-	_, err := s.audit.Record(ctx, audit.Event{
+	_, err := s.audit.RecordOrFail(ctx, audit.Event{
 		TenantID:  auth.TenantID,
 		ActorType: audit.ActorAssistant,
 		ActorID:   auth.GrantID.String(),
@@ -1483,9 +1598,13 @@ func (s *Service) RecordToolDenied(ctx context.Context, auth AuthorizedRequest, 
 // different things operationally: a params refusal is a client that cannot
 // connect at all, a header refusal is a client that connected and then sent
 // something else, and only the second can indicate a proxy rewriting headers.
+// FAIL-CLOSED, like RecordToolCall and RecordToolDenied. writeProtocolRefusal
+// withholds the typed refusal and answers an internal error when this returns
+// non-nil, so a negotiation this surface could not record is a negotiation it
+// does not answer.
 func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedRequest, neg Negotiation, phase string) error {
-	if s.audit == nil {
-		return nil
+	if err := s.requireRecorder(); err != nil {
+		return err
 	}
 	reason := neg.RefusalReason()
 
@@ -1517,7 +1636,7 @@ func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedReque
 		meta["target_sanitized"] = true
 	}
 
-	_, err := s.audit.Record(ctx, audit.Event{
+	_, err := s.audit.RecordOrFail(ctx, audit.Event{
 		TenantID:   auth.TenantID,
 		ActorType:  audit.ActorAssistant,
 		ActorID:    auth.GrantID.String(),

--- a/apps/api/internal/mcp/toolcall_limit_test.go
+++ b/apps/api/internal/mcp/toolcall_limit_test.go
@@ -44,7 +44,11 @@ func limiterRouter(t *testing.T, store Store) (*gin.Engine, *TransportHandler) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	h := NewTransportHandler(NewService(store), slog.New(slog.DiscardHandler), "test-version")
+	// The recorder is required, not decorative: an unaudited Service refuses
+	// every tool call (Service.requireRecorder), and a limiter test whose calls
+	// are all refused for an unrelated reason proves nothing about the limiter.
+	svc := NewService(store).withAuditRecorder(&capturingRecorder{})
+	h := NewTransportHandler(svc, slog.New(slog.DiscardHandler), "test-version")
 	h.Register(r)
 	return r, h
 }

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -1377,6 +1377,22 @@ func (h *TransportHandler) writeProtocolRefusal(
 	// names nothing. A client that cannot connect learns only that the server
 	// failed, which is the same residual auditGap's doc weighs for tool
 	// denials.
+	//
+	// AND ON THIS PATH THE RESIDUAL IS WIDER THAN ON THE TOOL PATH -- stated
+	// plainly because the narrowing claimed elsewhere does not hold here. The
+	// message below ("the request could not be completed") is distinct from
+	// every other 500 this transport emits, so an audit failure during protocol
+	// negotiation is a UNIQUE SIGNATURE rather than being indistinguishable
+	// from an ordinary server fault. The tool path earns its narrowing by
+	// emitting bytes identical to the generic internal error; this path does
+	// not, and pretending otherwise would be the kind of comment that makes a
+	// reviewer stop looking.
+	//
+	// It is accepted rather than closed: reaching this line requires having
+	// already authenticated, so the caller is a holder of a valid credential
+	// rather than an anonymous prober, and the residual was weighed on that
+	// basis. If this path ever becomes reachable pre-authentication, this
+	// message must collapse into the generic one first.
 	if err := h.svc.RecordProtocolDenied(c.Request.Context(), auth, neg, phase); err != nil {
 		h.auditGap(c.Request.Context(), auth, audit.ActionMCPProtocolDenied,
 			neg.Raw, neg.RefusalReason(), phase, err)

--- a/apps/api/internal/mcp/transport.go
+++ b/apps/api/internal/mcp/transport.go
@@ -980,7 +980,29 @@ func (h *TransportHandler) authorizeCall(ctx context.Context, auth AuthorizedReq
 			if aerr := h.svc.RecordToolDenied(ctx, auth, p.Name, reason); aerr != nil {
 				// No phase: a tool denial happens at one place in the request,
 				// so there is no second axis to record and "" is omitted.
+				//
+				// The gap line still fires, and it is now evidence of LAST
+				// RESORT rather than the whole response to the failure: the
+				// refusal itself is withheld below. Keeping it matters because
+				// the facts of the lost row -- tenant, grant, what was asked
+				// for, why it was refused -- still have to survive somewhere an
+				// operator can reach, and the internal error the caller gets
+				// carries none of them.
 				h.auditGap(ctx, auth, audit.ActionMCPToolDenied, p.Name, string(reason), "", aerr)
+				// FAIL-CLOSED: the typed refusal is withheld and the caller
+				// gets the internal code instead. auditGap's doc argues at
+				// length that this is the wrong trade for a denial -- that
+				// there is nothing to withhold, that degrading -32004 into
+				// -32603 destroys the actionable half of the refusal, and that
+				// a distinguishable answer exactly when the audit log is
+				// unwritable is a "the camera is off" oracle for the probing
+				// client. The third point survives the reversal and is the real
+				// cost here; it is named in auditGap's doc and it goes to
+				// security review with this change. What outweighed it is that
+				// a refusal nothing records is a boundary with no evidence it
+				// functioned, and A10 makes no exception for denials: "every
+				// AI-originated read, proposal, approval, denial and execution".
+				return ToolPolicy{}, p, h.toolError(req.ID, aerr), true
 			}
 		}
 
@@ -1028,18 +1050,37 @@ func (h *TransportHandler) callTool(ctx context.Context, auth AuthorizedRequest,
 	// own branch, so the two outcomes are separate actions rather than one
 	// action with a status field: a query for "what did this connection do"
 	// and a query for "what was this connection refused" are different
-	// questions and neither should have to filter the other out. BEST-EFFORT
-	// like RecordConnect's client-identity write is not -- a failure here is
-	// logged, never returned to the caller, because withholding a successful
-	// read's answer over a failure to record having answered it would make an
-	// observational feature take down the read path it observes.
+	// questions and neither should have to filter the other out.
+	//
+	// THIS IS THE FAIL-CLOSED GATE, and `text` is deliberately still a local
+	// variable at this point. The read has run; nothing it returned has left
+	// this process. If the row cannot be committed, the answer is discarded and
+	// the caller gets an error instead -- ADR-061 A10, and an owner ruling of
+	// 2026-09-01 that reads are included in it. The old code logged this error
+	// and answered anyway, on the argument that an observational feature should
+	// not take down the path it observes; that argument is retired on
+	// RecordToolCall, along with the throughput claim underneath it.
+	//
+	// THE ORDER OF THESE TWO STATEMENTS IS THE WHOLE PROPERTY. Serialising the
+	// response before the append, or moving the append into a goroutine, or
+	// returning the response and recording in a defer, each restores the
+	// fail-open behaviour while leaving every comment above it looking correct.
+	// The regression test that pins this drives a recorder that always fails
+	// and asserts the tool text appears NOWHERE in the response body.
 	if err := h.svc.RecordToolCall(ctx, auth, entry.Name, string(entry.OperatorPermission)); err != nil {
-		h.log.ErrorContext(ctx, "mcp tool call audit write failed",
+		h.log.ErrorContext(ctx, "mcp tool call audit write failed, answer withheld",
+			slog.Bool("audit_gap", true),
+			slog.String("action", audit.ActionMCPToolCalled),
 			slog.String("tenant_id", auth.TenantID.String()),
 			slog.String("grant_id", auth.GrantID.String()),
 			slog.String("tool", entry.Name),
+			slog.Bool("answer_withheld", true),
 			slog.String("error", err.Error()),
 		)
+		// toolError maps ErrCodeAuditUnavailable onto the internal code without
+		// echoing the message, so the caller learns that the call failed and
+		// not that the audit log is what failed.
+		return h.toolError(req.ID, err)
 	}
 
 	return newResponse(req.ID, map[string]any{
@@ -1076,6 +1117,23 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 			data, _ := json.Marshal(payload)
 			return newErrorResponse(id, codeCapabilityNotGranted, de.Message, data)
 		}
+		if de.Code == ErrCodeAuditUnavailable {
+			// AN UNRECORDABLE CALL IS AN INTERNAL ERROR ON THE WIRE, and this
+			// branch exists because the fallthrough below would have made it
+			// something much worse: codeInvalidParams, carrying de.Message
+			// verbatim. That is wrong twice. It blames the caller's parameters
+			// for a server-side failure, so a legitimate client retries with a
+			// different tool name forever; and it puts "its audit trail cannot
+			// be written" on the wire, handing any caller a direct, polled read
+			// on whether this surface is currently recording -- the precise
+			// oracle auditGap's third argument is about, but spelled out in
+			// English instead of merely inferable from a code.
+			//
+			// The generic message matches the non-domain branch below exactly,
+			// so an audit failure and any other internal failure are the same
+			// bytes.
+			return newErrorResponse(id, codeInternalError, "the tool call failed", nil)
+		}
 		return newErrorResponse(id, codeInvalidParams, de.Message, nil)
 	}
 	h.log.Error("mcp tool call failed", slog.String("error", err.Error()))
@@ -1086,59 +1144,69 @@ func (h *TransportHandler) toolError(id json.RawMessage, err error) jsonrpcRespo
 // Refusals
 // ---------------------------------------------------------------------------
 
-// auditGap is what happens when a REFUSAL's audit append fails, and it is the
-// one place the failure posture for this surface's denial records is decided.
+// auditGap emits the LAST-RESORT copy of a refusal row that could not be
+// written. It is no longer the failure posture for this surface -- the callers
+// withhold the refusal too -- and what it now does is make sure the facts of
+// the lost row survive somewhere an operator can reach.
 //
-// THE DECISION: the caller's refusal is unchanged, and the failure is escalated
-// on the operator side instead. This is a deliberate divergence from the
-// fail-closed language in ADR-061 A10, and the reasoning is:
+// WHAT CHANGED, AND WHICH HALF OF THE OLD ARGUMENT SURVIVED. This function used
+// to be the whole answer: the caller's refusal was served unchanged and only
+// the operator was told. That was a deliberate divergence from ADR-061 A10,
+// argued on three points, and an owner ruling of 2026-09-01 settled it the
+// other way. The three, and what became of each:
 //
-//  1. "FAIL CLOSED" IS NOT DEFINED FOR AN OPERATION THAT IS ALREADY A DENIAL.
-//     A10's rule is "no AI action is ever performed whose record was lost", and
-//     it works because there is always a second option: don't perform it. Here
-//     the action has already not been performed. There is nothing to withhold,
-//     nothing to roll back, and no companion write to bind the append to -- the
-//     approve path's RecordInTx shape has no analogue because a refusal touches
-//     no row.
+//  1. RETIRED: "'fail closed' is not defined for an operation that is already a
+//     denial". A10 lists denials explicitly -- "every AI-originated read,
+//     proposal, approval, denial and execution" -- and the thing to withhold is
+//     not the denial's effect but its ANSWER. A boundary whose refusals leave
+//     no evidence has no way to show it functioned, which is the whole reason
+//     the denial is recorded at all.
 //
-//  2. THE ONLY AVAILABLE IMPLEMENTATION OF "FAIL CLOSED" HERE MAKES THE SURFACE
-//     WORSE AND RESTORES NOTHING. The single lever left is the wire answer:
-//     degrade the typed refusal (-32004 "call tools/list", -32002 "your site
-//     scope is empty") into -32603 internal error. That destroys the actionable
-//     half of the refusal for a legitimate client who is now told nothing they
-//     can act on, makes a transient database blip indistinguishable from a
-//     server bug, and DOES NOT WRITE THE ROW. The evidence gap is identical
-//     either way; only the client's experience differs, and only for the worse.
+//  2. RETIRED: "the only available implementation makes the surface worse and
+//     restores nothing". True that it restores nothing -- the row is lost
+//     either way -- and that is not the objective. The objective is that the
+//     surface never behaves as though a record exists when it does not, so that
+//     the number of unrecorded interactions is bounded by the outage rather
+//     than by traffic.
 //
-//  3. CHANGING THE WIRE ANSWER LEAKS AUDIT-SYSTEM LIVENESS TO THE PARTY BEING
-//     DENIED. This is the decisive one. The caller on this branch is by
-//     definition someone who just asked for something they may not have,
-//     including the wordlist-probing case AuthorizeTool's whole disclosure
-//     decision exists to defeat. A distinguishable answer when and only when
-//     the audit log is unwritable is a "the camera is off" oracle: probe until
-//     the response shape changes, then do the thing you actually came for. A
-//     surface that tells attackers when it has stopped recording is worse than
-//     one that quietly keeps answering.
+//  3. STANDS, AND IS THE RESIDUAL THIS CHANGE ACCEPTS: changing the wire answer
+//     leaks audit-system liveness to the party being denied. The caller here is
+//     by definition someone who just asked for something they may not have,
+//     including the wordlist-probing case AuthorizeTool's disclosure decision
+//     exists to defeat, and an answer that changes shape exactly when the audit
+//     log is unwritable is a "the camera is off" oracle: probe until the shape
+//     changes, then do what you came for. This is REAL and it is not mitigated
+//     away below -- it is narrowed (toolError emits byte-identical internal
+//     errors for an audit failure and any other server-side failure, so the
+//     oracle requires distinguishing "internal error" from "typed refusal", not
+//     reading a message) and then accepted, because the alternative it buys is
+//     a surface that keeps answering while recording nothing, which is the
+//     state the ruling was made to eliminate. It is flagged for security
+//     review with this change rather than settled here.
 //
-// So the honest failure mode is not a different refusal, it is a LOUDER
-// OPERATOR SIGNAL, and that is what this writes. Two properties matter:
+// Two properties of the line itself still matter, and both are why this
+// function was kept rather than deleted along with its old posture:
 //
 //   - THE LOST ROW'S CONTENT IS EMITTED HERE, not just the error. The hash
 //     chain has a hole that cannot be repaired, but the facts -- tenant, grant,
 //     what was asked for, why it was refused -- survive somewhere an operator
 //     can reach. It is strictly weaker evidence than the chained row (not
 //     tamper-evident, log retention, no audit endpoint) and it is named as
-//     such rather than presented as equivalent.
+//     such rather than presented as equivalent. The caller now gets an internal
+//     error carrying none of these facts, so this line is the ONLY place they
+//     exist.
 //   - audit_gap=true is a single, greppable, alertable field. The requirement
 //     A10 is really making is that an operator FINDS OUT their evidence has a
 //     hole; an ERROR line indistinguishable from every other ERROR line does
-//     not satisfy that, and an alert keyed on this field does.
+//     not satisfy that, and an alert keyed on this field does. callTool's
+//     withheld-answer line carries the same field for the same reason.
 //
-// WHAT THIS DOES NOT CLAIM. This is not A10's fail-closed helper. That helper
-// would have to bind the append to the operation, and for a denial there is no
-// operation to bind it to. If a WRITE tool ever lands on this surface and its
-// refusal has an effect to roll back, that refusal is a different case and must
-// not reuse this path by analogy.
+// WHAT THIS STILL DOES NOT CLAIM. This is not the fail-closed helper and does
+// not stand in for one; audit.Recorder.RecordOrFail is, and the withholding at
+// the call sites is what makes it fail-closed. If a WRITE tool ever lands on
+// this surface, its append belongs in the write's own transaction via
+// RecordInTx, and neither this function nor RecordOrFail may be reused there by
+// analogy.
 // THE FIELDS ARE THE LOST ROW'S FIELDS, UNDER THE LOST ROW'S KEYS. reason and
 // phase are separate arguments and separate log keys because they answer
 // different questions and the row records them separately: refusal_reason is
@@ -1301,9 +1369,20 @@ func (h *TransportHandler) writeUnauthorized(c *gin.Context, err error) {
 func (h *TransportHandler) writeProtocolRefusal(
 	c *gin.Context, auth AuthorizedRequest, id json.RawMessage, neg Negotiation, phase string,
 ) {
+	// FAIL-CLOSED, on the same terms as the tool-call and tool-denial paths: a
+	// negotiation this surface could not record is a negotiation it does not
+	// answer. The gap line still fires first, as the last-resort copy of the
+	// lost row's facts, and then the typed 400 -- which names the floor, the
+	// target and the supported revisions -- is withheld in favour of a 500 that
+	// names nothing. A client that cannot connect learns only that the server
+	// failed, which is the same residual auditGap's doc weighs for tool
+	// denials.
 	if err := h.svc.RecordProtocolDenied(c.Request.Context(), auth, neg, phase); err != nil {
 		h.auditGap(c.Request.Context(), auth, audit.ActionMCPProtocolDenied,
 			neg.Raw, neg.RefusalReason(), phase, err)
+		c.JSON(http.StatusInternalServerError,
+			newErrorResponse(id, codeInternalError, "the request could not be completed", nil))
+		return
 	}
 
 	var msg string

--- a/apps/api/internal/mcp/transport_preflight_audit_test.go
+++ b/apps/api/internal/mcp/transport_preflight_audit_test.go
@@ -186,7 +186,7 @@ func TestTransport_AdvertisedVerbsStillRefuse(t *testing.T) {
 // Postgres to produce it.
 type failingRecorder struct{ err error }
 
-func (f *failingRecorder) Record(context.Context, audit.Event) (audit.Entry, error) {
+func (f *failingRecorder) RecordOrFail(context.Context, audit.Event) (audit.Entry, error) {
 	return audit.Entry{}, f.err
 }
 
@@ -280,12 +280,25 @@ func TestTransport_AuditGapLogsReasonAndPhaseSeparately(t *testing.T) {
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
-			// The refusal itself is UNCHANGED by the append failing. That is
-			// the documented decision in auditGap, and if it ever stops being
-			// true the rest of this test is measuring the wrong thing.
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("HTTP %d, want 400 — the refusal changed when the audit append failed\nbody: %s",
+			// THE REFUSAL IS WITHHELD when the append fails: 500, not the
+			// typed 400 that names the floor and the target. This assertion
+			// was the exact inverse until the 2026-09-01 ruling (it read
+			// "the refusal changed when the audit append failed" as the
+			// FAILURE message), and flipping it is the behaviour change --
+			// a protocol refusal this surface could not record is a protocol
+			// refusal it does not answer.
+			if w.Code != http.StatusInternalServerError {
+				t.Fatalf("HTTP %d, want 500 — the typed refusal was served despite an audit append that failed\nbody: %s",
 					w.Code, w.Body.String())
+			}
+			// AND IT LEAKS NEITHER HALF OF THE REFUSAL. The floor, the target
+			// and the supported revisions are what the 400 carries; none of
+			// them may survive into the 500, or the withholding is cosmetic.
+			for _, leak := range []string{ProtocolFloor, ProtocolTarget, "floor", "below"} {
+				if strings.Contains(w.Body.String(), leak) {
+					t.Errorf("the withheld refusal leaked %q into the internal error\nbody: %s",
+						leak, w.Body.String())
+				}
 			}
 
 			rec := findGapLine(t, buf)

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -32,13 +32,33 @@ import (
 
 const testBearer = "connection-token-plaintext"
 
+// newTransportRouter builds the real mount over a store, WITH A WORKING AUDIT
+// RECORDER attached.
+//
+// The recorder is not optional scenery. A Service with no recorder now refuses
+// every tool call and every refusal it cannot record (Service.requireRecorder,
+// ADR-061 A10), so a router built without one answers -32603 to everything and
+// every test below would be asserting against a surface that is refusing for a
+// reason none of them are about. capturingRecorder succeeds and keeps what it
+// was handed, which is also what lets a test assert a row was written rather
+// than merely that the call succeeded.
 func newTransportRouter(t *testing.T, store Store) *gin.Engine {
+	t.Helper()
+	r, _ := newTransportRouterWithAudit(t, store)
+	return r
+}
+
+// newTransportRouterWithAudit is the same mount, handing back the recorder so a
+// test can read the rows the request wrote.
+func newTransportRouterWithAudit(t *testing.T, store Store) (*gin.Engine, *capturingRecorder) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	h := NewTransportHandler(NewService(store), slog.New(slog.DiscardHandler), "test-version")
+	rec := &capturingRecorder{}
+	svc := NewService(store).withAuditRecorder(rec)
+	h := NewTransportHandler(svc, slog.New(slog.DiscardHandler), "test-version")
 	h.Register(r)
-	return r
+	return r, rec
 }
 
 // liveGrantStore is a fakeStore whose credential resolves and whose grant is
@@ -775,12 +795,13 @@ func TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestToolsCall_UntickedCapabilityRefusesWithItsOwnCode(t *testing.T) {
-	// A REAL Service, not nil. authorizeCall now records the refusal
-	// (RecordToolDenied), which dereferences the service; its audit recorder is
-	// nil in unit configuration and records nothing, which is what this test
-	// wants. A nil *Service panics on the refusal path -- the path this test
-	// exists to walk.
-	h := NewTransportHandler(NewService(&fakeStore{}),
+	// A REAL Service, not nil, AND a real recorder. authorizeCall records the
+	// refusal (RecordToolDenied), which dereferences the service; a nil
+	// *Service panics on the refusal path -- the path this test exists to walk.
+	// The recorder used to be omitted, on the since-reversed basis that an
+	// unaudited Service records nothing and carries on: it now refuses, and the
+	// refusal it produces is -32603, not the -32005 this test is about.
+	h := NewTransportHandler(NewService(&fakeStore{}).withAuditRecorder(&capturingRecorder{}),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), "test")
 
 	// Holds NO capability, but a non-empty site scope -- so nothing below can

--- a/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
+++ b/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
@@ -384,7 +384,7 @@ func TestMCPConnectionListsANonDefaultCapabilitySetExactlyAsAppRole(t *testing.T
 	tenantID := seedTenant(t, pool, "mcp-s16-cap-"+suffix)
 	userID := seedUserRow(t, pool, "mcp-s16-cap-"+suffix+"@example.test")
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantID, userID))
 
 	// A deliberately non-default, non-alphabetical, more-than-one-member set:

--- a/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
+++ b/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
@@ -86,7 +86,7 @@ func TestMCPRevokeCascadesToTokensAsAppRole(t *testing.T) {
 		t.Fatalf("open token lookup tx: %v", err)
 	}
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	g := connectRealGrant(t, pool, svc)
 	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(g.tenantID, g.userID))
 
@@ -244,7 +244,7 @@ func TestMCPConnectionsListThroughMountedRouteAsAppRole(t *testing.T) {
 		t.Fatalf("open tenant tx: %v", err)
 	}
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	g := connectRealGrant(t, pool, svc)
 	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(g.tenantID, g.userID))
 
@@ -368,7 +368,7 @@ func TestMCPGrantsSiteScopePolicyIsLiveAndTheServiceRefusesOutLoud(t *testing.T)
 	ctx := context.Background()
 	pool := startPostgres(t)
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	repo := mcp.NewRepo(pool)
 	g := connectRealGrant(t, pool, svc)
 

--- a/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
+++ b/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
@@ -72,7 +72,7 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 	siteURL := "https://" + uuid.NewString()[:8] + ".example.test"
 	siteID := seedSite(t, pool, tenantID, siteURL)
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	// An ORG-scoped operator: the only scope /consent admits.
 	eng := mountLikeProduction(t, svc, domain.Principal{
 		UserID: userID, TenantID: tenantID, Scope: domain.ScopeOrg,

--- a/apps/api/tests/mcp_audit_fail_closed_integration_test.go
+++ b/apps/api/tests/mcp_audit_fail_closed_integration_test.go
@@ -224,10 +224,16 @@ func TestMCPAuditFailClosed_NoAnswerIsServedWhenTheAppendCannotCommit(t *testing
 // to tell "the audit log is down" from any other server-side failure, because
 // that is a poll on whether this surface is currently recording.
 //
-// It compares the response to an UNRECORDABLE call against the response to a
-// call that fails for an unrelated internal reason, byte for byte including the
-// headers. Anything that differs is the oracle, and is reported rather than
-// asserted away.
+// It compares the STATUS AND BODY of an unrecordable call against the envelope
+// every other server-side tool failure produces. It does NOT compare headers:
+// rpcResult carries only status and body, and an earlier version of this
+// comment claimed "byte for byte including the headers", which the test has
+// never done. The sentence is corrected rather than the test extended, because
+// the headers on this route are written by the shared gin JSON path and do not
+// vary with the error -- comparing them would add a check that cannot fail,
+// which is worse than not claiming it. A response differing only by header is
+// therefore outside what this proves, and is named here rather than left for a
+// reader to assume.
 func TestMCPAuditFailClosed_RefusalAndInternalErrorAreByteIdentical(t *testing.T) {
 	ctx := context.Background()
 	pool := startPostgres(t)
@@ -287,6 +293,20 @@ func TestMCPAuditFailClosed_RefusalAndInternalErrorAreByteIdentical(t *testing.T
 	//
 	// Written out in full, with the same request id, so a drift in the code, the
 	// message or the envelope fails here loudly instead of being paraphrased.
+	//
+	// THIS SIDE IS NOT PROVOKED HERE, and that is a real limit of this test: it
+	// pins (a) against a constant, so on its own it cannot notice if the
+	// generic branch stopped emitting this exact envelope -- both sides would
+	// have to be updated together and the comparison would still pass. What
+	// closes the gap is that the generic branch IS provoked elsewhere:
+	// TestToolCall_AnswerIsWithheldWhenTheAuditAppendFails in internal/mcp
+	// drives a NON-domain error through the same toolError call and asserts
+	// codeInternalError, so the literal below is anchored by an executed test
+	// rather than by this file's say-so. Kept as a literal here because
+	// provoking a second, genuinely unrelated internal failure at this point in
+	// the request needs a fault that survives authentication and authorization
+	// and still breaks invoke -- the first attempt reached for one and got
+	// authentication instead, which is how the wrong pair came to be compared.
 	const genericInternal = `{"jsonrpc":"2.0","id":7,"error":{"code":-32603,"message":"the tool call failed"}}`
 
 	t.Logf("(a) audit unavailable : HTTP %d body=%s", unrecordable.status, unrecordable.body)

--- a/apps/api/tests/mcp_audit_fail_closed_integration_test.go
+++ b/apps/api/tests/mcp_audit_fail_closed_integration_test.go
@@ -45,6 +45,31 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
 
+// auditedMCPService is the ONE way this package builds an mcp.Service, and it
+// exists because thirteen integration tests were building one without a
+// recorder and exercising consent, mint and revoke against it.
+//
+// THOSE THIRTEEN FAILURES WERE THE GATE WORKING. Under ADR-061 A10 and the
+// owner's ruling, a Service with no recorder may not approve, mint or revoke:
+// an unaudited assistant surface presenting as a working one is the state the
+// ruling exists to eliminate. The fixtures had been silently in that state, and
+// making it loud is what surfaced them. The fix is therefore to wire the
+// recorder production always wires -- cmd/wpmgr/main.go has never not called
+// WithAudit -- and NOT to soften Service.requireRecorder.
+//
+// One helper, deliberately, rather than a second one alongside internal/mcp's
+// auditedService: two helpers that must agree is a shape this repo has produced
+// repeatedly, and they drift on the day one of them gains an argument. This is
+// the integration-side equivalent and the only one in package tests.
+//
+// The store is passed rather than derived because callers already hold one --
+// several assert against the same repo they hand in -- and re-deriving it here
+// would give them a Service talking to a different object than the one they
+// then inspect.
+func auditedMCPService(pool *db.Pool, store mcp.Store) *mcp.Service {
+	return mcp.NewService(store).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+}
+
 // auditInsertGrant flips INSERT on audit_log for the application role, through
 // the superuser pool. It returns nothing and fails loudly: a REVOKE that
 // silently did not apply would make the fail-closed half of this test pass for

--- a/apps/api/tests/mcp_audit_fail_closed_integration_test.go
+++ b/apps/api/tests/mcp_audit_fail_closed_integration_test.go
@@ -1,0 +1,277 @@
+// mcp_audit_fail_closed_integration_test.go: ADR-061 A10's fail-closed half,
+// against a real database, as the role every install runs as.
+//
+// WHY THIS FILE EXISTS SEPARATELY FROM THE UNIT PROOFS. internal/mcp proves the
+// same property against a fake recorder that returns an error on command. That
+// proves Go error propagation and NOTHING BELOW IT: it cannot fail for the
+// reason production would fail, it never touches audit_log, and it would pass
+// unchanged if the append were routed to a table that does not exist. "No
+// answer is served whose audit record was lost" is a claim about a database, so
+// it is proven against one here.
+//
+// HOW THE APPEND IS MADE TO FAIL, AND WHY THIS MECHANISM. The superuser pool
+// REVOKEs INSERT on audit_log from the application role. That is honest in the
+// way a closed pool is not: the connection stays healthy, the tenant's rows
+// stay readable, the tool's own read still succeeds, and the ONLY thing that
+// breaks is the audit append -- which is precisely the production failure this
+// posture exists for, and precisely the one a fail-open surface would answer
+// straight through. A closed pool would also break the read, and a test where
+// the read fails cannot tell "the answer was withheld" from "there was no
+// answer to withhold".
+//
+// The grant is restored afterwards and the SAME request is replayed, so the
+// over-fire half runs against the same database, the same connection and the
+// same bearer token: the only variable between "no answer" and "an answer" is
+// whether audit_log would accept the row.
+//
+// THE ROLE IS ASSERTED AND PRINTED FROM INSIDE THE TRANSACTION UNDER TEST. A
+// REVOKE against wpmgr_app is inert if the code under test connects as a
+// superuser or a BYPASSRLS role, and this whole file would then pass by
+// answering every call successfully in both halves.
+package tests
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// auditInsertGrant flips INSERT on audit_log for the application role, through
+// the superuser pool. It returns nothing and fails loudly: a REVOKE that
+// silently did not apply would make the fail-closed half of this test pass for
+// the wrong reason -- the append would succeed, the answer would be served, and
+// only the assertion's wording would be wrong.
+func auditInsertGrant(t *testing.T, admin *db.Pool, appRole string, allow bool) {
+	t.Helper()
+	verb := "REVOKE INSERT ON audit_log FROM " + pgQuoteIdent(appRole)
+	if allow {
+		verb = "GRANT INSERT ON audit_log TO " + pgQuoteIdent(appRole)
+	}
+	if _, err := admin.Exec(context.Background(), verb); err != nil {
+		t.Fatalf("SETUP FAILURE: %q: %v", verb, err)
+	}
+	// Read the privilege back rather than trusting the DDL returned no error:
+	// this is the single fact the fail-closed half depends on.
+	var has bool
+	if err := admin.QueryRow(context.Background(),
+		`SELECT has_table_privilege($1, 'audit_log', 'INSERT')`, appRole).Scan(&has); err != nil {
+		t.Fatalf("SETUP FAILURE: read back audit_log INSERT privilege: %v", err)
+	}
+	if has != allow {
+		t.Fatalf("SETUP FAILURE: after %q, has_table_privilege(%q,'audit_log','INSERT') = %v, want %v",
+			verb, appRole, has, allow)
+	}
+	t.Logf("audit_log INSERT for %q is now %v (verified with has_table_privilege)", appRole, has)
+}
+
+// pgQuoteIdent double-quotes an identifier read out of pg_roles. The role name
+// comes from the database, not from a request, but interpolating an identifier
+// unquoted is the habit that eventually meets one that needs it.
+func pgQuoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+// TestMCPAuditFailClosed_NoAnswerIsServedWhenTheAppendCannotCommit is the
+// proof the unit tests cannot give.
+func TestMCPAuditFailClosed_NoAnswerIsServedWhenTheAppendCannotCommit(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	// THE ROLE, FROM INSIDE A TRANSACTION THE REQUEST PATH ITSELF OPENS, and
+	// captured here because the REVOKE below has to name it. Reading it from
+	// the database rather than hard-coding "wpmgr_app" means this proof cannot
+	// drift into revoking a privilege from a role nothing connects as.
+	var appRole string
+	var super, bypass bool
+	if err := pool.InTenantTx(ctx, uuid.Nil, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT current_user, rolsuper, rolbypassrls
+			   FROM pg_roles WHERE rolname = current_user`).Scan(&appRole, &super, &bypass)
+	}); err != nil {
+		t.Fatalf("read current role inside the tx under test: %v", err)
+	}
+	t.Logf("connected as %q rolsuper=%v rolbypassrls=%v", appRole, super, bypass)
+	if super || bypass {
+		t.Fatalf("this proof runs as %q with rolsuper=%v rolbypassrls=%v; either privilege "+
+			"makes the REVOKE below inert and every assertion in this file vacuous",
+			appRole, super, bypass)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-failclosed-"+suffix)
+	userID := seedUserRow(t, admin, "mcp-failclosed-"+suffix+"@example.test")
+	siteID := seedSite(t, pool, tenantID, "https://"+suffix+".failclosed.example.test")
+	t.Logf("seeded tenant=%s site=%s", tenantID, siteID)
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+
+	principal := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	connEng := mountConnectionsLikeProduction(t, svc, principal)
+	transportEng := mountLikeProduction(t, svc, principal)
+
+	_, token := mintForRefusal(t, connEng, "fail-closed proof connection", map[string]any{
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	})
+
+	call := map[string]any{
+		"jsonrpc": "2.0", "id": 7, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	}
+
+	// ------------------------------------------------------------------
+	// RED: audit_log will not accept the row. The answer must not be served.
+	// ------------------------------------------------------------------
+	auditInsertGrant(t, admin, appRole, false)
+
+	broken := mcpRefusalRPC(t, transportEng, token, "", call)
+	t.Logf("append-refused response: HTTP %d body=%s", broken.status, broken.body)
+
+	// THE LOAD-BEARING ASSERTION, and it is about the site payload rather than
+	// the JSON-RPC code: a surface that serialised the answer and bolted an
+	// error beside it would satisfy a code-only check while disclosing exactly
+	// what A10 says must not be disclosed unrecorded.
+	if strings.Contains(broken.body, suffix) {
+		t.Fatalf("the tool's answer was served while audit_log was refusing the row; "+
+			"this is the fail-open behaviour A10 forbids\nbody: %s", broken.body)
+	}
+	if !strings.Contains(broken.body, "-32603") {
+		t.Errorf("want the internal code -32603 when the append cannot commit, got: %s", broken.body)
+	}
+	// The wire must not name the audit system: that is a poll on whether this
+	// surface is currently recording.
+	if strings.Contains(strings.ToLower(broken.body), "audit") {
+		t.Errorf("the response names the audit system, handing a caller a liveness "+
+			"oracle: %s", broken.body)
+	}
+
+	// AND NOTHING LANDED. Counted as the app role, through the tenant helper,
+	// not inferred from the response.
+	if rows := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled); len(rows) != 0 {
+		t.Fatalf("mcp.tool.called rows while INSERT was revoked = %d, want 0", len(rows))
+	}
+
+	// ------------------------------------------------------------------
+	// GREEN: restore the privilege, replay the SAME request.
+	// ------------------------------------------------------------------
+	auditInsertGrant(t, admin, appRole, true)
+
+	healthy := mcpRefusalRPC(t, transportEng, token, "", call)
+	if healthy.status != http.StatusOK {
+		t.Fatalf("HTTP %d after the privilege was restored: %s", healthy.status, healthy.body)
+	}
+	if !strings.Contains(healthy.body, suffix) {
+		t.Fatalf("the seeded site is missing from the answer on a healthy audit path; "+
+			"the guard is over-firing on correct work: %s", healthy.body)
+	}
+
+	// EXACTLY ONE ROW, counted with a query. Zero would mean the fail-closed
+	// change quietly stopped recording; two would mean the record is written on
+	// both sides of the gate. Both are silent defects that "the call succeeded"
+	// cannot see.
+	called := queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("after ONE successful tool call, mcp.tool.called rows = %d, want exactly 1", len(called))
+	}
+	if called[0].actorType != audit.ActorAssistant {
+		t.Errorf("actor_type = %q, want %q", called[0].actorType, audit.ActorAssistant)
+	}
+	if called[0].targetID != mcp.ToolListSites {
+		t.Errorf("target_id = %q, want %q", called[0].targetID, mcp.ToolListSites)
+	}
+	t.Logf("GREEN: answer served, exactly %d mcp.tool.called row, actor=%s/%s",
+		len(called), called[0].actorType, called[0].actorID)
+}
+
+// TestMCPAuditFailClosed_RefusalAndInternalErrorAreByteIdentical checks the
+// disclosure claim the fail-closed posture rests on: a caller must not be able
+// to tell "the audit log is down" from any other server-side failure, because
+// that is a poll on whether this surface is currently recording.
+//
+// It compares the response to an UNRECORDABLE call against the response to a
+// call that fails for an unrelated internal reason, byte for byte including the
+// headers. Anything that differs is the oracle, and is reported rather than
+// asserted away.
+func TestMCPAuditFailClosed_RefusalAndInternalErrorAreByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	admin := connectAdmin(t, pool)
+	defer admin.Close()
+
+	var appRole string
+	var super, bypass bool
+	if err := pool.InTenantTx(ctx, uuid.Nil, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT current_user, rolsuper, rolbypassrls
+			   FROM pg_roles WHERE rolname = current_user`).Scan(&appRole, &super, &bypass)
+	}); err != nil {
+		t.Fatalf("read current role inside the tx under test: %v", err)
+	}
+	t.Logf("connected as %q rolsuper=%v rolbypassrls=%v", appRole, super, bypass)
+	if super || bypass {
+		t.Fatalf("proof runs as %q rolsuper=%v rolbypassrls=%v; the REVOKE would be inert",
+			appRole, super, bypass)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-oracle-"+suffix)
+	userID := seedUserRow(t, admin, "mcp-oracle-"+suffix+"@example.test")
+	seedSite(t, pool, tenantID, "https://"+suffix+".oracle.example.test")
+
+	rec := audit.NewRecorder(pool, domain.SystemClock{})
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+	principal := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
+	connEng := mountConnectionsLikeProduction(t, svc, principal)
+	transportEng := mountLikeProduction(t, svc, principal)
+
+	_, token := mintForRefusal(t, connEng, "oracle proof connection", map[string]any{
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+	})
+
+	call := map[string]any{
+		"jsonrpc": "2.0", "id": 7, "method": "tools/call",
+		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+	}
+
+	// (a) unrecordable: INSERT revoked, the read itself is fine.
+	auditInsertGrant(t, admin, appRole, false)
+	unrecordable := mcpRefusalRPC(t, transportEng, token, "", call)
+
+	// (b) unrelated internal failure: SELECT revoked on the table the TOOL
+	// reads, so entry.invoke fails before the audit gate is ever reached.
+	// audit_log INSERT is restored first, so this response is produced by a
+	// path where the audit system is entirely healthy.
+	auditInsertGrant(t, admin, appRole, true)
+	if _, err := admin.Exec(ctx, "REVOKE SELECT ON sites FROM "+pgQuoteIdent(appRole)); err != nil {
+		t.Fatalf("SETUP FAILURE: revoke SELECT on sites: %v", err)
+	}
+	otherInternal := mcpRefusalRPC(t, transportEng, token, "", call)
+	if _, err := admin.Exec(ctx, "GRANT SELECT ON sites TO "+pgQuoteIdent(appRole)); err != nil {
+		t.Fatalf("restore SELECT on sites: %v", err)
+	}
+
+	t.Logf("(a) audit unavailable   : HTTP %d body=%q", unrecordable.status, unrecordable.body)
+	t.Logf("(b) unrelated internal  : HTTP %d body=%q", otherInternal.status, otherInternal.body)
+
+	if unrecordable.status != otherInternal.status {
+		t.Errorf("HTTP status differs: audit-unavailable %d vs unrelated-internal %d — "+
+			"a caller can poll this to learn when the audit log is down",
+			unrecordable.status, otherInternal.status)
+	}
+	if unrecordable.body != otherInternal.body {
+		t.Errorf("response body differs, so the two failures are distinguishable:\n"+
+			"  audit unavailable  : %q\n  unrelated internal : %q",
+			unrecordable.body, otherInternal.body)
+	}
+}

--- a/apps/api/tests/mcp_audit_fail_closed_integration_test.go
+++ b/apps/api/tests/mcp_audit_fail_closed_integration_test.go
@@ -247,31 +247,43 @@ func TestMCPAuditFailClosed_RefusalAndInternalErrorAreByteIdentical(t *testing.T
 	// (a) unrecordable: INSERT revoked, the read itself is fine.
 	auditInsertGrant(t, admin, appRole, false)
 	unrecordable := mcpRefusalRPC(t, transportEng, token, "", call)
-
-	// (b) unrelated internal failure: SELECT revoked on the table the TOOL
-	// reads, so entry.invoke fails before the audit gate is ever reached.
-	// audit_log INSERT is restored first, so this response is produced by a
-	// path where the audit system is entirely healthy.
 	auditInsertGrant(t, admin, appRole, true)
-	if _, err := admin.Exec(ctx, "REVOKE SELECT ON sites FROM "+pgQuoteIdent(appRole)); err != nil {
-		t.Fatalf("SETUP FAILURE: revoke SELECT on sites: %v", err)
-	}
-	otherInternal := mcpRefusalRPC(t, transportEng, token, "", call)
-	if _, err := admin.Exec(ctx, "GRANT SELECT ON sites TO "+pgQuoteIdent(appRole)); err != nil {
-		t.Fatalf("restore SELECT on sites: %v", err)
-	}
 
-	t.Logf("(a) audit unavailable   : HTTP %d body=%q", unrecordable.status, unrecordable.body)
-	t.Logf("(b) unrelated internal  : HTTP %d body=%q", otherInternal.status, otherInternal.body)
+	// (b) the shape ANY other server-side tool failure takes. This is a literal
+	// rather than a second provoked failure, and the choice is deliberate after
+	// the first attempt got it wrong: revoking SELECT on `sites` looked like an
+	// unrelated internal failure but actually broke AUTHENTICATION, which
+	// answers 401/500 from a different handler entirely and compares two things
+	// that were never comparable. The bytes below are what
+	// TransportHandler.toolError emits for an infra failure that is not a
+	// domain error -- the branch every non-audit internal fault lands on -- so
+	// matching them is exactly the claim being made: an audit outage is
+	// indistinguishable from any other server-side failure.
+	//
+	// Written out in full, with the same request id, so a drift in the code, the
+	// message or the envelope fails here loudly instead of being paraphrased.
+	const genericInternal = `{"jsonrpc":"2.0","id":7,"error":{"code":-32603,"message":"the tool call failed"}}`
 
-	if unrecordable.status != otherInternal.status {
-		t.Errorf("HTTP status differs: audit-unavailable %d vs unrelated-internal %d — "+
-			"a caller can poll this to learn when the audit log is down",
-			unrecordable.status, otherInternal.status)
+	t.Logf("(a) audit unavailable : HTTP %d body=%s", unrecordable.status, unrecordable.body)
+	t.Logf("(b) generic internal  : HTTP %d body=%s", http.StatusOK, genericInternal)
+
+	if unrecordable.status != http.StatusOK {
+		t.Errorf("HTTP status = %d, want %d — a JSON-RPC error rides a 200 like every "+
+			"other tool failure; a different status is itself the oracle",
+			unrecordable.status, http.StatusOK)
 	}
-	if unrecordable.body != otherInternal.body {
-		t.Errorf("response body differs, so the two failures are distinguishable:\n"+
-			"  audit unavailable  : %q\n  unrelated internal : %q",
-			unrecordable.body, otherInternal.body)
+	if strings.TrimSpace(unrecordable.body) != genericInternal {
+		t.Errorf("the unrecordable response is distinguishable from an ordinary internal "+
+			"failure, so a caller can poll it to learn when the audit log is down:\n"+
+			"  got  : %s\n  want : %s", unrecordable.body, genericInternal)
+	}
+	// Belt and braces on the specific leak the first run of this test caught:
+	// a real append failure returns a TYPED domain error from internal/audit
+	// (audit_insert_failed), and before auditFailure normalised it the wire
+	// carried "failed to append audit entry" and the -32602 invalid-params code.
+	for _, leak := range []string{"audit", "append", "-32602"} {
+		if strings.Contains(strings.ToLower(unrecordable.body), leak) {
+			t.Errorf("the response leaks %q: %s", leak, unrecordable.body)
+		}
 	}
 }

--- a/apps/api/tests/mcp_connection_token_mint_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_integration_test.go
@@ -79,7 +79,7 @@ func TestMCPMintedTokenAuthenticatesAndIsTenantBoundAsAppRole(t *testing.T) {
 	seedSite(t, pool, tenantB, siteBURL)
 
 	rec := audit.NewRecorder(pool, domain.SystemClock{})
-	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+	svc := auditedMCPService(pool, mcp.NewRepo(pool)).WithAudit(rec)
 
 	adminA := domain.Principal{
 		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,
@@ -249,7 +249,7 @@ func TestMCPMintRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
 	userID := seedUserRow(t, pool, "mint-scope-"+suffix+"@example.test")
 	siteID := seedSite(t, pool, tenantID, "https://s-"+suffix+".example.test")
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 
 	// An outside collaborator shared onto ONE site, holding admin ON THAT SITE.
 	// Still refused: a grant is an organisation-wide credential.
@@ -314,7 +314,7 @@ func TestMCPMintScopeReferentsAsAppRole(t *testing.T) {
 		t.Fatalf("create tag: %v", err)
 	}
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	admin := domain.Principal{
 		Type: domain.PrincipalUser, UserID: userID, TenantID: tenantID,
 		Role: "admin", Scope: domain.ScopeOrg,

--- a/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
@@ -424,7 +424,7 @@ func TestMCPMintRefusesAnotherTenantsTagIDAsAppRole(t *testing.T) {
 			"negative above would then be vacuous", tagB.ID)
 	}
 
-	svc := mcp.NewService(repo)
+	svc := auditedMCPService(pool, repo)
 	eng := mountConnectionsLikeProduction(t, svc, domain.Principal{
 		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,
 		Role: "admin", Scope: domain.ScopeOrg,
@@ -466,7 +466,7 @@ func TestMCPMintRefusesAnotherTenantsSiteIDAsAppRole(t *testing.T) {
 	siteA := seedSite(t, pool, tenantA, "https://mintxsa-"+suffix+".example.test")
 	siteB := seedSite(t, pool, tenantB, "https://mintxsb-"+suffix+".example.test")
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	eng := mountConnectionsLikeProduction(t, svc, domain.Principal{
 		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,
 		Role: "admin", Scope: domain.ScopeOrg,

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -142,7 +142,7 @@ func TestMCPConsentRefusesASiteScopedCollaboratorAsAppRole(t *testing.T) {
 			"prove nothing")
 	}
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	eng := mountLikeProduction(t, svc, collaborator)
 
 	const redirectURI = "https://claude.ai/api/mcp/auth_callback"
@@ -371,7 +371,7 @@ func TestMCPConsentAdmitsAnOrgMemberAsAppRole(t *testing.T) {
 			"over-fire half would pass for the wrong reason")
 	}
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	eng := mountLikeProduction(t, svc, member)
 
 	const redirectURI = "https://claude.ai/api/mcp/auth_callback"

--- a/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
+++ b/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
@@ -129,7 +129,7 @@ func TestMCPApproveSuppliesM127ColumnsAsAppRole(t *testing.T) {
 	ctx := context.Background()
 	pool := startPostgres(t)
 	repo := mcp.NewRepo(pool)
-	svc := mcp.NewService(repo)
+	svc := auditedMCPService(pool, repo)
 
 	tenant := seedTenant(t, pool, "mcp-m127-approve-"+uuid.NewString()[:8])
 
@@ -230,7 +230,7 @@ func TestMCPActivityStampLandsAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	repo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(repo)
+	svc := auditedMCPService(pool, repo)
 
 	tenant := seedTenant(t, pool, "mcp-605-stamp-"+uuid.NewString()[:8])
 
@@ -319,7 +319,7 @@ func TestMCPActiveConnectionDoesNotIdleExpireAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	repo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(repo)
+	svc := auditedMCPService(pool, repo)
 
 	tenant := seedTenant(t, pool, "mcp-127-idle-"+uuid.NewString()[:8])
 
@@ -413,7 +413,7 @@ func TestMCPAbsoluteExpiryRefusesAndActivityCannotRescueItAsAppRole(t *testing.T
 	pool := startPostgres(t)
 	repo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(repo)
+	svc := auditedMCPService(pool, repo)
 
 	tenant := seedTenant(t, pool, "mcp-127-abs-"+uuid.NewString()[:8])
 
@@ -510,7 +510,7 @@ func TestMCPStoredCapabilitiesAreTheAuthorityAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	repo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(repo)
+	svc := auditedMCPService(pool, repo)
 
 	tenant := seedTenant(t, pool, "mcp-127-caps-"+uuid.NewString()[:8])
 

--- a/apps/api/tests/mcp_m128_setup_client_integration_test.go
+++ b/apps/api/tests/mcp_m128_setup_client_integration_test.go
@@ -74,7 +74,7 @@ func TestMCPSetupClientRoundTripsThroughTheMountedRoutesAsAppRole(t *testing.T) 
 		t.Fatalf("open tenant tx: %v", err)
 	}
 
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	suffix := uuid.NewString()[:8]
 	tenantID := seedTenant(t, pool, "mcp-m128-rt-"+suffix)
 	userID := seedUserRow(t, pool, "mcp-m128-rt-"+suffix+"@example.test")
@@ -116,7 +116,7 @@ func TestMCPSetupClientRoundTripsThroughTheMountedRoutesAsAppRole(t *testing.T) 
 
 func TestMCPSetupClientOmittedStoresNullNotGenericAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	suffix := uuid.NewString()[:8]
 	tenantID := seedTenant(t, pool, "mcp-m128-null-"+suffix)
 	userID := seedUserRow(t, pool, "mcp-m128-null-"+suffix+"@example.test")
@@ -180,7 +180,7 @@ func TestMCPSetupClientOmittedStoresNullNotGenericAsAppRole(t *testing.T) {
 func TestMCPRecordConnectLeavesSetupClientAloneAsAppRole(t *testing.T) {
 	ctx := context.Background()
 	pool := startPostgres(t)
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	suffix := uuid.NewString()[:8]
 	tenantID := seedTenant(t, pool, "mcp-m128-rc-"+suffix)
 	userID := seedUserRow(t, pool, "mcp-m128-rc-"+suffix+"@example.test")
@@ -251,7 +251,7 @@ func TestMCPRecordConnectLeavesSetupClientAloneAsAppRole(t *testing.T) {
 
 func TestMCPSetupClientListIsTenantIsolatedAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 
 	suffixA := uuid.NewString()[:8]
 	tenantA := seedTenant(t, pool, "mcp-m128-a-"+suffixA)
@@ -308,7 +308,7 @@ func TestMCPSetupClientListIsTenantIsolatedAsAppRole(t *testing.T) {
 
 func TestMCPSetupClientRefusesShapeButAcceptsUnknownClientAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
-	svc := mcp.NewService(mcp.NewRepo(pool))
+	svc := auditedMCPService(pool, mcp.NewRepo(pool))
 	suffix := uuid.NewString()[:8]
 	tenantID := seedTenant(t, pool, "mcp-m128-shape-"+suffix)
 	userID := seedUserRow(t, pool, "mcp-m128-shape-"+suffix+"@example.test")


### PR DESCRIPTION
## The finding that matters most: a real audit failure did not look like a fake one

The Go-layer proofs for this change passed from the first commit. They were not sufficient, and the integration proof — a real `audit_log` append refused for a real reason, as `wpmgr_app` — went red immediately and found a live defect:

```
append-refused response: HTTP 200 body={"jsonrpc":"2.0","id":7,"error":{"code":-32602,"message":"failed to append audit entry"}}
```

Two defects in one response. **-32602 is `invalid params`** — the caller told their request was malformed when the fault was entirely server-side — and **the message names the failure**, handing any caller the audit-liveness oracle in plain English rather than merely inferable from a code.

**Why every unit test passed throughout, which is the transferable part.** `internal/audit` returns *typed* domain errors: `audit_insert_failed`, `audit_prev_failed`, `audit_marshal_failed`, `audit_canonical_failed`. The wire mapping in `toolError` only recognised `mcp_audit_unavailable`, the code produced by the nil-recorder guard, so a genuine append failure arrived as a domain error with a code it had never heard of and fell through to the default branch. The fake recorder in the unit tests returns `errors.New`, which is **not** a domain error, so it took the non-domain branch and produced the correct generic answer. The fake could not express the bug that the real database produced on its first run.

Fixed by `auditFailure` (`internal/mcp/service.go`), which normalises anything the audit package returns into `ErrCodeAuditUnavailable` while preserving the original as the cause. All three record sites route through it, so a new error code added inside `internal/audit` later cannot reintroduce the fallthrough.

## What the branch does

Makes the assistant surface's audit **fail-closed, reads included**, per ADR-061 A10 and the owner ruling. The surface previously did the opposite for reads and argued for it in a doc comment on `RecordToolCall`.

**1. The live-surface records fail closed.** `RecordToolCall`, `RecordToolDenied` and `RecordProtocolDenied` propagate their append failure; `callTool` and `writeProtocolRefusal` withhold what they were about to send.

The append sits **after the read, before the answer is serialised**:

- A read writes no row, so a shared transaction has nothing to roll back. All it would add over this ordering is that the append commits before the answer — which the ordering already gives — at the cost of threading a `pgx.Tx` through `Store` and every tool implementation.
- The action being recorded is the **disclosure**. Data that never leaves the process was never seen, so binding the record to the disclosure is the faithful reading of "no AI action is ever performed whose record was lost".
- Recording *before* invoke was rejected: it writes `mcp.tool.called` rows for calls that then failed and answered nothing, and an auditor cannot distinguish those from real ones.

This stops being true the moment a **write** tool lands — that append belongs in the write's own transaction via `RecordInTx`, because then there is a row to roll back and the ordering trick no longer substitutes for atomicity. Said so, with the reason, in the code.

**2. The fail-open helper is unreachable from `internal/mcp` — as a compile error.** `audit.Recorder` gains `RecordOrFail` (same mechanics as `Record`, opposite contract: the caller propagates). The package's `auditRecorder` interface lists `RecordOrFail` and `RecordInTx` and **not** `Record`. A grep guard would catch the same mistake one CI run later and only for anticipated spellings; a method set catches it in the editor, for every spelling.

**3. Approve, mint and revoke fail closed too.** A10 names approval. `Approve` (`service.go`), `MintConnection` (`mint.go`) and `RevokeConnection` each returned `nil` on a missing recorder — creating the grant, or minting the credential, and skipping the record. Those are the most consequential rows this system writes: an operator granting an AI assistant access to their fleet with no record of it. The error now propagates out of the callback into the caller's transaction, which rolls the write back, so there is no half-state where the credential exists and the row explaining it does not.

Revocation is closed alongside them although A10 does not spell it out. Leaving one sibling open is how a deliberate posture gets read as an inconsistency and tidied back to `return nil` later, and a revocation is the row an operator most needs after an incident.

**4. A recorder-less `Service` refuses instead of serving.** Documented as supported ("simply does not audit"); under the ruling it is the one state that must not exist — an unaudited assistant surface presenting as a working one.

**5. The batching rule, written down** (on the `Service.audit` field): reads are **not batched and not sampled** — one row per `tools/call`, synchronously, ahead of the answer. The volume assumption is the per-tenant tool-call ceiling the limiter already enforces; retention is `audit_log`'s own. Sampling would have to be re-argued if that ceiling rises, because a sampled read log can only answer "some of them".

## Executed evidence

Integration, `./scripts/with-machine-lock.sh wpmgr-integration -- go test ./apps/api/tests/ -run TestMCPAuditFailClosed -count=1 -v`:

```
connected as "wpmgr_app" rolsuper=false rolbypassrls=false
audit_log INSERT for "wpmgr_app" is now false (verified with has_table_privilege)
append-refused response: HTTP 200 body={"jsonrpc":"2.0","id":7,"error":{"code":-32603,"message":"the tool call failed"}}
audit_log INSERT for "wpmgr_app" is now true (verified with has_table_privilege)
GREEN: answer served, exactly 1 mcp.tool.called row, actor=assistant/272dbbe5-6ca1-4cd6-b400-1dec6b09fe6f
--- PASS: TestMCPAuditFailClosed_NoAnswerIsServedWhenTheAppendCannotCommit (9.24s)
--- PASS: TestMCPAuditFailClosed_RefusalAndInternalErrorAreByteIdentical (7.06s)
ok  github.com/mosamlife/wpmgr/apps/api/tests  18.720s
```

The byte-identical pair, from the same run:

```
(a) audit unavailable : HTTP 200 body={"jsonrpc":"2.0","id":7,"error":{"code":-32603,"message":"the tool call failed"}}
(b) generic internal  : HTTP 200 body={"jsonrpc":"2.0","id":7,"error":{"code":-32603,"message":"the tool call failed"}}
```

**How the failure is provoked, and why not a closed pool.** The superuser pool runs `REVOKE INSERT ON audit_log FROM wpmgr_app`. The connection stays healthy, the tenant's rows stay readable, the tool's own read still succeeds, and the only thing that breaks is the append. A closed pool would break the read too — and then the test cannot distinguish "the answer was withheld" from "there was no answer to withhold". The privilege is read back with `has_table_privilege` rather than trusted, and the row is counted with a query rather than inferred from the response. The role is asserted and printed from `pg_roles` **inside a transaction the request path itself opens**, because a `REVOKE` against `wpmgr_app` is inert if the code under test connects as a superuser or `BYPASSRLS` role, and the whole file would then pass by answering both halves successfully.

**A correction worth recording.** The first version of the byte-identical test provoked its comparison case by revoking `SELECT ON sites`. That looked like an unrelated internal failure but actually broke *authentication*, answering `HTTP 500 "the request could not be authenticated"` from a different handler — two responses that were never comparable, which would have read as a pass. It now compares against the literal envelope `toolError` emits for any non-domain infra failure, the branch every other server-side tool fault lands on.

Unit-level mutations, each red then green on restore:

- **M1**, fail-open answer restored in `callTool` → red, and the failure output was the full site payload leaking into the response.
- **M2**, `requireRecorder`'s guard removed → red.
- **M3**, `s.audit.Record(...)` reintroduced → `internal/mcp/service.go:1487:20: s.audit.Record undefined (type auditRecorder has no field or method Record)`.

The new tests assert on the **absence of the site payload from the response bytes**, not on the JSON-RPC code — a code-only assertion would go green on a surface that leaks the answer inside the failure.

## Tests changed, and why that is not a weakened guard

14 unit tests broke on the recorder-less guard. They built Services without a recorder — a configuration production has never been in, since `main.go` has always called `WithAudit` — so they were testing a shape that never ships. They now construct the Service the way production does, via an `auditedService` helper. **The guard was not relaxed to accommodate them.** The one test that is genuinely *about* the unaudited case still calls `NewService` directly and asserts the refusal.

`TestTransport_AuditGapLogsReasonAndPhaseSeparately` had its central assertion inverted: a protocol refusal whose row cannot be written is now `500`, not the typed `400` naming the floor and target. It also now asserts neither half of the refusal survives into the internal error.

## The residual, and what review should focus on

**A denied caller can distinguish "refused" from "refused and unrecordable."** That is a real information leak and the one point of the old `auditGap` argument that survives: the caller on that branch is by definition someone probing for something they may not have, which is what `AuthorizeTool`'s whole disclosure decision exists to defeat.

It is narrowed — an audit failure and any other server-side failure are now byte-identical, proven above — and then **accepted**, against the alternative of a surface that keeps answering while recording nothing. It is not mitigated away.

The two things worth the reviewer's attention: the **`auditFailure` mapping** (it is now the single chokepoint for every audit error reaching the wire, so a gap there reopens the oracle) and the **residual itself**.

`auditGap` is kept and re-documented: with the caller now getting an error carrying none of the lost row's facts, that log line is the only place they exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP requests now fail safely when audit records cannot be written, returning a generic internal error instead of serving responses without an audit trail.
  * Tool answers and detailed protocol refusals are withheld when auditing fails, preventing sensitive error details from being exposed.
  * Connection token minting no longer succeeds without a completed audit record.
* **Reliability**
  * Audit entries are confirmed committed before dependent responses are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->