### PR TITLE
release: 0.61.152

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.152] - 2026-09-01
+
+### Added
+
+- An operator can now see which capabilities each AI connection holds, directly on the connections list. That set was already stored on every grant but never rendered, so there was no way to audit what a connection could actually do without querying the database.
+
+### Fixed
+
+- A site no longer reports a WordPress core update with no version to update to. A blank target version was being read as "an update is available," which left the site detail page's core row showing an empty target and inflated the fleet's pending-update count.
+- An audit failure on the assistant surface no longer comes back as an invalid params error blaming the caller. A genuine server-side fault writing the audit record is now reported as a server fault, not a client mistake.
+
+### Security
+
+- Audit on the assistant surface is now fail-closed, reads included: when the record of what the assistant read cannot be written, the read itself is refused rather than answered silently. This is a deliberate posture change for this surface, taken by owner decision.
+
 ## [0.61.151] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.151**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.152**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.151
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.151
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.151
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.152
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.152
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.152
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.151   # omit to track :latest
+export WPMGR_VERSION=v0.61.152   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,30 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.152",
+    date: "2026-09-01",
+    summary:
+      "Sites stop reporting a phantom WordPress core update with no target version, AI connection capabilities are now visible on the connections list, and assistant-surface audit failures fail closed instead of silently answering.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "A site no longer reports a WordPress core update with no version to update to. A blank target version was being read as \"an update is available,\" which left the site detail page's core row showing an empty target and inflated the fleet's pending-update count.",
+      },
+      {
+        tag: "Fixed",
+        text: "An audit failure on the assistant surface no longer comes back as an invalid params error blaming the caller. A genuine server-side fault writing the audit record is now reported as a server fault, not a client mistake.",
+      },
+      {
+        tag: "Added",
+        text: "An operator can now see which capabilities each AI connection holds, directly on the connections list. That set was already stored on every grant but never rendered, so there was no way to audit what a connection could actually do without querying the database.",
+      },
+      {
+        tag: "Security",
+        text: "Audit on the assistant surface is now fail-closed, reads included: when the record of what the assistant read cannot be written, the read itself is refused rather than answered silently. This is a deliberate posture change for this surface, taken by owner decision.",
+      },
+    ],
+  },
+  {
     version: "0.61.151",
     date: "2026-09-01",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.151   # omit to track :latest
+export WPMGR_VERSION=v0.61.152   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.151
+  version: 0.61.152
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. The agent plugin did not change (zero non-test files in `apps/agent` since 295c7fd3), so the agent triple and the marketing hero badge stay at 0.61.147.

Puts three merged PRs in front of users for the first time (production 0.61.151 was built from ad8ecb8e, before these landed):

- Fixed: a site no longer reports a WordPress core update with no version to update to (#667). Customer-visible: this fixed a blank target version showing an empty "To" column and an inflated pending-update count.
- Fixed: an audit failure on the assistant surface no longer surfaces as an invalid params error blaming the caller (#662).
- Added: an operator can now see which capabilities each AI connection holds, on the connections list (#665, #663).
- Security: audit on the assistant surface is now fail-closed, reads included (#662), a deliberate posture change by owner decision.

#664 (comment/test correction, no user-visible effect) is not called out separately.

## Test plan

- [x] `make check-versions-test` - 76 passed, 0 failed
- [x] `make check-versions` - all surfaces consistent; agent badge unchanged at 0.61.147
- [x] `node apps/marketing/scripts/check-copy.mjs` - passed, no em/en dashes or competitor names
- [x] Docs vocabulary check (verbatim from `ci.yml`) - no hits