### PR TITLE
feat(web): give the connection-verification endpoint a screen

### DIFF
--- a/apps/web/src/features/ai-connections/connection-status-model.ts
+++ b/apps/web/src/features/ai-connections/connection-status-model.ts
@@ -220,11 +220,29 @@ export function verifyVerdict(wire: ConnectionStatusWire, now: Date): VerifyVerd
         : ageMs >= NOTHING_ARRIVED_AFTER_MS
           ? "silent"
           : "fresh";
+    // DEGRADE THE VERDICT, NEVER THE EVIDENCE.
+    //
+    // This reads the WIRE and not `firstCall`, and the difference is a defect
+    // that shipped here for one commit. `firstCallVerdict` correctly degrades a
+    // `succeeded` carrying no `called_at` to `unknown` -- a success without its
+    // timestamp is a response we cannot read, and rendering it as a success
+    // would put a blank where the proof goes. But a flag whose entire job is to
+    // notice a contradiction must consult the raw claim, not the conclusion
+    // already drawn from it. Reading `firstCall.kind === "succeeded"` meant that
+    // a wire saying "a call succeeded", with the timestamp missing and
+    // last_used_at null, produced contradictedByUse === false and printed
+    // "Nothing has reached us from this connection" -- over a response that
+    // records a call.
+    //
+    // That is the GH #636 shape one field across: the same absence-beats-
+    // evidence inversion this branch was added to prevent, reintroduced by
+    // sourcing it from a degraded value.
+    //
     // Either half is evidence of use. last_used_at is too weak to prove a READ
     // (tools/list stamps it), but it is plenty to disprove "nothing has ever
     // reached us" -- something set it.
     const contradictedByUse =
