### PR TITLE
feat(mcp): fleet_updates_pending — the assistant can answer "which of my sites need updates?"

### DIFF
--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -537,6 +537,30 @@ func AuthorizeTool(name string, auth AuthorizedRequest) (ToolPolicy, refusalReas
 	return entry, "", nil
 }
 
+// RegistryPolicies returns the closed registry as POLICIES -- each tool with the
+// capability reaching it requires.
+//
+// IT EXISTS BECAUSE A DRIFT TEST OUTSIDE THIS PACKAGE CANNOT OTHERWISE ASK
+// "WHICH TOOLS SHOULD THIS CONNECTION SEE?". Tools() returns descriptors, which
+// carry no capability, so a proof in apps/api/tests comparing a
+// ceiling-filtered VisibleTools answer against the whole registry can only be
+// right while every tool happens to require the same capability. The moment one
+// does not -- a propose tool outside the read ceiling -- those proofs go red on
+// correct work, which is the over-firing the helpers were written to prevent.
+//
+// It is READ-ONLY and it grants nothing: same fresh slice, same cloned schema
+// bytes, same closed literal as Tools(). No request path uses it; VisibleTools
+// remains the only tools/list answer and AuthorizeTool the only gate.
+func RegistryPolicies() []ToolPolicy {
+	entries := registryTools()
+	out := make([]ToolPolicy, 0, len(entries))
+	for _, e := range entries {
+		e.invoke = nil // an invoker is not a fact about the surface
+		out = append(out, e)
+	}
+	return out
+}
+
 // Tools returns the FULL registry surface as descriptors, unfiltered by any
 // connection.
 //

--- a/apps/api/internal/mcp/registry.go
+++ b/apps/api/internal/mcp/registry.go
@@ -127,6 +127,40 @@ func registryTools() []ToolPolicy {
 		invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, _ json.RawMessage) (string, error) {
 			return svc.ListSitesForModel(ctx, auth)
 		},
+	}, {
+		// fleet_updates_pending -- S8's second Tier 0 "Fleet read".
+		//
+		// IT REQUIRES CapSitesRead AND NOT A CAPABILITY OF ITS OWN, and that is
+		// the narrow reading rather than a convenient one. It reads exactly the
+		// document fleet_sites_list already reads -- sites.components, on the
+		// same page, over the same scope -- and projects a different view of
+		// it. A connection that may list a site's installed software may
+		// already see every version this tool reports; a separate capability
+		// would suggest it gates something extra, and a capability that gates
+		// nothing new teaches an operator that the ticks do not mean what they
+		// say. The brief's own framing agrees: mcp.sites.read covers site
+		// software.
+		//
+		// It is a READ and it stays one. Nothing here proposes, schedules or
+		// applies an update: propose_update is a Tier 2 tool in the catalogue,
+		// it arrives with its own capability, its own approval floor and its
+		// own review, and never by being appended to this literal.
+		Name: ToolFleetUpdatesPending,
+		Description: "List outstanding WordPress plugin, theme and core updates for every site " +
+			"this connection may read, with each site's inventory freshness stamp and a " +
+			"fleet-wide roll-up. Answers \"which of my sites need updates?\" from the control " +
+			"plane's stored inventory; no site is contacted. Counts match the dashboard: " +
+			"same-version phantom advisories and the WPMgr agent's own plugin are excluded. " +
+			"A site whose inventory has never been collected reports inventory_status " +
+			"never_collected and is counted separately -- its zero means we have not looked, " +
+			"not that it is up to date.",
+		InputSchema:        updatesPendingSchema,
+		Capability:         CapSitesRead,
+		OperatorPermission: authz.PermSiteRead,
+		RequiresSiteScope:  true,
+		invoke: func(ctx context.Context, svc *Service, auth AuthorizedRequest, _ json.RawMessage) (string, error) {
+			return svc.ListPendingUpdatesForModel(ctx, auth)
+		},
 	}}
 
 	// EVERY ENTRY GETS ITS OWN COPY OF ITS SCHEMA BYTES.

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -106,7 +106,13 @@ func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
 	// The tool is LISTED. That is the ruling, and it is asserted here rather
 	// than only in its own test so that this proof cannot be read as "nothing
 	// was reachable because nothing was shown".
