### PR TITLE
fix(web): three conformance defects in AI connection wizard

### DIFF
--- a/apps/web/src/features/ai-connections/client-table.ts
+++ b/apps/web/src/features/ai-connections/client-table.ts
@@ -126,7 +126,26 @@ export interface RawConfigShape {
   readonly reason: string;
 }
 
-export type ConfigShape = JsonConfigShape | GuiConfigShape | RawConfigShape;
+/**
+ * A client set up by running a command in a shell, not by editing a file or a
+ * GUI field.
+ *
+ * TOKEN AUTH HERE NEVER PUTS THE TOKEN IN THE COMMAND TEXT. A bearer
+ * credential typed or pasted as a shell argument is written to the shell
+ * history file in plain text and stays there, readable by anything that can
+ * read that file, for as long as the credential is valid. The generator
+ * (snippet.ts) reads the token interactively with `read -rs` -- never an
+ * argument, never echoed -- into `$WPMGR_CONNECTION_TOKEN` and references
+ * that variable rather than the value, so the value itself never appears in
+ * generated text at all.
+ */
+export interface ShellConfigShape {
+  readonly kind: "shell";
+  /** Rendered beside the block: why this client is set up by command rather than by file. */
+  readonly reason: string;
+}
+
+export type ConfigShape = JsonConfigShape | GuiConfigShape | RawConfigShape | ShellConfigShape;
 
 /**
  * A POSIX config file location.

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -376,6 +376,72 @@ describe("the step rail names all ten specified steps and marks the right one cu
       expect(el).not.toHaveAttribute("aria-current", "step");
     }
   });
+
+  // ---------------------------------------------------------------------------
+  // Greptile P1 on connect-wizard.tsx:589 (pre-fix). Completion here used to be
+  // pure position: once client and method were picked, site selection read
+  // completed and setup read current REGARDLESS of whether the fleet/tag read
+  // that step depends on had actually come back. Loading and failed are
+  // covered separately -- collapsing them into one appearance is the same
+  // defect shape the finding names, one level down.
+  // ---------------------------------------------------------------------------
+
+  it("does not mark site selection completed or setup current while the fleet read is still loading", async () => {
+    mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined, isPending: true }));
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+
+    const siteStep = document.querySelector('[data-step-n="3"]');
+    const setupStep = document.querySelector('[data-step-n="6"]');
+    // NOT "completed": the read behind this step has not resolved, whatever
+    // position the operator has otherwise reached.
+    expect(siteStep).toHaveAttribute("data-step-state", "loading");
+    expect(siteStep).toHaveTextContent(/\(loading\)/i);
+    // NOT "current" either -- setup is not the furthest ACTUAL step while the
+    // step behind it is unresolved, and the assistive-tech state has to agree:
+    // aria-current stays off setup and lands on the step still in progress.
+    expect(setupStep).not.toHaveAttribute("data-step-state", "current");
+    expect(setupStep).not.toHaveAttribute("aria-current", "step");
+    expect(siteStep).toHaveAttribute("aria-current", "step");
+  });
+
+  it("shows the fleet read as failed, distinctly from loading, and still refuses completion", async () => {
+    mockedSites.mockReturnValue(
+      mockQueryResult<Site[]>({ data: undefined, isPending: false, isError: true }),
+    );
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+
+    const siteStep = document.querySelector('[data-step-n="3"]');
+    const setupStep = document.querySelector('[data-step-n="6"]');
+    // A DIFFERENT STATE FROM LOADING, NOT THE SAME ONE RELABELLED. An operator
+    // told "loading" for a read that already failed keeps waiting for a state
+    // that will never arrive.
+    expect(siteStep).toHaveAttribute("data-step-state", "failed");
+    expect(siteStep).toHaveTextContent(/\(failed to load\)/i);
+    expect(siteStep).not.toHaveTextContent(/\(loading\)/i);
+    expect(setupStep).not.toHaveAttribute("data-step-state", "current");
+    expect(setupStep).not.toHaveAttribute("aria-current", "step");
+  });
+
+  it("still marks site selection completed and setup current once the read actually resolves", async () => {
+    // THE OVER-FIRE CASE. The fix must not hold the rail behind a resolved
+    // read out of over-caution -- that would just move the false state from
+    // "prematurely done" to "permanently stuck."
+    loadedFleet(3);
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+
+    expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
+    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+  });
 });
 
 describe("the method step is computed from the client, with the reason on the card", () => {

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -285,6 +285,99 @@ describe("the auth cards say what each method actually does", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// The step rail: aria-current placement (defect 2) and the ten specified
+// steps (defect 3, design S29 "ADD MCP CONNECTION: THE TEN STEPS").
+// ---------------------------------------------------------------------------
+
+/** The single element the rail marks as the operator's current step. */
+function currentRailStep(): HTMLElement {
+  const els = document.querySelectorAll('[data-step-state="current"]');
+  // Never zero, and never more than one: a rail agreeing with itself about
+  // where the operator is is the entire point of aria-current.
+  expect(els).toHaveLength(1);
+  const el = els[0];
+  if (!(el instanceof HTMLElement)) throw new Error("current step element is not an HTMLElement");
+  return el;
+}
+
+describe("the step rail names all ten specified steps and marks the right one current", () => {
+  it("renders all ten specified steps, in specified order, with only four built", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+
+    const segments = Array.from(document.querySelectorAll<HTMLElement>("[data-step-n]"));
+    expect(segments.map((s) => s.dataset.stepN)).toEqual(
+      Array.from({ length: 10 }, (_, i) => String(i + 1)),
+    );
+    const builtNs = segments.filter((s) => s.dataset.stepState !== "not-built").map((s) => s.dataset.stepN);
+    // The four shipped sections, and no others, are ever built.
+    expect(builtNs.sort()).toEqual(["2", "3", "5", "6"]);
+  });
+
+  it("marks specified step 2 current before any client is picked", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+    expect(currentRailStep()).toHaveTextContent(/^2\. Name it, pick the AI client$/);
+  });
+
+  it("marks specified step 5 current once a client is picked and no method chosen", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+    expect(currentRailStep()).toHaveTextContent(/^5\. Choose how it authenticates$/);
+    // The rail agrees this is later than step 2, not merely different from it.
+    expect(document.querySelector('[data-step-n="2"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
+  });
+
+  it("marks specified step 6 current once client and method are both picked -- THE DEFECT 2 FIX", async () => {
+    // Sections 3 ("Sites this connection may reach") and 4 ("Set it up") in
+    // this file share one reveal condition and always appear together, so by
+    // the time an operator can see either, step 6 (setup) is the furthest one
+    // actually revealed. Before the fix, aria-current stuck at the position
+    // in the shipped array (3), one behind reality.
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+  });
+
+  it("shows specified step 3 as passed, not merely unreached, once step 6 is current", async () => {
+    // THE NON-MONOTONIC CASE. Step 3 (site scope, specified number 3) is
+    // visited on screen AFTER step 5 (auth method, specified number 5) in
+    // this wizard, so a rail that compared raw specified numbers would call
+    // step 5 "incomplete" the moment the operator reached step 3, which is
+    // backwards. Both must read as completed once step 6 is current.
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+    expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
+    expect(document.querySelector('[data-step-n="5"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
+  });
+
+  it("never marks an unbuilt step current or completed, at any reachable stage -- NO FAKED PROGRESS", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+
+    for (const n of ["1", "4", "7", "8", "9", "10"]) {
+      const el = document.querySelector(`[data-step-n="${n}"]`);
+      expect(el).toHaveAttribute("data-step-state", "not-built");
+      expect(el).not.toHaveAttribute("aria-current", "step");
+    }
+  });
+});
+
 describe("the method step is computed from the client, with the reason on the card", () => {
   it("disables the token method for Claude Desktop and says exactly why", async () => {
     renderWizard();

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -397,10 +397,13 @@ describe("the step rail names all ten specified steps and marks the right one cu
   // ---------------------------------------------------------------------------
 
   it("does not mark site selection completed or setup current while the fleet read is still loading", async () => {
+    // THE TOKEN COLUMN: a mint button exists here for the unresolved read to
+    // block. OAuth's mirror image ("does not drag the rail back for OAuth...
+    // loading") is below, and deliberately asserts the opposite.
     mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined, isPending: true }));
     renderWizard();
     await pickClient("Cursor");
-    fireEvent.click(authCard("oauth"));
+    fireEvent.click(authCard("token"));
 
     const siteStep = document.querySelector('[data-step-n="3"]');
     const setupStep = document.querySelector('[data-step-n="6"]');
@@ -417,12 +420,13 @@ describe("the step rail names all ten specified steps and marks the right one cu
   });
 
   it("shows the fleet read as failed, distinctly from loading, and still refuses completion", async () => {
+    // THE TOKEN COLUMN, see the comment on the loading test above.
     mockedSites.mockReturnValue(
       mockQueryResult<Site[]>({ data: undefined, isPending: false, isError: true }),
     );
     renderWizard();
     await pickClient("Cursor");
-    fireEvent.click(authCard("oauth"));
+    fireEvent.click(authCard("token"));
 
     const siteStep = document.querySelector('[data-step-n="3"]');
     const setupStep = document.querySelector('[data-step-n="6"]');
@@ -486,6 +490,100 @@ describe("the step rail names all ten specified steps and marks the right one cu
     expect(siteStep).toHaveTextContent(/\(tags still loading\)/i);
     expect(setupStep).not.toHaveAttribute("data-step-state", "current");
     expect(setupStep).not.toHaveAttribute("aria-current", "step");
+  });
+
+  it("holds the rail back on the token path when nothing has been selected yet", async () => {
+    // THE UNSELECTED CELL, TOKEN COLUMN. The wizard opens on mode 'list' with
+    // no sites picked -- reachable by doing nothing at all -- and
+    // mintScopeRequest refuses to mint on it ("names-nothing").
+    loadedFleet(3);
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+
+    expect(screen.getByRole("button", { name: /generate connection token/i })).toBeDisabled();
+    const siteStep = document.querySelector('[data-step-n="3"]');
+    const setupStep = document.querySelector('[data-step-n="6"]');
+    expect(siteStep).toHaveAttribute("data-step-state", "unselected");
+    expect(siteStep).toHaveTextContent(/\(not chosen yet\)/i);
+    expect(setupStep).not.toHaveAttribute("data-step-state", "current");
+    expect(setupStep).not.toHaveAttribute("aria-current", "step");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Greptile P1 on connect-wizard.tsx:639, the OVER-FIRE ARM OF THE FIX ABOVE.
+  // On the OAuth path there is no mint button to block -- step 4 renders
+  // NextSteps, never TokenMintPanel -- and the scope chosen in this wizard is
+  // rehearsal for OAuth (SiteScopeStep's own copy: "nothing carries this
+  // selection to the approval screen"). Every one of the four unresolved
+  // states must therefore leave step 6 current and step 3 completed, the same
+  // as the resolved case, because nothing downstream is actually blocked.
+  // ---------------------------------------------------------------------------
+
+  it.each([
+    [
+      "loading",
+      () => mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined, isPending: true })),
+    ],
+    [
+      "failed",
+      () =>
+        mockedSites.mockReturnValue(
+          mockQueryResult<Site[]>({ data: undefined, isPending: false, isError: true }),
+        ),
+    ],
+  ] as const)(
+    "does not drag the rail back for OAuth while the fleet read is %s",
+    async (_label, mockRead) => {
+      mockRead();
+      renderWizard();
+      await pickClient("Cursor");
+      fireEvent.click(authCard("oauth"));
+
+      expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+      expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
+        "data-step-state",
+        "completed",
+      );
+    },
+  );
+
+  it("does not drag the rail back for OAuth while the tag registry is unresolved", async () => {
+    loadedFleet(3);
+    mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: undefined, isPending: true }));
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+    fireEvent.click(screen.getByRole("radio", { name: /by tag/i }));
+    // No TokenMintPanel exists on this path to show its own "could not be
+    // resolved" copy -- the radiogroup's own selected state is the only
+    // thing to wait for before the rail is asserted against.
+    expect(screen.getByRole("radio", { name: /by tag/i })).toBeChecked();
+
+    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+    expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
+  });
+
+  it("does not drag the rail back for OAuth when nothing has been selected yet", async () => {
+    // The wizard's opening state (mode 'list', nothing picked) is
+    // "unselected" on the token path; on OAuth it must not read as anything
+    // other than complete, because there is no button here for it to block.
+    loadedFleet(3);
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+
+    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+    expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
   });
 });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -341,6 +341,11 @@ describe("the step rail names all ten specified steps and marks the right one cu
     renderWizard();
     await pickClient("Cursor");
     fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+    // A scope has to actually be chosen for step 3 to be done -- see the
+    // "unselected" tests below for why the wizard's opening state (nothing
+    // picked yet) must not itself read as complete.
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("All sites"));
     expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
   });
 
