### PR TITLE
fix(site): drop the phantom core update with no target version

### DIFF
--- a/apps/api/internal/site/handler.go
+++ b/apps/api/internal/site/handler.go
@@ -12,13 +12,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
-	"github.com/mosamlife/wpmgr/apps/api/internal/agentplugin"
 	"github.com/mosamlife/wpmgr/apps/api/internal/api/gen"
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/authz"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/server/httpx"
-	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // RefreshEnqueuer schedules an immediate CP->agent inventory-refresh job for a
@@ -508,30 +506,15 @@ func (h *Handler) getAvailableUpdates(c *gin.Context) {
 	c.JSON(http.StatusOK, &out)
 }
 
-// actionableUpdate reports whether a component carries an update advisory the
-// operator can actually act on. It is the single read-side predicate shared by
-// the available-updates projection, the updates_available count, and the full
-// components inventory, so an already-persisted advisory self-heals on the next
-// read (no re-sync required) in all three at once:
+// actionableUpdate is the read-side update predicate. IT NOW LIVES IN model.go
+// AS site.ActionableUpdate and this is a one-line alias, kept so the several
+// call sites below read unchanged.
 //
-//   - no advisory, or an advisory with an empty new_version: nothing to action.
-//   - GH #211: a same-version phantom (new_version == the component's own
-//     installed Version). wpversion.SameVersion fails open (false) when either
-//     side is empty, so an unknown installed version keeps its advisory.
-//   - the agent's own plugin: the control plane must never offer it as a
-//     selectable update (see agentplugin). Its component row still surfaces
-//     with its installed version; only this advisory is withheld. The
-//     component's plugin-header name is passed alongside its slug so an agent
-//     installed under an unexpected directory name is still recognized.
-func actionableUpdate(c Component) bool {
-	if c.AvailableUpdate == nil || c.AvailableUpdate.NewVersion == "" {
-		return false
-	}
-	if wpversion.SameVersion(c.Version, c.AvailableUpdate.NewVersion) {
-		return false
-	}
-	return !agentplugin.IsComponent(c.Slug, c.Name)
-}
+// It moved because the MCP read surface consumes it: an assistant answering
+// "which of my sites need updates?" must count exactly what the dashboard
+// counts, and a second copy of this rule is how the two start disagreeing.
+// See ActionableUpdate for the three cases it excludes and why.
+func actionableUpdate(c Component) bool { return ActionableUpdate(c) }
 
 // buildAvailableUpdates projects a Site's JSONB inventory into the OpenAPI
 // SiteAvailableUpdates response: filters to components with an AvailableUpdate,
@@ -570,7 +553,13 @@ func buildAvailableUpdates(s Site) gen.SiteAvailableUpdates {
 		return items[i].Slug < items[j].Slug
 	})
 	out := gen.SiteAvailableUpdates{SiteID: s.ID, Items: items}
