### PR TITLE
docs: point CLAUDE.md at the wizard spec and add a compaction obligation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,8 +317,8 @@ hold for a whole session, it belongs here.
 ends.** The destination is not a free choice: this file takes guidance,
 rules, pointers, working agreements, whatever is true forever and fit to be
 public. `~/.wpmgr/worklog/` takes everything else that must survive, under
-the rule above. If it would not be fine to see this file public forever, it
-belongs in the worklog, never here.
+the rule above. If what you are about to write would not be fine to see
+public forever, it belongs in the worklog, never here.
 
 Reviews: `review.md`, read in full before reviewing anything.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,12 +313,12 @@ This file is re-injected from disk after compaction. Path-scoped
 `.claude/rules/` are not, until a matching file is read again. If a rule must
 hold for a whole session, it belongs here.
 
-**When a session compacts, put durable project state into a file before the
-turn ends**, into this file, or into the private worklog, whichever it is.
-Compaction summarises the conversation away, and this file is the only thing
-guaranteed to come back; a decision or a plan that lives only in the
-conversation does not survive it. Anything that must survive belongs in a
-file, not in a turn.
+**When a session compacts, write durable state to a file before the turn
+ends.** The destination is not a free choice: this file takes guidance,
+rules, pointers, working agreements, whatever is true forever and fit to be
+public. `~/.wpmgr/worklog/` takes everything else that must survive, under
+the rule above. If it would not be fine to see this file public forever, it
+belongs in the worklog, never here.
 
 Reviews: `review.md`, read in full before reviewing anything.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,4 +313,26 @@ This file is re-injected from disk after compaction. Path-scoped
 `.claude/rules/` are not, until a matching file is read again. If a rule must
 hold for a whole session, it belongs here.
 
+**When a session compacts, put durable project state into a file before the
+turn ends**, into this file, or into the private worklog, whichever it is.
+Compaction summarises the conversation away, and this file is the only thing
+guaranteed to come back; a decision or a plan that lives only in the
+conversation does not survive it. Anything that must survive belongs in a
+file, not in a turn.
+
 Reviews: `review.md`, read in full before reviewing anything.
+
+## AI connection wizard
+
+The plan for the AI connection wizard, its approved steps, the rulings behind
+them, a per-step gap analysis and a build order, lives in
+`~/.wpmgr/worklog/WIZARD-SPEC.md`. That path is outside this repository and
+stays there, same as every other worklog (see Long sessions, above); this file
+only names it, never quotes it. **Read the spec before any wizard work. Never
+reconstruct the plan by reading the code.**
+
+Current status belongs on the GitHub issues tracking each step, not here: a
+status list here is exactly the kind of fact this file already bans
+hard-coding, because it goes stale within days. On 2026-09-01 the session
+rebuilt the wizard roadmap from the code after every compaction instead,
+got it wrong each time, and the owner had to correct it repeatedly.


### PR DESCRIPTION
## Summary
- Add a short section naming `~/.wpmgr/worklog/WIZARD-SPEC.md` as the authority for the AI connection wizard's plan (approved steps, rulings, gap analysis, build order). Instructs reading the spec before wizard work instead of reconstructing the plan from code. Names the path only, never quotes its (private, never-committed) contents. Per-step status is pointed at GitHub issues rather than written into this file, since a status list here would rot the same way hard-coded counts do.
- Extend the existing "re-injected from disk after compaction" paragraph into a standing obligation: write durable project state to a file (this one, or the private worklog) before a turn ends, since compaction summarises the conversation away and CLAUDE.md is the only thing guaranteed to come back.

## Test plan
- [x] `grep -niE "wizard|WIZARD-SPEC" CLAUDE.md` returns the new section
- [x] `node apps/marketing/scripts/check-copy.mjs` passes
- [x] Docs vocabulary check command (copied verbatim from `.github/workflows/ci.yml`) prints no hits
- [x] `make check-versions-test && make check-versions` both pass
- [x] Only `CLAUDE.md` touched; no other file reworded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for preserving important project state across session transitions.
  * Documented the AI connection wizard workflow and where to find its authoritative specifications.
  * Clarified that current wizard progress should be tracked through project issues rather than local guidance documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->