### PR TITLE
fix(db): bound the assistant's site read over the connection's scope, not the tenant's

### DIFF
--- a/apps/api/db/query/sites.sql
+++ b/apps/api/db/query/sites.sql
@@ -103,6 +103,66 @@ ORDER BY
     s.id DESC
 LIMIT $2 OFFSET $3;
 
+-- name: ListSitesForMCPScope :many
+-- The assistant surface's site read (internal/mcp). It exists so that the row
+-- bound is taken over THE CALLER'S OWN SCOPE and never over the tenant.
+--
+-- What it replaces: internal/mcp read ListSites over the whole tenant with
+-- Limit = bound+1 and Sort = 'name', then applied the connection's site scope
+-- in Go AFTERWARDS. An in-scope site whose name sorted past the tenant's first
+-- page was therefore never in the rows the filter ran over. The order is
+-- deterministic, so no number of retries could ever produce it, and the caller
+-- was told to retry. Worse, the shortfall could only arise once the TENANT held
+-- more rows than the bound, so its arrival was a fact about sites the caller is
+-- not entitled to know exist.
+--
+-- WHY THIS IS A SEPARATE QUERY AND NOT A NULLABLE ARM ON ListSites.
+-- The alternative was sqlc.narg('site_ids') on ListSites, read as "NULL means
+-- no scope filter" so the dashboard's callers keep working untouched. Reject it,
+-- and the reason is specific rather than stylistic: for an ARRAY parameter sqlc
+-- emits the same Go type, []uuid.UUID, for sqlc.arg and sqlc.narg alike, because
+-- a Go slice is already nullable. The two options are therefore INDISTINGUISHABLE
+-- AT THE CALL SITE and differ only in what a nil slice means. On the narg arm nil
+-- means the whole tenant; here nil means zero rows, because `id = ANY(NULL::uuid[])`
+-- evaluates to NULL and `id = ANY('{}'::uuid[])` evaluates to false, and WHERE
+-- keeps neither. One identical mistake -- a scope set lost on an error path, a
+-- struct field left unassigned -- returns the fleet in one design and nothing in
+-- the other. That asymmetry is the whole justification for a second query over
+-- this table.
+--
+-- It is not a copy of ListSites and must not become one. This surface has one
+-- order and no filters, so there is deliberately no state/client_id/any_tags/
+-- all_tags/q arm here to drift out of step with the dashboard's. ListSites is
+-- unchanged by this addition.
+--
+-- No LEFT JOINs. ListSites carries site_perf_config and site_object_cache_config
+-- for the dashboard's cache badges; internal/mcp's toSiteRecord reads neither
+-- column, so joining them here would buy two index lookups per row, across the
+-- whole page, to produce two values nobody reads. `SELECT s.*` also means sqlc
+-- returns the shared `Site` model rather than a bespoke row struct.
+--
+-- The scope predicate is defense in depth and NOT the only gate, but it is the
+-- one that cannot be forgotten. `sites` carries the RESTRICTIVE sites_site_scope
+-- policy (m19, 20260531050000_m19_orgs_sharing.sql:330), whose USING clause is
+-- `app.site_scope <> 'on' OR id = ANY(app.allowed_site_ids)`. That is permissive
+-- whenever the GUC is unset -- correct, because the dashboard's org-scoped
+-- callers must not be filtered -- which also means the policy is inert for any
+-- caller that opens its transaction with InTenantTx rather than RunTenantTx.
+-- This predicate holds under either helper.
+--
+-- ORDER BY reproduces ListSites' 'name' sort exactly: lower(s.name) so "acme"
+-- and "Acme" sit together whatever the server's collation, then s.id DESC as the
+-- total-order tiebreak, without which two sites sharing a name are free to swap
+-- places between calls. Archived sites are excluded to match ListSites' default
+-- (ADR-041), which is what this surface was getting before.
+SELECT s.*
+FROM sites s
+WHERE s.tenant_id = @tenant_id
+  AND s.id = ANY(@site_ids::uuid[])
+  AND s.connection_state <> 'archived'
+ORDER BY lower(s.name) ASC, s.id DESC
+LIMIT @row_limit;
+
 -- name: ListSitesAgentVersions :many
 -- Tenant-scoped site_id/name/agent_version rollup for the read-only agent
 -- fleet-version dashboard (internal/agentrelease): "how many of my sites are

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -2656,6 +2656,58 @@ type Querier interface {
 	// The CASE guards a components document whose "plugins" key is absent or is not
 	// an array, which jsonb_array_elements would otherwise error on.
 	ListSitesAgentVersions(ctx context.Context, tenantID uuid.UUID) ([]ListSitesAgentVersionsRow, error)
+	// The assistant surface's site read (internal/mcp). It exists so that the row
+	// bound is taken over THE CALLER'S OWN SCOPE and never over the tenant.
+	//
+	// What it replaces: internal/mcp read ListSites over the whole tenant with
+	// Limit = bound+1 and Sort = 'name', then applied the connection's site scope
+	// in Go AFTERWARDS. An in-scope site whose name sorted past the tenant's first
+	// page was therefore never in the rows the filter ran over. The order is
+	// deterministic, so no number of retries could ever produce it, and the caller
+	// was told to retry. Worse, the shortfall could only arise once the TENANT held
+	// more rows than the bound, so its arrival was a fact about sites the caller is
+	// not entitled to know exist.
+	//
+	// WHY THIS IS A SEPARATE QUERY AND NOT A NULLABLE ARM ON ListSites.
+	// The alternative was sqlc.narg('site_ids') on ListSites, read as "NULL means
+	// no scope filter" so the dashboard's callers keep working untouched. Reject it,
+	// and the reason is specific rather than stylistic: for an ARRAY parameter sqlc
+	// emits the same Go type, []uuid.UUID, for sqlc.arg and sqlc.narg alike, because
+	// a Go slice is already nullable. The two options are therefore INDISTINGUISHABLE
+	// AT THE CALL SITE and differ only in what a nil slice means. On the narg arm nil
+	// means the whole tenant; here nil means zero rows, because `id = ANY(NULL::uuid[])`
+	// evaluates to NULL and `id = ANY('{}'::uuid[])` evaluates to false, and WHERE
+	// keeps neither. One identical mistake -- a scope set lost on an error path, a
+	// struct field left unassigned -- returns the fleet in one design and nothing in
+	// the other. That asymmetry is the whole justification for a second query over
+	// this table.
+	//
+	// It is not a copy of ListSites and must not become one. This surface has one
+	// order and no filters, so there is deliberately no state/client_id/any_tags/
+	// all_tags/q arm here to drift out of step with the dashboard's. ListSites is
+	// unchanged by this addition.
+	//
+	// No LEFT JOINs. ListSites carries site_perf_config and site_object_cache_config
+	// for the dashboard's cache badges; internal/mcp's toSiteRecord reads neither
+	// column, so joining them here would buy two index lookups per row, across the
+	// whole page, to produce two values nobody reads. `SELECT s.*` also means sqlc
+	// returns the shared `Site` model rather than a bespoke row struct.
+	//
+	// The scope predicate is defense in depth and NOT the only gate, but it is the
+	// one that cannot be forgotten. `sites` carries the RESTRICTIVE sites_site_scope
+	// policy (m19, 20260531050000_m19_orgs_sharing.sql:330), whose USING clause is
+	// `app.site_scope <> 'on' OR id = ANY(app.allowed_site_ids)`. That is permissive
+	// whenever the GUC is unset -- correct, because the dashboard's org-scoped
+	// callers must not be filtered -- which also means the policy is inert for any
+	// caller that opens its transaction with InTenantTx rather than RunTenantTx.
+	// This predicate holds under either helper.
+	//
+	// ORDER BY reproduces ListSites' 'name' sort exactly: lower(s.name) so "acme"
+	// and "Acme" sit together whatever the server's collation, then s.id DESC as the
+	// total-order tiebreak, without which two sites sharing a name are free to swap
+	// places between calls. Archived sites are excluded to match ListSites' default
+	// (ADR-041), which is what this surface was getting before.
+	ListSitesForMCPScope(ctx context.Context, arg ListSitesForMCPScopeParams) ([]Site, error)
 	// connected sites whose last heartbeat is older than the degrade cutoff.
 	// url is included so the active-verify sweeper can dial the agent without a
 	// secondary tenant-scoped lookup.

--- a/apps/api/internal/db/sqlc/sites.sql.go
+++ b/apps/api/internal/db/sqlc/sites.sql.go
@@ -1092,6 +1092,134 @@ func (q *Queries) ListSitesAgentVersions(ctx context.Context, tenantID uuid.UUID
 	return items, nil
 }
 
+const listSitesForMCPScope = `-- name: ListSitesForMCPScope :many
+SELECT s.id, s.tenant_id, s.url, s.name, s.status, s.wp_version, s.php_version, s.agent_version, s.agent_public_key, s.enrolled_at, s.last_seen_at, s.health_status, s.server_info, s.multisite, s.active_theme, s.components, s.components_updated_at, s.tags, s.age_recipient, s.wp_timezone, s.wp_gmt_offset, s.host_provider, s.host_provider_org, s.host_provider_ip, s.host_provider_checked_at, s.connection_state, s.connection_generation, s.disconnected_at, s.disconnected_reason, s.archived_at, s.missed_heartbeats, s.client_id, s.app_probe_path, s.app_alerts_disabled, s.monitoring_paused_at, s.monitoring_paused_by, s.monitoring_paused_reason, s.monitoring_resume_at, s.created_at, s.updated_at
+FROM sites s
+WHERE s.tenant_id = $1
+  AND s.id = ANY($2::uuid[])
+  AND s.connection_state <> 'archived'
+ORDER BY lower(s.name) ASC, s.id DESC
+LIMIT $3
+`
+
+type ListSitesForMCPScopeParams struct {
+	TenantID uuid.UUID   `json:"tenant_id"`
+	SiteIds  []uuid.UUID `json:"site_ids"`
+	RowLimit int32       `json:"row_limit"`
+}
+
+// The assistant surface's site read (internal/mcp). It exists so that the row
+// bound is taken over THE CALLER'S OWN SCOPE and never over the tenant.
+//
+// What it replaces: internal/mcp read ListSites over the whole tenant with
+// Limit = bound+1 and Sort = 'name', then applied the connection's site scope
+// in Go AFTERWARDS. An in-scope site whose name sorted past the tenant's first
+// page was therefore never in the rows the filter ran over. The order is
+// deterministic, so no number of retries could ever produce it, and the caller
+// was told to retry. Worse, the shortfall could only arise once the TENANT held
+// more rows than the bound, so its arrival was a fact about sites the caller is
+// not entitled to know exist.
+//
+// WHY THIS IS A SEPARATE QUERY AND NOT A NULLABLE ARM ON ListSites.
+// The alternative was sqlc.narg('site_ids') on ListSites, read as "NULL means
+// no scope filter" so the dashboard's callers keep working untouched. Reject it,
+// and the reason is specific rather than stylistic: for an ARRAY parameter sqlc
+// emits the same Go type, []uuid.UUID, for sqlc.arg and sqlc.narg alike, because
+// a Go slice is already nullable. The two options are therefore INDISTINGUISHABLE
+// AT THE CALL SITE and differ only in what a nil slice means. On the narg arm nil
+// means the whole tenant; here nil means zero rows, because `id = ANY(NULL::uuid[])`
+// evaluates to NULL and `id = ANY('{}'::uuid[])` evaluates to false, and WHERE
+// keeps neither. One identical mistake -- a scope set lost on an error path, a
+// struct field left unassigned -- returns the fleet in one design and nothing in
+// the other. That asymmetry is the whole justification for a second query over
+// this table.
+//
+// It is not a copy of ListSites and must not become one. This surface has one
+// order and no filters, so there is deliberately no state/client_id/any_tags/
+// all_tags/q arm here to drift out of step with the dashboard's. ListSites is
+// unchanged by this addition.
+//
+// No LEFT JOINs. ListSites carries site_perf_config and site_object_cache_config
+// for the dashboard's cache badges; internal/mcp's toSiteRecord reads neither
+// column, so joining them here would buy two index lookups per row, across the
+// whole page, to produce two values nobody reads. `SELECT s.*` also means sqlc
+// returns the shared `Site` model rather than a bespoke row struct.
+//
+// The scope predicate is defense in depth and NOT the only gate, but it is the
+// one that cannot be forgotten. `sites` carries the RESTRICTIVE sites_site_scope
+// policy (m19, 20260531050000_m19_orgs_sharing.sql:330), whose USING clause is
+// `app.site_scope <> 'on' OR id = ANY(app.allowed_site_ids)`. That is permissive
+// whenever the GUC is unset -- correct, because the dashboard's org-scoped
+// callers must not be filtered -- which also means the policy is inert for any
+// caller that opens its transaction with InTenantTx rather than RunTenantTx.
+// This predicate holds under either helper.
+//
+// ORDER BY reproduces ListSites' 'name' sort exactly: lower(s.name) so "acme"
+// and "Acme" sit together whatever the server's collation, then s.id DESC as the
+// total-order tiebreak, without which two sites sharing a name are free to swap
+// places between calls. Archived sites are excluded to match ListSites' default
+// (ADR-041), which is what this surface was getting before.
+func (q *Queries) ListSitesForMCPScope(ctx context.Context, arg ListSitesForMCPScopeParams) ([]Site, error) {
+	rows, err := q.db.Query(ctx, listSitesForMCPScope, arg.TenantID, arg.SiteIds, arg.RowLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Site
+	for rows.Next() {
+		var i Site
+		if err := rows.Scan(
+			&i.ID,
+			&i.TenantID,
+			&i.Url,
+			&i.Name,
+			&i.Status,
+			&i.WpVersion,
+			&i.PhpVersion,
+			&i.AgentVersion,
+			&i.AgentPublicKey,
+			&i.EnrolledAt,
+			&i.LastSeenAt,
+			&i.HealthStatus,
+			&i.ServerInfo,
+			&i.Multisite,
+			&i.ActiveTheme,
+			&i.Components,
+			&i.ComponentsUpdatedAt,
+			&i.Tags,
+			&i.AgeRecipient,
+			&i.WpTimezone,
+			&i.WpGmtOffset,
+			&i.HostProvider,
+			&i.HostProviderOrg,
+			&i.HostProviderIp,
+			&i.HostProviderCheckedAt,
+			&i.ConnectionState,
+			&i.ConnectionGeneration,
+			&i.DisconnectedAt,
+			&i.DisconnectedReason,
+			&i.ArchivedAt,
+			&i.MissedHeartbeats,
+			&i.ClientID,
+			&i.AppProbePath,
+			&i.AppAlertsDisabled,
+			&i.MonitoringPausedAt,
+			&i.MonitoringPausedBy,
+			&i.MonitoringPausedReason,
+			&i.MonitoringResumeAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markSiteUnreachable = `-- name: MarkSiteUnreachable :execrows
 UPDATE sites
 SET health_status = 'unreachable', updated_at = now()


### PR DESCRIPTION
Bounds the assistant surface's site read over **the connection's own scope** instead of over the tenant.

**Draft: this is a tenancy-relevant read and gets a `security-reviewer` pass.**

## The defect

`ListSitesForRead` (`apps/api/internal/mcp/repo.go`) reads one page of the **tenant's** sites — `ListSites`, `Sort: "name"`, `Limit: limit+1`, `sitesPageBound = 500` — and the connection's site scope is applied in Go afterwards.

An in-scope site whose name sorts past the tenant's first 500 rows is therefore never among the rows the filter runs over. The order is deterministic, so **no number of retries can ever produce it**, and the refusal text tells the caller to retry. It also can only arise once the tenant holds at least 500 sites, so its arrival is a fact about sites the caller is not entitled to know exist.

## What is in this PR

The query layer only: `ListSitesForMCPScope`, plus the sqlc regeneration.

```sql
SELECT s.*
FROM sites s
WHERE s.tenant_id = @tenant_id
  AND s.id = ANY(@site_ids::uuid[])
  AND s.connection_state <> 'archived'
ORDER BY lower(s.name) ASC, s.id DESC
LIMIT @row_limit;
```

**No migration, and none is needed.** `sites.id` is the primary key and already indexed; no column, constraint or policy changes, and `db/schema.sql` is untouched.

**No Go caller is switched here.** `internal/mcp` still calls `ListSites`. The repo/service change that consumes this query is `backend-architect`'s and follows separately — see "What must follow" below.

## Dedicated query, not a `narg` arm on `ListSites`

The alternative was `sqlc.narg('site_ids')` on the shared `ListSites`, where NULL means "no scope filter". Rejected, and for a sharper reason than the duplication trade-off:

**For an array parameter sqlc emits the same Go type — `[]uuid.UUID` — for `sqlc.arg` and `sqlc.narg` alike**, because a Go slice is already nullable. The two designs are therefore *indistinguishable at the call site* and differ only in what a nil slice means. That difference is measured in the proof below, not argued:

```
nil slice  -> id = ANY(NULL::uuid[]) returns 0 rows
narg arm with the SAME nil slice returns 600 rows (the whole tenant)
```

One identical mistake — a scope set lost on an error path, a struct field left unassigned — returns the fleet in one design and nothing in the other. `id = ANY(NULL::uuid[])` is NULL and `id = ANY('{}'::uuid[])` is false, so both spellings of an absent scope fail closed.

The drift objection does not really apply, because this is not a copy: the assistant surface has one order and no filters, so the new query carries no `state` / `client_id` / `any_tags` / `all_tags` / `q` arm to fall out of step with the dashboard's. It also drops both `LEFT JOIN`s, which exist for the dashboard's cache badges and whose columns `toSiteRecord` never reads.

## The dashboard `/sites` path is unchanged, by construction

The change is **purely additive**. Deleted-line count in each path, this turn:

```
$ git diff -U0 origin/main -- apps/api/db/query/sites.sql | grep -E '^-' | grep -vc '^---'
0
$ git diff -U0 origin/main -- apps/api/internal/db/sqlc/ | grep -E '^-' | grep -vc '^---'
0
```

`ListSites` and its generated Go are byte-identical, so every filter and all six sort orders on `/sites` are the same code. That is a stronger guarantee than a behavioural test.

## Proof

Run as `wpmgr_app`, with `current_user` / `rolsuper` / `rolbypassrls` read **inside the transaction under test** and asserted — the block refuses to prove anything if it finds itself superuser or `BYPASSRLS`. Fixture is 600 sites in one tenant, scope is the single site that sorts **last** by name, all inside a transaction that is rolled back.

```
NOTICE:  role under test: current_user=wpmgr_app rolsuper=f rolbypassrls=f
NOTICE:  tenant holds 600 sites; page bound is 501
NOTICE:  connection scope = 1 site, the last by name: site-0599
NOTICE:  OLD shape (bound over the tenant): in-scope rows surviving the page = 0
NOTICE:  NEW shape (bound over the scope): returned=1 out_of_scope=0
NOTICE:  nil slice  -> id = ANY(NULL::uuid[]) returns 0 rows
NOTICE:  empty slice -> id = ANY('{}'::uuid[]) returns 0 rows
NOTICE:  narg arm with the SAME nil slice returns 600 rows (the whole tenant)
NOTICE:  ALL ASSERTIONS PASSED as wpmgr_app (rolsuper=f, rolbypassrls=f)
```

The old shape returning `0` is the currently-impossible case stated as a measurement: that site cannot be read today.

**Mutation M1 — scope predicate removed.** The leak assertion is ordered *first* deliberately, so it fires on its own rather than behind the row-count check:

```
# MUTATED (psql exit 3)
NOTICE:  NEW shape (bound over the scope): returned=501 out_of_scope=501
ERROR:  LEAK: 501 out-of-scope rows were emitted by the scoped read

# RESTORED (psql exit 0)
NOTICE:  NEW shape (bound over the scope): returned=1 out_of_scope=0
NOTICE:  ALL ASSERTIONS PASSED as wpmgr_app (rolsuper=f, rolbypassrls=f)
```

`git grep -q "MUTATION M" -- apps/api` exits **1**; the fixture rolled back leaving 0 rows behind.

## Regeneration

`sqlc` resolved with `command -v sqlc` → `/Users/mosamgor/go/bin/sqlc`, `sqlc version` → `v1.31.1`, matching the tree stamp from `grep -h 'sqlc v' apps/api/internal/db/sqlc/*.go | sort -u` → `//   sqlc v1.31.1`. After regenerating, `git diff --quiet -- apps/api/internal/db/sqlc/` exits **0**. No hand-edits.

## What must follow, in `backend-architect`'s hands

1. **Switch the caller.** `Repo.ListSitesForRead` should take the resolved scope and call `ListSitesForMCPScope`. The return type moves from `[]sqlc.ListSitesRow` to `[]sqlc.Site`; `toSiteRecord` reads only `sites` columns, all of which `sqlc.Site` carries, so that is a type swap rather than a rewrite. Once it lands, `site_unread` is unreachable from this path.

2. **A second, separate finding — the RLS policy is inert on this path.** `ListSitesForRead` opens its transaction with `InTenantTx`, which never sets `app.site_scope`. The RESTRICTIVE `sites_site_scope` policy (m19, `20260531050000_m19_orgs_sharing.sql:330`) reads `app.site_scope <> 'on' OR id = ANY(app.allowed_site_ids)`, so with the GUC unset it is permissive and does no work here. That is correct behaviour for the dashboard's org-scoped callers, but it means this read currently has **no** database-level scope enforcement — the Go filter is the only gate. Moving to `RunTenantTx` with the principal would engage the policy as a genuine second layer, the way `ListGrants` already does. The new query's predicate holds under either helper, so this is defence in depth rather than a dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site listing for assistant-assisted workflows by ensuring all authorized sites are returned, even when they fall beyond the first page of tenant-wide results.
  * Excludes archived sites from scoped site listings.
  * Preserves consistent case-insensitive name ordering and result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->