### PR TITLE
release: 0.61.155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.155] - 2026-09-02
+
+### Added
+
+- The AI connection wizard's token path now asks which capabilities a new connection gets, instead of assuming a default. Every capability is read-only, one of them (reading site content) renders disabled because nothing in the product can serve it yet, and deselecting everything is refused rather than quietly falling back to a default.
+
 ## [0.61.154] - 2026-09-02
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.154**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.155**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.154
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.154
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.154
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.155
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.155
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.155
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.154   # omit to track :latest
+export WPMGR_VERSION=v0.61.155   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,18 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.155",
+    date: "2026-09-02",
+    summary:
+      "The AI connection wizard's token path now asks which capabilities a new connection gets, instead of assuming a default.",
+    items: [
+      {
+        tag: "Added",
+        text: "The AI connection wizard's token path now asks which capabilities a new connection gets, instead of assuming a default. Every capability is read-only, one of them (reading site content) renders disabled because nothing in the product can serve it yet, and deselecting everything is refused rather than quietly falling back to a default.",
+      },
+    ],
+  },
+  {
     version: "0.61.154",
     date: "2026-09-02",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.154   # omit to track :latest
+export WPMGR_VERSION=v0.61.155   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.154
+  version: 0.61.155
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Control-plane-only release. Version surfaces and CHANGELOG only, no code changes.

- The AI connection wizard's token path now asks which capabilities a new connection gets, instead of assuming a default. Every capability is read-only, one of them (reading site content) renders disabled because nothing in the product can serve it yet, and deselecting everything is refused rather than quietly falling back to a default (#690).
- #691 and #692 changed only CLAUDE.md working agreements, with no user-visible product behaviour, so they are not included in the changelog.
- The agent version does not move in this release; the marketing hero badge stays at 0.61.147.

## Test plan

- [x] `make check-versions-test` (self-test, 76 passed, 0 failed)
- [x] `make check-versions` (all surfaces OK)
- [x] `node apps/marketing/scripts/check-copy.mjs` (passed)
- [x] Docs vocabulary check run verbatim from ci.yml (no hits)
- [x] `git grep -n "0.61.154"` reviewed: both remaining hits are the historical 0.61.154 CHANGELOG/marketing entries, correctly unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The AI connection wizard now lets you choose read-only capabilities for each new connection.
  * Site-content access is shown as unavailable until supported.
  * Connections cannot be created without selecting at least one capability.

* **Documentation**
  * Added release notes for version 0.61.155.
  * Updated installation instructions and prebuilt image references to version 0.61.155.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->