### PR TITLE
fix(mcp): bound the assistant's site read over the caller's scope, and make the m19 policy live on it

### DIFF
--- a/apps/api/internal/mcp/audit_fail_closed_test.go
+++ b/apps/api/internal/mcp/audit_fail_closed_test.go
@@ -46,7 +46,7 @@ func failClosedStore(t *testing.T) (*fakeStore, uuid.UUID) {
 	collected := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
 	row := siteRow(failClosedSiteName, &collected)
 	row.ID = allowed
-	store.sites = []sqlc.ListSitesRow{row}
+	store.sites = []sqlc.Site{row}
 	return store, allowed
 }
 

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -115,9 +115,16 @@ type fakeStore struct {
 
 	// sites is what ListSitesForRead returns; sitesMore is its page-bound
 	// overflow flag; sitesErr forces the read to fail.
-	sites     []sqlc.ListSitesRow
+	sites     []sqlc.Site
 	sitesMore bool
 	sitesErr  error
+
+	// sitePrincipals records every principal ListSitesForRead was called with,
+	// so a test can assert the site read is dispatched SITE-CONSTRAINED. That
+	// assertion is the unit-speed guard on the second RLS layer: an org-scoped
+	// principal reaches InTenantTx, app.site_scope stays unset and
+	// sites_site_scope is inert, and nothing else in this package would notice.
+	sitePrincipals []domain.Principal
 
 	// S16 connections surface.
 	//
@@ -470,8 +477,21 @@ func (f *fakeStore) TouchActivity(
 	return time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC), nil
 }
 
