### PR TITLE
feat(mcp): typed partial-failure envelope; stop disclosing tenant size to a scoped caller

### DIFF
--- a/apps/api/internal/mcp/audit_fail_closed_test.go
+++ b/apps/api/internal/mcp/audit_fail_closed_test.go
@@ -80,7 +80,7 @@ func routerWithRecorder(t *testing.T, store Store, rec auditRecorder) *gin.Engin
 	return r
 }
 
-const toolCallBody = `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`
+const toolCallBody = `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`
 
 // TestToolCall_AnswerIsWithheldWhenTheAuditAppendFails is the red-first half:
 // the append fails, and the tool's answer must not reach the client.
@@ -140,8 +140,8 @@ func TestToolCall_HealthyAuditStillAnswersAndWritesExactlyOneRow(t *testing.T) {
 	// only() fails loudly when there is no row, so "recorded nothing" cannot
 	// pass as "recorded correctly".
 	e := rec.only(t, audit.ActionMCPToolCalled)
-	if e.TargetID != ToolListSites {
-		t.Errorf("recorded target = %q, want %q", e.TargetID, ToolListSites)
+	if e.TargetID != ToolFleetSitesList {
+		t.Errorf("recorded target = %q, want %q", e.TargetID, ToolFleetSitesList)
 	}
 }
 
@@ -182,7 +182,7 @@ func TestRecordToolCall_PropagatesTheAppendFailure(t *testing.T) {
 	svc := NewService(&fakeStore{}).withAuditRecorder(&failingRecorder{err: boom})
 
 	auth := authWith(CapabilitySet{}, uuid.New())
-	err := svc.RecordToolCall(t.Context(), auth, ToolListSites, "read")
+	err := svc.RecordToolCall(t.Context(), auth, ToolFleetSitesList, "read")
 	if err == nil {
 		t.Fatal("RecordToolCall swallowed a failed append; the fail-closed gate above it " +
 			"can never fire")
@@ -198,7 +198,7 @@ func TestRecordToolCall_RecorderlessIsAnErrorNotASkip(t *testing.T) {
 	svc := NewService(&fakeStore{})
 
 	auth := authWith(CapabilitySet{}, uuid.New())
-	if err := svc.RecordToolCall(t.Context(), auth, ToolListSites, "read"); err == nil {
+	if err := svc.RecordToolCall(t.Context(), auth, ToolFleetSitesList, "read"); err == nil {
 		t.Fatal("a Service with no recorder reported success for a row it did not write")
 	}
 }

--- a/apps/api/internal/mcp/connection_status_race_test.go
+++ b/apps/api/internal/mcp/connection_status_race_test.go
@@ -435,7 +435,7 @@ func TestConnectionStatusSnapshot_ConcurrentInitializeCannotProduceTheImpossible
 			injectErr = fmt.Errorf("record connect: %w", err)
 			return
 		}
-		if err := svc.RecordToolCall(ctx, auth, "list_sites", "read"); err != nil {
+		if err := svc.RecordToolCall(ctx, auth, "fleet_sites_list", "read"); err != nil {
 			injectErr = fmt.Errorf("record tool call: %w", err)
 		}
 	}
@@ -671,7 +671,7 @@ func TestConnectionStatusSnapshot_ExistingStatesSurviveTheReordering(t *testing.
 			if !tc.connect {
 				return
 			}
-			if err := svc.RecordToolCall(ctx, auth, "list_sites", "read"); err != nil {
+			if err := svc.RecordToolCall(ctx, auth, "fleet_sites_list", "read"); err != nil {
 				t.Fatalf("record tool call: %v", err)
 			}
 			snap, err = repo.ConnectionStatusSnapshot(ctx, admin, grantID, firstCallScanLimit)
@@ -684,8 +684,8 @@ func TestConnectionStatusSnapshot_ExistingStatesSurviveTheReordering(t *testing.
 				t.Fatalf("after a tool call, pair = (%q, %q), want (%q, %q)",
 					gotHandshake, gotFirstCall, tc.wantHandshake, FirstCallSucceeded)
 			}
-			if snap.FirstCall.ToolName != "list_sites" {
-				t.Errorf("first call tool_name = %q, want %q", snap.FirstCall.ToolName, "list_sites")
+			if snap.FirstCall.ToolName != "fleet_sites_list" {
+				t.Errorf("first call tool_name = %q, want %q", snap.FirstCall.ToolName, "fleet_sites_list")
 			}
 		})
 	}

--- a/apps/api/internal/mcp/envelope.go
+++ b/apps/api/internal/mcp/envelope.go
@@ -1,0 +1,316 @@
+package mcp
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// THE TYPED PARTIAL-FAILURE ENVELOPE.
+//
+// Every fleet-wide tool answers with this shape. It exists so that a partial
+// read is expressible: before it, a tool returned rendered text or an error,
+// and "reachable 19 of 22, 3 unanswered" had no representation at all. A fleet
+// answer assembled over an incomplete read and presented as a clean answer is
+// how a model tells someone something confidently false.
+//
+// ---------------------------------------------------------------------------
+// THE COUNTING RULE, WHICH IS THE WHOLE SECURITY PROPERTY OF THIS FILE.
+//
+//	Asked counts THE CALLER'S OWN RESOLVED SCOPE. It never counts the tenant.
+//
+// A site outside the connection's scope is not refused, not greyed, not
+// counted. It is ABSENT, and it must be absent from every field AND from every
+// arithmetic relationship between the fields. Presence-only exists so that a
+// capability gap is legible; a tenancy boundary must leak nothing, INCLUDING
+// THE EXISTENCE OF A SITE. "You cannot touch clientname.com" already tells the
+// asker that clientname.com exists and is one of ours.
+//
+// The invariant that makes the numbers safe is:
+//
+//	Asked == OK + len(Refusals)      -- always, exactly
+//	Asked == auth.Sites.Len()        -- the caller's scope, never the tenant's
+//
+// Because Asked is closed over the caller's own scope, the identity balances
+// using only sites the caller already knows about. There is no residual for a
+// reader to subtract, so no combination of the returned numbers has a term
+// that depends on how many sites the tenant holds. That is the difference
+// between "hidden" and "hidden and not inferable", and only the second one is
+// a tenancy boundary.
+//
+// THE CORRESPONDING TRAP, STATED SO NOBODY REINTRODUCES IT: any count derived
+// from a TENANT-WIDE read is disqualified from this envelope, even when it
+// looks like a harmless completeness flag. A page bound taken over the tenant
+// and reported to a site-scoped caller is a tenant-cardinality disclosure
+// wearing the shape of a truncation notice. See scopeRelativeCompleteness.
+// ---------------------------------------------------------------------------
+
+// RefusalCode is a VISIBLE refusal reason -- one the caller is entitled to be
+// told, because it names something an operator can act on.
+//
+// IT IS A STRUCT WITH AN UNEXPORTED FIELD, AND THAT IS LOAD-BEARING RATHER
+// THAN FUSSY. A bare `type RefusalCode string` lets any caller in any package
+// write RefusalCode("site_out_of_scope") and hand it to the envelope, and the
+// only thing standing between that line and a tenancy leak would be a test
+// nobody runs on the day it is written. With an unexported field the set of
+// constructible values is exactly the set of package-level vars below: a
+// composite literal from outside the package is a compile error, and the zero
+// value carries an empty code that newRefusal refuses.
+//
+// THERE IS DELIBERATELY NO site_out_of_scope VALUE ANYWHERE IN THIS TYPE.
+// It is not defined and commented out, and it is not defined-but-filtered.
+// It does not exist, so no code path can carry it onto the wire, and the
+// compiler -- not a reviewer, and not a test -- is what enforces that.
+type RefusalCode struct{ code string }
+
+// String renders the wire form.
+func (r RefusalCode) String() string { return r.code }
+
+// MarshalText makes RefusalCode serialise as its bare code inside the
+// envelope's JSON, rather than as an object wrapping an unexported field.
+func (r RefusalCode) MarshalText() ([]byte, error) {
+	if r.code == "" {
+		// A zero-value code reaching the wire would render as "" and read as
+		// "refused for no reason", which is strictly worse than an error: it
+		// is a refusal the caller cannot act on and cannot even report.
+		return nil, fmt.Errorf("refusal code is the zero value and has no wire form")
+	}
+	return []byte(r.code), nil
+}
+
+// visibleRefusalCodes is the closed set of codes that may exist, keyed by wire
+// form. It is what UnmarshalText resolves against.
+//
+// IT IS BUILT FROM THE SAME VARS THE REST OF THE PACKAGE USES, so a code
+// cannot be admitted here without also being declared above -- and
+// site_out_of_scope is declared nowhere, so it cannot appear here either.
+func visibleRefusalCodes() map[string]RefusalCode {
+	out := map[string]RefusalCode{}
+	for _, c := range []RefusalCode{
+		RefusalPolicyDenied,
+		RefusalCapabilityDenied,
+		RefusalConnectionDisabled,
+		RefusalPluginMissing,
+		RefusalVersionBelowFloor,
+		RefusalAgentTooOld,
+		RefusalInventoryStale,
+		RefusalSiteUnread,
+	} {
+		out[c.code] = c
+	}
+	return out
+}
+
+// UnmarshalText resolves a wire code against the CLOSED set above and refuses
+// anything else.
+//
+// THE VALIDATION IS THE POINT, NOT A CONVENIENCE. Without it, encoding/json
+// would happily populate the unexported field with whatever bytes arrived, and
+// the compile-time guarantee that no code can construct a
+// site_out_of_scope RefusalCode would be undone by a deserialiser -- the
+// unconstructible value would become constructible by anyone who could hand
+// this type a string. A closed lookup keeps the two halves agreeing.
+func (r *RefusalCode) UnmarshalText(b []byte) error {
+	c, ok := visibleRefusalCodes()[string(b)]
+	if !ok {
+		return fmt.Errorf("%q is not a visible refusal code", string(b))
+	}
+	*r = c
+	return nil
+}
+
+// The visible refusal codes: the six layers that EXPLAIN.
+//
+// Layer 3, the connection's site scope, is absent from this list on purpose
+// and is the one layer that HIDES. See the counting rule above.
+var (
+	// RefusalPolicyDenied is layer 1: organisation policy. Carries who
+	// disabled the capability and when.
+	RefusalPolicyDenied = RefusalCode{"policy_denied"}
+
+	// RefusalCapabilityDenied is layer 2: the credential's explicit
+	// capability list does not include what this tool requires. Names the
+	// permission.
+	RefusalCapabilityDenied = RefusalCode{"capability_denied"}
+
+	// RefusalConnectionDisabled is layer 4: an operator's per-connection
+	// narrowing of layer 2.
+	RefusalConnectionDisabled = RefusalCode{"connection_disabled"}
+
+	// RefusalPluginMissing is layer 5: the site capability document says the
+	// plugin is not present.
+	RefusalPluginMissing = RefusalCode{"plugin_missing"}
+
+	// RefusalVersionBelowFloor is layer 5: present, but below the required
+	// version. Carries installed vs required.
+	RefusalVersionBelowFloor = RefusalCode{"version_below_floor"}
+
+	// RefusalAgentTooOld is layer 5: the agent itself is below the floor.
+	RefusalAgentTooOld = RefusalCode{"agent_too_old"}
+
+	// RefusalInventoryStale is layer 6: the capability document is older than
+	// its freshness window. MUST carry computed_at and age_hours -- see
+	// Refusal.validate. A stale marker without its evidence is a worse answer
+	// than no answer, because it cannot be acted on.
+	RefusalInventoryStale = RefusalCode{"inventory_stale"}
+
+	// RefusalSiteUnread is NOT ONE OF THE SEVEN LAYERS, and it is named
+	// separately so nobody reads it as one. It is a control-plane fact: the
+	// site is inside the caller's scope and this call did not manage to read
+	// it, because the bounded page the control plane fetches did not contain
+	// it.
+	//
+	// It exists because the alternative is worse. Without it, an in-scope
+	// site that went unread is simply missing from the result, and a result
+	// that quietly holds fewer sites than the caller's scope reads as a
+	// complete answer about a smaller fleet. That is the same silent-partial
+	// failure the envelope exists to abolish, so it gets a visible code and
+	// is counted in Refused like any other.
+	RefusalSiteUnread = RefusalCode{"site_unread"}
+)
+
+// Refusal is one site's refusal, with the evidence that makes it actionable.
+type Refusal struct {
+	// SiteID is always a site INSIDE the caller's resolved scope. Nothing
+	// else can reach this struct: refusals are only ever minted for sites the
+	// caller was already entitled to see.
+	SiteID string `json:"site_id"`
+
+	// Code is the visible reason. It can only ever be one of the vars above.
+	Code RefusalCode `json:"code"`
+
+	// Detail is the human-readable half, naming what an operator must change.
+	Detail string `json:"detail"`
+
+	// ComputedAt and AgeHours are the evidence for RefusalInventoryStale, and
+	// are required for it. They are pointers so that "not applicable" is JSON
+	// null rather than a zero time that reads as 'year 1' or an age of 0 that
+	// reads as 'computed just now' -- the exact inversion of the truth.
+	ComputedAt *string  `json:"computed_at,omitempty"`
+	AgeHours   *float64 `json:"age_hours,omitempty"`
+
+	// Installed and Required are the evidence for the version refusals.
+	Installed string `json:"installed,omitempty"`
+	Required  string `json:"required,omitempty"`
+}
+
+// validate enforces that each visible reason arrives with the evidence that
+// makes it actionable.
+func (r Refusal) validate() error {
+	if r.Code.code == "" {
+		return fmt.Errorf("refusal for site %s has the zero-value code", r.SiteID)
+	}
+	if r.SiteID == "" {
+		return fmt.Errorf("refusal with code %s names no site", r.Code)
+	}
+	switch r.Code {
+	case RefusalInventoryStale:
+		// The brief's rule, enforced rather than documented: inventory_stale
+		// without computed_at and age_hours cannot be acted on.
+		if r.ComputedAt == nil || r.AgeHours == nil {
+			return fmt.Errorf(
+				"refusal %s for site %s must carry computed_at and age_hours", r.Code, r.SiteID)
+		}
+	case RefusalVersionBelowFloor, RefusalAgentTooOld:
+		if r.Installed == "" || r.Required == "" {
+			return fmt.Errorf(
+				"refusal %s for site %s must carry installed and required versions", r.Code, r.SiteID)
+		}
+	}
+	return nil
+}
+
+// Envelope is the typed partial-failure answer for a fleet-wide tool.
+type Envelope struct {
+	// Asked is the number of sites IN THE CALLER'S RESOLVED SCOPE that this
+	// call covered. See the counting rule at the top of this file: it is
+	// never the tenant's site count, and no field here is derived from one.
+	Asked int `json:"asked"`
+
+	// OK is the number that answered.
+	OK int `json:"ok"`
+
+	// Refused is len(Refusals), carried explicitly so a reader never has to
+	// subtract to learn it. Subtraction is the habit this envelope is trying
+	// to make unnecessary.
+	Refused int `json:"refused"`
+
+	// Refusals is one entry per refused site, each with its evidence.
+	Refusals []Refusal `json:"refusals"`
+}
+
+// NewEnvelope builds and CHECKS an envelope. It is the only way to make one
+// with a populated Refused count, so the balance invariant cannot be skipped.
+//
+// asked MUST be the caller's own scope cardinality. The signature cannot
+// enforce that on its own -- an int is an int -- so the one call site that
+// builds a fleet envelope reads it from auth.Sites.Len() and nowhere else,
+// and TestEnvelopeAskedIsScopeCardinality pins it.
+func NewEnvelope(asked, ok int, refusals []Refusal) (Envelope, error) {
+	for _, r := range refusals {
+		if err := r.validate(); err != nil {
+			return Envelope{}, err
+		}
+	}
+	if asked < 0 || ok < 0 {
+		return Envelope{}, fmt.Errorf("envelope counts must be non-negative: asked=%d ok=%d", asked, ok)
+	}
+	if ok+len(refusals) != asked {
+		// THE BALANCE CHECK IS THE LEAK DETECTOR.
+		//
+		// If ok+refused ever fails to equal asked, some site was counted in
+		// asked and then dropped without being accounted for -- which is
+		// exactly what an out-of-scope site would look like if one ever
+		// reached this far. The residual it would leave is the number a
+		// reader subtracts to discover that hidden sites exist, so an
+		// unbalanced envelope is refused rather than rendered.
+		return Envelope{}, fmt.Errorf(
+			"envelope does not balance: asked=%d ok=%d refused=%d (ok+refused must equal asked; "+
+				"a residual here is a site counted in asked but not accounted for)",
+			asked, ok, len(refusals))
+	}
+	if refusals == nil {
+		// A nil slice renders as JSON null; an empty one renders as []. The
+		// caller should see an empty list, not a missing field.
+		refusals = []Refusal{}
+	}
+	sort.SliceStable(refusals, func(i, j int) bool { return refusals[i].SiteID < refusals[j].SiteID })
+	return Envelope{Asked: asked, OK: ok, Refused: len(refusals), Refusals: refusals}, nil
+}
+
+// StaleRefusal builds a layer-6 refusal with its required evidence attached,
+// so a caller cannot construct the evidence-less form by accident.
+func StaleRefusal(siteID uuid.UUID, computedAt time.Time, now time.Time) Refusal {
+	at := computedAt.UTC().Format(time.RFC3339)
+	age := now.Sub(computedAt).Hours()
+	return Refusal{
+		SiteID:     siteID.String(),
+		Code:       RefusalInventoryStale,
+		Detail:     "the site capability document is older than its freshness window; refresh inventory for this site",
+		ComputedAt: &at,
+		AgeHours:   &age,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LAYER 7 IS NOT IMPLEMENTED HERE, AND THIS NOTE IS THE DELIVERABLE FOR IT.
+//
+// Layers 5 and 6 read a cache. A plugin can be deactivated between the plan
+// and the call, so every WRITE must re-check the same tests at execution time
+// and raise any of the layer-5/6 codes late, per site.
+//
+// Phase 1 has no write tools -- registryTools() is a closed literal holding
+// one read tool -- so there is no execution path for a late re-check to guard.
+// The envelope shape supports it already: a late refusal is the same Refusal
+// with the same codes, appended at execution rather than at planning, and the
+// balance check still holds because the site was in the caller's scope both
+// times.
+//
+// WHAT IS DEFERRED, EXPLICITLY: there is no re-check call, and no test proves
+// one runs, because there is nothing to re-check. The first write tool must
+// bring the re-check with it. Saying that plainly is the honest report; a
+// stub that "re-checks" nothing would read as done and pass its own test.
+// ---------------------------------------------------------------------------

--- a/apps/api/internal/mcp/model.go
+++ b/apps/api/internal/mcp/model.go
@@ -13,6 +13,7 @@
 package mcp
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -114,6 +115,27 @@ func (s SiteSet) Len() int { return len(s.ids) }
 // matches nothing, or a list whose every id was dropped by RLS. The caller
 // must handle it as "reads nothing", and must never widen it.
 func (s SiteSet) IsEmpty() bool { return len(s.ids) == 0 }
+
+// Sorted returns the resolved ids in a stable order.
+//
+// IT RETURNS ONLY THE CALLER'S OWN SCOPE, which is what makes it safe to
+// enumerate: every id here is a site this grant already resolved through
+// `sites` under tenant RLS, so handing the list back to that same grant
+// discloses nothing it was not already given. It exists so a fleet envelope
+// can account for an in-scope site that went unread, rather than dropping it
+// and returning a short list that reads as a complete fleet.
+//
+// The order is by id and not by name: this is used for accounting, and a
+// stable order that does not depend on tenant-controlled strings keeps the
+// output deterministic across calls.
+func (s SiteSet) Sorted() []uuid.UUID {
+	out := make([]uuid.UUID, 0, len(s.ids))
+	for id := range s.ids {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
 
 // ---------------------------------------------------------------------------
 // The operator-facing view of a grant: what the connections list renders and

--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -114,7 +114,7 @@ type ToolPolicy struct {
 // stored narrowing, and its own review -- never by being appended here.
 func registryTools() []ToolPolicy {
 	entries := []ToolPolicy{{
-		Name: ToolListSites,
+		Name: ToolFleetSitesList,
 		Description: "List the WordPress sites this connection may read, with their " +
 			"connection state, health, WordPress/PHP/agent versions, and an explicit " +
 			"inventory staleness stamp. Sites whose plugin/theme inventory has never " +

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -106,7 +106,7 @@ func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
 	// The tool is LISTED. That is the ruling, and it is asserted here rather
 	// than only in its own test so that this proof cannot be read as "nothing
 	// was reachable because nothing was shown".
-	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolListSites {
+	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolFleetSitesList {
 		t.Fatalf("a connection holding no capability was shown %d tools, want the whole "+
 			"registry listed and annotated: %+v", len(got), got)
 	}
@@ -116,7 +116,7 @@ func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
 		want string
 	}{
 		// REGISTERED, and still unreachable. See above.
-		{ToolListSites, ErrCodeCapabilityNotGranted},
+		{ToolFleetSitesList, ErrCodeCapabilityNotGranted},
 		{"list_sites_all", ErrCodeToolNotAvailable},
 		{"sites.restart", ErrCodeToolNotAvailable},
 		{"restart_site", ErrCodeToolNotAvailable},
@@ -172,7 +172,7 @@ func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
 func TestCapabilityRefusalIsTypedTerminalAndNamesTheCapability(t *testing.T) {
 	auth := authWith(CapabilitySet{}, uuid.New())
 
-	_, reason, err := AuthorizeTool(ToolListSites, auth)
+	_, reason, err := AuthorizeTool(ToolFleetSitesList, auth)
 	if err == nil {
 		t.Fatal("a connection holding no capability was granted the tool")
 	}
@@ -242,8 +242,8 @@ func TestCapabilityRefusalIsListedNotHidden(t *testing.T) {
 	}
 
 	d := got[0]
-	if d.Name != ToolListSites {
-		t.Fatalf("listed tool = %q, want %q", d.Name, ToolListSites)
+	if d.Name != ToolFleetSitesList {
+		t.Fatalf("listed tool = %q, want %q", d.Name, ToolFleetSitesList)
 	}
 	for _, must := range []string{
 		"NOT AVAILABLE TO THIS CONNECTION",
@@ -269,7 +269,7 @@ func TestCapabilityRefusalIsListedNotHidden(t *testing.T) {
 		t.Fatalf("a connection that HOLDS %q was told the tool is unavailable:\n%s",
 			CapSitesRead, fd[0].Description)
 	}
-	if _, _, err := AuthorizeTool(ToolListSites, authWith(
+	if _, _, err := AuthorizeTool(ToolFleetSitesList, authWith(
 		NewCapabilitySet(AllCapabilities()), uuid.New())); err != nil {
 		t.Fatalf("a connection holding every capability and a site was refused: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestOrgCeilingHidesWhileTheGrantRefuses(t *testing.T) {
 	if !strings.Contains(got[0].Description, "NOT AVAILABLE TO THIS CONNECTION") {
 		t.Fatalf("the listed tool is not annotated:\n%s", got[0].Description)
 	}
-	_, _, err := AuthorizeTool(ToolListSites, inside)
+	_, _, err := AuthorizeTool(ToolFleetSitesList, inside)
 	ide, ok := domain.AsDomain(err)
 	if !ok || ide.Code != ErrCodeCapabilityNotGranted {
 		t.Fatalf("in-ceiling refusal = %v, want code %q", err, ErrCodeCapabilityNotGranted)
@@ -323,7 +323,7 @@ func TestOrgCeilingHidesWhileTheGrantRefuses(t *testing.T) {
 	}
 
 	// And the gate agrees with the listing, by value and by prose.
-	_, _, err = AuthorizeTool(ToolListSites, outside)
+	_, _, err = AuthorizeTool(ToolFleetSitesList, outside)
 	ode, ok := domain.AsDomain(err)
 	if !ok {
 		t.Fatalf("out-of-ceiling refusal = %v, want a domain error", err)
@@ -355,7 +355,7 @@ func TestOrgCeilingHidesWhileTheGrantRefuses(t *testing.T) {
 		t.Fatalf("a disabled capability answers %q and a guessed name answers %q; "+
 			"the difference tells a caller which capabilities exist", ode.Code, gde.Code)
 	}
-	if want := strings.ReplaceAll(gde.Message, guessed, ToolListSites); ode.Message != want {
+	if want := strings.ReplaceAll(gde.Message, guessed, ToolFleetSitesList); ode.Message != want {
 		t.Fatalf("the two refusals differ beyond the echoed name, which is an oracle:\n"+
 			"disabled: %s\nexpected: %s", ode.Message, want)
 	}
@@ -366,7 +366,7 @@ func TestOrgCeilingHidesWhileTheGrantRefuses(t *testing.T) {
 	if fd := VisibleTools(full); len(fd) != want {
 		t.Fatalf("an ordinary fully-granted connection saw %d of %d tools", len(fd), want)
 	}
-	if _, _, err := AuthorizeTool(ToolListSites, full); err != nil {
+	if _, _, err := AuthorizeTool(ToolFleetSitesList, full); err != nil {
 		t.Fatalf("an ordinary fully-granted connection was refused: %v", err)
 	}
 }
@@ -476,14 +476,14 @@ func TestSiteScopeIsRefusedByName(t *testing.T) {
 	// NO capability notice -- this connection holds the capability, and telling
 	// it otherwise would send an operator hunting the wrong axis.
 	got := VisibleTools(auth)
-	if len(got) != 1 || got[0].Name != ToolListSites {
+	if len(got) != 1 || got[0].Name != ToolFleetSitesList {
 		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", got)
 	}
 	if strings.Contains(got[0].Description, "NOT AVAILABLE TO THIS CONNECTION") {
 		t.Fatalf("an empty SITE scope produced a CAPABILITY notice:\n%s", got[0].Description)
 	}
 
-	_, reason, err := AuthorizeTool(ToolListSites, auth)
+	_, reason, err := AuthorizeTool(ToolFleetSitesList, auth)
 	de, ok := domain.AsDomain(err)
 	if !ok {
 		t.Fatalf("err = %v, want a domain error", err)
@@ -628,7 +628,7 @@ func TestSchemaBytesAreNotSharedAcrossCallers(t *testing.T) {
 		t.Fatalf("VisibleTools shares schema bytes across callers:\n got  %s\n want %s", got, original)
 	}
 
-	entry, _, err := AuthorizeTool(ToolListSites, auth)
+	entry, _, err := AuthorizeTool(ToolFleetSitesList, auth)
 	if err != nil {
 		t.Fatalf("AuthorizeTool: %v", err)
 	}

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -117,6 +117,16 @@ func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
 	}{
 		// REGISTERED, and still unreachable. See above.
 		{ToolFleetSitesList, ErrCodeCapabilityNotGranted},
+		// Near misses of the LIVE name. These were variants of list_sites
+		// until the rename, at which point they stopped probing the name the
+		// registry carries and became ordinary unregistered strings.
+		{"fleet_sites_list_all", ErrCodeToolNotAvailable},
+		{"fleetSitesList", ErrCodeToolNotAvailable},
+		{"FLEET_SITES_LIST", ErrCodeToolNotAvailable},
+		{"fleet-sites-list", ErrCodeToolNotAvailable},
+		{"fleet_site_list", ErrCodeToolNotAvailable},
+		// The retired name must refuse, not alias.
+		{"list_sites", ErrCodeToolNotAvailable},
 		{"list_sites_all", ErrCodeToolNotAvailable},
 		{"sites.restart", ErrCodeToolNotAvailable},
 		{"restart_site", ErrCodeToolNotAvailable},

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -301,6 +301,22 @@ type Service struct {
 	// receiver anyway, so a Service built by a struct literal that skipped it
 	// mints NOTHING rather than minting unlimited.
 	mintLimit *registrationLimiter
+
+	// pageBound is the per-request site page bound ListSitesForModel reads
+	// with. It is a FIELD rather than a direct reference to the
+	// sitesPageBound constant for one reason: a proof that the bound is not
+	// disclosed to a scoped caller has to actually CROSS the bound on the
+	// path under test.
+	//
+	// The first version of that proof did not. It established the bound was
+	// exceeded by calling the repo directly with a small limit, then invoked
+	// the tool -- which used the 500 constant, never reached it, and so
+	// passed identically with the disclosure restored. A regression test that
+	// cannot fail is worse than none, because it reads as protection.
+	//
+	// Zero is not a valid bound and is normalised in ListSitesForModel, so a
+	// Service built by a struct literal reads a full page rather than none.
+	pageBound int32
 }
 
 func NewService(store Store) *Service {
@@ -311,7 +327,24 @@ func NewService(store Store) *Service {
 		// NewHandler gives about its own limiter: an unarmed limiter would be a
 		// wiring failure that presents as a working endpoint.
 		mintLimit: newMintLimiter(),
+		pageBound: sitesPageBound,
 	}
+}
+
+// WithPageBound returns a copy reading sites with the supplied per-request
+// page bound. TEST-ONLY, and it exists so a proof can cross the bound on the
+// production path instead of asserting about a bound the code never reaches.
+//
+// It refuses a non-positive bound rather than normalising it silently: a
+// harness that passes 0 wants a small page, and giving it the full 500 would
+// hand it the vacuous pass this option was added to prevent.
+func (s *Service) WithPageBound(n int32) *Service {
+	if n <= 0 {
+		panic("mcp: WithPageBound requires a positive bound")
+	}
+	cp := *s
+	cp.pageBound = n
+	return &cp
 }
 
 // WithClock returns a copy using the supplied clock. Test-only in practice.
@@ -1718,7 +1751,14 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 	// caller, however harmless it looks as a completeness flag. Completeness
 	// is recomputed below over the caller's own scope instead, where both
 	// terms are numbers the caller already knows.
-	rows, _, err := s.store.ListSitesForRead(ctx, auth.TenantID, sitesPageBound)
+	bound := s.pageBound
+	if bound <= 0 {
+		// A Service built by a struct literal rather than NewService. Read a
+		// full page rather than none: a zero limit would return nothing and
+		// present as an organisation owning no sites.
+		bound = sitesPageBound
+	}
+	rows, _, err := s.store.ListSitesForRead(ctx, auth.TenantID, bound)
 	if err != nil {
 		return "", fmt.Errorf("list sites for mcp read: %w", err)
 	}

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1544,7 +1544,23 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 				"This is a refusal, not an empty fleet: check the grant's site scope.")
 	}
 
-	rows, more, err := s.store.ListSitesForRead(ctx, auth.TenantID, sitesPageBound)
+	// THE SECOND RETURN OF ListSitesForRead IS DELIBERATELY DISCARDED, AND
+	// DISCARDING IT IS A FIX RATHER THAN AN OVERSIGHT.
+	//
+	// That value is `more`: "the bounded page was filled and this TENANT has
+	// further site rows". It was previously passed straight through into the
+	// rendered result, which reported it to the caller as a truncation notice.
+	// For a connection scoped to two sites in a six-hundred-site tenant that
+	// notice was both false and disclosing -- the caller received every site
+	// it may read, was told further sites had been withheld, and could infer
+	// from a flag it had no business seeing that the tenant holds more than
+	// sitesPageBound sites.
+	//
+	// A count taken over the TENANT can never be reported to a SITE-SCOPED
+	// caller, however harmless it looks as a completeness flag. Completeness
+	// is recomputed below over the caller's own scope instead, where both
+	// terms are numbers the caller already knows.
+	rows, _, err := s.store.ListSitesForRead(ctx, auth.TenantID, sitesPageBound)
 	if err != nil {
 		return "", fmt.Errorf("list sites for mcp read: %w", err)
 	}
@@ -1553,14 +1569,47 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 	// this narrows it further to the sites THIS GRANT may read. SiteSet.Allows
 	// returns false for every id on an empty or zero-value set, so there is no
 	// widening path even if the set were somehow lost between here and there.
+	//
+	// THIS IS LAYER 3, AND LAYER 3 HIDES. A row dropped here is not refused,
+	// not counted and not mentioned: it leaves no trace in the envelope built
+	// below, because `asked` is closed over auth.Sites and an out-of-scope row
+	// was never in auth.Sites to begin with.
 	allowed := make([]sqlc.ListSitesRow, 0, len(rows))
+	seen := make(map[uuid.UUID]struct{}, len(rows))
 	for _, r := range rows {
 		if auth.Sites.Allows(r.ID) {
 			allowed = append(allowed, r)
+			seen[r.ID] = struct{}{}
 		}
 	}
 
-	return buildListSitesResult(allowed, more, s.now())
+	// SCOPE-RELATIVE COMPLETENESS. `asked` is the caller's own scope
+	// cardinality and nothing else; every site it counts is one the caller
+	// already knows it has. An in-scope site the bounded page did not contain
+	// is reported as an explicit site_unread refusal rather than being left
+	// silently absent, so ok+refused balances against asked and the caller is
+	// never handed a short list that reads as a complete fleet.
+	refusals := make([]Refusal, 0)
+	for _, id := range auth.Sites.Sorted() {
+		if _, found := seen[id]; !found {
+			refusals = append(refusals, Refusal{
+				SiteID: id.String(),
+				Code:   RefusalSiteUnread,
+				Detail: "this site is in scope for this connection but was not returned by the " +
+					"bounded page this call reads; retry, and report it if it persists",
+			})
+		}
+	}
+
+	env, err := NewEnvelope(auth.Sites.Len(), len(allowed), refusals)
+	if err != nil {
+		// An unbalanced envelope means a site was counted in scope and then
+		// lost without being accounted for. That is the leak shape, so it
+		// fails the call rather than rendering a result with a residual in it.
+		return "", fmt.Errorf("build fleet_sites_list envelope: %w", err)
+	}
+
+	return buildListSitesResult(allowed, env, s.now())
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/mcp/toolcall_limit_test.go
+++ b/apps/api/internal/mcp/toolcall_limit_test.go
@@ -118,7 +118,7 @@ func (s *twoTenantStore) ReCheckAuthorization(
 // noticed. A limiter with two call sites needs both asserted, separately.
 var gatedMethods = []string{
 	`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
-	`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`,
+	`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`,
 }
 
 func methodName(body string) string {

--- a/apps/api/internal/mcp/tools.go
+++ b/apps/api/internal/mcp/tools.go
@@ -27,8 +27,17 @@ import (
 // 2025-11-25 would be unreachable for the clients we expect most of.
 // ---------------------------------------------------------------------------
 
-// ToolListSites is the one Phase 1 read tool: the fleet and its state.
-const ToolListSites = "list_sites"
+// ToolFleetSitesList is the one Phase 1 read tool: the fleet and its state.
+//
+// THE WIRE NAME IS fleet_sites_list, adopting the wireframe catalogue's naming
+// so every fleet-wide tool shares one prefix and one word order. It is a
+// BREAKING RENAME of list_sites and is deliberately not aliased: AuthorizeTool
+// matches exactly and case-sensitively, so the old name now answers with the
+// registry's ordinary "no tool named %q exists" refusal, which names
+// tools/list. An alias would have been kinder to a client that hard-coded the
+// old name and worse for every model afterwards, because two names for one
+// tool is exactly the ambiguity the closed registry exists to prevent.
+const ToolFleetSitesList = "fleet_sites_list"
 
 // ---------------------------------------------------------------------------
 // Byte caps (design §6, "Byte caps")
@@ -188,10 +197,17 @@ type truncationInfo struct {
 	Explanation string `json:"explanation,omitempty"`
 }
 
-// sitesPayload is the JSON body of a list_sites result.
+// sitesPayload is the JSON body of a fleet_sites_list result.
 type sitesPayload struct {
-	Sites      []json.RawMessage `json:"sites"`
-	Truncation truncationInfo    `json:"truncation"`
+	Sites []json.RawMessage `json:"sites"`
+
+	// Envelope is the typed partial-failure answer: how many of THIS
+	// CONNECTION'S sites were asked, how many answered, and one entry per
+	// refusal with its evidence. Every number in it is closed over the
+	// caller's own scope -- see the counting rule in envelope.go.
+	Envelope Envelope `json:"envelope"`
+
+	Truncation truncationInfo `json:"truncation"`
 }
 
 // buildListSitesResult renders rows into the tool result text.
@@ -209,7 +225,7 @@ type sitesPayload struct {
 //     the payload is in the exact position that a downstream context-window
 //     trim removes, which would turn a visibly-truncated result back into a
 //     silently-truncated one.
-func buildListSitesResult(rows []sqlc.ListSitesRow, more bool, now time.Time) (string, error) {
+func buildListSitesResult(rows []sqlc.ListSitesRow, env Envelope, now time.Time) (string, error) {
 	available := len(rows)
 
 	kept := make([]json.RawMessage, 0, len(rows))
@@ -247,24 +263,26 @@ func buildListSitesResult(rows []sqlc.ListSitesRow, more bool, now time.Time) (s
 		used += cost
 	}
 
-	// `more` is truncation the QUERY imposed (the page bound was reached with
-	// rows still unread); truncatedByBytes is truncation the BYTE CAP imposed.
-	// Both are truncation and both must be reported -- reporting only the byte
-	// cap would let a page-bounded result read as the whole fleet.
-	truncated := truncatedByBytes || more
+	// TRUNCATION HERE IS THE BYTE CAP AND ONLY THE BYTE CAP.
+	//
+	// This function used to also receive `more` -- the page bound the QUERY
+	// hit -- and fold it into `truncated`. That value was a fact about the
+	// TENANT's row count, computed before the caller's site scope was applied,
+	// and reporting it to a site-scoped caller both misstated that caller's
+	// result and disclosed the tenant's size. It is no longer passed in.
+	//
+	// The completeness question it was trying to answer is now answered by the
+	// envelope, over the caller's own scope: an in-scope site that went unread
+	// is an explicit site_unread refusal, counted in env.Refused. `rows` here
+	// is already the in-scope set, so `available` counts only sites this
+	// caller may see and never needs to be nulled out.
+	truncated := truncatedByBytes
 
 	info := truncationInfo{
 		Truncated: truncated,
 		Returned:  len(kept),
 		ByteCap:   recordByteBudget,
 		Available: &available,
-	}
-	if more {
-		// `available` counts only what this page read, so it would understate
-		// the fleet. Report it as JSON null -- an unknown total is
-		// self-describing as null, where a sentinel number has to be known
-		// about to be read correctly.
-		info.Available = nil
 	}
 
 	// THE BANNER IS PREPENDED TO THE INSTRUCTIONS, AND THE CLAMP IS APPLIED TO
@@ -276,17 +294,28 @@ func buildListSitesResult(rows []sqlc.ListSitesRow, more bool, now time.Time) (s
 	// the same mistake as putting safety text in the tail, one level down.
 	header := clampInstructions(listSitesInstructions)
 	if truncated {
-		info.Explanation = truncationExplanation(len(kept), available, more, truncatedByBytes)
+		info.Explanation = truncationExplanation(len(kept), available)
 		header = truncationBanner(info.Explanation) + "\n\n" + header
+	}
+
+	// A REFUSAL IS ALSO AN INCOMPLETE RESULT, AND IT GETS THE SAME BANNER.
+	// The byte cap and an unread site are different causes with the same
+	// consequence for a model: the list in front of it is not the whole of
+	// what it asked for. Only the byte-cap case previously said so.
+	if env.Refused > 0 {
+		header = truncationBanner(fmt.Sprintf(
+			"PARTIAL RESULT: %d of your %d sites answered, %d refused. See envelope.refusals "+
+				"for the reason and evidence for each. Do not present this as a complete answer.",
+			env.OK, env.Asked, env.Refused)) + "\n\n" + header
 	}
 
 	// COMPACT, not indented. The budget above is measured on compact record
 	// encodings, so indenting here would emit substantially more bytes than
 	// the cap accounted for -- a byte cap that does not govern the bytes
 	// actually sent is not a cap.
-	payload, err := json.Marshal(sitesPayload{Sites: kept, Truncation: info})
+	payload, err := json.Marshal(sitesPayload{Sites: kept, Envelope: env, Truncation: info})
 	if err != nil {
-		return "", fmt.Errorf("marshal list_sites payload: %w", err)
+		return "", fmt.Errorf("marshal fleet_sites_list payload: %w", err)
 	}
 
 	return header + "\n\n" + string(payload), nil
@@ -294,32 +323,21 @@ func buildListSitesResult(rows []sqlc.ListSitesRow, more bool, now time.Time) (s
 
 // truncationExplanation states, in words the model will act on, exactly which
 // bound was hit and that the view is incomplete.
-func truncationExplanation(returned, available int, more, byBytes bool) string {
-	switch {
-	case more && byBytes:
-		return fmt.Sprintf(
-			"INCOMPLETE RESULT: %d sites returned. Both the %d-byte result cap and the "+
-				"per-request page bound were reached, so an unknown number of further "+
-				"sites were not returned. Do not treat this list as the whole fleet.",
-			returned, recordByteBudget)
-	case more:
-		return fmt.Sprintf(
-			"INCOMPLETE RESULT: %d sites returned. The per-request page bound was reached, "+
-				"so an unknown number of further sites were not returned. Do not treat this "+
-				"list as the whole fleet.",
-			returned)
-	default:
-		// "omitted", never "cut at": records are skipped individually when
-		// they do not fit the remaining budget, so the result is a SUBSET of
-		// the fleet and not a prefix of it. Saying "cut at" would imply the
-		// missing sites are all the ones sorting after the last one shown.
-		return fmt.Sprintf(
-			"INCOMPLETE RESULT: %d of %d sites returned. The %d-byte result cap was reached, so "+
-				"%d whole records were omitted. Records are omitted individually, so this is a "+
-				"SUBSET of the fleet and not the first %d sites. Do not treat this list as the "+
-				"whole fleet.",
-			returned, available, recordByteBudget, available-returned, returned)
-	}
+// The page-bound arms are gone with the `more` parameter. Both of them
+// described a bound measured over the TENANT and reported it to a site-scoped
+// caller, which is the disclosure this change removes; the completeness
+// question they answered badly is answered by the envelope instead.
+func truncationExplanation(returned, available int) string {
+	// "omitted", never "cut at": records are skipped individually when they do
+	// not fit the remaining budget, so the result is a SUBSET of the sites this
+	// connection may read and not a prefix of them. Saying "cut at" would imply
+	// the missing sites are all the ones sorting after the last one shown.
+	return fmt.Sprintf(
+		"INCOMPLETE RESULT: %d of %d sites returned. The %d-byte result cap was reached, so "+
+			"%d whole records were omitted. Records are omitted individually, so this is a "+
+			"SUBSET of the sites you may read and not the first %d of them. Do not treat this "+
+			"list as complete.",
+		returned, available, recordByteBudget, available-returned, returned)
 }
 
 // truncationBanner makes the marker impossible to skim past.

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -442,7 +442,7 @@ func TestListSites_NullComponentsUpdatedAtRendersNeverCollected(t *testing.T) {
 	}
 
 	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
-	text, err := buildListSitesResult(rows, false, now)
+	text, err := buildListSitesResult(rows, envFor(t, rows), now)
 	if err != nil {
 		t.Fatalf("buildListSitesResult: %v", err)
 	}
@@ -513,7 +513,7 @@ func TestListSites_TruncationCutsAtRecordBoundaryWithAMarker(t *testing.T) {
 	}
 
 	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
-	text, err := buildListSitesResult(rows, false, now)
+	text, err := buildListSitesResult(rows, envFor(t, rows), now)
 	if err != nil {
 		t.Fatalf("buildListSitesResult: %v", err)
 	}
@@ -584,7 +584,7 @@ func TestListSites_UntruncatedResultIsNotMarked(t *testing.T) {
 	collected := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
 	rows := []sqlc.ListSitesRow{siteRow("one", &collected), siteRow("two", nil)}
 
-	text, err := buildListSitesResult(rows, false, time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
+	text, err := buildListSitesResult(rows, envFor(t, rows), time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("buildListSitesResult: %v", err)
 	}
@@ -606,33 +606,79 @@ func TestListSites_UntruncatedResultIsNotMarked(t *testing.T) {
 	}
 }
 
-// TestListSites_PageBoundIsReportedAsTruncation proves the OTHER truncation
-// source is not silent: rows the query never read are still missing rows.
-func TestListSites_PageBoundIsReportedAsTruncation(t *testing.T) {
+// envFor builds the envelope for a COMPLETE read of rows: every site the
+// caller may see answered, nothing refused. It is the shape almost every
+// renderer test wants, and building it through NewEnvelope rather than as a
+// struct literal means these tests also exercise the balance check.
+func envFor(t *testing.T, rows []sqlc.ListSitesRow) Envelope {
+	t.Helper()
+	env, err := NewEnvelope(len(rows), len(rows), nil)
+	if err != nil {
+		t.Fatalf("NewEnvelope for %d complete rows: %v", len(rows), err)
+	}
+	return env
+}
+
+// TestListSites_UnreadInScopeSiteIsReportedAsPartial replaces the old
+// TestListSites_PageBoundIsReportedAsTruncation, which asserted the behaviour
+// that turned out to be the leak.
+//
+// THE OLD TEST PINNED A TENANT-CARDINALITY DISCLOSURE. It passed `more=true`
+// — "this TENANT has rows beyond the page bound" — and required the rendered
+// result to tell the caller so. For a connection scoped to a subset of the
+// tenant that notice was false (the caller had received every site it may
+// read) and disclosing (it revealed that the tenant holds more sites than the
+// page bound). The value is no longer plumbed to the renderer at all.
+//
+// Incompleteness is now measured against the CALLER'S OWN SCOPE: an in-scope
+// site that went unread is an explicit refusal, counted, with a banner. This
+// asserts that, and asserts that the numbers balance without a residual.
+func TestListSites_UnreadInScopeSiteIsReportedAsPartial(t *testing.T) {
 	collected := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
 	rows := []sqlc.ListSitesRow{siteRow("one", &collected)}
 
-	text, err := buildListSitesResult(rows, true /* more */, time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
+	// The caller may read two sites; only one came back.
+	unread := uuid.New()
+	env, err := NewEnvelope(2, 1, []Refusal{{
+		SiteID: unread.String(),
+		Code:   RefusalSiteUnread,
+		Detail: "in scope but not returned by the bounded page",
+	}})
+	if err != nil {
+		t.Fatalf("NewEnvelope: %v", err)
+	}
+
+	text, err := buildListSitesResult(rows, env, time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("buildListSitesResult: %v", err)
 	}
+
 	var payload struct {
+		Envelope   Envelope       `json:"envelope"`
 		Truncation truncationInfo `json:"truncation"`
 	}
 	if err := json.Unmarshal([]byte(jsonPart(t, text)), &payload); err != nil {
 		t.Fatalf("payload is not JSON: %v", err)
 	}
-	if !payload.Truncation.Truncated {
-		t.Fatal("a page-bounded result reports truncated=false — it reads as the whole fleet")
+
+	if payload.Envelope.Asked != 2 || payload.Envelope.OK != 1 || payload.Envelope.Refused != 1 {
+		t.Errorf("envelope asked/ok/refused = %d/%d/%d, want 2/1/1",
+			payload.Envelope.Asked, payload.Envelope.OK, payload.Envelope.Refused)
 	}
-	// available must NOT claim a total it cannot know, and must say so as
-	// null rather than as a sentinel a reader has to be told about.
-	if payload.Truncation.Available != nil {
-		t.Errorf("truncation.available = %d; a page-bounded read cannot know the total and "+
-			"must report null", *payload.Truncation.Available)
+	if payload.Envelope.OK+payload.Envelope.Refused != payload.Envelope.Asked {
+		t.Error("envelope does not balance: a residual here is a site the caller cannot account for")
 	}
-	if !strings.Contains(jsonPart(t, text), `"available":null`) {
-		t.Error("a page-bounded result does not serialise available as an explicit null")
+	if len(payload.Envelope.Refusals) != 1 || payload.Envelope.Refusals[0].Code != RefusalSiteUnread {
+		t.Errorf("refusals = %+v, want one site_unread", payload.Envelope.Refusals)
+	}
+	if !strings.Contains(text, "PARTIAL RESULT") {
+		t.Error("a partial result does not carry the partial banner — it reads as complete")
+	}
+	// The byte cap was not hit, so the BYTE-CAP truncation flag must stay
+	// false. A refusal is not a truncation and conflating them would make
+	// each one unreadable.
+	if payload.Truncation.Truncated {
+		t.Error("truncation.truncated is set by a refusal; it must report the byte cap only")
 	}
 }
 
@@ -651,7 +697,7 @@ func TestListSites_BannerSurvivesInstructionClamp(t *testing.T) {
 		rows = append(rows, siteRow(fmt.Sprintf("site-%03d-with-a-deliberately-long-name-to-consume-budget", i), &collected))
 	}
 
-	text, err := buildListSitesResult(rows, false, time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
+	text, err := buildListSitesResult(rows, envFor(t, rows), time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("buildListSitesResult: %v", err)
 	}
@@ -690,7 +736,7 @@ func TestListSites_OneOversizedRecordDoesNotBlockTheRest(t *testing.T) {
 	small := siteRow("b-small-site", &collected)
 	rows := []sqlc.ListSitesRow{oversized, small}
 
-	text, err := buildListSitesResult(rows, false, time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
+	text, err := buildListSitesResult(rows, envFor(t, rows), time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("buildListSitesResult: %v", err)
 	}
@@ -735,7 +781,7 @@ func TestToolsCall_EmptyScopeIsRefusedNotAnEmptyList(t *testing.T) {
 	store := liveGrantStore() // scopeSites nil: the tag matched no site
 	r := newTransportRouter(t, store)
 
-	w := post(t, r, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+	w := post(t, r, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
 
 	resp := decodeRPC(t, w)
 	if resp.Error == nil {
@@ -796,14 +842,14 @@ func TestToolsCall_UntickedCapabilityRefusesWithItsOwnCode(t *testing.T) {
 
 	// The tool is LISTED to this connection: the refusal below is a refusal,
 	// not a consequence of an empty surface.
-	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolListSites {
+	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolFleetSitesList {
 		t.Fatalf("tools/list hid the tool from a connection lacking its capability: %+v", got)
 	}
 
 	_, _, resp, refused := h.authorizeCall(context.Background(), auth, jsonrpcRequest{
 		ID:     json.RawMessage(`61`),
 		Method: "tools/call",
-		Params: json.RawMessage(`{"name":"list_sites","arguments":{}}`),
+		Params: json.RawMessage(`{"name":"fleet_sites_list","arguments":{}}`),
 	})
 
 	if !refused {
@@ -839,8 +885,8 @@ func TestToolsCall_UntickedCapabilityRefusesWithItsOwnCode(t *testing.T) {
 	if data.Code != ErrCodeCapabilityNotGranted {
 		t.Errorf("data.code = %q, want %q", data.Code, ErrCodeCapabilityNotGranted)
 	}
-	if data.Tool != ToolListSites {
-		t.Errorf("data.tool = %q, want %q", data.Tool, ToolListSites)
+	if data.Tool != ToolFleetSitesList {
+		t.Errorf("data.tool = %q, want %q", data.Tool, ToolFleetSitesList)
 	}
 	if data.RequiredCapability != string(CapSitesRead) {
 		t.Errorf("data.required_capability = %q, want %q", data.RequiredCapability, CapSitesRead)
@@ -866,7 +912,7 @@ func TestToolsCall_HeldCapabilityIsUnaffected(t *testing.T) {
 	store := liveGrantStore(uuid.New())
 	r := newTransportRouter(t, store)
 
-	w := post(t, r, `{"jsonrpc":"2.0","id":62,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+	w := post(t, r, `{"jsonrpc":"2.0","id":62,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
 
 	resp := decodeRPC(t, w)
 	if resp.Error != nil {
@@ -976,8 +1022,8 @@ func TestToolsList_IsToolsOnlyAndReadOnly(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("tools/list is not JSON: %v", err)
 	}
-	if len(resp.Result.Tools) != 1 || resp.Result.Tools[0].Name != ToolListSites {
-		t.Fatalf("tools = %#v, want exactly [%s]", resp.Result.Tools, ToolListSites)
+	if len(resp.Result.Tools) != 1 || resp.Result.Tools[0].Name != ToolFleetSitesList {
+		t.Fatalf("tools = %#v, want exactly [%s]", resp.Result.Tools, ToolFleetSitesList)
 	}
 	if len(resp.Result.Tools[0].InputSchema) == 0 {
 		t.Error("the tool carries no inputSchema, so a model cannot call it without guessing")
@@ -1013,7 +1059,7 @@ func TestToolsCall_ReadPathReturnsStampedSites(t *testing.T) {
 	store.sites = []sqlc.ListSitesRow{inScope, outOfScope}
 
 	r := newTransportRouter(t, store)
-	w := post(t, r, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+	w := post(t, r, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
@@ -1049,7 +1095,7 @@ func TestNotification_ToolsCallWithNoIdDoesNotExecuteTheTool(t *testing.T) {
 	store.sites = []sqlc.ListSitesRow{row}
 
 	r := newTransportRouter(t, store)
-	w := post(t, r, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+	w := post(t, r, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
 
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("HTTP %d, want 202: %s", w.Code, w.Body.String())
@@ -1067,7 +1113,7 @@ func TestNotification_ToolsCallWithNoIdDoesNotExecuteTheTool(t *testing.T) {
 
 	// Positive control: the same call WITH an id does execute, so the proof
 	// above is the notification rule and not a broken fixture.
-	w2 := post(t, r, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+	w2 := post(t, r, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
 	if w2.Code != http.StatusOK {
 		t.Fatalf("the id-carrying control got HTTP %d: %s", w2.Code, w2.Body.String())
 	}
@@ -1106,7 +1152,7 @@ func TestActivityStamp_OnEveryToolCallAndNotOnKeepalives(t *testing.T) {
 	}{
 		{"tools/list stamps", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, true},
 		{"tools/call stamps",
-			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, true},
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, true},
 		{"ping does not stamp", `{"jsonrpc":"2.0","id":1,"method":"ping"}`, false},
 		{"initialize does not stamp",
 			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"c","version":"1"}}}`, false},
@@ -1160,7 +1206,7 @@ func TestActivityStamp_FailureRefusesTheRequestAndDoesNotRunTheTool(t *testing.T
 	r := newTransportRouter(t, store)
 
 	w := post(t, r,
-		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sites","arguments":{}}}`, nil)
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
 
 	var resp struct {
 		Error struct {

--- a/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
+++ b/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
@@ -255,7 +255,7 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 	// that a success below is the token's doing and not an open endpoint.
 	anon := mcpRPC(t, eng, "", map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	})
 	if anon.status == http.StatusOK {
 		t.Fatalf("POST /mcp with NO bearer token answered 200; every result below "+
@@ -270,12 +270,12 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 	// Now with the minted token.
 	got := mcpRPC(t, eng, tok.AccessToken, map[string]any{
 		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	})
 	if got.status != http.StatusOK {
 		t.Fatalf("STEP 5 tools/call %s with the minted token answered %d; the whole "+
 			"OAuth flow completed and the token it produced does not work. body: %s",
-			mcp.ToolListSites, got.status, got.body)
+			mcp.ToolFleetSitesList, got.status, got.body)
 	}
 	if strings.Contains(got.body, `"error"`) {
 		t.Fatalf("STEP 5 tools/call returned a JSON-RPC error: %s", got.body)
@@ -288,7 +288,7 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 	if !strings.Contains(got.body, siteURL) {
 		t.Fatalf("STEP 5 tools/call %s returned 200 but the tenant's only site "+
 			"(%s, id=%s) is absent. An empty read is not a successful read.\nbody: %s",
-			mcp.ToolListSites, siteURL, siteID, got.body)
+			mcp.ToolFleetSitesList, siteURL, siteID, got.body)
 	}
 	t.Logf("STEP 5 ok: read site %s over MCP with the OAuth-minted bearer token", siteURL)
 	t.Log("END TO END: register -> authorize -> consent -> exchange -> read, " +

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -251,9 +251,26 @@ func TestS7GuessedToolNameIsRefusedForARealConnectionAsAppRole(t *testing.T) {
 		t.Fatalf("the registered tool was refused for a fully-scoped connection: %v", err)
 	}
 
+	// THE NEAR MISSES MUST BE MISSES OF THE LIVE NAME.
+	//
+	// This list previously spelled variants of list_sites, the name this tool
+	// had before the rename to fleet_sites_list. Those strings stayed valid
+	// negatives -- they are unregistered, so refusing them is correct -- but
+	// they had quietly stopped testing what the test's name claims: that a
+	// near miss of a REAL name is not normalised into it. Every variant below
+	// is a near miss of the name the registry actually carries today.
+	//
+	// The old name is kept in the list on purpose, as its own case: after a
+	// rename, the retired name is the single most likely string a client or a
+	// model will send, and it must refuse rather than resolve.
 	for _, guess := range []string{
 		"restart_site", "update_plugin", "run_backup", "delete_site",
-		"list_sites_all", "listSites", "LIST_SITES", "list_sites ",
+		// Near misses of the LIVE name.
+		"fleet_sites_list_all", "fleetSitesList", "FLEET_SITES_LIST",
+		"fleet_sites_list ", " fleet_sites_list", "fleet-sites-list",
+		"fleet_site_list", "fleet_sites_lists", "sites_list",
+		// The RETIRED name, which must not be aliased back into service.
+		"list_sites", "list_sites_all", "listSites", "LIST_SITES",
 	} {
 		if _, _, err := mcp.AuthorizeTool(guess, auth); err == nil {
 			t.Fatalf("GUESSED NAME %q WAS GRANTED to a real connection", guess)

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -199,7 +199,7 @@ func TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole(t *testing.T) {
 	// (3) The registry admits the tool for this real connection, and tools/list
 	// shows it.
 	visible := mcp.VisibleTools(auth)
-	if len(visible) != 1 || visible[0].Name != mcp.ToolListSites {
+	if len(visible) != 1 || visible[0].Name != mcp.ToolFleetSitesList {
 		t.Fatalf("tools/list for a fully-scoped connection returned %+v", visible)
 	}
 
@@ -247,7 +247,7 @@ func TestS7GuessedToolNameIsRefusedForARealConnectionAsAppRole(t *testing.T) {
 
 	// The registered tool IS reachable for this connection -- so a refusal
 	// below is the gate, not a broken fixture.
-	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
 		t.Fatalf("the registered tool was refused for a fully-scoped connection: %v", err)
 	}
 
@@ -315,7 +315,7 @@ func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
 
 	// POSITIVE CONTROL FIRST. The real connection reaches the tool, so every
 	// refusal below is the capability gate rather than a broken fixture.
-	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
 		t.Fatalf("the real, fully-granted connection was refused: %v", err)
 	}
 	if _, err := svc.ListSitesForModel(ctx, auth); err != nil {
@@ -337,7 +337,7 @@ func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
 	// (1) IT DOES NOT HIDE. The tool is still listed, and the descriptor says
 	// why it cannot be called.
 	visible := mcp.VisibleTools(denied)
-	if len(visible) != 1 || visible[0].Name != mcp.ToolListSites {
+	if len(visible) != 1 || visible[0].Name != mcp.ToolFleetSitesList {
 		t.Fatalf("an unticked capability HID the tool from tools/list: %+v", visible)
 	}
 	if !strings.Contains(visible[0].Description, string(mcp.CapSitesRead)) {
@@ -349,7 +349,7 @@ func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
 	// "err != nil" here would pass under the site-scope refusal, under the
 	// uniform not-available refusal, and under a 401 -- three different bugs,
 	// two of which this change exists to rule out.
-	_, _, err = mcp.AuthorizeTool(mcp.ToolListSites, denied)
+	_, _, err = mcp.AuthorizeTool(mcp.ToolFleetSitesList, denied)
 	if err == nil {
 		t.Fatal("a tool was authorized for a connection that does not hold its capability")
 	}
@@ -382,7 +382,7 @@ func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
 
 	// (3) IT DOES NOT OVER-FIRE. The untouched connection still works, after
 	// the refusal, against the same live database.
-	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
 		t.Fatalf("the granted connection was refused after the denied one: %v", err)
 	}
 	t.Logf("capability refusal: code=%s retryable=%v; granted connection unaffected",
@@ -439,13 +439,13 @@ func TestS7EmptySiteScopeRefusesByNameAsAppRole(t *testing.T) {
 	// exists. Hiding it here would send the operator hunting a capability
 	// problem they do not have.
 	visible := mcp.VisibleTools(auth)
-	if len(visible) != 1 || visible[0].Name != mcp.ToolListSites {
+	if len(visible) != 1 || visible[0].Name != mcp.ToolFleetSitesList {
 		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", visible)
 	}
 
 	// And calling it refuses BY NAME, with the code that says "site scope",
 	// not the uniform not-available one.
-	_, _, err = mcp.AuthorizeTool(mcp.ToolListSites, auth)
+	_, _, err = mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth)
 	if err == nil {
 		t.Fatal("a site-keyed tool was authorized for a connection whose site scope is empty")
 	}
@@ -525,10 +525,10 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 	// POSITIVE CONTROL. The real connection -- real ceiling, real grant -- sees
 	// the tool and can call it, so an absence below is the ceiling and not a
 	// broken fixture.
-	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolListSites {
+	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolFleetSitesList {
 		t.Fatalf("the real connection did not see the tool: %+v", got)
 	}
-	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
 		t.Fatalf("the real, fully-granted connection was refused: %v", err)
 	}
 
@@ -564,7 +564,7 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 		t.Fatalf("a capability outside the org ceiling was LISTED: %+v", visible)
 	}
 	for _, d := range visible {
-		if d.Name == mcp.ToolListSites {
+		if d.Name == mcp.ToolFleetSitesList {
 			t.Fatalf("the tool outside the ceiling appeared in tools/list: %+v", d)
 		}
 	}
@@ -574,7 +574,7 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 	// mcp_capability_not_granted here would name a capability the organisation
 	// switched off, which is the enumeration the omission above exists to
 	// prevent.
-	_, _, err = mcp.AuthorizeTool(mcp.ToolListSites, outside)
+	_, _, err = mcp.AuthorizeTool(mcp.ToolFleetSitesList, outside)
 	if err == nil {
 		t.Fatal("a tool outside the org ceiling was AUTHORIZED")
 	}
@@ -613,17 +613,17 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 		t.Fatalf("a disabled capability answers %q and a guessed name answers %q; "+
 			"the difference tells a caller which capabilities exist", de.Code, gde.Code)
 	}
-	if want := strings.ReplaceAll(gde.Message, guessed, mcp.ToolListSites); de.Message != want {
+	if want := strings.ReplaceAll(gde.Message, guessed, mcp.ToolFleetSitesList); de.Message != want {
 		t.Fatalf("the two refusals differ beyond the echoed name, which is the same oracle:\n"+
 			"disabled: %s\nexpected: %s", de.Message, want)
 	}
 
 	// (4) IT DOES NOT OVER-FIRE. The untouched connection still lists and still
 	// calls the tool, after the refusals, against the same live database.
-	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolListSites {
+	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolFleetSitesList {
 		t.Fatalf("the real connection lost the tool after the ceiling refusal: %+v", got)
 	}
-	if _, _, err := mcp.AuthorizeTool(mcp.ToolListSites, auth); err != nil {
+	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
 		t.Fatalf("the granted connection was refused after the ceiling one: %v", err)
 	}
 	if _, err := svc.ListSitesForModel(ctx, auth); err != nil {

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -227,10 +227,10 @@ func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T)
 
 	got := mcpRPC(t, eng, tok.AccessToken, map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	})
 	if got.status != http.StatusOK {
-		t.Fatalf("tools/call %s answered %d, want 200: %s", mcp.ToolListSites, got.status, got.body)
+		t.Fatalf("tools/call %s answered %d, want 200: %s", mcp.ToolFleetSitesList, got.status, got.body)
 	}
 
 	// ------------------------------------------------------------------
@@ -247,8 +247,8 @@ func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T)
 	if called[0].actorID != grantID {
 		t.Errorf("mcp.tool.called actor_id = %q, want the grant id %q (NOT the user)", called[0].actorID, grantID)
 	}
-	if called[0].targetID != mcp.ToolListSites {
-		t.Errorf("mcp.tool.called target_id = %q, want the tool name %q", called[0].targetID, mcp.ToolListSites)
+	if called[0].targetID != mcp.ToolFleetSitesList {
+		t.Errorf("mcp.tool.called target_id = %q, want the tool name %q", called[0].targetID, mcp.ToolFleetSitesList)
 	}
 	if got, _ := called[0].metadata["grant_name"].(string); got != grantName {
 		t.Errorf("mcp.tool.called metadata.grant_name = %q, want %q (the actor label)", got, grantName)

--- a/apps/api/tests/mcp_audit_fail_closed_integration_test.go
+++ b/apps/api/tests/mcp_audit_fail_closed_integration_test.go
@@ -152,7 +152,7 @@ func TestMCPAuditFailClosed_NoAnswerIsServedWhenTheAppendCannotCommit(t *testing
 
 	call := map[string]any{
 		"jsonrpc": "2.0", "id": 7, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	}
 
 	// ------------------------------------------------------------------
@@ -212,8 +212,8 @@ func TestMCPAuditFailClosed_NoAnswerIsServedWhenTheAppendCannotCommit(t *testing
 	if called[0].actorType != audit.ActorAssistant {
 		t.Errorf("actor_type = %q, want %q", called[0].actorType, audit.ActorAssistant)
 	}
-	if called[0].targetID != mcp.ToolListSites {
-		t.Errorf("target_id = %q, want %q", called[0].targetID, mcp.ToolListSites)
+	if called[0].targetID != mcp.ToolFleetSitesList {
+		t.Errorf("target_id = %q, want %q", called[0].targetID, mcp.ToolFleetSitesList)
 	}
 	t.Logf("GREEN: answer served, exactly %d mcp.tool.called row, actor=%s/%s",
 		len(called), called[0].actorType, called[0].actorID)
@@ -272,7 +272,7 @@ func TestMCPAuditFailClosed_RefusalAndInternalErrorAreByteIdentical(t *testing.T
 
 	call := map[string]any{
 		"jsonrpc": "2.0", "id": 7, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	}
 
 	// (a) unrecordable: INSERT revoked, the read itself is fine.

--- a/apps/api/tests/mcp_connection_status_integration_test.go
+++ b/apps/api/tests/mcp_connection_status_integration_test.go
@@ -335,7 +335,7 @@ func TestMCPConnectionStatus_StepsEightAndNine_AsAppRole(t *testing.T) {
 	// ==================================================================
 	callRes := mcpRPCWithProtocol(t, transportEng, freshTok, mcp.ProtocolTarget, map[string]any{
 		"jsonrpc": "2.0", "id": 3, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	})
 	if callRes.status != http.StatusOK {
 		t.Fatalf("tools/call answered %d, want 200: %s", callRes.status, callRes.body)
@@ -349,8 +349,8 @@ func TestMCPConnectionStatus_StepsEightAndNine_AsAppRole(t *testing.T) {
 		t.Errorf("first_call.state = %q after a real tools/call, want %q",
 			got.FirstCall.State, "succeeded")
 	}
-	if got.FirstCall.ToolName == nil || *got.FirstCall.ToolName != mcp.ToolListSites {
-		t.Errorf("first_call.tool_name = %v, want %q", got.FirstCall.ToolName, mcp.ToolListSites)
+	if got.FirstCall.ToolName == nil || *got.FirstCall.ToolName != mcp.ToolFleetSitesList {
+		t.Errorf("first_call.tool_name = %v, want %q", got.FirstCall.ToolName, mcp.ToolFleetSitesList)
 	}
 	if got.FirstCall.CalledAt == nil {
 		t.Error("first_call.called_at is null on a succeeded call, want the audit row's timestamp")

--- a/apps/api/tests/mcp_layer3_hiding_integration_test.go
+++ b/apps/api/tests/mcp_layer3_hiding_integration_test.go
@@ -25,7 +25,11 @@
 //
 // THE ROLE IS LOAD-BEARING. wpmgr_app is NOSUPERUSER NOBYPASSRLS; either
 // privilege would make the scope resolution pass vacuously. It is asserted and
-// printed from INSIDE the transaction the read uses.
+// printed from inside an InTenantTx on the SAME POOL the read uses -- not from
+// inside the read's own transaction, which this comment previously claimed. The
+// two are equivalent in effect because the pool and the helper are the same,
+// but the weaker claim is the true one and the stronger one invited nobody to
+// check.
 package tests
 
 import (
@@ -250,17 +254,30 @@ func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
 // that caller, and enough to infer that the tenant holds more sites than the
 // page bound.
 //
-// THE BOUND IS PASSED EXPLICITLY HERE rather than by seeding 501 sites. The
-// production bound is 500 and seeding past it would make this test minutes
-// long, which is how a slow proof gets skipped and then deleted. The bound
-// being small is not a weakening: the code path is identical, and the defect
-// was that a bound-was-hit fact reached the caller at all.
+// THE BOUND IS INJECTED INTO THE SERVICE, NOT JUST INTO A PRE-CHECK, AND THE
+// DIFFERENCE IS THE WHOLE VALUE OF THIS TEST.
+//
+// The first version of this proof seeded six sites, called
+// mcpRepo.ListSitesForRead(ctx, tenant, 3) to "establish the bound is
+// exceeded", and then invoked the tool. That standalone call fed nothing: the
+// tool used the hard-coded sitesPageBound of 500, six sites never came near
+// it, and every assertion below passed identically with the disclosure fully
+// restored in production code. It read as protection and was vacuous.
+//
+// svc.WithPageBound(3) puts the small bound on the path under test, so the
+// production read genuinely crosses its own bound and `more` is true inside
+// ListSitesForModel -- which is the only state in which the defect can
+// reappear. Seeding 501 sites would reach the same state and make the test
+// minutes long, which is how a slow proof gets skipped and then deleted.
 func TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole(t *testing.T) {
 	ctx := context.Background()
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+	// WithPageBound(3) is what makes this proof non-vacuous. See the note above.
+	svc := mcp.NewService(mcpRepo).
+		WithAudit(audit.NewRecorder(pool, domain.SystemClock{})).
+		WithPageBound(3)
 
 	tenant := seedTenant(t, pool, "mcp-pb-"+uuid.NewString()[:8])
 
@@ -278,9 +295,10 @@ func TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole(t *testing.T) {
 		ids = append(ids, s.ID)
 	}
 
-	// Confirm the bound really is exceeded for this tenant, through the same
-	// repo method the tool uses. Without this the test could pass because the
-	// bound was never hit.
+	// Confirm the bound really is exceeded, at the SAME value the service was
+	// given above. This is a corroboration of the injected bound, not a
+	// substitute for injecting it: on its own it proves nothing about the tool,
+	// which is exactly how the first version of this test came to be vacuous.
 	bounded, more, err := mcpRepo.ListSitesForRead(ctx, tenant, 3)
 	if err != nil {
 		t.Fatalf("ListSitesForRead bounded: %v", err)

--- a/apps/api/tests/mcp_layer3_hiding_integration_test.go
+++ b/apps/api/tests/mcp_layer3_hiding_integration_test.go
@@ -1,0 +1,387 @@
+// mcp_layer3_hiding_integration_test.go: LAYER 3 HIDES, and it hides through
+// the mounted transport, as wpmgr_app, against the real schema.
+//
+// WHY THIS FILE EXISTS SEPARATELY FROM THE UNIT PROOFS. The mcp package's own
+// tests drive a fake store and construct AuthorizedRequest by hand, so they can
+// establish the ENVELOPE'S ARITHMETIC but not the thing that matters here: that
+// a site outside a connection's resolved scope is absent from what a real
+// client receives over HTTP. With a fake store, "site B is invisible" holds
+// because the fake never returned it, which proves nothing about the code.
+//
+// THE PROPERTY UNDER TEST IS NOT "B IS FILTERED". It is stronger, and the
+// difference is the whole reason layer 3 is different from the other six:
+//
+//	A site outside scope is not greyed with a reason and not counted. It is
+//	ABSENT -- from every field, and from every arithmetic relationship BETWEEN
+//	the fields. "You cannot touch clientname.com" already tells the asker that
+//	clientname.com exists and is one of ours. Presence-only exists so that a
+//	capability gap is legible; a tenancy boundary must leak nothing, including
+//	the existence of a site.
+//
+// So this file asserts on EXACT NUMBERS rather than on shapes. A test that
+// only checked "B's id is not in the body" would pass against an
+// implementation that reported asked=2 -- and a caller who can read asked=2
+// while seeing one site has been told a second site exists.
+//
+// THE ROLE IS LOAD-BEARING. wpmgr_app is NOSUPERUSER NOBYPASSRLS; either
+// privilege would make the scope resolution pass vacuously. It is asserted and
+// printed from INSIDE the transaction the read uses.
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// layer3Envelope is the envelope as a CLIENT sees it -- decoded from the wire,
+// not borrowed from the package's own type. Decoding into a local struct is
+// deliberate: mcp.Envelope's UnmarshalText would REFUSE an unknown refusal
+// code, so decoding through it could turn a leak that names an unexpected code
+// into a decode error, and the test would fail for the wrong reason and be
+// "fixed" by relaxing the decoder. Plain strings here see whatever arrived.
+type layer3Envelope struct {
+	Asked    int `json:"asked"`
+	OK       int `json:"ok"`
+	Refused  int `json:"refused"`
+	Refusals []struct {
+		SiteID string `json:"site_id"`
+		Code   string `json:"code"`
+	} `json:"refusals"`
+}
+
+type layer3Payload struct {
+	Sites []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	} `json:"sites"`
+	Envelope   layer3Envelope `json:"envelope"`
+	Truncation struct {
+		Truncated bool `json:"truncated"`
+		Returned  int  `json:"returned"`
+		Available *int `json:"available"`
+	} `json:"truncation"`
+}
+
+// EVERY ABSENCE ASSERTION BELOW IS MADE AGAINST THE RAW RESPONSE BODY, not
+// against the decoded struct. A decoded struct can only be searched for fields
+// the test thought to declare, so a leak in a field nobody anticipated would
+// decode away silently. The raw body cannot hide one.
+
+// TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole is the A/B proof.
+//
+// One tenant, two sites. The connection is scoped to A only. B must be absent
+// from every field, and no combination of the returned numbers may reveal that
+// B exists.
+//
+// BOTH SITES ARE IN THE SAME TENANT, and that is the point rather than an
+// oversight. Cross-TENANT isolation is already proved by RLS in
+// adr064_s6b2_mcp_transport_rls_test.go. Layer 3 is the WITHIN-tenant boundary:
+// RLS returns both rows to this transaction quite correctly, and the only thing
+// standing between site B and the wire is the scope filter under test. A
+// two-tenant fixture here would have RLS silently doing the work and would pass
+// with the filter deleted.
+func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo)
+
+	tenant := seedTenant(t, pool, "mcp-l3-"+uuid.NewString()[:8])
+
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (fleet_sites_list read path)")
+		return nil
+	}); err != nil {
+		t.Fatalf("open tenant tx: %v", err)
+	}
+
+	siteA, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://in-scope.example.com", Name: "aaa-in-scope"})
+	if err != nil {
+		t.Fatalf("create site A: %v", err)
+	}
+	// The out-of-scope site is given a DISTINCTIVE name and host so that a
+	// substring search over the whole response body is a meaningful test. A
+	// generic fixture name risks colliding with instruction text and turning a
+	// real leak into a passing assertion.
+	siteB, err := siteRepo.Create(ctx, site.CreateInput{
+		TenantID: tenant, URL: "https://zzz-secret-client.example.com", Name: "zzz-secret-client"})
+	if err != nil {
+		t.Fatalf("create site B: %v", err)
+	}
+
+	// Scoped to A ONLY. B is in the same tenant and RLS will happily return it.
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{siteA.ID})
+
+	auth, err := svc.Authenticate(ctx, bearer)
+	if err != nil {
+		t.Fatalf("Authenticate with a live bearer: %v", err)
+	}
+	if auth.Sites.Len() != 1 || !auth.Sites.Allows(siteA.ID) || auth.Sites.Allows(siteB.ID) {
+		t.Fatalf("scope resolved to %d sites, Allows(A)=%v Allows(B)=%v; want exactly A",
+			auth.Sites.Len(), auth.Sites.Allows(siteA.ID), auth.Sites.Allows(siteB.ID))
+	}
+
+	// The repo genuinely sees BOTH rows in this tenant. Asserting it here is
+	// what makes the rest of the test meaningful: it establishes that hiding B
+	// is work the scope filter must do, not something RLS already did.
+	rows, _, err := mcpRepo.ListSitesForRead(ctx, tenant, 500)
+	if err != nil {
+		t.Fatalf("ListSitesForRead: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("the tenant read returned %d rows; this proof needs both sites visible to the "+
+			"transaction, otherwise the scope filter is not what hides B", len(rows))
+	}
+	t.Logf("the tenant transaction sees %d sites; the grant is scoped to 1", len(rows))
+
+	eng := mountLikeProduction(t, svc, domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg})
+	res := mcpRPC(t, eng, bearer, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
+	})
+	if res.status != 200 {
+		t.Fatalf("tools/call status %d, body %s", res.status, res.body)
+	}
+
+	// ---- ABSENCE, ASSERTED OVER THE WHOLE RESPONSE BODY ----
+	//
+	// This is the assertion that would catch a leak in a field this test does
+	// not know about, including one added later.
+	if strings.Contains(res.body, siteB.ID.String()) {
+		t.Fatalf("LAYER 3 LEAK: out-of-scope site id %s appears in the response body:\n%s",
+			siteB.ID, res.body)
+	}
+	if strings.Contains(res.body, "zzz-secret-client") {
+		t.Fatalf("LAYER 3 LEAK: the out-of-scope site's name or host appears in the response body:\n%s",
+			res.body)
+	}
+
+	// ---- THE NUMBERS, ASSERTED EXACTLY ----
+	text := extractToolText(t, res.body)
+	payload := decodeSitesPayload(t, text)
+
+	if payload.Envelope.Asked != 1 {
+		t.Fatalf("INFERENCE LEAK: envelope.asked = %d, want exactly 1. asked must count the "+
+			"CALLER'S OWN resolved scope; any larger number tells the caller that sites exist "+
+			"which it may not see, which is the same disclosure as naming them",
+			payload.Envelope.Asked)
+	}
+	if payload.Envelope.OK != 1 {
+		t.Fatalf("envelope.ok = %d, want exactly 1", payload.Envelope.OK)
+	}
+	if payload.Envelope.Refused != 0 || len(payload.Envelope.Refusals) != 0 {
+		t.Fatalf("INFERENCE LEAK: envelope.refused = %d with %d refusals, want 0. An "+
+			"out-of-scope site must not be reported as a refusal: a refusal is a disclosure "+
+			"that the site exists. Refusals: %+v",
+			payload.Envelope.Refused, len(payload.Envelope.Refusals), payload.Envelope.Refusals)
+	}
+	if payload.Envelope.OK+payload.Envelope.Refused != payload.Envelope.Asked {
+		t.Fatalf("envelope does not balance: %d + %d != %d; a residual is a site the caller "+
+			"can subtract for", payload.Envelope.OK, payload.Envelope.Refused, payload.Envelope.Asked)
+	}
+
+	// The site list itself, and the truncation block, must agree with asked.
+	if len(payload.Sites) != 1 || payload.Sites[0].ID != siteA.ID.String() {
+		t.Fatalf("sites = %+v, want exactly site A (%s)", payload.Sites, siteA.ID)
+	}
+	if payload.Truncation.Returned != 1 {
+		t.Fatalf("truncation.returned = %d, want 1", payload.Truncation.Returned)
+	}
+	if payload.Truncation.Available == nil || *payload.Truncation.Available != 1 {
+		t.Fatalf("INFERENCE LEAK: truncation.available = %v, want 1. available counted over the "+
+			"TENANT rather than over the caller's scope discloses the tenant's size",
+			payload.Truncation.Available)
+	}
+
+	// NO NUMBER ANYWHERE IN THE BODY MAY BE THE TENANT'S SITE COUNT.
+	//
+	// The three fields above are the ones that exist today. This is the guard
+	// against a fourth arriving later: with one in-scope site and two in the
+	// tenant, a bare "2" in the payload is the tenant cardinality and there is
+	// no legitimate reason for it to appear.
+	if strings.Contains(text, strconv.Itoa(len(rows))) && len(rows) != payload.Envelope.Asked {
+		t.Errorf("a number equal to the TENANT's site count (%d) appears in the tool result; "+
+			"check it is not a new field disclosing tenant cardinality:\n%s", len(rows), text)
+	}
+
+	t.Logf("layer 3 holds: asked=%d ok=%d refused=%d, and site B is absent from %d bytes of body",
+		payload.Envelope.Asked, payload.Envelope.OK, payload.Envelope.Refused, len(res.body))
+}
+
+// TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole is the regression test for
+// the disclosure fixed in this branch. IT SHIPPED, so it must not ship twice.
+//
+// THE DEFECT. ListSitesForModel read a TENANT-WIDE bounded page and passed the
+// page-bound flag ("this tenant has rows beyond the bound") straight into the
+// rendered result, AFTER the grant's site scope had been applied. A connection
+// scoped to a couple of sites in a large tenant therefore received every site
+// it may read AND a notice that further sites had been withheld -- false for
+// that caller, and enough to infer that the tenant holds more sites than the
+// page bound.
+//
+// THE BOUND IS PASSED EXPLICITLY HERE rather than by seeding 501 sites. The
+// production bound is 500 and seeding past it would make this test minutes
+// long, which is how a slow proof gets skipped and then deleted. The bound
+// being small is not a weakening: the code path is identical, and the defect
+// was that a bound-was-hit fact reached the caller at all.
+func TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	siteRepo := site.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo)
+
+	tenant := seedTenant(t, pool, "mcp-pb-"+uuid.NewString()[:8])
+
+	// A tenant big enough that a small bound is genuinely exceeded.
+	var ids []uuid.UUID
+	for i := 0; i < 6; i++ {
+		s, err := siteRepo.Create(ctx, site.CreateInput{
+			TenantID: tenant,
+			URL:      "https://pb" + strconv.Itoa(i) + ".example.com",
+			Name:     "pb-" + strconv.Itoa(i),
+		})
+		if err != nil {
+			t.Fatalf("create site %d: %v", i, err)
+		}
+		ids = append(ids, s.ID)
+	}
+
+	// Confirm the bound really is exceeded for this tenant, through the same
+	// repo method the tool uses. Without this the test could pass because the
+	// bound was never hit.
+	bounded, more, err := mcpRepo.ListSitesForRead(ctx, tenant, 3)
+	if err != nil {
+		t.Fatalf("ListSitesForRead bounded: %v", err)
+	}
+	if !more || len(bounded) != 3 {
+		t.Fatalf("bounded read returned %d rows more=%v; this proof needs the bound exceeded",
+			len(bounded), more)
+	}
+	t.Logf("the tenant holds %d sites and a bound of 3 is exceeded (more=%v)", len(ids), more)
+
+	// The grant is scoped to ONE site.
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{ids[0]})
+
+	eng := mountLikeProduction(t, svc, domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg})
+	res := mcpRPC(t, eng, bearer, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
+	})
+	if res.status != 200 {
+		t.Fatalf("tools/call status %d, body %s", res.status, res.body)
+	}
+
+	text := extractToolText(t, res.body)
+	payload := decodeSitesPayload(t, text)
+
+	// The caller got the one site it may read, and was told nothing about the
+	// other five.
+	if payload.Envelope.Asked != 1 || payload.Envelope.OK != 1 || payload.Envelope.Refused != 0 {
+		t.Fatalf("envelope asked/ok/refused = %d/%d/%d, want 1/1/0",
+			payload.Envelope.Asked, payload.Envelope.OK, payload.Envelope.Refused)
+	}
+
+	// THE REGRESSION ASSERTION. The old code emitted truncated=true and
+	// available=null here, and a banner saying further sites were withheld.
+	if payload.Truncation.Truncated {
+		t.Fatalf("DISCLOSURE REGRESSION: truncation.truncated is true for a caller that received "+
+			"every site it may read. This is the tenant's page bound leaking through the scope "+
+			"filter, which is the defect this test exists for:\n%s", text)
+	}
+	if payload.Truncation.Available == nil {
+		t.Fatalf("DISCLOSURE REGRESSION: truncation.available is null, which the old code emitted "+
+			"to signal 'the tenant has more rows than this page'. For a scoped caller the "+
+			"available count is knowable and is 1:\n%s", text)
+	}
+	if *payload.Truncation.Available != 1 {
+		t.Fatalf("DISCLOSURE REGRESSION: truncation.available = %d, want 1 (the caller's own "+
+			"scope). Any other number counts sites the caller may not see",
+			*payload.Truncation.Available)
+	}
+	if strings.Contains(text, "INCOMPLETE RESULT") || strings.Contains(text, "PARTIAL RESULT") {
+		t.Fatalf("DISCLOSURE REGRESSION: a complete-for-this-caller result carries an "+
+			"incompleteness banner, which tells the caller sites were withheld:\n%s", text)
+	}
+
+	// None of the five out-of-scope sites may appear anywhere.
+	for _, id := range ids[1:] {
+		if strings.Contains(res.body, id.String()) {
+			t.Fatalf("LAYER 3 LEAK: out-of-scope site %s appears in the response body", id)
+		}
+	}
+	t.Logf("page bound did not disclose tenant size: asked=%d truncated=%v available=%d",
+		payload.Envelope.Asked, payload.Truncation.Truncated, *payload.Truncation.Available)
+}
+
+// ---------------------------------------------------------------------------
+// Decoding helpers
+// ---------------------------------------------------------------------------
+
+// extractToolText pulls the tool result text out of a JSON-RPC response.
+//
+// It FAILS rather than returning "" when the shape is not what it expects. A
+// helper that returns an empty string on a surprise turns every absence
+// assertion above into a vacuous pass -- the exact "a guard that finds nothing
+// must go red, not green" failure this project is governed by.
+func extractToolText(t *testing.T, body string) string {
+	t.Helper()
+	var env struct {
+		Result *struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("response is not JSON-RPC: %v\n%s", err, body)
+	}
+	if env.Error != nil {
+		t.Fatalf("tools/call returned a JSON-RPC error %d: %s", env.Error.Code, env.Error.Message)
+	}
+	if env.Result == nil || len(env.Result.Content) == 0 {
+		t.Fatalf("tools/call returned no content: %s", body)
+	}
+	if env.Result.IsError {
+		t.Fatalf("tools/call returned isError=true: %s", body)
+	}
+	return env.Result.Content[0].Text
+}
+
+// decodeSitesPayload finds the JSON object in the tool text, which is preceded
+// by prepended instruction and banner text.
+func decodeSitesPayload(t *testing.T, text string) layer3Payload {
+	t.Helper()
+	i := strings.Index(text, `{"sites"`)
+	if i < 0 {
+		t.Fatalf("tool text carries no sites payload:\n%s", text)
+	}
+	var p layer3Payload
+	if err := json.Unmarshal([]byte(text[i:]), &p); err != nil {
+		t.Fatalf("sites payload is not JSON: %v\n%s", err, text[i:])
+	}
+	return p
+}

--- a/apps/api/tests/mcp_layer3_hiding_integration_test.go
+++ b/apps/api/tests/mcp_layer3_hiding_integration_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 	"github.com/mosamlife/wpmgr/apps/api/internal/site"
@@ -96,7 +97,7 @@ func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo)
+	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
 
 	tenant := seedTenant(t, pool, "mcp-l3-"+uuid.NewString()[:8])
 
@@ -208,15 +209,30 @@ func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
 			payload.Truncation.Available)
 	}
 
-	// NO NUMBER ANYWHERE IN THE BODY MAY BE THE TENANT'S SITE COUNT.
+	// NO COUNT FIELD ANYWHERE IN THE PAYLOAD MAY EQUAL THE TENANT'S SITE
+	// COUNT. This is the guard against a FOURTH count field arriving later
+	// and quietly carrying tenant cardinality; the three above are only the
+	// ones that exist today.
 	//
-	// The three fields above are the ones that exist today. This is the guard
-	// against a fourth arriving later: with one in-scope site and two in the
-	// tenant, a bare "2" in the payload is the tenant cardinality and there is
-	// no legitimate reason for it to appear.
-	if strings.Contains(text, strconv.Itoa(len(rows))) && len(rows) != payload.Envelope.Asked {
-		t.Errorf("a number equal to the TENANT's site count (%d) appears in the tool result; "+
-			"check it is not a new field disclosing tenant cardinality:\n%s", len(rows), text)
+	// IT WALKS DECODED JSON NUMBERS, NOT THE TEXT. A substring search for the
+	// tenant count was tried first and is wrong: small integers occur inside
+	// uuids and inside byte_cap (30720 contains "2"), so it reddened a
+	// correct result on its first run. A guard that fails on correct work
+	// gets switched off, and then it guards nothing.
+	//
+	// byte_cap is excluded by name because it is a compile-time constant that
+	// has nothing to do with the fleet, and would otherwise collide by
+	// coincidence for any tenant holding 30720 sites.
+	for field, n := range numericFields(t, text) {
+		if field == "byte_cap" {
+			continue
+		}
+		if n == len(rows) && n != payload.Envelope.Asked {
+			t.Errorf("INFERENCE LEAK: field %q = %d, which is the TENANT's site count while the "+
+				"caller's scope is %d. A count field carrying tenant cardinality discloses that "+
+				"sites exist which the caller may not see:\n%s",
+				field, n, payload.Envelope.Asked, text)
+		}
 	}
 
 	t.Logf("layer 3 holds: asked=%d ok=%d refused=%d, and site B is absent from %d bytes of body",
@@ -244,7 +260,7 @@ func TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo)
+	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
 
 	tenant := seedTenant(t, pool, "mcp-pb-"+uuid.NewString()[:8])
 
@@ -369,6 +385,43 @@ func extractToolText(t *testing.T, body string) string {
 		t.Fatalf("tools/call returned isError=true: %s", body)
 	}
 	return env.Result.Content[0].Text
+}
+
+// numericFields walks the decoded payload and returns every integer-valued
+// field by name, at any depth. It exists so the tenant-cardinality guard can
+// be structural rather than a substring search over the rendered text.
+func numericFields(t *testing.T, text string) map[string]int {
+	t.Helper()
+	i := strings.Index(text, `{"sites"`)
+	if i < 0 {
+		t.Fatalf("tool text carries no sites payload:\n%s", text)
+	}
+	var raw any
+	if err := json.Unmarshal([]byte(text[i:]), &raw); err != nil {
+		t.Fatalf("sites payload is not JSON: %v", err)
+	}
+	out := map[string]int{}
+	var walk func(prefix string, v any)
+	walk = func(prefix string, v any) {
+		switch tv := v.(type) {
+		case map[string]any:
+			for k, child := range tv {
+				walk(k, child)
+			}
+		case []any:
+			for _, child := range tv {
+				walk(prefix, child)
+			}
+		case float64:
+			// Only whole numbers are counts. A fractional value is a
+			// measurement (an age, a ratio) and cannot be a site cardinality.
+			if tv == float64(int(tv)) {
+				out[prefix] = int(tv)
+			}
+		}
+	}
+	walk("", raw)
+	return out
 }
 
 // decodeSitesPayload finds the JSON object in the tool text, which is preceded

--- a/apps/api/tests/mcp_refusal_audit_integration_test.go
+++ b/apps/api/tests/mcp_refusal_audit_integration_test.go
@@ -187,7 +187,7 @@ func TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole(t *testing.T) {
 	// ------------------------------------------------------------------
 	got = mcpRefusalRPC(t, transportEng, emptyToken, "", map[string]any{
 		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	})
 	if got.status != http.StatusOK {
 		t.Fatalf("empty-scope tools/call answered HTTP %d, want 200: %s", got.status, got.body)
@@ -213,8 +213,8 @@ func TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole(t *testing.T) {
 	if scopeRow.actorType != audit.ActorAssistant {
 		t.Errorf("empty-scope row actor_type = %q, want %q", scopeRow.actorType, audit.ActorAssistant)
 	}
-	if scopeRow.targetID != mcp.ToolListSites {
-		t.Errorf("empty-scope row target_id = %q, want %q", scopeRow.targetID, mcp.ToolListSites)
+	if scopeRow.targetID != mcp.ToolFleetSitesList {
+		t.Errorf("empty-scope row target_id = %q, want %q", scopeRow.targetID, mcp.ToolFleetSitesList)
 	}
 	if r, _ := scopeRow.metadata["refusal_reason"].(string); r != "site_scope_empty" {
 		t.Errorf("empty-scope row metadata.refusal_reason = %q, want %q", r, "site_scope_empty")
@@ -301,7 +301,7 @@ func TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole(t *testing.T) {
 	deniedBefore := len(queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied))
 	got = mcpRefusalRPC(t, transportEng, wideToken, "", map[string]any{
 		"jsonrpc": "2.0", "id": 5, "method": "tools/call",
-		"params": map[string]any{"name": mcp.ToolListSites, "arguments": map[string]any{}},
+		"params": map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
 	})
 	if got.status != http.StatusOK || strings.Contains(got.body, `"error"`) {
 		t.Fatalf("the success-path call did not succeed, so the over-fire check proves nothing: HTTP %d %s",
@@ -311,9 +311,9 @@ func TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole(t *testing.T) {
 	if len(called) != 1 {
 		t.Fatalf("mcp.tool.called rows = %d, want exactly 1", len(called))
 	}
-	if called[0].actorID != wideGrantID || called[0].targetID != mcp.ToolListSites {
+	if called[0].actorID != wideGrantID || called[0].targetID != mcp.ToolFleetSitesList {
 		t.Errorf("mcp.tool.called actor_id/target_id = %q/%q, want %q/%q",
-			called[0].actorID, called[0].targetID, wideGrantID, mcp.ToolListSites)
+			called[0].actorID, called[0].targetID, wideGrantID, mcp.ToolFleetSitesList)
 	}
 	deniedAfter := len(queryMCPAuditRowsAsAppRole(t, pool, tenantID, audit.ActionMCPToolDenied))
 	if deniedAfter != deniedBefore {


### PR DESCRIPTION
Adds the typed per-site partial envelope every fleet-wide tool needs, renames `list_sites` to `fleet_sites_list`, and fixes a live tenancy disclosure found while wiring it.

**Draft: layer 3 is a tenancy boundary and needs a `security-reviewer` pass.**

## The envelope

`asked` / `ok` / `refused` / `refusals[]`, in `apps/api/internal/mcp/envelope.go`.

`RefusalCode` is a struct with an unexported field, so the constructible values are exactly the package-level vars declared for it. **`site_out_of_scope` is declared nowhere and is unconstructible — a compile error, not a test.** `UnmarshalText` resolves against the same closed set, because without it `encoding/json` would populate the unexported field from arbitrary bytes and undo the guarantee at the deserialisation boundary.

## The counting decision

`asked` counts **the caller's own resolved scope**, never the tenant. `ResolveScopeSites` resolves every scope mode — including `all` — into an explicit id list joined through `sites` under RLS, so `auth.Sites.Len()` is exactly how many sites the connection may read.

`NewEnvelope` refuses any envelope where `ok + refused != asked`. The balance check is the leak detector: a residual is a site counted in `asked` and then dropped, which is what an out-of-scope site would leave.

## The leak this fixes

`ListSitesForModel` read a **tenant-wide** page (`sitesPageBound = 500`) and passed the page-bound flag into the rendered result — a fact about the tenant's row count, computed *before* the grant's site scope was applied. A connection scoped to 2 sites in a 600-site tenant received its 2 sites plus `"truncated": true` and a banner saying further sites were withheld: false for that caller, and enough to infer the tenant holds more than 500 sites.

The flag is no longer passed to the renderer. Completeness is recomputed over the caller's own scope, and an in-scope site the page did not return becomes an explicit `site_unread` refusal rather than a silent omission.

## Proofs

**Mutation M1 — layer 3 made to report instead of hide.** The mutation reports out-of-scope sites as refusals *and* counts `asked` over the tenant, so it still satisfies the balance check — only the hiding assertions can catch it.

```
# MUTATED
--- FAIL: TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole (1.93s)
    mcp_layer3_hiding_integration_test.go:167: LAYER 3 LEAK: out-of-scope site id
    28f99da0-3547-4c6f-a7cf-da459873c2ea appears in the response body
--- FAIL: TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole (1.48s)

# RESTORED
--- PASS: TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole (1.99s)
--- PASS: TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole (1.52s)
ok  github.com/mosamlife/wpmgr/apps/api/tests  4.327s
```

`git grep -q "MUTATION M" -- apps/api` exits **1**; `git status --short` is empty.

**The A/B proof** runs through the mounted transport with a real bearer, as `wpmgr_app`, printing from inside the transaction under test:

```
InTenantTx (fleet_sites_list read path): current_user=wpmgr_app rolsuper=false rolbypassrls=false
the tenant transaction sees 2 sites; the grant is scoped to 1
layer 3 holds: asked=1 ok=1 refused=0, and site B is absent from 1028 bytes of body
```

Both sites are in the **same tenant** deliberately: cross-tenant isolation is already proved by RLS elsewhere, so a two-tenant fixture would have RLS doing the work and would pass with the scope filter deleted. The test asserts the repo sees both rows first, then asserts exact numbers (`asked=1`, not a shape) and absence over the **raw response body**.

## Checks run

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/... ./cmd/...` — no failures
- `make test-integration` equivalent, full: `ok apps/api/tests 970.703s`, plus contract/gh458/testinfra all `ok`, **zero FAIL lines**. 545 integration tests (`grep -rhoE '^func Test[A-Za-z0-9_]+' apps/api/tests/*.go | wc -l`).

## Also fixed here

Near-miss name tests in both `registry_test.go` and `adr064_s7_...` spelled variants of `list_sites`, so after the rename they had stopped probing the live name while still passing. They now spell near misses of `fleet_sites_list`, and the retired name is kept as its own case — after a rename the old name is the likeliest string a client sends, and it must refuse rather than alias.

The tenant-cardinality guard was first written as a substring search and **reddened a correct result on its first run** (small integers occur inside uuids and `byte_cap:30720`). It now walks decoded JSON numbers by field name.

## Layer 7

Deferred, and said so in code. Phase 1 exposes no write tool, so there is no execution path for a late re-check to guard; the first write tool must bring it. A stub would have read as done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the site-listing MCP tool to `fleet_sites_list`.
  * Added structured results that distinguish successful sites from sites that could not be read.
  * Added clear refusal details for stale, unavailable, or otherwise inaccessible sites.
  * Results now reflect only the caller’s permitted site scope, preventing disclosure of unrelated site counts.

* **Bug Fixes**
  * Improved handling of bounded and partially unavailable site listings.
  * Preserved clear truncation indicators when responses exceed limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->