@@ -354,6 +359,11 @@ describe("the step rail names all ten specified steps and marks the right one cu
     await pickClient("Cursor");
     fireEvent.click(authCard("oauth"));
     await screen.findByTestId("site-step-count");
+    // A SCOPE IS ACTUALLY CHOSEN HERE, not left at the wizard's opening
+    // 'list'-with-nothing state -- see "does not mark site selection
+    // completed... unselected" below for why an unmade choice must not
+    // read as done either.
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("All sites"));
     expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
       "data-step-state",
       "completed",
@@ -426,21 +436,56 @@ describe("the step rail names all ten specified steps and marks the right one cu
     expect(setupStep).not.toHaveAttribute("aria-current", "step");
   });
 
-  it("still marks site selection completed and setup current once the read actually resolves", async () => {
+  it("still marks site selection completed and setup current once the read AND the selection are actually resolved", async () => {
     // THE OVER-FIRE CASE. The fix must not hold the rail behind a resolved
-    // read out of over-caution -- that would just move the false state from
-    // "prematurely done" to "permanently stuck."
+    // read, or a made selection, out of over-caution -- that would just move
+    // the false state from "prematurely done" to "permanently stuck."
     loadedFleet(3);
     renderWizard();
     await pickClient("Cursor");
     fireEvent.click(authCard("oauth"));
     await screen.findByTestId("site-step-count");
+    fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("All sites"));
 
     expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
       "data-step-state",
       "completed",
     );
     expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Greptile P1 / CodeRabbit Major on connect-wizard.tsx:268 (pre-fix), found
+  // a third time through a third door: the fleet resolves fine, but the TAG
+  // registry has not, under mode 'tags'. `scope.kind` alone read this as
+  // "resolved" -- it only ever asks about the fleet read -- while
+  // `mintScopeRequest` was refusing to mint with `tags-unresolved`. This is
+  // the SAME scenario "refuses to mint on an unresolved tag scope..." above
+  // already proves blocks the button, so the state asserted here is the real
+  // blocked-mint state, not a fixture built to merely look like it.
+  // ---------------------------------------------------------------------------
+
+  it("does not mark site selection completed while the tag registry is unresolved and mint is actually blocked", async () => {
+    loadedFleet(3);
+    mockedTags.mockReturnValue(mockQueryResult<SiteTag[]>({ data: undefined, isPending: true }));
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    fireEvent.click(screen.getByRole("radio", { name: /by tag/i }));
+
+    // PROVE THE BLOCK IS REAL FIRST. Everything below is vacuous if the
+    // button was never actually disabled.
+    expect(await screen.findByText(/tag scope could not be resolved/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /generate connection token/i })).toBeDisabled();
+
+    const siteStep = document.querySelector('[data-step-n="3"]');
+    const setupStep = document.querySelector('[data-step-n="6"]');
+    expect(siteStep).toHaveAttribute("data-step-state", "tags-unresolved");
+    expect(siteStep).not.toHaveAttribute("data-step-state", "completed");
+    expect(siteStep).toHaveTextContent(/\(tags still loading\)/i);
+    expect(setupStep).not.toHaveAttribute("data-step-state", "current");
+    expect(setupStep).not.toHaveAttribute("aria-current", "step");
   });
 });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -290,7 +290,7 @@ export function ConnectWizard({
   // selection the operator had not made yet. One function, read by both the
   // button and the rail, is what makes a fourth door impossible rather than
   // merely unlikely.
-  const siteScopeState: SiteScopeReadiness = siteScopeReadiness(scope, scopeRequest);
+  const siteScopeState: SiteScopeReadiness = siteScopeReadiness(scope, scopeRequest, method);
 
   // A mint is a network round trip, and every control above is live during it.
   // Disabling them is the FIRST half of the fix (the operator is not offered a
@@ -1088,26 +1088,74 @@ function mintScopeRequest(
 }
 
 /**
- * Whether step 3 is actually done, for every reason mint can refuse it.
+ * Whether step 3 is actually done, for every reason mint can refuse it, ON
+ * THE PATH WHERE MINT IS THE THING BEING REFUSED.
  *
- * THE ONE PLACE THIS IS DECIDED. `mintBlockedReason` below and the step rail's
- * `siteScopeState` (ConnectWizard) both call this and nothing else, so
+ * THE FULL MATRIX THIS FUNCTION ANSWERS -- auth method x site-scope state,
+ * ten cells, derived from what actually gates the setup step on each path,
+ * not from what feels right:
+ *
+ *   TOKEN.    TokenMintPanel is the only caller of `mintBlockedReason`, so on
+ *   this path "is step 3 done" and "will mint accept this" are the same
+ *   question, and every unresolved state genuinely blocks:
+ *     unselected      -> mint blocked (mintScopeRequest: "names-nothing")
+ *     loading         -> mint blocked (scope.kind === "unresolved")
+ *     failed          -> mint blocked (scope.kind === "unresolved")
+ *     tags-unresolved -> mint blocked (mintScopeRequest: "tags-unresolved")
+ *     resolved        -> mint NOT blocked by scope (the name field is a
+ *                         separate, later gate -- see the note on that below)
+ *
+ *   OAUTH.    There is no mint button on this path at all -- step 4 renders
+ *   NextSteps, not TokenMintPanel, for `method === 'oauth'` -- and the scope
+ *   chosen in THIS wizard is rehearsal for it: SiteScopeStep's own copy says
+ *   "nothing carries this selection to the approval screen... deciding it
+ *   here is how you get there with the answer ready." Nothing downstream
+ *   reads it, so nothing here can be "blocked" by it, for any of the five
+ *   states:
+ *     unselected / loading / failed / tags-unresolved / resolved
+ *       -> mint N/A; NextSteps is unconditionally actionable the moment
+ *          client and method are picked, so step 3 reads by POSITION alone
+ *          (the ordinary completed/upcoming logic) and step 6 stays current.
+ *   Getting this wrong the other way was Greptile's P1 on :639: dragging
+ *   `aria-current` back to step 3 while an OAuth operator sits in an
+ *   already-actionable step 6, because the predicate could not tell "no
+ *   button exists here" from "the button here is disabled."
+ *
+ * THE ONE PLACE THIS IS DECIDED. `mintBlockedReason` below and the step
+ * rail's `siteScopeState` (ConnectWizard) both call this and nothing else, so
  * "minting is blocked" and "the rail says step 3 is done" cannot disagree --
- * they read the same value rather than two derivations of the same two inputs
- * that could drift the way `scope.kind` alone already did once.
+ * they read the same value, now including the method that changes what
+ * "blocked" even means, rather than two derivations that could drift the way
+ * `scope.kind` alone already did once, and the way a method-blind version of
+ * this very function did a second time.
  *
- * THE ORDER IS LOAD-BEARING, copied from `mintBlockedReason`'s own comment
- * because this function replaces that logic rather than duplicating it. An
- * unresolved tag registry is reported first, because a selection that cannot
- * be translated is not the same complaint as a selection that is empty. A
- * fleet still loading is reported before "you have picked nothing," because
- * telling an operator to pick a site out of a list that has not arrived is a
- * remedy they cannot follow.
+ * THE ORDER ON THE TOKEN PATH IS LOAD-BEARING, copied from
+ * `mintBlockedReason`'s own comment because this function replaces that logic
+ * rather than duplicating it. An unresolved tag registry is reported first,
+ * because a selection that cannot be translated is not the same complaint as
+ * a selection that is empty. A fleet still loading is reported before "you
+ * have picked nothing," because telling an operator to pick a site out of a
+ * list that has not arrived is a remedy they cannot follow.
+ *
+ * A NAMED NON-GOAL, NOT AN OVERSIGHT. The connection-name field (inside step
+ * 6 itself) can be empty while this returns `resolved` and the rail marks
+ * step 6 current -- mint is still blocked then, by `mintBlockedReason`'s own
+ * `!nameOk` branch, which this function does not see. That is correct rather
+ * than a fifth gap to close: the rail reports POSITION -- which section is
+ * the operator working in -- not "is the submit button enabled right now."
+ * An empty name field is the operator genuinely inside step 6, working on
+ * step 6's own control, not the rail lying about where they are the way the
+ * site-scope cases above did.
  */
 function siteScopeReadiness(
   scope: ResolvedSiteScope,
   scopeRequest: MintScopeRequest,
+  method: AuthMethod | null,
 ): SiteScopeReadiness {
+  // OAUTH (AND NO METHOD CHOSEN YET) NEVER GATES ON THIS. See the matrix
+  // above: no mint button exists to refuse on this path, so nothing here can
+  // be "unresolved" in a sense that blocks anything.
+  if (method !== "token") return "resolved";
   if (!scopeRequest.ok && scopeRequest.because === "tags-unresolved") return "tags-unresolved";
   if (scope.kind === "unresolved") return scope.because;
   if (!scopeRequest.ok) return "unselected";
@@ -1126,7 +1174,10 @@ function mintBlockedReason(
   scopeRequest: MintScopeRequest,
 ): string | null {
   if (!nameOk) return "Name this connection before minting a token.";
-  const readiness = siteScopeReadiness(scope, scopeRequest);
+  // Literally "token", not threaded through as a parameter: this function is
+  // only ever called from TokenMintPanel, which method === 'oauth' never
+  // renders, so the context is a fact about the caller, not a value to plumb.
+  const readiness = siteScopeReadiness(scope, scopeRequest, "token");
   if (readiness === "loading") {
     return "Still reading this organisation's sites for step 3. Wait for that to finish before minting.";
   }

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -93,16 +93,63 @@ import {
 
 type Step = 1 | 2 | 3 | 4;
 
-interface StepDef {
-  readonly n: Step;
-  readonly label: string;
+/**
+ * The rail this page renders is the design's own numbering (S29, "ADD MCP
+ * CONNECTION: THE TEN STEPS"), not the four sections built so far. Showing
+ * only the four built ones would show an operator four-tenths of a path and
+ * let them believe that was the whole of it; the approved wizard has ten
+ * steps and the operator is entitled to see all ten before starting.
+ *
+ * THE MAP FROM A BUILT SECTION TO ITS SPECIFIED NUMBER IS NOT MONOTONIC ON
+ * SCREEN. The four built sections answer specified steps 2, 5, 3 and 6, IN
+ * THAT ORDER: this wizard reaches specified step 3 ("which sites") AFTER
+ * specified step 5 ("how it authenticates"), because the site-scope section
+ * was inserted after the auth-method section by design (see the file-top
+ * comment on ordering). `BUILT_ORDER` below is that on-screen order; a
+ * "completed" segment is one earlier IN THIS ORDER, never one with a smaller
+ * specified number -- comparing raw numbers would call specified step 5
+ * incomplete the moment the operator reached specified step 3, which is
+ * backwards.
+ */
+const BUILT_ORDER: readonly [1 | 2 | 3 | 4, number][] = [
+  [1, 2],
+  [2, 5],
+  [3, 3],
+  [4, 6],
+];
+
+/** The specified step number a locally-built step answers. */
+function specStepFor(step: Step): number {
+  const found = BUILT_ORDER.find(([local]) => local === step);
+  // Unreachable: BUILT_ORDER has one entry per Step value. A throw here
+  // rather than a fallback number, because a fallback would silently mark
+  // the wrong segment current instead of failing loudly.
+  if (found === undefined) throw new Error(`no specified step for local step ${step}`);
+  return found[1];
 }
 
-const STEPS: readonly StepDef[] = [
-  { n: 1, label: "Pick your client" },
-  { n: 2, label: "How it signs in" },
-  { n: 3, label: "Sites it may reach" },
-  { n: 4, label: "Set it up" },
+interface SpecStepDef {
+  /** The specified step number (design S29), 1 through 10. */
+  readonly n: number;
+  readonly label: string;
+  /** True when this specified step has a built, reachable section today. */
+  readonly built: boolean;
+}
+
+// All ten, in specified order, so the operator sees the whole path before
+// starting. Only four are `built: true`; the rest render as not-yet-available
+// rather than being omitted or, worse, made to look done.
+const SPEC_STEPS: readonly SpecStepDef[] = [
+  { n: 1, label: "Start a connection", built: false },
+  { n: 2, label: "Name it, pick the AI client", built: true },
+  { n: 3, label: "Choose which sites", built: true },
+  { n: 4, label: "Choose what it may do", built: false },
+  { n: 5, label: "Choose how it authenticates", built: true },
+  { n: 6, label: "Get the setup artefact", built: true },
+  { n: 7, label: "Connect and authorize", built: false },
+  { n: 8, label: "WPMgr confirms connection is live", built: false },
+  { n: 9, label: "Verify with a first read", built: false },
+  { n: 10, label: "Done: tool list and first prompt", built: false },
 ];
 
 export interface ConnectWizardProps {
@@ -167,7 +214,16 @@ export function ConnectWizard({
   // The current step is derived, never stored, so it cannot disagree with the
   // answers. Picking a different client with an incompatible method drops the
   // method rather than carrying a stale one into step 3.
-  const step: Step = client === null ? 1 : method === null ? 2 : 3;
+  //
+  // THE LAST BRANCH IS 4, NOT 3. Section 3 ("Sites this connection may
+  // reach") and Section 4 ("Set it up") share the exact same reveal
+  // condition below (`client !== null && method !== null`) -- they always
+  // appear together, so there is no state in which section 3 is on screen
+  // and section 4 is not. Once that condition holds, 4 is the furthest
+  // section actually revealed, and aria-current has to say so; stopping at 3
+  // told a screen-reader user they were in a section behind the one they
+  // were actually working in.
+  const step: Step = client === null ? 1 : method === null ? 2 : 4;
 
   // Resolved once here rather than inside the mint panel, so the SAME answer
   // gates the mint button and is described back in the one-time reveal -- a
@@ -519,35 +575,55 @@ export function ConnectWizard({
 }
 
 function StepRail({ current }: { current: Step }) {
+  const currentSpec = specStepFor(current);
+  const currentPos = BUILT_ORDER.findIndex(([, spec]) => spec === currentSpec);
   return (
-    <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--color-muted-foreground)]">
-      {STEPS.map((s, i) => (
-        <li key={s.n} className="flex items-center gap-2">
-          {i > 0 ? <span aria-hidden="true">/</span> : null}
-          <span
-            aria-current={s.n === current ? "step" : undefined}
-            className={cn(
-              s.n === current && "font-medium text-[var(--color-foreground)]",
-              s.n < current && "text-[var(--color-foreground)]",
-            )}
-          >
-            {s.n}. {s.label}
-          </span>
-        </li>
-      ))}
-      <li className="flex items-center gap-2">
-        <span aria-hidden="true">/</span>
-        {/* Capabilities are NOT a numbered step in this rail. The vocabulary
-            and the grant column behind them exist now (policy.go,
-            mcp_grants.capabilities in schema.sql), but neither completion
-            path this wizard ends in lets an operator choose one today -- see
-            the comment above the wizard's STEPS export for the token/OAuth
-            split -- so a step number here would be for a choice nobody can
-            make yet. What it names instead is where the OAuth path's consent
-            is actually recorded. */}
-        <span>Permissions are chosen on the approval screen</span>
-      </li>
-    </ol>
+    <div className="space-y-1">
+      <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--color-muted-foreground)]">
+        {SPEC_STEPS.map((s, i) => {
+          const isCurrent = s.n === currentSpec;
+          // Completed means "earlier in the order this wizard actually
+          // visits built steps in," never "a smaller specified number" --
+          // see the comment on BUILT_ORDER above for why those disagree here.
+          const builtPos = BUILT_ORDER.findIndex(([, spec]) => spec === s.n);
+          const isCompleted = builtPos !== -1 && builtPos < currentPos;
+          return (
+            <li key={s.n} className="flex items-center gap-2">
+              {i > 0 ? <span aria-hidden="true">/</span> : null}
+              <span
+                aria-current={isCurrent ? "step" : undefined}
+                // A plain data attribute rather than only a class, so a test
+                // can assert the state this rail believes it is in without
+                // coupling to Tailwind class names.
+                data-step-n={s.n}
+                data-step-state={!s.built ? "not-built" : isCurrent ? "current" : isCompleted ? "completed" : "upcoming"}
+                // NOT FAKED PROGRESS. An unbuilt step gets none of the
+                // "current" or "completed" styling below, whatever its
+                // number is relative to the current one -- it is muted and
+                // marked not-yet-available instead, because it has no
+                // section behind it to have completed.
+                className={cn(
+                  !s.built && "italic opacity-70",
+                  s.built && isCurrent && "font-medium text-[var(--color-foreground)]",
+                  s.built && isCompleted && "text-[var(--color-foreground)]",
+                )}
+              >
+                {s.n}. {s.label}
+                {!s.built ? <span className="sr-only"> (not yet available)</span> : null}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+      {/* Step 4 in the rail above ("Choose what it may do") has no section on
+          this page: neither completion path this wizard ends in lets an
+          operator choose a capability today -- see the file-top comment on
+          the OAuth/token split. Naming where that choice IS made today keeps
+          the gap from reading as an oversight. */}
+      <p className="text-xs text-[var(--color-muted-foreground)]">
+        Permissions are chosen on the approval screen.
+      </p>
+    </div>
   );
 }
 
@@ -787,6 +863,26 @@ function SnippetBlock({ client, snippet }: { client: McpClientRow; snippet: Snip
           {snippet.headerLine !== null ? (
             <CopyableMono value={snippet.headerLine} label="Copy the authorization header" />
           ) : null}
+        </div>
+      ) : null}
+
+      {snippet.kind === "shell" ? (
+        <div className="space-y-2">
+          <span className="text-xs font-medium text-[var(--color-foreground)]">
+            Run this in a terminal for {client.name}
+          </span>
+          <p className="text-sm text-[var(--color-muted-foreground)]">{snippet.reason}</p>
+          <pre className="overflow-x-auto rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 font-mono text-xs text-[var(--color-foreground)]">
+            <code>{snippet.text}</code>
+          </pre>
+          <CopyableMono value={snippet.text} label={`Copy the ${client.name} setup command`} truncate />
+          {/* The mechanic, on screen rather than only in the generator's own
+              comment: a reader has to be able to tell this is safe without
+              reading snippet.ts. */}
+          <p className="text-xs text-[var(--color-muted-foreground)]">
+            Reads the token once, into your shell, and never types it as an argument -- so it is
+            never echoed and never written to your shell history.
+          </p>
         </div>
       ) : null}
 
@@ -1122,13 +1218,6 @@ function TokenMintPanel({
 /**
  * The one-time reveal itself. Rendered exactly once per mint, from state the
  * parent never repopulates -- see TokenMintPanel's own doc.
- *
- * THE SHELL SETUP COMMAND FOR {clientName} IS NOT RENDERED HERE. This client's
- * table entry (client-table.ts) emits a JSON or raw config, not a CLI
- * invocation, so there is no `claude mcp add`-shaped command in this codebase
- * to fill in without inventing a third snippet kind under time pressure. What
- * ships is the reveal itself, matching the wireframe's non-negotiables; the
- * setup-command shape is outstanding.
  */
 function TokenReveal({ reveal, onDismiss }: { reveal: MintedReveal; onDismiss: () => void }) {
   // Destructured from the one snapshot, and there is deliberately no second

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -152,6 +152,19 @@ const SPEC_STEPS: readonly SpecStepDef[] = [
   { n: 10, label: "Done: tool list and first prompt", built: false },
 ];
 
+/**
+ * Whether the site/tag read the site-scope step depends on has actually come
+ * back. Three states, not two: `loading` and `failed` are different facts an
+ * operator needs told apart -- "still working" against "it did not work, and
+ * an indefinite wait is not coming" -- so collapsing them into one appearance
+ * is its own defect, distinct from and in addition to marking either one
+ * "resolved" before it is.
+ */
+type SiteScopeResolution = "loading" | "failed" | "resolved";
+
+/** The specified step number (design S29) that answers "which sites." */
+const SITE_SCOPE_SPEC_N = 3;
+
 export interface ConnectWizardProps {
   /** Absolute MCP endpoint for this deployment. Passed in, never assembled here. */
   endpointUrl: string;
@@ -241,6 +254,18 @@ export function ConnectWizard({
       }),
     [selection, fleet, tagsBySiteId, sitesLoading],
   );
+
+  // THE RAIL'S SITE-SCOPE STATE, FROM THE SAME VALUE THAT GATES MINTING,
+  // NEVER RE-DERIVED. A P1 shipped from the rail computing "has this step's
+  // data resolved" by POSITION (has the operator picked a client and method
+  // yet) rather than by asking the read itself: once client and method were
+  // picked, the rail marked site selection completed and setup current even
+  // while `scope` above was still `unresolved` -- loading, or failed
+  // outright -- and minting was in fact blocked. Reading `scope.kind` here
+  // is the same fix in spirit as scopeRequest below: one computation feeds
+  // both the gate and everything that describes it, so they cannot disagree.
+  const siteScopeResolution: SiteScopeResolution =
+    scope.kind === "unresolved" ? scope.because : "resolved";
 
   // NULL means a selected tag name no longer resolves to an id -- see
   // resolveTagIds. The mint panel refuses to submit on null rather than
@@ -348,7 +373,7 @@ export function ConnectWizard({
 
   return (
     <div className={cn("space-y-6", className)}>
-      <StepRail current={step} />
+      <StepRail current={step} siteScopeResolution={siteScopeResolution} />
 
       {/* THE ONE AND ONLY PLACE A REVEAL IS RENDERED, and it is deliberately
           outside every step. A second render site inside step 4 would restore
@@ -574,19 +599,69 @@ export function ConnectWizard({
   );
 }
 
-function StepRail({ current }: { current: Step }) {
+function StepRail({
+  current,
+  siteScopeResolution,
+}: {
+  current: Step;
+  /**
+   * From the SAME `scope` computation that gates the mint button, never
+   * re-derived here. THE P1 THIS PARAMETER FIXES: the rail used to decide
+   * "is site selection done" from POSITION alone -- has the operator picked
+   * a client and method -- which says nothing about whether the fleet/tag
+   * read that step actually depends on came back. Once client and method
+   * were picked, the rail marked site selection completed and setup current
+   * even while the read was still loading, or had failed outright, so the
+   * screen and a screen reader both told the operator they had finished
+   * something, and that minting was reachable, when neither was true.
+   */
+  siteScopeResolution: SiteScopeResolution;
+}) {
   const currentSpec = specStepFor(current);
   const currentPos = BUILT_ORDER.findIndex(([, spec]) => spec === currentSpec);
+  const siteScopeBuiltPos = BUILT_ORDER.findIndex(([, spec]) => spec === SITE_SCOPE_SPEC_N);
+  // BLOCKING, NOT MERELY "NOT YET RESOLVED". The positional walk has to have
+  // actually passed through the site-scope step for its resolution to be
+  // relevant: while the operator is still on "how it authenticates," step 3
+  // is correctly "upcoming" no matter what the fleet/tag read is doing in
+  // the background, because the operator has not been told otherwise yet.
+  const siteScopeBlocking =
+    siteScopeResolution !== "resolved" &&
+    siteScopeBuiltPos !== -1 &&
+    siteScopeBuiltPos <= currentPos;
+  // THE OVERRIDE ITSELF. While site scope has not resolved, IT is where the
+  // operator's process actually stands, not whatever position the local step
+  // has otherwise reached -- so aria-current moves back to it instead of
+  // sitting on a "setup" step whose mint button it, in fact, still blocks.
+  const effectiveCurrentSpec = siteScopeBlocking ? SITE_SCOPE_SPEC_N : currentSpec;
+  const effectiveCurrentPos = siteScopeBlocking ? siteScopeBuiltPos : currentPos;
   return (
     <div className="space-y-1">
       <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--color-muted-foreground)]">
         {SPEC_STEPS.map((s, i) => {
-          const isCurrent = s.n === currentSpec;
+          const isCurrent = s.n === effectiveCurrentSpec;
           // Completed means "earlier in the order this wizard actually
           // visits built steps in," never "a smaller specified number" --
           // see the comment on BUILT_ORDER above for why those disagree here.
           const builtPos = BUILT_ORDER.findIndex(([, spec]) => spec === s.n);
-          const isCompleted = builtPos !== -1 && builtPos < currentPos;
+          const isCompleted = builtPos !== -1 && builtPos < effectiveCurrentPos;
+          // SITE SCOPE'S OWN THREE STATES, CHECKED BEFORE THE GENERIC ONES
+          // BELOW AND OVERRIDING THEM. "completed" here would be the exact P1:
+          // a step reading as finished while the read behind it has not come
+          // back. `loading` and `failed` are kept apart rather than both
+          // reading as one muted "not done yet" -- an operator told nothing
+          // when a read has actually failed keeps waiting for a state that is
+          // never coming.
+          const state: "not-built" | "current" | "completed" | "upcoming" | SiteScopeResolution =
+            !s.built
+              ? "not-built"
+              : s.n === SITE_SCOPE_SPEC_N && siteScopeBlocking
+                ? siteScopeResolution
+                : isCurrent
+                  ? "current"
+                  : isCompleted
+                    ? "completed"
+                    : "upcoming";
           return (
             <li key={s.n} className="flex items-center gap-2">
               {i > 0 ? <span aria-hidden="true">/</span> : null}
@@ -596,20 +671,23 @@ function StepRail({ current }: { current: Step }) {
                 // can assert the state this rail believes it is in without
                 // coupling to Tailwind class names.
                 data-step-n={s.n}
-                data-step-state={!s.built ? "not-built" : isCurrent ? "current" : isCompleted ? "completed" : "upcoming"}
-                // NOT FAKED PROGRESS. An unbuilt step gets none of the
-                // "current" or "completed" styling below, whatever its
-                // number is relative to the current one -- it is muted and
-                // marked not-yet-available instead, because it has no
-                // section behind it to have completed.
+                data-step-state={state}
+                // NOT FAKED PROGRESS, IN EITHER DIRECTION. An unbuilt step
+                // gets none of the "current" or "completed" styling below,
+                // because it has no section behind it to have completed; a
+                // built step whose own data has not resolved gets neither
+                // "current" nor "completed" either, for the same reason.
                 className={cn(
                   !s.built && "italic opacity-70",
-                  s.built && isCurrent && "font-medium text-[var(--color-foreground)]",
-                  s.built && isCompleted && "text-[var(--color-foreground)]",
+                  state === "current" && "font-medium text-[var(--color-foreground)]",
+                  state === "completed" && "text-[var(--color-foreground)]",
+                  state === "failed" && "text-[var(--color-destructive)]",
                 )}
               >
                 {s.n}. {s.label}
                 {!s.built ? <span className="sr-only"> (not yet available)</span> : null}
+                {state === "loading" ? " (loading)" : null}
+                {state === "failed" ? " (failed to load)" : null}
               </span>
             </li>
           );

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -33,7 +33,6 @@ import {
 import { formatAbsolute } from "@/features/updates/schedule";
 import {
   describeSiteScope,
-  isScopeApprovable,
   resolveSiteScope,
   resolveTagIds,
   type FleetSnapshot,
@@ -153,14 +152,23 @@ const SPEC_STEPS: readonly SpecStepDef[] = [
 ];
 
 /**
- * Whether the site/tag read the site-scope step depends on has actually come
- * back. Three states, not two: `loading` and `failed` are different facts an
- * operator needs told apart -- "still working" against "it did not work, and
- * an indefinite wait is not coming" -- so collapsing them into one appearance
- * is its own defect, distinct from and in addition to marking either one
- * "resolved" before it is.
+ * Whether the site-scope step is actually done, for every reason
+ * `mintBlockedReason` below can refuse to mint on it -- READ BY BOTH THE
+ * BUTTON AND THE RAIL FROM ONE FUNCTION, `siteScopeReadiness`, rather than
+ * each asking a narrower question of its own.
+ *
+ * THIS TYPE EXISTS BECAUSE A NARROWER ONE WAS FOUND WRONG THREE TIMES, THROUGH
+ * THREE DIFFERENT DOORS, IN ONE REVIEW PASS. The rail first asked only
+ * `scope.kind`, which answers "did the fleet read resolve" and says nothing
+ * about `mintScopeRequest`'s OWN refusals: `tags-unresolved` (the tag
+ * registry, a different read from the fleet) and `unselected` (the operator
+ * has not picked anything under 'tags' or 'list' mode yet). Both left minting
+ * blocked while the rail called step 3 done and put `aria-current` on step 6.
+ * Patching the rail's own condition a second time would have been a fourth
+ * door on the same room; this widens the ONE predicate both consumers read
+ * instead.
  */
-type SiteScopeResolution = "loading" | "failed" | "resolved";
+type SiteScopeReadiness = "loading" | "failed" | "tags-unresolved" | "unselected" | "resolved";
 
 /** The specified step number (design S29) that answers "which sites." */
 const SITE_SCOPE_SPEC_N = 3;
@@ -255,18 +263,6 @@ export function ConnectWizard({
     [selection, fleet, tagsBySiteId, sitesLoading],
   );
 
-  // THE RAIL'S SITE-SCOPE STATE, FROM THE SAME VALUE THAT GATES MINTING,
-  // NEVER RE-DERIVED. A P1 shipped from the rail computing "has this step's
-  // data resolved" by POSITION (has the operator picked a client and method
-  // yet) rather than by asking the read itself: once client and method were
-  // picked, the rail marked site selection completed and setup current even
-  // while `scope` above was still `unresolved` -- loading, or failed
-  // outright -- and minting was in fact blocked. Reading `scope.kind` here
-  // is the same fix in spirit as scopeRequest below: one computation feeds
-  // both the gate and everything that describes it, so they cannot disagree.
-  const siteScopeResolution: SiteScopeResolution =
-    scope.kind === "unresolved" ? scope.because : "resolved";
-
   // NULL means a selected tag name no longer resolves to an id -- see
   // resolveTagIds. The mint panel refuses to submit on null rather than
   // sending the smaller array that survives, because that would narrow the
@@ -284,6 +280,17 @@ export function ConnectWizard({
     () => mintScopeRequest(selection.mode, scopeTagIds, selection.siteIds),
     [selection.mode, scopeTagIds, selection.siteIds],
   );
+
+  // THE RAIL'S SITE-SCOPE STATE, FROM `siteScopeReadiness` -- THE SAME
+  // FUNCTION `mintBlockedReason` CALLS BELOW, NEVER A NARROWER RE-DERIVATION.
+  // This found the same defect a second time: reading only `scope.kind` fixed
+  // the case where the FLEET read hadn't resolved, and left the rail calling
+  // step 3 done while `mintScopeRequest` was still refusing to mint on
+  // `tags-unresolved` (the TAG registry, a different read) or on an empty
+  // selection the operator had not made yet. One function, read by both the
+  // button and the rail, is what makes a fourth door impossible rather than
+  // merely unlikely.
+  const siteScopeState: SiteScopeReadiness = siteScopeReadiness(scope, scopeRequest);
 
   // A mint is a network round trip, and every control above is live during it.
   // Disabling them is the FIRST half of the fix (the operator is not offered a
@@ -373,7 +380,7 @@ export function ConnectWizard({
 
   return (
     <div className={cn("space-y-6", className)}>
-      <StepRail current={step} siteScopeResolution={siteScopeResolution} />
+      <StepRail current={step} siteScopeState={siteScopeState} />
 
       {/* THE ONE AND ONLY PLACE A REVEAL IS RENDERED, and it is deliberately
           outside every step. A second render site inside step 4 would restore
@@ -601,38 +608,33 @@ export function ConnectWizard({
 
 function StepRail({
   current,
-  siteScopeResolution,
+  siteScopeState,
 }: {
   current: Step;
   /**
-   * From the SAME `scope` computation that gates the mint button, never
-   * re-derived here. THE P1 THIS PARAMETER FIXES: the rail used to decide
-   * "is site selection done" from POSITION alone -- has the operator picked
-   * a client and method -- which says nothing about whether the fleet/tag
-   * read that step actually depends on came back. Once client and method
-   * were picked, the rail marked site selection completed and setup current
-   * even while the read was still loading, or had failed outright, so the
-   * screen and a screen reader both told the operator they had finished
-   * something, and that minting was reachable, when neither was true.
+   * From `siteScopeReadiness`, the SAME function `mintBlockedReason` calls
+   * for its own scope-related refusals -- never a narrower re-derivation
+   * here. See that function's doc for why: reading only whether the fleet
+   * read resolved fixed one door minting could be blocked through and left
+   * two open (`tags-unresolved`, `unselected`), each reachable while the rail
+   * still called step 3 done and put `aria-current` on step 6.
    */
-  siteScopeResolution: SiteScopeResolution;
+  siteScopeState: SiteScopeReadiness;
 }) {
   const currentSpec = specStepFor(current);
   const currentPos = BUILT_ORDER.findIndex(([, spec]) => spec === currentSpec);
   const siteScopeBuiltPos = BUILT_ORDER.findIndex(([, spec]) => spec === SITE_SCOPE_SPEC_N);
   // BLOCKING, NOT MERELY "NOT YET RESOLVED". The positional walk has to have
-  // actually passed through the site-scope step for its resolution to be
+  // actually passed through the site-scope step for its state to be
   // relevant: while the operator is still on "how it authenticates," step 3
-  // is correctly "upcoming" no matter what the fleet/tag read is doing in
-  // the background, because the operator has not been told otherwise yet.
+  // is correctly "upcoming" no matter what siteScopeState says, because the
+  // operator has not been told otherwise yet.
   const siteScopeBlocking =
-    siteScopeResolution !== "resolved" &&
-    siteScopeBuiltPos !== -1 &&
-    siteScopeBuiltPos <= currentPos;
-  // THE OVERRIDE ITSELF. While site scope has not resolved, IT is where the
-  // operator's process actually stands, not whatever position the local step
-  // has otherwise reached -- so aria-current moves back to it instead of
-  // sitting on a "setup" step whose mint button it, in fact, still blocks.
+    siteScopeState !== "resolved" && siteScopeBuiltPos !== -1 && siteScopeBuiltPos <= currentPos;
+  // THE OVERRIDE ITSELF. While step 3 is not done, IT is where the operator's
+  // process actually stands, not whatever position the local step has
+  // otherwise reached -- so aria-current moves back to it instead of sitting
+  // on a "setup" step whose mint button it, in fact, still blocks.
   const effectiveCurrentSpec = siteScopeBlocking ? SITE_SCOPE_SPEC_N : currentSpec;
   const effectiveCurrentPos = siteScopeBlocking ? siteScopeBuiltPos : currentPos;
   return (
@@ -645,18 +647,19 @@ function StepRail({
           // see the comment on BUILT_ORDER above for why those disagree here.
           const builtPos = BUILT_ORDER.findIndex(([, spec]) => spec === s.n);
           const isCompleted = builtPos !== -1 && builtPos < effectiveCurrentPos;
-          // SITE SCOPE'S OWN THREE STATES, CHECKED BEFORE THE GENERIC ONES
-          // BELOW AND OVERRIDING THEM. "completed" here would be the exact P1:
-          // a step reading as finished while the read behind it has not come
-          // back. `loading` and `failed` are kept apart rather than both
-          // reading as one muted "not done yet" -- an operator told nothing
-          // when a read has actually failed keeps waiting for a state that is
-          // never coming.
-          const state: "not-built" | "current" | "completed" | "upcoming" | SiteScopeResolution =
+          // SITE SCOPE'S OWN STATES, CHECKED BEFORE THE GENERIC ONES BELOW AND
+          // OVERRIDING THEM. "completed" here would be the exact defect this
+          // whole rework exists for: a step reading as finished while mint
+          // would still refuse it. Each reason is kept distinct rather than
+          // collapsing into one muted "not done yet" -- an operator told
+          // nothing when a read has actually failed keeps waiting for a state
+          // that is never coming, and one told "loading" for their own
+          // unmade selection is told something false about themselves.
+          const state: "not-built" | "current" | "completed" | "upcoming" | SiteScopeReadiness =
             !s.built
               ? "not-built"
               : s.n === SITE_SCOPE_SPEC_N && siteScopeBlocking
-                ? siteScopeResolution
+                ? siteScopeState
                 : isCurrent
                   ? "current"
                   : isCompleted
@@ -675,8 +678,8 @@ function StepRail({
                 // NOT FAKED PROGRESS, IN EITHER DIRECTION. An unbuilt step
                 // gets none of the "current" or "completed" styling below,
                 // because it has no section behind it to have completed; a
-                // built step whose own data has not resolved gets neither
-                // "current" nor "completed" either, for the same reason.
+                // built step mint would still refuse gets neither "current"
+                // nor "completed" either, for the same reason.
                 className={cn(
                   !s.built && "italic opacity-70",
                   state === "current" && "font-medium text-[var(--color-foreground)]",
@@ -688,6 +691,8 @@ function StepRail({
                 {!s.built ? <span className="sr-only"> (not yet available)</span> : null}
                 {state === "loading" ? " (loading)" : null}
                 {state === "failed" ? " (failed to load)" : null}
+                {state === "tags-unresolved" ? " (tags still loading)" : null}
+                {state === "unselected" ? " (not chosen yet)" : null}
               </span>
             </li>
           );
@@ -1083,16 +1088,37 @@ function mintScopeRequest(
 }
 
 /**
+ * Whether step 3 is actually done, for every reason mint can refuse it.
+ *
+ * THE ONE PLACE THIS IS DECIDED. `mintBlockedReason` below and the step rail's
+ * `siteScopeState` (ConnectWizard) both call this and nothing else, so
+ * "minting is blocked" and "the rail says step 3 is done" cannot disagree --
+ * they read the same value rather than two derivations of the same two inputs
+ * that could drift the way `scope.kind` alone already did once.
+ *
+ * THE ORDER IS LOAD-BEARING, copied from `mintBlockedReason`'s own comment
+ * because this function replaces that logic rather than duplicating it. An
+ * unresolved tag registry is reported first, because a selection that cannot
+ * be translated is not the same complaint as a selection that is empty. A
+ * fleet still loading is reported before "you have picked nothing," because
+ * telling an operator to pick a site out of a list that has not arrived is a
+ * remedy they cannot follow.
+ */
+function siteScopeReadiness(
+  scope: ResolvedSiteScope,
+  scopeRequest: MintScopeRequest,
+): SiteScopeReadiness {
+  if (!scopeRequest.ok && scopeRequest.because === "tags-unresolved") return "tags-unresolved";
+  if (scope.kind === "unresolved") return scope.because;
+  if (!scopeRequest.ok) return "unselected";
+  return "resolved";
+}
+
+/**
  * The reason minting is refused, or null when it is not.
  *
  * Every branch here is a FAILURE, rendered with a remedy, never a silently
  * disabled button.
- *
- * THE ORDER IS LOAD-BEARING. An unresolved tag registry is reported first,
- * because a selection that cannot be translated is not the same complaint as a
- * selection that is empty. A fleet still loading is reported before "you have
- * picked nothing", because telling an operator to pick a site out of a list
- * that has not arrived is a remedy they cannot follow.
  */
 function mintBlockedReason(
   nameOk: boolean,
@@ -1100,12 +1126,17 @@ function mintBlockedReason(
   scopeRequest: MintScopeRequest,
 ): string | null {
   if (!nameOk) return "Name this connection before minting a token.";
-  if (!scopeRequest.ok && scopeRequest.because === "tags-unresolved") return scopeRequest.refusal;
-  if (!isScopeApprovable(scope)) {
-    return scope.kind === "unresolved" && scope.because === "loading"
-      ? "Still reading this organisation's sites for step 3. Wait for that to finish before minting."
-      : "This organisation's sites could not be read for step 3, so we cannot tell what this connection would cover. Fix that above before minting.";
+  const readiness = siteScopeReadiness(scope, scopeRequest);
+  if (readiness === "loading") {
+    return "Still reading this organisation's sites for step 3. Wait for that to finish before minting.";
   }
+  if (readiness === "failed") {
+    return "This organisation's sites could not be read for step 3, so we cannot tell what this connection would cover. Fix that above before minting.";
+  }
+  // "tags-unresolved" and "unselected" both mean scopeRequest itself refused,
+  // which already carries its own remedy -- reusing it here, rather than a
+  // second copy of the sentence, is what keeps this and the refusal text from
+  // drifting apart.
   if (!scopeRequest.ok) return scopeRequest.refusal;
   return null;
 }

--- a/apps/web/src/features/ai-connections/snippet.test.ts
+++ b/apps/web/src/features/ai-connections/snippet.test.ts
@@ -415,6 +415,26 @@ describe("the shell setup shape never puts the token in the generated text", () 
     expect(readLine.startsWith(" ")).toBe(true);
   });
 
+  it("never prompts with read -p -- bash and zsh disagree on what -p means", () => {
+    // In bash, `-p` prints the prompt string. In zsh, `-p` reads from a
+    // coprocess instead, so `read -rs -p "..." VAR` fails outright on zsh
+    // ("-p: no coprocess") and leaves the variable empty -- verified by
+    // actually running both shells, not assumed:
+    //   printf 'x\n' | bash -c 'read -rs -p "..." T; echo "[$T]"'  -> [x]
+    //   printf 'x\n' | zsh  -c 'read -rs -p "..." T; echo "[$T]"'  -> [] (errors)
+    // zsh is the default shell on macOS, so a snippet that only works on
+    // bash fails silently confusingly for most of the audience it is for.
+    const text = shellSnippet().text;
+    expect(text).not.toMatch(/read\s+[^\n]*-p\b/);
+    // The prompt still has to reach the terminal somehow: printed on its own
+    // line, before the read, is the form that behaves identically in both.
+    const lines = text.split("\n");
+    const promptLineIndex = lines.findIndex((l) => l.includes("Paste your connection token"));
+    const readLineIndex = lines.findIndex((l) => l.includes("read -rs"));
+    expect(promptLineIndex).toBeGreaterThanOrEqual(0);
+    expect(readLineIndex).toBeGreaterThan(promptLineIndex);
+  });
+
   it("refuses a shell snippet for a method the row does not offer", () => {
     expect(() =>
       buildSnippet({

--- a/apps/web/src/features/ai-connections/snippet.test.ts
+++ b/apps/web/src/features/ai-connections/snippet.test.ts
@@ -19,6 +19,7 @@ import { basename, join } from "node:path";
 import {
   MCP_CLIENTS,
   CLIENT_TABLE_TARGET_NAMED_COUNT,
+  CLIENT_TABLE_VERIFIED_AT,
   availableAuthMethods,
   findClient,
   isAuthAvailable,
@@ -337,6 +338,92 @@ describe("token substitution", () => {
     if (snippet.kind !== "json") throw new Error("expected json");
     const server = serverObject(snippet, "mcpServers");
     expect(String(server.url)).not.toContain("wpm_live_abc123");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The shell shape (S16 addendum): a setup command, never a config file, and
+// never a token typed as a shell argument.
+// ---------------------------------------------------------------------------
+
+describe("the shell setup shape never puts the token in the generated text", () => {
+  // A local fixture, not a row in MCP_CLIENTS: no named client's shell
+  // invocation syntax is sourced yet (see CONFIG_PATH_GAP's sibling
+  // reasoning), so this exercises the mechanism the builder guarantees
+  // rather than asserting an unverified command for a real client.
+  const shellClient: McpClientRow = {
+    id: "test-shell-fixture",
+    name: "Shell Fixture Client",
+    blurb: "Exercises the shell snippet shape only.",
+    docsUrl: "https://example.com/docs",
+    docsLabel: "Fixture docs",
+    verifiedAt: CLIENT_TABLE_VERIFIED_AT,
+    configPath: null,
+    config: {
+      kind: "shell",
+      reason: "This fixture is set up by running a command, not editing a file.",
+    },
+    auth: {
+      oauth: {
+        state: "unavailable",
+        reason: "This fixture only exercises the token path.",
+      },
+      token: { state: "available", detail: "Reads the token interactively." },
+    },
+    generic: false,
+  };
+
+  const SECRET = "wpm_live_should_never_appear_in_any_generated_text";
+
+  function shellSnippet(token: string | null = null) {
+    const snippet = buildSnippet({
+      client: shellClient,
+      endpointUrl: ENDPOINT,
+      serverName: "wpmgr",
+      authMethod: "token",
+      token,
+    });
+    if (snippet.kind !== "shell") throw new Error(`expected a shell snippet, got "${snippet.kind}"`);
+    return snippet;
+  }
+
+  it("never contains the token value, minted or not", () => {
+    // THE ASSERTION THE DEFECT IS ABOUT. A token substituted into command text
+    // is a token written to the shell history file the moment the command
+    // runs; this fixture must never construct that string in the first place.
+    expect(shellSnippet(SECRET).text).not.toContain(SECRET);
+    expect(shellSnippet(null).text).not.toContain(TOKEN_PLACEHOLDER);
+  });
+
+  it("reads the token with read -rs, never as a positional argument", () => {
+    // -r: no backslash escaping surprises. -s: not echoed to the terminal.
+    expect(shellSnippet().text).toMatch(/\bread\s+-rs\b/);
+  });
+
+  it("references the token from the environment, never interpolated", () => {
+    expect(shellSnippet().text).toContain("$WPMGR_CONNECTION_TOKEN");
+    expect(shellSnippet().text).toContain("export WPMGR_CONNECTION_TOKEN");
+  });
+
+  it("keeps the read line out of shell history with a leading space", () => {
+    // HISTCONTROL=ignorespace (bash) / setopt HIST_IGNORE_SPACE (zsh): a line
+    // starting with whitespace is never written to history at all.
+    const readLine = shellSnippet()
+      .text.split("\n")
+      .find((line) => line.includes("read -rs"));
+    if (readLine === undefined) throw new Error("no read line in the generated script");
+    expect(readLine.startsWith(" ")).toBe(true);
+  });
+
+  it("refuses a shell snippet for a method the row does not offer", () => {
+    expect(() =>
+      buildSnippet({
+        client: shellClient,
+        endpointUrl: ENDPOINT,
+        serverName: "wpmgr",
+        authMethod: "oauth",
+      }),
+    ).toThrow(UnsupportedAuthMethodError);
   });
 });
 

--- a/apps/web/src/features/ai-connections/snippet.ts
+++ b/apps/web/src/features/ai-connections/snippet.ts
@@ -159,12 +159,23 @@ export function buildSnippet(input: SnippetInput): Snippet {
       throw new UnsupportedAuthMethodError(client, authMethod);
     }
     const lines = [
-      // A LEADING SPACE, ON PURPOSE, NOT A STRAY CHARACTER. Under
-      // `HISTCONTROL=ignorespace` (bash) or `setopt HIST_IGNORE_SPACE` (zsh),
-      // a line starting with whitespace is never written to shell history at
-      // all -- this is what keeps the read itself, not only the token, out of
-      // a history file an operator may not think to check.
-      ` read -rs -p "Paste your connection token, then press Enter: " WPMGR_CONNECTION_TOKEN`,
+      // NOT `read -p`. In bash `-p` prints the prompt string; in zsh `-p`
+      // means something else entirely -- it reads from a coprocess -- so
+      // `read -rs -p "..." VAR` fails outright on zsh (`-p: no coprocess`)
+      // and leaves the variable empty. Verified directly, not assumed:
+      //   printf 'x\n' | zsh -c 'read -rs -p "..." T; echo "[$T]"'
+      //   -> zsh:read:1: -p: no coprocess
+      //      []
+      // zsh is the default shell on macOS, which is most of the audience
+      // this snippet is for, so the prompt is printed separately instead --
+      // identical behaviour in both bash and zsh, verified the same way.
+      `printf '%s' "Paste your connection token, then press Enter: "`,
+      // A LEADING SPACE, ON PURPOSE, NOT A STRAY CHARACTER, ON THIS LINE.
+      // Under `HISTCONTROL=ignorespace` (bash) or `setopt HIST_IGNORE_SPACE`
+      // (zsh), a line starting with whitespace is never written to shell
+      // history at all -- this is what keeps the read itself, not only the
+      // token, out of a history file an operator may not think to check.
+      ` read -rs WPMGR_CONNECTION_TOKEN`,
       `export WPMGR_CONNECTION_TOKEN`,
       // Referenced from the environment, never interpolated: the token text
       // itself never becomes part of this string, at any point, for any

--- a/apps/web/src/features/ai-connections/snippet.ts
+++ b/apps/web/src/features/ai-connections/snippet.ts
@@ -48,6 +48,17 @@ export type Snippet =
       readonly reason: string;
       /** The exact header to send, or null when this method needs no header. */
       readonly headerLine: string | null;
+    }
+  | {
+      readonly kind: "shell";
+      /**
+       * The full script, ready to paste as-is. NEVER CONTAINS THE TOKEN VALUE --
+       * see UnsupportedAuthMethodError's sibling guarantee below and
+       * snippet.test.ts's assertion on this exact property. The token is read
+       * interactively by the script itself, not substituted into it.
+       */
+      readonly text: string;
+      readonly reason: string;
     };
 
 export interface SnippetInput {
@@ -138,6 +149,32 @@ export function buildSnippet(input: SnippetInput): Snippet {
         authMethod === "token"
           ? `${AUTH_HEADER_NAME}: ${bearerHeaderValue(input.token)}`
           : null,
+    };
+  }
+
+  if (config.kind === "shell") {
+    // Shell setup exists to protect a token, so it has nothing to say for
+    // OAuth, which mints no token at this step at all.
+    if (authMethod !== "token") {
+      throw new UnsupportedAuthMethodError(client, authMethod);
+    }
+    const lines = [
+      // A LEADING SPACE, ON PURPOSE, NOT A STRAY CHARACTER. Under
+      // `HISTCONTROL=ignorespace` (bash) or `setopt HIST_IGNORE_SPACE` (zsh),
+      // a line starting with whitespace is never written to shell history at
+      // all -- this is what keeps the read itself, not only the token, out of
+      // a history file an operator may not think to check.
+      ` read -rs -p "Paste your connection token, then press Enter: " WPMGR_CONNECTION_TOKEN`,
+      `export WPMGR_CONNECTION_TOKEN`,
+      // Referenced from the environment, never interpolated: the token text
+      // itself never becomes part of this string, at any point, for any
+      // input. That is the property snippet.test.ts asserts directly.
+      `curl -sS -H "${AUTH_HEADER_NAME}: Bearer $WPMGR_CONNECTION_TOKEN" ${endpointUrl}`,
+    ];
+    return {
+      kind: "shell",
+      text: lines.join("\n"),
+      reason: config.reason,
     };
   }
 


### PR DESCRIPTION
## Summary

Three specific conformance defects from an approved spec's build order, in
the AI connection wizard (`apps/web/src/features/ai-connections/`). Copy and
markup only -- no restructuring, no new routes, no backend.

- **Defect 1 (security, fixed first)**: the setup-snippet builder had three
  shapes (json, gui, raw) and not the fourth, a shell command. An operator
  pasting a token into a shell command puts a long-lived bearer credential
  into their shell history in plain text. Added a `shell` shape
  (`client-table.ts`, `snippet.ts`) that reads the token with `read -rs`
  (never an argument, never echoed) into `$WPMGR_CONNECTION_TOKEN` and
  references it from the environment, with a leading space so
  `HISTCONTROL=ignorespace` / `setopt HIST_IGNORE_SPACE` keeps the read line
  itself out of history too. The token value never appears in the generated
  string -- asserted directly in `snippet.test.ts`. Deleted the stale comment
  recording the shape's absence.
- **Defect 2**: `step` derivation never produced `4`, so `aria-current`
  stayed on section 3 while the operator worked in section 4. Sections 3 and
  4 share one reveal condition (`client !== null && method !== null`) and
  always appear together, so once that holds, 4 is the furthest section
  actually revealed. Fixed the last branch of the ternary from `3` to `4`.
- **Defect 3**: the stepper showed 4 segments; the approved wizard is 10.
  Added the full ten-step model from design S29 ("ADD MCP CONNECTION: THE
  TEN STEPS"), mapping the four shipped sections to their specified numbers
  (2, 5, 3, 6 -- non-monotonic on screen, since site-scope is visited after
  auth-method by design) and rendering the other six as not-yet-available
  (muted, `sr-only` "(not yet available)", never marked current or
  completed) rather than omitting them or making them look done.

## Test plan

- [x] `pnpm -C apps/web typecheck` -- clean
- [x] `pnpm -C apps/web lint` -- 0 errors (10 pre-existing warnings, none in
      touched files)
- [x] `pnpm -C apps/web test` -- 2173 passed / 168 files
- [x] `pnpm -C apps/web build` -- succeeds, `routeTree.gen.ts` unaffected (no
      route files touched)
- [x] `impeccable detect` on `apps/web/src/features/ai-connections` -- clean
- [x] Each fix mutation-tested: planted the real defect, watched the new
      tests go red, restored, watched them go green (pasted in the PR
      description below is the same evidence given to the requester)
- [x] `git grep "MUTATION M" -- apps` exits 1; `git status --porcelain` is
      empty

Not run: `make test-integration` / anything under
`scripts/with-machine-lock.sh` (explicitly out of scope for this change --
another run is queued on that lock).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell-based setup instructions for supported AI connections.
  * Shell snippets securely collect tokens interactively instead of embedding them in commands.
  * Expanded the connection wizard with clearer step progress, including loading and error states.
  * Prevented setup actions and navigation while connection requests are processing.
* **Bug Fixes**
  * Corrected wizard step completion and current-step behavior across different setup states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->