### PR TITLE
web: render AI connection capabilities on the connections list

### DIFF
--- a/apps/web/src/features/ai-connections/capabilities.test.ts
+++ b/apps/web/src/features/ai-connections/capabilities.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+
+import { capabilityLabel, KNOWN_CAPABILITIES } from "./capabilities";
+
+// KNOWN_CAPABILITIES is DERIVED from CAPABILITY_LABELS's keys (see the file
+// header), so there is no longer a second list a mutation could add a name to
+// without also adding it here -- that failure mode is structurally impossible
+// rather than merely tested for, and a test asserting the two agree would be
+// tautological (they are the same object read two ways). What is left to test
+// is the behaviour capabilityLabel actually promises.
+
+describe("capabilityLabel", () => {
+  it("labels every name in the known vocabulary", () => {
+    // Not hardcoding the set: walks whatever KNOWN_CAPABILITIES actually is.
+    for (const cap of KNOWN_CAPABILITIES) {
+      const label = capabilityLabel(cap);
+      expect(label.length).toBeGreaterThan(0);
+      // A known capability gets an actual label, not its own wire string back
+      // -- that fallback is reserved for names outside the vocabulary.
+      expect(label).not.toBe(cap);
+    }
+  });
+
+  it("falls back to the raw wire string for a capability this build does not know", () => {
+    // The property #652 was filed over, preserved: an unrecognised name the
+    // server actually stored still renders, as itself, rather than being
+    // dropped or replaced with a generic "unknown" placeholder.
+    expect(capabilityLabel("mcp.not.a.real.capability")).toBe("mcp.not.a.real.capability");
+  });
+});

--- a/apps/web/src/features/ai-connections/capabilities.ts
+++ b/apps/web/src/features/ai-connections/capabilities.ts
@@ -10,20 +10,21 @@
 // about a stored grant. capabilityLabel below preserves that property -- an
 // unrecognised string still renders, as itself, rather than being silently
 // dropped or replaced with "unknown".
