### PR TITLE
fix(web): remove the false "can propose changes" claim from AI connections

### DIFF
--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -376,7 +376,8 @@ describe("an empty scope is a working state, not an error", () => {
 
     const empty = screen.getByTestId("site-step-empty");
     expect(empty).toHaveTextContent(/working state, not an error/i);
-    expect(empty).toHaveTextContent(/read nothing and propose nothing/i);
+    expect(empty).toHaveTextContent(/can read nothing/i);
+    expect(empty).not.toHaveTextContent(/propose/i);
     // Not an alert, because it is not one. An empty scope announced by a
     // screen reader as an error is the same defect as rendering it in red.
     expect(screen.queryByTestId("site-step-blocked")).toBeNull();

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -112,6 +112,18 @@ describe("ConnectionsList renders each state as a different thing", () => {
     expect(screen.queryByText(/could not load/i)).not.toBeInTheDocument();
   });
 
+  it("tells the truth in the empty state: read, limited to scoped sites, and nothing more", async () => {
+    // Nothing in the product can propose anything (no proposal table, no
+    // approval queue, no approval screen anywhere in the route tree). This
+    // used to say "It can propose changes, and it can never approve them" --
+    // a false capability claim.
+    renderList({ status: "empty" });
+    const copy = await screen.findByText(/connect one and it can read your fleet/i);
+    expect(copy).toHaveTextContent(/limited to the sites you scope it to/i);
+    expect(copy).toHaveTextContent(/it cannot change anything/i);
+    expect(copy).not.toHaveTextContent(/propose/i);
+  });
+
   it("renders 'we cannot list these yet' as neither empty nor error", async () => {
     renderList({ status: "unavailable", reason: "no endpoint exists yet" });
     expect(await screen.findByText(/cannot list your connections yet/i)).toBeInTheDocument();

--- a/apps/web/src/features/ai-connections/connections-list.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.tsx
@@ -126,8 +126,8 @@ export function ConnectionsList({
             No AI clients are connected
           </p>
           <p className="text-sm text-[var(--color-muted-foreground)]">
-            Connect one and it can read your fleet. It can propose changes, and it can never approve
-            them.
+            Connect one and it can read your fleet, limited to the sites you scope it to. It cannot
+            change anything.
           </p>
         </div>
         {connectAction}

--- a/apps/web/src/features/ai-connections/site-scope-step.tsx
+++ b/apps/web/src/features/ai-connections/site-scope-step.tsx
@@ -229,7 +229,7 @@ export function SiteScopeStep({
           data-testid="site-step-empty"
           className="text-sm text-[var(--color-muted-foreground)]"
         >
-          A connection with an empty scope can read nothing and propose nothing. That is a
+          A connection with an empty scope can read nothing. That is a
           working state, not an error. It is how you mint a credential now and decide its
           reach later.
         </p>

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -121,6 +121,22 @@ describe("ConsentScreen — what it can do and what it cannot", () => {
     expect(screen.getByText(/It cannot read your backups' contents\./i)).toBeTruthy();
   });
 
+  it("says who makes a change, without claiming an approval screen this connection cannot reach", () => {
+    // Nothing in the product can propose anything (no proposal table, no
+    // approval queue, no approval screen anywhere in the route tree). This
+    // bullet used to say "It can suggest work to you and nothing more.
+    // Anything that changes a site is approved by a person, in this
+    // dashboard, on a screen this connection cannot reach" -- both a false
+    // capability claim and a pointer at a screen that does not exist.
+    renderWithProviders(<ConsentScreen {...props()} />);
+    // The bold lead-in stays exactly as it was.
+    expect(screen.getByText(/It cannot approve anything\./i)).toBeTruthy();
+    const bullet = screen.getByText(/It cannot approve anything\./i).closest("li")!;
+    expect(bullet).toHaveTextContent(/everything that changes a site is done by a person/i);
+    expect(bullet).not.toHaveTextContent(/propose/i);
+    expect(bullet).not.toHaveTextContent(/screen this connection cannot reach/i);
+  });
+
   it("refuses approval when a requested scope is not recognised", () => {
     const odd = parseConsentContext({
       client_id: "c_x",
@@ -227,7 +243,8 @@ describe("ConsentScreen — an empty site scope is a working state, not an error
     renderWithProviders(<ConsentScreen {...props()} />);
     const summary = screen.getByTestId("consent-scope-summary").textContent ?? "";
     expect(summary).toMatch(/No sites are selected/i);
-    expect(summary).toMatch(/read nothing and propose nothing/i);
+    expect(summary).toMatch(/will read nothing/i);
+    expect(summary).not.toMatch(/propose/i);
     expect(summary).toMatch(/working state, not an error/i);
     expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);
   });
@@ -254,7 +271,8 @@ describe("ConsentScreen — an empty site scope is a working state, not an error
     fireEvent.click(screen.getByRole("checkbox", { name: /archived/i }));
     const summary = screen.getByTestId("consent-scope-summary");
     expect(summary.textContent).toMatch(/matches no sites/i);
-    expect(summary.textContent).toMatch(/read nothing and propose nothing/i);
+    expect(summary.textContent).toMatch(/will read nothing/i);
+    expect(summary.textContent).not.toMatch(/propose/i);
     expect(summary.textContent).toMatch(/working state, not an error/i);
     expect(screen.queryByTestId("consent-scope-sites")).toBeNull();
     expect(screen.getByTestId("consent-approve").hasAttribute("disabled")).toBe(false);

--- a/apps/web/src/features/mcp-consent/consent-screen.test.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.test.tsx
@@ -128,12 +128,26 @@ describe("ConsentScreen — what it can do and what it cannot", () => {
     // Anything that changes a site is approved by a person, in this
     // dashboard, on a screen this connection cannot reach" -- both a false
     // capability claim and a pointer at a screen that does not exist.
+    //
+    // The first rewrite, "Everything that changes a site is done by a
+    // person, here in this dashboard," went too far the other way: it is a
+    // categorical claim the product falsifies twice over --
+    // update_runs.scheduled_at (apps/api/db/schema.sql:1185) fires a run
+    // later from DispatchWorker with nobody present, and POST /updates is
+    // reachable by an API-key principal with no dashboard and no person
+    // (apps/api/internal/update/handler.go:44, RequireOrgScope +
+    // PermSiteWrite only; middleware/auth.go:56 gives API-key principals org
+    // scope; schema.sql:1147-1148 documents created_by as NULL for them). The
+    // sentence below claims only what is categorically true: never THIS
+    // connection, without asserting who or what else does it.
     renderWithProviders(<ConsentScreen {...props()} />);
     // The bold lead-in stays exactly as it was.
     expect(screen.getByText(/It cannot approve anything\./i)).toBeTruthy();
     const bullet = screen.getByText(/It cannot approve anything\./i).closest("li")!;
-    expect(bullet).toHaveTextContent(/everything that changes a site is done by a person/i);
+    expect(bullet).toHaveTextContent(/site changes are made elsewhere in wpmgr/i);
+    expect(bullet).toHaveTextContent(/never by this connection/i);
     expect(bullet).not.toHaveTextContent(/propose/i);
+    expect(bullet).not.toHaveTextContent(/done by a person/i);
     expect(bullet).not.toHaveTextContent(/screen this connection cannot reach/i);
   });
 

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -208,8 +208,8 @@ function PermissionsBlock({ consent }: { consent: ConsentContext }) {
             <span className="font-medium text-[var(--color-foreground)]">
               It cannot approve anything.
             </span>{" "}
-            Everything that changes a site is done by a person, here in this dashboard. There is
-            no setting or mode that lets this connection do it instead.
+            Site changes are made elsewhere in wpmgr, never by this connection. There is no
+            setting or mode that lets this connection do it instead.
           </li>
           <li>
             <span className="font-medium text-[var(--color-foreground)]">

--- a/apps/web/src/features/mcp-consent/consent-screen.tsx
+++ b/apps/web/src/features/mcp-consent/consent-screen.tsx
@@ -36,7 +36,11 @@ import { SiteEnforcementBox } from "./site-enforcement-box";
 // -- and instructs that every sentence be written fresh from it, because "blunt
 // beats euphemistic here".
 //
-// Each checklist item is marked below with the section that discharges it.
+// Each checklist item is marked below with the section that discharges it. The
+// "propose" item is deliberately left undischarged: no capability in the
+// shipped vocabulary does anything but read (the capability CHECK constraint
+// admits only members ending `.read`; see migration m131), so there is no
+// propose behaviour for this screen to describe.
 
 export const REVOKE_LOCATION = "Settings, under AI connections";
 
@@ -155,6 +159,12 @@ function SelfAssertedSite({ value }: { value: SelfAsserted }) {
 // ---------------------------------------------------------------------------
 // Checklist items 2, 3 and 4: what it may read, what it may propose, and that
 // it cannot approve anything
+//
+// The "may propose" third of that checklist item has no section below: no
+// capability in the shipped vocabulary does anything but read (the capability
+// CHECK constraint admits only members ending `.read`; see migration m131),
+// so there is nothing to disclose here and adding placeholder copy for it
+// would be a false capability claim.
 // ---------------------------------------------------------------------------
 
 function PermissionsBlock({ consent }: { consent: ConsentContext }) {
@@ -198,8 +208,8 @@ function PermissionsBlock({ consent }: { consent: ConsentContext }) {
             <span className="font-medium text-[var(--color-foreground)]">
               It cannot approve anything.
             </span>{" "}
-            It can suggest work to you and nothing more. Anything that changes a site is
-            approved by a person, in this dashboard, on a screen this connection cannot reach.
+            Everything that changes a site is done by a person, here in this dashboard. There is
+            no setting or mode that lets this connection do it instead.
           </li>
           <li>
             <span className="font-medium text-[var(--color-foreground)]">

--- a/apps/web/src/features/mcp-consent/site-scope.ts
+++ b/apps/web/src/features/mcp-consent/site-scope.ts
@@ -244,9 +244,16 @@ export function describeSiteScope(scope: ResolvedSiteScope): string {
       // working state, not an error -- it is how you mint a credential now and
       // decide its reach later." Both branches say that consequence plainly
       // rather than treating the choice as incomplete.
+      //
+      // The wireframe's own phrase pairs "read nothing" with "propose
+      // nothing"; the propose half is dropped here on purpose. Nothing in the
+      // shipped product proposes anything -- the capability CHECK constraint
+      // admits only members ending `.read` (see migration m131) -- so saying
+      // it would be a false capability claim, not a description of what this
+      // scope withholds.
       return scope.because === "no-selection"
-        ? "No sites are selected. That is a working state, not an error: this connection will read nothing and propose nothing until you give it sites to cover, now or later."
-        : "This selection matches no sites, so this connection will read nothing and propose nothing right now. That is a working state, not an error: you can widen its scope later.";
+        ? "No sites are selected. That is a working state, not an error: this connection will read nothing until you give it sites to cover, now or later."
+        : "This selection matches no sites, so this connection will read nothing right now. That is a working state, not an error: you can widen its scope later.";
     case "unresolved":
       return scope.because === "loading"
         ? "Working out which sites this covers."

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -161,6 +161,20 @@ describe("/ai's static surfaces", () => {
     ).toBeInTheDocument();
   });
 
+  it("tells the truth about what a connection can do: read, scoped to sites, nothing else", async () => {
+    // Nothing in the product can propose anything (no proposal table, no
+    // approval queue, no approval screen anywhere in the route tree). The
+    // subline used to say "It can propose changes; it can never approve
+    // them." -- a false capability claim. It must now say only what is true.
+    renderPage();
+    const subline = await screen.findByText(
+      /let an ai client read your fleet through one endpoint/i,
+    );
+    expect(subline).toHaveTextContent(/limited to the sites you scope it to/i);
+    expect(subline).toHaveTextContent(/it cannot change anything/i);
+    expect(subline).not.toHaveTextContent(/propose/i);
+  });
+
   it("offers a route into the wizard, which is how that page is reached at all", async () => {
     renderPage();
     await screen.findByTestId("connections-empty");

--- a/apps/web/src/routes/_authed/ai/index.tsx
+++ b/apps/web/src/routes/_authed/ai/index.tsx
@@ -66,7 +66,7 @@ function AiConnectionsPage() {
     <div className="space-y-6">
       <PageHeader
         title="AI connections"
-        subline="Let an AI client read your fleet through one endpoint. It can propose changes; it can never approve them."
+        subline="Let an AI client read your fleet through one endpoint, limited to the sites you scope it to. It cannot change anything."
         actions={
           <Button asChild>
             <Link to="/ai/connect">Connect an AI client</Link>


### PR DESCRIPTION
## Summary

Nothing in this product can propose anything to an operator: verified this
session across the migrations, the Go MCP registry, and the whole web route
tree — there is no proposal table, no approval queue, and no approval screen
anywhere in the route tree. The capability CHECK constraint admits only
members ending `.read` (migration m131).

The dashboard nonetheless told customers a connection "can propose changes"
in five places: the /ai page subline, the empty connections-list state, the
connect wizard's site-scope step, the consent-summary strings for an empty
scope, and the consent screen's "what it cannot do" bullet — which also
pointed at an approval screen that does not exist ("on a screen this
connection cannot reach").

- Removed the false claim from all five customer-visible surfaces and
  replaced the consent bullet with a true statement of who makes a change.
  The bold lead-in "It cannot approve anything." is untouched.
- Left the two wireframe-quotation comments (each cited to a `wireframes.html`
  line) as historical record of the design decision; they read as quotations,
  not as statements of current product behaviour.
- Added a short note at each of the three anti-regression comments explaining
  that the propose half is deliberately absent because no propose capability
  exists in the shipped vocabulary — not a promise that one is coming.
- Replaced the three test assertions that pinned the old false copy with
  two-sided assertions (positive pins the new sentence, negative fails if the
  old copy comes back), and added new coverage for the corrected copy on all
  three customer-visible screens.

Copy only. No behaviour, props, types or exports changed.

## Test plan
- [x] `pnpm -C apps/web typecheck` — exit 0
- [x] `pnpm -C apps/web lint` — exit 0 (0 errors, pre-existing warnings only, none in touched files)
- [x] `pnpm -C apps/web test` — 167 files / 2123 tests passed, exit 0
- [x] `pnpm -C apps/web build` — exit 0, `routeTree.gen.ts` unchanged (no route added/removed)
- [x] `impeccable detect` over the three touched feature directories — exit 0, no findings
- [x] Mutation-tested every changed/added assertion: reverted the source to the old false copy, watched the specific test go red with a failure message naming the old copy, restored, watched it go green. Done for all five copy sites.
- [x] `grep -rn "propose" apps/web/src` — every remaining hit is either an unrelated feature (context restore, perf), a cited wireframe quotation, a negative test assertion (`not.toHaveTextContent(/propose/i)`), or one of the deliberate anti-regression comments explaining the omission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updated Messaging**
  * Clarified that AI connections can read fleet data only within their assigned site scope.
  * Updated empty-scope messages to state that no data will be read.
  * Clarified that connections cannot propose, approve, or make site changes; changes occur elsewhere in WPMgr.
* **Tests**
  * Added and updated coverage for capability descriptions across AI connections, consent screens, and the AI connections page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->