-func (f *fakeStore) ListSitesForRead(_ context.Context, _ uuid.UUID, limit int32) ([]sqlc.ListSitesRow, bool, error) {
+// ListSitesForRead records the principal and returns f.sites UNFILTERED.
+//
+// NOT FILTERING BY principal.AllowedSiteIDs IS DELIBERATE AND IS NOT AN
+// UNFAITHFUL FAKE. The real query and the real RESTRICTIVE policy both drop
+// out-of-scope rows, and both are proved against a live database in
+// apps/api/tests. What this fake models here is the state in which those two
+// layers have failed or been switched off -- which is the only state in which
+// layer 3, the Go filter in ListSitesForModel, can be observed doing anything.
+// A fake that filtered would make every layer-3 proof in this package pass
+// without layer 3 existing.
+func (f *fakeStore) ListSitesForRead(_ context.Context, p domain.Principal, limit int32) ([]sqlc.Site, bool, error) {
 	f.note("ListSitesForRead")
+	f.mu.Lock()
+	f.sitePrincipals = append(f.sitePrincipals, p)
+	f.mu.Unlock()
 	if f.sitesErr != nil {
 		return nil, false, f.sitesErr
 	}

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -106,11 +106,24 @@ type Store interface {
 	// reason, and pgx.ErrNoRows here means the row was not visible.
 	TouchActivity(ctx context.Context, tenantID, grantID, tokenID uuid.UUID) (time.Time, error)
 
-	// ListSitesForRead reads one bounded page of the tenant's sites for the
-	// list_sites tool. It returns the rows AND whether the bound was reached
-	// with rows still unread, because a page-bounded list that reports itself
-	// as complete is a lie about the fleet.
-	ListSitesForRead(ctx context.Context, tenantID uuid.UUID, limit int32) ([]sqlc.ListSitesRow, bool, error)
+	// ListSitesForRead reads one bounded page of THE SITES THIS CONNECTION MAY
+	// READ for the list_sites tool. It returns the rows AND whether the bound
+	// was reached with rows still unread, because a page-bounded list that
+	// reports itself as complete is a lie about the fleet.
+	//
+	// IT TAKES THE PRINCIPAL AND NOT A BARE tenantID, for the reason ListGrants
+	// and ConnectionStatusSnapshot do above -- and here the principal carries a
+	// second job. `sites` carries the RESTRICTIVE sites_site_scope policy (m19),
+	// keyed on the app.site_scope GUC that only InScopedTenantTx sets, so a
+	// tenantID-only signature could reach nothing but InTenantTx and would leave
+	// that policy inert on the one read this surface performs. The principal's
+	// AllowedSiteIDs is ALSO the query's site_ids parameter, so the GUC the
+	// policy reads and the predicate the query carries are the same value rather
+	// than two copies free to drift.
+	//
+	// The principal MUST be site-constrained; an org-scoped one is an error
+	// rather than a tenant-wide read. See the method on Repo.
+	ListSitesForRead(ctx context.Context, principal domain.Principal, limit int32) ([]sqlc.Site, bool, error)
 
 	// ListGrants and RevokeGrantWithTokens are the operator-facing pair (S16).
 	//
@@ -627,25 +640,68 @@ func (r *Repo) TouchActivity(ctx context.Context, tenantID, grantID, tokenID uui
 	return stamped, nil
 }
 
-// ListSitesForRead reads one bounded page of the tenant's sites inside
-// InTenantTx, so `sites` RLS scopes the read to this tenant regardless of what
-// the grant claims.
+// ListSitesForRead reads one bounded page of the sites THIS CONNECTION MAY
+// READ, through RunTenantTx, using ListSitesForMCPScope.
+//
+// THE BOUND IS TAKEN OVER THE CALLER'S OWN SCOPE AND NEVER OVER THE TENANT,
+// AND THAT IS THE FIX THIS METHOD EXISTS TO CARRY. It read ListSites with
+// Limit = bound+1 over the whole tenant and let the service apply the site
+// scope in Go afterwards. An in-scope site whose name sorted past the tenant's
+// first page was therefore never among the rows the filter ran over: the
+// caller received a site_unread refusal for a site that was perfectly healthy,
+// the order is deterministic so no retry could ever produce it, and the
+// shortfall could only arise once the TENANT held more rows than the bound --
+// making its very existence a fact about sites the caller is not entitled to
+// know exist. LIMIT now applies after the scope predicate, so the page is the
+// caller's page.
+//
+// RunTenantTx, NOT InTenantTx, AND THAT IS THE SECOND LAYER RATHER THAN A
+// STYLE CHOICE. m19 carries sites_site_scope as a RESTRICTIVE policy whose
+// USING clause is `app.site_scope <> 'on' OR id = ANY(app.allowed_site_ids)`
+// (20260531050000_m19_orgs_sharing.sql). app.site_scope is set by exactly one
+// helper -- InScopedTenantTx, which RunTenantTx dispatches to for a
+// site-constrained principal -- so under InTenantTx the GUC is unset, the
+// first disjunct is true for every row, and the policy is INERT. That is the
+// state this read was in: the Go filter in ListSitesForModel was the ONLY gate
+// on the site axis, and a bug anywhere between this method and that loop
+// returned the tenant. Now the database refuses independently of Go.
+//
+// THIS IS NOT THE ADR-061 A14 EXCEPTION AND MUST NOT BE "FIXED" BACK INTO IT.
+// ResolveScopeSites above genuinely cannot be scoped: it is the bootstrap that
+// COMPUTES the allowlist, so constraining it by its own output is circular --
+// see bootstrapTenantPrincipal in service.go. This method runs strictly AFTER
+// that resolution has already happened; its caller holds the resolved set in
+// auth.Sites and hands it here as a principal. There is no circularity to
+// avoid, so the exception does not reach this call site.
+//
+// principal.AllowedSiteIDs is BOTH the GUC allowlist and the query's site_ids
+// parameter. Deriving the two from one value is deliberate: they must agree,
+// and passing them separately is an invitation for them to stop agreeing.
+//
+// AN ORG-SCOPED PRINCIPAL IS AN ERROR, NOT A TENANT-WIDE READ. With a nil or
+// empty allowlist the query's `id = ANY($2::uuid[])` matches nothing, so the
+// fail-closed outcome is already zero rows -- but zero rows reaches the caller
+// looking exactly like an organisation that owns no sites, which is this
+// project's signature defect. It is refused by name instead.
 //
 // It asks for limit+1 rows and reports the overflow as `more` rather than
-// silently returning a short list. A page bound that is invisible to the
-// caller is how "these are your sites" becomes false for any org with more
-// sites than one page.
-func (r *Repo) ListSitesForRead(ctx context.Context, tenantID uuid.UUID, limit int32) ([]sqlc.ListSitesRow, bool, error) {
-	var rows []sqlc.ListSitesRow
-	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
-		out, err := sqlc.New(tx).ListSites(ctx, sqlc.ListSitesParams{
-			TenantID: tenantID,
-			Limit:    limit + 1,
-			Offset:   0,
-			// Sort is bound as a parameter and compared against fixed literals
-			// in the query; "name" is one of them and gives the model a stable
-			// order across calls.
-			Sort: "name",
+// silently returning a short list. `more` is now a fact about THE CALLER'S OWN
+// SCOPE ("your scope holds more sites than one page"), not about the tenant,
+// so it discloses nothing; the previous value was a tenant row count and could
+// not be reported to a scoped caller at all.
+func (r *Repo) ListSitesForRead(ctx context.Context, principal domain.Principal, limit int32) ([]sqlc.Site, bool, error) {
+	if !principal.IsSiteConstrained() {
+		return nil, false, fmt.Errorf(
+			"list sites for mcp read: principal is not site-constrained; this read is bounded "+
+				"over the connection's resolved scope and has no tenant-wide form (tenant %s)",
+			principal.TenantID)
+	}
+	var rows []sqlc.Site
+	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		out, err := sqlc.New(tx).ListSitesForMCPScope(ctx, sqlc.ListSitesForMCPScopeParams{
+			TenantID: principal.TenantID,
+			SiteIds:  principal.AllowedSiteIDs,
+			RowLimit: limit + 1,
 		})
 		if err != nil {
 			return fmt.Errorf("list sites for mcp read: %w", err)

--- a/apps/api/internal/mcp/repo.go
+++ b/apps/api/internal/mcp/repo.go
@@ -698,6 +698,45 @@ func (r *Repo) ListSitesForRead(ctx context.Context, principal domain.Principal,
 	}
 	var rows []sqlc.Site
 	err := r.pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		// THE SECOND LAYER IS ASSERTED FROM INSIDE THE TRANSACTION THAT
+		// CARRIES IT, AND THAT PLACEMENT IS THE WHOLE VALUE OF THESE FOUR
+		// LINES.
+		//
+		// A test cannot ask this question from outside. app.site_scope is
+		// transaction-local, so a proof that opens its own RunTenantTx and
+		// reads the GUC there hard-codes the answer it is checking: it reports
+		// 'on' however this method opens its transaction. That is exactly the
+		// m112 shape -- a proof that goes around the code path it claims to
+		// test -- and it left this method's dispatch unguarded until a review
+		// planted the mutation and watched the whole suite stay green.
+		//
+		// Swapping RunTenantTx for InTenantTx here produces an identical
+		// RESULT SET, because the query's own site_ids predicate returns the
+		// same rows either way. There is therefore NO query whose output can
+		// distinguish the two, and no behavioural test can be written. The
+		// only thing that can observe it is the transaction itself.
+		//
+		// WHAT THE POLICY BUYS, said here because the redundancy invites
+		// deleting one of the two layers: the site_ids predicate scopes THIS
+		// query and nothing else, while the GUC scopes the TRANSACTION -- so
+		// any query added inside this fn later inherits the boundary without
+		// its author doing anything. That is the layer that covers queries
+		// which do not exist yet, and it is worth an assertion.
+		var siteScope string
+		if err := tx.QueryRow(ctx,
+			"SELECT coalesce(current_setting('app.site_scope', true), '')").Scan(&siteScope); err != nil {
+			return fmt.Errorf("read app.site_scope: %w", err)
+		}
+		if siteScope != "on" {
+			return fmt.Errorf(
+				"list sites for mcp read: app.site_scope is %q inside this read's own "+
+					"transaction, want \"on\". The RESTRICTIVE sites_site_scope policy (m19) is "+
+					"INERT at any other value, so the database is enforcing nothing on the site "+
+					"axis. Only InScopedTenantTx sets this GUC, and only RunTenantTx with a "+
+					"site-constrained principal reaches it",
+				siteScope)
+		}
+
 		out, err := sqlc.New(tx).ListSitesForMCPScope(ctx, sqlc.ListSitesForMCPScopeParams{
 			TenantID: principal.TenantID,
 			SiteIds:  principal.AllowedSiteIDs,

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1738,19 +1738,24 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 	// THE SECOND RETURN OF ListSitesForRead IS DELIBERATELY DISCARDED, AND
 	// DISCARDING IT IS A FIX RATHER THAN AN OVERSIGHT.
 	//
-	// That value is `more`: "the bounded page was filled and this TENANT has
-	// further site rows". It was previously passed straight through into the
-	// rendered result, which reported it to the caller as a truncation notice.
-	// For a connection scoped to two sites in a six-hundred-site tenant that
-	// notice was both false and disclosing -- the caller received every site
-	// it may read, was told further sites had been withheld, and could infer
-	// from a flag it had no business seeing that the tenant holds more than
-	// sitesPageBound sites.
+	// That value is `more`: "the bounded page was filled and further rows were
+	// left unread". It was once passed straight through into the rendered
+	// result as a truncation notice, and at that time it was a fact about THE
+	// TENANT: the read was tenant-wide and the bound was applied before the
+	// site scope. For a connection scoped to two sites in a six-hundred-site
+	// tenant the notice was both false and disclosing -- the caller received
+	// every site it may read, was told further sites had been withheld, and
+	// could infer from a flag it had no business seeing that the tenant holds
+	// more than sitesPageBound sites.
 	//
-	// A count taken over the TENANT can never be reported to a SITE-SCOPED
-	// caller, however harmless it looks as a completeness flag. Completeness
-	// is recomputed below over the caller's own scope instead, where both
-	// terms are numbers the caller already knows.
+	// The read is now bounded over the caller's own scope, so `more` is no
+	// longer a tenant fact and could be reported without disclosing anything.
+	// It is still discarded, because it is now REDUNDANT: every site it would
+	// account for is already enumerated below as an explicit site_unread
+	// refusal against auth.Sites, which is the stronger report -- it names the
+	// sites rather than raising a flag, and it keeps ok+refused balanced
+	// against asked. Two completeness signals computed from different values
+	// is how the pair comes to disagree.
 	bound := s.pageBound
 	if bound <= 0 {
 		// A Service built by a struct literal rather than NewService. Read a
@@ -1758,21 +1763,26 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 		// present as an organisation owning no sites.
 		bound = sitesPageBound
 	}
-	rows, _, err := s.store.ListSitesForRead(ctx, auth.TenantID, bound)
+	rows, _, err := s.store.ListSitesForRead(ctx, connectionScopedPrincipal(auth), bound)
 	if err != nil {
 		return "", fmt.Errorf("list sites for mcp read: %w", err)
 	}
 
-	// Filter to the grant's resolved set. The query is tenant-scoped by RLS;
-	// this narrows it further to the sites THIS GRANT may read. SiteSet.Allows
-	// returns false for every id on an empty or zero-value set, so there is no
-	// widening path even if the set were somehow lost between here and there.
+	// Filter to the grant's resolved set. The read is now scoped on the site
+	// axis twice before it reaches here -- by the query's own site_ids
+	// predicate and by the RESTRICTIVE sites_site_scope policy the scoped
+	// transaction switches on -- so in a correct system this loop drops
+	// nothing. IT STAYS ANYWAY, and not as ceremony: it is the only one of the
+	// three layers that cannot be switched off by a mistake in the other two,
+	// and SiteSet.Allows returns false for every id on an empty or zero-value
+	// set, so there is no widening path even if the set were lost between here
+	// and there.
 	//
 	// THIS IS LAYER 3, AND LAYER 3 HIDES. A row dropped here is not refused,
 	// not counted and not mentioned: it leaves no trace in the envelope built
 	// below, because `asked` is closed over auth.Sites and an out-of-scope row
 	// was never in auth.Sites to begin with.
-	allowed := make([]sqlc.ListSitesRow, 0, len(rows))
+	allowed := make([]sqlc.Site, 0, len(rows))
 	seen := make(map[uuid.UUID]struct{}, len(rows))
 	for _, r := range rows {
 		if auth.Sites.Allows(r.ID) {
@@ -1787,6 +1797,23 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 	// is reported as an explicit site_unread refusal rather than being left
 	// silently absent, so ok+refused balances against asked and the caller is
 	// never handed a short list that reads as a complete fleet.
+	//
+	// THIS BRANCH IS MUCH NARROWER THAN IT WAS, AND ITS ADVICE CHANGED WITH IT.
+	// While the page was bounded over the TENANT, any in-scope site sorting
+	// past the tenant's first page landed here, and the detail told the caller
+	// to "retry" -- advice that could never work, because the order is
+	// deterministic and the same page comes back every time. The page is now
+	// bounded over the caller's own scope, which removes that cause entirely.
+	//
+	// Two causes remain, and neither is a transient. A connection whose scope
+	// holds more sites than one page will always be short by the same
+	// overflow; and a site that is in scope but ARCHIVED is resolved into
+	// auth.Sites (ResolveMCPGrantScopeSitesInTenantTx has no archived
+	// predicate) while ListSitesForMCPScope excludes it, matching the
+	// dashboard's default (ADR-041). Both are stable facts about this
+	// connection, so the detail says what is true and does not invite a retry
+	// that cannot help. Naming them discloses nothing: every site named here
+	// is already in the caller's own scope.
 	refusals := make([]Refusal, 0)
 	for _, id := range auth.Sites.Sorted() {
 		if _, found := seen[id]; !found {
@@ -1794,7 +1821,10 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 				SiteID: id.String(),
 				Code:   RefusalSiteUnread,
 				Detail: "this site is in scope for this connection but was not returned by the " +
-					"bounded page this call reads; retry, and report it if it persists",
+					"page this call reads. The page is bounded over this connection's own scope " +
+					"in a fixed order, so retrying returns the same page and will not reach it: " +
+					"either this connection's scope holds more sites than one page, or the site " +
+					"is archived. Ask an operator to narrow the scope or restore the site.",
 			})
 		}
 	}
@@ -1926,6 +1956,47 @@ func orEmpty(ids []uuid.UUID) []uuid.UUID {
 // ADR-061 A11 item 2 literally here.
 func bootstrapTenantPrincipal(tenantID uuid.UUID) domain.Principal {
 	return domain.Principal{TenantID: tenantID}
+}
+
+// connectionScopedPrincipal builds the SITE-CONSTRAINED principal the
+// assistant's site read runs under. It is the counterpart of
+// bootstrapTenantPrincipal directly above, and the two exist as a named pair
+// because the difference between them is the whole of ADR-061 A11 item 2 on
+// this surface: one call site is genuinely the exception and one is not, and
+// nothing in the type system tells them apart.
+//
+// WHY THIS ONE IS SCOPED, WHERE THE BOOTSTRAP IS NOT. bootstrapTenantPrincipal
+// exists because ResolveScopeSites COMPUTES this connection's allowlist, so
+// scoping that query by the allowlist it is producing is circular -- read A14
+// there before touching it. ListSitesForModel runs strictly afterwards. By the
+// time it calls this, Authenticate has already resolved the scope through the
+// audited chokepoint and auth.Sites holds the answer. The allowlist is in hand,
+// so there is nothing circular to avoid and the exception simply does not
+// apply here.
+//
+// DO NOT "FIX" THIS BACK TO bootstrapTenantPrincipal BY ANALOGY WITH A14. That
+// substitution compiles, every unit test passes, and the observable behaviour
+// is identical, because the Go filter in ListSitesForModel still hides
+// out-of-scope rows. What it silently removes is the DATABASE layer:
+// RunTenantTx would dispatch an org-scoped principal to InTenantTx,
+// app.site_scope would go unset, and the RESTRICTIVE sites_site_scope policy
+// (m19) would be inert -- leaving the Go loop as the only gate on the site
+// axis, which is the state this change exists to end. Repo.ListSitesForRead
+// refuses an unconstrained principal rather than reading tenant-wide, so the
+// substitution fails loudly instead; that refusal is the executed guard.
+//
+// Scope is set explicitly as well as AllowedSiteIDs even though
+// domain.IsSiteConstrained accepts either. The empty-scope case never reaches
+// here -- ListSitesForModel refuses auth.Sites.IsEmpty() first -- but a
+// principal that depended on a non-empty slice for its constraint would become
+// tenant-wide the moment that refusal moved, and "the caller checks first" is
+// not a property this value should rest on.
+func connectionScopedPrincipal(auth AuthorizedRequest) domain.Principal {
+	return domain.Principal{
+		TenantID:       auth.TenantID,
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: auth.Sites.Sorted(),
+	}
 }
 
 // requireOrgScopedPrincipal is the site-scope refusal, and it is the SECOND of

--- a/apps/api/internal/mcp/tools.go
+++ b/apps/api/internal/mcp/tools.go
@@ -133,7 +133,13 @@ type siteRecord struct {
 // because a 60s heartbeat bumps updated_at without touching components, so
 // using it dated an inventory that was never refreshed and reported a stale
 // fleet as fresh.
-func toSiteRecord(row sqlc.ListSitesRow, now time.Time) siteRecord {
+// THE PARAMETER IS sqlc.Site AND NOT sqlc.ListSitesRow, and the swap was a type
+// change rather than a rewrite. ListSitesRow is `sites.*` plus
+// page_cache_enabled and object_cache_enabled, two LEFT JOIN columns for the
+// dashboard's cache badges that this function has never read; sqlc.Site is
+// `sites.*` alone. Every field below is present on both, which is why the body
+// is untouched. ListSitesForMCPScope drops those two joins with the columns.
+func toSiteRecord(row sqlc.Site, now time.Time) siteRecord {
 	rec := siteRecord{
 		ID:              row.ID.String(),
 		Name:            row.Name,
@@ -225,7 +231,7 @@ type sitesPayload struct {
 //     the payload is in the exact position that a downstream context-window
 //     trim removes, which would turn a visibly-truncated result back into a
 //     silently-truncated one.
-func buildListSitesResult(rows []sqlc.ListSitesRow, env Envelope, now time.Time) (string, error) {
+func buildListSitesResult(rows []sqlc.Site, env Envelope, now time.Time) (string, error) {
 	available := len(rows)
 
 	kept := make([]json.RawMessage, 0, len(rows))

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -433,8 +434,8 @@ func TestTransport_OversizedBodyIsRefused(t *testing.T) {
 // updated_at without touching components.
 // ---------------------------------------------------------------------------
 
-func siteRow(name string, componentsAt *time.Time) sqlc.ListSitesRow {
-	row := sqlc.ListSitesRow{
+func siteRow(name string, componentsAt *time.Time) sqlc.Site {
+	row := sqlc.Site{
 		ID:              uuid.New(),
 		Name:            name,
 		Url:             "https://" + name + ".example",
@@ -456,7 +457,7 @@ func siteRow(name string, componentsAt *time.Time) sqlc.ListSitesRow {
 
 func TestListSites_NullComponentsUpdatedAtRendersNeverCollected(t *testing.T) {
 	collected := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
-	rows := []sqlc.ListSitesRow{
+	rows := []sqlc.Site{
 		siteRow("never", nil),
 		siteRow("collected", &collected),
 	}
@@ -527,7 +528,7 @@ func TestListSites_TruncationCutsAtRecordBoundaryWithAMarker(t *testing.T) {
 
 	// Build enough records to overrun recordByteBudget several times over, so
 	// the budget is certain to run out mid-list.
-	var rows []sqlc.ListSitesRow
+	var rows []sqlc.Site
 	for i := 0; i < 400; i++ {
 		rows = append(rows, siteRow(fmt.Sprintf("site-%03d-with-a-deliberately-long-name-to-consume-budget", i), &collected))
 	}
@@ -602,7 +603,7 @@ func TestListSites_TruncationCutsAtRecordBoundaryWithAMarker(t *testing.T) {
 // NOT carry the marker.
 func TestListSites_UntruncatedResultIsNotMarked(t *testing.T) {
 	collected := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
-	rows := []sqlc.ListSitesRow{siteRow("one", &collected), siteRow("two", nil)}
+	rows := []sqlc.Site{siteRow("one", &collected), siteRow("two", nil)}
 
 	text, err := buildListSitesResult(rows, envFor(t, rows), time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
 	if err != nil {
@@ -630,7 +631,7 @@ func TestListSites_UntruncatedResultIsNotMarked(t *testing.T) {
 // caller may see answered, nothing refused. It is the shape almost every
 // renderer test wants, and building it through NewEnvelope rather than as a
 // struct literal means these tests also exercise the balance check.
-func envFor(t *testing.T, rows []sqlc.ListSitesRow) Envelope {
+func envFor(t *testing.T, rows []sqlc.Site) Envelope {
 	t.Helper()
 	env, err := NewEnvelope(len(rows), len(rows), nil)
 	if err != nil {
@@ -655,7 +656,7 @@ func envFor(t *testing.T, rows []sqlc.ListSitesRow) Envelope {
 // asserts that, and asserts that the numbers balance without a residual.
 func TestListSites_UnreadInScopeSiteIsReportedAsPartial(t *testing.T) {
 	collected := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
-	rows := []sqlc.ListSitesRow{siteRow("one", &collected)}
+	rows := []sqlc.Site{siteRow("one", &collected)}
 
 	// The caller may read two sites; only one came back.
 	unread := uuid.New()
@@ -712,7 +713,7 @@ func TestListSites_UnreadInScopeSiteIsReportedAsPartial(t *testing.T) {
 // past the budget must not silently reintroduce the bug.
 func TestListSites_BannerSurvivesInstructionClamp(t *testing.T) {
 	collected := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
-	var rows []sqlc.ListSitesRow
+	var rows []sqlc.Site
 	for i := 0; i < 400; i++ {
 		rows = append(rows, siteRow(fmt.Sprintf("site-%03d-with-a-deliberately-long-name-to-consume-budget", i), &collected))
 	}
@@ -754,7 +755,7 @@ func TestListSites_OneOversizedRecordDoesNotBlockTheRest(t *testing.T) {
 	// "a..." sorts first by name, and on its own exceeds the whole budget.
 	oversized := siteRow("a"+strings.Repeat("x", recordByteBudget+512), &collected)
 	small := siteRow("b-small-site", &collected)
-	rows := []sqlc.ListSitesRow{oversized, small}
+	rows := []sqlc.Site{oversized, small}
 
 	text, err := buildListSitesResult(rows, envFor(t, rows), time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC))
 	if err != nil {
@@ -1077,7 +1078,7 @@ func TestToolsCall_ReadPathReturnsStampedSites(t *testing.T) {
 	inScope := siteRow("in-scope", &collected)
 	inScope.ID = allowed
 	outOfScope := siteRow("out-of-scope", &collected) // a different, unscoped id
-	store.sites = []sqlc.ListSitesRow{inScope, outOfScope}
+	store.sites = []sqlc.Site{inScope, outOfScope}
 
 	r := newTransportRouter(t, store)
 	w := post(t, r, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
@@ -1093,6 +1094,70 @@ func TestToolsCall_ReadPathReturnsStampedSites(t *testing.T) {
 	// must not appear even though the tenant read returned it.
 	if strings.Contains(body, "out-of-scope") {
 		t.Error("a site outside the grant's resolved site set was returned")
+	}
+}
+
+// TestToolsCall_SiteReadIsDispatchedSiteConstrained is the unit-speed guard on
+// the SECOND RLS layer, and it is the counterpart of
+// TestAuthenticateHandsTheChokepointAnUnscopedPrincipal in oauth_test.go: that
+// one asserts the bootstrap read is NOT site-constrained, this one asserts the
+// site read IS.
+//
+// WHY IT IS NEEDED AT ALL, when the layer-3 test above already passes. Swapping
+// connectionScopedPrincipal for bootstrapTenantPrincipal at the call site
+// compiles, changes no rendered output, and leaves every other test in this
+// package green -- because the Go filter in ListSitesForModel still hides
+// out-of-scope rows. What it silently removes is the database layer:
+// db.RunTenantTx routes an org-scoped principal to InTenantTx, app.site_scope
+// is never set, and the RESTRICTIVE sites_site_scope policy (m19) evaluates its
+// first disjunct to true for every row. Nothing observable at this layer
+// changes. This test is what goes red.
+func TestToolsCall_SiteReadIsDispatchedSiteConstrained(t *testing.T) {
+	allowed := uuid.New()
+	store := liveGrantStore(allowed)
+
+	collected := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	inScope := siteRow("in-scope", &collected)
+	inScope.ID = allowed
+	store.sites = []sqlc.Site{inScope}
+
+	r := newTransportRouter(t, store)
+	w := post(t, r, `{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+	}
+
+	store.mu.Lock()
+	principals := append([]domain.Principal(nil), store.sitePrincipals...)
+	store.mu.Unlock()
+
+	if len(principals) != 1 {
+		t.Fatalf("ListSitesForRead was called %d times, want exactly 1", len(principals))
+	}
+	p := principals[0]
+
+	// THE ASSERTION THAT NAMES THE LEAK, FIRST. An unconstrained principal here
+	// means the site read ran with app.site_scope unset and the m19 policy
+	// inert, leaving the Go filter as the only gate on the site axis.
+	if !p.IsSiteConstrained() {
+		t.Fatalf("RLS LAYER LOST: the assistant's site read was dispatched with an "+
+			"UNCONSTRAINED principal (scope=%q, %d allowed site ids). RunTenantTx routes that "+
+			"to InTenantTx, app.site_scope is never set, and the RESTRICTIVE sites_site_scope "+
+			"policy is inert -- the database enforces nothing and the Go filter is the only "+
+			"gate. Build the principal with connectionScopedPrincipal, not "+
+			"bootstrapTenantPrincipal: the ADR-061 A14 exception is the scope BOOTSTRAP and "+
+			"does not reach this call site, which runs after the allowlist is resolved",
+			p.Scope, len(p.AllowedSiteIDs))
+	}
+
+	// The allowlist must be the connection's resolved scope, not something
+	// wider that merely happens to be non-empty.
+	if len(p.AllowedSiteIDs) != 1 || p.AllowedSiteIDs[0] != allowed {
+		t.Fatalf("the site read's allowlist = %v, want exactly the resolved scope [%s]",
+			p.AllowedSiteIDs, allowed)
+	}
+	if p.TenantID != store.token.TenantID {
+		t.Fatalf("the site read ran under tenant %s, want %s", p.TenantID, store.token.TenantID)
 	}
 }
 
@@ -1113,7 +1178,7 @@ func TestNotification_ToolsCallWithNoIdDoesNotExecuteTheTool(t *testing.T) {
 	store := liveGrantStore(allowed)
 	row := siteRow("should-never-be-read", nil)
 	row.ID = allowed
-	store.sites = []sqlc.ListSitesRow{row}
+	store.sites = []sqlc.Site{row}
 
 	r := newTransportRouter(t, store)
 	w := post(t, r, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"fleet_sites_list","arguments":{}}}`, nil)

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -153,27 +153,27 @@ func TestMCPListSitesForReadIsTenantIsolatedAsAppRole(t *testing.T) {
 		AllowedSiteIDs: []uuid.UUID{siteA1.ID, siteA2.ID, siteB1.ID},
 	}
 
-	// Confirm the role inside the very transaction the read uses, and confirm
-	// the scoped helper genuinely engaged: RunTenantTx routes a site-
-	// constrained principal to InScopedTenantTx, and app.site_scope='on' is
-	// what makes the RESTRICTIVE m19 policy live. Reading the GUC back here is
-	// what separates "the helper ran" from "the helper was named".
-	if err := pool.RunTenantTx(ctx, principalA, func(tx pgx.Tx) error {
-		mcpAssertAndReportRole(t, tx, "RunTenantTx (ListSitesForRead path)")
-		var scope string
-		if err := tx.QueryRow(ctx,
-			"SELECT current_setting('app.site_scope', true)").Scan(&scope); err != nil {
-			return err
-		}
-		if scope != "on" {
-			t.Fatalf("app.site_scope = %q inside the site read's transaction, want \"on\"; "+
-				"the RESTRICTIVE sites_site_scope policy is INERT at any other value",
-				scope)
-		}
-		t.Logf("app.site_scope=%q inside the read's own transaction", scope)
+	// Confirm the ROLE, and nothing more, in a SIBLING transaction. The role is
+	// a property of the pool's connections rather than of any one transaction,
+	// so a sibling is a truthful place to read it.
+	//
+	// THIS BLOCK DELIBERATELY NO LONGER ASSERTS app.site_scope, AND THE REASON
+	// IS A DEFECT THIS TEST ONCE HAD. It opened its own pool.RunTenantTx, read
+	// the GUC there, found "on", and reported that as evidence about
+	// ListSitesForRead's dispatch. It is not: this transaction hard-codes
+	// RunTenantTx, so it answers "on" no matter which helper the repo picks. A
+	// review planted RunTenantTx -> InTenantTx in the repo and the whole suite
+	// stayed green -- the m112 shape exactly, a proof that goes around the code
+	// path it claims to cover.
+	//
+	// The GUC is now asserted by Repo.ListSitesForRead from INSIDE the
+	// transaction it opens itself, which is the only place that can observe it,
+	// and the read below fails with that message if the dispatch is wrong.
+	if err := pool.InTenantTx(ctx, tenantA, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "sibling tx (role only; the GUC is asserted by the repo)")
 		return nil
 	}); err != nil {
-		t.Fatalf("open scoped tenant tx: %v", err)
+		t.Fatalf("open tenant tx: %v", err)
 	}
 
 	rows, more, err := mcpRepo.ListSitesForRead(ctx, principalA, 500)

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -121,15 +121,6 @@ func TestMCPListSitesForReadIsTenantIsolatedAsAppRole(t *testing.T) {
 	tenantA := seedTenant(t, pool, "mcp-s6b2-org-a-"+uuid.NewString()[:8])
 	tenantB := seedTenant(t, pool, "mcp-s6b2-org-b-"+uuid.NewString()[:8])
 
-	// Confirm the role inside the very transaction the read uses, not on some
-	// other connection.
-	if err := pool.InTenantTx(ctx, tenantA, func(tx pgx.Tx) error {
-		mcpAssertAndReportRole(t, tx, "InTenantTx (ListSitesForRead path)")
-		return nil
-	}); err != nil {
-		t.Fatalf("open tenant tx: %v", err)
-	}
-
 	siteA1, err := siteRepo.Create(ctx, site.CreateInput{
 		TenantID: tenantA, URL: "https://a1.example.com", Name: "a1-alpha"})
 	if err != nil {
@@ -147,7 +138,45 @@ func TestMCPListSitesForReadIsTenantIsolatedAsAppRole(t *testing.T) {
 	}
 
 	// THE READ, through the method list_sites calls.
-	rows, more, err := mcpRepo.ListSitesForRead(ctx, tenantA, 500)
+	//
+	// THE ALLOWLIST DELIBERATELY NAMES ORG B's SITE. The read is now bounded
+	// over the caller's own scope, so the interesting cross-tenant question
+	// moved with it: not "does a tenant-wide read stay in its tenant" but
+	// "does a foreign id smuggled into the scope reach across". Both the
+	// query's own `tenant_id = $1` and the tenant RLS policy must drop it, and
+	// planting it is the only way to execute that rather than read it.
+	// mcp_grants.scope_site_ids is a uuid[] with no foreign key, so a grant
+	// really can carry this.
+	principalA := domain.Principal{
+		TenantID:       tenantA,
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{siteA1.ID, siteA2.ID, siteB1.ID},
+	}
+
+	// Confirm the role inside the very transaction the read uses, and confirm
+	// the scoped helper genuinely engaged: RunTenantTx routes a site-
+	// constrained principal to InScopedTenantTx, and app.site_scope='on' is
+	// what makes the RESTRICTIVE m19 policy live. Reading the GUC back here is
+	// what separates "the helper ran" from "the helper was named".
+	if err := pool.RunTenantTx(ctx, principalA, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "RunTenantTx (ListSitesForRead path)")
+		var scope string
+		if err := tx.QueryRow(ctx,
+			"SELECT current_setting('app.site_scope', true)").Scan(&scope); err != nil {
+			return err
+		}
+		if scope != "on" {
+			t.Fatalf("app.site_scope = %q inside the site read's transaction, want \"on\"; "+
+				"the RESTRICTIVE sites_site_scope policy is INERT at any other value",
+				scope)
+		}
+		t.Logf("app.site_scope=%q inside the read's own transaction", scope)
+		return nil
+	}); err != nil {
+		t.Fatalf("open scoped tenant tx: %v", err)
+	}
+
+	rows, more, err := mcpRepo.ListSitesForRead(ctx, principalA, 500)
 	if err != nil {
 		t.Fatalf("ListSitesForRead as wpmgr_app: %v", err)
 	}
@@ -159,32 +188,68 @@ func TestMCPListSitesForReadIsTenantIsolatedAsAppRole(t *testing.T) {
 	seen := map[uuid.UUID]bool{}
 	for _, r := range rows {
 		seen[r.ID] = true
-		// Belt and braces: no row may carry another tenant's id.
+	}
+
+	// THE LEAK ASSERTION COMES FIRST, AND THE ORDER IS THE POINT. Behind a
+	// row-count check it would never execute on the run that matters: a read
+	// that returned org B's row instead of one of org A's has a count of 2 and
+	// is a cross-tenant leak, and the count check would have failed the test
+	// for the wrong reason with the leak assertion never reached. A leak check
+	// that only runs when nothing leaked is not a proof of anything.
+	if seen[siteB1.ID] {
+		t.Fatalf("CROSS-TENANT LEAK: org A's list_sites returned org B's site %s, named in "+
+			"org A's own scope allowlist. tenant_id in the query and the tenant RLS policy "+
+			"must both drop it", siteB1.ID)
+	}
+	for _, r := range rows {
 		if r.TenantID != tenantA {
-			t.Errorf("org A's read returned a row owned by tenant %s", r.TenantID)
+			t.Fatalf("CROSS-TENANT LEAK: org A's read returned a row owned by tenant %s",
+				r.TenantID)
 		}
 	}
+
 	if !seen[siteA1.ID] || !seen[siteA2.ID] {
 		t.Errorf("org A cannot see its own sites: got %v", seen)
-	}
-	// THE ASSERTION THAT MATTERS.
-	if seen[siteB1.ID] {
-		t.Fatalf("CROSS-TENANT LEAK: org A's list_sites returned org B's site %s", siteB1.ID)
 	}
 	if len(rows) != 2 {
 		t.Errorf("org A read %d rows, want exactly its own 2", len(rows))
 	}
 
 	// And the mirror, so this is not an artefact of ordering or of A simply
-	// having been created first.
-	rowsB, _, err := mcpRepo.ListSitesForRead(ctx, tenantB, 500)
+	// having been created first. B's scope names A's sites this time.
+	principalB := domain.Principal{
+		TenantID:       tenantB,
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{siteB1.ID, siteA1.ID, siteA2.ID},
+	}
+	rowsB, _, err := mcpRepo.ListSitesForRead(ctx, principalB, 500)
 	if err != nil {
 		t.Fatalf("ListSitesForRead for org B: %v", err)
+	}
+	for _, r := range rowsB {
+		if r.TenantID != tenantB {
+			t.Fatalf("CROSS-TENANT LEAK: org B's read returned a row owned by tenant %s",
+				r.TenantID)
+		}
 	}
 	if len(rowsB) != 1 || rowsB[0].ID != siteB1.ID {
 		t.Fatalf("org B read %d rows, want exactly its own 1", len(rowsB))
 	}
 	t.Logf("mirror ok: org B read %d row and it is its own", len(rowsB))
+
+	// AN ORG-SCOPED PRINCIPAL IS REFUSED, NOT SERVED THE TENANT. This is the
+	// executed half of the guard that stops someone "fixing" the call site back
+	// to bootstrapTenantPrincipal by analogy with ADR-061 A14: the substitution
+	// would leave app.site_scope unset and the m19 policy inert, so it fails
+	// here by name rather than succeeding quietly.
+	if _, _, err := mcpRepo.ListSitesForRead(ctx,
+		domain.Principal{TenantID: tenantA, Scope: domain.ScopeOrg}, 500); err == nil {
+		t.Fatal("ListSitesForRead accepted an ORG-SCOPED principal. That principal reaches " +
+			"InTenantTx, app.site_scope is never set, and the RESTRICTIVE sites_site_scope " +
+			"policy is inert -- the read must refuse rather than run unscoped")
+	} else {
+		t.Logf("org-scoped principal refused by name: %v", err)
+	}
 }
 
 // TestMCPScopeResolutionDropsForeignSiteIDsAsAppRole is m124 obligation 2

--- a/apps/api/tests/mcp_layer3_hiding_integration_test.go
+++ b/apps/api/tests/mcp_layer3_hiding_integration_test.go
@@ -61,6 +61,11 @@ type layer3Envelope struct {
 	Refusals []struct {
 		SiteID string `json:"site_id"`
 		Code   string `json:"code"`
+		// Detail is decoded because it is CUSTOMER-FACING TEXT that a model
+		// acts on. A refusal whose advice cannot work ("retry" against a
+		// deterministic page) is a defect in the same way a wrong number is,
+		// and it is only testable if the wire text is read back.
+		Detail string `json:"detail"`
 	} `json:"refusals"`
 }
 
@@ -139,18 +144,46 @@ func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
 			auth.Sites.Len(), auth.Sites.Allows(siteA.ID), auth.Sites.Allows(siteB.ID))
 	}
 
-	// The repo genuinely sees BOTH rows in this tenant. Asserting it here is
-	// what makes the rest of the test meaningful: it establishes that hiding B
-	// is work the scope filter must do, not something RLS already did.
-	rows, _, err := mcpRepo.ListSitesForRead(ctx, tenant, 500)
+	// A TENANT TRANSACTION GENUINELY SEES BOTH ROWS. Asserting it here is what
+	// makes the rest of the test meaningful: it establishes that hiding B is
+	// work the scope layers must do, not something tenant RLS already did.
+	//
+	// This is read through pool.InTenantTx rather than through the repo BECAUSE
+	// the repo method is no longer capable of a tenant-wide read -- which is
+	// itself the change under test. It is a fixture assertion about what the
+	// tenant holds, never a substitute for exercising the production path.
+	var tenantSiteCount int
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (fixture: what the tenant holds)")
+		return tx.QueryRow(ctx,
+			"SELECT count(*) FROM sites WHERE tenant_id = $1", tenant).Scan(&tenantSiteCount)
+	}); err != nil {
+		t.Fatalf("count the tenant's sites: %v", err)
+	}
+	if tenantSiteCount != 2 {
+		t.Fatalf("the tenant holds %d sites; this proof needs both visible to a tenant "+
+			"transaction, otherwise hiding B is not work anything had to do", tenantSiteCount)
+	}
+
+	// AND THE SCOPED READ RETURNS ONLY A. This is the database doing the
+	// hiding, before the Go filter below ever runs: the query's site_ids
+	// predicate and the RESTRICTIVE sites_site_scope policy both drop B.
+	rows, _, err := mcpRepo.ListSitesForRead(ctx,
+		domain.Principal{TenantID: tenant, Scope: domain.ScopeSite,
+			AllowedSiteIDs: []uuid.UUID{siteA.ID}}, 500)
 	if err != nil {
 		t.Fatalf("ListSitesForRead: %v", err)
 	}
-	if len(rows) != 2 {
-		t.Fatalf("the tenant read returned %d rows; this proof needs both sites visible to the "+
-			"transaction, otherwise the scope filter is not what hides B", len(rows))
+	for _, r := range rows {
+		if r.ID == siteB.ID {
+			t.Fatalf("SCOPE LEAK AT THE DATABASE: the scoped read returned out-of-scope site %s",
+				siteB.ID)
+		}
 	}
-	t.Logf("the tenant transaction sees %d sites; the grant is scoped to 1", len(rows))
+	if len(rows) != 1 {
+		t.Fatalf("the scoped read returned %d rows, want exactly the 1 site in scope", len(rows))
+	}
+	t.Logf("the tenant holds %d sites; the scoped read returned %d", tenantSiteCount, len(rows))
 
 	eng := mountLikeProduction(t, svc, domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg})
 	res := mcpRPC(t, eng, bearer, map[string]any{
@@ -265,10 +298,20 @@ func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
 // restored in production code. It read as protection and was vacuous.
 //
 // svc.WithPageBound(3) puts the small bound on the path under test, so the
-// production read genuinely crosses its own bound and `more` is true inside
-// ListSitesForModel -- which is the only state in which the defect can
-// reappear. Seeding 501 sites would reach the same state and make the test
-// minutes long, which is how a slow proof gets skipped and then deleted.
+// production read genuinely runs against a tenant that exceeds it. Seeding 501
+// sites would reach the same state and make the test minutes long, which is how
+// a slow proof gets skipped and then deleted.
+//
+// WHAT CHANGED UNDER THIS TEST, AND WHY IT IS KEPT ANYWAY. The read is now
+// bounded over the CALLER'S OWN SCOPE (ListSitesForMCPScope), so `more` inside
+// ListSitesForModel is false here and the tenant's row count is no longer
+// measured against the page bound at all. The disclosure this test names is
+// therefore structurally out of reach rather than merely discarded in Go. The
+// test stays because "out of reach" is a property of the current query, and one
+// signature change -- a caller passing the tenant's sites as the allowlist, a
+// helper reverting to ListSites -- puts it back within reach with every other
+// proof in this package still green. The scoped assertion added below is what
+// pins the structural half.
 func TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole(t *testing.T) {
 	ctx := context.Background()
 	pool := startPostgres(t)
@@ -295,22 +338,52 @@ func TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole(t *testing.T) {
 		ids = append(ids, s.ID)
 	}
 
-	// Confirm the bound really is exceeded, at the SAME value the service was
-	// given above. This is a corroboration of the injected bound, not a
+	// Confirm the TENANT would exceed the bound the service was given, at the
+	// SAME value. This is a corroboration of the injected bound, not a
 	// substitute for injecting it: on its own it proves nothing about the tool,
 	// which is exactly how the first version of this test came to be vacuous.
-	bounded, more, err := mcpRepo.ListSitesForRead(ctx, tenant, 3)
-	if err != nil {
-		t.Fatalf("ListSitesForRead bounded: %v", err)
+	//
+	// It is counted through InTenantTx rather than through the repo because the
+	// repo can no longer take a tenant-wide read at all -- see below.
+	var tenantSiteCount int
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			"SELECT count(*) FROM sites WHERE tenant_id = $1", tenant).Scan(&tenantSiteCount)
+	}); err != nil {
+		t.Fatalf("count the tenant's sites: %v", err)
 	}
-	if !more || len(bounded) != 3 {
-		t.Fatalf("bounded read returned %d rows more=%v; this proof needs the bound exceeded",
-			len(bounded), more)
+	if tenantSiteCount <= 3 {
+		t.Fatalf("the tenant holds %d sites; this proof needs it to exceed the injected bound of 3",
+			tenantSiteCount)
 	}
-	t.Logf("the tenant holds %d sites and a bound of 3 is exceeded (more=%v)", len(ids), more)
 
 	// The grant is scoped to ONE site.
 	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{ids[0]})
+
+	// AND THE CALLER'S OWN PAGE IS NOT BOUNDED, which is the structural half of
+	// the fix rather than a restatement of the assertions below. The tenant
+	// exceeds the bound; this caller's scope does not, so `more` is false and
+	// there is no page-bound fact about this call in the first place. While the
+	// bound was applied over the tenant, `more` was true here and the only
+	// thing standing between it and the caller was Go code choosing to discard
+	// it.
+	scoped, more, err := mcpRepo.ListSitesForRead(ctx,
+		domain.Principal{TenantID: tenant, Scope: domain.ScopeSite,
+			AllowedSiteIDs: []uuid.UUID{ids[0]}}, 3)
+	if err != nil {
+		t.Fatalf("ListSitesForRead scoped: %v", err)
+	}
+	if more {
+		t.Fatalf("DISCLOSURE REGRESSION: more=true for a caller scoped to 1 site under a bound "+
+			"of 3 in a %d-site tenant. `more` must be a fact about the CALLER'S OWN scope; a "+
+			"true here is the tenant's row count reaching a page bound it should never have "+
+			"been measured against", tenantSiteCount)
+	}
+	if len(scoped) != 1 {
+		t.Fatalf("the scoped read returned %d rows, want exactly the 1 site in scope", len(scoped))
+	}
+	t.Logf("the tenant holds %d sites (bound 3, exceeded); the caller's scoped page holds %d "+
+		"with more=%v", tenantSiteCount, len(scoped), more)
 
 	eng := mountLikeProduction(t, svc, domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg})
 	res := mcpRPC(t, eng, bearer, map[string]any{

--- a/apps/api/tests/mcp_layer3_hiding_integration_test.go
+++ b/apps/api/tests/mcp_layer3_hiding_integration_test.go
@@ -260,11 +260,38 @@ func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
 	// byte_cap is excluded by name because it is a compile-time constant that
 	// has nothing to do with the fleet, and would otherwise collide by
 	// coincidence for any tenant holding 30720 sites.
+	//
+	// IT COMPARES AGAINST tenantSiteCount AND NOT len(rows), AND THE
+	// DIFFERENCE IS WHETHER THIS GUARD CAN FIRE AT ALL. It read `len(rows)`
+	// while `rows` was the TENANT-WIDE read; scoping that read (#671) made
+	// len(rows) the CALLER'S count, which is payload.Envelope.Asked. The two
+	// conditions then became mutually exclusive -- `n == len(rows) && n !=
+	// Asked` is unsatisfiable when len(rows) == Asked -- and the guard could
+	// not fire on any input. It was not written wrong; a correct change
+	// elsewhere silently emptied it, which is why it is now proven to fire by
+	// planting a field rather than by being read.
+	//
+	// tenantSiteCount is counted at the top of this test through InTenantTx and
+	// is the value the guard was always about: what the TENANT holds, which
+	// this caller must not be able to learn.
+	// THE GUARD REFUSES TO BE DEAD. Its two conditions are `n == tenantSiteCount`
+	// and `n != Asked`, which are mutually exclusive -- and the loop therefore
+	// unsatisfiable on every input -- whenever the fixture makes those two
+	// numbers equal. That is precisely how this guard spent a period being
+	// green on everything, so the precondition is asserted rather than assumed.
+	// A fixture that drifts into tenantSiteCount == Asked now fails loudly
+	// instead of quietly guarding nothing.
+	if tenantSiteCount == payload.Envelope.Asked {
+		t.Fatalf("this guard cannot fire: the tenant holds %d sites and the caller's scope is "+
+			"also %d, so `n == tenantSiteCount && n != Asked` is unsatisfiable. The fixture must "+
+			"keep the tenant strictly larger than the caller's scope for the sweep below to "+
+			"distinguish anything", tenantSiteCount, payload.Envelope.Asked)
+	}
 	for field, n := range numericFields(t, text) {
 		if field == "byte_cap" {
 			continue
 		}
-		if n == len(rows) && n != payload.Envelope.Asked {
+		if n == tenantSiteCount && n != payload.Envelope.Asked {
 			t.Errorf("INFERENCE LEAK: field %q = %d, which is the TENANT's site count while the "+
 				"caller's scope is %d. A count field carrying tenant cardinality discloses that "+
 				"sites exist which the caller may not see:\n%s",

--- a/apps/api/tests/mcp_scoped_site_read_integration_test.go
+++ b/apps/api/tests/mcp_scoped_site_read_integration_test.go
@@ -1,0 +1,368 @@
+// mcp_scoped_site_read_integration_test.go: the assistant's site read is
+// bounded over THE CALLER'S OWN SCOPE, and the m19 site-scope policy is a live
+// second layer under it. Executed against the real schema as wpmgr_app.
+//
+// TWO SEPARATE CLAIMS LIVE HERE AND THEY FAIL INDEPENDENTLY.
+//
+//  1. THE BOUND. ListSitesForRead read ListSites over the whole tenant with
+//     Limit = bound+1 and Sort = 'name', and ListSitesForModel applied the
+//     connection's site scope in Go afterwards. An in-scope site whose name
+//     sorted past the tenant's first page was never among the rows the filter
+//     ran over, so a perfectly healthy site came back as a site_unread refusal
+//     advising a retry -- advice that could never work, because the order is
+//     deterministic and every call returns the same page. The first test seeds
+//     the exact shape (600 sites, scope = the one that sorts LAST) and runs the
+//     OLD read alongside the new one, so the difference is executed rather than
+//     asserted from the commit message.
+//
+//  2. THE POLICY. That read opened with InTenantTx, which never sets
+//     app.site_scope. The RESTRICTIVE sites_site_scope policy (m19,
+//     20260531050000_m19_orgs_sharing.sql) is `app.site_scope <> 'on' OR
+//     id = ANY(app.allowed_site_ids)`, so with the GUC unset its first disjunct
+//     is true for every row and the policy does nothing. The Go filter in
+//     ListSitesForModel was the only gate on the site axis. The second test
+//     runs ONE predicate-free statement under both helpers and shows the row
+//     count differ -- the policy alone, with the query's own site_ids predicate
+//     deliberately out of the way, because a proof that cannot separate the two
+//     cannot tell a live policy from a well-written WHERE clause.
+//
+// The role is load-bearing: wpmgr_app is NOSUPERUSER NOBYPASSRLS, and either
+// privilege makes every assertion here vacuous. It is asserted and printed from
+// INSIDE the transaction under test.
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// scopedSiteReadFleetSize is the tenant size the first proof needs. It must
+// exceed the service's own page bound (mcp.sitesPageBound, 500) or the defect
+// cannot arise at all: the shortfall only appears once the TENANT holds more
+// rows than one page.
+const scopedSiteReadFleetSize = 600
+
+// seedSitesBulk inserts n sites in one statement and returns the id of the one
+// named lastName, which is seeded to sort LAST under `lower(name) ASC`.
+//
+// IT IS A FIXTURE AND IT IS DELIBERATELY NOT site.Repo.Create. Six hundred
+// round trips would make this proof slow enough to be skipped and then deleted,
+// which is how the page-bound test in this package became vacuous once already.
+// The thing under test is the READ, and the read is reached through the
+// production repo below; nothing about how the rows arrived is in question.
+func seedSitesBulk(t *testing.T, pool *db.Pool, tenantID uuid.UUID, n int, lastName string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	var lastID uuid.UUID
+	if err := pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		// n-1 fillers, all sorting before lastName.
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO sites (tenant_id, url, name)
+			SELECT $1,
+			       'https://filler-' || lpad(i::text, 4, '0') || '.example.com',
+			       'aaa-filler-' || lpad(i::text, 4, '0')
+			FROM generate_series(1, $2) AS i`, tenantID, n-1); err != nil {
+			return fmt.Errorf("insert fillers: %w", err)
+		}
+		return tx.QueryRow(ctx, `
+			INSERT INTO sites (tenant_id, url, name)
+			VALUES ($1, 'https://last.example.com', $2)
+			RETURNING id`, tenantID, lastName).Scan(&lastID)
+	}); err != nil {
+		t.Fatalf("seed %d sites: %v", n, err)
+	}
+	return lastID
+}
+
+// TestMCPSiteReadReturnsTheLastSortingInScopeSiteAsAppRole is the case that was
+// impossible before this change.
+//
+// 600 sites in one tenant; the connection is scoped to the SINGLE site that
+// sorts last by name. Under the old tenant-wide read with a bound of 500 that
+// site was not in the page, so the caller received zero sites and one
+// site_unread refusal. The old read is executed here, in this test, so the
+// number it produces is measured rather than quoted.
+func TestMCPSiteReadReturnsTheLastSortingInScopeSiteAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+
+	tenant := seedTenant(t, pool, "mcp-ssr-"+uuid.NewString()[:8])
+	const lastName = "zzz-sorts-last"
+	lastID := seedSitesBulk(t, pool, tenant, scopedSiteReadFleetSize, lastName)
+
+	principal := domain.Principal{
+		TenantID:       tenant,
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{lastID},
+	}
+
+	// ---- THE CONTROL: what the OLD read returned, executed ----
+	//
+	// ListSites over the whole tenant, Sort 'name', Limit bound+1, then the
+	// scope filter in Go. This is the exact shape ListSitesForRead had, and it
+	// is run here so "the old shape returned 0" is a number this test produced
+	// rather than a claim inherited from a commit message.
+	var oldShapeInScope int
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (the OLD tenant-wide read)")
+		rows, err := sqlc.New(tx).ListSites(ctx, sqlc.ListSitesParams{
+			TenantID: tenant, Limit: 501, Offset: 0, Sort: "name"})
+		if err != nil {
+			return err
+		}
+		for _, r := range rows {
+			if r.ID == lastID {
+				oldShapeInScope++
+			}
+		}
+		t.Logf("the OLD tenant-wide read returned %d rows and %d of them were in scope",
+			len(rows), oldShapeInScope)
+		return nil
+	}); err != nil {
+		t.Fatalf("run the old read shape: %v", err)
+	}
+	if oldShapeInScope != 0 {
+		t.Fatalf("the old tenant-wide read found the in-scope site (%d rows). This proof needs "+
+			"the defect to be reproducible in this fixture; if it is not, the fixture no "+
+			"longer reproduces the bug and the assertions below prove nothing", oldShapeInScope)
+	}
+
+	// ---- THE READ UNDER TEST ----
+	rows, more, err := mcpRepo.ListSitesForRead(ctx, principal, 500)
+	if err != nil {
+		t.Fatalf("ListSitesForRead as wpmgr_app: %v", err)
+	}
+
+	// THE ASSERTION THAT NAMES THE DEFECT, FIRST. A zero here is the shipped
+	// bug: the caller's own site, unreachable at any number of retries.
+	if len(rows) != 1 || rows[0].ID != lastID {
+		t.Fatalf("SCOPE-BOUND DEFECT: the read returned %d rows for a connection scoped to the "+
+			"single site that sorts LAST in a %d-site tenant, want exactly that site (%s). The "+
+			"bound must be applied AFTER the scope predicate, not over the tenant; the old "+
+			"shape returned %d in-scope rows for this same fixture",
+			len(rows), scopedSiteReadFleetSize, lastID, oldShapeInScope)
+	}
+	if more {
+		t.Fatalf("more=true for a caller scoped to 1 site under a bound of 500; `more` must be "+
+			"a fact about the caller's own scope and never about the tenant")
+	}
+	if rows[0].Name != lastName {
+		t.Fatalf("the returned site is named %q, want %q", rows[0].Name, lastName)
+	}
+	t.Logf("old shape: %d in-scope rows; new shape: %d rows, more=%v",
+		oldShapeInScope, len(rows), more)
+
+	// ---- AND THROUGH THE TOOL, WHERE site_unread WOULD HAVE APPEARED ----
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{lastID})
+	eng := mountLikeProduction(t, svc, domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg})
+	res := mcpRPC(t, eng, bearer, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
+	})
+	if res.status != 200 {
+		t.Fatalf("tools/call status %d, body %s", res.status, res.body)
+	}
+	text := extractToolText(t, res.body)
+	payload := decodeSitesPayload(t, text)
+
+	// site_unread IS ASSERTED UNREACHABLE HERE, NOT ASSUMED. This is the exact
+	// state that produced it: an in-scope site outside the tenant's first page.
+	for _, r := range payload.Envelope.Refusals {
+		if r.Code == "site_unread" {
+			t.Fatalf("site_unread is still reachable for an in-scope site that sorts past the "+
+				"TENANT's first page. The bound is meant to be taken over the caller's own "+
+				"scope, which removes this cause entirely. Refusal: %+v", r)
+		}
+	}
+	if payload.Envelope.Asked != 1 || payload.Envelope.OK != 1 || payload.Envelope.Refused != 0 {
+		t.Fatalf("envelope asked/ok/refused = %d/%d/%d, want 1/1/0",
+			payload.Envelope.Asked, payload.Envelope.OK, payload.Envelope.Refused)
+	}
+	if len(payload.Sites) != 1 || payload.Sites[0].ID != lastID.String() {
+		t.Fatalf("the tool returned %d sites, want exactly %s", len(payload.Sites), lastID)
+	}
+	if payload.Truncation.Truncated {
+		t.Fatalf("truncation.truncated is true for a caller that received every site it may "+
+			"read:\n%s", text)
+	}
+	t.Logf("the tool returned the last-sorting in-scope site with envelope %d/%d/%d and no "+
+		"site_unread", payload.Envelope.Asked, payload.Envelope.OK, payload.Envelope.Refused)
+}
+
+// TestMCPSitesSiteScopePolicyIsLiveNotJustTheGoFilterAsAppRole is part 2, and
+// it is the test that would have caught the original defect.
+//
+// ONE STATEMENT, TWO HELPERS, AND THE STATEMENT CARRIES NO SCOPE PREDICATE OF
+// ITS OWN. `SELECT count(*) FROM sites WHERE tenant_id = $1` is exactly the
+// query a future caller writes when it forgets the site_ids parameter, and it
+// is the only shape that can tell a LIVE POLICY apart from a well-written WHERE
+// clause. Run under InTenantTx it sees the tenant; run under the dispatch a
+// site-constrained principal takes, the policy must cut it to the allowlist.
+//
+// If these two numbers are ever equal, the m19 policy is inert on this path and
+// the Go filter in ListSitesForModel is the only thing standing between a
+// scoped connection and the whole fleet -- which is the state this change ends.
+func TestMCPSitesSiteScopePolicyIsLiveNotJustTheGoFilterAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+
+	tenant := seedTenant(t, pool, "mcp-pol-"+uuid.NewString()[:8])
+	const fleet = 12
+	inScope := seedSitesBulk(t, pool, tenant, fleet, "zzz-in-scope")
+
+	// The SAME statement both times. No site_ids, no id filter, nothing but the
+	// tenant -- so every difference below is the policy's doing.
+	const predicateFree = "SELECT count(*) FROM sites WHERE tenant_id = $1"
+
+	// ---- GUC UNSET: the policy's first disjunct is true for every row ----
+	var unscopedCount int
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (app.site_scope UNSET)")
+		return tx.QueryRow(ctx, predicateFree, tenant).Scan(&unscopedCount)
+	}); err != nil {
+		t.Fatalf("predicate-free read under InTenantTx: %v", err)
+	}
+	if unscopedCount != fleet {
+		t.Fatalf("the unscoped read saw %d sites, want the tenant's %d; without this the "+
+			"comparison below has no baseline", unscopedCount, fleet)
+	}
+
+	// ---- GUC SET: through db.Pool.RunTenantTx with the principal
+	// mcp.connectionScopedPrincipal builds, which is the identical dispatch
+	// Repo.ListSitesForRead takes. ----
+	principal := domain.Principal{
+		TenantID:       tenant,
+		Scope:          domain.ScopeSite,
+		AllowedSiteIDs: []uuid.UUID{inScope},
+	}
+	var scopedCount int
+	var guc string
+	if err := pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "RunTenantTx (app.site_scope ON)")
+		if err := tx.QueryRow(ctx,
+			"SELECT current_setting('app.site_scope', true)").Scan(&guc); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, predicateFree, tenant).Scan(&scopedCount)
+	}); err != nil {
+		t.Fatalf("predicate-free read under RunTenantTx: %v", err)
+	}
+
+	// THE ASSERTION THAT NAMES THE LEAK, FIRST -- ahead of the GUC check and
+	// ahead of the exact-count check. Behind either of them it would not run on
+	// the failure that matters: a transaction that set no GUC still returns the
+	// whole tenant here, and the GUC check would have failed the test with the
+	// leak assertion never reached.
+	if scopedCount == unscopedCount {
+		t.Fatalf("POLICY INERT: a predicate-free read saw all %d of the tenant's sites inside "+
+			"the SITE-SCOPED transaction, the same number an unscoped transaction saw. "+
+			"sites_site_scope (m19) is RESTRICTIVE on `app.site_scope <> 'on' OR id = ANY(...)`, "+
+			"so an equal count means the GUC was never set (app.site_scope=%q) and the database "+
+			"is enforcing nothing on the site axis -- the Go filter in ListSitesForModel is the "+
+			"only gate", unscopedCount, guc)
+	}
+	if guc != "on" {
+		t.Fatalf("app.site_scope = %q inside the scoped transaction, want \"on\"", guc)
+	}
+	if scopedCount != 1 {
+		t.Fatalf("the scoped predicate-free read saw %d sites, want exactly the 1 in the "+
+			"allowlist", scopedCount)
+	}
+	t.Logf("BEHAVIOURAL DIFFERENCE: the identical statement saw %d sites under InTenantTx and "+
+		"%d under the scoped dispatch (app.site_scope=%q)", unscopedCount, scopedCount, guc)
+}
+
+// TestMCPSiteReadArchivedInScopeSiteIsAccountedAsAppRole records the ONE
+// residual cause of site_unread on this path, because "unreachable" was the
+// expectation and it is not quite true.
+//
+// ResolveMCPGrantScopeSitesInTenantTx has no archived predicate, so an ARCHIVED
+// site named in a grant's scope resolves into auth.Sites. ListSitesForMCPScope
+// excludes archived rows, matching the dashboard's default (ADR-041) and
+// matching what ListSites gave this surface before. The site is therefore in
+// scope and unread, which is exactly what site_unread is for.
+//
+// WHAT THIS TEST PINS IS THE HONESTY OF THE MESSAGE. The old detail told the
+// caller to "retry", and no retry can ever restore an archived site. The
+// shortfall must be accounted (ok+refused == asked, never a short list reading
+// as a complete fleet) and the advice must not be a retry.
+func TestMCPSiteReadArchivedInScopeSiteIsAccountedAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	mcpRepo := mcp.NewRepo(pool)
+	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+
+	tenant := seedTenant(t, pool, "mcp-arch-"+uuid.NewString()[:8])
+	liveID := seedSitesBulk(t, pool, tenant, 2, "aaa-live")
+	var archivedID uuid.UUID
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			INSERT INTO sites (tenant_id, url, name, connection_state)
+			VALUES ($1, 'https://archived.example.com', 'bbb-archived', 'archived')
+			RETURNING id`, tenant).Scan(&archivedID)
+	}); err != nil {
+		t.Fatalf("seed the archived site: %v", err)
+	}
+
+	_, bearer := s7GrantWithBearer(t, mcpRepo, tenant, "list", []uuid.UUID{liveID, archivedID})
+	eng := mountLikeProduction(t, svc, domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg})
+	res := mcpRPC(t, eng, bearer, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": mcp.ToolFleetSitesList, "arguments": map[string]any{}},
+	})
+	if res.status != 200 {
+		t.Fatalf("tools/call status %d, body %s", res.status, res.body)
+	}
+	payload := decodeSitesPayload(t, extractToolText(t, res.body))
+
+	// ACCOUNTED, NOT DROPPED. A short list that reads as a complete fleet is
+	// the failure this envelope exists to prevent.
+	if payload.Envelope.OK+payload.Envelope.Refused != payload.Envelope.Asked {
+		t.Fatalf("envelope does not balance: %d + %d != %d; an in-scope site went missing "+
+			"without being accounted for",
+			payload.Envelope.OK, payload.Envelope.Refused, payload.Envelope.Asked)
+	}
+	if payload.Envelope.Asked != 2 || payload.Envelope.OK != 1 || payload.Envelope.Refused != 1 {
+		t.Fatalf("envelope asked/ok/refused = %d/%d/%d, want 2/1/1",
+			payload.Envelope.Asked, payload.Envelope.OK, payload.Envelope.Refused)
+	}
+	if len(payload.Envelope.Refusals) != 1 ||
+		payload.Envelope.Refusals[0].SiteID != archivedID.String() ||
+		payload.Envelope.Refusals[0].Code != "site_unread" {
+		t.Fatalf("refusals = %+v, want one site_unread naming %s",
+			payload.Envelope.Refusals, archivedID)
+	}
+
+	// THE ADVICE MUST NOT BE A RETRY. The shortfall is deterministic: the same
+	// page comes back every time, so "retry" sends the caller round a loop that
+	// cannot terminate.
+	detail := payload.Envelope.Refusals[0].Detail
+	if strings.Contains(strings.ToLower(detail), "retry, and report it") {
+		t.Fatalf("MISLEADING REFUSAL: site_unread still advises a bare retry. The page is "+
+			"bounded over the caller's own scope in a fixed order, so retrying returns the "+
+			"same page. Detail: %q", detail)
+	}
+	if !strings.Contains(strings.ToLower(detail), "archived") {
+		t.Fatalf("site_unread does not name archiving as a cause, so an operator reading it "+
+			"has nothing to act on. Detail: %q", detail)
+	}
+	t.Logf("archived in-scope site accounted as site_unread with actionable detail: %q", detail)
+}

--- a/apps/api/tests/mcp_scoped_site_read_integration_test.go
+++ b/apps/api/tests/mcp_scoped_site_read_integration_test.go
@@ -243,9 +243,17 @@ func TestMCPSitesSiteScopePolicyIsLiveNotJustTheGoFilterAsAppRole(t *testing.T) 
 			"comparison below has no baseline", unscopedCount, fleet)
 	}
 
-	// ---- GUC SET: through db.Pool.RunTenantTx with the principal
-	// mcp.connectionScopedPrincipal builds, which is the identical dispatch
-	// Repo.ListSitesForRead takes. ----
+	// ---- GUC SET: through db.Pool.RunTenantTx with a principal of the shape
+	// mcp.connectionScopedPrincipal builds. ----
+	//
+	// THIS TRANSACTION IS OPENED BY THE TEST, SO IT PROVES THE POLICY AND NOT
+	// THE REPO'S DISPATCH. It hard-codes RunTenantTx, so it would report "on"
+	// however Repo.ListSitesForRead opens its own transaction; reading it as
+	// evidence about the repo is the mistake that let a planted
+	// RunTenantTx -> InTenantTx survive a green suite. The repo's dispatch is
+	// asserted by the repo itself, from inside the transaction it opens.
+	// What is genuinely in question HERE is whether the m19 policy does
+	// anything at all, and that needs a statement carrying no scope predicate.
 	principal := domain.Principal{
 		TenantID:       tenant,
 		Scope:          domain.ScopeSite,

--- a/infra/mcp-site-containment-allowlist.txt
+++ b/infra/mcp-site-containment-allowlist.txt
@@ -63,7 +63,25 @@ PARAM RedeemAuthorizationCode.codeID                    # authorization code row
 PARAM CreateGrantWithCode.grantID                       # callback parameter: the id of the row just inserted
 PARAM CreateGrantWithToken.grantID                      # callback parameter: the id of the row just inserted
 PARAM ListTagIDs.tenantID                               # tenant of the resolved principal
-PARAM ListSitesForRead.tenantID                         # tenant of the resolved principal; the list_sites tool then filters the rows through SiteSet.Allows
+# ListSitesForRead.tenantID is GONE, deliberately not replaced, for the same
+# reason ResolveScopeSites.tenantID is (see below). #671 changed the assistant's
+# site read to take `principal domain.Principal` instead of a bare tenant uuid,
+# so the read can route on scope: RunTenantTx dispatches a site-constrained
+# principal to InScopedTenantTx, the only helper that sets app.site_scope, which
+# the RESTRICTIVE sites_site_scope policy (m19) keys on. Under the old bare-uuid
+# signature the method could only reach InTenantTx and that policy was inert.
+#
+# domain.Principal is not a uuid type, so Rule B does not extract it and NO
+# entry is owed. The method now has no uuid parameter at all -- the site ids it
+# reads are principal.AllowedSiteIDs, which is the chokepoint's OWN OUTPUT
+# carried on the principal, not a request-supplied id. That is the question A11
+# asks, and the answer is that a site id cannot reach the database through this
+# method without having passed ResolveScopeSites first: Service.ListSitesForModel
+# builds the principal from auth.Sites, which Authenticate resolved.
+#
+# Re-derived rather than edited. The old reason described a bare tenant uuid
+# whose scope the caller then applied in Go; that sentence is not true of a
+# principal and could not have been repaired by changing the parameter name.
 PARAM ReCheckAuthorization.tenantID                     # tenant of the resolved principal
 PARAM ReCheckAuthorization.tokenID                      # token row id, from the token lookup
 # ResolveScopeSites.tenantID is GONE, deliberately not replaced. #649 changed


### PR DESCRIPTION
Follows #670, which added `ListSitesForMCPScope` but left `internal/mcp` calling `ListSites`. Two defects on one path, fixed together because the second is invisible while the first exists.

## Part 1 — the bound was over the tenant

`Repo.ListSitesForRead` read `ListSites` with `Limit = bound+1` and `Sort = 'name'` across the whole tenant, and `ListSitesForModel` applied the connection's site scope in Go afterwards. An in-scope site whose name sorted past the tenant's first page was never among the rows the filter ran over, so a healthy site came back as a `site_unread` refusal advising a **retry** — advice that can never work, because the order is deterministic and every call returns the same page.

It now calls `ListSitesForMCPScope`, where `LIMIT` applies after the scope predicate. Return type moves `[]sqlc.ListSitesRow` → `[]sqlc.Site`.

## Part 2 — the m19 policy was inert on this read

That read opened with `InTenantTx`, which never sets `app.site_scope`. `sites_site_scope` (`apps/api/migrations/20260531050000_m19_orgs_sharing.sql:330`) is RESTRICTIVE on `app.site_scope <> 'on' OR id = ANY(app.allowed_site_ids)`, so with the GUC unset its first disjunct is true for every row. **The Go filter in `ListSitesForModel` was the only gate on the site axis.**

It moves to `RunTenantTx` with a site-constrained principal built from the already-resolved `auth.Sites`. `principal.AllowedSiteIDs` is both the GUC allowlist and the query's `site_ids` parameter, so the two cannot drift. An org-scoped principal is **refused by name** rather than read tenant-wide.

`connectionScopedPrincipal` sits directly beside `bootstrapTenantPrincipal` and says why this call site is **not** the ADR-061 A14 exception: A14 covers the scope *bootstrap*, which cannot be scoped by the allowlist it computes. This read runs strictly after that resolution, so there is no circularity and the exception does not reach it.

## Finding: `site_unread` is not unreachable

The expectation was that scoping the bound makes `site_unread` unreachable from this path. It does remove the cause the defect report names, and that is asserted. **Two deterministic causes remain**, and neither is transient:

1. a connection whose scope holds more sites than one page;
2. an in-scope site that is **archived** — `ResolveMCPGrantScopeSitesInTenantTx` has no archived predicate, so it resolves into `auth.Sites`, while `ListSitesForMCPScope` excludes archived rows to match ADR-041 (as `ListSites` did before it).

The refusal detail no longer advises a retry. It names both causes and what an operator can do. That text is customer-facing and was in a file already being touched, so it is fixed here rather than filed.

## Proofs

All as `wpmgr_app`, with `current_user` / `rolsuper` / `rolbypassrls` asserted and printed, reached through `mcp.Repo` and `db.Pool`.

- `TestMCPSiteReadReturnsTheLastSortingInScopeSiteAsAppRole` — 600 sites, scope = the single site sorting last by name. **The old read shape is executed in the same test as a control**, so its in-scope row count is measured rather than quoted: `old shape: 0 in-scope rows; new shape: 1 rows, more=false`.
- `TestMCPSitesSiteScopePolicyIsLiveNotJustTheGoFilterAsAppRole` — one **predicate-free** statement (`SELECT count(*) FROM sites WHERE tenant_id = $1`) under both helpers: `the identical statement saw 12 sites under InTenantTx and 1 under the scoped dispatch`.
- `TestMCPSiteReadArchivedInScopeSiteIsAccountedAsAppRole` — the residual, asserting the envelope balances and the advice is not a retry.
- `TestToolsCall_SiteReadIsDispatchedSiteConstrained` — unit-speed guard that the **call site** passes a site-constrained principal.
- Cross-tenant: `adr064_s6b2` plants a **foreign site id in the caller's own allowlist**, since the interesting question moved with the bound.

Leak assertions are ordered **first** in each test, ahead of row-count and GUC checks.

## What the two layers are for, and why they share one value

They are redundant *by construction*: both derive from `principal.AllowedSiteIDs`, so they return the same rows and no query output can distinguish them. That is what a redundant layer is — one that produced an observable difference would be a second boundary free to disagree with the first.

Single-source is deliberate. Two independent derivations would need reconciling at runtime and **neither resolution is safe**: intersection silently hides sites the caller is entitled to, which is the `site_unread` defect reintroduced; union silently widens.

What the policy buys is the thing the predicate cannot: the `site_ids` predicate scopes *this query*, while the GUC scopes *the transaction*, so **any query added inside that `fn` later inherits the boundary for free**. The predicate-free proof above is the evidence.

Honest summary: **one boundary, enforced twice against different implementation mistakes — and not at all against a wrong scope resolution.**

## Mutation results

| Mutation | Result |
|---|---|
| **M1** — query predicate removed, policy live | **green.** The policy alone returns the correct 1 row of 600. |
| **M2a** — call site swapped to `bootstrapTenantPrincipal` | **red**, `TestToolsCall_SiteReadIsDispatchedSiteConstrained`, at unit speed. |
| **M2b** — `RunTenantTx` → `InTenantTx` in the repo | **red**, five integration tests, each naming the inert policy. |
| **M1 + M2b** | **red**: `the read returned 500 rows for a connection scoped to the single site that sorts LAST in a 600-site tenant`. |

M2b was **green** in the first revision, and that is the defect this branch's second commit fixes. Two tests read `app.site_scope` from a transaction *they* opened with `RunTenantTx`, which hard-codes the answer — the m112 shape, a proof going around the path it claims to cover. `Repo.ListSitesForRead` now reads the GUC back inside the transaction `RunTenantTx` opened for it and fails loudly when it is not `on`. Both misleading comments are corrected in place, naming the defect they had, so the sibling-transaction shape is not reintroduced as a "clearer" proof.

The `connectionScopedPrincipal` org-scoped guard is **unreachable from the service** (`Scope: domain.ScopeSite` is hard-coded, so `IsSiteConstrained()` is unconditionally true). It is a future-edit guard, and no comment counts it as a live gate.

## Known cost

The new `site_unread` detail is ~330 bytes and repeats per refusal, and refusals are **not** under `recordByteBudget`. A grant scoped wider than `sitesPageBound` emits one per overflow site: count unchanged, bytes roughly tripled. Left as-is — the old text was shorter and told the caller to do something that cannot work.

## Review

Draft: this is a tenancy boundary and wants a `security-reviewer` pass before it leaves draft.

## Not in this PR

No migration, no schema change, no generated tree edited. `internal/db/sqlc/**` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Access Control**
  * Site listings now enforce each connection’s permitted site scope at the database level.
  * Organization-wide requests are rejected for site-specific reads.
  * Out-of-scope sites and tenant-wide counts are no longer exposed.

* **Site Listing**
  * Pagination reflects the caller’s accessible sites rather than the full tenant.
  * Archived sites in scope provide clearer refusal details without suggesting ineffective retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->