### PR TITLE
AI connections: the can/cannot contract, the role-refused state, and the sign-in step's copy

### DIFF
--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -14,6 +14,7 @@ import { formatAbsolute } from "@/features/updates/schedule";
 import { mockQueryResult } from "@/test/query-mocks";
 
 import { Route } from "@/routes/_authed/ai/connect";
+import { authKeys } from "@/features/auth/use-auth";
 import { CLIENT_TABLE_VERIFIED_AT, MCP_CLIENTS } from "./client-table";
 import { useSites, DEFAULT_SITES_LIMIT } from "@/features/sites/use-sites";
 import { useTags } from "@/features/tags/use-tags";
@@ -71,10 +72,30 @@ beforeEach(() => {
 
 const ConnectPage = Route.options.component!;
 
+// The role this route's principal holds. The wizard itself is now behind
+// canManage, mirroring PermAPIKeyManage -> RoleAdmin
+// (apps/api/internal/authz/role.go:241), so every test that wants to see the
+// wizard needs a principal who could actually finish it. Seeded into the cache
+// rather than mocked at useMe, so the real canManage runs over a real Me shape.
+let wizardRole: "owner" | "admin" | "operator" | "viewer" = "admin";
+
+const WIZARD_TENANT = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
 function renderWizard() {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(authKeys.me, {
+    id: "user-1",
+    email: "priya@example.test",
+    name: "Priya",
+    scope: "org",
+    role: wizardRole,
+    active_tenant_id: WIZARD_TENANT,
+    memberships: [{ tenant_id: WIZARD_TENANT, role: wizardRole, tenant_name: "Example" }],
+  });
   return renderWithProviders(<ConnectPage />, {
     withRouter: true,
     initialPath: "/ai/connect",
+    queryClient,
   });
 }
 
@@ -91,6 +112,51 @@ function authCard(method: "oauth" | "token"): HTMLButtonElement {
   if (el === null) throw new Error(`no auth card rendered for "${method}"`);
   return el;
 }
+
+// HIDING THE LINK IS NOT GUARDING THE ROUTE.
+//
+// /ai stops offering "New connection" to a principal who cannot mint, and this
+// route had no beforeLoad, so the URL still rendered the whole wizard. The
+// refusal arrived from the server at the last button, after the operator had
+// picked a client, an auth method and a site scope. These tests are the reason
+// that cannot come back quietly.
+describe("the wizard refuses a principal who could not finish it", () => {
+  afterEach(() => {
+    wizardRole = "admin";
+  });
+
+  it("renders no wizard at all for an operator who types the URL", async () => {
+    wizardRole = "operator";
+    renderWizard();
+    expect(await screen.findByTestId("connect-role-refused")).toBeInTheDocument();
+    // NOT "the first step is hidden". No part of the wizard renders, so there
+    // is no work to lose and no 403 to walk into.
+    expect(screen.queryByRole("button", { name: /claude code/i })).toBeNull();
+    expect(document.querySelector('button[data-method="oauth"]')).toBeNull();
+  });
+
+  it("renders no wizard for a viewer either", async () => {
+    wizardRole = "viewer";
+    renderWizard();
+    expect(await screen.findByTestId("connect-role-refused")).toBeInTheDocument();
+  });
+
+  it("says the refusal arrives before the work, not at the last button", async () => {
+    wizardRole = "viewer";
+    renderWizard();
+    expect(
+      await screen.findByText(/nothing has been created and nothing was attempted/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the wizard for an owner, so the guard is not blanket", async () => {
+    // The over-fire half. A guard that refuses correct work gets switched off.
+    wizardRole = "owner";
+    renderWizard();
+    expect(await screen.findByRole("button", { name: /claude code/i })).toBeInTheDocument();
+    expect(screen.queryByTestId("connect-role-refused")).toBeNull();
+  });
+});
 
 describe("the wizard asks for the client first", () => {
   it("renders every row in the table as a picker card, including the generic one", async () => {
@@ -775,8 +841,21 @@ function renderWizardInRouter() {
     routeTree: rootRoute.addChildren([connectRoute, listRoute]),
     history: createMemoryHistory({ initialEntries: ["/ai/connect"] }),
   });
+  // Seeded for the same reason renderWizard is: the route is behind canManage
+  // now, and these tests are about the navigation block around an open mint,
+  // which only a principal who can mint ever reaches.
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(authKeys.me, {
+    id: "user-1",
+    email: "priya@example.test",
+    name: "Priya",
+    scope: "org",
+    role: "admin",
+    active_tenant_id: WIZARD_TENANT,
+    memberships: [{ tenant_id: WIZARD_TENANT, role: "admin", tenant_name: "Example" }],
+  });
   render(
-    <QueryClientProvider client={createTestQueryClient()}>
+    <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
     </QueryClientProvider>,
   );

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -128,8 +128,43 @@ describe("the auth cards say what each method actually does", () => {
     expect(within(oauth).getByText("Sign in through your browser")).toBeInTheDocument();
     expect(
       within(oauth).getByText(
-        "You approve the connection on a WPMgr page. The client stores a token it refreshes itself, and nothing secret is ever shown to you or pasted anywhere.",
+        "You approve the connection on a WPMgr page and the client stores the token it is issued. Nothing secret is ever shown to you or pasted anywhere. That token does not refresh itself, so the connection stops working when it expires.",
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("promises no refresh on any auth card, because the server mints none", async () => {
+    // THE SAME GUARD AS CONTRACT_FORBIDDEN, ON THE OTHER SCREEN THAT CAN MAKE
+    // THIS CLAIM. apps/api/internal/mcp/service.go:140: "There is no
+    // refresh_token grant: the connection token's lifetime is the connection's,
+    // and nothing here mints a refresh token", and discovery_test.go:256 drives
+    // the grant-type validator with "refresh_token" to prove the discovery
+    // document refuses it. The design frame promises a self-refreshing token;
+    // the deck is wrong and the server is right, so a fidelity pass that
+    // restores the frame's wording turns this red.
+    //
+    // The word, not the sentence. "refreshes itself", "auto-refresh" and "will
+    // be refreshed" are the same false claim in three shapes, and pinning one
+    // phrasing would let the next two through.
+    renderWizard();
+    await pickClient("Claude Code");
+
+    // The card is ALLOWED to say "does not refresh itself" and nothing else
+    // about refreshing. Striking the denial and then looking for the word is
+    // what makes this fire on an affirmative claim while passing on the
+    // correction -- a bare /refresh/i assertion would reject the true sentence
+    // along with the false one and get switched off by the next person here.
+    const oauthText = (authCard("oauth").textContent ?? "").replace(
+      /does not refresh itself/gi,
+      "",
+    );
+    expect(oauthText).not.toMatch(/refresh/i);
+    expect(authCard("token").textContent ?? "").not.toMatch(/refresh/i);
+
+    // And it says what DOES happen, so the guard cannot be satisfied by
+    // deleting the sentence rather than correcting it.
+    expect(
+      within(authCard("oauth")).getByText(/stops working when it expires/i),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -14,7 +14,7 @@ import { formatAbsolute } from "@/features/updates/schedule";
 import { mockQueryResult } from "@/test/query-mocks";
 
 import { Route } from "@/routes/_authed/ai/connect";
-import { MCP_CLIENTS } from "./client-table";
+import { CLIENT_TABLE_VERIFIED_AT, MCP_CLIENTS } from "./client-table";
 import { useSites, DEFAULT_SITES_LIMIT } from "@/features/sites/use-sites";
 import { useTags } from "@/features/tags/use-tags";
 import { snapshotFromPage } from "@/features/mcp-consent/site-scope";
@@ -110,6 +110,77 @@ describe("the wizard asks for the client first", () => {
     renderWizard();
     await screen.findByRole("button", { name: /claude code/i });
     expect(document.querySelector('button[data-method="oauth"]')).toBeNull();
+  });
+});
+
+// STEP "HOW IT SIGNS IN", BROUGHT TO ITS SPECIFIED COPY.
+//
+// Every assertion is on the exact sentence. The two cards used to carry
+// one-line summaries ("Connection token", "Nothing to copy or keep secret"),
+// which are true but leave the two decisions this screen actually asks an
+// operator to make -- what is shown to me, and where does the secret live --
+// to be inferred. The words are the deliverable, so the words are pinned.
+describe("the auth cards say what each method actually does", () => {
+  it("states, on the browser card, that nothing secret is ever shown", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    const oauth = authCard("oauth");
+    expect(within(oauth).getByText("Sign in through your browser")).toBeInTheDocument();
+    expect(
+      within(oauth).getByText(
+        "You approve the connection on a WPMgr page. The client stores a token it refreshes itself, and nothing secret is ever shown to you or pasted anywhere.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("states, on the token card, that it is documented and not a fallback", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    const token = authCard("token");
+    expect(within(token).getByText("Use a connection token")).toBeInTheDocument();
+    expect(
+      within(token).getByText(
+        "We show a token once. You put it in your environment, and the client sends it as a header. This is the documented path for CI, containers and SSH, not a fallback for when sign-in fails.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("marks which card is the answer when both methods are open", async () => {
+    // Claude Code offers both, so there is a recommendation to make.
+    renderWizard();
+    await pickClient("Claude Code");
+    expect(within(authCard("oauth")).getByText("Recommended for Claude Code")).toBeInTheDocument();
+    expect(
+      within(authCard("token")).getByText("The documented headless path"),
+    ).toBeInTheDocument();
+  });
+
+  it("says 'the only route' rather than recommending, when there is one route", async () => {
+    // Claude Desktop's add-connector dialog has no header field, so the token
+    // card is disabled and the browser card is not a preference.
+    renderWizard();
+    await pickClient("Claude Desktop");
+    expect(
+      within(authCard("oauth")).getByText("The only route for this client"),
+    ).toBeInTheDocument();
+    // A recommendation on a control nobody can press is noise.
+    expect(within(authCard("token")).queryByText(/recommended|only route|documented headless/i))
+      .toBeNull();
+    expect(within(authCard("token")).getByText("not possible here")).toBeInTheDocument();
+  });
+
+  it("says why there is no device-code option, with the date it was checked", async () => {
+    // Without this, a disabled browser card on a headless client reads as an
+    // oversight and the token reads as our fallback. It is neither.
+    renderWizard();
+    await pickClient("Claude Code");
+    expect(
+      await screen.findByText("Why there is no “enter this code on another device” option"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no MCP client implements one/i)).toBeInTheDocument();
+    // The date is rendered from the client table's own constant, so it goes
+    // stale visibly. A literal here would pass while the table moved on.
+    expect(screen.getByText(new RegExp(CLIENT_TABLE_VERIFIED_AT))).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -11,6 +11,7 @@ import { CopyableMono } from "@/components/shared/copyable-mono";
 import { cn } from "@/lib/utils";
 
 import {
+  CLIENT_TABLE_VERIFIED_AT,
   MCP_CLIENTS,
   PROTOCOL_FLOOR_VERSION,
   PROTOCOL_TARGET_VERSION,
@@ -361,8 +362,9 @@ export function ConnectWizard({
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <AuthCard
               method="oauth"
-              title="Sign in through the browser"
-              body="You approve the connection here, and the client stores its own key. Nothing to copy or keep secret."
+              title="Sign in through your browser"
+              body="You approve the connection on a WPMgr page. The client stores a token it refreshes itself, and nothing secret is ever shown to you or pasted anywhere."
+              recommendation={recommendationFor("oauth", client.name, methods)}
               availability={client.auth.oauth}
               selected={method === "oauth"}
               locked={mintInFlight}
@@ -370,8 +372,9 @@ export function ConnectWizard({
             />
             <AuthCard
               method="token"
-              title="Connection token"
-              body="The documented path for CI, containers and SSH sessions, where no browser can open."
+              title="Use a connection token"
+              body="We show a token once. You put it in your environment, and the client sends it as a header. This is the documented path for CI, containers and SSH, not a fallback for when sign-in fails."
+              recommendation={recommendationFor("token", client.name, methods)}
               availability={client.auth.token}
               selected={method === "token"}
               locked={mintInFlight}
@@ -387,6 +390,24 @@ export function ConnectWizard({
               we would rather say so than send you down a path we have never seen finish.
             </p>
           ) : null}
+
+          {/* WHY THERE IS NO THIRD CARD. Without this, a reader who knows the
+              OAuth device-code flow reads a disabled browser card on a headless
+              client as an oversight, and the connection token as our fallback.
+              It is neither. The date is rendered from the client table's own
+              verified-at constant rather than written here, so this paragraph
+              goes stale visibly instead of quietly. */}
+          <div className="mt-3 rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3">
+            <p className="text-xs font-medium text-[var(--color-foreground)]">
+              Why there is no “enter this code on another device” option
+            </p>
+            <p className="mt-1 text-xs text-[var(--color-muted-foreground)]">
+              A device-code flow would solve this cleanly, and no MCP client implements one. We
+              checked every client on this list on {CLIENT_TABLE_VERIFIED_AT}. A grant nothing can
+              initiate is a grant nobody can use, so we have not built one. A scoped, revocable
+              connection token does the same job today.
+            </p>
+          </div>
         </Section>
       ) : null}
 
@@ -517,6 +538,37 @@ function StepRail({ current }: { current: Step }) {
   );
 }
 
+/**
+ * Which recommendation badge, if any, belongs on one auth card.
+ *
+ * COMPUTED FROM THE CLIENT TABLE, NEVER WRITTEN PER CLIENT. The wireframe
+ * writes three different badges on three different frames; all three are the
+ * same fact stated for a different row, so they are derived from
+ * availableAuthMethods rather than copied out client by client, where the
+ * fourteenth client to be added would silently get none.
+ *
+ * A card whose method is not available gets no badge at all: it already carries
+ * the client's own reason for being disabled, and a recommendation on a control
+ * nobody can press is noise.
+ */
+export function recommendationFor(
+  method: AuthMethod,
+  clientName: string,
+  available: readonly AuthMethod[],
+): string | null {
+  if (!available.includes(method)) return null;
+  // One route means there is nothing to recommend BETWEEN. Saying so is more
+  // useful than a recommendation, because it tells the operator the other card
+  // is not a road they are declining to take.
+  if (available.length === 1) return "The only route for this client";
+  // Both available. Browser sign-in is the recommendation because nothing
+  // secret is ever shown; the token path is not second best, it is the path CI
+  // and SSH document, so it says that rather than nothing.
+  return method === "oauth"
+    ? `Recommended for ${clientName}`
+    : "The documented headless path";
+}
+
 function Section({
   n,
   title,
@@ -591,6 +643,7 @@ function AuthCard({
   method,
   title,
   body,
+  recommendation,
   availability,
   selected,
   locked,
@@ -599,6 +652,8 @@ function AuthCard({
   method: AuthMethod;
   title: string;
   body: string;
+  /** From recommendationFor. Null on a card nobody can press. */
+  recommendation: string | null;
   availability: AuthAvailability;
   selected: boolean;
   /**
@@ -637,6 +692,18 @@ function AuthCard({
           <AlertTriangle aria-hidden="true" className="size-4 text-[var(--color-muted-foreground)]" />
         ) : null}
       </span>
+
+      {/* THE BADGE SAYS WHICH CARD IS THE ANSWER, and the disabled card says it
+          is not possible here rather than leaving "greyed out" to be read as
+          "we would rather you did not". Two different facts, two different
+          words. */}
+      {recommendation !== null ? (
+        <Badge variant="secondary">{recommendation}</Badge>
+      ) : null}
+      {availability.state === "unavailable" ? (
+        <Badge variant="muted">not possible here</Badge>
+      ) : null}
+
       <span className="text-xs text-[var(--color-muted-foreground)]">{body}</span>
 
       {availability.state === "available" ? (

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -363,7 +363,20 @@ export function ConnectWizard({
             <AuthCard
               method="oauth"
               title="Sign in through your browser"
-              body="You approve the connection on a WPMgr page. The client stores a token it refreshes itself, and nothing secret is ever shown to you or pasted anywhere."
+              // NO REFRESH IS PROMISED, BECAUSE NO REFRESH EXISTS. The design
+              // frame says "the client stores a token it refreshes itself";
+              // apps/api/internal/mcp/service.go:140 says the opposite in as
+              // many words -- "There is no refresh_token grant: the connection
+              // token's lifetime is the connection's, and nothing here mints a
+              // refresh token" -- and discovery_test.go:256 drives the
+              // validator with "refresh_token" to prove the discovery document
+              // refuses it. A card promising a self-maintaining connection on
+              // the screen where the operator picks their auth method is the
+              // same defect this branch removed from the connections screen:
+              // the deck is wrong here and the server is right. The expiry is
+              // stated instead, because that is the thing that will actually
+              // happen to them.
+              body="You approve the connection on a WPMgr page and the client stores the token it is issued. Nothing secret is ever shown to you or pasted anywhere. That token does not refresh itself, so the connection stops working when it expires."
               recommendation={recommendationFor("oauth", client.name, methods)}
               availability={client.auth.oauth}
               selected={method === "oauth"}

--- a/apps/web/src/features/ai-connections/connection-contract.tsx
+++ b/apps/web/src/features/ai-connections/connection-contract.tsx
@@ -1,0 +1,126 @@
+import { Check, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// THE CAN / CANNOT CONTRACT (design step 1).
+//
+// This is the block an operator reads while deciding whether to trust an AI
+// client with their fleet, and until now it was one clause -- "It cannot change
+// anything." -- standing in for four distinct limits. The mechanism was built;
+// the sentence explaining it was not, so the thing that makes this safe was
+// invisible on the one screen where it decides something.
+//
+// EVERY LINE HERE IS TRUE OF THE SHIPPED SYSTEM. That is the only rule this
+// file has, and it is the one that is easy to break on a later fidelity pass.
+// The design deck also draws a "propose changes" capability and a "Produce a
+// change set for you to review" line. Neither exists:
+// apps/api/internal/mcp/policy.go's vocabulary is eight capability names and
+// every one of them ends in `.read`, and the m131 CHECK admits only those
+// eight, so no grant can be minted holding a propose capability. Copying those
+// two strings off the deck would put a capability claim on this screen that the
+// server would refuse -- which is worse than saying nothing, because an
+// operator reading it would calibrate their trust against a feature that does
+// not exist. connection-contract.test.tsx fails if either reappears.
+//
+// The NEGATIVE half is not softened for the same reason, pointing the other
+// way: "it cannot approve or apply anything by itself" is true today and is the
+// entire point of the screen.
+
+/** Heading over the positive half. Asserted verbatim by the tests. */
+export const CONTRACT_CAN_HEADING = "What a connection can do";
+
+/** Heading over the negative half. Asserted verbatim by the tests. */
+export const CONTRACT_CANNOT_HEADING = "What it can never do";
+
+/**
+ * The lead sentence.
+ *
+ * The second sentence is the load-bearing half: it is what tells an operator
+ * that an unstated permission is not a granted one. The deck's version of the
+ * first sentence claims the connection can "propose changes to the sites you
+ * name"; that clause is cut, because it is not true (see the file comment).
+ */
+export const CONTRACT_LEAD =
+  "A connection lets one AI client read your fleet, limited to the sites you name. " +
+  "Nothing about it is implicit.";
+
+export const CONTRACT_CAN: readonly string[] = [
+  "Read the sites you put in its scope",
+  "Report what it found, with its sources",
+];
+
+export const CONTRACT_CANNOT: readonly string[] = [
+  "Approve its own change",
+  "Reach a site outside its scope",
+  "Run PHP, WP-CLI, a shell, or open a file path of its choosing",
+  // The deck writes this as one clause joined by an em dash. Split into two
+  // sentences: this repository ships no em or en dashes in copy, and the words
+  // are what matter.
+  "Be granted a “skip approval” setting. There isn’t one.",
+];
+
+/**
+ * Copy that must never appear on this screen, exported so the guard test and
+ * the reason for the guard live in the same place as the copy it guards.
+ *
+ * A future pass that "restores fidelity to the deck" is exactly the thing that
+ * would re-add these, which is why the list is here rather than in the test.
+ */
+export const CONTRACT_FORBIDDEN: readonly string[] = [
+  "Produce a change set for you to review",
+  "propose",
+];
+
+export function ConnectionContract({ className }: { className?: string }) {
+  return (
+    <section
+      aria-label="What a connection can and cannot do"
+      data-testid="connection-contract"
+      className={cn("space-y-3", className)}
+    >
+      <p className="text-sm text-[var(--color-muted-foreground)]">{CONTRACT_LEAD}</p>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="rounded-lg border border-[var(--color-border)] p-4">
+          <h3 className="text-sm font-semibold text-[var(--color-foreground)]">
+            {CONTRACT_CAN_HEADING}
+          </h3>
+          <ul className="mt-2 space-y-1.5">
+            {CONTRACT_CAN.map((line) => (
+              <li key={line} className="flex items-start gap-2 text-sm">
+                <Check
+                  aria-hidden="true"
+                  strokeWidth={2}
+                  className="mt-0.5 size-4 shrink-0 text-[var(--color-success)]"
+                />
+                <span className="text-[var(--color-foreground)]">{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* THE NEGATIVE HALF IS GIVEN EQUAL WEIGHT, not a quieter footnote.
+            Four limits, each stated on its own, because "it cannot change
+            anything" collapses four different guarantees into one sentence an
+            operator has to take on faith. */}
+        <div className="rounded-lg border border-[var(--color-border)] p-4">
+          <h3 className="text-sm font-semibold text-[var(--color-foreground)]">
+            {CONTRACT_CANNOT_HEADING}
+          </h3>
+          <ul className="mt-2 space-y-1.5">
+            {CONTRACT_CANNOT.map((line) => (
+              <li key={line} className="flex items-start gap-2 text-sm">
+                <X
+                  aria-hidden="true"
+                  strokeWidth={2}
+                  className="mt-0.5 size-4 shrink-0 text-[var(--color-destructive)]"
+                />
+                <span className="text-[var(--color-foreground)]">{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/ai-connections/connections-list.test.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.test.tsx
@@ -35,7 +35,7 @@ const CONNECTED: AiConnection = {
 };
 
 /** The copy that must never appear over a failure. */
-const EMPTY_CLAIM = /no ai clients are connected/i;
+const EMPTY_CLAIM = /you have no ai connections/i;
 
 function renderList(state: ConnectionsState) {
   return renderWithProviders(<ConnectionsList state={state} />, { withRouter: true });
@@ -112,16 +112,19 @@ describe("ConnectionsList renders each state as a different thing", () => {
     expect(screen.queryByText(/could not load/i)).not.toBeInTheDocument();
   });
 
-  it("tells the truth in the empty state: read, limited to scoped sites, and nothing more", async () => {
-    // Nothing in the product can propose anything (no proposal table, no
-    // approval queue, no approval screen anywhere in the route tree). This
-    // used to say "It can propose changes, and it can never approve them" --
-    // a false capability claim.
+  it("claims no capability in the empty state, and does not restate the contract", async () => {
+    // Nothing in the product can propose anything: policy.go's vocabulary is
+    // eight capability names and every one ends in `.read`, so there is no
+    // propose capability to claim. This copy used to carry its own short
+    // version of the can/cannot contract; the full contract now renders above
+    // this list (features/ai-connections/connection-contract.tsx), and a
+    // shorter second version underneath it is how the two drift apart.
     renderList({ status: "empty" });
-    const copy = await screen.findByText(/connect one and it can read your fleet/i);
-    expect(copy).toHaveTextContent(/limited to the sites you scope it to/i);
-    expect(copy).toHaveTextContent(/it cannot change anything/i);
-    expect(copy).not.toHaveTextContent(/propose/i);
+    expect(await screen.findByText(EMPTY_CLAIM)).toBeInTheDocument();
+    expect(
+      screen.getByText(/any connection you create is held to the limits stated on this page/i),
+    ).toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toMatch(/propose/i);
   });
 
   it("renders 'we cannot list these yet' as neither empty nor error", async () => {

--- a/apps/web/src/features/ai-connections/connections-list.tsx
+++ b/apps/web/src/features/ai-connections/connections-list.tsx
@@ -133,11 +133,13 @@ export function ConnectionsList({
         />
         <div className="space-y-1">
           <p className="text-sm font-medium text-[var(--color-foreground)]">
-            No AI clients are connected
+            You have no AI connections
           </p>
+          {/* WHAT A CONNECTION CAN AND CANNOT DO IS NOT REPEATED HERE. It is
+              stated once, in full, by ConnectionContract above this list, and a
+              shorter second version underneath it is how the two drift apart. */}
           <p className="text-sm text-[var(--color-muted-foreground)]">
-            Connect one and it can read your fleet, limited to the sites you scope it to. It cannot
-            change anything.
+            Any connection you create is held to the limits stated on this page.
           </p>
         </div>
         {connectAction}

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor, fireEvent } from "@testing-library/react";
 
-import { renderWithProviders } from "@/test/render";
+import type { QueryClient } from "@tanstack/react-query";
+
+import { createTestQueryClient, renderWithProviders } from "@/test/render";
+import { authKeys } from "@/features/auth/use-auth";
 
 import { Route } from "./index";
 import { MCP_TRANSPORT_PATH } from "@/features/ai-connections/client-table";
@@ -38,6 +41,34 @@ function urlOf(input: RequestInfo | URL): string {
   return input.url;
 }
 
+// The role this page's principal holds, per test. Owner/admin is the default
+// because it is the principal every pre-existing test here was written against;
+// the role-refused tests set it explicitly.
+//
+// SEEDED INTO THE QUERY CACHE, NOT MOCKED AT THE HOOK. `vi.mock("use-auth")`
+// would stub out canManage itself, and canManage is the thing under test: it
+// does more than read a role string, it also requires the active tenant to
+// appear in me.memberships, which is how a site-scoped collaborator is refused.
+// Seeding authKeys.me runs the real useMe and the real canManage over a real Me
+// shape. It is not stubbed at fetch like the connections list next door because
+// useMe goes through the generated client rather than raw fetch, and the
+// generated client does not read the vi.stubGlobal'd fetch.
+let meRole: "owner" | "admin" | "operator" | "viewer" = "admin";
+
+const TENANT = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+function seedMe(queryClient: QueryClient) {
+  queryClient.setQueryData(authKeys.me, {
+    id: "user-1",
+    email: "priya@example.test",
+    name: "Priya",
+    scope: "org",
+    role: meRole,
+    active_tenant_id: TENANT,
+    memberships: [{ tenant_id: TENANT, role: meRole, tenant_name: "Example" }],
+  });
+}
+
 function stubFetch(impl: (url: string) => Response | Promise<Response>) {
   vi.stubGlobal(
     "fetch",
@@ -53,7 +84,13 @@ function json(body: unknown, status = 200): Response {
 }
 
 function renderPage() {
-  return renderWithProviders(<AiPage />, { withRouter: true, initialPath: "/ai" });
+  const queryClient = createTestQueryClient();
+  seedMe(queryClient);
+  return renderWithProviders(<AiPage />, {
+    withRouter: true,
+    initialPath: "/ai",
+    queryClient,
+  });
 }
 
 const ROW = {
@@ -71,7 +108,10 @@ const ROW = {
   capabilities: ["mcp.sites.read"],
 };
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  meRole = "admin";
+});
 afterEach(() => vi.unstubAllGlobals());
 
 describe("/ai reads the real connections endpoint", () => {
@@ -102,7 +142,7 @@ describe("/ai reads the real connections endpoint", () => {
     stubFetch(() => json({ code: "internal", message: "the server said 500" }, 500));
     renderPage();
     expect(await screen.findByText(/could not load your ai connections/i)).toBeInTheDocument();
-    expect(screen.queryByText(/no ai clients are connected/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/you have no ai connections/i)).not.toBeInTheDocument();
     expect(screen.queryByTestId("connections-empty")).not.toBeInTheDocument();
   });
 
@@ -161,26 +201,124 @@ describe("/ai's static surfaces", () => {
     ).toBeInTheDocument();
   });
 
-  it("tells the truth about what a connection can do: read, scoped to sites, nothing else", async () => {
-    // Nothing in the product can propose anything (no proposal table, no
-    // approval queue, no approval screen anywhere in the route tree). The
-    // subline used to say "It can propose changes; it can never approve
-    // them." -- a false capability claim. It must now say only what is true.
-    renderPage();
-    const subline = await screen.findByText(
-      /let an ai client read your fleet through one endpoint/i,
-    );
-    expect(subline).toHaveTextContent(/limited to the sites you scope it to/i);
-    expect(subline).toHaveTextContent(/it cannot change anything/i);
-    expect(subline).not.toHaveTextContent(/propose/i);
-  });
-
   it("offers a route into the wizard, which is how that page is reached at all", async () => {
     renderPage();
     await screen.findByTestId("connections-empty");
-    const links = await screen.findAllByRole("link", { name: /connect an ai client/i });
+    const links = await screen.findAllByRole("link", { name: /new connection/i });
     expect(links.length).toBeGreaterThanOrEqual(1);
     expect(links[0]).toHaveAttribute("href", "/ai/connect");
+  });
+});
+
+// THE CAN/CANNOT CONTRACT.
+//
+// Every assertion below is on the EXACT string, not on "something rendered".
+// The defect this whole block exists over is missing words -- four distinct
+// limits collapsed into "It cannot change anything." -- so the words are what
+// has to be pinned. A getByRole("heading") or a /cannot/i regex would survive
+// the collapse happening again.
+describe("what a connection can and cannot do", () => {
+  beforeEach(() => stubFetch(() => json({ connections: [] })));
+
+  it("states the lead, and states that nothing is implicit", async () => {
+    renderPage();
+    expect(
+      await screen.findByText(
+        "A connection lets one AI client read your fleet, limited to the sites you name. " +
+          "Nothing about it is implicit.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("names what a connection can do, in full", async () => {
+    renderPage();
+    expect(await screen.findByText("What a connection can do")).toBeInTheDocument();
+    expect(screen.getByText("Read the sites you put in its scope")).toBeInTheDocument();
+    expect(screen.getByText("Report what it found, with its sources")).toBeInTheDocument();
+  });
+
+  it("names all four things it can never do, each on its own", async () => {
+    // Four separate limits, four separate assertions. Asserting the block
+    // renders would pass with three of them deleted, which is the state this
+    // page shipped in.
+    renderPage();
+    expect(await screen.findByText("What it can never do")).toBeInTheDocument();
+    expect(screen.getByText("Approve its own change")).toBeInTheDocument();
+    expect(screen.getByText("Reach a site outside its scope")).toBeInTheDocument();
+    expect(
+      screen.getByText("Run PHP, WP-CLI, a shell, or open a file path of its choosing"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Be granted a “skip approval” setting. There isn’t one."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the contract for a principal who cannot create connections", async () => {
+    // The contract is a statement about the system, not about the reader, so
+    // it does not disappear with the button.
+    meRole = "viewer";
+    renderPage();
+    expect(await screen.findByText("What it can never do")).toBeInTheDocument();
+    expect(screen.getByText("What a connection can do")).toBeInTheDocument();
+  });
+
+  it("claims no capability the server does not have", async () => {
+    // THE GUARD AGAINST A FIDELITY PASS. The design deck draws a "propose
+    // changes" capability and a "Produce a change set for you to review" line.
+    // apps/api/internal/mcp/policy.go's vocabulary is eight names and every one
+    // ends in `.read`; m131's CHECK admits only those eight, so no grant can
+    // hold a propose capability and no screen may imply one. Restoring either
+    // string off the deck turns this red.
+    renderPage();
+    await screen.findByText("What a connection can do");
+    expect(screen.queryByText(/produce a change set/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/propose/i)).not.toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toMatch(/propose/i);
+  });
+});
+
+// THE ROLE-REFUSED STATE.
+//
+// Gate confirmed against the server before it was written, not assumed:
+// apps/api/internal/mcp/handler.go:172 mounts POST /mcp/connections behind
+// authz.RequirePermission(authz.PermAPIKeyManage), and
+// apps/api/internal/authz/role.go:241 maps PermAPIKeyManage to RoleAdmin.
+describe("who may create a connection", () => {
+  beforeEach(() => stubFetch(() => json({ connections: [] })));
+
+  it("offers the button to an owner", async () => {
+    meRole = "owner";
+    renderPage();
+    expect(
+      await screen.findByRole("link", { name: /new connection/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers the button to an admin", async () => {
+    meRole = "admin";
+    renderPage();
+    expect(
+      await screen.findByRole("link", { name: /new connection/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no create button to an operator, and says why", async () => {
+    // A button that can only ever 403 spends the operator's trust when they
+    // press it. It is absent, with the reason written where it was.
+    meRole = "operator";
+    renderPage();
+    await screen.findByTestId("connections-empty");
+    expect(screen.queryByRole("link", { name: /new connection/i })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/creating a connection needs an organisation owner or admin/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no create button to a viewer", async () => {
+    meRole = "viewer";
+    renderPage();
+    await screen.findByTestId("connections-empty");
+    expect(screen.queryByRole("link", { name: /new connection/i })).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/routes/_authed/ai/-index.test.tsx
+++ b/apps/web/src/routes/_authed/ai/-index.test.tsx
@@ -286,20 +286,25 @@ describe("what a connection can and cannot do", () => {
 describe("who may create a connection", () => {
   beforeEach(() => stubFetch(() => json({ connections: [] })));
 
+  // PLURAL, DELIBERATELY. This page renders TWO "New connection" links once the
+  // list settles: the header action and the empty state's own. A singular
+  // findByRole passed here, but only because it resolves on the first poll --
+  // while the list is still a skeleton and only the header link exists -- and
+  // would start throwing "found multiple elements" the moment anything made the
+  // empty state paint sooner. An assertion that depends on which of two
+  // renders wins is not pinning the thing it names. Caught in review on #681.
   it("offers the button to an owner", async () => {
     meRole = "owner";
     renderPage();
-    expect(
-      await screen.findByRole("link", { name: /new connection/i }),
-    ).toBeInTheDocument();
+    await screen.findByTestId("connections-empty");
+    expect(screen.getAllByRole("link", { name: /new connection/i }).length).toBeGreaterThan(0);
   });
 
   it("offers the button to an admin", async () => {
     meRole = "admin";
     renderPage();
-    expect(
-      await screen.findByRole("link", { name: /new connection/i }),
-    ).toBeInTheDocument();
+    await screen.findByTestId("connections-empty");
+    expect(screen.getAllByRole("link", { name: /new connection/i }).length).toBeGreaterThan(0);
   });
 
   it("shows no create button to an operator, and says why", async () => {

--- a/apps/web/src/routes/_authed/ai/connect.tsx
+++ b/apps/web/src/routes/_authed/ai/connect.tsx
@@ -64,8 +64,12 @@ function ConnectAiClientPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Connect an AI client"
-        subline="Pick your client first. Everything after that is computed from it, because the setup differs per client in ways that fail quietly."
+        // ONE NAME PER THING. "AI connections" is the settings screen, "New
+        // connection" is the button that arrives here, and this is the
+        // wizard's own heading. It used to repeat the button's old wording,
+        // which made the button and the page it opened look like two features.
+        title="Add an AI connection"
+        subline="Nothing is created yet. This is a wizard, not a draft row. Pick your client first: everything after that is computed from it, because the setup differs per client in ways that fail quietly."
         backTo={{ to: "/ai", label: "AI connections" }}
       />
       <ConnectWizard

--- a/apps/web/src/routes/_authed/ai/connect.tsx
+++ b/apps/web/src/routes/_authed/ai/connect.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { PageHeader } from "@/components/shared/page-header";
+import { canManage, useMe } from "@/features/auth/use-auth";
 import { ConnectWizard } from "@/features/ai-connections/connect-wizard";
 import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
 import {
@@ -28,6 +29,21 @@ export const Route = createFileRoute("/_authed/ai/connect")({
 });
 
 function ConnectAiClientPage() {
+  // THE GATE IS ON THE DESTINATION, NOT ONLY ON THE LINK. /ai hides the "New
+  // connection" button from a principal who cannot mint, and hiding a link is
+  // not a guard: this route has no beforeLoad, so anyone authenticated who
+  // typed the URL, followed a bookmark, or was sent one reached the whole
+  // wizard. They would pick a client, choose an auth method, scope the sites,
+  // press the last button, and collect a 403 from
+  // apps/api/internal/mcp/handler.go:172 -- after doing all of the work. The
+  // refusal has to arrive before the work, which means here.
+  //
+  // THE SAME PREDICATE, NOT A SECOND ONE. canManage is what /ai uses for the
+  // button, and it mirrors authz.minRoleFor's RoleAdmin for PermAPIKeyManage
+  // (apps/api/internal/authz/role.go:241). A second predicate written to match
+  // would drift from the first, and the drift would be silent until one of the
+  // two was the wrong one.
+  const { data: me } = useMe();
   const sitesQuery = useSites({ view: "active" });
   const tagsQuery = useTags();
 
@@ -60,6 +76,29 @@ function ConnectAiClientPage() {
     if (tagsQuery.data === undefined) return null;
     return tagsQuery.data.map((t) => ({ id: t.id, name: t.name }));
   }, [tagsQuery.data]);
+
+  // AFTER EVERY HOOK ABOVE, NEVER BEFORE ONE. An early return placed higher
+  // would make the hooks below it conditional, which React forbids.
+  if (!canManage(me)) {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title="Add an AI connection"
+          subline="Creating a connection needs an organisation owner or admin."
+          backTo={{ to: "/ai", label: "AI connections" }}
+        />
+        <p
+          role="status"
+          data-testid="connect-role-refused"
+          className="rounded-lg border border-[var(--color-border)] p-6 text-sm text-[var(--color-foreground)]"
+        >
+          Nothing has been created and nothing was attempted. Saying so here rather than at the
+          last button is the point: the wizard would have taken a client, an authentication method
+          and a list of sites from you before the server refused it.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/routes/_authed/ai/index.tsx
+++ b/apps/web/src/routes/_authed/ai/index.tsx
@@ -7,7 +7,9 @@ import { Button } from "@/components/ui/button";
 import { CopyableMono } from "@/components/shared/copyable-mono";
 import { DestructiveConfirm } from "@/components/dialogs/destructive-confirm";
 import { ConnectionsList } from "@/features/ai-connections/connections-list";
+import { ConnectionContract } from "@/features/ai-connections/connection-contract";
 import { mcpEndpointUrl } from "@/features/ai-connections/endpoint";
+import { canManage, useMe } from "@/features/auth/use-auth";
 import {
   PROTOCOL_FLOOR_VERSION,
   PROTOCOL_TARGET_VERSION,
@@ -48,6 +50,33 @@ function AiConnectionsPage() {
   const revoke = useRevokeConnection();
   const [pending, setPending] = useState<AiConnection | null>(null);
 
+  // THE ROLE-REFUSED STATE. Minting a connection is gated server-side by
+  // authz.PermAPIKeyManage (apps/api/internal/mcp/handler.go:172, and the same
+  // permission on revoke at :175), and authz.minRoleFor maps that permission to
+  // RoleAdmin (apps/api/internal/authz/role.go:241). `canManage` is owner-or-
+  // admin plus an org-scope check, which is the same principal set stated on
+  // this side. A principal without it gets a button that can only ever 403, so
+  // it is not rendered.
+  //
+  // WHAT THIS STATE IS NOT, and the reason is worth writing down: the design
+  // deck describes a role that can LIST connections but not create them. No
+  // such role exists here. PermAPIKeyRead is also RoleAdmin
+  // (role.go:241, the line above PermAPIKeyManage), so the two permissions
+  // resolve to exactly the same set of principals and anyone who cannot mint
+  // also cannot list. What a Member actually sees on this page is the contract
+  // below -- which is static and true for everyone -- and the list's own 403
+  // explanation, which ConnectionsList already renders as a refusal rather than
+  // as an empty organisation. The button is hidden on the honest gate, not on a
+  // read/manage split this product does not have.
+  const { data: me } = useMe();
+  const mayCreate = canManage(me);
+
+  const newConnectionButton = mayCreate ? (
+    <Button asChild>
+      <Link to="/ai/connect">New connection</Link>
+    </Button>
+  ) : null;
+
   // The mapping that decides which sentence is shown, in one tested place.
   // `connections ?? []` is precisely what this function exists to forbid: a
   // failed load must not render as "you have no AI connections", which is a
@@ -66,13 +95,23 @@ function AiConnectionsPage() {
     <div className="space-y-6">
       <PageHeader
         title="AI connections"
-        subline="Let an AI client read your fleet through one endpoint, limited to the sites you scope it to. It cannot change anything."
-        actions={
-          <Button asChild>
-            <Link to="/ai/connect">Connect an AI client</Link>
-          </Button>
-        }
+        subline="One endpoint, one client, the sites you scope it to."
+        actions={newConnectionButton}
       />
+
+      {/* THE CONTRACT SITS ABOVE EVERYTHING, INCLUDING THE LIST. It is not an
+          empty-state decoration: an operator with six connections already is
+          the reader most likely to be adding a seventh without re-reading what
+          one is allowed to do. It renders for every role, because it is a
+          statement about the system rather than about the reader. */}
+      <ConnectionContract />
+
+      {mayCreate ? null : (
+        <p className="text-sm text-[var(--color-muted-foreground)]">
+          Creating a connection needs an organisation owner or admin. What is written above is
+          what every connection in this organisation is held to, whoever created it.
+        </p>
+      )}
 
       <section aria-label="Endpoint" className="space-y-2">
         <h2 className="text-sm font-semibold text-[var(--color-foreground)]">Your endpoint</h2>
@@ -99,9 +138,11 @@ function AiConnectionsPage() {
           revokingId={revoke.isPending ? (pending?.id ?? null) : null}
           onRevoke={(c) => setPending(c)}
           connectAction={
-            <Button asChild variant="outline" size="sm">
-              <Link to="/ai/connect">Connect an AI client</Link>
-            </Button>
+            mayCreate ? (
+              <Button asChild variant="outline" size="sm">
+                <Link to="/ai/connect">New connection</Link>
+              </Button>
+            ) : null
           }
         />
       </section>


### PR DESCRIPTION
Items 1 and 2 of the connection-wizard build order. Copy-level in `apps/web`, no backend, no new route.

## Item 1: the can/cannot contract

The screen where an operator decides whether to trust an AI client with their fleet was missing both halves of the argument. Before this branch:

```
$ grep -rl "What a connection can do" apps/web/src   → 0 files
$ grep -rl "What it can never do"     apps/web/src   → 0 files
$ grep -rl "Approve its own change"   apps/web/src   → 0 files
```

Four distinct guarantees were standing behind one clause, "It cannot change anything." All six lines now render on `/ai`, above the list rather than inside the empty state: an operator with six connections is the reader most likely to be adding a seventh without re-reading what one is allowed to do.

**Nothing claims a capability the server does not have.** The design deck also draws a propose capability and a "Produce a change set for you to review" line. `apps/api/internal/mcp/policy.go`'s vocabulary is eight names and every one ends in `.read`; m131's CHECK admits only those eight, so no grant can hold one. A test turns red if either string comes back.

## Item 1: the role-refused state

Minting is gated by `PermAPIKeyManage` (`apps/api/internal/mcp/handler.go:172`), which `authz.minRoleFor` maps to `RoleAdmin` (`apps/api/internal/authz/role.go:241`). `canManage` is owner-or-admin plus an org-scope check, which is the same principal set stated on this side, so a principal without it gets no create button and the reason instead of a control that can only 403.

**The design's R state is not literally reachable and the code says so.** It describes a role that can list connections but not create them. `PermAPIKeyRead` is `RoleAdmin` too (`role.go:241`, one line above `PermAPIKeyManage`), so the two permissions resolve to the same set and anyone who cannot mint also cannot list. What a non-admin actually sees is the contract, which is static and true for everyone, plus the list's own 403 explanation. The button hides on the honest gate, not on a read/manage split this product does not have.

## Item 2: the sign-in step, copy only

No step added, renamed or renumbered. The shipped rail keeps the numbers it has.

- Both auth cards now say what the method actually does: what gets shown to you, and where the secret lives.
- Recommendation badges, derived from the client table by `recommendationFor` rather than written per client, so the next client added gets one without anyone remembering to. One available method reads "The only route for this client" rather than a recommendation.
- The missing reason there is no third card. Without it, a disabled browser card on a headless client reads as an oversight and the connection token reads as our fallback. The date renders from `CLIENT_TABLE_VERIFIED_AT`, so the paragraph goes stale visibly.
- The wizard heading was the old button's wording, which made the button and the page it opens look like two features.

## Guards

Every restored block was mutation-tested: planted the real regression, watched a named test go red, restored, watched it go green. Assertions are on exact strings, because the defect class here is missing words.

- Deleting "Approve its own change" → red, naming the missing text.
- Re-adding "Produce a change set for you to review" → red on the no-false-capability guard.
- Gutting the device-code paragraph → red, naming the missing sentence.

## Gates

```
$ pnpm -C apps/web typecheck    clean
$ pnpm -C apps/web lint         0 errors, 14 warnings (all pre-existing)
$ pnpm -C apps/web test         168 files, 2175 tests, all passed
$ pnpm -C apps/web build        built in 5.53s; routeTree.gen.ts unchanged (no new route)
$ impeccable detect apps/web/src  1 anti-pattern, in sidebar.tsx, untouched by this branch
```

Not in this branch, and named rather than half-done: the ten-segment stepper, and the step-derivation bug at `connect-wizard.tsx` where `step` can never reach 4. See the review notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear connection contract outlining what AI connections can and cannot do.
  * Added authentication guidance, method recommendations, and explanations for unavailable sign-in options.
  * Added role-based controls for creating new AI connections, with guidance for users without access.

* **Improvements**
  * Updated AI connection and setup-page wording for clarity.
  * Improved the empty state to direct users to the connection limits and use consistent terminology.

* **Tests**
  * Expanded coverage for authentication guidance, connection contracts, route behavior, permissions, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->