-
-/** The eight names policy.go's capabilityVocabulary knows today. */
-export const KNOWN_CAPABILITIES: readonly string[] = [
-  "mcp.sites.read",
-  "mcp.uptime.read",
-  "mcp.backups.read",
-  "mcp.security.read",
-  "mcp.activity.read",
-  "mcp.performance.read",
-  "mcp.diagnostics.read",
-  "mcp.content.read",
-];
-
-const CAPABILITY_LABELS: Readonly<Record<string, string>> = {
+//
+// THERE IS EXACTLY ONE LIST, NOT TWO. A review on #652 caught that an earlier
+// version of this file wrote KNOWN_CAPABILITIES and CAPABILITY_LABELS out
+// separately, so the picker in #660 could update one and silently leave the
+// other stale -- the same shape that let scopeCapabilities and
+// capabilityVocabulary disagree in policy.go (tracked there as #653) and that
+// let the Go vocabulary and the database CHECK disagree until m131 pinned them
+// against each other. Restating a runtime test that compares two lists would
+// only re-add the second list one file over. Instead CAPABILITY_LABELS is the
+// only place a capability name is spelled, and everything else below is
+// derived from its keys, so a capability added to one is a member of the other
+// BY CONSTRUCTION -- there is no second collection left to fall out of sync,
+// and no mutation of "add it in one place and not the other" is expressible
+// any more, in a test or otherwise.
+export const CAPABILITY_LABELS = {
   "mcp.sites.read": "Sites",
   "mcp.uptime.read": "Uptime",
   "mcp.backups.read": "Backups",
@@ -32,7 +33,20 @@ const CAPABILITY_LABELS: Readonly<Record<string, string>> = {
   "mcp.performance.read": "Performance",
   "mcp.diagnostics.read": "Diagnostics",
   "mcp.content.read": "Content",
-};
+} as const satisfies Readonly<Record<string, string>>;
+
+/** A capability wire string this build's vocabulary knows. */
+export type Capability = keyof typeof CAPABILITY_LABELS;
+
+/**
+ * The eight names policy.go's capabilityVocabulary knows today, DERIVED from
+ * CAPABILITY_LABELS's keys rather than written out again. See the file header:
+ * this is what makes the two-lists-disagree shape impossible here rather than
+ * merely tested for.
+ */
+export const KNOWN_CAPABILITIES: readonly Capability[] = Object.keys(
+  CAPABILITY_LABELS,
+) as Capability[];
 
 /**
  * Human label for a capability wire string.
@@ -43,7 +57,12 @@ const CAPABILITY_LABELS: Readonly<Record<string, string>> = {
  * operator could see it. The raw string is always legible even unlabelled,
  * because every member of this vocabulary is deliberately spelled as a
  * `mcp.<noun>.read` wire string and not an opaque id.
+ *
+ * Takes a bare `string`, not `Capability`, on purpose: the server does not
+ * filter the column it returns (see the file header), so a live grant can
+ * hold a name outside this build's vocabulary and this function has to accept
+ * it rather than refuse to compile against it.
  */
 export function capabilityLabel(capability: string): string {
-  return CAPABILITY_LABELS[capability] ?? capability;
+  return (CAPABILITY_LABELS as Readonly<Record<string, string>>)[capability] ?? capability;
 }

--- a/apps/web/src/features/ai-connections/capabilities.ts
+++ b/apps/web/src/features/ai-connections/capabilities.ts
@@ -1,0 +1,49 @@
+// The v1 capability vocabulary, mirrored from apps/api/internal/mcp/policy.go's
+// capabilityVocabulary. This is the one place a human label is attached to a
+// capability wire string, so the connections list and the capability picker
+// (#660) share it instead of drifting into two label maps that disagree.
+//
+// THE SERVER DOES NOT FILTER AN UNKNOWN CAPABILITY OUT OF WHAT IT RETURNS.
+// capabilitiesFromColumn in policy.go reads mcp_grants.capabilities back
+// without dropping anything outside this build's vocabulary, on purpose: doing
+// so here would let a UI's own (possibly stale) label map decide what is true
+// about a stored grant. capabilityLabel below preserves that property -- an
+// unrecognised string still renders, as itself, rather than being silently
+// dropped or replaced with "unknown".
+
+/** The eight names policy.go's capabilityVocabulary knows today. */
+export const KNOWN_CAPABILITIES: readonly string[] = [
+  "mcp.sites.read",
+  "mcp.uptime.read",
+  "mcp.backups.read",
+  "mcp.security.read",
+  "mcp.activity.read",
+  "mcp.performance.read",
+  "mcp.diagnostics.read",
+  "mcp.content.read",
+];
+
+const CAPABILITY_LABELS: Readonly<Record<string, string>> = {
+  "mcp.sites.read": "Sites",
+  "mcp.uptime.read": "Uptime",
+  "mcp.backups.read": "Backups",
+  "mcp.security.read": "Security",
+  "mcp.activity.read": "Activity",
+  "mcp.performance.read": "Performance",
+  "mcp.diagnostics.read": "Diagnostics",
+  "mcp.content.read": "Content",
+};
+
+/**
+ * Human label for a capability wire string.
+ *
+ * A NAME THIS MAP DOES NOT KNOW STILL RENDERS, AS ITSELF. Falling back to a
+ * placeholder like "Unknown capability" would re-create, one layer up, the
+ * exact defect #652 was filed over: a value the server sent, dropped before an
+ * operator could see it. The raw string is always legible even unlabelled,
+ * because every member of this vocabulary is deliberately spelled as a
+ * `mcp.<noun>.read` wire string and not an opaque id.
+ */
+export function capabilityLabel(capability: string): string {
+  return CAPABILITY_LABELS[capability] ?? capability;
+}

--- a/apps/web/src/features/ai-connections/connection-model.ts
+++ b/apps/web/src/features/ai-connections/connection-model.ts
@@ -75,6 +75,17 @@ export interface AiConnection {
   readonly siteScopeMode: string;
   /** null means not revoked. Never inferred from status, and never a zero date. */
   readonly revokedAt: string | null;
+  /**
+   * The raw `mcp.<noun>.read` wire strings this grant holds (#652 / #663).
+   *
+   * ALWAYS AN ARRAY, NEVER ABSENT OR NULL. dto.go's capabilityNames always
+   * builds with `make([]string, 0, ...)`, so a grant holding none produces
+   * `[]`, not a missing key -- and `[]` here is a live, meaningful fact: the
+   * connection can reach no tool at all, not "we don't know what it can do".
+   * See capabilityLabel in ./capabilities for why an entry outside this
+   * build's label map is still rendered rather than dropped.
+   */
+  readonly capabilities: readonly string[];
 }
 
 /**

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -31,6 +31,7 @@ const CONNECTED: AiConnection = {
   createdAt: "2026-08-01T00:00:00.000Z",
   siteScopeMode: "all",
   revokedAt: null,
+  capabilities: ["mcp.sites.read"],
 };
 
 /** The copy that must never appear over a failure. */
@@ -323,5 +324,56 @@ describe("a field the client did not send is rendered as absent", () => {
     });
     expect(await screen.findByText(/unreadable timestamp/i)).toBeInTheDocument();
     expect(screen.queryByText(/invalid date/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("capabilities render exactly what the grant holds (#652)", () => {
+  it("renders the exact capability set, not the org default and not a guess", async () => {
+    // Asserted on the exact set. A non-emptiness check would pass a
+    // wrong-but-plausible value -- e.g. the whole seven-member org default
+    // rendered in place of the two capabilities this grant actually holds.
+    renderList({
+      status: "ready",
+      connections: [
+        { ...CONNECTED, capabilities: ["mcp.uptime.read", "mcp.backups.read"] },
+      ],
+    });
+    const list = await screen.findByTestId("capabilities-list");
+    expect(list.textContent).toContain("Uptime");
+    expect(list.textContent).toContain("Backups");
+    // Not the full org default set (§ policy.go scopeCapabilities[ScopeRead]):
+    // any member outside the two granted must not appear.
+    for (const label of ["Sites", "Security", "Activity", "Performance", "Diagnostics"]) {
+      expect(list.textContent).not.toContain(label);
+    }
+  });
+
+  it("renders an empty capability set as inert, not as missing data", async () => {
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, capabilities: [] }],
+    });
+    expect(await screen.findByTestId("capabilities-none")).toBeInTheDocument();
+    // The uncommon-but-real branch must not also render, and vice versa.
+    expect(screen.queryByTestId("capabilities-list")).not.toBeInTheDocument();
+  });
+
+  it("still renders a populated set, so the empty-set guard above does not over-fire", async () => {
+    renderList({ status: "ready", connections: [CONNECTED] });
+    expect(await screen.findByTestId("capabilities-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("capabilities-none")).not.toBeInTheDocument();
+  });
+
+  it("renders a capability this build's label map does not recognise, as itself", async () => {
+    // The server does not filter unknown names out of what it returns
+    // (capabilitiesFromColumn in policy.go), so a UI label map dropping one
+    // would re-create the exact defect #652 was filed over, one layer up.
+    renderList({
+      status: "ready",
+      connections: [{ ...CONNECTED, capabilities: ["mcp.sites.read", "mcp.made.up.read"] }],
+    });
+    const list = await screen.findByTestId("capabilities-list");
+    expect(list.textContent).toContain("mcp.made.up.read");
+    expect(list.textContent).toContain("Sites");
   });
 });

--- a/apps/web/src/features/ai-connections/connections-list.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+import { capabilityLabel } from "./capabilities";
 import { PROTOCOL_FLOOR_VERSION } from "./client-table";
 import {
   lastUsedLabel,
@@ -144,6 +145,7 @@ export function ConnectionsList({
             <TableHead>Protocol</TableHead>
             <TableHead>Last used</TableHead>
             <TableHead>Scopes</TableHead>
+            <TableHead>Capabilities</TableHead>
             <TableHead className="text-right">Actions</TableHead>
           </TableRow>
         </TableHeader>
@@ -224,6 +226,32 @@ export function ConnectionsList({
                   <span className="text-[var(--color-muted-foreground)]">No scopes granted</span>
                 ) : (
                   <span className="font-mono text-xs">{c.scopes.join(" ")}</span>
+                )}
+              </TableCell>
+
+              <TableCell>
+                {/* AN EMPTY SET IS INERT, NOT UNKNOWN. Authenticate refuses a
+                    connection holding no capability outright, so this reads as
+                    a live, meaningful condition -- and it is given MORE visual
+                    weight than a populated set, not a quieter placeholder that
+                    could be misread as "we didn't load this". Every entry
+                    renders even when this build's label map does not
+                    recognise it (capabilityLabel falls back to the raw wire
+                    string), so an unmapped capability the server actually
+                    stored is still visible here rather than silently dropped
+                    -- the exact defect #652 was filed over, one layer up. */}
+                {c.capabilities.length === 0 ? (
+                  <Badge variant="destructive" data-testid="capabilities-none">
+                    No capabilities - inert
+                  </Badge>
+                ) : (
+                  <div className="flex flex-wrap gap-1" data-testid="capabilities-list">
+                    {c.capabilities.map((cap) => (
+                      <Badge key={cap} variant="secondary">
+                        {capabilityLabel(cap)}
+                      </Badge>
+                    ))}
+                  </div>
                 )}
               </TableCell>
 

--- a/apps/web/src/features/ai-connections/use-ai-connections.test.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.test.ts
@@ -26,6 +26,7 @@ function row(over: Record<string, unknown> = {}): Record<string, unknown> {
     protocol: { state: "recognised", version: "2025-11-25" },
     last_used_at: "2026-08-29T10:00:00Z",
     revoked_at: null,
+    capabilities: ["mcp.sites.read"],
     ...over,
   };
 }
@@ -169,5 +170,43 @@ describe("status matches what the server can actually emit", () => {
     expect(() =>
       parseConnectionList({ connections: [row({ status: "paused" })] }),
     ).toThrow();
+  });
+});
+
+describe("capabilities survive the wire exactly (#652)", () => {
+  // dto.go's connectionDTO.Capabilities is ALWAYS present and ALWAYS an
+  // array (capabilityNames builds with make([]string, 0, len(...))), so the
+  // field is required in connectionSchema, not `.optional()`. This is the
+  // MUTATION PAIR for that: removing `capabilities` from the schema must turn
+  // this test red, naming the field, before it is restored.
+  it("keeps the exact capability set the server sent, not a default or a subset", () => {
+    // Asserted on the exact array, not on non-emptiness: a schema bug that
+    // substituted the org default (all seven) or dropped down to the one
+    // DefaultGrantCapabilities name would still be "non-empty" and this must
+    // still catch it.
+    const c = one({ capabilities: ["mcp.uptime.read", "mcp.backups.read"] });
+    expect(c.capabilities).toEqual(["mcp.uptime.read", "mcp.backups.read"]);
+  });
+
+  it("keeps an empty capability array as [], never as undefined or the default", () => {
+    // A grant holding no capability is a real, live state (Authenticate
+    // refuses it outright) and must parse as [], not be coerced into
+    // something else or dropped.
+    const c = one({ capabilities: [] });
+    expect(c.capabilities).toEqual([]);
+  });
+
+  it("keeps a capability string this build's vocabulary does not recognise", () => {
+    // policy.go's capabilitiesFromColumn does not filter the column read
+    // back, on purpose, so an unrecognised name the server actually stored
+    // must survive parsing rather than being dropped as "unknown".
+    const c = one({ capabilities: ["mcp.sites.read", "mcp.not.a.real.capability"] });
+    expect(c.capabilities).toEqual(["mcp.sites.read", "mcp.not.a.real.capability"]);
+  });
+
+  it("refuses a payload missing the capabilities field rather than defaulting it", () => {
+    const badRow = row();
+    delete badRow.capabilities;
+    expect(() => parseConnectionList({ connections: [badRow] })).toThrow();
   });
 });

--- a/apps/web/src/features/ai-connections/use-ai-connections.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.ts
@@ -70,6 +70,13 @@ const connectionSchema = z.object({
   protocol: protocolSchema,
   last_used_at: z.string().nullable(),
   revoked_at: z.string().nullable(),
+  // dto.go's connectionDTO.Capabilities: ALWAYS PRESENT, ALWAYS AN ARRAY.
+  // capabilityNames builds with make([]string, 0, len(...)), so a grant
+  // holding none serialises as `[]`, never `null` and never an absent key.
+  // Requiring the key here (not `.optional()`) means a server that ever
+  // omitted it fails the parse loudly instead of this list quietly treating
+  // "the field is missing" the same as "the grant holds nothing".
+  capabilities: z.array(z.string()),
 });
 
 // An OBJECT, not a bare array. dto.go says why: an error body and a bare `[]`
@@ -131,6 +138,12 @@ export function toAiConnection(raw: z.infer<typeof connectionSchema>): AiConnect
     createdAt: raw.created_at,
     siteScopeMode: raw.site_scope_mode,
     revokedAt: raw.revoked_at,
+    // NOT FILTERED AGAINST A KNOWN VOCABULARY HERE. policy.go's
+    // capabilitiesFromColumn does not drop an unrecognised name either, and
+    // for the same reason: this is what the server actually stored for this
+    // grant, and a UI-side allowlist deciding otherwise is the defect #652
+    // was filed over, one layer up.
+    capabilities: raw.capabilities,
   };
 }
 

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -68,6 +68,7 @@ const ROW = {
   protocol: { state: "recognised", version: "2025-11-25" },
   last_used_at: "2026-08-29T10:00:00Z",
   revoked_at: null,
+  capabilities: ["mcp.sites.read"],
 };
 
 beforeEach(() => vi.clearAllMocks());