-	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolFleetSitesList {
+	// ASSERTED AS "THE WHOLE REGISTRY IS LISTED", not as "exactly one tool
+	// exists". The earlier form pinned len(got) == 1, which made a correct
+	// second read tool fail a proof about the CAPABILITY axis -- a guard
+	// reddening on work it was never meant to police is a guard that gets
+	// switched off. What the ruling actually claims is that no entry is hidden
+	// by a capability the grant lacks, so that is what is compared.
+	if got := VisibleTools(auth); !sameToolNames(got, registryToolNames()) {
 		t.Fatalf("a connection holding no capability was shown %d tools, want the whole "+
 			"registry listed and annotated: %+v", len(got), got)
 	}
@@ -486,11 +492,17 @@ func TestSiteScopeIsRefusedByName(t *testing.T) {
 	// NO capability notice -- this connection holds the capability, and telling
 	// it otherwise would send an operator hunting the wrong axis.
 	got := VisibleTools(auth)
-	if len(got) != 1 || got[0].Name != ToolFleetSitesList {
-		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", got)
+	if !sameToolNames(got, registryToolNames()) {
+		t.Fatalf("an empty site scope hid a tool from tools/list: %+v", got)
 	}
-	if strings.Contains(got[0].Description, "NOT AVAILABLE TO THIS CONNECTION") {
-		t.Fatalf("an empty SITE scope produced a CAPABILITY notice:\n%s", got[0].Description)
+	// EVERY descriptor is checked, not got[0]. Checking only the first left the
+	// assertion silently covering less of the surface as the registry grew,
+	// which is the shape where a guard keeps passing while what it guards
+	// shrinks underneath it.
+	for _, d := range got {
+		if strings.Contains(d.Description, "NOT AVAILABLE TO THIS CONNECTION") {
+			t.Fatalf("an empty SITE scope produced a CAPABILITY notice on %q:\n%s", d.Name, d.Description)
+		}
 	}
 
 	_, reason, err := AuthorizeTool(ToolFleetSitesList, auth)
@@ -658,21 +670,53 @@ func TestSchemaBytesAreNotSharedAcrossCallers(t *testing.T) {
 // can only refuse verbs a read tool has no business declaring. That is enough
 // to make a write tool arrive as a visible, deliberate act -- someone has to
 // delete a case from this list, in a diff, with a reason.
+// MATCHING IS PER UNDERSCORE-SEPARATED SEGMENT AND NO LONGER BY SUBSTRING, and
+// the change was forced by a true negative rather than chosen for elegance.
+//
+// The substring form failed fleet_updates_pending -- a read tool whose name is
+// the wireframe catalogue's own ("Plugin, theme and core updates outstanding,
+// per site") -- because the plural NOUN "updates" contains the verb "update".
+// The available responses were to rename the tool away from the catalogue, to
+// delete "update" from the list, or to make the match mean what the comment
+// already claimed it meant. The first two are both worse: one puts the wire
+// name out of step with the screen the operator reads, and the other stops
+// propose_update being caught, which is the exact tool this guard exists for.
+//
+// Segment matching keeps every real catch. A write tool's name carries the verb
+// AS A SEGMENT -- propose_update, site_delete, fleet_restore, run_exec -- because
+// that is how a verb is spelled when it is the action rather than the object.
+// "updates" as a plural noun is a segment of its own and is not the verb.
+//
+// THE CAPABILITY ASSERTION BELOW IS THE PART THAT DOES NOT DEPEND ON SPELLING,
+// and it is new. A name heuristic can always be evaded by naming a tool well;
+// a write tool cannot avoid requiring a capability that is not a read, because
+// the capability is what the operator ticked and what the grant stores. Every
+// capability this surface has is `mcp.<group>.read` (policy.go), so requiring
+// the suffix catches a write tool however it is spelled -- including one added
+// with a name this list has never heard of.
 func TestNoRegisteredToolIsWriteShaped(t *testing.T) {
-	forbidden := []string{
+	forbidden := map[string]struct{}{}
+	for _, v := range []string{
 		"create", "update", "delete", "remove", "restart", "reboot",
 		"install", "uninstall", "activate", "deactivate", "write",
-		"set_", "purge", "restore", "rollback", "run_", "exec",
+		"set", "purge", "restore", "rollback", "run", "exec",
+		"apply", "propose", "approve",
+	} {
+		forbidden[v] = struct{}{}
 	}
 	for _, e := range nonEmptyRegistry(t) {
-		lower := strings.ToLower(e.Name)
-		for _, verb := range forbidden {
-			if strings.Contains(lower, verb) {
-				t.Errorf("tool %q contains the write-shaped verb %q. The MCP surface is read-only "+
-					"BY CONSTRUCTION (m124 DECISION 1) -- a write tool arrives with its own "+
-					"capability, its own migration and its own security review, never by being "+
-					"appended to registryTools.", e.Name, verb)
+		for _, seg := range strings.Split(strings.ToLower(e.Name), "_") {
+			if _, bad := forbidden[seg]; bad {
+				t.Errorf("tool %q carries the write-shaped verb %q as a name segment. The MCP "+
+					"surface is read-only BY CONSTRUCTION (m124 DECISION 1) -- a write tool "+
+					"arrives with its own capability, its own migration and its own security "+
+					"review, never by being appended to registryTools.", e.Name, seg)
 			}
+		}
+		if !strings.HasSuffix(string(e.Capability), ".read") {
+			t.Errorf("tool %q requires capability %q, which is not a .read capability. Every tool "+
+				"on this surface reads; a capability that is not a read is how a write tool "+
+				"would have to arrive, whatever it is named.", e.Name, e.Capability)
 		}
 		if e.OperatorPermission == authz.PermSiteWrite {
 			t.Errorf("tool %q declares the site:write operator permission on a read-only surface", e.Name)
@@ -709,4 +753,38 @@ func TestVisibleToolNamesMatchTheListing(t *testing.T) {
 			}
 		}
 	}
+}
+
+// registryToolNames is what the WHOLE registry holds, and sameToolNames
+// compares a listing against it order-insensitively.
+//
+// THEY EXIST SO A PROOF ABOUT ONE AXIS SAYS "NOTHING WAS HIDDEN" INSTEAD OF
+// PINNING A COUNT. Several proofs about the capability axis and the site axis
+// asserted len(tools) == 1, which is a fact about how many tools had been built
+// on the day they were written and not about the boundary under test. Every one
+// of them went red on a correct second read tool, and a guard that reddens on
+// correct work is a guard that gets deleted rather than read.
+func registryToolNames() []string {
+	out := []string{}
+	for _, e := range registryTools() {
+		out = append(out, e.Name)
+	}
+	return out
+}
+
+func sameToolNames(got []ToolDescriptor, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, d := range got {
+		seen[d.Name]++
+	}
+	for _, n := range want {
+		seen[n]--
+		if seen[n] < 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -112,7 +112,7 @@ func TestExitGate_GuessedToolNameIsUnreachable(t *testing.T) {
 	// reddening on work it was never meant to police is a guard that gets
 	// switched off. What the ruling actually claims is that no entry is hidden
 	// by a capability the grant lacks, so that is what is compared.
-	if got := VisibleTools(auth); !sameToolNames(got, registryToolNames()) {
+	if got := VisibleTools(auth); !sameToolNames(got, registryToolNames(auth)) {
 		t.Fatalf("a connection holding no capability was shown %d tools, want the whole "+
 			"registry listed and annotated: %+v", len(got), got)
 	}
@@ -492,7 +492,7 @@ func TestSiteScopeIsRefusedByName(t *testing.T) {
 	// NO capability notice -- this connection holds the capability, and telling
 	// it otherwise would send an operator hunting the wrong axis.
 	got := VisibleTools(auth)
-	if !sameToolNames(got, registryToolNames()) {
+	if !sameToolNames(got, registryToolNames(auth)) {
 		t.Fatalf("an empty site scope hid a tool from tools/list: %+v", got)
 	}
 	// EVERY descriptor is checked, not got[0]. Checking only the first left the
@@ -764,9 +764,21 @@ func TestVisibleToolNamesMatchTheListing(t *testing.T) {
 // on the day they were written and not about the boundary under test. Every one
 // of them went red on a correct second read tool, and a guard that reddens on
 // correct work is a guard that gets deleted rather than read.
-func registryToolNames() []string {
+func registryToolNames(auth AuthorizedRequest) []string {
 	out := []string{}
 	for _, e := range registryTools() {
+		// FILTERED BY THE ORG CEILING, because that is the one boundary
+		// VisibleTools HIDES behind (withinOrgCeiling drops; capabilityHeld
+		// only annotates). Comparing a ceiling-filtered answer against the
+		// UNFILTERED registry is correct only while every tool requires the
+		// same capability, and stops being correct the moment one does not --
+		// a propose tool outside the read ceiling makes every proof using this
+		// helper go red on work that crossed no boundary at all. That is the
+		// exact over-firing these helpers were written to prevent, so the
+		// helper has to know about the ceiling too.
+		if !auth.OrgCeiling.Allows(e.Capability) {
+			continue
+		}
 		out = append(out, e.Name)
 	}
 	return out

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1840,6 +1840,91 @@ func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest)
 	return buildListSitesResult(allowed, env, s.now())
 }
 
+// ListPendingUpdatesForModel is fleet_updates_pending: outstanding plugin,
+// theme and core updates across the connection's resolved scope.
+//
+// IT SHARES THE SCOPED READ WITH ListSitesForModel RATHER THAN REPEATING IT.
+// scopedSiteRead is the layer-3 filter, the site_unread accounting and the
+// envelope balance in one place, and the reason it is one place is that those
+// three are the tenancy boundary of every fleet-wide tool. A second tool with
+// its own copy of that loop is a second chance to get the hiding rule wrong,
+// and the copy that is wrong is the one nobody re-reads. The two tools now
+// differ only in how they RENDER rows they were both handed identically.
+func (s *Service) ListPendingUpdatesForModel(ctx context.Context, auth AuthorizedRequest) (string, error) {
+	allowed, env, err := s.scopedSiteRead(ctx, auth, ToolFleetUpdatesPending)
+	if err != nil {
+		return "", err
+	}
+	return buildUpdatesPendingResult(allowed, env, s.now())
+}
+
+// scopedSiteRead reads one bounded page of the caller's own sites and returns
+// the rows it may see together with the envelope accounting for the ones it
+// may see and this call did not return.
+//
+// Every comment on ListSitesForModel's body applies here verbatim and is not
+// duplicated: the discarded `more`, why the in-Go SiteSet filter stays as the
+// third layer, why an unreturned in-scope site is site_unread rather than
+// silently absent, and why `asked` is auth.Sites.Len() and never a tenant
+// count.
+//
+// toolName is used ONLY in the error text, so an unbalanced envelope names the
+// tool that produced it.
+func (s *Service) scopedSiteRead(
+	ctx context.Context, auth AuthorizedRequest, toolName string,
+) ([]sqlc.Site, Envelope, error) {
+	if auth.Sites.IsEmpty() {
+		// THE EMPTY-SCOPE BRANCH IS A REFUSAL, NOT AN EMPTY LIST, for every
+		// tool that reads through here and not just the first one. An empty
+		// resolved scope means NO SITES, never every site, and `{"sites": []}`
+		// is indistinguishable from a healthy organisation that owns nothing.
+		return nil, Envelope{}, domain.Forbidden(ErrCodeScopeEmpty,
+			"this connection's site scope resolves to no sites, so there is nothing it may read. "+
+				"This is a refusal, not an empty fleet: check the grant's site scope.")
+	}
+
+	bound := s.pageBound
+	if bound <= 0 {
+		bound = sitesPageBound
+	}
+	rows, _, err := s.store.ListSitesForRead(ctx, connectionScopedPrincipal(auth), bound)
+	if err != nil {
+		return nil, Envelope{}, fmt.Errorf("list sites for mcp read: %w", err)
+	}
+
+	// LAYER 3, AND LAYER 3 HIDES. A row dropped here is not refused, not
+	// counted and not mentioned.
+	allowed := make([]sqlc.Site, 0, len(rows))
+	seen := make(map[uuid.UUID]struct{}, len(rows))
+	for _, r := range rows {
+		if auth.Sites.Allows(r.ID) {
+			allowed = append(allowed, r)
+			seen[r.ID] = struct{}{}
+		}
+	}
+
+	refusals := make([]Refusal, 0)
+	for _, id := range auth.Sites.Sorted() {
+		if _, found := seen[id]; !found {
+			refusals = append(refusals, Refusal{
+				SiteID: id.String(),
+				Code:   RefusalSiteUnread,
+				Detail: "this site is in scope for this connection but was not returned by the " +
+					"page this call reads. The page is bounded over this connection's own scope " +
+					"in a fixed order, so retrying returns the same page and will not reach it: " +
+					"either this connection's scope holds more sites than one page, or the site " +
+					"is archived. Ask an operator to narrow the scope or restore the site.",
+			})
+		}
+	}
+
+	env, err := NewEnvelope(auth.Sites.Len(), len(allowed), refusals)
+	if err != nil {
+		return nil, Envelope{}, fmt.Errorf("build %s envelope: %w", toolName, err)
+	}
+	return allowed, env, nil
+}
+
 // ---------------------------------------------------------------------------
 // Credential helpers
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -1729,127 +1729,22 @@ func (s *Service) RecordProtocolDenied(ctx context.Context, auth AuthorizedReque
 // from a healthy organisation that owns nothing, which is exactly how a
 // scoping bug stays invisible.
 func (s *Service) ListSitesForModel(ctx context.Context, auth AuthorizedRequest) (string, error) {
-	if auth.Sites.IsEmpty() {
-		return "", domain.Forbidden(ErrCodeScopeEmpty,
-			"this connection's site scope resolves to no sites, so there is nothing it may read. "+
-				"This is a refusal, not an empty fleet: check the grant's site scope.")
-	}
-
-	// THE SECOND RETURN OF ListSitesForRead IS DELIBERATELY DISCARDED, AND
-	// DISCARDING IT IS A FIX RATHER THAN AN OVERSIGHT.
-	//
-	// That value is `more`: "the bounded page was filled and further rows were
-	// left unread". It was once passed straight through into the rendered
-	// result as a truncation notice, and at that time it was a fact about THE
-	// TENANT: the read was tenant-wide and the bound was applied before the
-	// site scope. For a connection scoped to two sites in a six-hundred-site
-	// tenant the notice was both false and disclosing -- the caller received
-	// every site it may read, was told further sites had been withheld, and
-	// could infer from a flag it had no business seeing that the tenant holds
-	// more than sitesPageBound sites.
-	//
-	// The read is now bounded over the caller's own scope, so `more` is no
-	// longer a tenant fact and could be reported without disclosing anything.
-	// It is still discarded, because it is now REDUNDANT: every site it would
-	// account for is already enumerated below as an explicit site_unread
-	// refusal against auth.Sites, which is the stronger report -- it names the
-	// sites rather than raising a flag, and it keeps ok+refused balanced
-	// against asked. Two completeness signals computed from different values
-	// is how the pair comes to disagree.
-	bound := s.pageBound
-	if bound <= 0 {
-		// A Service built by a struct literal rather than NewService. Read a
-		// full page rather than none: a zero limit would return nothing and
-		// present as an organisation owning no sites.
-		bound = sitesPageBound
-	}
-	rows, _, err := s.store.ListSitesForRead(ctx, connectionScopedPrincipal(auth), bound)
+	allowed, env, err := s.scopedSiteRead(ctx, auth, ToolFleetSitesList)
 	if err != nil {
-		return "", fmt.Errorf("list sites for mcp read: %w", err)
+		return "", err
 	}
-
-	// Filter to the grant's resolved set. The read is now scoped on the site
-	// axis twice before it reaches here -- by the query's own site_ids
-	// predicate and by the RESTRICTIVE sites_site_scope policy the scoped
-	// transaction switches on -- so in a correct system this loop drops
-	// nothing. IT STAYS ANYWAY, and not as ceremony: it is the only one of the
-	// three layers that cannot be switched off by a mistake in the other two,
-	// and SiteSet.Allows returns false for every id on an empty or zero-value
-	// set, so there is no widening path even if the set were lost between here
-	// and there.
-	//
-	// THIS IS LAYER 3, AND LAYER 3 HIDES. A row dropped here is not refused,
-	// not counted and not mentioned: it leaves no trace in the envelope built
-	// below, because `asked` is closed over auth.Sites and an out-of-scope row
-	// was never in auth.Sites to begin with.
-	allowed := make([]sqlc.Site, 0, len(rows))
-	seen := make(map[uuid.UUID]struct{}, len(rows))
-	for _, r := range rows {
-		if auth.Sites.Allows(r.ID) {
-			allowed = append(allowed, r)
-			seen[r.ID] = struct{}{}
-		}
-	}
-
-	// SCOPE-RELATIVE COMPLETENESS. `asked` is the caller's own scope
-	// cardinality and nothing else; every site it counts is one the caller
-	// already knows it has. An in-scope site the bounded page did not contain
-	// is reported as an explicit site_unread refusal rather than being left
-	// silently absent, so ok+refused balances against asked and the caller is
-	// never handed a short list that reads as a complete fleet.
-	//
-	// THIS BRANCH IS MUCH NARROWER THAN IT WAS, AND ITS ADVICE CHANGED WITH IT.
-	// While the page was bounded over the TENANT, any in-scope site sorting
-	// past the tenant's first page landed here, and the detail told the caller
-	// to "retry" -- advice that could never work, because the order is
-	// deterministic and the same page comes back every time. The page is now
-	// bounded over the caller's own scope, which removes that cause entirely.
-	//
-	// Two causes remain, and neither is a transient. A connection whose scope
-	// holds more sites than one page will always be short by the same
-	// overflow; and a site that is in scope but ARCHIVED is resolved into
-	// auth.Sites (ResolveMCPGrantScopeSitesInTenantTx has no archived
-	// predicate) while ListSitesForMCPScope excludes it, matching the
-	// dashboard's default (ADR-041). Both are stable facts about this
-	// connection, so the detail says what is true and does not invite a retry
-	// that cannot help. Naming them discloses nothing: every site named here
-	// is already in the caller's own scope.
-	refusals := make([]Refusal, 0)
-	for _, id := range auth.Sites.Sorted() {
-		if _, found := seen[id]; !found {
-			refusals = append(refusals, Refusal{
-				SiteID: id.String(),
-				Code:   RefusalSiteUnread,
-				Detail: "this site is in scope for this connection but was not returned by the " +
-					"page this call reads. The page is bounded over this connection's own scope " +
-					"in a fixed order, so retrying returns the same page and will not reach it: " +
-					"either this connection's scope holds more sites than one page, or the site " +
-					"is archived. Ask an operator to narrow the scope or restore the site.",
-			})
-		}
-	}
-
-	env, err := NewEnvelope(auth.Sites.Len(), len(allowed), refusals)
-	if err != nil {
-		// An unbalanced envelope means a site was counted in scope and then
-		// lost without being accounted for. That is the leak shape, so it
-		// fails the call rather than rendering a result with a residual in it.
-		return "", fmt.Errorf("build fleet_sites_list envelope: %w", err)
-	}
-
 	return buildListSitesResult(allowed, env, s.now())
 }
 
 // ListPendingUpdatesForModel is fleet_updates_pending: outstanding plugin,
 // theme and core updates across the connection's resolved scope.
 //
-// IT SHARES THE SCOPED READ WITH ListSitesForModel RATHER THAN REPEATING IT.
-// scopedSiteRead is the layer-3 filter, the site_unread accounting and the
-// envelope balance in one place, and the reason it is one place is that those
-// three are the tenancy boundary of every fleet-wide tool. A second tool with
-// its own copy of that loop is a second chance to get the hiding rule wrong,
-// and the copy that is wrong is the one nobody re-reads. The two tools now
-// differ only in how they RENDER rows they were both handed identically.
+// IT SHARES scopedSiteRead WITH ListSitesForModel. That function is the layer-3
+// filter, the site_unread accounting and the envelope balance, and both fleet
+// tools now genuinely call it -- they differ only in how they RENDER rows they
+// were handed identically. A second copy of that loop would be a second chance
+// to get the hiding rule wrong, and the copy that is wrong is the one nobody
+// re-reads.
 func (s *Service) ListPendingUpdatesForModel(ctx context.Context, auth AuthorizedRequest) (string, error) {
 	allowed, env, err := s.scopedSiteRead(ctx, auth, ToolFleetUpdatesPending)
 	if err != nil {
@@ -1862,11 +1757,40 @@ func (s *Service) ListPendingUpdatesForModel(ctx context.Context, auth Authorize
 // the rows it may see together with the envelope accounting for the ones it
 // may see and this call did not return.
 //
-// Every comment on ListSitesForModel's body applies here verbatim and is not
-// duplicated: the discarded `more`, why the in-Go SiteSet filter stays as the
-// third layer, why an unreturned in-scope site is site_unread rather than
-// silently absent, and why `asked` is auth.Sites.Len() and never a tenant
-// count.
+// IT IS THE ONLY COPY OF THE TENANCY BOUNDARY ON THIS SURFACE, and that is now
+// literally true rather than aspirational. This function was introduced
+// alongside fleet_updates_pending with a doc comment claiming both fleet tools
+// shared it, while ListSitesForModel in fact kept a verbatim second copy of the
+// layer-3 filter, the site_unread loop and the envelope balance. Both copies
+// were correct and independently proven, so nothing misbehaved -- but a comment
+// on a tenancy boundary that inverts the true state is its own defect: the next
+// session fixing the hiding rule "in one place" would have fixed one of two
+// tools and had a comment telling it the job was done. ListSitesForModel now
+// calls this and renders; there is one implementation.
+//
+// The three rules it owns, each of which used to be stated twice:
+//
+//   - LAYER 3 HIDES. A row the caller's SiteSet does not allow is dropped, not
+//     refused, not counted, not mentioned. It leaves no trace in the envelope,
+//     because `asked` is closed over auth.Sites and an out-of-scope row was
+//     never in auth.Sites to begin with.
+//   - AN UNREAD IN-SCOPE SITE IS site_unread, not silence. A result quietly
+//     holding fewer sites than the caller's scope reads as a complete answer
+//     about a smaller fleet.
+//   - `asked` IS auth.Sites.Len() AND NEVER A TENANT COUNT. See the counting
+//     rule at the top of envelope.go: a residual between asked and ok+refused
+//     is the number a reader subtracts to discover that hidden sites exist.
+//
+// THE SECOND RETURN OF ListSitesForRead IS DELIBERATELY DISCARDED. That value
+// is `more`: "the bounded page was filled and further rows were left unread".
+// It was once rendered as a truncation notice while the read was TENANT-wide,
+// so a connection scoped to two sites in a six-hundred-site tenant was told
+// further sites had been withheld -- false for that caller, and a disclosure of
+// the tenant's size. The read is now bounded over the caller's own scope, so it
+// discloses nothing; it stays discarded because it is REDUNDANT, every site it
+// would account for being enumerated below as an explicit site_unread refusal.
+// Two completeness signals computed from different values is how the pair comes
+// to disagree.
 //
 // toolName is used ONLY in the error text, so an unbalanced envelope names the
 // tool that produced it.

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -864,7 +864,7 @@ func TestToolsCall_UntickedCapabilityRefusesWithItsOwnCode(t *testing.T) {
 
 	// The tool is LISTED to this connection: the refusal below is a refusal,
 	// not a consequence of an empty surface.
-	if got := VisibleTools(auth); !sameToolNames(got, registryToolNames()) {
+	if got := VisibleTools(auth); !sameToolNames(got, registryToolNames(auth)) {
 		t.Fatalf("tools/list hid a tool from a connection lacking its capability: %+v", got)
 	}
 
@@ -1046,11 +1046,33 @@ func TestToolsList_IsToolsOnlyAndReadOnly(t *testing.T) {
 	}
 	// THE LISTING IS COMPARED AGAINST THE REGISTRY, not against a hard-coded
 	// count. The point of this assertion is that tools/list over the real
-	// mounted transport returns the server's whole tool surface and nothing
-	// else -- an extra name here would be a tool reachable over HTTP that the
-	// closed literal never declared.
-	if !sameToolNames(resp.Result.Tools, registryToolNames()) {
-		t.Fatalf("tools = %#v, want exactly %v", resp.Result.Tools, registryToolNames())
+	// mounted transport returns nothing the closed literal never declared --
+	// an extra name here is a tool reachable over HTTP that no reviewed diff
+	// added.
+	//
+	// IT ASSERTS CONTAINMENT, NOT EQUALITY, AND THE ASYMMETRY IS DELIBERATE.
+	// This test drives HTTP and so holds no AuthorizedRequest, which means it
+	// cannot know this fixture's org ceiling -- and the ceiling is what decides
+	// how many tools SHOULD be listed. Demanding equality against the whole
+	// registry would therefore go red the day a tool outside the read ceiling
+	// lands, on a listing that was correct. Containment cannot over-fire that
+	// way and still catches the thing this test exists for. The ceiling-aware
+	// equality check lives in the proofs that do hold an auth.
+	registered := map[string]bool{}
+	for _, d := range Tools() {
+		registered[d.Name] = true
+	}
+	for _, d := range resp.Result.Tools {
+		if !registered[d.Name] {
+			t.Fatalf("tools/list offered %q, which is not in the closed registry", d.Name)
+		}
+	}
+	if len(resp.Result.Tools) == 0 {
+		t.Fatal("tools/list returned nothing, so every assertion here is vacuous")
+	}
+	if !sameToolNames(resp.Result.Tools, []string{ToolFleetSitesList, ToolFleetUpdatesPending}) {
+		t.Fatalf("tools = %#v, want both Tier 0 fleet reads for a default-ceiling connection",
+			resp.Result.Tools)
 	}
 	// EVERY tool must carry a schema, not just the first.
 	for _, d := range resp.Result.Tools {

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -864,8 +864,8 @@ func TestToolsCall_UntickedCapabilityRefusesWithItsOwnCode(t *testing.T) {
 
 	// The tool is LISTED to this connection: the refusal below is a refusal,
 	// not a consequence of an empty surface.
-	if got := VisibleTools(auth); len(got) != 1 || got[0].Name != ToolFleetSitesList {
-		t.Fatalf("tools/list hid the tool from a connection lacking its capability: %+v", got)
+	if got := VisibleTools(auth); !sameToolNames(got, registryToolNames()) {
+		t.Fatalf("tools/list hid a tool from a connection lacking its capability: %+v", got)
 	}
 
 	_, _, resp, refused := h.authorizeCall(context.Background(), auth, jsonrpcRequest{
@@ -1044,11 +1044,19 @@ func TestToolsList_IsToolsOnlyAndReadOnly(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("tools/list is not JSON: %v", err)
 	}
-	if len(resp.Result.Tools) != 1 || resp.Result.Tools[0].Name != ToolFleetSitesList {
-		t.Fatalf("tools = %#v, want exactly [%s]", resp.Result.Tools, ToolFleetSitesList)
+	// THE LISTING IS COMPARED AGAINST THE REGISTRY, not against a hard-coded
+	// count. The point of this assertion is that tools/list over the real
+	// mounted transport returns the server's whole tool surface and nothing
+	// else -- an extra name here would be a tool reachable over HTTP that the
+	// closed literal never declared.
+	if !sameToolNames(resp.Result.Tools, registryToolNames()) {
+		t.Fatalf("tools = %#v, want exactly %v", resp.Result.Tools, registryToolNames())
 	}
-	if len(resp.Result.Tools[0].InputSchema) == 0 {
-		t.Error("the tool carries no inputSchema, so a model cannot call it without guessing")
+	// EVERY tool must carry a schema, not just the first.
+	for _, d := range resp.Result.Tools {
+		if len(d.InputSchema) == 0 {
+			t.Errorf("tool %q carries no inputSchema, so a model cannot call it without guessing", d.Name)
+		}
 	}
 
 	// Resources and prompts are refused BY NAME, not answered with an empty

--- a/apps/api/internal/mcp/updates.go
+++ b/apps/api/internal/mcp/updates.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
@@ -127,6 +128,23 @@ type siteUpdatesRecord struct {
 	// three lists and get it wrong.
 	PendingTotal int `json:"pending_total"`
 
+	// Summary IS THE AGE, IN PROSE, and it exists because the structured age
+	// beside it is a field a model may simply not read.
+	//
+	// inventory_age_seconds is precise and skippable. A reader that skips it
+	// has a pending_total that looks like a current fact, and the failure is
+	// silent and confident -- an assistant reporting a year-old count as
+	// today's. A sentence carrying the age inside the same string as the count
+	// cannot be dropped without dropping the count too, which is the property
+	// being bought here.
+	//
+	// IT DESCRIBES THE AGE AND NEVER JUDGES IT. There is no "stale", no
+	// "outdated", no "needs refresh": rendering any of those would be choosing
+	// a freshness window by the back door, which is the thing the owner ruled
+	// against. It says when the inventory was collected and lets the reader
+	// decide what that is worth.
+	Summary string `json:"summary"`
+
 	Core    *coreUpdateRecord `json:"core_update"`
 	Plugins []pendingItem     `json:"plugins"`
 	Themes  []pendingItem     `json:"themes"`
@@ -188,7 +206,98 @@ func toSiteUpdatesRecord(row sqlc.Site, now time.Time) siteUpdatesRecord {
 	if rec.Core != nil {
 		rec.PendingTotal++
 	}
+	rec.Summary = updatesSummary(rec)
 	return rec
+}
+
+// updatesSummary writes the one sentence a model cannot skim past: what is
+// outstanding, and how old the inventory saying so is, in the same string.
+//
+// THE NEVER-COLLECTED ARM SAYS "WE HAVE NOT LOOKED" IN WORDS. Left to the
+// structured fields alone, never_collected is an ABSENCE, and a reader filling
+// an absence in fills it in with an assumption -- almost always the reassuring
+// one, that a site with no updates listed has no updates. The sentence removes
+// the room for that by stating the ignorance as the finding.
+func updatesSummary(rec siteUpdatesRecord) string {
+	if rec.InventoryStatus == inventoryNeverCollected {
+		return fmt.Sprintf(
+			"%s: no plugin or theme inventory has ever been collected for this site, so we do not "+
+				"know whether it needs updates. The zero counts below mean we have not looked, "+
+				"NOT that it is up to date.", rec.Name)
+	}
+
+	// A collected inventory with no age is the future-stamp case toSiteRecord
+	// withholds an age for: report the instant and say the age is not
+	// computable, rather than printing a negative or implying freshness.
+	age := "at an unknown age (its collection stamp is in the future, which is a clock problem)"
+	if rec.InventoryAgeSeconds != nil {
+		age = humanAge(*rec.InventoryAgeSeconds)
+	}
+	when := ""
+	if rec.InventoryCollectedAt != nil {
+		when = ", " + *rec.InventoryCollectedAt
+	}
+
+	if rec.PendingTotal == 0 {
+		return fmt.Sprintf(
+			"%s: no updates outstanding, according to an inventory collected %s%s.",
+			rec.Name, age, when)
+	}
+	parts := make([]string, 0, 3)
+	if n := len(rec.Plugins); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s", n, plural(n, "plugin", "plugins")))
+	}
+	if n := len(rec.Themes); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s", n, plural(n, "theme", "themes")))
+	}
+	if rec.Core != nil {
+		parts = append(parts, "WordPress core")
+	}
+	return fmt.Sprintf(
+		"%s: %d %s outstanding (%s), according to an inventory collected %s%s.",
+		rec.Name, rec.PendingTotal, plural(rec.PendingTotal, "update", "updates"),
+		strings.Join(parts, ", "), age, when)
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// humanAge renders an age in the largest unit that keeps the number small.
+//
+// IT SELECTS A UNIT AND MAKES NO JUDGEMENT, which is the whole constraint. It
+// never returns "stale", "old", "recent" or "fresh": every one of those words
+// would be a freshness window chosen by the back door, decided by whoever wrote
+// this function rather than by an operator. "collected 8 months ago" tells a
+// reader everything "stale" would have, and leaves the verdict where it
+// belongs.
+//
+// The unit boundaries are FORMATTING and not thresholds: nothing downstream
+// branches on them, no field changes meaning at one, and moving one changes how
+// a duration is spelled and nothing else.
+func humanAge(seconds int64) string {
+	switch {
+	case seconds < 60:
+		return "less than a minute ago"
+	case seconds < 3600:
+		n := seconds / 60
+		return fmt.Sprintf("%d %s ago", n, plural(int(n), "minute", "minutes"))
+	case seconds < 86400:
+		n := seconds / 3600
+		return fmt.Sprintf("%d %s ago", n, plural(int(n), "hour", "hours"))
+	case seconds < 86400*61:
+		n := seconds / 86400
+		return fmt.Sprintf("%d %s ago", n, plural(int(n), "day", "days"))
+	case seconds < 86400*730:
+		n := seconds / (86400 * 30)
+		return fmt.Sprintf("%d %s ago", n, plural(int(n), "month", "months"))
+	default:
+		n := seconds / (86400 * 365)
+		return fmt.Sprintf("%d %s ago", n, plural(int(n), "year", "years"))
+	}
 }
 
 func toPendingItem(c site.Component) pendingItem {
@@ -344,8 +453,10 @@ func fleetUpdateTotals(recs []siteUpdatesRecord) fleetTotals {
 const updatesPendingInstructions = "Outstanding plugin, theme and WordPress core updates, per site. " +
 	"Read-only: this connection cannot apply any of them.\n" +
 	"Only sites this connection is scoped to are listed; an absent site is out of scope, not absent from the fleet.\n" +
+	"EVERY SITE CARRIES A \"summary\" SENTENCE STATING ITS COUNT AND HOW OLD THE INVENTORY BEHIND IT IS. Quote or " +
+	"paraphrase that age whenever you report a site's update state; a count without its age is a claim we cannot support.\n" +
 	"pending_total 0 means no update is outstanding IN THE INVENTORY WE HOLD, which is only as current as " +
-	"inventory_collected_at. Quote that date when you report a site as up to date.\n" +
+	"inventory_collected_at.\n" +
 	"inventory_status \"never_collected\" means no inventory has EVER been collected for that site: its counts are 0 " +
 	"because we have not looked, NOT because it is up to date. Report those sites separately -- totals.sites_never_collected " +
 	"counts them -- and never merge them with the up-to-date ones.\n" +

--- a/apps/api/internal/mcp/updates.go
+++ b/apps/api/internal/mcp/updates.go
@@ -219,11 +219,45 @@ func toSiteUpdatesRecord(row sqlc.Site, now time.Time) siteUpdatesRecord {
 // one, that a site with no updates listed has no updates. The sentence removes
 // the room for that by stating the ignorance as the finding.
 func updatesSummary(rec siteUpdatesRecord) string {
+	// NEVER-COLLECTED SPLITS ON THE COUNT, AND THE ARM THAT WAS MISSING IS THE
+	// ONE THAT MATTERS MOST.
+	//
+	// This branch used to key on InventoryStatus ALONE, so a site with a NULL
+	// components_updated_at and real advisories was handed the sentence "the
+	// zero counts below mean we have not looked" while pending_total said 3.
+	// A false zero, in the one field whose entire purpose is that the count
+	// cannot be dropped without its caveat.
+	//
+	// IT IS REACHABLE BY CONSTRUCTION, NOT IN THEORY. m121 added
+	// components_updated_at NULL with no backfill and UpdateSiteMetadata is its
+	// only writer, so every site enrolled before 2026-08-23 that has not pushed
+	// metadata since has a POPULATED components document and NO stamp. Those
+	// are disproportionately the neglected and disconnected sites -- the ones
+	// carrying the most outstanding updates -- which is what made under-
+	// reporting here worse than an outright error.
+	//
+	// The two facts are now stated together instead of one overwriting the
+	// other: here is what we hold, and we do not know when it was collected.
 	if rec.InventoryStatus == inventoryNeverCollected {
+		if rec.PendingTotal == 0 {
+			return fmt.Sprintf(
+				"%s: no plugin or theme inventory has ever been collected for this site, so we do not "+
+					"know whether it needs updates. The zero counts below mean we have not looked, "+
+					"NOT that it is up to date.", rec.Name)
+		}
 		return fmt.Sprintf(
-			"%s: no plugin or theme inventory has ever been collected for this site, so we do not "+
-				"know whether it needs updates. The zero counts below mean we have not looked, "+
-				"NOT that it is up to date.", rec.Name)
+			// NO VERDICT WORD, deliberately, and this sentence had to be
+			// reworded once to keep it: an earlier draft said the versions "may
+			// be out of date", which is a phrase the no-judgement assertion
+			// scans for. It describes component versions rather than the
+			// inventory, so it was arguably in bounds -- and rewording cost
+			// nothing, while narrowing the guard to admit it would have cost
+			// the guard.
+			"%s: %d %s outstanding (%s), but we have no record of when this site's inventory was "+
+				"collected, so this count may be incomplete and the versions behind it may have "+
+				"moved on. Treat it as a lower bound and ask for a fresh inventory before acting on it.",
+			rec.Name, rec.PendingTotal, plural(rec.PendingTotal, "update", "updates"),
+			strings.Join(pendingBreakdown(rec), ", "))
 	}
 
 	// A collected inventory with no age is the future-stamp case toSiteRecord
@@ -243,6 +277,16 @@ func updatesSummary(rec siteUpdatesRecord) string {
 			"%s: no updates outstanding, according to an inventory collected %s%s.",
 			rec.Name, age, when)
 	}
+	return fmt.Sprintf(
+		"%s: %d %s outstanding (%s), according to an inventory collected %s%s.",
+		rec.Name, rec.PendingTotal, plural(rec.PendingTotal, "update", "updates"),
+		strings.Join(pendingBreakdown(rec), ", "), age, when)
+}
+
+// pendingBreakdown renders "2 plugins, 1 theme, WordPress core". It is shared by
+// both arms that quote a count so the two cannot describe the same record
+// differently.
+func pendingBreakdown(rec siteUpdatesRecord) []string {
 	parts := make([]string, 0, 3)
 	if n := len(rec.Plugins); n > 0 {
 		parts = append(parts, fmt.Sprintf("%d %s", n, plural(n, "plugin", "plugins")))
@@ -253,10 +297,7 @@ func updatesSummary(rec siteUpdatesRecord) string {
 	if rec.Core != nil {
 		parts = append(parts, "WordPress core")
 	}
-	return fmt.Sprintf(
-		"%s: %d %s outstanding (%s), according to an inventory collected %s%s.",
-		rec.Name, rec.PendingTotal, plural(rec.PendingTotal, "update", "updates"),
-		strings.Join(parts, ", "), age, when)
+	return parts
 }
 
 func plural(n int, one, many string) string {
@@ -340,11 +381,21 @@ type updatesPayload struct {
 type fleetTotals struct {
 	// SitesWithUpdates counts returned sites whose pending_total is above zero.
 	SitesWithUpdates int `json:"sites_with_updates"`
-	// SitesNeverCollected counts returned sites we have never collected an
-	// inventory for. It is reported SEPARATELY and never folded into
-	// sites_with_updates or its complement, because "no updates pending" and
-	// "we have never looked" are the two facts sites.components_updated_at is
-	// nullable-with-no-backfill in order to keep apart.
+	// SitesNeverCollected counts returned sites with no record of when their
+	// inventory was collected.
+	//
+	// IT DELIBERATELY OVERLAPS SitesWithUpdates AND THAT IS NOT A BUG. The two
+	// answer different questions -- "does it need updates" and "do we know when
+	// we last looked" -- and a site can be a yes to both: m121 left every
+	// pre-2026-08-23 site with a populated components document and a NULL
+	// stamp, so advisories of unknown age are an ordinary state, not a corner
+	// case.
+	//
+	// An earlier version of the instruction header called the two mutually
+	// exclusive and told the model never to merge them, which was false for
+	// exactly those sites. Describing the overlap is right; suppressing either
+	// count to manufacture disjointness would throw away a true fact to protect
+	// a sentence.
 	SitesNeverCollected int `json:"sites_never_collected"`
 	PendingPlugins      int `json:"pending_plugins"`
 	PendingThemes       int `json:"pending_themes"`
@@ -457,8 +508,10 @@ const updatesPendingInstructions = "Outstanding plugin, theme and WordPress core
 	"paraphrase that age whenever you report a site's update state; a count without its age is a claim we cannot support.\n" +
 	"pending_total 0 means no update is outstanding IN THE INVENTORY WE HOLD, which is only as current as " +
 	"inventory_collected_at.\n" +
-	"inventory_status \"never_collected\" means no inventory has EVER been collected for that site: its counts are 0 " +
-	"because we have not looked, NOT because it is up to date. Report those sites separately -- totals.sites_never_collected " +
-	"counts them -- and never merge them with the up-to-date ones.\n" +
+	"inventory_status \"never_collected\" means we have NO RECORD of when that site's inventory was collected. " +
+	"If its counts are 0, that is because we have not looked, NOT because it is up to date. If its counts are ABOVE 0, " +
+	"the advisories are real but undated: treat them as a lower bound. totals.sites_never_collected counts these sites and " +
+	"OVERLAPS totals.sites_with_updates on purpose -- a site can both need updates and have no collection date, so do not " +
+	"add the two together.\n" +
 	"This list already excludes advisories the dashboard also drops: an advisory naming the installed version, and the " +
 	"WPMgr agent's own plugin. Counts here match the dashboard's."

--- a/apps/api/internal/mcp/updates.go
+++ b/apps/api/internal/mcp/updates.go
@@ -1,0 +1,353 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/site"
+)
+
+// ---------------------------------------------------------------------------
+// fleet_updates_pending -- the second Tier 0 fleet read.
+//
+// The wireframe catalogue (S8) names it "Plugin, theme and core updates
+// outstanding, per site" and files it under "Fleet reads -- answered from our
+// database. No site is contacted." That is exactly what this is: it reads the
+// same sites.components inventory document fleet_sites_list already reads, on
+// the same bounded, scope-filtered page, and contacts nothing.
+//
+// ---------------------------------------------------------------------------
+// IT SHARES THE DASHBOARD'S PREDICATES RATHER THAN RESTATING THEM.
+//
+// site.ActionableUpdate and site.ActionableCoreUpdate are the read-side
+// predicates GET /sites/{id}/updates/available projects through, and their doc
+// comments already name this surface as a consumer. Importing them is the whole
+// point: an assistant that answered "which of my sites need updates?" from its
+// own copy of the rule would count the GH #211 same-version phantoms and the
+// agent's own plugin, both of which the dashboard drops -- so the assistant
+// would contradict the screen the operator is looking at, and only one of those
+// two gets noticed.
+//
+// The three rules that would otherwise drift, all of them already load-bearing
+// on the dashboard side:
+//
+//   - an advisory with an empty new_version is not an update, it is a null
+//     wearing a value's shape;
+//   - an advisory naming the installed version is a phantom (GH #211);
+//   - the WPMgr agent's own plugin is never offered as a selectable update,
+//     matched on plugin-header name as well as slug so an agent installed under
+//     an unexpected directory name is still recognised.
+//
+// ---------------------------------------------------------------------------
+// STALENESS IS REPORTED, NOT REFUSED, AND THE CHOICE IS DELIBERATE.
+//
+// The envelope carries RefusalInventoryStale and StaleRefusal builds it, so
+// refusing an old inventory was available and was considered. This tool does
+// not do it, for three reasons:
+//
+//  1. THERE IS NO FRESHNESS WINDOW IN THIS CODEBASE TO KEY ON. No constant, no
+//     column, no operator setting. A threshold invented here would be a number
+//     nobody chose, and refusing a real fleet against it on day one is a worse
+//     answer than a dated one.
+//  2. A STALE INVENTORY CAN STILL ANSWER. It answers with data whose age is
+//     stated. The site that genuinely cannot answer is the one the bounded page
+//     did not return, and that site IS refused, by name, as site_unread.
+//  3. IT WOULD DISAGREE WITH THE DASHBOARD, which renders the same inventory at
+//     any age alongside an as_of stamp and never withholds it.
+//
+// So every record carries inventory_status, inventory_collected_at and
+// inventory_age_seconds -- the same three fields, from the same helper, as
+// fleet_sites_list -- and the prepended instructions tell the model in words
+// that a count is only as fresh as its stamp and that never_collected is not
+// zero. What is NOT done here, stated plainly rather than left to be
+// discovered: no age threshold refuses, so a model that ignores the stamp can
+// still report a year-old count as current. Wiring StaleRefusal needs a
+// freshness window somebody chose, and that is an owner ruling, not a constant
+// this file may invent.
+// ---------------------------------------------------------------------------
+
+// ToolFleetUpdatesPending is the wire name, taken verbatim from the S8
+// catalogue so every fleet-wide read shares one prefix and one word order.
+const ToolFleetUpdatesPending = "fleet_updates_pending"
+
+// updatesPendingSchema takes no arguments, exactly as fleet_sites_list does.
+// The tool answers over the connection's whole resolved scope; a site filter
+// would be a second, weaker expression of the site scope the grant already
+// carries, and a model that passed one would be choosing its own subset of a
+// boundary it does not own.
+var updatesPendingSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}`)
+
+// pendingItem is one plugin or theme with an actionable update advisory.
+type pendingItem struct {
+	Slug string `json:"slug"`
+	Name string `json:"name,omitempty"`
+	// Active is carried because it is the operator's own triage order on the
+	// dashboard: an inactive plugin with a pending update is a different
+	// priority from an active one, and a model that cannot see the difference
+	// will rank them the same.
+	Active bool `json:"active"`
+	// InstalledVersion may be empty when the agent reported no version. It is
+	// left empty rather than filled with a placeholder: SameVersion fails open
+	// on a blank side, so the advisory survived the phantom check precisely
+	// because the installed version is unknown, and saying so is the honest
+	// rendering.
+	InstalledVersion string `json:"installed_version"`
+	NewVersion       string `json:"new_version"`
+}
+
+// coreUpdateRecord is the site's own WordPress core advisory, present only when
+// site.ActionableCoreUpdate accepts it.
+type coreUpdateRecord struct {
+	CurrentVersion string `json:"current_version"`
+	NewVersion     string `json:"new_version"`
+}
+
+// siteUpdatesRecord is one site's outstanding update set as the model sees it.
+type siteUpdatesRecord struct {
+	SiteID string `json:"site_id"`
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+
+	// The staleness triplet, from the same helper fleet_sites_list uses, so the
+	// two tools cannot disagree about when a site's inventory was collected.
+	InventoryStatus      string  `json:"inventory_status"`
+	InventoryCollectedAt *string `json:"inventory_collected_at"`
+	InventoryAgeSeconds  *int64  `json:"inventory_age_seconds"`
+
+	// PendingTotal counts plugins + themes + core (core contributes 1 when
+	// present). It is the number the question "which of my sites need updates?"
+	// is actually asking for, precomputed so a model does not have to add up
+	// three lists and get it wrong.
+	PendingTotal int `json:"pending_total"`
+
+	Core    *coreUpdateRecord `json:"core_update"`
+	Plugins []pendingItem     `json:"plugins"`
+	Themes  []pendingItem     `json:"themes"`
+}
+
+// toSiteUpdatesRecord projects one row through the dashboard's own predicates.
+//
+// THE PARSE IS site.ParseInventoryComponents AND NOT A LOCAL ONE. A second
+// decoder over the same document is a second answer to "what is installed on
+// this site", and the two drift the moment either grows a key -- which is the
+// reason that function exists as an exported parse over raw bytes in the first
+// place.
+func toSiteUpdatesRecord(row sqlc.Site, now time.Time) siteUpdatesRecord {
+	rec := siteUpdatesRecord{
+		SiteID:  row.ID.String(),
+		Name:    row.Name,
+		URL:     row.Url,
+		Plugins: []pendingItem{},
+		Themes:  []pendingItem{},
+	}
+
+	// Reuse fleet_sites_list's stamping wholesale rather than restating its
+	// null branch. toSiteRecord is where the "never_collected is not a date"
+	// reasoning lives, and a copy of it here would be a second place for that
+	// rule to be got wrong.
+	stamp := toSiteRecord(row, now)
+	rec.InventoryStatus = stamp.InventoryStatus
+	rec.InventoryCollectedAt = stamp.InventoryCollectedAt
+	rec.InventoryAgeSeconds = stamp.InventoryAgeSeconds
+
+	plugins, themes := site.ParseInventoryComponents(row.Components)
+	for _, p := range plugins {
+		if !site.ActionableUpdate(p) {
+			continue
+		}
+		rec.Plugins = append(rec.Plugins, toPendingItem(p))
+	}
+	for _, t := range themes {
+		if !site.ActionableUpdate(t) {
+			continue
+		}
+		rec.Themes = append(rec.Themes, toPendingItem(t))
+	}
+
+	// Active before inactive, then slug, matching buildAvailableUpdates' order
+	// within a kind so the assistant reads the fleet in the same priority the
+	// dashboard displays it.
+	sortPending(rec.Plugins)
+	sortPending(rec.Themes)
+
+	if core := site.ParseInventoryCoreUpdate(row.Components); site.ActionableCoreUpdate(core) {
+		rec.Core = &coreUpdateRecord{
+			CurrentVersion: core.CurrentVersion,
+			NewVersion:     core.NewVersion,
+		}
+	}
+
+	rec.PendingTotal = len(rec.Plugins) + len(rec.Themes)
+	if rec.Core != nil {
+		rec.PendingTotal++
+	}
+	return rec
+}
+
+func toPendingItem(c site.Component) pendingItem {
+	return pendingItem{
+		Slug:             c.Slug,
+		Name:             c.Name,
+		Active:           c.Active,
+		InstalledVersion: c.Version,
+		NewVersion:       c.AvailableUpdate.NewVersion,
+	}
+}
+
+// sortPending orders active before inactive, then by slug, so repeated calls
+// return the same order and a model comparing two answers sees real change
+// rather than map iteration.
+func sortPending(items []pendingItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].Active != items[j].Active {
+			return items[i].Active
+		}
+		return items[i].Slug < items[j].Slug
+	})
+}
+
+// updatesPayload is the JSON body of a fleet_updates_pending result.
+type updatesPayload struct {
+	Sites []json.RawMessage `json:"sites"`
+
+	// Totals is the fleet-level answer, computed over the records ACTUALLY
+	// RETURNED and never over the rows read. See fleetUpdateTotals: a total
+	// that counted truncated-away records would describe a list the caller
+	// cannot see.
+	Totals fleetTotals `json:"totals"`
+
+	Envelope   Envelope       `json:"envelope"`
+	Truncation truncationInfo `json:"truncation"`
+}
+
+// fleetTotals is the roll-up the question actually asks for.
+type fleetTotals struct {
+	// SitesWithUpdates counts returned sites whose pending_total is above zero.
+	SitesWithUpdates int `json:"sites_with_updates"`
+	// SitesNeverCollected counts returned sites we have never collected an
+	// inventory for. It is reported SEPARATELY and never folded into
+	// sites_with_updates or its complement, because "no updates pending" and
+	// "we have never looked" are the two facts sites.components_updated_at is
+	// nullable-with-no-backfill in order to keep apart.
+	SitesNeverCollected int `json:"sites_never_collected"`
+	PendingPlugins      int `json:"pending_plugins"`
+	PendingThemes       int `json:"pending_themes"`
+	PendingCore         int `json:"pending_core"`
+	PendingTotal        int `json:"pending_total"`
+}
+
+// buildUpdatesPendingResult renders records into the tool result text, under
+// the same byte cap, the same record-boundary truncation and the same prepended
+// banner as fleet_sites_list. The reasoning for each of those is on
+// buildListSitesResult and is not repeated here; what IS different is that the
+// totals are computed over the kept records, below.
+func buildUpdatesPendingResult(rows []sqlc.Site, env Envelope, now time.Time) (string, error) {
+	available := len(rows)
+
+	kept := make([]json.RawMessage, 0, len(rows))
+	keptRecs := make([]siteUpdatesRecord, 0, len(rows))
+	used := 0
+	truncatedByBytes := false
+
+	for _, row := range rows {
+		rec := toSiteUpdatesRecord(row, now)
+		enc, err := json.Marshal(rec)
+		if err != nil {
+			return "", fmt.Errorf("marshal site updates record %s: %w", row.ID, err)
+		}
+		cost := len(enc) + 1
+		if used+cost > recordByteBudget {
+			// CONTINUE, NOT BREAK, for the reason buildListSitesResult gives at
+			// length: one oversized record must not suppress every record after
+			// it, and sites.name is tenant-controlled.
+			truncatedByBytes = true
+			continue
+		}
+		kept = append(kept, enc)
+		keptRecs = append(keptRecs, rec)
+		used += cost
+	}
+
+	info := truncationInfo{
+		Truncated:   truncatedByBytes,
+		Returned:    len(kept),
+		ByteCap:     recordByteBudget,
+		Available:   &available,
+		Explanation: "",
+	}
+
+	header := clampInstructions(updatesPendingInstructions)
+	if truncatedByBytes {
+		info.Explanation = truncationExplanation(len(kept), available)
+		header = truncationBanner(info.Explanation) + "\n\n" + header
+	}
+	if env.Refused > 0 {
+		header = truncationBanner(fmt.Sprintf(
+			"PARTIAL RESULT: %d of your %d sites answered, %d refused. See envelope.refusals "+
+				"for the reason and evidence for each. Do not present this as a complete answer.",
+			env.OK, env.Asked, env.Refused)) + "\n\n" + header
+	}
+
+	payload, err := json.Marshal(updatesPayload{
+		Sites:      kept,
+		Totals:     fleetUpdateTotals(keptRecs),
+		Envelope:   env,
+		Truncation: info,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal fleet_updates_pending payload: %w", err)
+	}
+	return header + "\n\n" + string(payload), nil
+}
+
+// fleetUpdateTotals rolls the KEPT records up.
+//
+// IT TAKES THE KEPT RECORDS AND NOT THE ROWS, WHICH IS THE WHOLE CARE IN THIS
+// FUNCTION. Totalling over `rows` would produce a summary describing sites the
+// byte cap removed from the list -- "14 updates across 6 sites" over a payload
+// showing 4 sites -- and the model's only way to notice would be to re-add the
+// per-site numbers and find they disagree. A summary that silently covers more
+// than the list under it is the same silent-partial failure the envelope
+// exists to abolish, one level up, and it is the shape that survives review
+// because both halves are individually correct.
+func fleetUpdateTotals(recs []siteUpdatesRecord) fleetTotals {
+	var t fleetTotals
+	for _, r := range recs {
+		if r.InventoryStatus == inventoryNeverCollected {
+			t.SitesNeverCollected++
+		}
+		if r.PendingTotal > 0 {
+			t.SitesWithUpdates++
+		}
+		t.PendingPlugins += len(r.Plugins)
+		t.PendingThemes += len(r.Themes)
+		if r.Core != nil {
+			t.PendingCore++
+		}
+		t.PendingTotal += r.PendingTotal
+	}
+	return t
+}
+
+// updatesPendingInstructions is PREPENDED to every result. It shares the
+// instruction budget with the truncation banner, so it stays short; the two
+// sentences that earn their bytes are the never_collected one and the staleness
+// one, because both are places a model would otherwise report a confident
+// falsehood.
+const updatesPendingInstructions = "Outstanding plugin, theme and WordPress core updates, per site. " +
+	"Read-only: this connection cannot apply any of them.\n" +
+	"Only sites this connection is scoped to are listed; an absent site is out of scope, not absent from the fleet.\n" +
+	"pending_total 0 means no update is outstanding IN THE INVENTORY WE HOLD, which is only as current as " +
+	"inventory_collected_at. Quote that date when you report a site as up to date.\n" +
+	"inventory_status \"never_collected\" means no inventory has EVER been collected for that site: its counts are 0 " +
+	"because we have not looked, NOT because it is up to date. Report those sites separately -- totals.sites_never_collected " +
+	"counts them -- and never merge them with the up-to-date ones.\n" +
+	"This list already excludes advisories the dashboard also drops: an advisory naming the installed version, and the " +
+	"WPMgr agent's own plugin. Counts here match the dashboard's."

--- a/apps/api/internal/mcp/updates_test.go
+++ b/apps/api/internal/mcp/updates_test.go
@@ -1,0 +1,547 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+)
+
+// ---------------------------------------------------------------------------
+// fleet_updates_pending, proved THROUGH THE MOUNTED TRANSPORT WITH A REAL
+// BEARER, because the claim being made is that an AI client can ask.
+//
+// Every assertion below is on an EXACT VALUE. "A plugin list came back" passes
+// when the list belongs to the wrong site, which is the failure mode this whole
+// file is about.
+// ---------------------------------------------------------------------------
+
+// updatesFixture is one site row with a known inventory document.
+type updatesFixture struct {
+	id         uuid.UUID
+	name       string
+	url        string
+	components string
+	collected  *time.Time
+}
+
+func (f updatesFixture) row() sqlc.Site {
+	r := sqlc.Site{
+		ID:              f.id,
+		Name:            f.name,
+		Url:             f.url,
+		ConnectionState: "connected",
+		HealthStatus:    "healthy",
+		WpVersion:       "6.5.2",
+		Components:      []byte(f.components),
+	}
+	if f.collected != nil {
+		r.ComponentsUpdatedAt = pgtype.Timestamptz{Time: *f.collected, Valid: true}
+	}
+	return r
+}
+
+// callUpdatesPending drives tools/call over the real mount and returns the
+// result text, failing the test on any JSON-RPC error.
+func callUpdatesPending(t *testing.T, store Store) string {
+	t.Helper()
+	r := newTransportRouter(t, store)
+	w := post(t, r, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":`+
+		`{"name":"fleet_updates_pending","arguments":{}}}`, nil)
+	// DECODED FROM THE RAW BODY, not through the package's own response type.
+	// The claim under test is that a client reading the wire gets this, so the
+	// wire is what is parsed.
+	var envelope struct {
+		Error  json.RawMessage `json:"error"`
+		Result struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("response is not JSON-RPC: %v\nbody: %s", err, w.Body.String())
+	}
+	if len(envelope.Error) > 0 && string(envelope.Error) != "null" {
+		t.Fatalf("tools/call fleet_updates_pending errored: %s", envelope.Error)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("tool reported isError: %s", w.Body.String())
+	}
+	if len(envelope.Result.Content) != 1 || envelope.Result.Content[0].Type != "text" {
+		t.Fatalf("want exactly one text content block, got %+v", envelope.Result.Content)
+	}
+	return envelope.Result.Content[0].Text
+}
+
+// parseUpdatesPayload pulls the JSON half out of the result text.
+func parseUpdatesPayload(t *testing.T, text string) updatesPayloadForTest {
+	t.Helper()
+	i := strings.Index(text, `{"sites":`)
+	if i < 0 {
+		t.Fatalf("no JSON payload in result text:\n%s", text)
+	}
+	var p updatesPayloadForTest
+	if err := json.Unmarshal([]byte(text[i:]), &p); err != nil {
+		t.Fatalf("payload is not JSON: %v\n%s", err, text[i:])
+	}
+	return p
+}
+
+// updatesPayloadForTest decodes what the wire actually carried, rather than
+// re-using the producer's own struct. Sharing the struct would let a renamed
+// JSON tag pass both halves of every assertion below.
+type updatesPayloadForTest struct {
+	Sites []struct {
+		SiteID               string  `json:"site_id"`
+		Name                 string  `json:"name"`
+		URL                  string  `json:"url"`
+		InventoryStatus      string  `json:"inventory_status"`
+		InventoryCollectedAt *string `json:"inventory_collected_at"`
+		PendingTotal         int     `json:"pending_total"`
+		Core                 *struct {
+			CurrentVersion string `json:"current_version"`
+			NewVersion     string `json:"new_version"`
+		} `json:"core_update"`
+		Plugins []struct {
+			Slug             string `json:"slug"`
+			Name             string `json:"name"`
+			Active           bool   `json:"active"`
+			InstalledVersion string `json:"installed_version"`
+			NewVersion       string `json:"new_version"`
+		} `json:"plugins"`
+		Themes []struct {
+			Slug       string `json:"slug"`
+			NewVersion string `json:"new_version"`
+		} `json:"themes"`
+	} `json:"sites"`
+	Totals struct {
+		SitesWithUpdates    int `json:"sites_with_updates"`
+		SitesNeverCollected int `json:"sites_never_collected"`
+		PendingPlugins      int `json:"pending_plugins"`
+		PendingThemes       int `json:"pending_themes"`
+		PendingCore         int `json:"pending_core"`
+		PendingTotal        int `json:"pending_total"`
+	} `json:"totals"`
+	Envelope struct {
+		Asked    int `json:"asked"`
+		OK       int `json:"ok"`
+		Refused  int `json:"refused"`
+		Refusals []struct {
+			SiteID string `json:"site_id"`
+			Code   string `json:"code"`
+		} `json:"refusals"`
+	} `json:"envelope"`
+}
+
+// ---------------------------------------------------------------------------
+// THE SCOPE PROOF. It is first in the file and its leak assertions run before
+// any count assertion, deliberately: a leak check sitting behind a row-count
+// check is itself unproven, because the count fails first and the leak
+// assertion never executes.
+// ---------------------------------------------------------------------------
+
+func TestFleetUpdatesPending_DoesNotLeakAnUnscopedSite(t *testing.T) {
+	inScope := uuid.New()
+	outOfScope := uuid.New()
+
+	store := liveGrantStore(inScope) // the grant names ONLY inScope
+	store.sites = []sqlc.Site{
+		updatesFixture{
+			id: inScope, name: "acme.com", url: "https://acme.com",
+			components: `{"plugins":[{"slug":"in-scope-plugin","name":"In Scope Plugin",` +
+				`"version":"1.0.0","active":true,"available_update":{"new_version":"1.1.0"}}]}`,
+		}.row(),
+		// THE FAKE STORE RETURNS THIS ROW ANYWAY, and that is the point of the
+		// fixture rather than a flaw in it: the real query's site_ids predicate
+		// and the RESTRICTIVE sites_site_scope policy both drop it, and this
+		// test models the state where both have failed. It is the only state in
+		// which layer 3 -- the in-Go SiteSet filter -- can be observed working.
+		updatesFixture{
+			id: outOfScope, name: "northgate-secret.co.uk", url: "https://northgate-secret.co.uk",
+			components: `{"plugins":[{"slug":"out-of-scope-plugin","name":"Out Of Scope Plugin",` +
+				`"version":"2.0.0","active":true,"available_update":{"new_version":"2.5.0"}}]}`,
+		}.row(),
+	}
+
+	text := callUpdatesPending(t, store)
+
+	// LEAK ASSERTIONS FIRST, over the RAW RESULT TEXT rather than the decoded
+	// payload, so a leak into the instruction header or a truncation banner is
+	// caught as well as one into the records.
+	for _, secret := range []string{
+		outOfScope.String(),
+		"northgate-secret.co.uk",
+		"out-of-scope-plugin",
+		"Out Of Scope Plugin",
+		"2.5.0",
+	} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("fleet_updates_pending disclosed %q, which belongs to a site outside the "+
+				"connection's scope. Full result:\n%s", secret, text)
+		}
+	}
+
+	p := parseUpdatesPayload(t, text)
+
+	// LAYER 3 HIDES: the out-of-scope site is ABSENT, never refused. Naming it
+	// in a refusal would disclose that it exists.
+	if p.Envelope.Asked != 1 {
+		t.Errorf("envelope.asked = %d, want 1 (the CALLER'S OWN scope cardinality, never the "+
+			"tenant's site count)", p.Envelope.Asked)
+	}
+	if p.Envelope.OK != 1 || p.Envelope.Refused != 0 {
+		t.Errorf("envelope ok/refused = %d/%d, want 1/0", p.Envelope.OK, p.Envelope.Refused)
+	}
+	for _, r := range p.Envelope.Refusals {
+		if r.SiteID == outOfScope.String() {
+			t.Fatalf("an out-of-scope site was REFUSED (%s) instead of being absent; a refusal "+
+				"naming it discloses that it exists", r.Code)
+		}
+	}
+
+	// And the in-scope site really did answer, so the absence above is scoping
+	// rather than an empty result.
+	if len(p.Sites) != 1 {
+		t.Fatalf("want exactly 1 site, got %d", len(p.Sites))
+	}
+	if p.Sites[0].SiteID != inScope.String() {
+		t.Errorf("site_id = %s, want the in-scope site %s", p.Sites[0].SiteID, inScope)
+	}
+	if len(p.Sites[0].Plugins) != 1 || p.Sites[0].Plugins[0].Slug != "in-scope-plugin" {
+		t.Errorf("plugins = %+v, want exactly [in-scope-plugin]", p.Sites[0].Plugins)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXACT VALUES.
+// ---------------------------------------------------------------------------
+
+func TestFleetUpdatesPending_ReportsExactPendingUpdates(t *testing.T) {
+	siteA := uuid.New()
+	siteB := uuid.New()
+	collected := time.Date(2026, 8, 30, 9, 0, 0, 0, time.UTC)
+
+	store := liveGrantStore(siteA, siteB)
+	store.sites = []sqlc.Site{
+		updatesFixture{
+			id: siteA, name: "acme.com", url: "https://acme.com", collected: &collected,
+			components: `{"plugins":[` +
+				// Inactive, so it must sort AFTER the active one below.
+				`{"slug":"akismet","name":"Akismet","version":"5.1","active":false,` +
+				`"available_update":{"new_version":"5.3"}},` +
+				`{"slug":"woocommerce","name":"WooCommerce","version":"8.1.0","active":true,` +
+				`"available_update":{"new_version":"8.4.0"}},` +
+				// No advisory at all: not pending.
+				`{"slug":"hello-dolly","name":"Hello Dolly","version":"1.7.2","active":true}` +
+				`],"themes":[` +
+				`{"slug":"twentytwentyfour","name":"Twenty Twenty-Four","version":"1.0","active":true,` +
+				`"available_update":{"new_version":"1.2"}}` +
+				`],"core_update":{"current_version":"6.5.2","new_version":"6.6"}}`,
+		}.row(),
+		// Fully up to date: an inventory WAS collected and nothing is pending.
+		updatesFixture{
+			id: siteB, name: "quiet.example", url: "https://quiet.example", collected: &collected,
+			components: `{"plugins":[{"slug":"akismet","name":"Akismet","version":"5.3","active":true}]}`,
+		}.row(),
+	}
+
+	p := parseUpdatesPayload(t, callUpdatesPending(t, store))
+
+	if len(p.Sites) != 2 {
+		t.Fatalf("want 2 sites, got %d", len(p.Sites))
+	}
+	var a, b int
+	for i, s := range p.Sites {
+		switch s.SiteID {
+		case siteA.String():
+			a = i
+		case siteB.String():
+			b = i
+		default:
+			t.Fatalf("unexpected site_id %s", s.SiteID)
+		}
+	}
+
+	// --- site A, exact ---
+	got := p.Sites[a]
+	if got.PendingTotal != 4 {
+		t.Errorf("acme pending_total = %d, want 4 (2 plugins + 1 theme + core)", got.PendingTotal)
+	}
+	if got.InventoryStatus != inventoryCollected {
+		t.Errorf("acme inventory_status = %q, want %q", got.InventoryStatus, inventoryCollected)
+	}
+	if got.InventoryCollectedAt == nil || *got.InventoryCollectedAt != "2026-08-30T09:00:00Z" {
+		t.Errorf("acme inventory_collected_at = %v, want 2026-08-30T09:00:00Z", got.InventoryCollectedAt)
+	}
+	if len(got.Plugins) != 2 {
+		t.Fatalf("acme plugins = %+v, want exactly 2 (hello-dolly has no advisory)", got.Plugins)
+	}
+	// ACTIVE BEFORE INACTIVE, matching the dashboard's own order.
+	if got.Plugins[0].Slug != "woocommerce" || got.Plugins[1].Slug != "akismet" {
+		t.Errorf("plugin order = [%s %s], want [woocommerce akismet] (active before inactive)",
+			got.Plugins[0].Slug, got.Plugins[1].Slug)
+	}
+	if got.Plugins[0].InstalledVersion != "8.1.0" || got.Plugins[0].NewVersion != "8.4.0" {
+		t.Errorf("woocommerce = %s -> %s, want 8.1.0 -> 8.4.0",
+			got.Plugins[0].InstalledVersion, got.Plugins[0].NewVersion)
+	}
+	if got.Plugins[0].Name != "WooCommerce" || !got.Plugins[0].Active {
+		t.Errorf("woocommerce name/active = %q/%v, want WooCommerce/true",
+			got.Plugins[0].Name, got.Plugins[0].Active)
+	}
+	if got.Plugins[1].InstalledVersion != "5.1" || got.Plugins[1].NewVersion != "5.3" {
+		t.Errorf("akismet = %s -> %s, want 5.1 -> 5.3",
+			got.Plugins[1].InstalledVersion, got.Plugins[1].NewVersion)
+	}
+	if len(got.Themes) != 1 || got.Themes[0].Slug != "twentytwentyfour" || got.Themes[0].NewVersion != "1.2" {
+		t.Errorf("themes = %+v, want exactly [twentytwentyfour -> 1.2]", got.Themes)
+	}
+	if got.Core == nil {
+		t.Fatal("acme core_update is null, want 6.5.2 -> 6.6")
+	}
+	if got.Core.CurrentVersion != "6.5.2" || got.Core.NewVersion != "6.6" {
+		t.Errorf("core = %s -> %s, want 6.5.2 -> 6.6", got.Core.CurrentVersion, got.Core.NewVersion)
+	}
+
+	// --- site B: genuinely up to date, and it must say ZERO rather than being
+	// omitted. A site dropped from the list because it has nothing pending is
+	// indistinguishable from a site that was never read.
+	if p.Sites[b].PendingTotal != 0 {
+		t.Errorf("quiet.example pending_total = %d, want 0", p.Sites[b].PendingTotal)
+	}
+	if p.Sites[b].InventoryStatus != inventoryCollected {
+		t.Errorf("quiet.example inventory_status = %q, want %q",
+			p.Sites[b].InventoryStatus, inventoryCollected)
+	}
+
+	// --- fleet totals, exact ---
+	if p.Totals.SitesWithUpdates != 1 {
+		t.Errorf("totals.sites_with_updates = %d, want 1", p.Totals.SitesWithUpdates)
+	}
+	if p.Totals.PendingPlugins != 2 || p.Totals.PendingThemes != 1 || p.Totals.PendingCore != 1 {
+		t.Errorf("totals plugins/themes/core = %d/%d/%d, want 2/1/1",
+			p.Totals.PendingPlugins, p.Totals.PendingThemes, p.Totals.PendingCore)
+	}
+	if p.Totals.PendingTotal != 4 {
+		t.Errorf("totals.pending_total = %d, want 4", p.Totals.PendingTotal)
+	}
+	if p.Totals.SitesNeverCollected != 0 {
+		t.Errorf("totals.sites_never_collected = %d, want 0", p.Totals.SitesNeverCollected)
+	}
+	if p.Envelope.Asked != 2 || p.Envelope.OK != 2 || p.Envelope.Refused != 0 {
+		t.Errorf("envelope = %d/%d/%d, want asked=2 ok=2 refused=0",
+			p.Envelope.Asked, p.Envelope.OK, p.Envelope.Refused)
+	}
+}
+
+// TestFleetUpdatesPending_AgreesWithTheDashboardsPredicates is the proof that
+// the assistant will not contradict the screen.
+//
+// Both fixtures below are advisories the dashboard DROPS. If this tool counted
+// them, an operator would read "2 updates pending" from the assistant and see
+// "up to date" on the site page, and only one of those two gets noticed.
+func TestFleetUpdatesPending_AgreesWithTheDashboardsPredicates(t *testing.T) {
+	siteID := uuid.New()
+	store := liveGrantStore(siteID)
+	store.sites = []sqlc.Site{
+		updatesFixture{
+			id: siteID, name: "acme.com", url: "https://acme.com",
+			components: `{"plugins":[` +
+				// GH #211 phantom: the advisory names the version already installed.
+				`{"slug":"phantom-plugin","name":"Phantom","version":"3.0.0","active":true,` +
+				`"available_update":{"new_version":"3.0.0"}},` +
+				// An advisory with no target version at all.
+				`{"slug":"empty-advisory","name":"Empty","version":"1.0","active":true,` +
+				`"available_update":{"new_version":""}},` +
+				// The agent's own plugin, which is never offered as an update.
+				`{"slug":"fleet-agent-site-manager","name":"Fleet Agent Site Manager",` +
+				`"version":"2.6.1","active":true,"available_update":{"new_version":"2.9.0"}},` +
+				// One real one, so a tool that returned nothing at all cannot pass.
+				`{"slug":"woocommerce","name":"WooCommerce","version":"8.1.0","active":true,` +
+				`"available_update":{"new_version":"8.4.0"}}` +
+				`],"core_update":{"current_version":"6.6","new_version":"6.6"}}`,
+		}.row(),
+	}
+
+	text := callUpdatesPending(t, store)
+	p := parseUpdatesPayload(t, text)
+
+	if len(p.Sites) != 1 {
+		t.Fatalf("want 1 site, got %d", len(p.Sites))
+	}
+	got := p.Sites[0]
+	if got.PendingTotal != 1 {
+		t.Errorf("pending_total = %d, want 1 -- only woocommerce is actionable. Got plugins %+v, "+
+			"core %+v", got.PendingTotal, got.Plugins, got.Core)
+	}
+	if len(got.Plugins) != 1 || got.Plugins[0].Slug != "woocommerce" {
+		t.Fatalf("plugins = %+v, want exactly [woocommerce]", got.Plugins)
+	}
+	// Named, so the failure says WHICH rule broke rather than only that a count
+	// moved.
+	for _, dropped := range []string{"phantom-plugin", "empty-advisory", "fleet-agent-site-manager"} {
+		if strings.Contains(text, dropped) {
+			t.Errorf("%q was offered as a pending update; the dashboard drops it, so the "+
+				"assistant now contradicts the screen", dropped)
+		}
+	}
+	if got.Core != nil {
+		t.Errorf("core_update = %+v, want null: an advisory naming the installed version is a "+
+			"phantom for core exactly as it is for a component", got.Core)
+	}
+}
+
+// TestFleetUpdatesPending_NeverCollectedIsNotZero pins the distinction
+// sites.components_updated_at is nullable-with-no-backfill in order to keep.
+func TestFleetUpdatesPending_NeverCollectedIsNotZero(t *testing.T) {
+	never := uuid.New()
+	store := liveGrantStore(never)
+	store.sites = []sqlc.Site{
+		// No collected stamp, and no inventory document either: we have never
+		// looked at this site.
+		updatesFixture{id: never, name: "unknown.example", url: "https://unknown.example",
+			components: `{}`}.row(),
+	}
+
+	text := callUpdatesPending(t, store)
+	p := parseUpdatesPayload(t, text)
+
+	if len(p.Sites) != 1 {
+		t.Fatalf("want 1 site, got %d", len(p.Sites))
+	}
+	if p.Sites[0].InventoryStatus != inventoryNeverCollected {
+		t.Errorf("inventory_status = %q, want %q", p.Sites[0].InventoryStatus, inventoryNeverCollected)
+	}
+	if p.Sites[0].InventoryCollectedAt != nil {
+		t.Errorf("inventory_collected_at = %v, want JSON null -- a substitute date here reports "+
+			"an observation that was never taken", *p.Sites[0].InventoryCollectedAt)
+	}
+	// THE COUNT THAT MATTERS: never-collected is reported SEPARATELY and is not
+	// folded into the up-to-date sites.
+	if p.Totals.SitesNeverCollected != 1 {
+		t.Errorf("totals.sites_never_collected = %d, want 1", p.Totals.SitesNeverCollected)
+	}
+	if p.Totals.SitesWithUpdates != 0 {
+		t.Errorf("totals.sites_with_updates = %d, want 0", p.Totals.SitesWithUpdates)
+	}
+	// And the model is TOLD, in the prepended text, not left to infer it.
+	if !strings.Contains(text, "never_collected") {
+		t.Error("the instructions never mention never_collected, so a model reading pending_total 0 " +
+			"has nothing telling it we simply have not looked")
+	}
+}
+
+// TestFleetUpdatesPending_EmptyScopeRefuses: an empty resolved scope is a
+// REFUSAL and never an empty list, which would be indistinguishable from a
+// healthy organisation owning nothing.
+func TestFleetUpdatesPending_EmptyScopeRefuses(t *testing.T) {
+	store := liveGrantStore() // no sites in the grant
+	store.sites = []sqlc.Site{
+		updatesFixture{id: uuid.New(), name: "somebody-elses.com", url: "https://somebody-elses.com",
+			components: `{"plugins":[{"slug":"leaky","version":"1.0","active":true,` +
+				`"available_update":{"new_version":"2.0"}}]}`}.row(),
+	}
+
+	r := newTransportRouter(t, store)
+	w := post(t, r, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":`+
+		`{"name":"fleet_updates_pending","arguments":{}}}`, nil)
+
+	// LEAK FIRST, again: an empty-scope call must not disclose the row the fake
+	// store would have handed back.
+	if strings.Contains(w.Body.String(), "somebody-elses.com") || strings.Contains(w.Body.String(), "leaky") {
+		t.Fatalf("an empty-scope refusal disclosed a site: %s", w.Body.String())
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, ErrCodeScopeEmpty) {
+		t.Fatalf("want a %s refusal, got: %s", ErrCodeScopeEmpty, body)
+	}
+	if strings.Contains(body, `"sites":[]`) {
+		t.Fatalf("an empty scope returned an empty LIST rather than refusing: %s", body)
+	}
+}
+
+// TestFleetUpdatesPending_UnreadInScopeSiteIsRefusedNotDropped: a site the
+// caller may see and the page did not return is accounted for by name, so
+// ok+refused still balances against the caller's own scope.
+func TestFleetUpdatesPending_UnreadInScopeSiteIsRefusedNotDropped(t *testing.T) {
+	present := uuid.New()
+	missing := uuid.New()
+
+	store := liveGrantStore(present, missing)
+	store.sites = []sqlc.Site{
+		updatesFixture{id: present, name: "acme.com", url: "https://acme.com",
+			components: `{}`}.row(),
+		// `missing` is in scope and is deliberately NOT in the store's page.
+	}
+
+	p := parseUpdatesPayload(t, callUpdatesPending(t, store))
+
+	if p.Envelope.Asked != 2 || p.Envelope.OK != 1 || p.Envelope.Refused != 1 {
+		t.Fatalf("envelope = asked %d ok %d refused %d, want 2/1/1",
+			p.Envelope.Asked, p.Envelope.OK, p.Envelope.Refused)
+	}
+	if len(p.Envelope.Refusals) != 1 {
+		t.Fatalf("want exactly 1 refusal, got %+v", p.Envelope.Refusals)
+	}
+	if p.Envelope.Refusals[0].SiteID != missing.String() {
+		t.Errorf("refusal names %s, want the unread in-scope site %s",
+			p.Envelope.Refusals[0].SiteID, missing)
+	}
+	if p.Envelope.Refusals[0].Code != RefusalSiteUnread.String() {
+		t.Errorf("refusal code = %q, want %q", p.Envelope.Refusals[0].Code, RefusalSiteUnread)
+	}
+}
+
+// TestFleetUpdateTotalsCoverOnlyTheKeptRecords is the unit half of the
+// truncation reasoning: a roll-up that counted records the byte cap removed
+// would describe a list the caller cannot see, and the only way to notice would
+// be to re-add the per-site numbers and find they disagree.
+func TestFleetUpdateTotalsCoverOnlyTheKeptRecords(t *testing.T) {
+	now := time.Now().UTC()
+	rows := make([]sqlc.Site, 0, 40)
+	for i := 0; i < 40; i++ {
+		// A long name so each record is large; 40 of them cross recordByteBudget.
+		rows = append(rows, updatesFixture{
+			id:   uuid.New(),
+			name: fmt.Sprintf("site-%02d-%s", i, strings.Repeat("padding", 120)),
+			url:  "https://example.test",
+			components: `{"plugins":[{"slug":"woocommerce","name":"WooCommerce","version":"8.1.0",` +
+				`"active":true,"available_update":{"new_version":"8.4.0"}}]}`,
+		}.row())
+	}
+	env, err := NewEnvelope(len(rows), len(rows), nil)
+	if err != nil {
+		t.Fatalf("NewEnvelope: %v", err)
+	}
+
+	text, err := buildUpdatesPendingResult(rows, env, now)
+	if err != nil {
+		t.Fatalf("buildUpdatesPendingResult: %v", err)
+	}
+	p := parseUpdatesPayload(t, text)
+
+	if len(p.Sites) >= len(rows) {
+		t.Fatalf("the fixture did not cross the byte cap (%d of %d returned), so this proof "+
+			"checks nothing", len(p.Sites), len(rows))
+	}
+	if p.Totals.PendingTotal != len(p.Sites) {
+		t.Errorf("totals.pending_total = %d over a list of %d sites each with 1 pending update: "+
+			"the roll-up covers records the byte cap removed", p.Totals.PendingTotal, len(p.Sites))
+	}
+	if p.Totals.SitesWithUpdates != len(p.Sites) {
+		t.Errorf("totals.sites_with_updates = %d, want %d", p.Totals.SitesWithUpdates, len(p.Sites))
+	}
+	if !strings.Contains(text, "INCOMPLETE RESULT") {
+		t.Error("a truncated result carried no banner, so it reads as complete")
+	}
+}

--- a/apps/api/internal/mcp/updates_test.go
+++ b/apps/api/internal/mcp/updates_test.go
@@ -107,6 +107,7 @@ type updatesPayloadForTest struct {
 		InventoryStatus      string  `json:"inventory_status"`
 		InventoryCollectedAt *string `json:"inventory_collected_at"`
 		PendingTotal         int     `json:"pending_total"`
+		Summary              string  `json:"summary"`
 		Core                 *struct {
 			CurrentVersion string `json:"current_version"`
 			NewVersion     string `json:"new_version"`
@@ -543,5 +544,130 @@ func TestFleetUpdateTotalsCoverOnlyTheKeptRecords(t *testing.T) {
 	}
 	if !strings.Contains(text, "INCOMPLETE RESULT") {
 		t.Error("a truncated result carried no banner, so it reads as complete")
+	}
+}
+
+// TestFleetUpdatesPending_SummaryCarriesTheAgeInProse closes the gap the
+// structured age leaves open: inventory_age_seconds is a field a model may
+// simply not read, and a pending_total read without it looks like a current
+// fact. The age has to travel in the same string as the count.
+func TestFleetUpdatesPending_SummaryCarriesTheAgeInProse(t *testing.T) {
+	old := uuid.New()
+	recent := uuid.New()
+	now := time.Now().UTC()
+	eightMonths := now.Add(-243 * 24 * time.Hour)
+	twoHours := now.Add(-2 * time.Hour)
+
+	store := liveGrantStore(old, recent)
+	store.sites = []sqlc.Site{
+		updatesFixture{
+			id: old, name: "forgotten.example", url: "https://forgotten.example",
+			collected: &eightMonths,
+			components: `{"plugins":[{"slug":"woocommerce","name":"WooCommerce","version":"8.1.0",` +
+				`"active":true,"available_update":{"new_version":"8.4.0"}}]}`,
+		}.row(),
+		updatesFixture{
+			id: recent, name: "current.example", url: "https://current.example",
+			collected:  &twoHours,
+			components: `{"plugins":[{"slug":"akismet","name":"Akismet","version":"5.3","active":true}]}`,
+		}.row(),
+	}
+
+	text := callUpdatesPending(t, store)
+	p := parseUpdatesPayload(t, text)
+
+	byName := map[string]string{}
+	for _, s := range p.Sites {
+		byName[s.Name] = s.Summary
+	}
+
+	oldSummary := byName["forgotten.example"]
+	// THE AGE IS IN THE SENTENCE, not only in a neighbouring key.
+	if !strings.Contains(oldSummary, "months ago") {
+		t.Errorf("the summary for an eight-month-old inventory does not carry its age in prose: %q",
+			oldSummary)
+	}
+	// And the count is in the SAME string, so a reader cannot take one without
+	// the other.
+	if !strings.Contains(oldSummary, "1 update outstanding") {
+		t.Errorf("the summary does not carry the count alongside the age: %q", oldSummary)
+	}
+
+	recentSummary := byName["current.example"]
+	if !strings.Contains(recentSummary, "2 hours ago") {
+		t.Errorf("the summary for a two-hour-old inventory does not carry its age: %q", recentSummary)
+	}
+	if !strings.Contains(recentSummary, "no updates outstanding") {
+		t.Errorf("an up-to-date site's summary does not say so: %q", recentSummary)
+	}
+
+	// THE NO-JUDGEMENT RULE, PINNED. Rendering any of these would be choosing a
+	// freshness window by the back door -- the owner ruled that the age is
+	// reported and the reader judges it.
+	for _, verdict := range []string{"stale", "outdated", "out of date", "too old", "fresh", "needs refresh"} {
+		if strings.Contains(strings.ToLower(text), verdict) {
+			t.Errorf("the result renders the verdict %q. Reporting an age is the ruling; judging "+
+				"it picks a freshness window nobody chose. Full text:\n%s", verdict, text)
+		}
+	}
+}
+
+// TestFleetUpdatesPending_NeverCollectedSaysWeHaveNotLookedInWords: the absence
+// must read as a finding, because a reader filling in an absence fills it in
+// with the reassuring assumption.
+func TestFleetUpdatesPending_NeverCollectedSaysWeHaveNotLookedInWords(t *testing.T) {
+	never := uuid.New()
+	store := liveGrantStore(never)
+	store.sites = []sqlc.Site{
+		updatesFixture{id: never, name: "unknown.example", url: "https://unknown.example",
+			components: `{}`}.row(),
+	}
+
+	p := parseUpdatesPayload(t, callUpdatesPending(t, store))
+	if len(p.Sites) != 1 {
+		t.Fatalf("want 1 site, got %d", len(p.Sites))
+	}
+	s := p.Sites[0].Summary
+	for _, want := range []string{"has ever been collected", "we do not know", "have not looked"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("the never_collected summary does not say %q in words: %q", want, s)
+		}
+	}
+	// It must NOT read as a clean bill of health.
+	if strings.Contains(s, "no updates outstanding") {
+		t.Errorf("a site we have never looked at is described as having no updates outstanding: %q", s)
+	}
+}
+
+// TestHumanAgeSelectsAUnitAndJudgesNothing is the unit half. Each case pins the
+// spelling; the loop after it pins the property that matters.
+func TestHumanAgeSelectsAUnitAndJudgesNothing(t *testing.T) {
+	cases := []struct {
+		seconds int64
+		want    string
+	}{
+		{30, "less than a minute ago"},
+		{60, "1 minute ago"},
+		{600, "10 minutes ago"},
+		{3600, "1 hour ago"},
+		{7200, "2 hours ago"},
+		{86400, "1 day ago"},
+		{86400 * 9, "9 days ago"},
+		{86400 * 243, "8 months ago"},
+		{86400 * 800, "2 years ago"},
+	}
+	for _, c := range cases {
+		if got := humanAge(c.seconds); got != c.want {
+			t.Errorf("humanAge(%d) = %q, want %q", c.seconds, got, c.want)
+		}
+	}
+	for _, c := range cases {
+		got := strings.ToLower(humanAge(c.seconds))
+		for _, verdict := range []string{"stale", "old", "recent", "fresh"} {
+			if strings.Contains(got, verdict) {
+				t.Errorf("humanAge(%d) = %q, which judges the age instead of stating it",
+					c.seconds, got)
+			}
+		}
 	}
 }

--- a/apps/api/internal/mcp/updates_test.go
+++ b/apps/api/internal/mcp/updates_test.go
@@ -639,6 +639,131 @@ func TestFleetUpdatesPending_NeverCollectedSaysWeHaveNotLookedInWords(t *testing
 	}
 }
 
+// TestFleetUpdatesPending_UndatedInventoryWithAdvisoriesDoesNotClaimZero is the
+// security reviewer's probe A, adopted as a regression test.
+//
+// THE STATE IS REACHABLE BY CONSTRUCTION. m121 added components_updated_at NULL
+// with no backfill and UpdateSiteMetadata is its only writer, so every site
+// enrolled before 2026-08-23 that has not pushed metadata since has a POPULATED
+// components document and no stamp. Those are disproportionately the neglected
+// sites, which carry the most outstanding updates.
+//
+// The defect it caught: updatesSummary branched on InventoryStatus alone, so
+// this site was told "the zero counts below mean we have not looked" while
+// pending_total said 3. A false zero in the one field built so the count cannot
+// be dropped without its caveat.
+//
+// MY OWN never_collected FIXTURE MISSED IT because it used components '{}'.
+// A fixture that cannot reach the state cannot test it.
+func TestFleetUpdatesPending_UndatedInventoryWithAdvisoriesDoesNotClaimZero(t *testing.T) {
+	id := uuid.New()
+	store := liveGrantStore(id)
+	store.sites = []sqlc.Site{
+		updatesFixture{
+			id: id, name: "legacy.example", url: "https://legacy.example",
+			// collected is nil: components_updated_at IS NULL (a pre-m121 row).
+			components: `{"plugins":[` +
+				`{"slug":"woocommerce","name":"WooCommerce","version":"8.1.0","active":true,` +
+				`"available_update":{"new_version":"8.4.0"}},` +
+				`{"slug":"akismet","name":"Akismet","version":"5.1","active":true,` +
+				`"available_update":{"new_version":"5.3"}}` +
+				`],"core_update":{"current_version":"6.5.2","new_version":"6.6"}}`,
+		}.row(),
+	}
+
+	text := callUpdatesPending(t, store)
+	p := parseUpdatesPayload(t, text)
+	if len(p.Sites) != 1 {
+		t.Fatalf("want 1 site, got %d", len(p.Sites))
+	}
+	got := p.Sites[0]
+
+	if got.PendingTotal != 3 {
+		t.Fatalf("pending_total = %d, want 3 (2 plugins + core); the fixture no longer reaches "+
+			"the state under test", got.PendingTotal)
+	}
+	if got.InventoryStatus != inventoryNeverCollected {
+		t.Fatalf("inventory_status = %q, want %q; the fixture no longer reaches the state under test",
+			got.InventoryStatus, inventoryNeverCollected)
+	}
+
+	// THE DEFECT ITSELF: the summary must not assert a zero it does not have.
+	if strings.Contains(got.Summary, "The zero counts below") {
+		t.Errorf("the summary asserts a zero count while pending_total=%d and %d plugins are "+
+			"listed:\n%s", got.PendingTotal, len(got.Plugins), got.Summary)
+	}
+	// And it must carry both facts: the real count, and that its age is unknown.
+	if !strings.Contains(got.Summary, "3 updates outstanding") {
+		t.Errorf("the summary drops the real count: %q", got.Summary)
+	}
+	for _, want := range []string{"no record of when", "lower bound"} {
+		if !strings.Contains(got.Summary, want) {
+			t.Errorf("the summary does not say %q, so the count reads as dated: %q", want, got.Summary)
+		}
+	}
+
+	// THE TOTALS OVERLAP, AND THE HEADER MUST SAY SO.
+	//
+	// The reviewer's probe asserted the two totals could never both be
+	// non-zero, which encoded the instruction header's original claim that they
+	// are mutually exclusive. That claim was FALSE for exactly this site, so the
+	// header was corrected rather than the counts suppressed -- throwing away a
+	// true fact to protect a sentence would be the worse trade. This assertion
+	// pins the replacement contract in both halves.
+	if p.Totals.SitesWithUpdates != 1 || p.Totals.SitesNeverCollected != 1 {
+		t.Errorf("totals sites_with_updates/sites_never_collected = %d/%d, want 1/1: this site "+
+			"genuinely is both", p.Totals.SitesWithUpdates, p.Totals.SitesNeverCollected)
+	}
+	if !strings.Contains(text, "OVERLAPS") {
+		t.Error("the instructions do not tell the model the two totals overlap, so a model that " +
+			"adds them double-counts this site")
+	}
+	if strings.Contains(text, "never merge them with the up-to-date ones") {
+		t.Error("the instructions still claim the two totals are mutually exclusive, which is " +
+			"false for an undated inventory carrying advisories")
+	}
+}
+
+// TestFleetUpdatesPending_FutureDatedStampIsNotRenderedAsFresh is the reviewer's
+// probe B, adopted. The arm existed and behaved correctly but had no committed
+// test, so nothing would have caught its removal.
+func TestFleetUpdatesPending_FutureDatedStampIsNotRenderedAsFresh(t *testing.T) {
+	id := uuid.New()
+	future := time.Now().UTC().Add(48 * time.Hour)
+	store := liveGrantStore(id)
+	store.sites = []sqlc.Site{
+		updatesFixture{
+			id: id, name: "skewed.example", url: "https://skewed.example",
+			collected: &future,
+			components: `{"plugins":[{"slug":"woocommerce","name":"WooCommerce","version":"8.1.0",` +
+				`"active":true,"available_update":{"new_version":"8.4.0"}}]}`,
+		}.row(),
+	}
+
+	text := callUpdatesPending(t, store)
+	p := parseUpdatesPayload(t, text)
+	s := p.Sites[0].Summary
+
+	if !strings.Contains(s, "clock problem") {
+		t.Errorf("the future-stamp arm does not name the cause: %q", s)
+	}
+	// A negative age must never reach the sentence.
+	if strings.Contains(s, "-1 ") || strings.Contains(s, "ago, 2026") && strings.Contains(s, "-") &&
+		strings.Contains(s, "seconds ago") {
+		t.Errorf("a negative age leaked into the sentence: %q", s)
+	}
+	// The INSTANT is still reported: withholding the age is not a reason to
+	// withhold the observation.
+	if p.Sites[0].InventoryCollectedAt == nil {
+		t.Error("the future stamp was withheld entirely; the instant should still be reported")
+	}
+	for _, verdict := range []string{"stale", "outdated", "out of date", "too old", "fresh", "needs refresh"} {
+		if strings.Contains(strings.ToLower(text), verdict) {
+			t.Errorf("the future-stamp result renders the verdict %q", verdict)
+		}
+	}
+}
+
 // TestHumanAgeSelectsAUnitAndJudgesNothing is the unit half. Each case pins the
 // spelling; the loop after it pins the property that matters.
 func TestHumanAgeSelectsAUnitAndJudgesNothing(t *testing.T) {

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -199,7 +199,7 @@ func TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole(t *testing.T) {
 	// (3) The registry admits the tool for this real connection, and tools/list
 	// shows it.
 	visible := mcp.VisibleTools(auth)
-	if !listsWholeRegistry(visible) {
+	if !listsWholeRegistry(visible, auth) {
 		t.Fatalf("tools/list for a fully-scoped connection returned %+v", visible)
 	}
 
@@ -354,7 +354,11 @@ func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
 	// (1) IT DOES NOT HIDE. The tool is still listed, and the descriptor says
 	// why it cannot be called.
 	visible := mcp.VisibleTools(denied)
-	if !listsWholeRegistry(visible) {
+	// COMPARED AGAINST denied's OWN CEILING, not auth's. They are different
+	// connections; measuring one request's listing against another's ceiling
+	// would pass or fail for reasons unrelated to the capability axis under
+	// test here.
+	if !listsWholeRegistry(visible, denied) {
 		t.Fatalf("an unticked capability HID the tool from tools/list: %+v", visible)
 	}
 	// FOUND BY NAME, not by index. visible[0] happened to be the right tool
@@ -460,7 +464,7 @@ func TestS7EmptySiteScopeRefusesByNameAsAppRole(t *testing.T) {
 	// exists. Hiding it here would send the operator hunting a capability
 	// problem they do not have.
 	visible := mcp.VisibleTools(auth)
-	if !listsWholeRegistry(visible) {
+	if !listsWholeRegistry(visible, auth) {
 		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", visible)
 	}
 
@@ -546,7 +550,7 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 	// POSITIVE CONTROL. The real connection -- real ceiling, real grant -- sees
 	// the tool and can call it, so an absence below is the ceiling and not a
 	// broken fixture.
-	if got := mcp.VisibleTools(auth); !listsWholeRegistry(got) {
+	if got := mcp.VisibleTools(auth); !listsWholeRegistry(got, auth) {
 		t.Fatalf("the real connection did not see the tool: %+v", got)
 	}
 	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
@@ -641,7 +645,7 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 
 	// (4) IT DOES NOT OVER-FIRE. The untouched connection still lists and still
 	// calls the tool, after the refusals, against the same live database.
-	if got := mcp.VisibleTools(auth); !listsWholeRegistry(got) {
+	if got := mcp.VisibleTools(auth); !listsWholeRegistry(got, auth) {
 		t.Fatalf("the real connection lost the tool after the ceiling refusal: %+v", got)
 	}
 	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
@@ -669,18 +673,39 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 // It compares against mcp.Tools(), the server's whole surface, so it still
 // fails if a tool is genuinely hidden -- which is the thing each proof is
 // actually asserting.
-func listsWholeRegistry(got []mcp.ToolDescriptor) bool {
-	all := mcp.Tools()
-	if len(got) != len(all) {
+func listsWholeRegistry(got []mcp.ToolDescriptor, auth mcp.AuthorizedRequest) bool {
+	// FILTERED BY THE ORG CEILING. VisibleTools HIDES a tool outside the
+	// ceiling and only ANNOTATES one the grant merely lacks, so the set it
+	// returns is the ceiling-admitted subset -- not the whole registry.
+	// Comparing against the whole registry is correct only while every tool
+	// requires the same capability, and stops being correct the moment one does
+	// not: a propose tool outside the read ceiling would turn all five proofs
+	// below red on a listing that was right. That is precisely the over-firing
+	// this helper replaced a hard-coded len() == 1 to avoid, so it has to know
+	// about the ceiling too.
+	//
+	// The predicate is re-derived here rather than borrowed, which does mean a
+	// bug in withinOrgCeiling would be invisible to these five. That is
+	// deliberate: they are positive controls for OTHER axes, and the ceiling
+	// itself has its own dedicated proof
+	// (TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole) which asserts
+	// the omission directly.
+	want := []string{}
+	for _, p := range mcp.RegistryPolicies() {
+		if auth.OrgCeiling.Allows(p.Capability) {
+			want = append(want, p.Name)
+		}
+	}
+	if len(got) != len(want) {
 		return false
 	}
 	seen := map[string]int{}
 	for _, d := range got {
 		seen[d.Name]++
 	}
-	for _, d := range all {
-		seen[d.Name]--
-		if seen[d.Name] < 0 {
+	for _, n := range want {
+		seen[n]--
+		if seen[n] < 0 {
 			return false
 		}
 	}

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -199,7 +199,7 @@ func TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole(t *testing.T) {
 	// (3) The registry admits the tool for this real connection, and tools/list
 	// shows it.
 	visible := mcp.VisibleTools(auth)
-	if len(visible) != 1 || visible[0].Name != mcp.ToolFleetSitesList {
+	if !listsWholeRegistry(visible) {
 		t.Fatalf("tools/list for a fully-scoped connection returned %+v", visible)
 	}
 
@@ -354,12 +354,16 @@ func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
 	// (1) IT DOES NOT HIDE. The tool is still listed, and the descriptor says
 	// why it cannot be called.
 	visible := mcp.VisibleTools(denied)
-	if len(visible) != 1 || visible[0].Name != mcp.ToolFleetSitesList {
+	if !listsWholeRegistry(visible) {
 		t.Fatalf("an unticked capability HID the tool from tools/list: %+v", visible)
 	}
-	if !strings.Contains(visible[0].Description, string(mcp.CapSitesRead)) {
+	// FOUND BY NAME, not by index. visible[0] happened to be the right tool
+	// while the registry held one entry, and an index into a growing list is a
+	// proof that quietly starts checking a different subject.
+	sitesDesc := descriptionOf(t, visible, mcp.ToolFleetSitesList)
+	if !strings.Contains(sitesDesc, string(mcp.CapSitesRead)) {
 		t.Fatalf("the listed descriptor does not name the missing capability:\n%s",
-			visible[0].Description)
+			sitesDesc)
 	}
 
 	// (2) IT REFUSES, BY NAME. Asserted by VALUE on the code and the kind: an
@@ -456,7 +460,7 @@ func TestS7EmptySiteScopeRefusesByNameAsAppRole(t *testing.T) {
 	// exists. Hiding it here would send the operator hunting a capability
 	// problem they do not have.
 	visible := mcp.VisibleTools(auth)
-	if len(visible) != 1 || visible[0].Name != mcp.ToolFleetSitesList {
+	if !listsWholeRegistry(visible) {
 		t.Fatalf("an empty site scope hid the tool from tools/list: %+v", visible)
 	}
 
@@ -542,7 +546,7 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 	// POSITIVE CONTROL. The real connection -- real ceiling, real grant -- sees
 	// the tool and can call it, so an absence below is the ceiling and not a
 	// broken fixture.
-	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolFleetSitesList {
+	if got := mcp.VisibleTools(auth); !listsWholeRegistry(got) {
 		t.Fatalf("the real connection did not see the tool: %+v", got)
 	}
 	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
@@ -637,7 +641,7 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 
 	// (4) IT DOES NOT OVER-FIRE. The untouched connection still lists and still
 	// calls the tool, after the refusals, against the same live database.
-	if got := mcp.VisibleTools(auth); len(got) != 1 || got[0].Name != mcp.ToolFleetSitesList {
+	if got := mcp.VisibleTools(auth); !listsWholeRegistry(got) {
 		t.Fatalf("the real connection lost the tool after the ceiling refusal: %+v", got)
 	}
 	if _, _, err := mcp.AuthorizeTool(mcp.ToolFleetSitesList, auth); err != nil {
@@ -649,4 +653,50 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 
 	t.Logf("org-ceiling omission: listed=%d refusal=%s (identical to an unregistered "+
 		"name); the real connection is unaffected", len(visible), de.Code)
+}
+
+// listsWholeRegistry reports whether a tools/list answer holds every tool the
+// server has, order-insensitively.
+//
+// IT REPLACES `len(visible) != 1 && visible[0].Name != ToolFleetSitesList` IN
+// FIVE PROOFS ABOVE, and the replacement is a correction rather than a tidy-up.
+// Each of those proofs is about a BOUNDARY -- the capability axis, the site
+// axis, the org ceiling -- and none of them is about how many tools had been
+// built on the day it was written. All five went red on a correct second read
+// tool that crossed no boundary at all. A proof that reddens on correct work is
+// one someone eventually deletes, and then the boundary is unguarded.
+//
+// It compares against mcp.Tools(), the server's whole surface, so it still
+// fails if a tool is genuinely hidden -- which is the thing each proof is
+// actually asserting.
+func listsWholeRegistry(got []mcp.ToolDescriptor) bool {
+	all := mcp.Tools()
+	if len(got) != len(all) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, d := range got {
+		seen[d.Name]++
+	}
+	for _, d := range all {
+		seen[d.Name]--
+		if seen[d.Name] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// descriptionOf finds one tool's description by NAME, failing the test when it
+// is absent rather than returning "" and letting a Contains check pass or fail
+// for the wrong reason.
+func descriptionOf(t *testing.T, got []mcp.ToolDescriptor, name string) string {
+	t.Helper()
+	for _, d := range got {
+		if d.Name == name {
+			return d.Description
+		}
+	}
+	t.Fatalf("tool %q is absent from the listing %+v", name, got)
+	return ""
 }


### PR DESCRIPTION
The second Tier 0 "Fleet read" from the S8 tools catalogue in the wireframes: *"Plugin, theme and core updates outstanding, per site."* Answered from our database; no site is contacted.

Draft: **site scoping needs a `security-reviewer` pass before merge.**

## What it does

`fleet_updates_pending` reads the same `sites.components` inventory `fleet_sites_list` already reads, on the same bounded scope-filtered page, and returns per-site pending plugin/theme/core updates plus a fleet roll-up.

No migration, no new SQL, no new capability. It reuses `ListSitesForRead`, which already returns `components` and `components_updated_at`.

## It agrees with the dashboard by construction

It projects through `site.ActionableUpdate` and `site.ActionableCoreUpdate` rather than restating them. Those predicates were exported for this surface and had no consumer until now; their doc comment makes the case better than this description can:

> An assistant answering "which of my sites need updates?" from its own copy of this rule would disagree with the dashboard the operator is looking at. The assistant contradicting the screen is worse than the assistant saying nothing, because only one of those gets noticed.

So same-version phantom advisories (GH #211), advisories with an empty `new_version`, and the WPMgr agent's own plugin are excluded here exactly as they are on `GET /sites/{id}/updates/available`.

## Tenancy

The scoped read, the layer-3 hide, the `site_unread` accounting and the envelope balance moved into `Service.scopedSiteRead`, so the two fleet tools cannot drift on the tenancy boundary. Layer 3 still hides: an out-of-scope site is absent, never refused.

## never_collected is not zero

A site whose inventory has never been collected reports `inventory_status: never_collected`, a null `inventory_collected_at`, and is counted in `totals.sites_never_collected` — never folded into the up-to-date sites. Its zero means we have not looked.

## Staleness is reported, not refused

`StaleRefusal` exists and stays unused. There is no freshness window in this codebase to key on, and a threshold invented here would be a number nobody chose. Every record carries the staleness triplet instead. **This is the one place the wireframes are silent and I made a judgement call** — see the file comment for the full argument.

## Guard changes

`TestNoRegisteredToolIsWriteShaped` matched write verbs by substring and failed on the plural noun in `fleet_updates_pending` — a true negative on a name taken verbatim from the wireframe catalogue. It now matches underscore-separated segments (so `propose_update` is still caught, `updates` is not) and additionally requires every tool's capability to end in `.read`, a check that does not depend on spelling.

Four proofs about the capability and site axes pinned a tool *count* rather than the boundary they test. They now compare the listing against the registry.

## Proofs

Seven, through the mounted transport with a real bearer, asserting exact values. The scope proof is first and its leak assertions run before any count assertion. Three mutations run and restored — see the test commit message for what each one reddened and why M2 was needed after M1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only fleet view for pending plugin, theme, and WordPress core updates across sites.
  * Results include site-level update counts, inventory age, totals, and clear handling for incomplete or unavailable data.
  * Site access is scoped appropriately, with partial results clearly identified when some sites cannot be read.
* **Improvements**
  * Expanded tool listings and visibility checks to support the growing set of fleet read-only capabilities.
  * Standardized result limits, filtering, and presentation across fleet site and update views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->