-      firstCall.kind === "succeeded" || wire.first_call.last_used_at !== null;
+      wire.first_call.state === "succeeded" || wire.first_call.last_used_at !== null;
     return {
       kind: "live",
       handshake: { kind: "never_arrived", phase, ageMs, contradictedByUse },

--- a/apps/web/src/features/ai-connections/connection-status-model.ts
+++ b/apps/web/src/features/ai-connections/connection-status-model.ts
@@ -1,0 +1,223 @@
+// The verdict the verification screen renders, derived from one status poll.
+//
+// WHY A PURE MODULE. The whole risk on this screen is a sentence that claims
+// more than the response supports, and a sentence is easiest to pin in a test
+// when the thing that chose it is a function rather than a render. Every
+// branch below is reachable from a fixture in connection-status-model.test.ts.
+//
+// THE ONE RULE. "Nothing has reached us" and "something reached us and went
+// wrong" are different facts with different fixes, and this endpoint can only
+// tell us the first. The frontend must not upgrade one into the other. See
+// apps/api/internal/mcp/connection_status.go:149 (HandshakeRefusal) for the
+// server's own statement of the gap: a client refused for speaking a protocol
+// revision below the floor writes NOTHING to mcp_grants, so it is byte
+// identical to a client that was never started. The wireframe (S5, X frame)
+// draws that refusal as a live diagnosis. WE CANNOT DRAW IT. Where the deck
+// asks for a cause we do not have, this model returns the absence and the
+// screen says so in words.
+
+import type { ConnectionStatusWire } from "./use-connection-status";
+
+/**
+ * How long a connection may sit unused before the screen stops saying "any
+ * second now" and starts saying "nothing has arrived".
+ *
+ * FIVE MINUTES, AND THE NUMBER IS THE WIREFRAME'S. S5's timeout frame is
+ * titled "No client has connected in 5 minutes". THE SERVER REFUSES TO OWN
+ * THIS THRESHOLD ON PURPOSE -- connection_status.go:224 says a not-yet and a
+ * has-not-happened-for-a-while "are the same server-side fact and they differ
+ * only in how long the operator has been staring at it, which is a clock the
+ * browser owns". So the browser owns it, here, once, named.
+ */
+export const NOTHING_ARRIVED_AFTER_MS = 5 * 60 * 1000;
+
+/**
+ * When an unused connection stops being a note and becomes something to act on.
+ *
+ * THIRTY DAYS, from S5's E frame: "At 30 days we escalate this from a note to a
+ * banner." Escalating the TONE, never the CLAIM: a 40-day-old unused credential
+ * is still only an unused credential, and this model does not start calling it
+ * broken because it got old.
+ */
+export const ESCALATE_UNUSED_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * What the client said about the protocol revision it speaks.
+ *
+ * Deliberately NOT reusing ProtocolHeader from ./connection-model. That type
+ * answers the list's question ("what did it report"); this one answers the
+ * wizard's ("does that leave anything working differently"), and it carries the
+ * assumed floor as its own field because the status endpoint sends
+ * `assumed` separately from `version` for exactly that reason
+ * (connection_status.go:180: writing the floor into Version "would print a
+ * header the client never sent").
+ */
+export type ProtocolNote =
+  | { readonly kind: "recognised"; readonly version: string }
+  // The client sent no header and the specification says to assume the floor.
+  // A SUCCESS STATE. connection_status.go:104 calls this out: "treated as the
+  // floor, deliberately not an error".
+  | { readonly kind: "assumed"; readonly assumed: string }
+  // A revision is stored that this build no longer speaks. Reachable only
+  // through history (a revision dropped from the supported window after it was
+  // recorded), never through a live refusal.
+  | { readonly kind: "unrecognised"; readonly version: string }
+  // The response disagreed with itself: a state that must carry a version,
+  // carrying none. OUR failure to read the answer, never a claim about the
+  // client. Same reasoning as ProtocolHeader's `unreadable` kind.
+  | { readonly kind: "unreadable" };
+
+/** Has a client ever opened a session with this credential. */
+export type HandshakeVerdict =
+  | {
+      readonly kind: "never_arrived";
+      /**
+       * How loudly to say it. NOT three different facts -- one fact, three
+       * ages. `fresh` is the wizard's live wait, `silent` is past the
+       * five-minute mark, `stale` is past thirty days.
+       */
+      readonly phase: "fresh" | "silent" | "stale";
+      readonly ageMs: number;
+    }
+  | {
+      readonly kind: "connected";
+      readonly recordedAtIso: string;
+      readonly protocol: ProtocolNote;
+      readonly reportedClientName: string | null;
+      readonly reportedClientVersion: string | null;
+    };
+
+/** Has the client actually read anything. */
+export type FirstCallVerdict =
+  // No tool call recorded, and the scan was complete, so this is definitive.
+  | { readonly kind: "none_yet" }
+  | {
+      readonly kind: "succeeded";
+      readonly calledAtIso: string;
+      /** null when the audit row carried no tool name. Never defaulted. */
+      readonly toolName: string | null;
+      readonly auditEventId: string | null;
+    }
+  // The server's third state: the scan hit its bound without finding a row, so
+  // it DOES NOT KNOW. Rendered as not knowing. Rounding this down to `none_yet`
+  // would send a working connection into troubleshooting advice, which is the
+  // exact harm connection_status.go:236 names.
+  | { readonly kind: "unknown" };
+
+/**
+ * The whole screen's verdict.
+ *
+ * `revoked` short-circuits both axes: a revoked grant's handshake history is
+ * still true but it is no longer the question, and the screen must stop polling
+ * rather than wait forever for a call that can never arrive.
+ */
+export type VerifyVerdict =
+  | { readonly kind: "revoked"; readonly everConnected: boolean }
+  | {
+      readonly kind: "live";
+      readonly handshake: HandshakeVerdict;
+      readonly firstCall: FirstCallVerdict;
+    };
+
+/**
+ * Whether this connection is still worth polling.
+ *
+ * A verified connection and a revoked one are both terminal: nothing further
+ * will change on this screen, and a poll that can only ever return the same
+ * answer is a request the operator's browser makes for no one.
+ */
+export function shouldKeepPolling(v: VerifyVerdict): boolean {
+  if (v.kind === "revoked") return false;
+  return v.firstCall.kind !== "succeeded";
+}
+
+function protocolNote(p: ConnectionStatusWire["handshake"]["protocol"]): ProtocolNote {
+  switch (p.state) {
+    case "absent":
+      // `assumed` is the only field that can carry the floor here. When the
+      // server sent none we still must not substitute `floor` -- that would be
+      // us deciding what the server assumed on its behalf.
+      return p.assumed === null ? { kind: "unreadable" } : { kind: "assumed", assumed: p.assumed };
+    case "recognised":
+      return p.version === null ? { kind: "unreadable" } : { kind: "recognised", version: p.version };
+    case "unrecognised":
+      return p.version === null
+        ? { kind: "unreadable" }
+        : { kind: "unrecognised", version: p.version };
+    case "never_connected":
+      // Reachable only alongside handshake.state === "awaiting_client", where
+      // nothing reads this note. Returning `unreadable` rather than inventing a
+      // fifth kind keeps the union closed; if it ever DID render, "we could not
+      // read it" is the only sentence that is true.
+      return { kind: "unreadable" };
+  }
+}
+
+function firstCallVerdict(f: ConnectionStatusWire["first_call"]): FirstCallVerdict {
+  switch (f.state) {
+    case "succeeded":
+      // called_at is set ONLY for this state (connection_status.go:246). A
+      // success without one is a response we cannot read, and reading it as a
+      // success anyway would put a blank where the proof goes.
+      return f.called_at === null
+        ? { kind: "unknown" }
+        : {
+            kind: "succeeded",
+            calledAtIso: f.called_at,
+            toolName: f.tool_name,
+            auditEventId: f.audit_event_id,
+          };
+    case "awaiting_call":
+      return { kind: "none_yet" };
+    case "indeterminate":
+      return { kind: "unknown" };
+  }
+}
+
+/**
+ * Build the verdict from one poll.
+ *
+ * `now` is passed in, never read from the clock here, so the age thresholds are
+ * testable and so the caller can hand us the SERVER's instant. The status
+ * response carries `observed_at` for that purpose (connection_status.go:317:
+ * relative times computed "against the server's clock and not against a browser
+ * clock that may be minutes out").
+ */
+export function verifyVerdict(wire: ConnectionStatusWire, now: Date): VerifyVerdict {
+  const everConnected = wire.handshake.state !== "awaiting_client";
+  if (wire.status === "revoked") return { kind: "revoked", everConnected };
+
+  const firstCall = firstCallVerdict(wire.first_call);
+
+  if (wire.handshake.state === "awaiting_client") {
+    const created = Date.parse(wire.created_at);
+    // An unparseable created_at must not become age zero -- that would pin the
+    // screen in its "any second now" phase forever. Unknown age gets the
+    // middle phase: it says nothing has arrived, which is true, without
+    // claiming the connection is fresh or that it is old.
+    const ageMs = Number.isNaN(created) ? NOTHING_ARRIVED_AFTER_MS : now.getTime() - created;
+    const phase =
+      ageMs >= ESCALATE_UNUSED_AFTER_MS
+        ? "stale"
+        : ageMs >= NOTHING_ARRIVED_AFTER_MS
+          ? "silent"
+          : "fresh";
+    return { kind: "live", handshake: { kind: "never_arrived", phase, ageMs }, firstCall };
+  }
+
+  // Every remaining handshake state means a client identified itself, so
+  // recorded_at is non-null (connection_status.go:194). A missing one is a
+  // response we cannot read; falling back to created_at would print the moment
+  // the credential was minted as the moment a client dialled in.
+  return {
+    kind: "live",
+    handshake: {
+      kind: "connected",
+      recordedAtIso: wire.handshake.recorded_at ?? "",
+      protocol: protocolNote(wire.handshake.protocol),
+      reportedClientName: wire.handshake.reported_client_name,
+      reportedClientVersion: wire.handshake.reported_client_version,
+    },
+    firstCall,
+  };
+}

--- a/apps/web/src/features/ai-connections/connection-status-model.ts
+++ b/apps/web/src/features/ai-connections/connection-status-model.ts
@@ -78,6 +78,24 @@ export type HandshakeVerdict =
        */
       readonly phase: "fresh" | "silent" | "stale";
       readonly ageMs: number;
+      /**
+       * The response contradicted itself: no session was recorded, and yet this
+       * connection has demonstrably been used.
+       *
+       * THIS IS GH #636 ARRIVING ON A SCREEN. "tools/call is served without a
+       * recorded initialize", so a live, working connection can carry
+       * client_identity_recorded_at IS NULL while its tool calls are in the
+       * audit log. Without this flag the panel prints "Nothing has reached us
+       * from this connection" directly above "It read your fleet", which is
+       * both alarming and false, and which sends an operator to debug a
+       * connection that is working.
+       *
+       * The screen resolves it in the direction of the EVIDENCE, not the
+       * absence: a recorded call is a thing that happened, a null column is a
+       * thing that was not written. So the contradiction is reported as a gap
+       * in our own recording, never as a fault in the operator's client.
+       */
+      readonly contradictedByUse: boolean;
     }
   | {
       readonly kind: "connected";
@@ -202,7 +220,16 @@ export function verifyVerdict(wire: ConnectionStatusWire, now: Date): VerifyVerd
         : ageMs >= NOTHING_ARRIVED_AFTER_MS
           ? "silent"
           : "fresh";
-    return { kind: "live", handshake: { kind: "never_arrived", phase, ageMs }, firstCall };
+    // Either half is evidence of use. last_used_at is too weak to prove a READ
+    // (tools/list stamps it), but it is plenty to disprove "nothing has ever
+    // reached us" -- something set it.
+    const contradictedByUse =
+      firstCall.kind === "succeeded" || wire.first_call.last_used_at !== null;
+    return {
+      kind: "live",
+      handshake: { kind: "never_arrived", phase, ageMs, contradictedByUse },
+      firstCall,
+    };
   }
 
   // Every remaining handshake state means a client identified itself, so

--- a/apps/web/src/features/ai-connections/connection-verify.test.tsx
+++ b/apps/web/src/features/ai-connections/connection-verify.test.tsx
@@ -10,7 +10,12 @@ import {
   shouldKeepPolling,
   verifyVerdict,
 } from "./connection-status-model";
-import { parseConnectionStatus, type ConnectionStatusWire } from "./use-connection-status";
+import {
+  nextPollInterval,
+  parseConnectionStatus,
+  POLL_FLOOR_MS,
+  type ConnectionStatusWire,
+} from "./use-connection-status";
 
 // THE THREE STATES THIS SCREEN EXISTS TO KEEP APART, AND THE FOURTH IT MUST NOT
 // INVENT.
@@ -303,10 +308,14 @@ describe("connected and healthy", () => {
   });
 
   it("stops polling once the first call has succeeded", () => {
+    // THIS TEST USED TO ASSERT THE VERDICT SHAPE ONLY, which made it vacuous
+    // for the thing it is named after: `shouldKeepPolling` could have returned
+    // true for a succeeded call and this would still have passed. The
+    // behaviour, not the shape, is what the panel depends on.
     const w = healthy();
-    expect(verifyVerdict(w, new Date(w.observed_at))).toMatchObject({
-      firstCall: { kind: "succeeded" },
-    });
+    const v = verifyVerdict(w, new Date(w.observed_at));
+    expect(v).toMatchObject({ firstCall: { kind: "succeeded" } });
+    expect(shouldKeepPolling(v)).toBe(false);
   });
 
   it("says 'no header sent, treated as the floor' without printing a header the client never sent", async () => {
@@ -440,6 +449,81 @@ describe("connected, and something is wrong", () => {
       }),
     );
     expect(screen.getByTestId("firstcall-unknown")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The polling stops. All three ways it must.
+// ---------------------------------------------------------------------------
+
+describe("nextPollInterval", () => {
+  const stopWhen = (d: ConnectionStatusWire) =>
+    !shouldKeepPolling(verifyVerdict(d, new Date(d.observed_at)));
+
+  it("stops on a terminal verdict rather than polling a settled panel forever", () => {
+    // The defect this replaced: the terminal decision lived on a SECOND query
+    // observer's `enabled`, and one enabled observer is all TanStack needs to
+    // keep the interval alive, so a revoked connection polled for as long as
+    // the panel stayed open.
+    const revoked = wire({ status: "revoked" });
+    expect(nextPollInterval(revoked, { enabled: true, stopWhen })).toBe(false);
+  });
+
+  it("stops when the caller's budget is spent", () => {
+    expect(nextPollInterval(wire(), { enabled: false, stopWhen })).toBe(false);
+  });
+
+  it("stops when the server names a cadence of zero", () => {
+    // Zero is the server asking us to stop, and it is a DIFFERENT answer from
+    // a missing field. `ms || 2000` would fold the two together.
+    expect(nextPollInterval(wire({ poll_after_ms: 0 }), { enabled: true })).toBe(false);
+  });
+
+  it("keeps polling a connection that has not answered yet", () => {
+    // THE OVER-FIRE HALF. A screen that stopped watching the one state it
+    // exists to watch would be worse than one that polls too long.
+    expect(nextPollInterval(wire(), { enabled: true, stopWhen })).toBe(2000);
+  });
+
+  it("honours a cadence the server actually names", () => {
+    expect(nextPollInterval(wire({ poll_after_ms: 5000 }), { enabled: true })).toBe(5000);
+  });
+
+  it("falls back to the floor on a negative cadence, never to a tight loop", () => {
+    expect(nextPollInterval(wire({ poll_after_ms: -1 }), { enabled: true })).toBe(
+      POLL_FLOOR_MS,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// An unreadable observation time is reported, never substituted.
+// ---------------------------------------------------------------------------
+
+describe("an unreadable observed_at", () => {
+  it("renders as not knowing, never as a verdict from the browser clock", async () => {
+    // Every age-derived verdict is measured FROM this instant. Substituting
+    // the local clock produces a confident "waiting" / "nothing arrived" /
+    // "unused for 40 days" with nothing behind it, and all three read exactly
+    // like a correct answer.
+    await renderBody(wire({ observed_at: "not-a-timestamp" }));
+    expect(screen.getByTestId("verify-unreadable-instant")).toBeInTheDocument();
+    expect(screen.getByText(/We cannot place this check in time/i)).toBeInTheDocument();
+  });
+
+  it("renders no verdict at all in that state", async () => {
+    await renderBody(wire({ observed_at: "not-a-timestamp" }));
+    // None of the three age phases may appear: each would be a guess.
+    expect(screen.queryByTestId("handshake-waiting")).toBeNull();
+    expect(screen.queryByTestId("handshake-silent")).toBeNull();
+    expect(screen.queryByTestId("handshake-connected")).toBeNull();
+  });
+
+  it("still renders the normal verdict when the time IS readable", async () => {
+    // The over-fire half: the guard must not swallow every good response.
+    await renderBody(wire(), new Date(Date.parse(CREATED) + 30_000));
+    expect(screen.queryByTestId("verify-unreadable-instant")).toBeNull();
+    expect(screen.getByTestId("handshake-waiting")).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/ai-connections/connection-verify.test.tsx
+++ b/apps/web/src/features/ai-connections/connection-verify.test.tsx
@@ -194,6 +194,59 @@ describe("never connected", () => {
     expect(container.textContent).not.toMatch(/\d+\.\d+\.\d+\.\d+/);
   });
 
+  it("never says 'nothing has reached us' about a connection that has demonstrably been used", async () => {
+    // GH #636: tools/call is served without a recorded initialize, so a live,
+    // working connection can carry an unrecorded handshake. The naive render
+    // prints "Nothing has reached us from this connection" directly above "It
+    // read your fleet". Both cannot be true, and the false one is the absence.
+    await renderBody(
+      wire({
+        first_call: {
+          state: "succeeded",
+          called_at: "2026-08-15T09:21:04Z",
+          tool_name: "fleet_updates_pending",
+          audit_event_id: null,
+          last_used_at: "2026-08-15T09:21:04Z",
+          partial: null,
+        },
+      }),
+      new Date(Date.parse(CREATED) + NOTHING_ARRIVED_AFTER_MS),
+    );
+    expect(screen.getByTestId("handshake-contradicted")).toBeInTheDocument();
+    expect(screen.queryByTestId("handshake-silent")).toBeNull();
+    // And the success beneath it still stands: the call really did happen.
+    expect(screen.getByTestId("firstcall-succeeded")).toBeInTheDocument();
+  });
+
+  it("treats last_used_at alone as enough to disprove 'nothing has reached us'", async () => {
+    // last_used_at is too weak to prove a READ (tools/list stamps it) and
+    // plenty to disprove an absence -- something set it.
+    await renderBody(
+      wire({
+        first_call: {
+          state: "awaiting_call",
+          called_at: null,
+          tool_name: null,
+          audit_event_id: null,
+          last_used_at: "2026-08-15T09:00:05Z",
+          partial: null,
+        },
+      }),
+      new Date(Date.parse(CREATED) + NOTHING_ARRIVED_AFTER_MS),
+    );
+    expect(screen.getByTestId("handshake-contradicted")).toBeInTheDocument();
+    // ...and it still must NOT be upgraded into a successful first read.
+    expect(screen.getByTestId("firstcall-none")).toBeInTheDocument();
+  });
+
+  it("still says nothing arrived when nothing actually has", async () => {
+    // THE OVER-FIRE HALF. The contradiction branch must not swallow the real
+    // never-used case, which is the state of most connections.
+    await renderBody(wire(), new Date(Date.parse(CREATED) + NOTHING_ARRIVED_AFTER_MS));
+    expect(screen.getByTestId("handshake-silent")).toBeInTheDocument();
+    expect(screen.queryByTestId("handshake-contradicted")).toBeNull();
+  });
+
   it("does not become fresh again when created_at is unreadable", async () => {
     // An unparseable date must not floor the age to zero and pin the screen in
     // "any second now" forever.

--- a/apps/web/src/features/ai-connections/connection-verify.test.tsx
+++ b/apps/web/src/features/ai-connections/connection-verify.test.tsx
@@ -1,0 +1,423 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/render";
+
+import { ConnectionVerifyBody } from "./connection-verify";
+import {
+  ESCALATE_UNUSED_AFTER_MS,
+  NOTHING_ARRIVED_AFTER_MS,
+  shouldKeepPolling,
+  verifyVerdict,
+} from "./connection-status-model";
+import { parseConnectionStatus, type ConnectionStatusWire } from "./use-connection-status";
+
+// THE THREE STATES THIS SCREEN EXISTS TO KEEP APART, AND THE FOURTH IT MUST NOT
+// INVENT.
+//
+// never connected / connected and healthy / connected and something is wrong
+// are the three. The fourth is a CAUSE for the first, which this endpoint does
+// not have: `refusal` is hard-coded null in connection_status.go:751, so a
+// client that tried and was turned away is byte-identical to one that was never
+// started. Every fixture below is the shape connectionStatusResponse
+// (connection_status.go:738) actually emits.
+
+const CREATED = "2026-08-15T09:00:00Z";
+
+function wire(over: Record<string, unknown> = {}): ConnectionStatusWire {
+  return parseConnectionStatus({
+    id: "11111111-1111-1111-1111-111111111111",
+    status: "active",
+    created_at: CREATED,
+    expires_at: "2027-08-15T09:00:00Z",
+    handshake: {
+      state: "awaiting_client",
+      recorded_at: null,
+      reported_client_name: null,
+      reported_client_version: null,
+      protocol: {
+        state: "never_connected",
+        version: null,
+        assumed: null,
+        floor: "2025-03-26",
+        target: "2025-06-18",
+        supported: ["2025-03-26", "2025-06-18"],
+      },
+      refusal: null,
+    },
+    first_call: {
+      state: "awaiting_call",
+      called_at: null,
+      tool_name: null,
+      audit_event_id: null,
+      last_used_at: null,
+      partial: null,
+    },
+    observed_at: CREATED,
+    poll_after_ms: 2000,
+    ...over,
+  });
+}
+
+/** A handshake block for a client that connected and reported everything. */
+function connectedHandshake(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    state: "connected",
+    recorded_at: "2026-08-15T09:00:04Z",
+    reported_client_name: "claude-code",
+    reported_client_version: "2.4.1",
+    protocol: {
+      state: "recognised",
+      version: "2025-06-18",
+      assumed: null,
+      floor: "2025-03-26",
+      target: "2025-06-18",
+      supported: ["2025-03-26", "2025-06-18"],
+    },
+    refusal: null,
+    ...over,
+  };
+}
+
+// RENDER THROUGH THE REAL ROUTER AND QueryClient, and await the first paint.
+// render.tsx's module doc is explicit that RouterProvider resolves its initial
+// match on a microtask, so the first assertion in every test below must be a
+// findBy*. Awaiting the wrapper here is what makes the getBy* that follow safe.
+async function renderBody(w: ConnectionStatusWire, now?: Date) {
+  const r = renderWithProviders(<ConnectionVerifyBody wire={w} now={now} />, {
+    withRouter: true,
+  });
+  await screen.findByTestId("verify-root");
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// The wire schema is the Go DTO's, and this is where the two are compared.
+// ---------------------------------------------------------------------------
+
+describe("the status wire shape parses", () => {
+  it("accepts the never-connected response the server actually sends", () => {
+    const w = wire();
+    expect(w.handshake.state).toBe("awaiting_client");
+    expect(w.first_call.state).toBe("awaiting_call");
+    expect(w.poll_after_ms).toBe(2000);
+  });
+
+  it("refuses a handshake state this build does not know", () => {
+    // A fifth member must fail the parse rather than being coerced into
+    // awaiting_client, which would report a client that did something as one
+    // that did nothing.
+    expect(() =>
+      wire({ handshake: { ...connectedHandshake(), state: "connected_and_shouting" } }),
+    ).toThrow();
+  });
+
+  it("refuses the house error envelope rather than reading it as a status", () => {
+    expect(() => parseConnectionStatus({ code: "forbidden", message: "nope" })).toThrow();
+  });
+
+  it("keeps `assumed` as its own field, never folded into `version`", () => {
+    // The separation is the whole point: one is what the client sent, the other
+    // is what we assumed on its behalf.
+    const w = wire({
+      handshake: connectedHandshake({
+        state: "connected_protocol_assumed",
+        protocol: {
+          state: "absent",
+          version: null,
+          assumed: "2025-03-26",
+          floor: "2025-03-26",
+          target: "2025-06-18",
+          supported: ["2025-03-26"],
+        },
+      }),
+    });
+    expect(w.handshake.protocol.version).toBeNull();
+    expect(w.handshake.protocol.assumed).toBe("2025-03-26");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State 1 -- never connected. The shipped default, and NOT a failure.
+// ---------------------------------------------------------------------------
+
+describe("never connected", () => {
+  it("reads as waiting, not as a failure, in the first five minutes", async () => {
+    await renderBody(wire(), new Date(Date.parse(CREATED) + 30_000));
+    expect(screen.getByTestId("handshake-waiting")).toBeInTheDocument();
+    expect(screen.getByText(/Nothing is wrong yet/i)).toBeInTheDocument();
+    // The failure copy must be absent, not merely quieter.
+    expect(screen.queryByTestId("handshake-silent")).toBeNull();
+  });
+
+  it("crosses to 'nothing has reached us' at the five-minute mark", async () => {
+    await renderBody(wire(), new Date(Date.parse(CREATED) + NOTHING_ARRIVED_AFTER_MS));
+    expect(screen.getByTestId("handshake-silent")).toBeInTheDocument();
+    expect(
+      screen.getByText(/The connection exists and the key is valid/i),
+    ).toBeInTheDocument();
+  });
+
+  it("counts the days on a long-unused credential", async () => {
+    const elevenDays = Date.parse(CREATED) + 11 * 24 * 60 * 60 * 1000;
+    await renderBody(wire(), new Date(elevenDays));
+    // EXACT VALUE, not a shape. "11 days ago" is wrong if the arithmetic is
+    // wrong, and a regex for /days ago/ would pass on "NaN days ago".
+    expect(
+      screen.getByText(/created 11 days ago and no client has ever opened a session/i),
+    ).toBeInTheDocument();
+  });
+
+  it("escalates the wording past thirty days without calling it broken", async () => {
+    await renderBody(wire(), new Date(Date.parse(CREATED) + ESCALATE_UNUSED_AFTER_MS));
+    expect(
+      screen.getByText(/An unused credential is still a credential/i),
+    ).toBeInTheDocument();
+  });
+
+  it("states that it cannot tell a refusal from a never-started client", async () => {
+    // THE ANTI-INVENTION ASSERTION. The wireframe draws "3 attempts from
+    // 198.51.100.24 presented a key we do not recognise"; the endpoint has no
+    // such fact, so the screen must admit the gap instead of filling it.
+    await renderBody(wire(), new Date(Date.parse(CREATED) + NOTHING_ARRIVED_AFTER_MS));
+    expect(screen.getByTestId("refusal-gap")).toHaveTextContent(
+      /cannot tell from here whether a client tried and was turned away/i,
+    );
+  });
+
+  it("never renders an attempt count or a source address", async () => {
+    const { container } = await renderBody(
+      wire(),
+      new Date(Date.parse(CREATED) + NOTHING_ARRIVED_AFTER_MS),
+    );
+    expect(container.textContent).not.toMatch(/attempts?\s+from/i);
+    expect(container.textContent).not.toMatch(/\d+\.\d+\.\d+\.\d+/);
+  });
+
+  it("does not become fresh again when created_at is unreadable", async () => {
+    // An unparseable date must not floor the age to zero and pin the screen in
+    // "any second now" forever.
+    await renderBody(wire({ created_at: "not-a-date" }), new Date(Date.parse(CREATED)));
+    expect(screen.getByTestId("handshake-silent")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State 2 -- connected and healthy.
+// ---------------------------------------------------------------------------
+
+describe("connected and healthy", () => {
+  const healthy = () =>
+    wire({
+      handshake: connectedHandshake(),
+      first_call: {
+        state: "succeeded",
+        called_at: "2026-08-15T09:21:04Z",
+        tool_name: "fleet_updates_pending",
+        audit_event_id: "22222222-2222-2222-2222-222222222222",
+        last_used_at: "2026-08-15T09:21:04Z",
+        partial: null,
+      },
+    });
+
+  it("names the tool the client actually called", async () => {
+    await renderBody(healthy());
+    expect(screen.getByTestId("firstcall-succeeded")).toBeInTheDocument();
+    // EXACT NAME. "something rendered" would pass while showing another
+    // connection's tool.
+    expect(screen.getByTestId("verify-tool-name")).toHaveTextContent(
+      "fleet_updates_pending",
+    );
+  });
+
+  it("names the client's own reported version, not the operator's choice", async () => {
+    await renderBody(healthy());
+    expect(screen.getByTestId("verify-client-name")).toHaveTextContent("claude-code 2.4.1");
+  });
+
+  it("shows the negotiated revision the client sent", async () => {
+    await renderBody(healthy());
+    expect(screen.getByTestId("verify-protocol")).toHaveTextContent("2025-06-18");
+  });
+
+  it("does not claim the call covered every site", async () => {
+    // S29-9's P frame wants "22 sites -- every site in its scope". The response
+    // carries no coverage at all, so a success must say so.
+    await renderBody(healthy());
+    expect(screen.getByTestId("coverage-gap")).toHaveTextContent(
+      /do not record how many sites that call reached/i,
+    );
+  });
+
+  it("stops polling once the first call has succeeded", () => {
+    const w = healthy();
+    expect(verifyVerdict(w, new Date(w.observed_at))).toMatchObject({
+      firstCall: { kind: "succeeded" },
+    });
+  });
+
+  it("says 'no header sent, treated as the floor' without printing a header the client never sent", async () => {
+    await renderBody(
+      wire({
+        handshake: connectedHandshake({
+          state: "connected_protocol_assumed",
+          protocol: {
+            state: "absent",
+            version: null,
+            assumed: "2025-03-26",
+            floor: "2025-03-26",
+            target: "2025-06-18",
+            supported: ["2025-03-26"],
+          },
+        }),
+      }),
+    );
+    expect(screen.getByTestId("verify-protocol")).toHaveTextContent(
+      "None sent, treated as 2025-03-26",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State 3 -- it connected and something is wrong.
+// ---------------------------------------------------------------------------
+
+describe("connected, and something is wrong", () => {
+  it("reports a revision this build no longer speaks, as connected", async () => {
+    // The one reachable "tried and it is not right" state. It is NOT a refusal:
+    // the session was accepted, and the revision stored is one we have since
+    // stopped speaking.
+    await renderBody(
+      wire({
+        handshake: connectedHandshake({
+          state: "connected_protocol_unrecognised",
+          protocol: {
+            state: "unrecognised",
+            version: "2024-11-05",
+            assumed: null,
+            floor: "2025-03-26",
+            target: "2025-06-18",
+            supported: ["2025-03-26", "2025-06-18"],
+          },
+        }),
+      }),
+    );
+    expect(screen.getByTestId("handshake-connected")).toBeInTheDocument();
+    expect(screen.getByTestId("verify-protocol")).toHaveTextContent(
+      "2024-11-05, which this build does not currently speak",
+    );
+  });
+
+  it("calls a contradictory protocol pair our failure, never the client's", async () => {
+    await renderBody(
+      wire({
+        handshake: connectedHandshake({
+          protocol: {
+            state: "recognised",
+            // recognised with no version: the response disagrees with itself.
+            version: null,
+            assumed: null,
+            floor: "2025-03-26",
+            target: "2025-06-18",
+            supported: ["2025-03-26"],
+          },
+        }),
+      }),
+    );
+    expect(screen.getByTestId("verify-protocol")).toHaveTextContent(
+      "We could not read what it reported",
+    );
+  });
+
+  it("renders the indeterminate scan as not knowing, never as 'no calls yet'", async () => {
+    await renderBody(
+      wire({
+        handshake: connectedHandshake(),
+        first_call: {
+          state: "indeterminate",
+          called_at: null,
+          tool_name: null,
+          audit_event_id: null,
+          last_used_at: "2026-08-15T09:21:04Z",
+          partial: null,
+        },
+      }),
+    );
+    expect(screen.getByTestId("firstcall-unknown")).toBeInTheDocument();
+    expect(screen.queryByTestId("firstcall-none")).toBeNull();
+    expect(
+      screen.getByText(/limit of the check, not a fault in the connection/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not read last_used_at as proof of a first call", async () => {
+    // THE TRAP connection_status.go:258 NAMES. Every client issues tools/list
+    // right after initialize, which stamps last_used_at without anyone asking.
+    // A screen deriving success from it shows "it read your fleet" for a client
+    // that read nothing.
+    await renderBody(
+      wire({
+        handshake: connectedHandshake(),
+        first_call: {
+          state: "awaiting_call",
+          called_at: null,
+          tool_name: null,
+          audit_event_id: null,
+          last_used_at: "2026-08-15T09:00:05Z",
+          partial: null,
+        },
+      }),
+    );
+    expect(screen.getByTestId("firstcall-none")).toBeInTheDocument();
+    expect(screen.queryByTestId("firstcall-succeeded")).toBeNull();
+  });
+
+  it("refuses to render a success that carries no timestamp", async () => {
+    await renderBody(
+      wire({
+        handshake: connectedHandshake(),
+        first_call: {
+          state: "succeeded",
+          called_at: null,
+          tool_name: "fleet_updates_pending",
+          audit_event_id: null,
+          last_used_at: null,
+          partial: null,
+        },
+      }),
+    );
+    expect(screen.getByTestId("firstcall-unknown")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Revoked -- terminal, and it must stop polling.
+// ---------------------------------------------------------------------------
+
+describe("revoked", () => {
+  it("says a revoked connection HAD connected, when it had", async () => {
+    await renderBody(wire({ status: "revoked", handshake: connectedHandshake() }));
+    expect(screen.getByTestId("verify-revoked")).toHaveTextContent(
+      /A client did connect with it before it was revoked/i,
+    );
+  });
+
+  it("says a revoked connection never connected, when it never did", async () => {
+    // The two are different facts about what happened before the revoke, and
+    // an operator auditing a leak needs them apart.
+    await renderBody(wire({ status: "revoked" }));
+    expect(screen.getByTestId("verify-revoked")).toHaveTextContent(
+      /Nothing ever connected with it/i,
+    );
+  });
+
+  it("stops polling a revoked connection rather than waiting forever", () => {
+    const w = wire({ status: "revoked" });
+    expect(shouldKeepPolling(verifyVerdict(w, new Date(w.observed_at)))).toBe(false);
+  });
+
+  it("keeps polling one that has not connected yet", () => {
+    const w = wire();
+    expect(shouldKeepPolling(verifyVerdict(w, new Date(w.observed_at)))).toBe(true);
+  });
+});

--- a/apps/web/src/features/ai-connections/connection-verify.test.tsx
+++ b/apps/web/src/features/ai-connections/connection-verify.test.tsx
@@ -252,6 +252,34 @@ describe("never connected", () => {
     expect(screen.queryByTestId("handshake-contradicted")).toBeNull();
   });
 
+  it("does not claim nothing arrived when the wire records a succeeded call with no timestamp", async () => {
+    // THE SAME INVERSION, ONE FIELD ACROSS, AND THE CASE THE OTHER FIXTURES
+    // MISSED. `firstCallVerdict` rightly degrades a `succeeded` carrying no
+    // `called_at` to `unknown`. The contradiction flag then read that degraded
+    // verdict rather than the wire, so with last_used_at also null it printed
+    // "Nothing has reached us" over a response that records a call.
+    //
+    // Degrade the verdict, never the evidence.
+    await renderBody(
+      wire({
+        first_call: {
+          state: "succeeded",
+          called_at: null,
+          tool_name: null,
+          audit_event_id: null,
+          last_used_at: null,
+          partial: null,
+        },
+      }),
+      new Date(Date.parse(CREATED) + NOTHING_ARRIVED_AFTER_MS),
+    );
+    expect(screen.getByTestId("handshake-contradicted")).toBeInTheDocument();
+    expect(screen.queryByTestId("handshake-silent")).toBeNull();
+    // The first-call half still degrades honestly: a success with no timestamp
+    // is not renderable as a success.
+    expect(screen.getByTestId("firstcall-unknown")).toBeInTheDocument();
+  });
+
   it("does not become fresh again when created_at is unreadable", async () => {
     // An unparseable date must not floor the age to zero and pin the screen in
     // "any second now" forever.

--- a/apps/web/src/features/ai-connections/connection-verify.tsx
+++ b/apps/web/src/features/ai-connections/connection-verify.tsx
@@ -81,6 +81,26 @@ function protocolLine(note: ProtocolNote): string {
 
 function HandshakeSection({ h }: { h: HandshakeVerdict }) {
   if (h.kind === "never_arrived") {
+    // THE CONTRADICTION IS RESOLVED TOWARDS THE EVIDENCE. GH #636: a call can be
+    // served without a recorded initialize, so this connection has no session on
+    // record and has still plainly been used. Saying "nothing has reached us"
+    // here would be false, and would sit directly above the first-call section
+    // saying it read the fleet.
+    if (h.contradictedByUse) {
+      return (
+        <div data-testid="handshake-contradicted">
+          <p className="text-sm font-medium text-[var(--color-foreground)]">
+            This connection has been used, but we recorded no session for it
+          </p>
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+            Something has presented this credential, so it is reaching us. We did not
+            record the client identifying itself, so we cannot tell you what it is or
+            which protocol revision it speaks. That is a gap in our recording, not a
+            fault in your client.
+          </p>
+        </div>
+      );
+    }
     if (h.phase === "fresh") {
       return (
         <div data-testid="handshake-waiting">

--- a/apps/web/src/features/ai-connections/connection-verify.tsx
+++ b/apps/web/src/features/ai-connections/connection-verify.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageError } from "@/components/feedback/page-error";
@@ -316,16 +318,55 @@ export function ConnectionVerifyBody({
   wire: ConnectionStatusWire;
   now?: Date;
 }) {
-  // The SERVER's instant by default, not the browser's: observed_at exists so
-  // "4 seconds ago" is not computed against a clock that may be minutes out.
+  // The SERVER's instant, not the browser's: observed_at exists so "4 seconds
+  // ago" is not computed against a clock that may be minutes out.
   const observed = now ?? new Date(wire.observed_at);
-  const instant = Number.isNaN(observed.getTime()) ? new Date() : observed;
+  if (Number.isNaN(observed.getTime())) {
+    // AN UNREADABLE INSTANT IS REPORTED, NEVER SUBSTITUTED.
+    //
+    // This branch used to fall back to `new Date()`, and that was this
+    // codebase's signature defect verbatim: a failure quietly coerced into a
+    // plausible value. Every age-derived verdict below is measured FROM this
+    // instant, so a browser clock standing in for an unreadable server one
+    // produces a confident "waiting", "nothing has arrived" or "unused for 40
+    // days" with nothing behind it -- and the operator cannot tell which. The
+    // three read identically to a correct answer, which is what makes the
+    // substitution worse than the gap.
+    return (
+      <div data-testid="verify-root">
+        <div data-testid="verify-unreadable-instant">
+          <p className="text-sm font-medium text-[var(--color-foreground)]">
+            We cannot place this check in time
+          </p>
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+            The server did not give us a readable observation time, so anything we said
+            about how long this connection has been waiting would be a guess. Try the check
+            again. If it keeps happening, the status endpoint is returning a malformed
+            timestamp.
+          </p>
+        </div>
+      </div>
+    );
+  }
   return (
     <div data-testid="verify-root">
-      <VerdictBody v={verifyVerdict(wire, instant)} />
+      <VerdictBody v={verifyVerdict(wire, observed)} />
     </div>
   );
 }
+
+/**
+ * How long a mounted panel may keep polling before it stops and says so.
+ *
+ * TEN MINUTES, AND A BOUND RATHER THAN NO BOUND IS THE POINT. The repository's
+ * rule -- "Never wait on a process with an unbounded loop" -- was written about
+ * shell loops, and a browser tab left open on this panel is the same shape: an
+ * operator who walks away mid-setup should not leave a tab hitting the status
+ * endpoint until the laptop sleeps. Ten minutes is comfortably longer than the
+ * five-minute mark at which the screen already says nothing has arrived, so the
+ * budget can only expire on a screen that has already given its answer.
+ */
+export const POLL_BUDGET_MS = 10 * 60 * 1000;
 
 export interface ConnectionVerifyProps {
   connectionId: string;
@@ -342,18 +383,48 @@ export interface ConnectionVerifyProps {
  * own broken request as a fact about the operator's client.
  */
 export function ConnectionVerify({ connectionId, className }: ConnectionVerifyProps) {
-  // Two-pass polling: read once to learn the verdict, and use the verdict to
-  // decide whether to keep asking. `enabled` cannot depend on data that does
-  // not exist yet, so the first pass always runs.
-  const first = useConnectionStatus(connectionId);
-  const wire = first.data;
-  const keepPolling =
-    wire === undefined
-      ? true
-      : shouldKeepPolling(verifyVerdict(wire, new Date(wire.observed_at)));
-  // Re-registering with the same key does not open a second request; it swaps
-  // the interval on the one cache entry.
-  const q = useConnectionStatus(connectionId, { enabled: keepPolling });
+  // The budget's start, and whether it has run out. `budgetFrom` is state and
+  // not a ref because "Check again" resets it and the reset has to re-run the
+  // timer effect below.
+  // ONE PIECE OF STATE, NOT TWO. `from` and `spent` always change together, and
+  // splitting them forced a synchronous `setSpent(false)` at the top of the
+  // effect to undo the previous budget -- a cascading render, and a lint error.
+  // Resetting both in the same update makes the effect's only setState the one
+  // inside the timer, where it belongs.
+  const [budget, setBudget] = useState(() => ({ from: Date.now(), spent: false }));
+
+  useEffect(() => {
+    // `from` is always stamped at Date.now(), so the remaining budget is always
+    // positive here and there is no already-expired branch to write.
+    const startedAt = budget.from;
+    const t = setTimeout(
+      () => {
+        // Guarded on `from` so a timer left over from a superseded budget
+        // cannot mark a freshly reset one as spent.
+        setBudget((b) => (b.from === startedAt ? { ...b, spent: true } : b));
+      },
+      POLL_BUDGET_MS - (Date.now() - startedAt),
+    );
+    return () => {
+      clearTimeout(t);
+    };
+  }, [budget.from]);
+
+  // ONE OBSERVER. The terminal decision goes inside the hook via `stopWhen`,
+  // because a second observer on the same key kept the interval alive no matter
+  // what the first one's `enabled` said.
+  const q = useConnectionStatus(connectionId, {
+    enabled: !budget.spent,
+    stopWhen: (data) => !shouldKeepPolling(verifyVerdict(data, new Date(data.observed_at))),
+  });
+  const wire = q.data;
+
+  function checkAgain() {
+    // Resetting the budget FIRST, so a click during a spent budget resumes
+    // polling rather than firing one shot into a stopped panel.
+    setBudget({ from: Date.now(), spent: false });
+    void q.refetch();
+  }
 
   if (q.error !== null) {
     return (
@@ -364,7 +435,7 @@ export function ConnectionVerify({ connectionId, className }: ConnectionVerifyPr
         <PageError
           what="We could not check this connection"
           why={q.error.message}
-          onRetry={() => void q.refetch()}
+          onRetry={checkAgain}
           isRetrying={q.isFetching}
         />
       </div>
@@ -379,15 +450,24 @@ export function ConnectionVerify({ connectionId, className }: ConnectionVerifyPr
     );
   }
 
+  // Whether this verdict is one the panel is still waiting on. A spent budget
+  // is only worth mentioning while something was still expected to change.
+  const stillWaiting = shouldKeepPolling(verifyVerdict(wire, new Date(wire.observed_at)));
+
   return (
     <div className={cn("space-y-4", className)} data-testid="verify-panel">
       <ConnectionVerifyBody wire={wire} />
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => void q.refetch()}
-        disabled={q.isFetching}
-      >
+      {budget.spent && stillWaiting ? (
+        // THE BUDGET RUNNING OUT IS SAID, NOT HIDDEN. A panel that silently
+        // stopped polling looks identical to one that is still watching, and
+        // an operator waiting on a screen that stopped watching waits forever.
+        <p className={cn("text-sm", NOT_KNOWN_CLASS)} data-testid="verify-budget-spent">
+          We have stopped checking automatically. Nothing has changed for a while, and
+          nothing is wrong with the connection because of it. Check again when you have
+          started your client.
+        </p>
+      ) : null}
+      <Button variant="outline" size="sm" onClick={checkAgain} disabled={q.isFetching}>
         {q.isFetching ? "Checking..." : "Check again"}
       </Button>
     </div>

--- a/apps/web/src/features/ai-connections/connection-verify.tsx
+++ b/apps/web/src/features/ai-connections/connection-verify.tsx
@@ -1,0 +1,375 @@
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageError } from "@/components/feedback/page-error";
+import { DefinitionList, KvRow } from "@/components/shared/definition-list";
+import { LiveIndicator } from "@/components/shared/live-indicator";
+import { cn } from "@/lib/utils";
+
+import {
+  shouldKeepPolling,
+  verifyVerdict,
+  type FirstCallVerdict,
+  type HandshakeVerdict,
+  type ProtocolNote,
+  type VerifyVerdict,
+} from "./connection-status-model";
+import { useConnectionStatus, type ConnectionStatusWire } from "./use-connection-status";
+
+// Connection verification -- the wireframe's S5, and Steps 8 and 9 of S29.
+//
+// WHICH WIZARD DRAWING THIS FOLLOWS. The deck contains two and retracts
+// neither: S29 is titled "ADD MCP CONNECTION: THE TEN STEPS", and the shipped
+// wizard in connect-wizard.tsx has four (STEPS, line 100). THIS COMPONENT IS
+// BUILT TO THE TEN-STEP DRAWING'S STEPS 8 AND 9, because they are the only
+// drawing of this screen that exists -- the short drawing does not draw a
+// verification frame at all, so following it would mean building nothing.
+// Nothing here renumbers the shipped wizard: this is one panel, and it is
+// rendered after the setup step rather than replacing it, so a four-step rail
+// and a ten-step design document can both stay true.
+//
+// WHAT THE DECK ASKS FOR THAT THE SERVER CANNOT ANSWER, AND SO IS NOT DRAWN:
+//
+//   1. S5's X frame, "Auth failed -- something arrived and was rejected", with
+//      an attempt count and a source IP. NOT RENDERABLE. The status response's
+//      `refusal` is hard-coded null (connection_status.go:751) because a
+//      refused client writes nothing to mcp_grants at all. There is no attempt
+//      count anywhere in the response, so a screen showing one would be
+//      showing a number it made up.
+//   2. S5's X frame, "Version unsupported -- it connected and we ended the
+//      session". Same gap, same reason.
+//   3. S29-9's P frame, partial multi-site coverage ("17 answered, 3 stale, 2
+//      unreachable"). `first_call.partial` is always null and the server says
+//      why (connection_status.go:271): internal/mcp has no typed per-site
+//      partial to report.
+//   4. S5's S frame lines "Sites reachable 3 of 61" and "Approvals it can
+//      grant". Neither number is in this response.
+//
+// In place of all four, the silent case says what is known and states plainly
+// what is not. A confident wrong cause is worse than an admitted gap: it sends
+// the operator to check a firewall over a client that was never restarted.
+
+const NOT_KNOWN_CLASS = "text-[var(--color-muted-foreground)]";
+
+function formatIso(iso: string): string {
+  if (iso === "") return "Unknown time";
+  const d = new Date(iso);
+  // Never "Invalid Date", and never silently now.
+  if (Number.isNaN(d.getTime())) return "Unreadable timestamp";
+  return d.toLocaleString();
+}
+
+/** Whole days, floored, for the unused-credential sentence. */
+function daysFrom(ms: number): number {
+  return Math.floor(ms / (24 * 60 * 60 * 1000));
+}
+
+function protocolLine(note: ProtocolNote): string {
+  switch (note.kind) {
+    case "recognised":
+      return note.version;
+    case "assumed":
+      // BOTH HALVES SAID. The client sent nothing and we assumed the floor;
+      // printing only the floor would be printing a header it never sent.
+      return `None sent, treated as ${note.assumed}`;
+    case "unrecognised":
+      return `${note.version}, which this build does not currently speak`;
+    case "unreadable":
+      // Phrased as our failure. Nothing here claims anything about the client.
+      return "We could not read what it reported";
+  }
+}
+
+function HandshakeSection({ h }: { h: HandshakeVerdict }) {
+  if (h.kind === "never_arrived") {
+    if (h.phase === "fresh") {
+      return (
+        <div data-testid="handshake-waiting">
+          <div className="flex items-center gap-2">
+            <LiveIndicator state="connecting" label="Waiting for the client" />
+          </div>
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+            Nothing is wrong yet. The client opens a session the next time you start it.
+          </p>
+        </div>
+      );
+    }
+    const days = daysFrom(h.ageMs);
+    return (
+      <div data-testid="handshake-silent">
+        <p className="text-sm font-medium text-[var(--color-foreground)]">
+          Nothing has reached us from this connection
+        </p>
+        {/* THE AGE IS SAID AS SOON AS THERE IS AN AGE TO SAY. S5's E frame
+            pairs "Created 11 days ago" with "Never used", and eleven days is
+            well inside the thirty-day escalation, so the count belongs to the
+            whole silent range and not only to its far end. Below a day there is
+            no whole number to print, so that case says the cause instead. */}
+        {days >= 1 ? (
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+            This connection was created {days} days ago and no client has ever opened a
+            session with it. It still holds a valid key.
+          </p>
+        ) : (
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+            The connection exists and the key is valid, and no client has opened a session
+            with it. The usual cause is a client that was not restarted after its config
+            file changed.
+          </p>
+        )}
+        {/* THIRTY DAYS ESCALATES THE TONE, NEVER THE CLAIM. An old unused
+            credential is still only an unused credential. */}
+        {h.phase === "stale" ? (
+          <p className="mt-2 text-sm font-medium text-[var(--color-foreground)]">
+            An unused credential is still a credential. Revoke it if nothing is going to
+            use it.
+          </p>
+        ) : null}
+        {/* THE HONEST GAP, IN THE COPY, NOT ONLY IN A COMMENT. The operator is
+            told what this screen cannot distinguish, because the alternative is
+            letting them read "nothing arrived" as "nothing was tried". */}
+        <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)} data-testid="refusal-gap">
+          We cannot tell from here whether a client tried and was turned away. A refused
+          connection is not recorded, so it looks exactly like one that was never started.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="handshake-connected">
+      <p className="text-sm font-medium text-[var(--color-foreground)]">
+        A client opened a session
+      </p>
+      <DefinitionList className="mt-2">
+        <KvRow label="Session opened" value={formatIso(h.recordedAtIso)} />
+        <KvRow
+          label="Reported itself as"
+          value={
+            h.reportedClientName === null ? (
+              <span className={NOT_KNOWN_CLASS} data-testid="verify-client-unnamed">
+                Reported no name
+                {h.reportedClientVersion === null ? null : `, version ${h.reportedClientVersion}`}
+              </span>
+            ) : (
+              <span data-testid="verify-client-name">
+                {h.reportedClientName}
+                {h.reportedClientVersion === null
+                  ? " (no version)"
+                  : ` ${h.reportedClientVersion}`}
+              </span>
+            )
+          }
+        />
+        <KvRow
+          label="Protocol revision"
+          value={<span data-testid="verify-protocol">{protocolLine(h.protocol)}</span>}
+        />
+      </DefinitionList>
+    </div>
+  );
+}
+
+function FirstCallSection({ f }: { f: FirstCallVerdict }) {
+  switch (f.kind) {
+    case "none_yet":
+      return (
+        <div data-testid="firstcall-none">
+          <LiveIndicator state="connecting" label="Waiting for its first tool call" />
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+            Ask it something read only to finish this, for example: which of my sites are
+            behind on plugin updates?
+          </p>
+        </div>
+      );
+    case "succeeded":
+      return (
+        <div data-testid="firstcall-succeeded">
+          <p className="text-sm font-medium text-[var(--color-foreground)]">
+            It read your fleet
+          </p>
+          <DefinitionList className="mt-2">
+            <KvRow label="First call" value={formatIso(f.calledAtIso)} />
+            <KvRow
+              label="Tool it called"
+              value={
+                f.toolName === null ? (
+                  <span className={NOT_KNOWN_CLASS}>The audit row named no tool</span>
+                ) : (
+                  <span data-testid="verify-tool-name">{f.toolName}</span>
+                )
+              }
+            />
+            {f.auditEventId === null ? null : (
+              <KvRow label="Audit row" value={f.auditEventId} mono copyable={f.auditEventId} />
+            )}
+          </DefinitionList>
+          {/* NOT "it read all 22 of your sites". The response cannot
+              characterise the call's coverage, and claiming completeness is the
+              exact wrongness connection_status.go:271 refuses to put on screen. */}
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)} data-testid="coverage-gap">
+            We do not record how many sites that call reached, so this does not tell you it
+            covered all of them.
+          </p>
+        </div>
+      );
+    case "unknown":
+      return (
+        <div data-testid="firstcall-unknown">
+          <p className="text-sm font-medium text-[var(--color-foreground)]">
+            We cannot tell whether it has made a call yet
+          </p>
+          {/* NOT ROUNDED DOWN TO "no calls yet". A busy organisation pushes this
+              connection's call past the scan's bound, and telling that operator
+              to start troubleshooting a working connection is worse than
+              admitting the limit. */}
+          <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+            There is too much recent activity in this organisation for us to find this
+            connection&rsquo;s first call. This is a limit of the check, not a fault in the
+            connection.
+          </p>
+        </div>
+      );
+  }
+}
+
+function VerdictBody({ v }: { v: VerifyVerdict }) {
+  if (v.kind === "revoked") {
+    return (
+      <div data-testid="verify-revoked">
+        <p className="text-sm font-medium text-[var(--color-foreground)]">
+          This connection is revoked
+        </p>
+        <p className={cn("mt-2 text-sm", NOT_KNOWN_CLASS)}>
+          {v.everConnected
+            ? "A client did connect with it before it was revoked. Nothing can use it now."
+            : "Nothing ever connected with it, and nothing can now."}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-4">
+      {/* THE DECK'S TWO STEP TITLES, WITHOUT THEIR NUMBERS, AND THE OMISSION IS
+          DELIBERATE. The owner's ruling is that the ten-step flow is final, so
+          these two panels ARE steps 8 and 9 and the deck's wording is used
+          verbatim. The NUMBERS are left off because the shipped rail
+          (connect-wizard.tsx:100) still shows four steps whose fourth,
+          "Set it up", is the deck's step 6. Printing "Step 8" beside a rail
+          that ends at 4 puts two contradictory numbers on one screen, and the
+          operator has no way to tell which is wrong. Numbering the deck down to
+          match the code is the wrong direction -- the deck is the contract --
+          so these carry no number until the rail carries all ten. */}
+      <section aria-labelledby="verify-handshake-heading">
+        <h3
+          id="verify-handshake-heading"
+          className="text-xs font-semibold uppercase tracking-wide text-[var(--color-muted-foreground)]"
+        >
+          Is the connection live
+        </h3>
+        <div className="mt-2">
+          <HandshakeSection h={v.handshake} />
+        </div>
+      </section>
+      <section aria-labelledby="verify-firstcall-heading">
+        <h3
+          id="verify-firstcall-heading"
+          className="text-xs font-semibold uppercase tracking-wide text-[var(--color-muted-foreground)]"
+        >
+          Verify with a first read
+        </h3>
+        <div className="mt-2">
+          <FirstCallSection f={v.firstCall} />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/**
+ * The pure render, given a status snapshot. Exported so a test can pin the
+ * exact sentence for a wire fixture without standing up a fetch.
+ */
+export function ConnectionVerifyBody({
+  wire,
+  now,
+}: {
+  wire: ConnectionStatusWire;
+  now?: Date;
+}) {
+  // The SERVER's instant by default, not the browser's: observed_at exists so
+  // "4 seconds ago" is not computed against a clock that may be minutes out.
+  const observed = now ?? new Date(wire.observed_at);
+  const instant = Number.isNaN(observed.getTime()) ? new Date() : observed;
+  return (
+    <div data-testid="verify-root">
+      <VerdictBody v={verifyVerdict(wire, instant)} />
+    </div>
+  );
+}
+
+export interface ConnectionVerifyProps {
+  connectionId: string;
+  className?: string;
+}
+
+/**
+ * Poll one connection and render whether its client actually connected.
+ *
+ * FOUR STATES, ALL RENDERED: skeleton while the first poll is in flight,
+ * PageError when it failed, and then the verdict, which itself covers the
+ * never-connected, connected and cannot-tell cases. There is no branch that
+ * turns a failed poll into "nothing has connected yet" -- that would report our
+ * own broken request as a fact about the operator's client.
+ */
+export function ConnectionVerify({ connectionId, className }: ConnectionVerifyProps) {
+  // Two-pass polling: read once to learn the verdict, and use the verdict to
+  // decide whether to keep asking. `enabled` cannot depend on data that does
+  // not exist yet, so the first pass always runs.
+  const first = useConnectionStatus(connectionId);
+  const wire = first.data;
+  const keepPolling =
+    wire === undefined
+      ? true
+      : shouldKeepPolling(verifyVerdict(wire, new Date(wire.observed_at)));
+  // Re-registering with the same key does not open a second request; it swaps
+  // the interval on the one cache entry.
+  const q = useConnectionStatus(connectionId, { enabled: keepPolling });
+
+  if (q.error !== null) {
+    return (
+      <div className={className} data-testid="verify-error">
+        {/* THE FAILED CHECK IS OUR FAILURE, SAID AS OURS. It must never render
+            as "nothing has connected yet": that sentence is a claim about the
+            operator's client, made out of a fact about our own request. */}
+        <PageError
+          what="We could not check this connection"
+          why={q.error.message}
+          onRetry={() => void q.refetch()}
+          isRetrying={q.isFetching}
+        />
+      </div>
+    );
+  }
+  if (wire === undefined) {
+    return (
+      <div className={cn("space-y-2", className)} data-testid="verify-loading">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-4", className)} data-testid="verify-panel">
+      <ConnectionVerifyBody wire={wire} />
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => void q.refetch()}
+        disabled={q.isFetching}
+      >
+        {q.isFetching ? "Checking..." : "Check again"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/ai-connections/connections-list.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Fragment, useState, type ReactNode } from "react";
 import { PlugZap } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -16,6 +16,7 @@ import {
 
 import { capabilityLabel } from "./capabilities";
 import { PROTOCOL_FLOOR_VERSION } from "./client-table";
+import { ConnectionVerify } from "./connection-verify";
 import {
   lastUsedLabel,
   protocolHeaderLabel,
@@ -66,6 +67,15 @@ export function ConnectionsList({
   onRevoke,
   revokingId,
 }: ConnectionsListProps) {
+  // Which row has its verification panel open. AT THE TOP, BEFORE THE EARLY
+  // RETURNS BELOW, because a hook after a conditional return is a hook that
+  // sometimes does not run.
+  //
+  // ONE AT A TIME, DELIBERATELY. Each open panel polls its own connection, so
+  // an "expand all" would put one request per connection per poll interval on
+  // a fleet that may hold dozens.
+  const [verifyingId, setVerifyingId] = useState<string | null>(null);
+
   if (state.status === "loading") {
     return (
       <div className="space-y-2" data-testid="connections-loading">
@@ -151,7 +161,8 @@ export function ConnectionsList({
         </TableHeader>
         <TableBody>
           {state.connections.map((c) => (
-            <TableRow key={c.id}>
+            <Fragment key={c.id}>
+            <TableRow>
               <TableCell>
                 <span className="font-medium text-[var(--color-foreground)]">{c.name}</span>
                 <span className="ml-2">
@@ -256,11 +267,29 @@ export function ConnectionsList({
               </TableCell>
 
               <TableCell className="text-right">
+                {/* THE ONE QUESTION THIS PAGE COULD NOT ANSWER UNTIL NOW.
+                    "Last used" says whether anything has ever touched the
+                    credential; it does not say whether the client the operator
+                    just configured actually opened a session, and it is
+                    stamped by tools/list as well as tools/call, so it says
+                    "used" for a client that has read nothing. The panel behind
+                    this button asks the endpoint that can tell the two apart.
+                    Offered on a REVOKED connection too: "did anything ever use
+                    this before I killed it" is exactly the question asked
+                    after a leak. */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-expanded={verifyingId === c.id}
+                  onClick={() => setVerifyingId(verifyingId === c.id ? null : c.id)}
+                >
+                  {verifyingId === c.id ? "Hide check" : "Check connection"}
+                </Button>
                 {/* An ALREADY-REVOKED grant gets no revoke button. The
                     endpoint is idempotent, so pressing it would succeed and
                     teach the operator nothing. */}
                 {c.status === "revoked" ? (
-                  <span className="text-xs text-[var(--color-muted-foreground)]">
+                  <span className="ml-2 text-xs text-[var(--color-muted-foreground)]">
                     Revoked
                   </span>
                 ) : (
@@ -275,6 +304,16 @@ export function ConnectionsList({
                 )}
               </TableCell>
             </TableRow>
+            {verifyingId === c.id ? (
+              <TableRow>
+                {/* colSpan MATCHES THE HEADER above: seven columns. A short
+                    span leaves the panel boxed into one cell. */}
+                <TableCell colSpan={7} className="bg-[var(--color-muted)]/30">
+                  <ConnectionVerify connectionId={c.id} />
+                </TableCell>
+              </TableRow>
+            ) : null}
+            </Fragment>
           ))}
         </TableBody>
       </Table>

--- a/apps/web/src/features/ai-connections/use-ai-connections.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.ts
@@ -177,7 +177,11 @@ export class ConnectionsRequestError extends Error {
   }
 }
 
-async function readHouseError(res: Response): Promise<ConnectionsRequestError> {
+// Exported so the status poll (use-connection-status.ts) reads failures through
+// the SAME envelope parser as the list. A second copy would drift, and the 403
+// sentence below is the one an operator sees on the one route where a
+// site-constrained principal is genuinely refused.
+export async function readHouseError(res: Response): Promise<ConnectionsRequestError> {
   // A NON-JSON OR UNPARSEABLE BODY IS STILL A FAILURE. The catch returns an
   // error, never a success with empty fields.
   let code = "server_error";

--- a/apps/web/src/features/ai-connections/use-connection-status.ts
+++ b/apps/web/src/features/ai-connections/use-connection-status.ts
@@ -113,6 +113,40 @@ export function connectionStatusPath(id: string): string {
   return `${CONNECTIONS_PATH}/${encodeURIComponent(id)}/status`;
 }
 
+/** Default cadence when the server named none we can use. */
+export const POLL_FLOOR_MS = 2000;
+
+/**
+ * How long to wait before asking again, or `false` to stop asking.
+ *
+ * EXTRACTED SO IT CAN BE TESTED. Inlined in `refetchInterval` this was a
+ * decision no test could reach without standing up a live query and watching a
+ * clock, and "the polling never stops" is precisely the defect that shipped
+ * here once already.
+ */
+export function nextPollInterval(
+  data: ConnectionStatusWire | undefined,
+  opts: {
+    enabled: boolean;
+    stopWhen?: (data: ConnectionStatusWire) => boolean;
+  },
+): number | false {
+  if (!opts.enabled) return false;
+  // Nothing read yet: keep the floor so the first poll happens.
+  if (data === undefined) return POLL_FLOOR_MS;
+  if (opts.stopWhen?.(data) === true) return false;
+  const ms = data.poll_after_ms;
+  // ZERO MEANS STOP, and it is a different answer from "the field was missing".
+  // The server naming a cadence of zero is the server asking us to stop asking;
+  // a missing or nonsensical one is us having no instruction, which gets the
+  // floor rather than a tight loop. Never `ms || POLL_FLOOR_MS`: that folds the
+  // two together, which is the flattening this whole feature exists to avoid,
+  // one layer down.
+  if (ms === 0) return false;
+  if (!Number.isFinite(ms) || ms < 0) return POLL_FLOOR_MS;
+  return ms;
+}
+
 /**
  * Poll one connection's verification status.
  *
@@ -126,29 +160,50 @@ export function connectionStatusPath(id: string): string {
  */
 export function useConnectionStatus(
   connectionId: string,
-  options: { enabled?: boolean } = {},
+  options: {
+    /**
+     * Stop asking, whatever the last response said. The caller uses this for
+     * its own polling budget: a browser tab left open is a loop, and the
+     * repository's own rule against waiting on an unbounded one applies to it
+     * exactly as it does to a shell.
+     */
+    enabled?: boolean;
+    /**
+     * Terminal-state predicate, consulted against the LATEST response.
+     *
+     * ONE OBSERVER, AND THAT IS THE POINT. This used to be two `useQuery` calls
+     * on the same key -- an unconditional one to learn the verdict and a second
+     * whose `enabled` carried the decision. It did not work: disabling the
+     * second observer leaves the first one registered, and a single enabled
+     * observer is all TanStack needs to keep the interval running. A revoked
+     * connection therefore polled forever behind a panel that had already
+     * stopped changing. The decision belongs INSIDE the interval callback,
+     * where the data it depends on already is.
+     */
+    stopWhen?: (data: ConnectionStatusWire) => boolean;
+  } = {},
 ): UseQueryResult<ConnectionStatusWire, Error> {
   const enabled = options.enabled ?? true;
+  const stopWhen = options.stopWhen;
   return useQuery({
     queryKey: connectionStatusKey(connectionId),
-    enabled,
-    // A status snapshot is never fresh: the whole screen exists to notice a
-    // change. Anything above zero here shows a stale verdict after a remount.
+    // NOT `enabled`. Disabling the query would also block the first read and
+    // strand the panel on a skeleton; the budget stops the POLLING, not the
+    // one-shot fetch that tells the operator where they stand.
     staleTime: 0,
-    refetchInterval: (query) => {
-      if (!enabled) return false;
-      const ms = query.state.data?.poll_after_ms;
-      // A response that named no cadence, or named a nonsensical one, gets the
-      // floor rather than a tight loop. Never `ms || 2000`: a legitimate 0 and
-      // a missing field would take the same branch, and one of them is the
-      // server asking us to stop.
-      if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return 2000;
-      return ms;
-    },
+    refetchInterval: (query) => nextPollInterval(query.state.data, { enabled, stopWhen }),
     queryFn: async (): Promise<ConnectionStatusWire> => {
       const res = await fetch(connectionStatusPath(connectionId), {
         method: "GET",
         credentials: "include",
+        // NO HTTP CACHE FOR A CREDENTIALED STATUS READ. `staleTime: 0` governs
+        // TanStack's cache and says nothing about the browser's: without this,
+        // a back-navigation can re-serve a stored response and show a stale
+        // verdict, and the body carries the audit event id of a tool call.
+        // The server half of this (a `Cache-Control: no-store` on the status
+        // response) is in apps/api and is NOT changed here -- that path belongs
+        // to another agent, and it is flagged on the PR instead.
+        cache: "no-store",
         headers: { Accept: "application/json" },
       });
       if (!res.ok) throw await readHouseError(res);

--- a/apps/web/src/features/ai-connections/use-connection-status.ts
+++ b/apps/web/src/features/ai-connections/use-connection-status.ts
@@ -1,0 +1,158 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { z } from "zod";
+
+import { CONNECTIONS_PATH, connectionKeys, readHouseError } from "./use-ai-connections";
+
+// GET /api/v1/mcp/connections/:id/status -- the wizard's Step 8 and Step 9.
+//
+// NO GENERATED CLIENT, AND THAT IS CHECKED RATHER THAN ASSUMED. The MCP surface
+// is not in packages/openapi/openapi.yaml; internal/mcp hand-shapes its own
+// DTOs (connection_status.go:738, connectionStatusResponse, a gin.H built by
+// hand). `grep -rn "mcp" packages/openapi-client/src/generated` returns nothing.
+// So this module follows the same house pattern its two siblings already use --
+// use-ai-connections.ts and features/mcp-consent/use-consent.ts -- a same-origin
+// /api/v1 path with credentials included and a zod parse at the boundary.
+//
+// EVERY FIELD BELOW IS QUOTED FROM connectionStatusResponse. The keys, the
+// nullability and the enum members are that function's, not a guess: the
+// nullable fields are the ones it passes through emptyToNil or a *time.Time,
+// and the two enums are HandshakeState (connection_status.go:88) and
+// FirstCallState (:209) verbatim.
+
+/**
+ * The handshake states, mirroring HandshakeState in connection_status.go:88.
+ *
+ * A CLOSED ENUM. A fifth member fails the parse and the screen says it could
+ * not read the answer, which is the honest outcome; coercing an unknown state
+ * into `awaiting_client` would report a client that did something as one that
+ * did nothing.
+ */
+const handshakeStateSchema = z.enum([
+  "awaiting_client",
+  "connected",
+  "connected_protocol_assumed",
+  "connected_protocol_unrecognised",
+]);
+
+/** FirstCallState, connection_status.go:209. Closed for the same reason. */
+const firstCallStateSchema = z.enum(["awaiting_call", "succeeded", "indeterminate"]);
+
+const statusProtocolSchema = z.object({
+  // ClientProtocolState, the same four the list already parses.
+  state: z.enum(["never_connected", "absent", "recognised", "unrecognised"]),
+  version: z.string().nullable(),
+  // SEPARATE FROM version, and that separation is the point: `assumed` is what
+  // WE assumed, `version` is what the CLIENT sent. Folding them would print a
+  // header the client never sent.
+  assumed: z.string().nullable(),
+  // Properties of the server, true on every response including one for a
+  // connection nothing has ever touched. Never nullable.
+  floor: z.string(),
+  target: z.string(),
+  supported: z.array(z.string()),
+});
+
+const handshakeSchema = z.object({
+  state: handshakeStateSchema,
+  recorded_at: z.string().nullable(),
+  reported_client_name: z.string().nullable(),
+  reported_client_version: z.string().nullable(),
+  protocol: statusProtocolSchema,
+  // ALWAYS null today. connection_status.go:149 states the data gap in the
+  // type: a client refused for a below-floor protocol revision writes nothing
+  // to mcp_grants, so the server has no refusal to report and returns the key
+  // as null "so the frontend can bind it now and light up when the refusal is
+  // recorded". Parsed as unknown-but-present so a future non-null body does not
+  // fail the parse; nothing reads it, and NOTHING RENDERS A REFUSAL, because
+  // there is no refusal to render.
+  refusal: z.unknown(),
+});
+
+const firstCallSchema = z.object({
+  state: firstCallStateSchema,
+  called_at: z.string().nullable(),
+  tool_name: z.string().nullable(),
+  audit_event_id: z.string().nullable(),
+  // REPORTED, NEVER USED TO DERIVE THE STATE. connection_status.go:258 spends a
+  // paragraph on why: RecordActivity stamps last_used_at from tools/list as
+  // well as tools/call, and every client issues tools/list right after
+  // initialize without anyone asking. A screen that read "has it done
+  // anything?" off this column would show "connected and working" for a client
+  // that has read nothing at all.
+  last_used_at: z.string().nullable(),
+  // Always null; the per-site coverage breakdown is not answerable today
+  // (connection_status.go:271). Bound, never rendered.
+  partial: z.unknown(),
+});
+
+const statusSchema = z.object({
+  id: z.string(),
+  // A REVOKED GRANT STILL ANSWERS. The server returns 200 rather than 404 on
+  // purpose (connection_status.go:305) so the screen can stop polling and say
+  // so; a 404 would read as "wrong id".
+  status: z.enum(["active", "revoked"]),
+  created_at: z.string(),
+  expires_at: z.string(),
+  handshake: handshakeSchema,
+  first_call: firstCallSchema,
+  observed_at: z.string(),
+  poll_after_ms: z.number(),
+});
+
+export type ConnectionStatusWire = z.infer<typeof statusSchema>;
+
+/** Exported for the test that compares this schema against the Go DTO. */
+export function parseConnectionStatus(raw: unknown): ConnectionStatusWire {
+  return statusSchema.parse(raw);
+}
+
+export const connectionStatusKey = (id: string) =>
+  [...connectionKeys.all, "status", id] as const;
+
+export function connectionStatusPath(id: string): string {
+  return `${CONNECTIONS_PATH}/${encodeURIComponent(id)}/status`;
+}
+
+/**
+ * Poll one connection's verification status.
+ *
+ * THE SERVER SETS THE CADENCE. `poll_after_ms` comes back on every response and
+ * is used as the next interval, rather than a constant chosen here: the
+ * endpoint knows what its own scan costs and this screen does not.
+ *
+ * `enabled` lets a caller stop entirely. The verify panel passes false once the
+ * verdict is terminal (verified, or revoked), so a finished screen left open in
+ * a tab is not an endless request loop.
+ */
+export function useConnectionStatus(
+  connectionId: string,
+  options: { enabled?: boolean } = {},
+): UseQueryResult<ConnectionStatusWire, Error> {
+  const enabled = options.enabled ?? true;
+  return useQuery({
+    queryKey: connectionStatusKey(connectionId),
+    enabled,
+    // A status snapshot is never fresh: the whole screen exists to notice a
+    // change. Anything above zero here shows a stale verdict after a remount.
+    staleTime: 0,
+    refetchInterval: (query) => {
+      if (!enabled) return false;
+      const ms = query.state.data?.poll_after_ms;
+      // A response that named no cadence, or named a nonsensical one, gets the
+      // floor rather than a tight loop. Never `ms || 2000`: a legitimate 0 and
+      // a missing field would take the same branch, and one of them is the
+      // server asking us to stop.
+      if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return 2000;
+      return ms;
+    },
+    queryFn: async (): Promise<ConnectionStatusWire> => {
+      const res = await fetch(connectionStatusPath(connectionId), {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) throw await readHouseError(res);
+      return parseConnectionStatus((await res.json()) as unknown);
+    },
+  });
+}


### PR DESCRIPTION
## The gap

`GET /api/v1/mcp/connections/:id/status` has been mounted and serving since `apps/api/internal/mcp/handler.go:184`. Its own route comment says it exists for "the add-connection wizard's Step 8 and Step 9". **No dashboard code called it.**

Confirmed before starting, not assumed:

```
$ grep -rn "fetch(" apps/web/src --include="*.ts" --include="*.tsx" | grep -v "\.test\." | grep ai-connections
apps/web/src/features/ai-connections/use-ai-connections.ts:215   (GET list)
apps/web/src/features/ai-connections/use-ai-connections.ts:305   (POST create)
apps/web/src/features/ai-connections/use-ai-connections.ts:352   (POST revoke)
```

Three requests, and none of them the status endpoint. "Is my connection working?" had no answer in the product.

## What this adds

- `connection-status-model.ts` - the pure verdict mapping, so the sentence chosen is testable without a render.
- `use-connection-status.ts` - the poll. Hand-written zod, quoted field by field from `connectionStatusResponse` (`connection_status.go:738`). Confirmed there is no generated client: `grep -rn "mcp" packages/openapi-client/src/generated/` returns nothing, so this follows the sibling hooks' house pattern.
- `connection-verify.tsx` - the screen. Skeleton, `PageError`, and the verdict.
- Reachable from the connections list behind a per-row **Check connection** disclosure, offered on revoked connections too, because "did anything ever use this before I killed it" is exactly the question asked after a leak.

## What it refuses to say

The wireframe draws diagnoses this endpoint cannot support. Each is left undrawn and the gap is stated in the copy, not only in a comment:

| The deck draws | The response holds | What the screen says |
|---|---|---|
| S5 X, "3 attempts from 198.51.100.24 presented a key we do not recognise" | `refusal` hard-coded `null` (`connection_status.go:751`) | that it cannot tell a refusal from a never-started client |
| S5 X, "Version unsupported, we ended the session" | same gap, same reason | nothing |
| S29-9 P, "17 answered, 3 stale, 2 unreachable" | `partial` always `null` | that we do not record how many sites the call reached |
| S5 S, "Sites reachable 3 of 61", "Approvals it can grant" | neither number is in the response | nothing |

A refused client writes nothing to `mcp_grants`, so it is byte-identical to one that was never started. Naming a cause we do not have sends the operator to check a firewall over a client that was never restarted.

## Three states, kept apart

- **Never connected** is the shipped default and is not a failure. Under five minutes it reads as waiting; past that it says nothing has arrived; past thirty days it escalates the tone, never the claim. Both thresholds are the deck's own numbers and live in the browser because `connection_status.go:224` deliberately refuses to own them.
- **Connected and healthy** names the tool actually called, the client's own reported version, and the negotiated revision.
- **Connected and something is wrong** is the reachable one: a revision this build no longer speaks. It is not a refusal, and it does not claim to be.

`last_used_at` is reported, never used to derive the verdict. `RecordActivity` stamps it from `tools/list`, which every client issues unprompted, so deriving success from it would show "it read your fleet" for a client that read nothing (`connection_status.go:258`).

## Wizard numbering

Built to the ten-step drawing, per the owner's ruling. The panel carries the deck's step titles **without their numbers**: the shipped rail has four steps whose fourth ("Set it up") is the deck's step 6, so printing "Step 8" beside it would put two contradictory numbers on one screen. The deck is not renumbered down to match the code.

## Second commit: the contradiction #636 puts on this screen

`7360a4a4`. GH #636 says `tools/call` is served without a recorded `initialize`, so a live, working connection can carry `client_identity_recorded_at IS NULL` while its tool calls sit in the audit log. The naive render of that response prints "Nothing has reached us from this connection" directly above "It read your fleet".

Both cannot be true, and the false half is the absence: a recorded call is a thing that happened, a null column is a thing that was not written. The screen resolves towards the evidence and reports the mismatch as a gap in our own recording, while still declining to name the client or its revision, because that part really is unknown.

This was fixed here rather than filed: it is customer-visible, and it is in a file this PR already touches.

## Proof

Three real defects planted, four tests went red naming what was missing:

```
$ pnpm -C apps/web test -- --run src/features/ai-connections/connection-verify.test.tsx
x never connected > states that it cannot tell a refusal from a never-started client
x never connected > never renders an attempt count or a source address
x connected, and something is wrong > renders the indeterminate scan as not knowing, never as 'no calls yet'
x connected, and something is wrong > does not read last_used_at as proof of a first call
Tests  4 failed | 2145 passed (2149)
```

Restored, byte-exact (`git status --short` clean), green again.

A fourth defect planted for the second commit, the naive "print the absence anyway":

```
x never connected > never says 'nothing has reached us' about a connection that has demonstrably been used
x never connected > treats last_used_at alone as enough to disprove 'nothing has reached us'
Tests  2 failed | 2150 passed (2152)
```

A third test pins the over-fire half, so the branch cannot swallow the real never-used case.

Gates, final state:

```
$ pnpm -C apps/web typecheck   -> exit 0
$ pnpm -C apps/web lint        -> 10 problems (0 errors, 10 warnings), all pre-existing
$ pnpm -C apps/web test        -> Test Files 168 passed, Tests 2152 passed
$ pnpm -C apps/web build       -> built in 5.37s; routeTree.gen.ts unchanged (no new route)
$ apps/web/node_modules/.bin/impeccable detect apps/web/src/features/ai-connections -> no output, exit 0
```

Two caveats on that block, both stated rather than glossed:

1. **The impeccable result is weak evidence, per GH #631** ("impeccable detect exits 0 on an unreadable path and on a planted violation, so the design gate proves nothing"). Its exit code means nothing. What I can say is that the tool is not silent here: run over `apps/web/src` it prints 1 pre-existing anti-pattern at `components/layout/sidebar.tsx:642`, so it is reading files and reporting. Over the touched directory it prints nothing.
2. **One flake observed.** On one full-suite run, `src/routes/_authed/ai/-index.test.tsx > asks the path the API actually mounts` failed at 1065ms. It passes in isolation at 416ms and passed on the next two full runs. This PR adds a button to that page's table but no request, so a timing flake under load is the likely cause. Recording it rather than dropping it.

## Findings, not fixed here

- **The wizard cannot resume after the step 7 authorize redirect.** It holds all state in React and persists nothing, so an operator who leaves for the consent screen returns to step 1. Filed as #678.
- **#636 is the live cause of the contradiction handled above.** The screen now degrades honestly, but the underlying recording gap is in `apps/api` and is not this PR's to close.

## Where the deck is silent

Stated rather than invented:

- The `indeterminate` first-call state has no frame anywhere in the deck. The server added a third state (the scan hit its bound without finding a row) after the wireframes were drawn. Rendered as "we cannot tell", which is the only true sentence available.
- A **revoked** connection's verification has no frame. `connection_status.go:305` says the endpoint answers 200 for one deliberately so the wizard can stop polling, so the panel says so and stops.
- The deck never says what happens when the response contradicts itself (a `recognised` protocol state carrying a null version, or a `succeeded` first call carrying no timestamp). Both are rendered as our failure to read the answer, matching the vocabulary `connection-model.ts` already established for the list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection verification for AI connections, including handshake and first-call status.
  * Added per-connection “Check connection” controls with manual retry and automatic status updates.
  * Displays clear outcomes for healthy, revoked, inactive, and recording-gap scenarios.
  * Reports connection details such as tool name, client name, and protocol revision.

* **Bug Fixes**
  * Identifies cases where a credential was used but the session was not recorded, avoiding incorrect client fault reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->