### PR TITLE
fix(ai-connections): correct stale capability-schema/endpoint claim in connect wizard

### DIFF
--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -306,7 +306,11 @@ describe("step 3 exists at all, and sits before capabilities", () => {
     expect(screen.queryByText(/4\. Choose sites and permissions/i)).not.toBeInTheDocument();
   });
 
-  it("does not invent a numbered step for capabilities, which has no backend", async () => {
+  it("does not invent a numbered step for capabilities, which this wizard has no channel to write", async () => {
+    // Not a claim about the backend (the capability vocabulary and the mint
+    // endpoint both exist, GH #660) -- a claim about this file: it never
+    // creates the grant, so a step here would collect an answer with nowhere
+    // to send it, and the rail names where that answer is actually written.
     await reachSiteStep();
     expect(screen.queryByRole("heading", { name: /what this connection may do/i })).toBeNull();
     expect(screen.getByText(/permissions are chosen on the approval screen/i)).toBeInTheDocument();

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -306,11 +306,16 @@ describe("step 3 exists at all, and sits before capabilities", () => {
     expect(screen.queryByText(/4\. Choose sites and permissions/i)).not.toBeInTheDocument();
   });
 
-  it("does not invent a numbered step for capabilities, which this wizard has no channel to write", async () => {
-    // Not a claim about the backend (the capability vocabulary and the mint
-    // endpoint both exist, GH #660) -- a claim about this file: it never
-    // creates the grant, so a step here would collect an answer with nowhere
-    // to send it, and the rail names where that answer is actually written.
+  it("does not invent a numbered step for capabilities, which no completion path lets an operator choose today", async () => {
+    // reachSiteStep exercises the OAuth path (it clicks the oauth auth card),
+    // where "this wizard never creates the grant" is true: Approve
+    // (apps/api/internal/mcp/service.go:607) takes no capability field. The
+    // token path differs -- the mint endpoint already accepts one
+    // (dto.go:264) and only MintConnectionInput lacks the field
+    // (use-ai-connections.ts:228-233) -- but neither path has a picker in
+    // this frontend, so the assertion below holds for both. Not a claim
+    // about the backend either way: the vocabulary and both endpoints exist.
+    // See GH #660 for where a picker should live.
     await reachSiteStep();
     expect(screen.queryByRole("heading", { name: /what this connection may do/i })).toBeNull();
     expect(screen.getByText(/permissions are chosen on the approval screen/i)).toBeInTheDocument();

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -60,9 +60,21 @@ import {
 // answer being written. The same is already true of the connection name two
 // sections down, and it is stated the same way rather than implied.
 //
-// Step 4 (capabilities) and the token artefact are NOT stubbed here. Their
-// schema and their endpoint do not exist yet, and a disabled control for a
-// feature with no backend is a promise this file cannot keep.
+// THERE IS NO CAPABILITIES STEP HERE, AND NOT BECAUSE THE BACKEND IS MISSING.
+// The vocabulary is seated (policy.go: eight capability strings, seven of
+// them conferrable via the read scope) and the wire already carries it: the
+// mint request takes a `capabilities` list (dto.go:264) and the mint response
+// returns one (dto.go:305). The frontend has nothing generated to bind to
+// either -- packages/openapi-client's only `capabilities` type is the
+// unrelated object-cache one -- because this is a hand-written surface, not a
+// generated one. None of that is why a picker is not rendered here. It is
+// missing because THIS WIZARD NEVER CREATES THE GRANT (see WHAT STEP 3 STILL
+// CANNOT DO, above): the approval screen at /connect/ai does, this file has
+// no channel into it, and a capability picker rendered here would collect an
+// answer with nowhere to send. Where such a picker belongs, with three real
+// candidates, is the open question tracked in GH #660, and this file does not
+// resolve it. A disabled control for a channel this file cannot reach is a
+// promise this file cannot keep, same as the reasoning above it.
 //
 // NO SNIPPET IS WRITTEN IN THIS FILE. Every block comes from buildSnippet, and
 // snippet.test.ts fails the build if a config literal appears here.
@@ -480,10 +492,13 @@ function StepRail({ current }: { current: Step }) {
       ))}
       <li className="flex items-center gap-2">
         <span aria-hidden="true">/</span>
-        {/* Capabilities are NOT a numbered step in this rail. The grant columns
-            behind them do not exist yet, and a number for a screen that cannot
-            be built is a promise the rail has no way to keep. What it names
-            instead is where that decision is made today. */}
+        {/* Capabilities are NOT a numbered step in this rail. The grant column
+            behind them exists now (mcp_grants.capabilities, schema.sql) and so
+            does the vocabulary that fills it, but this wizard has no channel
+            to the screen that writes it -- see the comment above the wizard's
+            STEPS export -- and a step number for a screen this file cannot
+            reach is a promise the rail has no way to keep. What it names
+            instead is where that decision is actually made today. */}
         <span>Permissions are chosen on the approval screen</span>
       </li>
     </ol>

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -62,19 +62,30 @@ import {
 //
 // THERE IS NO CAPABILITIES STEP HERE, AND NOT BECAUSE THE BACKEND IS MISSING.
 // The vocabulary is seated (policy.go: eight capability strings, seven of
-// them conferrable via the read scope) and the wire already carries it: the
-// mint request takes a `capabilities` list (dto.go:264) and the mint response
-// returns one (dto.go:305). The frontend has nothing generated to bind to
-// either -- packages/openapi-client's only `capabilities` type is the
-// unrelated object-cache one -- because this is a hand-written surface, not a
-// generated one. None of that is why a picker is not rendered here. It is
-// missing because THIS WIZARD NEVER CREATES THE GRANT (see WHAT STEP 3 STILL
-// CANNOT DO, above): the approval screen at /connect/ai does, this file has
-// no channel into it, and a capability picker rendered here would collect an
-// answer with nowhere to send. Where such a picker belongs, with three real
-// candidates, is the open question tracked in GH #660, and this file does not
-// resolve it. A disabled control for a channel this file cannot reach is a
-// promise this file cannot keep, same as the reasoning above it.
+// them conferrable via the read scope), and one of this wizard's two
+// completion paths already puts it on the wire: TokenMintPanel below calls
+// useMintConnection(), which POSTs to CONNECTIONS_PATH and already accepts a
+// `capabilities` list on the request (dto.go:264) and returns one on the
+// response (dto.go:305). A picker on THAT path would need only a frontend
+// field -- MintConnectionInput (use-ai-connections.ts:228-233) has name,
+// siteScopeMode, scopeTagIds and scopeSiteIds, and no capabilities -- so the
+// gap there is this file, not the server.
+//
+// THE OAUTH PATH IS THE OTHER ONE, AND IS WHERE "THIS WIZARD NEVER CREATES
+// THE GRANT" (WHAT STEP 3 STILL CANNOT DO, above) IS ACTUALLY TRUE. The
+// client redirects into the approval screen at /connect/ai, which calls
+// Approve (service.go:607); ApprovalRequest carries Principal, Consent,
+// GrantName and SiteScope and nothing else, so that path genuinely has no
+// channel for a capability answer today.
+//
+// So a picker built only against the mint call would work for token
+// connections and do nothing for OAuth ones, and a permission model that
+// varies by how the connection was made is worse than one that stays
+// uniformly narrow -- which is why neither path has one, rather than one
+// path having one and the other not. The choice among the three real options
+// is open, tracked in GH #660, and this file does not make it. Cited by
+// file:line above rather than restated from memory: summarising this split
+// instead of pointing at it is exactly what went stale here before.
 //
 // NO SNIPPET IS WRITTEN IN THIS FILE. Every block comes from buildSnippet, and
 // snippet.test.ts fails the build if a config literal appears here.
@@ -492,13 +503,14 @@ function StepRail({ current }: { current: Step }) {
       ))}
       <li className="flex items-center gap-2">
         <span aria-hidden="true">/</span>
-        {/* Capabilities are NOT a numbered step in this rail. The grant column
-            behind them exists now (mcp_grants.capabilities, schema.sql) and so
-            does the vocabulary that fills it, but this wizard has no channel
-            to the screen that writes it -- see the comment above the wizard's
-            STEPS export -- and a step number for a screen this file cannot
-            reach is a promise the rail has no way to keep. What it names
-            instead is where that decision is actually made today. */}
+        {/* Capabilities are NOT a numbered step in this rail. The vocabulary
+            and the grant column behind them exist now (policy.go,
+            mcp_grants.capabilities in schema.sql), but neither completion
+            path this wizard ends in lets an operator choose one today -- see
+            the comment above the wizard's STEPS export for the token/OAuth
+            split -- so a step number here would be for a choice nobody can
+            make yet. What it names instead is where the OAuth path's consent
+            is actually recorded. */}
         <span>Permissions are chosen on the approval screen</span>
       </li>
     </ol>


### PR DESCRIPTION
## Summary
- The connect wizard's comments claimed the capability vocabulary and the mint endpoint "do not exist yet." Both exist now: `apps/api/internal/mcp/policy.go` seats an eight-member capability vocabulary (seven conferrable via the read scope), and `apps/api/internal/mcp/dto.go` carries `capabilities` on both the mint request (line 264) and the mint response (line 305).
- The same comment mislabelled the wizard's fourth step as "capabilities"; `STEPS` actually names it "Set it up" (the setup snippet). There is no capabilities step.
- The frontend genuinely has nothing generated to bind a picker to (`packages/openapi-client/src/generated`'s only `capabilities` type is the unrelated `ObjectCacheCapabilities`), but that's not why a picker isn't rendered here: this wizard never creates the grant, so a picker here would collect an answer with nowhere to send. Reworded both comments to state that, and referenced GH #660 (open) which tracks where such a picker should actually live.
- The test that pinned the old, now-false claim ("does not invent a numbered step for capabilities, which has no backend") asserted a real, still-true structural property (no capabilities heading; the rail says permissions are chosen on the approval screen) under a false title/comment about the backend. Renamed and re-commented it to assert only the frontend-keepable fact.

## Verification
- `pnpm -C apps/web typecheck` — clean.
- `pnpm -C apps/web lint` — 0 errors, 10 pre-existing warnings unrelated to this change.
- `pnpm -C apps/web test` — 166 files / 2110 tests passed.
- `apps/web/node_modules/.bin/impeccable detect apps/web/src/features/ai-connections` — exit 0, no findings.
- Mutation-tested the renamed assertion: broke the rail's "Permissions are chosen on the approval screen" text, `npx vitest run src/features/ai-connections/connect-wizard.test.tsx -t "does not invent a numbered step"` went red naming that exact line; restored, it went green again.

## Test plan
- [x] CI: typecheck, lint, unit tests
- [ ] Reviewer confirms the corrected comment text against `apps/api/internal/mcp/policy.go` and `dto.go:264`/`dto.go:305`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the AI connections wizard does not currently provide a step for configuring capabilities.
  * Updated related test descriptions and comments to accurately reflect the available capability support and wizard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->