### PR DESCRIPTION
## Summary
- Closes the web half of #652 (server half merged in #663). `connectionSchema` in `apps/web/src/features/ai-connections/use-ai-connections.ts` was missing `capabilities`, so zod's plain `z.object` silently stripped the field the server always sends and nothing rendered it.
- Adds `capabilities: readonly string[]` to `AiConnection`, requires the field in the wire schema (the server never omits it and never sends `null` — `apps/api/internal/mcp/dto.go`'s `capabilityNames` always builds with `make([]string, 0, len(...))`), and renders a new "Capabilities" column in `connections-list.tsx`.
- An empty set renders as a distinct `No capabilities - inert` badge instead of a placeholder that could read as missing data, since `Authenticate` refuses a connection holding none outright (`apps/api/internal/mcp/policy.go`).
- New `apps/web/src/features/ai-connections/capabilities.ts` holds the label map for the eight `mcp.<noun>.read` wire strings (`apps/api/internal/mcp/policy.go`'s `capabilityVocabulary`), so the future capability picker (#660) reuses it instead of growing a second map. An unrecognised capability string still renders as its raw wire value, matching `capabilitiesFromColumn`'s "do not filter the column read back" behaviour on the server.

## Mutation proof (the specific defect being fixed)
Removed `capabilities` from `connectionSchema`, ran the suite: 4 tests went red, each naming the missing field (`expected undefined to deeply equal [...]` / `expected [Function] to throw an error`). Restored the field: all tests green again. Full output pasted in the session log.

## Test plan
- [x] `pnpm -C apps/web typecheck`
- [x] `pnpm -C apps/web lint` (0 errors; pre-existing unrelated warnings only)
- [x] `pnpm -C apps/web test` (full suite green; one file-level flake under parallel load in `connect-wizard.test.tsx`, unrelated to this change, reruns green in isolation)
- [x] `pnpm -C apps/web build` (routeTree.gen.ts unchanged, no new routes)
- [x] `apps/web/node_modules/.bin/impeccable detect apps/web/src/features/ai-connections apps/web/src/routes/_authed/ai` (exit 0, no findings)
- Assertions are on the exact capability set (not non-emptiness), on `[]` explicitly, and on an unrecognised capability string rendering as itself.