### PR TITLE
fix(mcp): populate stored capability set on the connections list

### DIFF
--- a/apps/api/internal/mcp/connections_test.go
+++ b/apps/api/internal/mcp/connections_test.go
@@ -670,3 +670,74 @@ func newConnectionsRouter(t *testing.T, store Store, p domain.Principal) *gin.En
 	NewHandler(NewService(store)).RegisterConnections(g)
 	return eng
 }
+
+// ---------------------------------------------------------------------------
+// PROOF 8 -- GH #652. THE LISTED CAPABILITY SET IS THE STORED ONE, EXACTLY,
+// FOR A GRANT HOLDING MORE THAN THE DEFAULT.
+//
+// Until the capability vocabulary widened to eight strings every grant held
+// exactly {mcp.sites.read}, so an omitted field here was indistinguishable
+// from a correct one -- there was only ever one answer. This grant carries
+// three, in a deliberately non-alphabetical, non-insertion-order column value,
+// so a test that happened to pass on a coincidental ordering would not be
+// mistaken for one that reads the column.
+//
+// This runs through the MOUNTED HANDLER, not connectionFromGrant directly, so
+// it also proves toConnectionDTO does not drop the field on the way to JSON.
+// ---------------------------------------------------------------------------
+
+func TestListedCapabilitiesAreTheStoredSetExactlyForANonDefaultGrant(t *testing.T) {
+	tenantID := uuid.New()
+	stored := []string{
+		string(CapPerformanceRead),
+		string(CapSitesRead),
+		string(CapUptimeRead),
+	}
+	store := &fakeStore{grants: []sqlc.McpGrant{
+		{
+			ID:            uuid.New(),
+			Name:          "ci runner",
+			Status:        string(GrantStatusActive),
+			SiteScopeMode: string(SiteScopeModeAll),
+			Capabilities:  stored,
+		},
+	}}
+	eng := newConnectionsRouter(t, store, orgPrincipal(tenantID))
+
+	w := httptest.NewRecorder()
+	eng.ServeHTTP(w, httptest.NewRequest(http.MethodGet, ConnectionsPath, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list answered %d, want 200. body: %s", w.Code, w.Body.String())
+	}
+
+	var got connectionListDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("list body did not decode: %v. body: %s", err, w.Body.String())
+	}
+	if len(got.Connections) != 1 {
+		t.Fatalf("got %d connections, want 1", len(got.Connections))
+	}
+
+	gotCaps := got.Connections[0].Capabilities
+	if len(gotCaps) != len(stored) {
+		t.Fatalf("listed %d capabilities %v, want the %d stored ones %v",
+			len(gotCaps), gotCaps, len(stored), stored)
+	}
+	want := map[string]bool{}
+	for _, c := range stored {
+		want[c] = true
+	}
+	for _, c := range gotCaps {
+		if !want[c] {
+			t.Errorf("listed capability %q was never in the stored set %v", c, stored)
+		}
+		delete(want, c)
+	}
+	if len(want) != 0 {
+		remaining := make([]string, 0, len(want))
+		for c := range want {
+			remaining = append(remaining, c)
+		}
+		t.Errorf("stored capabilities %v never made it to the wire", remaining)
+	}
+}

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -170,7 +170,21 @@ type connectionDTO struct {
 	Status        string   `json:"status"`
 	SiteScopeMode string   `json:"site_scope_mode"`
 	Scopes        []string `json:"scopes"`
-	CreatedAt     string   `json:"created_at"`
+
+	// Capabilities is the RAW STORED VOCABULARY -- "mcp.sites.read" and its
+	// seven siblings, not a human label. GH #652: the consent screen and the
+	// connect wizard already treat this vocabulary as opaque wire strings the
+	// FRONTEND labels (apps/web/src/features/ai-connections/connect-wizard.tsx
+	// joins token.capabilities verbatim; use-ai-connections.ts's zod schema
+	// already types the mint response's own capabilities as z.array(z.string())).
+	// No label mapping exists on either side of this wire today, so returning
+	// prose here would be a new, undocumented contract, not a reuse of an
+	// existing one -- and a server that returns prose is a server that has to
+	// be redeployed to fix a typo. Non-nil even when empty, matching this
+	// struct's other slice fields: [] on the wire, never null.
+	Capabilities []string `json:"capabilities"`
+
+	CreatedAt string `json:"created_at"`
 
 	// The client's OWN unverified claims. Never defaulted to Name: one is the
 	// client's assertion and the other is the operator's, and the `reported_`
@@ -369,6 +383,7 @@ func toConnectionDTO(c Connection) connectionDTO {
 		Status:                string(c.Status),
 		SiteScopeMode:         string(c.SiteScopeMode),
 		Scopes:                scopes,
+		Capabilities:          capabilityNames(c.Capabilities),
 		CreatedAt:             c.CreatedAt.UTC().Format(time.RFC3339Nano),
 		ReportedClientName:    c.ReportedClientName,
 		ReportedClientVersion: c.ReportedClientVersion,
@@ -378,8 +393,8 @@ func toConnectionDTO(c Connection) connectionDTO {
 		// DECISION 1 exists to refuse.
 		SetupClient: c.SetupClient,
 		Protocol:    proto,
-		LastUsedAt:            isoOrNil(c.LastUsedAt),
-		RevokedAt:             isoOrNil(c.RevokedAt),
+		LastUsedAt:  isoOrNil(c.LastUsedAt),
+		RevokedAt:   isoOrNil(c.RevokedAt),
 	}
 }
 

--- a/apps/api/internal/mcp/model.go
+++ b/apps/api/internal/mcp/model.go
@@ -232,8 +232,20 @@ type Connection struct {
 	SiteScopeMode SiteScopeMode
 	// Scopes is the OAuth scope set. See Service.ListConnections for why this
 	// is currently derived rather than read from the row.
-	Scopes    []Scope
-	CreatedAt time.Time
+	Scopes []Scope
+
+	// Capabilities is READ STRAIGHT OFF mcp_grants.capabilities, the same
+	// column and the same authority Authenticate reads chk.GrantCapabilities
+	// from to decide the `authorized` verdict. It is NOT recomputed from the
+	// scope registry -- that is exactly the mistake m127 DECISION 1 exists to
+	// forbid, because a recomputed set agrees with the stored one only until
+	// they diverge, and a connections list is precisely where an operator goes
+	// to find out whether they have. GH #652: until the capability vocabulary
+	// widened to eight strings, every grant held exactly {mcp.sites.read}, so
+	// an omitted field here was indistinguishable from a correct one. It no
+	// longer is.
+	Capabilities []Capability
+	CreatedAt    time.Time
 
 	// ReportedClientName and ReportedClientVersion are the client's OWN claims,
 	// recorded at connect. They are UNVERIFIED -- registration is

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1641,8 +1641,10 @@ func orEmpty(ids []uuid.UUID) []uuid.UUID {
 //     because an empty result correctly means "no sites" and never "no filter",
 //     every tag-scoped connection would authenticate to nothing. That is
 //     fail-closed and still a total outage of the mode.
+//
 //   - 'all'   -- names no ids. Org-wide IS the intended meaning; a site-scoped
 //     principal here contradicts the stored grant.
+//
 //   - 'list'  -- the allowlist would be exactly the requested ids, so the
 //     policy would intersect the set with itself and could refuse nothing the
 //     query does not already refuse. Zero security gain, and a second copy of
@@ -1873,11 +1875,15 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 // grant instead of a constant.
 func connectionFromGrant(g sqlc.McpGrant) Connection {
 	return Connection{
-		ID:                    g.ID,
-		Name:                  g.Name,
-		Status:                GrantStatus(g.Status),
-		SiteScopeMode:         SiteScopeMode(g.SiteScopeMode),
-		Scopes:                grantScopes(),
+		ID:            g.ID,
+		Name:          g.Name,
+		Status:        GrantStatus(g.Status),
+		SiteScopeMode: SiteScopeMode(g.SiteScopeMode),
+		Scopes:        grantScopes(),
+		// Read straight off the row via capabilitiesFromColumn -- the same
+		// reader Authenticate uses on chk.GrantCapabilities -- and never
+		// recomputed. See Connection.Capabilities.
+		Capabilities:          capabilitiesFromColumn(g.Capabilities),
 		CreatedAt:             g.CreatedAt,
 		ReportedClientName:    g.ClientName,
 		ReportedClientVersion: g.ClientVersion,

--- a/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
+++ b/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
@@ -355,6 +355,99 @@ func TestMCPConnectionsListThroughMountedRouteAsAppRole(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// PROOF 2B -- GH #652. A NON-DEFAULT CAPABILITY SET ROUND-TRIPS EXACTLY,
+// THROUGH THE MOUNTED ROUTE, AS wpmgr_app.
+//
+// TestMCPConnectionsListThroughMountedRouteAsAppRole above only ever produces
+// {mcp.sites.read}: the consent flow it drives has no capability picker yet,
+// so it cannot exercise anything the vocabulary widened to. This proof mints
+// through the SAME headless POST /connections route the wizard's step 2 uses,
+// asking explicitly for three capabilities, and reads them back through the
+// SAME GET the list uses -- as wpmgr_app, inside InTenantTx, never on a
+// connection opened by the test itself. A proof against a hand-rolled
+// connection would pass even if mcp_grants_capabilities_vocabulary_check or
+// the site-scope policy quietly dropped the row this reads.
+// ---------------------------------------------------------------------------
+
+func TestMCPConnectionListsANonDefaultCapabilitySetExactlyAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	if err := pool.InTenantTx(ctx, uuid.New(), func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	suffix := uuid.NewString()[:8]
+	tenantID := seedTenant(t, pool, "mcp-s16-cap-"+suffix)
+	userID := seedUserRow(t, pool, "mcp-s16-cap-"+suffix+"@example.test")
+
+	svc := mcp.NewService(mcp.NewRepo(pool))
+	eng := mountConnectionsLikeProduction(t, svc, adminPrincipal(tenantID, userID))
+
+	// A deliberately non-default, non-alphabetical, more-than-one-member set:
+	// the exact case that was indistinguishable from an omitted field before
+	// the vocabulary widened, and is not any more.
+	wantCaps := []string{
+		string(mcp.CapPerformanceRead),
+		string(mcp.CapSitesRead),
+		string(mcp.CapUptimeRead),
+	}
+	var minted struct {
+		GrantID string `json:"grant_id"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodPost, mcp.ConnectionsPath, map[string]any{
+		"name":            "s16 capability round-trip",
+		"site_scope_mode": string(mcp.SiteScopeModeAll),
+		"capabilities":    wantCaps,
+	}, nil, &minted); code != http.StatusCreated {
+		t.Fatalf("fixture: mint answered %d, want 201", code)
+	}
+	if minted.GrantID == "" {
+		t.Fatal("fixture: mint returned no grant_id")
+	}
+
+	var list struct {
+		Connections []struct {
+			ID           string   `json:"id"`
+			Capabilities []string `json:"capabilities"`
+		} `json:"connections"`
+	}
+	code := mcpDoJSON(t, eng, http.MethodGet, mcp.ConnectionsPath, nil, nil, &list)
+	if code != http.StatusOK {
+		t.Fatalf("list answered %d, want 200", code)
+	}
+	if len(list.Connections) != 1 {
+		t.Fatalf("list returned %d connections, want the 1 just minted", len(list.Connections))
+	}
+	got := list.Connections[0]
+	if got.ID != minted.GrantID {
+		t.Fatalf("listed connection id %q, want the minted %q", got.ID, minted.GrantID)
+	}
+
+	if len(got.Capabilities) != len(wantCaps) {
+		t.Fatalf("listed %d capabilities %v, want the %d requested %v",
+			len(got.Capabilities), got.Capabilities, len(wantCaps), wantCaps)
+	}
+	want := map[string]bool{}
+	for _, c := range wantCaps {
+		want[c] = true
+	}
+	for _, c := range got.Capabilities {
+		if !want[c] {
+			t.Errorf("listed capability %q was never requested (requested %v)", c, wantCaps)
+		}
+		delete(want, c)
+	}
+	for c := range want {
+		t.Errorf("requested capability %q never made it to the list", c)
+	}
+	t.Logf("capability round-trip ok: grant %s, capabilities=%v", got.ID, got.Capabilities)
+}
+
+// ---------------------------------------------------------------------------
 // PROOF 3 -- THE SITE-SCOPE GATE, AT BOTH LAYERS.
 //
 // Constraint 2. mcp_grants_site_scope_select is RESTRICTIVE and refuses by


### PR DESCRIPTION
## Summary
- `connectionFromGrant` (`apps/api/internal/mcp/service.go`) left `Connection.Capabilities` unset, so the connections list rendered no capabilities. Harmless while every grant held exactly `{mcp.sites.read}`; the vocabulary now spans eight strings (seven conferrable), so an omitted field is no longer indistinguishable from a correct one. Filed as GH #652.
- Reads straight off `mcp_grants.capabilities` via the existing `capabilitiesFromColumn` reader — the same one `Authenticate` uses on `chk.GrantCapabilities` — never recomputed from the scope registry (m127's fix).
- Added `capabilities []string` to `connectionDTO` (`apps/api/internal/mcp/dto.go`), populated via the existing `capabilityNames` helper. Raw wire values (`"mcp.sites.read"`, etc.), not prose — the connect wizard and its zod schema already treat this vocabulary as opaque strings the frontend labels; no server-side label mapping exists anywhere in this repo to reuse.

## Sweep of every read path returning a connection
- `GET /api/v1/mcp/connections` (list) — fixed, this PR.
- `GET /api/v1/mcp/connections/:connectionId/status` — the wizard's polling endpoint; returns a separate `connectionStatusDTO` with no capability field at all today, and adding one is a separate, deliberate decision outside this bug's scope (that endpoint answers "is this thing alive", not "what can it do").
- `POST /api/v1/mcp/connections` (mint response) — already correct; `toMintConnectionResponse` has populated `Capabilities` since the mint endpoint shipped.
- There is no single-connection GET/detail route — the list is the only read surface for the full row.

## Contract
This is a hand-written Gin route (`Handler.RegisterConnections`, mounted directly on the `v1` router group in `server.go`), not modelled in `packages/openapi/openapi.yaml` — grep of that file turns up only an unrelated email-connections path. **No OpenAPI regeneration needed.** The frontend has no generated type for this field; `apps/web/src/features/ai-connections/use-ai-connections.ts` hand-writes its own zod schema for this response today, so the frontend can add `capabilities: z.array(z.string())` there directly.

## Proof
- `TestListedCapabilitiesAreTheStoredSetExactlyForANonDefaultGrant` (`apps/api/internal/mcp/connections_test.go`) seeds a grant with a 3-member, non-default, non-alphabetical capability set and reads it back through the mounted handler (not by calling `connectionFromGrant` directly), asserting the exact set.
- Mutation-tested: forced `Capabilities: nil` in `connectionFromGrant`, ran the test — red, naming the missing capabilities (`listed 0 capabilities [], want the 3 stored ones [...]`). Restored, ran again — green. `git grep "MUTATION M" -- apps/api` exits 1 and the tree is clean.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./internal/... ./cmd/...` — green
- [x] Mutation proof (red → green) on the new test
- [ ] `make test-integration` — running separately; will report the real exit status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection listings now include the exact capabilities assigned to each connection.
  * Capability information is preserved as configured, including custom selections and ordering-independent results.

* **Tests**
  * Added coverage confirming non-default capability sets are returned accurately in connection listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->