-	if core != nil && !wpversion.SameVersion(core.CurrentVersion, core.NewVersion) {
+	// ActionableCoreUpdate, not an inline SameVersion compare. The inline form
+	// this replaces also emitted a core row for an advisory whose new_version
+	// was EMPTY: SameVersion fails open (false) when either side is blank, so
+	// `{"current_version":"6.5","new_version":""}` read as "an update to
+	// nothing is available" and the dashboard offered a core update with no
+	// target. The named predicate requires a non-empty new_version.
+	if ActionableCoreUpdate(core) {
 		out.CoreUpdate = gen.NewOptNilSiteAvailableUpdatesCoreUpdate(gen.SiteAvailableUpdatesCoreUpdate{
 			NewVersion:     core.NewVersion,
 			CurrentVersion: core.CurrentVersion,
@@ -797,7 +786,10 @@ func toAPI(s Site) gen.Site {
 					updates++
 				}
 			}
-			hasCoreUpdate := comp.CoreUpdate != nil && !wpversion.SameVersion(comp.CoreUpdate.CurrentVersion, comp.CoreUpdate.NewVersion)
+			// Same predicate as buildAvailableUpdates uses for the core row, by
+			// name rather than by a repeated inline compare, so the count and
+			// the list can no longer disagree about whether core is countable.
+			hasCoreUpdate := ActionableCoreUpdate(comp.CoreUpdate)
 			if hasCoreUpdate {
 				updates++
 			}

--- a/apps/api/internal/site/inventory_read_test.go
+++ b/apps/api/internal/site/inventory_read_test.go
@@ -1,0 +1,174 @@
+package site
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The read-side inventory predicates are now exported because the MCP read
+// surface consumes them: an assistant answering "which of my sites need
+// updates?" must count exactly what the dashboard counts. These tests assert
+// the exact verdicts, not the shapes -- a test that only checked "a bool came
+// back" would pass with the predicate inverted.
+
+// TestActionableCoreUpdate_RejectsEmptyNewVersion is the regression for the bug
+// this change fixes.
+//
+// buildAvailableUpdates and the updates_available count both used to ask
+// `core != nil && !wpversion.SameVersion(current, new)` inline.
+// wpversion.SameVersion FAILS OPEN -- it returns false when either side is
+// blank -- so an advisory of {"current_version":"6.5","new_version":""} made
+// that expression true, and the site was reported as having a core update
+// available to no version at all. The operator saw a core update row with an
+// empty target, and the count included it.
+//
+// It is the empty side that matters here, not the equal side: the equal case
+// was always handled and has its own case below.
+func TestActionableCoreUpdate_RejectsEmptyNewVersion(t *testing.T) {
+	cu := &CoreUpdate{CurrentVersion: "6.5", NewVersion: ""}
+	if ActionableCoreUpdate(cu) {
+		t.Fatalf("ActionableCoreUpdate(%+v) = true, want false: an advisory naming no "+
+			"target version is not an available update, and reporting it as one puts a "+
+			"core update with an empty To column in front of the operator", cu)
+	}
+}
+
+func TestActionableCoreUpdate_Verdicts(t *testing.T) {
+	tests := []struct {
+		name string
+		cu   *CoreUpdate
+		want bool
+	}{
+		{"nil advisory is not actionable", nil, false},
+		{"real upgrade", &CoreUpdate{CurrentVersion: "6.5", NewVersion: "6.7.1"}, true},
+		{"same-version phantom", &CoreUpdate{CurrentVersion: "6.7.1", NewVersion: "6.7.1"}, false},
+		{"empty new_version", &CoreUpdate{CurrentVersion: "6.5", NewVersion: ""}, false},
+		{
+			// Unknown installed version keeps the advisory: we know a version is
+			// on offer and we do not know what is installed, so withholding it
+			// would assert "up to date" from ignorance.
+			"unknown current keeps the advisory",
+			&CoreUpdate{CurrentVersion: "", NewVersion: "6.7.1"},
+			true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ActionableCoreUpdate(tc.cu); got != tc.want {
+				t.Fatalf("ActionableCoreUpdate(%+v) = %v, want %v", tc.cu, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestActionableUpdate_Verdicts(t *testing.T) {
+	tests := []struct {
+		name string
+		c    Component
+		want bool
+	}{
+		{
+			"real upgrade",
+			Component{Slug: "woocommerce", Version: "8.9.1",
+				AvailableUpdate: &AvailableUpdate{NewVersion: "8.9.4"}},
+			true,
+		},
+		{
+			"no advisory",
+			Component{Slug: "woocommerce", Version: "8.9.1"},
+			false,
+		},
+		{
+			"advisory with empty new_version",
+			Component{Slug: "woocommerce", Version: "8.9.1",
+				AvailableUpdate: &AvailableUpdate{NewVersion: ""}},
+			false,
+		},
+		{
+			// GH #211.
+			"same-version phantom",
+			Component{Slug: "woocommerce", Version: "8.9.4",
+				AvailableUpdate: &AvailableUpdate{NewVersion: "8.9.4"}},
+			false,
+		},
+		{
+			// The control plane must never offer its own agent as a selectable
+			// update. The component still surfaces with its installed version;
+			// only the advisory is withheld.
+			"the agent's own plugin is never offered",
+			Component{Slug: "fleet-agent-site-manager", Name: "WPMgr Agent", Version: "2.6.1",
+				AvailableUpdate: &AvailableUpdate{NewVersion: "2.9.0"}},
+			false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ActionableUpdate(tc.c); got != tc.want {
+				t.Fatalf("ActionableUpdate(%+v) = %v, want %v", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseInventory_RawMatchesSiteMethod pins the delegation. The Site methods
+// and the raw functions must be the SAME decode: two decoders over one document
+// are two answers to "what is installed on this site", and the MCP read tools
+// take the raw path while the dashboard takes the method path.
+func TestParseInventory_RawMatchesSiteMethod(t *testing.T) {
+	raw := json.RawMessage(`{
+	  "plugins":[{"slug":"woocommerce","name":"WooCommerce","version":"9.2.0","active":true,
+	              "available_update":{"new_version":"9.3.0"}}],
+	  "themes":[{"slug":"twentytwentyfour","name":"Twenty Twenty-Four","version":"1.2","active":true}],
+	  "core_update":{"current_version":"6.7.1","new_version":"6.8"}
+	}`)
+
+	s := Site{Components: raw}
+
+	sitePlugins, siteThemes := s.ParsedComponents()
+	rawPlugins, rawThemes := ParseInventoryComponents(raw)
+
+	// Exact values, not lengths. A length assertion passes when the decoder
+	// returns the wrong site's plugins.
+	if len(rawPlugins) != 1 || rawPlugins[0].Slug != "woocommerce" ||
+		rawPlugins[0].Version != "9.2.0" || rawPlugins[0].AvailableUpdate == nil ||
+		rawPlugins[0].AvailableUpdate.NewVersion != "9.3.0" {
+		t.Fatalf("ParseInventoryComponents plugins = %+v, want one woocommerce 9.2.0 -> 9.3.0", rawPlugins)
+	}
+	if len(rawThemes) != 1 || rawThemes[0].Slug != "twentytwentyfour" || rawThemes[0].Version != "1.2" {
+		t.Fatalf("ParseInventoryComponents themes = %+v, want one twentytwentyfour 1.2", rawThemes)
+	}
+	if len(sitePlugins) != len(rawPlugins) || sitePlugins[0].Slug != rawPlugins[0].Slug ||
+		sitePlugins[0].Version != rawPlugins[0].Version {
+		t.Fatalf("Site.ParsedComponents plugins %+v disagree with ParseInventoryComponents %+v",
+			sitePlugins, rawPlugins)
+	}
+	if len(siteThemes) != len(rawThemes) || siteThemes[0].Slug != rawThemes[0].Slug {
+		t.Fatalf("Site.ParsedComponents themes %+v disagree with ParseInventoryComponents %+v",
+			siteThemes, rawThemes)
+	}
+
+	core := ParseInventoryCoreUpdate(raw)
+	if core == nil || core.CurrentVersion != "6.7.1" || core.NewVersion != "6.8" {
+		t.Fatalf("ParseInventoryCoreUpdate = %+v, want 6.7.1 -> 6.8", core)
+	}
+	siteCore := s.ParsedCoreUpdate()
+	if siteCore == nil || *siteCore != *core {
+		t.Fatalf("Site.ParsedCoreUpdate %+v disagrees with ParseInventoryCoreUpdate %+v", siteCore, core)
+	}
+}
+
+// TestParseInventory_UnreadableYieldsNothingNotAnError pins that a malformed or
+// absent document decodes to nothing rather than to an error or to a partial
+// guess. The caller pairs this with the staleness stamp; the decoder must never
+// be the thing that implies "up to date".
+func TestParseInventory_UnreadableYieldsNothingNotAnError(t *testing.T) {
+	for _, raw := range [][]byte{nil, {}, []byte(`not json`), []byte(`{"plugins":`)} {
+		plugins, themes := ParseInventoryComponents(raw)
+		if plugins != nil || themes != nil {
+			t.Fatalf("ParseInventoryComponents(%q) = (%+v, %+v), want (nil, nil)", raw, plugins, themes)
+		}
+		if cu := ParseInventoryCoreUpdate(raw); cu != nil {
+			t.Fatalf("ParseInventoryCoreUpdate(%q) = %+v, want nil", raw, cu)
+		}
+	}
+}

--- a/apps/api/internal/site/model.go
+++ b/apps/api/internal/site/model.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/agentplugin"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
 )
 
 // Site is a managed WordPress site.
@@ -341,14 +343,31 @@ type CoreUpdate struct {
 // and themes. A malformed/empty inventory yields empty slices (never an error)
 // — callers use it only to seed best-effort from-versions.
 func (s Site) ParsedComponents() (plugins, themes []Component) {
-	if len(s.Components) == 0 {
+	return ParseInventoryComponents(s.Components)
+}
+
+// ParseInventoryComponents is ParsedComponents over the RAW inventory document,
+// for callers holding the JSONB bytes without a Site around them — the MCP read
+// tools read sqlc rows, not domain Sites.
+//
+// IT IS THE SAME DECODE AND THAT IS THE POINT. A second decoder over the same
+// document is a second answer to "what is installed on this site", and the two
+// drift the moment either grows a key. The Site method delegates here rather
+// than the other way round so there is exactly one implementation.
+//
+// A malformed or empty document yields nil slices, never an error. The caller's
+// question is "what is installed", and the honest answer for an unreadable
+// inventory is nothing — paired, at every call site, with the staleness stamp
+// that says when or whether it was ever collected.
+func ParseInventoryComponents(raw []byte) (plugins, themes []Component) {
+	if len(raw) == 0 {
 		return nil, nil
 	}
 	var comp struct {
 		Plugins []Component `json:"plugins"`
 		Themes  []Component `json:"themes"`
 	}
-	if json.Unmarshal(s.Components, &comp) != nil {
+	if json.Unmarshal(raw, &comp) != nil {
 		return nil, nil
 	}
 	return comp.Plugins, comp.Themes
@@ -358,16 +377,71 @@ func (s Site) ParsedComponents() (plugins, themes []Component) {
 // core update advisory (nil when there is none, or the inventory is
 // empty/malformed).
 func (s Site) ParsedCoreUpdate() *CoreUpdate {
-	if len(s.Components) == 0 {
+	return ParseInventoryCoreUpdate(s.Components)
+}
+
+// ParseInventoryCoreUpdate is ParsedCoreUpdate over the RAW inventory document.
+// See ParseInventoryComponents for why the method delegates here.
+func ParseInventoryCoreUpdate(raw []byte) *CoreUpdate {
+	if len(raw) == 0 {
 		return nil
 	}
 	var comp struct {
 		CoreUpdate *CoreUpdate `json:"core_update,omitempty"`
 	}
-	if json.Unmarshal(s.Components, &comp) != nil {
+	if json.Unmarshal(raw, &comp) != nil {
 		return nil
 	}
 	return comp.CoreUpdate
+}
+
+// ActionableUpdate reports whether a component carries an update advisory the
+// operator can actually act on. It is the single read-side predicate shared by
+// the available-updates projection, the updates_available count, the full
+// components inventory and the MCP read tools, so an already-persisted advisory
+// self-heals on the next read (no re-sync required) in all of them at once:
+//
+//   - no advisory, or an advisory with an empty new_version: nothing to action.
+//   - GH #211: a same-version phantom (new_version == the component's own
+//     installed Version). wpversion.SameVersion fails open (false) when either
+//     side is empty, so an unknown installed version keeps its advisory.
+//   - the agent's own plugin: the control plane must never offer it as a
+//     selectable update (see agentplugin). Its component row still surfaces
+//     with its installed version; only this advisory is withheld. The
+//     component's plugin-header name is passed alongside its slug so an agent
+//     installed under an unexpected directory name is still recognized.
+//
+// IT IS EXPORTED BECAUSE THE MCP READ SURFACE CONSUMES IT, and it moved here
+// from handler.go for that reason: it is a domain predicate, not an HTTP one.
+// An assistant answering "which of my sites need updates?" from its own copy of
+// this rule would disagree with the dashboard the operator is looking at — it
+// would count the phantom advisories and the agent's own plugin that the
+// dashboard drops. The assistant contradicting the screen is worse than the
+// assistant saying nothing, because only one of those gets noticed.
+func ActionableUpdate(c Component) bool {
+	if c.AvailableUpdate == nil || c.AvailableUpdate.NewVersion == "" {
+		return false
+	}
+	if wpversion.SameVersion(c.Version, c.AvailableUpdate.NewVersion) {
+		return false
+	}
+	return !agentplugin.IsComponent(c.Slug, c.Name)
+}
+
+// ActionableCoreUpdate reports whether a core advisory names a version the site
+// is not already on. A core_update whose new_version equals current_version is
+// a phantom in exactly the way a component's is, and buildAvailableUpdates has
+// always dropped it; naming the predicate keeps the MCP surface and the
+// dashboard agreeing on the core row as well as on the component rows.
+//
+// A nil advisory is NOT actionable, and that is a different fact from
+// "inventory never collected" — which no caller may infer from this function,
+// because it is carried separately by the staleness stamp.
+func ActionableCoreUpdate(cu *CoreUpdate) bool {
+	if cu == nil || cu.NewVersion == "" {
+		return false
+	}
+	return !wpversion.SameVersion(cu.CurrentVersion, cu.NewVersion)
 }
 
 // ParsedAgentSelfUpdate decodes the site's JSONB inventory and returns the


### PR DESCRIPTION
## What

Two things, one of them a real defect.

**The defect.** `buildAvailableUpdates` and the `updates_available` count both
asked `core != nil && !wpversion.SameVersion(current, new)` inline.
`wpversion.SameVersion` fails open — it returns `false` when either side is
blank — so an advisory of `{"current_version":"6.5","new_version":""}` made that
expression **true**. The site was reported as having a WordPress core update
available to no version at all: a core row with an empty *To* column on the
site detail page, and a `updates_available` count that included it.

Fixed by naming the predicate. `site.ActionableCoreUpdate` requires a non-empty
`new_version`, and both the list and the count call it, so the two can no longer
disagree about whether core is countable.

**The refactor that motivated finding it.** The read-side inventory predicates
move out of `handler.go` into `model.go` and are exported, because the MCP read
surface is about to consume them:

- `site.ActionableUpdate` — was the unexported `actionableUpdate`
- `site.ActionableCoreUpdate` — new; was an inline compare, in two places
- `site.ParseInventoryComponents` / `site.ParseInventoryCoreUpdate` — the raw
  `[]byte` forms; the `Site` methods now delegate to them

The MCP tools read sqlc rows, not domain `Site`s, so without the raw forms they
would need a second decoder over the same JSONB document — a second answer to
"what is installed on this site", drifting the moment either one grows a key.
An assistant answering *"which of my sites need updates?"* from its own copy of
the rule would contradict the dashboard the operator is looking at: it would
count the same-version phantoms (GH #211) and the agent's own plugin that the
dashboard drops.

## Proof

`apps/api/internal/site/inventory_read_test.go` asserts exact verdicts, not
shapes. Mutation-tested: restoring the pre-fix inline expression (dropping the
`new_version == ""` guard) turns `TestActionableCoreUpdate_RejectsEmptyNewVersion`
red, naming the missing guard:

```
--- FAIL: TestActionableCoreUpdate_RejectsEmptyNewVersion (0.00s)
    inventory_read_test.go:30: ActionableCoreUpdate(&{NewVersion: CurrentVersion:6.5}) = true,
    want false: an advisory naming no target version is not an available update, and
    reporting it as one puts a core update with an empty To column in front of the operator
```

Restored, green:

```
$ go test ./internal/site/... ./internal/mcp/...
ok  	github.com/mosamlife/wpmgr/apps/api/internal/site	0.474s
ok  	github.com/mosamlife/wpmgr/apps/api/internal/site/events	(cached)
ok  	github.com/mosamlife/wpmgr/apps/api/internal/mcp	(cached)
```

`git grep "MUTATION M" -- apps/api` exits 1. `go build ./... && go vet ./...`
clean.

## Not in this PR

No MCP tool is added here. See the session report for why: the wireframes bind
`fleet_updates_pending` to a typed per-site partial-failure envelope that does
not exist yet, and shipping the name without the envelope would be worse than
shipping neither.

## Scope

No migration, no schema change, no generated tree touched, no RLS or tenancy
path touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented update recommendations when no valid target version is available.
  * Improved filtering of irrelevant, duplicate, same-version, and agent-owned component updates.
  * Ensured malformed or missing inventory data is safely ignored without producing partial results.

* **Tests**
  * Added coverage for update eligibility, version handling, inventory parsing, and unreadable inventory documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->