### PR TITLE
release: 0.61.153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.153] - 2026-09-01
+
+### Security
+
+- A connection scoped to a subset of a tenant's sites could learn that the tenant held more sites than the connection was allowed to see. The assistant's site list read a fixed-size page across the whole tenant and then filtered it, so a caller receiving every site it was entitled to could still be told that sites had been withheld. The read is now bounded over the connection's own scope, so the page it receives can never carry a fact about the wider tenant. **This was live in 0.61.151 and 0.61.152.**
+- The same read now also runs under the database's own site-scope policy, rather than relying solely on the application-level filter above. This is one boundary enforced twice against different implementation mistakes, not two independent protections.
+
+### Added
+
+- A typed partial-result format for fleet-wide assistant questions: a response can now say that some sites could not be answered and why, with a stated reason per site and a timestamp on any answer drawn from stale data. A site outside a connection's scope is left out of the result entirely rather than named in a refusal, because naming it would itself disclose that it exists.
+
+### Changed
+
+- **Client-visible.** The fleet site-listing tool is renamed from `list_sites` to `fleet_sites_list` to match the published tool catalogue. A client re-reads the tool list when it reconnects, so this is picked up automatically; a client that has cached the old name will get an ordinary "no such tool" refusal rather than a silent alias.
+
 ## [0.61.152] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.152**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.153**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.152
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.152
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.152
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.153
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.153
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.153
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.152   # omit to track :latest
+export WPMGR_VERSION=v0.61.153   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,30 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.153",
+    date: "2026-09-01",
+    summary:
+      "A connection scoped to a subset of a tenant's sites could learn the tenant held more sites than it was allowed to see; the assistant's site read is now bounded over the connection's own scope and enforced again at the database. Fleet-wide assistant questions get a typed partial-result format, and the site-listing tool is renamed to match the published catalogue.",
+    items: [
+      {
+        tag: "Security",
+        text: "A connection scoped to a subset of a tenant's sites could learn that the tenant held more sites than the connection was allowed to see. The assistant's site list read a fixed-size page across the whole tenant and then filtered it, so a caller receiving every site it was entitled to could still be told that sites had been withheld. The read is now bounded over the connection's own scope, so the page it receives can never carry a fact about the wider tenant. This was live in 0.61.151 and 0.61.152.",
+      },
+      {
+        tag: "Security",
+        text: "The same read now also runs under the database's own site-scope policy, rather than relying solely on the application-level filter above. This is one boundary enforced twice against different implementation mistakes, not two independent protections.",
+      },
+      {
+        tag: "Added",
+        text: "A typed partial-result format for fleet-wide assistant questions: a response can now say that some sites could not be answered and why, with a stated reason per site and a timestamp on any answer drawn from stale data. A site outside a connection's scope is left out of the result entirely rather than named in a refusal, because naming it would itself disclose that it exists.",
+      },
+      {
+        tag: "Changed",
+        text: "The fleet site-listing tool is renamed from list_sites to fleet_sites_list to match the published tool catalogue. A client re-reads the tool list when it reconnects, so this is picked up automatically; a client that has cached the old name will get an ordinary \"no such tool\" refusal rather than a silent alias.",
+      },
+    ],
+  },
+  {
     version: "0.61.152",
     date: "2026-09-01",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.152   # omit to track :latest
+export WPMGR_VERSION=v0.61.153   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.152
+  version: 0.61.153
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. The agent plugin did not change (`git diff --name-only 8411cbb6 origin/main -- apps/agent | grep -vc '^apps/agent/tests/'` returns 0), so the marketing hero badge stays at the agent's 0.61.147 and only the control-plane surfaces move to 0.61.153.

- **Security (lead item, live in 0.61.151 and 0.61.152):** a connection scoped to a subset of a tenant's sites could learn the tenant held more sites than it was allowed to see, because the assistant's site list read a fixed-size page across the whole tenant and filtered it afterward. The read is now bounded over the connection's own scope.
- **Security (defense in depth):** the same read now also runs under the database's own site-scope policy, one boundary enforced twice against different implementation mistakes, not two independent protections.
- **Added:** a typed partial-result format for fleet-wide assistant questions, with a reason per unanswered site and a timestamp on stale answers; out-of-scope sites are omitted rather than named in a refusal.
- **Changed (client-visible):** the fleet site-listing tool is renamed from `list_sites` to `fleet_sites_list` to match the published tool catalogue.

## Test plan

- [x] `make check-versions-test` — 76 passed, 0 failed
- [x] `make check-versions` — all surfaces consistent, agent badge correctly frozen at 0.61.147
- [x] `node apps/marketing/scripts/check-copy.mjs` — passed, no em/en dashes or competitor names
- [x] Docs vocabulary check (copied verbatim from `ci.yml`) — no hits outside `docs/adr/ADR-055`
- [ ] CI (`ci.yml`) on this PR
- [ ] Owner QA, then deploy, then tag (not done in this PR per standing release order)