### PR TITLE
docs: add PR #685 wizard rail fixes to 0.61.154 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 ### Fixed
 
 - Removed a false claim from the AI connections screens that a connection could propose changes to a site. No connection can; every one is read-only.
+- The connection wizard's progress rail now shows all ten steps of the approved connection flow, not only the four that are currently built. The other six render as not yet available and are never shown as complete or current.
+- The progress rail no longer marks a step complete, or moves current onto it, while the data that step depends on is still loading, has failed to load, or has not been resolved yet. It previously could tell an operator a step was finished while the action it gates was still blocked.
 
 ## [0.61.153] - 2026-09-01
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -53,7 +53,7 @@ const RELEASES: ChangeEntry[] = [
     version: "0.61.154",
     date: "2026-09-02",
     summary:
-      "Two routes that create an AI connection are brought onto the same permission requirement. The assistant can now answer which sites in your fleet need updates, AI connections get a status panel and a plain statement of what a connection can and cannot do, and an organisation owner can pause and resume the assistant over the API.",
+      "Two routes that create an AI connection are brought onto the same permission requirement. The assistant can now answer which sites in your fleet need updates, AI connections get a status panel and a plain statement of what a connection can and cannot do, an organisation owner can pause and resume the assistant over the API, and the connection wizard's progress rail is more accurate.",
     items: [
       {
         tag: "Security",
@@ -78,6 +78,14 @@ const RELEASES: ChangeEntry[] = [
       {
         tag: "Fixed",
         text: "Removed a false claim from the AI connections screens that a connection could propose changes to a site. No connection can; every one is read-only.",
+      },
+      {
+        tag: "Fixed",
+        text: "The connection wizard's progress rail now shows all ten steps of the approved connection flow, not only the four that are currently built. The other six render as not yet available and are never shown as complete or current.",
+      },
+      {
+        tag: "Fixed",
+        text: "The progress rail no longer marks a step complete, or moves current onto it, while the data that step depends on is still loading, has failed to load, or has not been resolved yet. It previously could tell an operator a step was finished while the action it gates was still blocked.",
       },
     ],
   },


### PR DESCRIPTION
## Summary

0.61.154 merged to main (922a3cbd) but has not been tagged or deployed. #685 merged shortly after, at main. Since 0.61.154 has not shipped, this adds its two operator-visible fixes into the existing 0.61.154 section rather than minting 0.61.155.

- CHANGELOG.md: two new Fixed lines under the existing 0.61.154 heading.
- apps/marketing/app/(marketing)/changelog/page.tsx: the same two entries added to the matching version block, and the summary sentence extended to mention the rail fix.

No version number moves anywhere (openapi info.version, README, docs/install.md pins are untouched).

### What is included from #685

- The connection wizard's progress rail now renders all ten approved steps, not only the four built ones; the other six show as not yet available and are never marked complete or current.
- The rail no longer marks a step complete, or moves current onto it, while the data that step depends on is still loading, has failed, or is unresolved.

### What is deliberately left out

#685 also added a `shell` config shape to the setup-snippet builder (reads a connection token via `read -rs` instead of putting it in a shell argument). Checked `apps/web/src/features/ai-connections/client-table.ts`: no client entry sets `kind: "shell"` yet, so no operator can reach this today. Writing a changelog line for it would imply usable behavior that does not exist yet, so it is left for issue #687 to carry when a client actually wires it up.

## Test plan

- [x] `make check-versions-test` -- 76 passed, 0 failed
- [x] `make check-versions` -- all surfaces OK, no version drift
- [x] `node apps/marketing/scripts/check-copy.mjs` -- passed, no em/en dashes or competitor names
- [x] Docs vocabulary check command copied verbatim from `.github/workflows/ci.yml` this turn -- no hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the connection wizard progress rail to display all ten approved steps.
  * Clearly marks unavailable steps that are not yet built.
  * Prevents steps from appearing complete or current while required data is loading, unavailable, or unresolved.

* **Documentation**
  * Updated the release changelog with details about the improved progress rail accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->