### PR TITLE
feat(web): capability picker for AI connection wizard (token path)

### DIFF
--- a/apps/web/src/features/ai-connections/capabilities.ts
+++ b/apps/web/src/features/ai-connections/capabilities.ts
@@ -66,3 +66,50 @@ export const KNOWN_CAPABILITIES: readonly Capability[] = Object.keys(
 export function capabilityLabel(capability: string): string {
   return (CAPABILITY_LABELS as Readonly<Record<string, string>>)[capability] ?? capability;
 }
+
+/**
+ * What each capability actually permits, in an operator's words, for the
+ * capability picker (step 4, "Choose what it may do", TOKEN path only --
+ * connect-wizard.tsx). `Record<Capability, string>` rather than a partial map
+ * so TypeScript itself refuses to compile a ninth capability added to
+ * CAPABILITY_LABELS above without a blurb here -- the same "one list, derived
+ * everywhere else" property the file header describes, extended to copy.
+ *
+ * ALL EIGHT ARE READ-ONLY, INCLUDING THE ONE THAT CANNOT BE GRANTED YET. There
+ * is no ninth "write" or "propose" capability anywhere in this build --
+ * mcp.sites.write and mcp.sites.restart appear only as REJECTED-VALUE test
+ * fixtures in apps/api, never as something Authenticate can hold. Every blurb
+ * below describes seeing something, never changing it.
+ */
+export const CAPABILITY_DESCRIPTIONS: Readonly<Record<Capability, string>> = {
+  "mcp.sites.read": "See the fleet inventory: site names, URLs and tags.",
+  "mcp.uptime.read": "See uptime checks and outage history for sites in scope.",
+  "mcp.backups.read": "See backup runs, their status, and when each last completed.",
+  "mcp.security.read": "See security findings and scan results for sites in scope.",
+  "mcp.activity.read": "See the activity log: what changed, and when.",
+  "mcp.performance.read": "See Core Web Vitals and other performance metrics.",
+  "mcp.diagnostics.read": "See health checks and diagnostic reports for sites in scope.",
+  // Seated but unreachable -- see CONFERRABLE_CAPABILITIES below for why this
+  // one is never offered as a live checkbox.
+  "mcp.content.read": "Read post and page content.",
+} as const;
+
+/**
+ * The seven capabilities the server will actually confer, mirrored from
+ * apps/api/internal/mcp/policy.go's scopeCapabilities[ScopeRead] (lines
+ * 190-198). `mcp.content.read` is deliberately excluded: policy.go's own
+ * comment above CapContentRead (~line 100-104) says there is no post/page
+ * table, no agent command that returns content, and ADR-062 holds it behind
+ * ship blockers -- the eighth name exists only because the DB CHECK constraint
+ * (m131 DECISION 5) requires the Go vocabulary and the database to agree on
+ * all eight, not because it can be granted.
+ *
+ * DERIVED, NOT A HAND-COPIED SUBSET. Filtering KNOWN_CAPABILITIES rather than
+ * writing the seven names out again means a capability added to
+ * CAPABILITY_LABELS defaults to "not conferrable" until this list is updated
+ * on purpose -- the safer direction for a name the picker cannot yet prove the
+ * server will honour.
+ */
+export const CONFERRABLE_CAPABILITIES: readonly Capability[] = KNOWN_CAPABILITIES.filter(
+  (c) => c !== "mcp.content.read",
+);

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -302,7 +302,7 @@ function currentRailStep(): HTMLElement {
 }
 
 describe("the step rail names all ten specified steps and marks the right one current", () => {
-  it("renders all ten specified steps, in specified order, with only four built", async () => {
+  it("renders all ten specified steps, in specified order, with only five built", async () => {
     renderWizard();
     await screen.findByRole("button", { name: /claude code/i });
 
@@ -311,8 +311,11 @@ describe("the step rail names all ten specified steps and marks the right one cu
       Array.from({ length: 10 }, (_, i) => String(i + 1)),
     );
     const builtNs = segments.filter((s) => s.dataset.stepState !== "not-built").map((s) => s.dataset.stepN);
-    // The four shipped sections, and no others, are ever built.
-    expect(builtNs.sort()).toEqual(["2", "3", "5", "6"]);
+    // The five shipped sections, and no others, are ever built. Step 4 (the
+    // capability picker) is built on the token path only, but `built: true`
+    // is a static property of SPEC_STEPS, not conditioned on the method
+    // chosen -- the same standard step 3 and step 6 already meet.
+    expect(builtNs.sort()).toEqual(["2", "3", "4", "5", "6"]);
   });
 
   it("marks specified step 2 current before any client is picked", async () => {
@@ -380,11 +383,22 @@ describe("the step rail names all ten specified steps and marks the right one cu
     fireEvent.click(authCard("oauth"));
     await screen.findByTestId("site-step-count");
 
-    for (const n of ["1", "4", "7", "8", "9", "10"]) {
+    // Step 4 (the capability picker) is excluded from this list -- it is
+    // `built: true` in SPEC_STEPS (it renders on the token path), so on this
+    // OAuth walk it is a real built-but-position-completed step, the same as
+    // step 3, and asserted separately below.
+    for (const n of ["1", "7", "8", "9", "10"]) {
       const el = document.querySelector(`[data-step-n="${n}"]`);
       expect(el).toHaveAttribute("data-step-state", "not-built");
       expect(el).not.toHaveAttribute("aria-current", "step");
     }
+    // Step 4 IS built, and on this OAuth walk is completed by position, same
+    // as step 3 -- neither is "faked": both really are earlier, in
+    // BUILT_ORDER, than the setup step this walk has actually reached.
+    expect(document.querySelector('[data-step-n="4"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -775,23 +789,20 @@ describe("step 3 exists at all, and sits before capabilities", () => {
 
   it("numbers the setup artefact after it, so the rail and the page agree", async () => {
     await reachSiteStep();
-    expect(screen.getByRole("heading", { name: /^4\. Set it up$/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^5\. Set it up$/ })).toBeInTheDocument();
     // And the rail no longer claims sites are chosen somewhere else.
     expect(screen.queryByText(/4\. Choose sites and permissions/i)).not.toBeInTheDocument();
   });
 
-  it("does not invent a numbered step for capabilities, which no completion path lets an operator choose today", async () => {
+  it("still renders no capability heading on the OAuth path, which has no channel for the answer", async () => {
     // reachSiteStep exercises the OAuth path (it clicks the oauth auth card),
     // where "this wizard never creates the grant" is true: Approve
     // (apps/api/internal/mcp/service.go:607) takes no capability field. The
-    // token path differs -- the mint endpoint already accepts one
-    // (dto.go:264) and only MintConnectionInput lacks the field
-    // (use-ai-connections.ts:228-233) -- but neither path has a picker in
-    // this frontend, so the assertion below holds for both. Not a claim
-    // about the backend either way: the vocabulary and both endpoints exist.
-    // See GH #660 for where a picker should live.
+    // TOKEN path now DOES have a picker (Section n=4, "Choose what it may
+    // do" -- see the describe block below), so this assertion is scoped to
+    // OAuth specifically rather than claiming neither path has one.
     await reachSiteStep();
-    expect(screen.queryByRole("heading", { name: /what this connection may do/i })).toBeNull();
+    expect(screen.queryByRole("heading", { name: /choose what it may do/i })).toBeNull();
     expect(screen.getByText(/permissions are chosen on the approval screen/i)).toBeInTheDocument();
   });
 });
@@ -864,7 +875,7 @@ describe("an empty scope is a working state, not an error", () => {
     // The setup artefact is reachable with nothing selected. An earlier
     // revision of this surface disabled Continue here; that is the behaviour
     // being corrected.
-    expect(screen.getByRole("heading", { name: /^4\. Set it up$/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^5\. Set it up$/ })).toBeInTheDocument();
     expect(await screen.findByText(/"mcpServers"/)).toBeInTheDocument();
   });
 });
@@ -1198,6 +1209,156 @@ function heldMint(body: unknown = MINTED, status = 201) {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// Step 4 -- "Choose what it may do" (spec S29 step 4), TOKEN PATH ONLY.
+// ---------------------------------------------------------------------------
+
+/** Client and token method picked, sitting at the capability picker. */
+async function reachCapabilityStep() {
+  renderWizard();
+  await pickClient("Cursor");
+  fireEvent.click(authCard("token"));
+  await screen.findByTestId("site-step-count");
+  return screen.findByRole("heading", { name: /choose what it may do/i });
+}
+
+describe("choosing what a token may do (step 4, token path only)", () => {
+  it("renders no capability heading at all on the OAuth path", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+    expect(screen.queryByRole("heading", { name: /choose what it may do/i })).toBeNull();
+  });
+
+  it("renders every conferrable capability with a real description, and Content disabled with its reason", async () => {
+    await reachCapabilityStep();
+
+    // The seven conferrable rows, each carrying label AND description --
+    // never a bare label, which would leave "what it permits" to be guessed.
+    // findAllByRole rather than a singular query: a still-loading render could
+    // otherwise let this pass against a skeleton.
+    const boxes = await screen.findAllByRole("checkbox", { name: /.+/ });
+    expect(boxes.length).toBe(8); // seven conferrable + the disabled Content row
+
+    expect(screen.getByRole("checkbox", { name: /^Sites/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/see the fleet inventory: site names, urls and tags/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/see uptime checks and outage history/i)).toBeInTheDocument();
+    expect(screen.getByText(/see backup runs, their status/i)).toBeInTheDocument();
+
+    // Content: seated in the vocabulary, never conferrable -- disabled, with
+    // the reason stated in an operator's words, not "coming soon".
+    const content = screen.getByRole("checkbox", { name: /^Content/i });
+    expect(content).toBeDisabled();
+    expect(
+      screen.getByText(/not available yet.*no content tools.*for a connection to call/i),
+    ).toBeInTheDocument();
+  });
+
+  it("states the negative space once: nothing here can change WordPress content or configuration", async () => {
+    await reachCapabilityStep();
+    expect(
+      screen.getByText(/no capability on this screen can change wordpress content or configuration/i),
+    ).toBeInTheDocument();
+  });
+
+  it("opens with only sites-read checked -- the server's own default for an omitted field, never empty and never all seven", async () => {
+    await reachCapabilityStep();
+    expect(screen.getByRole("checkbox", { name: /^Sites/i })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /^Uptime/i })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /^Backups/i })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /^Security/i })).not.toBeChecked();
+  });
+
+  it("refuses to mint when every capability is deselected, rather than defaulting or sending nothing", async () => {
+    // THE GUARD UNDER MUTATION TEST. See the PR description for the red/green
+    // proof: temporarily changing mintCapabilitiesRequest's `selected.length
+    // === 0` to `selected.length === -1` turns this red, and restoring it
+    // turns it green again.
+    loadedFleet(3);
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    // A valid site scope, so the ONLY thing left blocking the button is the
+    // capability deselection this test is actually about.
+    fireEvent.click(screen.getByRole("button", { name: /\+ add sites/i }));
+    fireEvent.click(pickerBoxes()[0]!);
+    await screen.findByRole("heading", { name: /choose what it may do/i });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Sites/i }));
+
+    // Rendered TWICE by design -- once beside the picker (an operator working
+    // the checkboxes sees it immediately) and once inside the mint panel
+    // (an operator who scrolled straight to the button sees it there) -- so
+    // this asserts on the plural.
+    expect((await screen.findAllByText(/no capability is selected/i)).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /generate connection token/i })).toBeDisabled();
+  });
+
+  it("re-enables minting the moment a capability is checked again -- the over-fire arm of the guard above", async () => {
+    loadedFleet(3);
+    renderWizard();
+    await pickClient("Cursor");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    fireEvent.click(screen.getByRole("button", { name: /\+ add sites/i }));
+    fireEvent.click(pickerBoxes()[0]!);
+    await screen.findByRole("heading", { name: /choose what it may do/i });
+
+    const sites = screen.getByRole("checkbox", { name: /^Sites/i });
+    fireEvent.click(sites);
+    expect(screen.getByRole("button", { name: /generate connection token/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Uptime/i }));
+    expect(screen.queryByText(/no capability is selected/i)).toBeNull();
+    expect(screen.getByRole("button", { name: /generate connection token/i })).toBeEnabled();
+  });
+
+  it("never sends `capabilities: []` on the wire, and sends exactly the selected set", async () => {
+    // Asserted on the ACTUAL SERIALIZED FETCH BODY, not on hook-internal state
+    // or React state -- a hook-level assertion could pass while a stray `?? []`
+    // still reached the network.
+    loadedFleet(3);
+    let capturedBody: Record<string, unknown> | null = null;
+    stubMintFetch((init) => {
+      capturedBody =
+        typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+      return jsonResponse(MINTED, 201);
+    });
+
+    fireEvent.click(await reachMintButton());
+    await screen.findByText(/this is the only time this token is shown/i);
+
+    expect(capturedBody).not.toBeNull();
+    const body = capturedBody as Record<string, unknown>;
+    expect(Array.isArray(body.capabilities)).toBe(true);
+    expect(body.capabilities).toEqual(["mcp.sites.read"]);
+    expect(body.capabilities).not.toEqual([]);
+  });
+
+  it("sends every capability actually checked, not only the default", async () => {
+    loadedFleet(3);
+    let capturedBody: Record<string, unknown> | null = null;
+    stubMintFetch((init) => {
+      capturedBody =
+        typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+      return jsonResponse(MINTED, 201);
+    });
+
+    const mintButton = await reachMintButton();
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Uptime/i }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Backups/i }));
+    fireEvent.click(mintButton);
+    await screen.findByText(/this is the only time this token is shown/i);
+
+    const body = capturedBody as Record<string, unknown>;
+    expect(body.capabilities).toEqual(["mcp.sites.read", "mcp.uptime.read", "mcp.backups.read"]);
+  });
 });
 
 describe("minting a connection token", () => {

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1324,10 +1324,9 @@ describe("choosing what a token may do (step 4, token path only)", () => {
     // or React state -- a hook-level assertion could pass while a stray `?? []`
     // still reached the network.
     loadedFleet(3);
-    let capturedBody: Record<string, unknown> | null = null;
+    let capturedBody: unknown = null;
     stubMintFetch((init) => {
-      capturedBody =
-        typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+      capturedBody = typeof init?.body === "string" ? (JSON.parse(init.body) as unknown) : null;
       return jsonResponse(MINTED, 201);
     });
 
@@ -1343,10 +1342,9 @@ describe("choosing what a token may do (step 4, token path only)", () => {
 
   it("sends every capability actually checked, not only the default", async () => {
     loadedFleet(3);
-    let capturedBody: Record<string, unknown> | null = null;
+    let capturedBody: unknown = null;
     stubMintFetch((init) => {
-      capturedBody =
-        typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+      capturedBody = typeof init?.body === "string" ? (JSON.parse(init.body) as unknown) : null;
       return jsonResponse(MINTED, 201);
     });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -615,8 +615,8 @@ export function ConnectWizard({
         >
           <div className="space-y-3">
             <p className="text-xs text-[var(--color-muted-foreground)]">
-              {describeSiteScope(scope)} This decides what it may see there -- not to how many
-              sites, which stays step 3's answer.
+              {describeSiteScope(scope)} This decides what it may see there -- how many sites
+              it reaches is step 3's answer, already given.
             </p>
             <ul className="space-y-2">
               {KNOWN_CAPABILITIES.map((cap) => {

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -15,7 +15,6 @@ import {
   CONFERRABLE_CAPABILITIES,
   KNOWN_CAPABILITIES,
   capabilityLabel,
-  type Capability,
 } from "./capabilities";
 
 import {
@@ -651,7 +650,7 @@ export function ConnectWizard({
                           {capabilityLabel(cap)}
                         </span>
                         <span className="block text-xs text-[var(--color-muted-foreground)]">
-                          {CAPABILITY_DESCRIPTIONS[cap as Capability]}
+                          {CAPABILITY_DESCRIPTIONS[cap]}
                         </span>
                         {!conferrable ? (
                           <span className="block text-xs text-[var(--color-muted-foreground)]">

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -5,10 +5,18 @@ import { AlertTriangle, Check, ExternalLink, Lock } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CopyableMono } from "@/components/shared/copyable-mono";
 import { cn } from "@/lib/utils";
+import {
+  CAPABILITY_DESCRIPTIONS,
+  CONFERRABLE_CAPABILITIES,
+  KNOWN_CAPABILITIES,
+  capabilityLabel,
+  type Capability,
+} from "./capabilities";
 
 import {
   CLIENT_TABLE_VERIFIED_AT,
@@ -60,37 +68,35 @@ import {
 // answer being written. The same is already true of the connection name two
 // sections down, and it is stated the same way rather than implied.
 //
-// THERE IS NO CAPABILITIES STEP HERE, AND NOT BECAUSE THE BACKEND IS MISSING.
-// The vocabulary is seated (policy.go: eight capability strings, seven of
-// them conferrable via the read scope), and one of this wizard's two
-// completion paths already puts it on the wire: TokenMintPanel below calls
-// useMintConnection(), which POSTs to CONNECTIONS_PATH and already accepts a
-// `capabilities` list on the request (dto.go:264) and returns one on the
-// response (dto.go:305). A picker on THAT path would need only a frontend
-// field -- MintConnectionInput (use-ai-connections.ts:228-233) has name,
-// siteScopeMode, scopeTagIds and scopeSiteIds, and no capabilities -- so the
-// gap there is this file, not the server.
+// THERE IS NOW A CAPABILITIES STEP HERE, ON THE TOKEN PATH ONLY. The
+// vocabulary is seated (policy.go: eight capability strings, seven of them
+// conferrable via the read scope), and TokenMintPanel calls useMintConnection(),
+// which POSTs to CONNECTIONS_PATH and accepts a `capabilities` list on the
+// request (dto.go:264) and returns one on the response (dto.go:305).
+// MintConnectionInput (use-ai-connections.ts) now carries that field, and the
+// new Section n=4 below ("Choose what it may do") is the picker that fills it.
 //
-// THE OAUTH PATH IS THE OTHER ONE, AND IS WHERE "THIS WIZARD NEVER CREATES
-// THE GRANT" (WHAT STEP 3 STILL CANNOT DO, above) IS ACTUALLY TRUE. The
-// client redirects into the approval screen at /connect/ai, which calls
-// Approve (service.go:607); ApprovalRequest carries Principal, Consent,
-// GrantName and SiteScope and nothing else, so that path genuinely has no
-// channel for a capability answer today.
+// THE OAUTH PATH IS THE ONE WHERE "THIS WIZARD NEVER CREATES THE GRANT" (WHAT
+// STEP 3 STILL CANNOT DO, above) IS ACTUALLY TRUE, AND STILL HAS NO
+// CAPABILITIES STEP. The client redirects into the approval screen at
+// /connect/ai, which calls Approve (service.go:607); ApprovalRequest carries
+// Principal, Consent, GrantName and SiteScope and nothing else, so that path
+// genuinely has no channel for a capability answer today. Section n=4 below
+// is therefore rendered only for `method === "token"`; for OAuth, NextSteps
+// still says permissions are chosen on the approval screen, because that
+// remains true there and only there.
 //
-// So a picker built only against the mint call would work for token
-// connections and do nothing for OAuth ones, and a permission model that
-// varies by how the connection was made is worse than one that stays
-// uniformly narrow -- which is why neither path has one, rather than one
-// path having one and the other not. The choice among the three real options
-// is open, tracked in GH #660, and this file does not make it. Cited by
-// file:line above rather than restated from memory: summarising this split
-// instead of pointing at it is exactly what went stale here before.
+// A permission model that varies by how the connection was made is a real
+// asymmetry, not a bug: the token path can put an answer on the wire today,
+// and the OAuth path genuinely cannot until the approval screen grows a
+// channel for one (tracked in GH #660). Cited by file:line above rather than
+// restated from memory: summarising this split instead of pointing at it is
+// exactly what went stale here before.
 //
 // NO SNIPPET IS WRITTEN IN THIS FILE. Every block comes from buildSnippet, and
 // snippet.test.ts fails the build if a config literal appears here.
 
-type Step = 1 | 2 | 3 | 4;
+type Step = 1 | 2 | 3 | 4 | 5;
 
 /**
  * The rail this page renders is the design's own numbering (S29, "ADD MCP
@@ -100,7 +106,7 @@ type Step = 1 | 2 | 3 | 4;
  * steps and the operator is entitled to see all ten before starting.
  *
  * THE MAP FROM A BUILT SECTION TO ITS SPECIFIED NUMBER IS NOT MONOTONIC ON
- * SCREEN. The four built sections answer specified steps 2, 5, 3 and 6, IN
+ * SCREEN. The five built sections answer specified steps 2, 5, 3, 4 and 6, IN
  * THAT ORDER: this wizard reaches specified step 3 ("which sites") AFTER
  * specified step 5 ("how it authenticates"), because the site-scope section
  * was inserted after the auth-method section by design (see the file-top
@@ -109,12 +115,18 @@ type Step = 1 | 2 | 3 | 4;
  * specified number -- comparing raw numbers would call specified step 5
  * incomplete the moment the operator reached specified step 3, which is
  * backwards.
+ *
+ * SPECIFIED STEP 4 ("CHOOSE WHAT IT MAY DO") IS NEW HERE, TOKEN PATH ONLY. It
+ * sits between site scope (spec 3) and the setup artefact (spec 6), matching
+ * the specified order, so the local step numbers below shift: the setup
+ * section that used to be local step 4 is now local step 5.
  */
-const BUILT_ORDER: readonly [1 | 2 | 3 | 4, number][] = [
+const BUILT_ORDER: readonly [1 | 2 | 3 | 4 | 5, number][] = [
   [1, 2],
   [2, 5],
   [3, 3],
-  [4, 6],
+  [4, 4],
+  [5, 6],
 ];
 
 /** The specified step number a locally-built step answers. */
@@ -136,13 +148,17 @@ interface SpecStepDef {
 }
 
 // All ten, in specified order, so the operator sees the whole path before
-// starting. Only four are `built: true`; the rest render as not-yet-available
+// starting. Only five are `built: true`; the rest render as not-yet-available
 // rather than being omitted or, worse, made to look done.
 const SPEC_STEPS: readonly SpecStepDef[] = [
   { n: 1, label: "Start a connection", built: false },
   { n: 2, label: "Name it, pick the AI client", built: true },
   { n: 3, label: "Choose which sites", built: true },
-  { n: 4, label: "Choose what it may do", built: false },
+  // Built on the TOKEN path only -- see the file-top comment on the OAuth
+  // split. `built: true` still means "reachable on at least one path", the
+  // same standard site-scope and setup already meet even though the sites
+  // page's copy names its own limits per method.
+  { n: 4, label: "Choose what it may do", built: true },
   { n: 5, label: "Choose how it authenticates", built: true },
   { n: 6, label: "Get the setup artefact", built: true },
   { n: 7, label: "Connect and authorize", built: false },
@@ -172,6 +188,22 @@ type SiteScopeReadiness = "loading" | "failed" | "tags-unresolved" | "unselected
 
 /** The specified step number (design S29) that answers "which sites." */
 const SITE_SCOPE_SPEC_N = 3;
+
+/**
+ * Whether the capability picker is actually done, for the one reason mint can
+ * refuse it on the token path: nobody has been left checked. Deliberately a
+ * NARROWER union than SiteScopeReadiness -- there is no fleet read behind this
+ * step, so there is no "loading" or "failed" state for it to be in, only
+ * "an operator has not settled on an answer" or "they have."
+ *
+ * `"unselected"` is a member of SiteScopeReadiness too, so the rail's
+ * per-segment rendering below (which already prints "(not chosen yet)" for
+ * that string) needs no new branch to cover this step as well.
+ */
+type CapabilityReadiness = "unselected" | "resolved";
+
+/** The specified step number (design S29) that answers "what it may do." */
+const CAPABILITY_SPEC_N = 4;
 
 export interface ConnectWizardProps {
   /** Absolute MCP endpoint for this deployment. Passed in, never assembled here. */
@@ -224,6 +256,16 @@ export function ConnectWizard({
     tagNames: [],
     siteIds: [],
   });
+  // DEFAULTS TO `["mcp.sites.read"]`, NOT `[]` AND NOT ALL SEVEN. Empty would
+  // silently mint a token that can reach nothing the moment an operator
+  // skipped this step without reading it -- the same defect this project's
+  // signature bug takes elsewhere, one layer up: a state nobody chose read as
+  // a deliberate answer. All seven would defeat the point of asking at all,
+  // the same reasoning the site-scope step's "no default 'all'" comment above
+  // already gives. Sites-read matches dto.go's own default for an OMITTED
+  // field, so an operator who changes nothing here ends up with exactly what
+  // they would have gotten by not answering.
+  const [capabilities, setCapabilities] = useState<readonly string[]>(["mcp.sites.read"]);
 
   const client = useMemo(
     () => MCP_CLIENTS.find((c) => c.id === clientId) ?? null,
@@ -236,15 +278,17 @@ export function ConnectWizard({
   // answers. Picking a different client with an incompatible method drops the
   // method rather than carrying a stale one into step 3.
   //
-  // THE LAST BRANCH IS 4, NOT 3. Section 3 ("Sites this connection may
-  // reach") and Section 4 ("Set it up") share the exact same reveal
+  // THE LAST BRANCH IS 5, NOT 3 OR 4. Section 3 ("Sites this connection may
+  // reach") and Section 5 ("Set it up") share the exact same reveal
   // condition below (`client !== null && method !== null`) -- they always
   // appear together, so there is no state in which section 3 is on screen
-  // and section 4 is not. Once that condition holds, 4 is the furthest
+  // and section 5 is not. Once that condition holds, 5 is the furthest
   // section actually revealed, and aria-current has to say so; stopping at 3
   // told a screen-reader user they were in a section behind the one they
-  // were actually working in.
-  const step: Step = client === null ? 1 : method === null ? 2 : 4;
+  // were actually working in. (Section 4, the capability picker, renders only
+  // for `method === "token"`, but its BUILT_ORDER position is still crossed
+  // the moment client and method are both picked, same as section 3.)
+  const step: Step = client === null ? 1 : method === null ? 2 : 5;
 
   // Resolved once here rather than inside the mint panel, so the SAME answer
   // gates the mint button and is described back in the one-time reveal -- a
@@ -291,6 +335,21 @@ export function ConnectWizard({
   // button and the rail, is what makes a fourth door impossible rather than
   // merely unlikely.
   const siteScopeState: SiteScopeReadiness = siteScopeReadiness(scope, scopeRequest, method);
+
+  // THE CAPABILITY PAYLOAD, OR THE REASON THERE IS NONE -- built once, here,
+  // the same pattern as `scopeRequest` two blocks up and for the same reason:
+  // the gate and the mint call must read one value, never two derivations of
+  // the same selection that could disagree.
+  const capabilitiesRequest = useMemo(
+    () => mintCapabilitiesRequest(capabilities),
+    [capabilities],
+  );
+
+  // THE RAIL'S CAPABILITY STATE, mirroring siteScopeState immediately above:
+  // one function, read by both the rail and `mintBlockedReason` below, so
+  // "step 4 reads done" and "mint will actually accept this" cannot drift
+  // apart the way `scope.kind` alone once did for site scope.
+  const capabilityState: CapabilityReadiness = capabilityReadiness(capabilitiesRequest, method);
 
   // A mint is a network round trip, and every control above is live during it.
   // Disabling them is the FIRST half of the fix (the operator is not offered a
@@ -380,7 +439,11 @@ export function ConnectWizard({
 
   return (
     <div className={cn("space-y-6", className)}>
-      <StepRail current={step} siteScopeState={siteScopeState} />
+      <StepRail
+        current={step}
+        siteScopeState={siteScopeState}
+        capabilityState={capabilityState}
+      />
 
       {/* THE ONE AND ONLY PLACE A REVEAL IS RENDERED, and it is deliberately
           outside every step. A second render site inside step 4 would restore
@@ -539,9 +602,88 @@ export function ConnectWizard({
         </Section>
       ) : null}
 
-      {client !== null && method !== null ? (
+      {/* TOKEN PATH ONLY. On OAuth there is no channel to carry an answer
+          anywhere -- see the file-top comment -- so rendering a picker here
+          would look like a decision that does something when it does
+          nothing, the same defect this whole file elsewhere refuses to
+          commit. NextSteps below already tells the OAuth operator where this
+          choice is actually made. */}
+      {client !== null && method === "token" ? (
         <Section
           n={4}
+          title="Choose what it may do"
+          hint="Every capability here is read-only. Nothing on this list can change WordPress content or configuration."
+        >
+          <div className="space-y-3">
+            <p className="text-xs text-[var(--color-muted-foreground)]">
+              {describeSiteScope(scope)} This decides what it may see there -- not to how many
+              sites, which stays step 3's answer.
+            </p>
+            <ul className="space-y-2">
+              {KNOWN_CAPABILITIES.map((cap) => {
+                const conferrable = (CONFERRABLE_CAPABILITIES as readonly string[]).includes(cap);
+                const checked = capabilities.includes(cap);
+                return (
+                  <li key={cap}>
+                    <label
+                      className={cn(
+                        "flex items-start gap-2 rounded-md border border-[var(--color-border)] p-2 text-sm",
+                        !conferrable && "cursor-not-allowed opacity-70",
+                      )}
+                    >
+                      <Checkbox
+                        className="mt-0.5"
+                        checked={checked}
+                        disabled={!conferrable || mintInFlight}
+                        onChange={(e) => {
+                          const next = e.target.checked;
+                          setCapabilities((current) =>
+                            next
+                              ? current.includes(cap)
+                                ? current
+                                : [...current, cap]
+                              : current.filter((c) => c !== cap),
+                          );
+                        }}
+                      />
+                      <span>
+                        <span className="block font-medium text-[var(--color-foreground)]">
+                          {capabilityLabel(cap)}
+                        </span>
+                        <span className="block text-xs text-[var(--color-muted-foreground)]">
+                          {CAPABILITY_DESCRIPTIONS[cap as Capability]}
+                        </span>
+                        {!conferrable ? (
+                          <span className="block text-xs text-[var(--color-muted-foreground)]">
+                            Not available yet -- there are no content tools for a connection to
+                            call, so there is nothing this permission could reach.
+                          </span>
+                        ) : null}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+            <p className="text-xs text-[var(--color-muted-foreground)]">
+              These are all read-only. No capability on this screen can change WordPress
+              content or configuration, whichever ones you pick.
+            </p>
+            {!capabilitiesRequest.ok ? (
+              <p
+                role="alert"
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 text-sm text-[var(--color-foreground)]"
+              >
+                {capabilitiesRequest.refusal}
+              </p>
+            ) : null}
+          </div>
+        </Section>
+      ) : null}
+
+      {client !== null && method !== null ? (
+        <Section
+          n={5}
           title="Set it up"
           hint="Generated for this client. Every difference below is a real difference between clients."
         >
@@ -592,6 +734,7 @@ export function ConnectWizard({
                 name={name}
                 scope={scope}
                 scopeRequest={scopeRequest}
+                capabilitiesRequest={capabilitiesRequest}
               />
             )}
           </div>
@@ -609,6 +752,7 @@ export function ConnectWizard({
 function StepRail({
   current,
   siteScopeState,
+  capabilityState,
 }: {
   current: Step;
   /**
@@ -620,6 +764,12 @@ function StepRail({
    * still called step 3 done and put `aria-current` on step 6.
    */
   siteScopeState: SiteScopeReadiness;
+  /**
+   * From `capabilityReadiness`, the same pattern one step later: the rail and
+   * `mintBlockedReason` read one value for "has the operator settled a
+   * capability answer," never two.
+   */
+  capabilityState: CapabilityReadiness;
 }) {
   const currentSpec = specStepFor(current);
   const currentPos = BUILT_ORDER.findIndex(([, spec]) => spec === currentSpec);
@@ -631,12 +781,29 @@ function StepRail({
   // operator has not been told otherwise yet.
   const siteScopeBlocking =
     siteScopeState !== "resolved" && siteScopeBuiltPos !== -1 && siteScopeBuiltPos <= currentPos;
-  // THE OVERRIDE ITSELF. While step 3 is not done, IT is where the operator's
-  // process actually stands, not whatever position the local step has
-  // otherwise reached -- so aria-current moves back to it instead of sitting
-  // on a "setup" step whose mint button it, in fact, still blocks.
-  const effectiveCurrentSpec = siteScopeBlocking ? SITE_SCOPE_SPEC_N : currentSpec;
-  const effectiveCurrentPos = siteScopeBlocking ? siteScopeBuiltPos : currentPos;
+  const capabilityBuiltPos = BUILT_ORDER.findIndex(([, spec]) => spec === CAPABILITY_SPEC_N);
+  // SAME BLOCKING TEST, ONE STEP LATER. Not relevant until the walk has
+  // actually reached the capability picker's position.
+  const capabilityBlocking =
+    capabilityState !== "resolved" &&
+    capabilityBuiltPos !== -1 &&
+    capabilityBuiltPos <= currentPos;
+  // THE OVERRIDE ITSELF, AND WHICH ONE WINS WHEN BOTH BLOCK. Site scope (built
+  // position 2) sits before the capability picker (built position 3) in
+  // BUILT_ORDER, so an operator who has resolved neither is, in fact, still
+  // working on the earlier one -- reporting the capability picker instead
+  // would tell them they are stuck on a step they have not been let reach in
+  // any meaningful sense yet.
+  const effectiveCurrentSpec = siteScopeBlocking
+    ? SITE_SCOPE_SPEC_N
+    : capabilityBlocking
+      ? CAPABILITY_SPEC_N
+      : currentSpec;
+  const effectiveCurrentPos = siteScopeBlocking
+    ? siteScopeBuiltPos
+    : capabilityBlocking
+      ? capabilityBuiltPos
+      : currentPos;
   return (
     <div className="space-y-1">
       <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--color-muted-foreground)]">
@@ -647,19 +814,27 @@ function StepRail({
           // see the comment on BUILT_ORDER above for why those disagree here.
           const builtPos = BUILT_ORDER.findIndex(([, spec]) => spec === s.n);
           const isCompleted = builtPos !== -1 && builtPos < effectiveCurrentPos;
-          // SITE SCOPE'S OWN STATES, CHECKED BEFORE THE GENERIC ONES BELOW AND
-          // OVERRIDING THEM. "completed" here would be the exact defect this
-          // whole rework exists for: a step reading as finished while mint
-          // would still refuse it. Each reason is kept distinct rather than
-          // collapsing into one muted "not done yet" -- an operator told
-          // nothing when a read has actually failed keeps waiting for a state
-          // that is never coming, and one told "loading" for their own
-          // unmade selection is told something false about themselves.
-          const state: "not-built" | "current" | "completed" | "upcoming" | SiteScopeReadiness =
-            !s.built
-              ? "not-built"
-              : s.n === SITE_SCOPE_SPEC_N && siteScopeBlocking
-                ? siteScopeState
+          // SITE SCOPE'S AND THE CAPABILITY PICKER'S OWN STATES, CHECKED
+          // BEFORE THE GENERIC ONES BELOW AND OVERRIDING THEM. "completed"
+          // here would be the exact defect this whole rework exists for: a
+          // step reading as finished while mint would still refuse it. Each
+          // reason is kept distinct rather than collapsing into one muted
+          // "not done yet" -- an operator told nothing when a read has
+          // actually failed keeps waiting for a state that is never coming,
+          // and one told "loading" for their own unmade selection is told
+          // something false about themselves.
+          const state:
+            | "not-built"
+            | "current"
+            | "completed"
+            | "upcoming"
+            | SiteScopeReadiness
+            | CapabilityReadiness = !s.built
+            ? "not-built"
+            : s.n === SITE_SCOPE_SPEC_N && siteScopeBlocking
+              ? siteScopeState
+              : s.n === CAPABILITY_SPEC_N && capabilityBlocking
+                ? capabilityState
                 : isCurrent
                   ? "current"
                   : isCompleted
@@ -698,13 +873,16 @@ function StepRail({
           );
         })}
       </ol>
-      {/* Step 4 in the rail above ("Choose what it may do") has no section on
-          this page: neither completion path this wizard ends in lets an
-          operator choose a capability today -- see the file-top comment on
-          the OAuth/token split. Naming where that choice IS made today keeps
-          the gap from reading as an oversight. */}
+      {/* Step 4 in the rail above ("Choose what it may do") now has a section
+          on this page, on the TOKEN path only -- see the file-top comment on
+          the OAuth/token split. The OAuth path still has no channel for this
+          choice, so the second sentence below remains true only there; it is
+          kept rather than dropped, because an OAuth operator reading this
+          rail must not be led to look for a step 4 that will not appear for
+          them. */}
       <p className="text-xs text-[var(--color-muted-foreground)]">
-        Permissions are chosen on the approval screen.
+        Chosen here for a connection token. The browser sign-in path has no channel for it yet,
+        so for that path permissions are chosen on the approval screen.
       </p>
     </div>
   );
@@ -1162,6 +1340,52 @@ function siteScopeReadiness(
   return "resolved";
 }
 
+/** The capability payload a mint would send, or the reason there is none. */
+type MintCapabilitiesRequest =
+  | { readonly ok: true; readonly capabilities: readonly string[] }
+  | { readonly ok: false; readonly refusal: string };
+
+/**
+ * The capability payload for the CURRENT selection, or the reason there is
+ * none -- the same shape and the same reason `mintScopeRequest` above returns
+ * one, so the gate (`mintBlockedReason`) and the wire payload
+ * (`TokenMintPanel`'s mint call) read one value rather than two derivations
+ * of the same checkbox state.
+ *
+ * THE ONLY REFUSAL: NOTHING IS CHECKED. dto.go's mintConnectionRequestDTO
+ * treats an OMITTED `capabilities` field as the default preset
+ * `["mcp.sites.read"]`, but an explicitly empty array is a different wire
+ * value entirely -- it mints a connection that authenticates and can reach no
+ * tool at all, because Authenticate refuses by name on every request. A
+ * request naming no capabilities and a request naming none-on-purpose are not
+ * the same thing, so this is refused client-side rather than silently
+ * becoming the default or being sent as `[]`.
+ */
+function mintCapabilitiesRequest(selected: readonly string[]): MintCapabilitiesRequest {
+  if (selected.length === 0) {
+    return {
+      ok: false,
+      refusal:
+        "No capability is selected, so this token would authenticate and be able to reach nothing. Pick at least one capability above, or leave Sites checked. An empty selection is refused rather than becoming the default.",
+    };
+  }
+  return { ok: true, capabilities: selected };
+}
+
+/**
+ * Whether the capability picker is actually done, mirroring
+ * `siteScopeReadiness` immediately above -- OAuth (and no method chosen yet)
+ * never gates on this, for the same reason: NextSteps is unconditionally
+ * actionable on that path, and the picker below does not even render there.
+ */
+function capabilityReadiness(
+  capabilitiesRequest: MintCapabilitiesRequest,
+  method: AuthMethod | null,
+): CapabilityReadiness {
+  if (method !== "token") return "resolved";
+  return capabilitiesRequest.ok ? "resolved" : "unselected";
+}
+
 /**
  * The reason minting is refused, or null when it is not.
  *
@@ -1172,6 +1396,7 @@ function mintBlockedReason(
   nameOk: boolean,
   scope: ResolvedSiteScope,
   scopeRequest: MintScopeRequest,
+  capabilitiesRequest: MintCapabilitiesRequest,
 ): string | null {
   if (!nameOk) return "Name this connection before minting a token.";
   // Literally "token", not threaded through as a parameter: this function is
@@ -1189,6 +1414,10 @@ function mintBlockedReason(
   // second copy of the sentence, is what keeps this and the refusal text from
   // drifting apart.
   if (!scopeRequest.ok) return scopeRequest.refusal;
+  // Site scope is checked before capabilities, matching the on-screen order
+  // (step 3, then step 4): an operator missing both should be told about the
+  // earlier gap first, not the later one.
+  if (!capabilitiesRequest.ok) return capabilitiesRequest.refusal;
   return null;
 }
 
@@ -1285,6 +1514,7 @@ function TokenMintPanel({
   name,
   scope,
   scopeRequest,
+  capabilitiesRequest,
 }: {
   /**
    * The mutation, OWNED BY THE WIZARD. This panel drives it and reads it, and
@@ -1300,10 +1530,12 @@ function TokenMintPanel({
   name: string;
   scope: ResolvedSiteScope;
   scopeRequest: MintScopeRequest;
+  /** From `mintCapabilitiesRequest`, built once by the wizard -- see its doc. */
+  capabilitiesRequest: MintCapabilitiesRequest;
 }) {
   const trimmedName = name.trim();
   const nameOk = trimmedName.length > 0;
-  const blocked = mintBlockedReason(nameOk, scope, scopeRequest);
+  const blocked = mintBlockedReason(nameOk, scope, scopeRequest, capabilitiesRequest);
   const canMint = blocked === null && !mint.isPending;
 
   if (revealed) {
@@ -1355,14 +1587,21 @@ function TokenMintPanel({
         onClick={() => {
           // canMint already proved this, and an enabled button with no payload
           // would be the gate and the request disagreeing again. Refusing here
-          // rather than sending `?? []` keeps that impossible instead of quiet.
+          // rather than sending `?? []` / `?? ["mcp.sites.read"]` keeps that
+          // impossible instead of quiet -- see mintCapabilitiesRequest's doc
+          // for why an empty selection must never reach the wire as `[]`.
           if (!scopeRequest.ok) return;
+          if (!capabilitiesRequest.ok) return;
           // Read here, at the moment the request is built, and closed over.
           // Reading them again inside onSuccess is the whole defect: that runs
           // after a round trip the operator can type through.
           const mintedFor = { scope, clientName };
           mint.mutate(
-            { name: trimmedName, ...scopeRequest.scope },
+            {
+              name: trimmedName,
+              ...scopeRequest.scope,
+              capabilities: capabilitiesRequest.capabilities,
+            },
             // onMinted writes state the WIZARD owns, so this callback lands on
             // a mounted component whatever happened to this panel meanwhile.
             { onSuccess: (token) => onMinted({ token, ...mintedFor }) },

--- a/apps/web/src/features/ai-connections/use-ai-connections.ts
+++ b/apps/web/src/features/ai-connections/use-ai-connections.ts
@@ -247,6 +247,20 @@ export interface MintConnectionInput {
   readonly siteScopeMode: string;
   readonly scopeTagIds: readonly string[];
   readonly scopeSiteIds: readonly string[];
+  /**
+   * The capability list this request confers, wire key `capabilities`
+   * (dto.go's mintConnectionRequestDTO, ~line 264). NEVER `[]` ON THE WIRE.
+   * dto.go treats an omitted field as the default preset `["mcp.sites.read"]`,
+   * but an explicitly empty array is a different thing entirely: it stores a
+   * connection that authenticates and can reach no tool at all, because
+   * Authenticate refuses by name on every request. A request naming no
+   * capabilities and a request naming none-on-purpose are not the same wire
+   * value, so this mutation never sends the latter -- the caller
+   * (connect-wizard.tsx's mintCapabilitiesRequest) refuses to build a request
+   * at all when the operator has deselected every row, rather than letting an
+   * empty array reach this function.
+   */
+  readonly capabilities: readonly string[];
 }
 
 /**
@@ -315,6 +329,10 @@ export function useMintConnection(): UseMutationResult<
           site_scope_mode: input.siteScopeMode,
           scope_tag_ids: [...input.scopeTagIds],
           scope_site_ids: [...input.scopeSiteIds],
+          // NEVER `[]` HERE -- see MintConnectionInput's own doc. This spreads
+          // whatever the caller resolved, and the caller's contract is to have
+          // already refused to reach this call with zero entries.
+          capabilities: [...input.capabilities],
         }),
       });
       if (!res.ok) throw await readHouseError(res);


### PR DESCRIPTION
## Summary
- Adds step 4, "Choose what it may do", to the AI connection wizard's TOKEN path only (spec S29 step 4).
- Renders the 7 conferrable capabilities (mcp.*.read except content) as checkboxes with plain-language descriptions; `mcp.content.read` renders disabled with the reason it is seated but unreachable (policy.go).
- Refuses to mint when zero capabilities are selected, rather than defaulting or sending `capabilities: []` on the wire.
- `MintConnectionInput` (use-ai-connections.ts) now carries `capabilities`, wired into the mint POST body.
- OAuth path is unchanged; it still has no channel for this choice, and NextSteps still says the approval screen asks again.
- Rail (step 4 in the ten-step S29 list) now reads "built", showing "not chosen yet" until at least one capability is checked, mirroring the existing site-scope pattern.

## Test plan
- [x] `pnpm -C apps/web typecheck`
- [x] `pnpm -C apps/web lint` (0 errors; 14 pre-existing warnings in unrelated files)
- [x] `pnpm -C apps/web test` (168 files / 2209 tests passed)
- [x] `pnpm -C apps/web build` (routeTree.gen.ts unaffected, no route files touched)
- [x] `impeccable detect apps/web/src/features/ai-connections` (clean, exit 0)
- [x] mutation-tested the empty-selection refusal guard (RED with the guard disabled, GREEN restored)
- [x] asserted on the actual serialized mint request body: `capabilities` is present, never `[]`, and matches the checked set

## Test plan detail (mutation test)
Guard: `mintCapabilitiesRequest`'s `selected.length === 0` check in connect-wizard.tsx.
- RED: changed to `selected.length === -1`, ran `npx vitest run src/features/ai-connections/connect-wizard.test.tsx -t "choosing what a token may do"` → 2 of 8 tests failed (the empty-selection refusal test and its re-enable counterpart).
- GREEN: restored `=== 0`, re-ran the same command → all 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a capability-selection step to the connection setup wizard.
  * Preselects a default capability and prevents continuing without a valid selection.
  * Includes selected capabilities when creating a token.
  * Displays read-only descriptions for available capabilities and preserves selections throughout token setup and reveal flows.
  * OAuth connections continue selecting permissions during approval.
  * Supports the capabilities currently available for server-issued tokens while excluding unavailable options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->