### PR TITLE
fix(web): make the AI connection wizard rail a real stepper

### DIFF
--- a/apps/web/e2e/ai-connect-stepper.spec.ts
+++ b/apps/web/e2e/ai-connect-stepper.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// THE LAYOUT HALF OF THE STEPPER'S COVERAGE, AND THE ONLY HALF THAT CAN SEE A
+// WRAP. jsdom has no layout: every element measures 0x0 there, so a unit test
+// can assert that the rail carries `flex-nowrap` and still not know whether
+// ten segments end up on one row at 390px. The orphaned-connector defect (a
+// connector travelling with the step after it, so the first step on every
+// wrapped row opened with a line coming out of empty space) was invisible to
+// every class-level assertion on this component, which is why it is measured
+// here instead.
+
+const TENANT = "22222222-2222-2222-2222-222222222222";
+
+const ME = {
+  user: {
+    id: "33333333-3333-3333-3333-333333333333",
+    email: "admin@example.com",
+    name: "Admin",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  memberships: [
+    { user_id: "33333333-3333-3333-3333-333333333333", tenant_id: TENANT, role: "owner" },
+  ],
+  active_tenant_id: TENANT,
+};
+
+async function mockApi(page: Page) {
+  await page.route("**/auth/me", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(ME) });
+  });
+  await page.route("**/api/v1/mcp/connections*", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/v1/tags*", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/v1/sites*", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+}
+
+/**
+ * The measured rows of the rail: every step circle grouped by its vertical
+ * position. One entry means the rail did not wrap.
+ */
+async function stepRows(page: Page): Promise<number[][]> {
+  const boxes: { n: number; y: number }[] = [];
+  for (let n = 1; n <= 10; n++) {
+    const box = await page.getByTestId(`step-circle-${n}`).boundingBox();
+    // A circle that cannot be measured must fail the test rather than being
+    // quietly dropped out of the grouping, which would report "one row".
+    if (box === null) throw new Error(`step circle ${n} has no bounding box`);
+    boxes.push({ n, y: Math.round(box.y) });
+  }
+  const rows = new Map<number, number[]>();
+  for (const b of boxes) rows.set(b.y, [...(rows.get(b.y) ?? []), b.n]);
+  return [...rows.entries()].sort(([a], [b]) => a - b).map(([, ns]) => ns);
+}
+
+test.describe("the connection wizard stepper", () => {
+  test("keeps all ten steps on one row at a phone width, so no connector starts a row", async ({
+    page,
+  }) => {
+    await mockApi(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/ai/connect");
+    await expect(page.getByTestId("step-rail")).toBeVisible();
+
+    // ONE row. Two or more is the defect: the first circle of every row after
+    // the first has a connector to its left, drawn from nothing.
+    expect(await stepRows(page)).toEqual([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
+
+    // And the rail is scrollable rather than clipped, so the steps that do not
+    // fit are still reachable at this width.
+    const rail = page.getByTestId("step-rail");
+    const overflow = await rail.evaluate(
+      (el) => el.scrollWidth > el.clientWidth && getComputedStyle(el).overflowX,
+    );
+    expect(overflow).toBe("auto");
+
+    // The deck's own breakpoint, measured rather than asserted by class name:
+    // the connector is 16px below 640px.
+    const line = await page.getByTestId("step-line-2").boundingBox();
+    expect(line?.width).toBeCloseTo(16, 0);
+
+    await page.screenshot({
+      path: process.env.STEPPER_SHOT_DIR
+        ? `${process.env.STEPPER_SHOT_DIR}/wizard-phone-390.png`
+        : "test-results/wizard-phone-390.png",
+      fullPage: true,
+    });
+  });
+
+  test("keeps all ten steps on one row at desktop width, with the wide connector", async ({
+    page,
+  }) => {
+    await mockApi(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/ai/connect");
+    await expect(page.getByTestId("step-rail")).toBeVisible();
+
+    expect(await stepRows(page)).toEqual([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
+
+    // 44px above the breakpoint, which is the other half of the deck's media
+    // query. If `sm` ever moved off 640px this is what would catch it.
+    const line = await page.getByTestId("step-line-2").boundingBox();
+    expect(line?.width).toBeCloseTo(44, 0);
+
+    await page.screenshot({
+      path: process.env.STEPPER_SHOT_DIR
+        ? `${process.env.STEPPER_SHOT_DIR}/wizard-desktop-1440.png`
+        : "test-results/wizard-desktop-1440.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/e2e/ai-connect-stepper.spec.ts
+++ b/apps/web/e2e/ai-connect-stepper.spec.ts
@@ -92,6 +92,58 @@ test.describe("the connection wizard stepper", () => {
     });
   });
 
+  test("changing the current step scrolls the rail and leaves the page where it was", async ({
+    page,
+  }) => {
+    // THE ONLY PLACE THIS IS TESTABLE. jsdom has no layout and no scrolling, so
+    // a unit test could assert at most that some scroll function was called --
+    // which is what missed this: the page was being dragged to the top while
+    // the "right" call was being made. Here the document's own scroll position
+    // is measured before and after.
+    await mockApi(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/ai/connect");
+    await expect(page.getByTestId("step-rail")).toBeVisible();
+
+    // Pick a client so the page grows past a phone screen and the auth cards
+    // are down at the bottom of it, which is where an operator would be
+    // standing when their next click changes the current step.
+    await page.getByRole("button", { name: /claude code/i }).click();
+    const tokenCard = page.locator('button[data-method="token"]');
+    await tokenCard.scrollIntoViewIfNeeded();
+    await expect(tokenCard).toBeVisible();
+
+    // MEASURED IN VIEWPORT COORDINATES, NOT window.scrollY. This app scrolls an
+    // inner container rather than the document, so window.scrollY stays 0 no
+    // matter how far down the operator is; asserting on it would pass whatever
+    // happened. What an operator actually notices is the section they are
+    // working in moving, so that is what is measured.
+    const railBox = await page.getByTestId("step-rail").boundingBox();
+    // The operator has genuinely scrolled past the rail: if the rail were still
+    // on screen the assertion below could hold trivially.
+    expect(railBox === null || railBox.y < 0).toBe(true);
+    const cardBefore = await tokenCard.boundingBox();
+    const railBefore = await page
+      .getByTestId("step-rail")
+      .evaluate((el) => el.scrollLeft);
+
+    // This click moves the current step (auth -> the blocked site scope), so
+    // the rail's scroll effect runs.
+    await tokenCard.click();
+    await expect(page.locator('[data-step-n="3"]')).toHaveAttribute("aria-current", "step");
+    // The smooth scroll settles; poll rather than sleep so this is not timing
+    // dependent.
+    await expect
+      .poll(async () => page.getByTestId("step-rail").evaluate((el) => Math.round(el.scrollLeft)))
+      .not.toBe(Math.round(railBefore));
+
+    // THE ASSERTION THIS TEST EXISTS FOR: the section the operator was using
+    // has not moved. The rail brought its current segment into view on its own
+    // axis and left every other axis alone.
+    const cardAfter = await tokenCard.boundingBox();
+    expect(Math.round(cardAfter?.y ?? -1)).toBe(Math.round(cardBefore?.y ?? -2));
+  });
+
   test("keeps all ten steps on one row at desktop width, with the wide connector", async ({
     page,
   }) => {

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -793,7 +793,7 @@ describe("step 3 exists at all, and sits before capabilities", () => {
 
   it("numbers the setup artefact after it, so the rail and the page agree", async () => {
     await reachSiteStep();
-    expect(screen.getByRole("heading", { name: /^6\. Set it up$/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^6\. Get the setup artefact$/ })).toBeInTheDocument();
     // And the rail no longer claims sites are chosen somewhere else.
     expect(screen.queryByText(/4\. Choose sites and permissions/i)).not.toBeInTheDocument();
   });
@@ -879,7 +879,7 @@ describe("an empty scope is a working state, not an error", () => {
     // The setup artefact is reachable with nothing selected. An earlier
     // revision of this surface disabled Continue here; that is the behaviour
     // being corrected.
-    expect(screen.getByRole("heading", { name: /^6\. Set it up$/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^6\. Get the setup artefact$/ })).toBeInTheDocument();
     expect(await screen.findByText(/"mcpServers"/)).toBeInTheDocument();
   });
 });
@@ -2106,6 +2106,109 @@ describe("the rail and the section heading agree on which step this is", () => {
     expect(screen.getByTestId("step-label-6")).toHaveTextContent("Setup");
     // The heading over the section the operator is looking at carries that
     // same 6, not the "4" its position on the page would give it.
-    expect(screen.getByRole("heading", { name: /^6\. Set it up$/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^6\. Get the setup artefact$/ })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review round five. Three findings, each held by a test below.
+// ---------------------------------------------------------------------------
+
+describe("the rail is one row, so no connector can start a row", () => {
+  it("never wraps, at any width", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+
+    // The orphan-connector defect is only possible if the rail can wrap: a
+    // connector travels with the step that follows it, so the first step on
+    // any row after the first would open with a line coming from nowhere. CSS
+    // cannot tell a flex item that it starts a visual row, so the rail does
+    // not wrap at all. This is the class-level half; the layout half is
+    // e2e/ai-connect-stepper.spec.ts, which measures the rendered rows at
+    // 390px, because no jsdom assertion can see a wrap.
+    const rail = screen.getByTestId("step-rail");
+    expect(rail.className).toContain("flex-nowrap");
+    expect(rail.className).not.toContain("flex-wrap");
+    // And it stays reachable when it does not fit, rather than clipping.
+    expect(rail.className).toContain("overflow-x-auto");
+  });
+});
+
+describe("a blocked step never renders as the current one", () => {
+  // FINDING 3, AND THE FIFTH INSTANCE OF THIS COMPONENT'S ONE DEFECT FAMILY.
+  // While site scope is unresolved the rail correctly points at step 3, so the
+  // POSITIONAL "is this the current step" answer is true -- and the ring used
+  // to render off that boolean, telling the operator step 3 was in hand while
+  // the mint button was refusing it. Every visual now reads the state value
+  // and nothing else.
+
+  async function reachBlockedSiteScopeOnTokenPath() {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    const siteStep = document.querySelector('[data-step-n="3"]');
+    if (!(siteStep instanceof HTMLElement)) throw new Error("no step 3 segment");
+    return siteStep;
+  }
+
+  it("gives the ring to no step at all while site scope is unselected", async () => {
+    const siteStep = await reachBlockedSiteScopeOnTokenPath();
+    // The rail points here: this IS where the operator is standing.
+    expect(siteStep).toHaveAttribute("data-step-state", "unselected");
+    expect(siteStep).toHaveAttribute("aria-current", "step");
+
+    // And it is drawn as blocked, not as current: no ring, no fill.
+    const circle = screen.getByTestId("step-circle-3");
+    expect(circle.className).not.toContain("border-2");
+    expect(circle.className).not.toContain("bg-[var(--color-primary)]");
+
+    // No OTHER segment picked up the ring either -- the styling did not move
+    // to a step further along and call that step current instead.
+    expect(document.querySelectorAll('[data-step-state="current"]')).toHaveLength(0);
+    for (const n of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+      expect(screen.getByTestId(`step-circle-${n}`).className).not.toContain("border-2");
+    }
+  });
+
+  it("gives the ring to no step while the fleet read is still loading", async () => {
+    mockedSites.mockReturnValue(mockQueryResult<Site[]>({ data: undefined, isPending: true }));
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+
+    const siteStep = document.querySelector('[data-step-n="3"]');
+    expect(siteStep).toHaveAttribute("data-step-state", "loading");
+    expect(siteStep).toHaveAttribute("aria-current", "step");
+    expect(screen.getByTestId("step-circle-3").className).not.toContain("border-2");
+    expect(document.querySelectorAll('[data-step-state="current"]')).toHaveLength(0);
+  });
+});
+
+describe("the heading a section renders is the canonical one", () => {
+  // FINDING 2. `heading` on the spec entry was canonical and `title` on the
+  // Section was what actually rendered, so a step's name was written twice
+  // with nothing making the two agree. The expected strings below are the
+  // deck's own frame titles, written out here rather than imported, so this
+  // test reddens on drift from the DECK and not merely on drift within the
+  // file.
+  it("renders the deck's frame title over every section it reveals", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+
+    const headings = screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent);
+    expect(headings).toEqual([
+      // The single declared narrowing, and the only one: this section picks
+      // the client and does not yet ask for the name step 2's frame title
+      // promises, so it says what it does.
+      "2. Pick your client",
+      "5. Choose how it authenticates",
+      "3. Choose which sites",
+      "4. Choose what it may do",
+      "6. Get the setup artefact",
+    ]);
   });
 });

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -339,7 +339,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
     );
   });
 
-  it("marks specified step 6 current once client and method are both picked -- THE DEFECT 2 FIX", async () => {
+  it("marks specified step 6 current once client and method are both picked", async () => {
     // Sections 3 ("Sites this connection may reach") and 4 ("Set it up") in
     // this file share one reveal condition and always appear together, so by
     // the time an operator can see either, step 6 (setup) is the furthest one
@@ -406,7 +406,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
   });
 
   // ---------------------------------------------------------------------------
-  // Greptile P1 on connect-wizard.tsx:589 (pre-fix). Completion here used to be
+  // Completion here used to be
   // pure position: once client and method were picked, site selection read
   // completed and setup read current REGARDLESS of whether the fleet/tag read
   // that step depends on had actually come back. Loading and failed are
@@ -477,7 +477,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
   });
 
   // ---------------------------------------------------------------------------
-  // Greptile P1 / CodeRabbit Major on connect-wizard.tsx:268 (pre-fix), found
+  // The same failure through a third door, found
   // a third time through a third door: the fleet resolves fine, but the TAG
   // registry has not, under mode 'tags'. `scope.kind` alone read this as
   // "resolved" -- it only ever asks about the fleet read -- while
@@ -530,7 +530,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
   });
 
   // ---------------------------------------------------------------------------
-  // Greptile P1 on connect-wizard.tsx:639, the OVER-FIRE ARM OF THE FIX ABOVE.
+  // THE OVER-FIRE ARM OF THE FIX ABOVE.
   // On the OAuth path there is no mint button to block -- step 4 renders
   // NextSteps, never TokenMintPanel -- and the scope chosen in this wizard is
   // rehearsal for OAuth (SiteScopeStep's own copy: "nothing carries this
@@ -2053,9 +2053,9 @@ describe("the rail is a stepper, not a paragraph", () => {
 });
 
 describe("the rail and the section heading agree on which step this is", () => {
-  // THE DEFECT THE OWNER REPORTED. Two numbering systems were visible at once
-  // and disagreed: the rail called the setup section step 6 while the heading
-  // over that same section said "4. Set it up". Every heading on this screen
+  // Two numbering systems on one screen contradict each other as soon as the
+  // page order stops matching the spine: the rail calling the setup section
+  // step 6 while the heading over it says "4. Set it up". Every heading here
   // is now numbered with the specified step it answers, so a section and its
   // rail segment cannot name the same step differently.
 
@@ -2111,7 +2111,7 @@ describe("the rail and the section heading agree on which step this is", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Review round five. Three findings, each held by a test below.
+// The stepper rail: one row, one current step, one canonical heading.
 // ---------------------------------------------------------------------------
 
 describe("the rail is one row, so no connector can start a row", () => {
@@ -2135,7 +2135,7 @@ describe("the rail is one row, so no connector can start a row", () => {
 });
 
 describe("a blocked step never renders as the current one", () => {
-  // FINDING 3, AND THE FIFTH INSTANCE OF THIS COMPONENT'S ONE DEFECT FAMILY.
+  // A RAIL MUST NOT PRESENT A STEP AS IN HAND WHILE ITS ACTION IS REFUSED.
   // While site scope is unresolved the rail correctly points at step 3, so the
   // POSITIONAL "is this the current step" answer is true -- and the ring used
   // to render off that boolean, telling the operator step 3 was in hand while
@@ -2187,7 +2187,7 @@ describe("a blocked step never renders as the current one", () => {
 });
 
 describe("the heading a section renders is the canonical one", () => {
-  // FINDING 2. `heading` on the spec entry was canonical and `title` on the
+  // `heading` on the spec entry was canonical and `title` on the
   // Section was what actually rendered, so a step's name was written twice
   // with nothing making the two agree. The expected strings below are the
   // deck's own frame titles, written out here rather than imported, so this
@@ -2210,5 +2210,86 @@ describe("the heading a section renders is the canonical one", () => {
       "4. Choose what it may do",
       "6. Get the setup artefact",
     ]);
+  });
+});
+
+describe("exactly one segment answers for the operator's position", () => {
+  /**
+   * The count of segments claiming to be current. A COUNT and not a presence
+   * check: a rail with two current steps still has "a" current step, so
+   * `getByRole`-style presence passes over the very defect this asserts
+   * against.
+   */
+  function currentCount(): number {
+    return document.querySelectorAll('[data-step-n][aria-current="step"]').length;
+  }
+
+  it("keeps one current segment when site scope AND capabilities are both blocked", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+
+    // BOTH BLOCKING AT ONCE. Nothing is selected under 'list' mode (the
+    // wizard's opening state, deliberately empty), and now no capability is
+    // ticked either, so `siteScopeBlocking` and `capabilityBlocking` are both
+    // true. Each used to promote its own segment, giving the rail two
+    // positions and handing the scroll ref to the later one.
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Sites/i }));
+    expect(screen.getByRole("checkbox", { name: /^Sites/i })).not.toBeChecked();
+
+    // Both steps still report their own blocked reason -- a reason is not a
+    // claim on the operator's position, and each is worth showing.
+    expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
+      "data-step-state",
+      "unselected",
+    );
+    expect(document.querySelector('[data-step-n="4"]')).toHaveAttribute(
+      "data-step-state",
+      "unselected",
+    );
+
+    // ONE position, and it is the earlier blocked step.
+    expect(currentCount()).toBe(1);
+    const current = document.querySelector('[data-step-n][aria-current="step"]');
+    expect(current).toHaveAttribute("data-step-n", "3");
+  });
+
+  it("keeps one current segment in every state this wizard can reach", async () => {
+    // The invariant, not one scenario of it: at no point in the walk from an
+    // empty screen to a fully answered token path does the rail hold two
+    // positions.
+    loadedFleet(3);
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+    expect(currentCount()).toBe(1);
+
+    await pickClient("Claude Code");
+    expect(currentCount()).toBe(1);
+
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+    expect(currentCount()).toBe(1);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Sites/i }));
+    expect(currentCount()).toBe(1);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Sites/i }));
+    expect(currentCount()).toBe(1);
+  });
+
+  it("numbers every specified step exactly once, which is what makes one current possible", async () => {
+    // The premise the invariant above rests on. `aria-current` is placed by
+    // comparing a segment's specified number against one number; that yields
+    // at most one match only while the specified numbers are unique. If a
+    // duplicate `n` were ever added to SPEC_STEPS, two segments could match
+    // again -- so the uniqueness is asserted rather than assumed.
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+
+    const ns = Array.from(document.querySelectorAll<HTMLElement>("[data-step-n]")).map(
+      (s) => s.dataset.stepN,
+    );
+    expect(new Set(ns).size).toBe(ns.length);
   });
 });

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1999,22 +1999,25 @@ describe("the rail is a stepper, not a paragraph", () => {
     // Tailwind's default is 40rem/640px and this app must not have moved it.
     // Moving it would silently change where the connector shortens, which no
     // class-name assertion could see.
-    const { readFileSync, existsSync } = await import("node:fs");
-    const { resolve } = await import("node:path");
+    const fs = await import("node:fs");
+    const nodePath = await import("node:path");
     // Resolved from the process, and a MISSING file throws rather than
     // letting this test pass over nothing -- a check that cannot find its
     // input has to go red, not green.
     const candidates = [
-      resolve(process.cwd(), "src/styles/globals.css"),
-      resolve(process.cwd(), "apps/web/src/styles/globals.css"),
+      nodePath.resolve(process.cwd(), "src/styles/globals.css"),
+      nodePath.resolve(process.cwd(), "apps/web/src/styles/globals.css"),
     ];
-    const path = candidates.find((p) => existsSync(p));
-    if (path === undefined) throw new Error(`globals.css not found at ${candidates.join(" or ")}`);
-    const css = readFileSync(path, "utf8");
-    const override = /--breakpoint-sm:\s*([^;]+);/.exec(css);
+    const found = candidates.find((p) => fs.existsSync(p));
+    if (found === undefined) throw new Error(`globals.css not found at ${candidates.join(" or ")}`);
+    const css = fs.readFileSync(found, "utf8");
+    // The file has to have actually been read, or the regex below matches
+    // nothing and the assertion is skipped over an empty string.
+    expect(css).toContain("@theme");
+    const override = /--breakpoint-sm:\s*([^;]+);/.exec(css)?.[1];
     // Either untouched (Tailwind's own 40rem = 640px), or explicitly set to
     // the same value. Anything else moves the design's boundary.
-    if (override !== null) expect(override[1].trim()).toBe("40rem");
+    if (override !== undefined) expect(override.trim()).toBe("40rem");
   });
 
   it("fills the circle only for a step actually behind the operator, and rings the current one", async () => {

--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -321,13 +321,17 @@ describe("the step rail names all ten specified steps and marks the right one cu
   it("marks specified step 2 current before any client is picked", async () => {
     renderWizard();
     await screen.findByRole("button", { name: /claude code/i });
-    expect(currentRailStep()).toHaveTextContent(/^2\. Name it, pick the AI client$/);
+    // "2Client" is the numbered circle plus the SHORT rail label, run together
+    // as textContent. Ruling 15 makes the short labels canonical for the rail;
+    // the long frame title belongs on the section heading and is asserted
+    // there, not here.
+    expect(currentRailStep()).toHaveTextContent(/^2Client$/);
   });
 
   it("marks specified step 5 current once a client is picked and no method chosen", async () => {
     renderWizard();
     await pickClient("Cursor");
-    expect(currentRailStep()).toHaveTextContent(/^5\. Choose how it authenticates$/);
+    expect(currentRailStep()).toHaveTextContent(/^5Auth$/);
     // The rail agrees this is later than step 2, not merely different from it.
     expect(document.querySelector('[data-step-n="2"]')).toHaveAttribute(
       "data-step-state",
@@ -349,7 +353,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
     // "unselected" tests below for why the wizard's opening state (nothing
     // picked yet) must not itself read as complete.
     fireEvent.click(within(screen.getByRole("radiogroup", { name: /site scope/i })).getByText("All sites"));
-    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+    expect(currentRailStep()).toHaveTextContent(/^6Setup$/);
   });
 
   it("shows specified step 3 as passed, not merely unreached, once step 6 is current", async () => {
@@ -469,7 +473,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
       "data-step-state",
       "completed",
     );
-    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+    expect(currentRailStep()).toHaveTextContent(/^6Setup$/);
   });
 
   // ---------------------------------------------------------------------------
@@ -555,7 +559,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
       await pickClient("Cursor");
       fireEvent.click(authCard("oauth"));
 
-      expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+      expect(currentRailStep()).toHaveTextContent(/^6Setup$/);
       expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
         "data-step-state",
         "completed",
@@ -576,7 +580,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
     // thing to wait for before the rail is asserted against.
     expect(screen.getByRole("radio", { name: /by tag/i })).toBeChecked();
 
-    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+    expect(currentRailStep()).toHaveTextContent(/^6Setup$/);
     expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
       "data-step-state",
       "completed",
@@ -593,7 +597,7 @@ describe("the step rail names all ten specified steps and marks the right one cu
     fireEvent.click(authCard("oauth"));
     await screen.findByTestId("site-step-count");
 
-    expect(currentRailStep()).toHaveTextContent(/^6\. Get the setup artefact$/);
+    expect(currentRailStep()).toHaveTextContent(/^6Setup$/);
     expect(document.querySelector('[data-step-n="3"]')).toHaveAttribute(
       "data-step-state",
       "completed",
@@ -789,7 +793,7 @@ describe("step 3 exists at all, and sits before capabilities", () => {
 
   it("numbers the setup artefact after it, so the rail and the page agree", async () => {
     await reachSiteStep();
-    expect(screen.getByRole("heading", { name: /^5\. Set it up$/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^6\. Set it up$/ })).toBeInTheDocument();
     // And the rail no longer claims sites are chosen somewhere else.
     expect(screen.queryByText(/4\. Choose sites and permissions/i)).not.toBeInTheDocument();
   });
@@ -875,7 +879,7 @@ describe("an empty scope is a working state, not an error", () => {
     // The setup artefact is reachable with nothing selected. An earlier
     // revision of this surface disabled Continue here; that is the behaviour
     // being corrected.
-    expect(screen.getByRole("heading", { name: /^5\. Set it up$/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^6\. Set it up$/ })).toBeInTheDocument();
     expect(await screen.findByText(/"mcpServers"/)).toBeInTheDocument();
   });
 });
@@ -1898,5 +1902,207 @@ describe("minting a connection token", () => {
     expect(await screen.findByText(/too many connection tokens minted recently/i)).toBeInTheDocument();
     expect(screen.getByText(/wait about 42 seconds/i)).toBeInTheDocument();
     expect(screen.queryByText(/organisation-wide credential/i)).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE STEPPER ITSELF. The owner looked at the shipped screen and said it was
+// neither a stepper nor a wizard, and he was right about the rail: it printed
+// the ten LONG frame titles run together with slashes, which is a paragraph in
+// a stepper's place, and it disagreed with the numbers on the sections below
+// it. These tests hold the component the deck actually draws.
+// ---------------------------------------------------------------------------
+
+/** Every rail segment, in the order the DOM has them. */
+function railSegments(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>("[data-step-n]"));
+}
+
+describe("the rail is a stepper, not a paragraph", () => {
+  it("labels the rail with the deck's SHORT labels and never the long frame titles", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+
+    // Ruling 15, verbatim in its ordering: "Start, Client, Sites,
+    // Capabilities, Auth, Setup, Authorize, Confirm, Test, Done".
+    // The label's own text node, without the sr-only "(not yet available)"
+    // that an unbuilt step carries for a screen reader -- that suffix is
+    // asserted by the "not-built" tests above and is not part of the label.
+    expect(
+      railSegments().map(
+        (s) => screen.getByTestId(`step-label-${s.dataset.stepN}`).childNodes[0]?.textContent,
+      ),
+    ).toEqual([
+      "Start",
+      "Client",
+      "Sites",
+      "Capabilities",
+      "Auth",
+      "Setup",
+      "Authorize",
+      "Confirm",
+      "Test",
+      "Done",
+    ]);
+
+    // And the long frame titles are gone from the rail specifically. Asserting
+    // their absence from the whole document would be wrong: "Choose what it
+    // may do" is a legitimate SECTION heading, which is exactly where ruling
+    // 15 puts the long form.
+    const railText = railSegments()
+      .map((s) => s.textContent ?? "")
+      .join(" ");
+    for (const long of [
+      "Name it, pick the AI client",
+      "Choose how it authenticates",
+      "Get the setup artefact",
+      "WPMgr confirms connection is live",
+    ]) {
+      expect(railText).not.toContain(long);
+    }
+  });
+
+  it("draws a numbered circle per step and a connector between every pair", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+
+    // Ten circles, each carrying its own specified number -- the number lives
+    // in the circle now, not in a "6. Get the setup artefact" run of prose.
+    expect(
+      Array.from({ length: 10 }, (_, i) => screen.getByTestId(`step-circle-${i + 1}`).textContent),
+    ).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
+
+    // Nine connectors for ten steps: one before every segment except the
+    // first. A connector before step 1 would draw a line coming from nowhere.
+    expect(document.querySelectorAll('[data-testid^="step-line-"]')).toHaveLength(9);
+    expect(screen.queryByTestId("step-line-1")).toBeNull();
+  });
+
+  it("shortens the connector below the deck's 640px breakpoint", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+
+    // The deck: `.step .line { width: 44px }` with
+    // `@media (max-width: 640px) { .step .line { width: 16px } }`. In this
+    // project that is the unprefixed utility for the narrow case and the `sm:`
+    // variant for the wide one -- w-4 is 16px, w-11 is 44px.
+    const line = screen.getByTestId("step-line-2");
+    expect(line.className).toContain("w-4");
+    expect(line.className).toContain("sm:w-11");
+    expect(line.className).toContain("mx-1.5");
+    expect(line.className).toContain("sm:mx-2.5");
+  });
+
+  it("puts `sm:` at the 640px the deck specifies, so those classes mean what they say", async () => {
+    // THE HALF THAT MAKES THE TEST ABOVE ABOUT BEHAVIOUR RATHER THAN SPELLING.
+    // `sm:w-11` only implements the deck's breakpoint while `sm` IS 640px;
+    // Tailwind's default is 40rem/640px and this app must not have moved it.
+    // Moving it would silently change where the connector shortens, which no
+    // class-name assertion could see.
+    const { readFileSync, existsSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    // Resolved from the process, and a MISSING file throws rather than
+    // letting this test pass over nothing -- a check that cannot find its
+    // input has to go red, not green.
+    const candidates = [
+      resolve(process.cwd(), "src/styles/globals.css"),
+      resolve(process.cwd(), "apps/web/src/styles/globals.css"),
+    ];
+    const path = candidates.find((p) => existsSync(p));
+    if (path === undefined) throw new Error(`globals.css not found at ${candidates.join(" or ")}`);
+    const css = readFileSync(path, "utf8");
+    const override = /--breakpoint-sm:\s*([^;]+);/.exec(css);
+    // Either untouched (Tailwind's own 40rem = 640px), or explicitly set to
+    // the same value. Anything else moves the design's boundary.
+    if (override !== null) expect(override[1].trim()).toBe("40rem");
+  });
+
+  it("fills the circle only for a step actually behind the operator, and rings the current one", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+
+    // Step 2 is behind them: filled. The fill is the strongest "done" signal
+    // on the screen and it is drawn from the rail's own state, so it cannot
+    // claim progress the wizard has not made.
+    expect(document.querySelector('[data-step-n="2"]')).toHaveAttribute(
+      "data-step-state",
+      "completed",
+    );
+    expect(screen.getByTestId("step-circle-2").className).toContain("bg-[var(--color-primary)]");
+
+    // Step 5 is where they are: ringed, never filled.
+    expect(screen.getByTestId("step-circle-5").className).toContain("border-2");
+    expect(screen.getByTestId("step-circle-5").className).not.toContain(
+      "bg-[var(--color-primary)]",
+    );
+
+    // Step 8 does not exist yet. No fill, no ring: an unbuilt step must never
+    // render as done or current.
+    expect(document.querySelector('[data-step-n="8"]')).toHaveAttribute(
+      "data-step-state",
+      "not-built",
+    );
+    expect(screen.getByTestId("step-circle-8").className).not.toContain(
+      "bg-[var(--color-primary)]",
+    );
+    expect(screen.getByTestId("step-circle-8").className).not.toContain("border-2");
+  });
+});
+
+describe("the rail and the section heading agree on which step this is", () => {
+  // THE DEFECT THE OWNER REPORTED. Two numbering systems were visible at once
+  // and disagreed: the rail called the setup section step 6 while the heading
+  // over that same section said "4. Set it up". Every heading on this screen
+  // is now numbered with the specified step it answers, so a section and its
+  // rail segment cannot name the same step differently.
+
+  /** Every "N. Title" heading on screen, as its leading number. */
+  function headingNumbers(): string[] {
+    return screen
+      .getAllByRole("heading", { level: 2 })
+      .map((h) => /^(\d+)\./.exec(h.textContent ?? "")?.[1])
+      .filter((n): n is string => n !== undefined);
+  }
+
+  it("numbers the client section 2, the way the rail does, before anything is picked", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /claude code/i });
+
+    expect(screen.getByRole("heading", { name: /^2\. Pick your client$/ })).toBeInTheDocument();
+    expect(currentRailStep()).toHaveAttribute("data-step-n", "2");
+    // Nothing on screen is numbered 1: local position numbering is gone.
+    expect(headingNumbers()).toEqual(["2"]);
+  });
+
+  it("numbers every revealed section with a step the rail also names, on the token path", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("token"));
+    await screen.findByTestId("site-step-count");
+
+    // The specified numbers for the five built sections, in the order this
+    // page reveals them -- deliberately non-monotonic (ruling: the on-screen
+    // order maps to the deck's numbers, the numbers are never renumbered to
+    // match the page).
+    expect(headingNumbers()).toEqual(["2", "5", "3", "4", "6"]);
+
+    // And every one of those numbers is a step the rail draws, in the rail's
+    // own order, so there is exactly one numbering system on the screen.
+    const railNs = railSegments().map((s) => s.dataset.stepN);
+    for (const n of headingNumbers()) expect(railNs).toContain(n);
+  });
+
+  it("gives the setup section the same number the rail marks current", async () => {
+    renderWizard();
+    await pickClient("Claude Code");
+    fireEvent.click(authCard("oauth"));
+    await screen.findByTestId("site-step-count");
+
+    const current = currentRailStep();
+    expect(current).toHaveAttribute("data-step-n", "6");
+    expect(screen.getByTestId("step-label-6")).toHaveTextContent("Setup");
+    // The heading over the section the operator is looking at carries that
+    // same 6, not the "4" its position on the page would give it.
+    expect(screen.getByRole("heading", { name: /^6\. Set it up$/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -781,13 +781,6 @@ interface RailSegmentStyle {
   /** Circle styling on top of the base ring. */
   readonly circle: string;
   readonly label: string;
-  /**
-   * Whether this segment carries `aria-current="step"`. A BLOCKED step is
-   * still where the operator is standing, so it keeps aria-current and loses
-   * the ring: those are different questions and this table is where they are
-   * answered separately, once each.
-   */
-  readonly ariaCurrent: boolean;
   /** The visible reason, if the state has one. */
   readonly suffix: string | null;
 }
@@ -795,33 +788,29 @@ interface RailSegmentStyle {
 /**
  * THE ONE PLACE A RAIL SEGMENT'S APPEARANCE IS DECIDED.
  *
- * This table exists because the same defect has now been found on this
- * component FIVE times, through five different doors: the rail presenting a
- * step as fine while the action that step gates is refused. Rounds two, three
- * and four widened the readiness predicate; round five was the ring, which had
- * gone on rendering from a positional `isCurrent` boolean that stayed true
- * while the derived state said "loading", "tags-unresolved" or "unselected".
+ * Every visual a segment renders is looked up here from its single state
+ * value, so a style that contradicts the state is not expressible: there is no
+ * second boolean for a style to read. The blocked states share the "upcoming"
+ * circle deliberately -- no fill, no ring, nothing that reads as progress on a
+ * step whose action is being refused.
  *
- * Patching the ring's condition would have been a sixth door on the same room.
- * Instead the styles have exactly ONE input -- the state value -- so a visual
- * that contradicts the state is not expressible: there is no second boolean
- * left for it to read. The blocked states below deliberately share the
- * "upcoming" circle: no fill, no ring, nothing that reads as progress.
+ * WHAT IS DELIBERATELY NOT IN THIS TABLE: whether a segment is the operator's
+ * current position. That is not a property of a state value, because several
+ * segments can hold a blocked state at once; it is a property of the rail, has
+ * exactly one answer, and is decided once in StepRail.
  */
 const RAIL_SEGMENT_STYLES: Record<RailSegmentState, RailSegmentStyle> = {
-  "not-built": { circle: "opacity-70", label: "italic opacity-70", ariaCurrent: false, suffix: null },
-  upcoming: { circle: "", label: "", ariaCurrent: false, suffix: null },
+  "not-built": { circle: "opacity-70", label: "italic opacity-70", suffix: null },
+  upcoming: { circle: "", label: "", suffix: null },
   completed: {
     circle:
       "border-[var(--color-primary)] bg-[var(--color-primary)] text-[var(--color-primary-foreground)]",
     label: "text-[var(--color-foreground)]",
-    ariaCurrent: false,
     suffix: null,
   },
   current: {
     circle: "border-2 border-[var(--color-primary)] text-[var(--color-primary)]",
     label: "font-medium text-[var(--color-foreground)]",
-    ariaCurrent: true,
     suffix: null,
   },
   // THE BLOCKED FOUR. Each keeps its own distinct reason on screen -- an
@@ -835,16 +824,15 @@ const RAIL_SEGMENT_STYLES: Record<RailSegmentState, RailSegmentStyle> = {
   // the table as a partial record, and a partial record is how a future state
   // gets added with no style and renders as whatever the base class happens to
   // be. If it is ever reached, it claims nothing.
-  resolved: { circle: "", label: "", ariaCurrent: false, suffix: null },
-  loading: { circle: "", label: "", ariaCurrent: true, suffix: " (loading)" },
+  resolved: { circle: "", label: "", suffix: null },
+  loading: { circle: "", label: "", suffix: " (loading)" },
   failed: {
     circle: "border-[var(--color-destructive)] text-[var(--color-destructive)]",
     label: "text-[var(--color-destructive)]",
-    ariaCurrent: true,
     suffix: " (failed to load)",
   },
-  "tags-unresolved": { circle: "", label: "", ariaCurrent: true, suffix: " (tags still loading)" },
-  unselected: { circle: "", label: "", ariaCurrent: true, suffix: " (not chosen yet)" },
+  "tags-unresolved": { circle: "", label: "", suffix: " (tags still loading)" },
+  unselected: { circle: "", label: "", suffix: " (not chosen yet)" },
 };
 
 function StepRail({
@@ -945,10 +933,15 @@ function StepRail({
         className="mb-1 flex snap-x snap-mandatory flex-nowrap items-center overflow-x-auto pb-1"
       >
         {SPEC_STEPS.map((s, i) => {
-          // POSITION ONLY. This is an input to `state` below and to nothing
-          // else -- see the comment on RAIL_SEGMENT_STYLES for why no visual
-          // may read it directly.
-          const positionallyCurrent = s.n === effectiveCurrentSpec;
+          // THE ONE QUESTION, ASKED ONCE PER SEGMENT: am I the step the rail
+          // is pointing at? `effectiveCurrentSpec` is a single number and
+          // SPEC_STEPS holds each `n` exactly once, so at most one segment can
+          // answer yes. Nothing else may promote a segment to current -- in
+          // particular the blocking flags must not, because two of them can be
+          // true at the same moment (an operator who has chosen no sites AND
+          // no capabilities blocks on both), and a rail with two current steps
+          // has no answer to "where am I".
+          const isCurrentStep = s.n === effectiveCurrentSpec;
           // Completed means "earlier in the order this wizard actually
           // visits built steps in," never "a smaller specified number" --
           // see the comment on BUILT_ORDER above for why those disagree here.
@@ -969,7 +962,7 @@ function StepRail({
               ? siteScopeState
               : s.n === CAPABILITY_SPEC_N && capabilityBlocking
                 ? capabilityState
-                : positionallyCurrent
+                : isCurrentStep
                   ? "current"
                   : isCompleted
                     ? "completed"
@@ -989,7 +982,7 @@ function StepRail({
               // The ref goes on whichever segment the rail is pointing at,
               // blocked or not: the operator needs to see the step they are
               // held on just as much as one they have finished.
-              ref={style.ariaCurrent ? currentSegment : undefined}
+              ref={isCurrentStep ? currentSegment : undefined}
               className="flex items-center"
             >
               {i > 0 ? (
@@ -1005,7 +998,7 @@ function StepRail({
                 />
               ) : null}
               <span
-                aria-current={style.ariaCurrent ? "step" : undefined}
+                aria-current={isCurrentStep ? "step" : undefined}
                 // A plain data attribute rather than only a class, so a test
                 // can assert the state this rail believes it is in without
                 // coupling to Tailwind class names.

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -503,7 +503,9 @@ export function ConnectWizard({
 
       <Section
         specN={2}
-        title="Pick your client"
+        // The one narrowing, and its reason: this section picks the client and
+        // does not yet ask for the name the deck s step 2 title promises.
+        narrowerTitle="Pick your client"
         hint="Everything after this is computed from your answer, so nothing asks you twice."
       >
         <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -523,7 +525,7 @@ export function ConnectWizard({
       {client !== null ? (
         <Section
           specN={5}
-          title="How it signs in"
+
           hint={`Computed from ${client.name}. A method it cannot use is disabled with the reason.`}
         >
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -594,7 +596,6 @@ export function ConnectWizard({
       {client !== null && method !== null ? (
         <Section
           specN={3}
-          title="Sites this connection may reach"
           hint="Chosen before capabilities, on purpose. What a connection may do is only meaningful once you have fixed what it may do it to."
         >
           <SiteScopeStep
@@ -627,7 +628,6 @@ export function ConnectWizard({
       {client !== null && method === "token" ? (
         <Section
           specN={4}
-          title="Choose what it may do"
           hint="Every capability here is read-only. Nothing on this list can change WordPress content or configuration."
         >
           <div className="space-y-3">
@@ -700,7 +700,6 @@ export function ConnectWizard({
       {client !== null && method !== null ? (
         <Section
           specN={6}
-          title="Set it up"
           hint="Generated for this client. Every difference below is a real difference between clients."
         >
           <div className="space-y-4">
@@ -764,6 +763,89 @@ export function ConnectWizard({
     </div>
   );
 }
+
+/**
+ * EVERY STATE ONE RAIL SEGMENT CAN BE IN, AS ONE CLOSED UNION. A segment has
+ * exactly one of these, and every visual it renders is looked up from it in
+ * RAIL_SEGMENT_STYLES below.
+ */
+type RailSegmentState =
+  | "not-built"
+  | "current"
+  | "completed"
+  | "upcoming"
+  | SiteScopeReadiness
+  | CapabilityReadiness;
+
+interface RailSegmentStyle {
+  /** Circle styling on top of the base ring. */
+  readonly circle: string;
+  readonly label: string;
+  /**
+   * Whether this segment carries `aria-current="step"`. A BLOCKED step is
+   * still where the operator is standing, so it keeps aria-current and loses
+   * the ring: those are different questions and this table is where they are
+   * answered separately, once each.
+   */
+  readonly ariaCurrent: boolean;
+  /** The visible reason, if the state has one. */
+  readonly suffix: string | null;
+}
+
+/**
+ * THE ONE PLACE A RAIL SEGMENT'S APPEARANCE IS DECIDED.
+ *
+ * This table exists because the same defect has now been found on this
+ * component FIVE times, through five different doors: the rail presenting a
+ * step as fine while the action that step gates is refused. Rounds two, three
+ * and four widened the readiness predicate; round five was the ring, which had
+ * gone on rendering from a positional `isCurrent` boolean that stayed true
+ * while the derived state said "loading", "tags-unresolved" or "unselected".
+ *
+ * Patching the ring's condition would have been a sixth door on the same room.
+ * Instead the styles have exactly ONE input -- the state value -- so a visual
+ * that contradicts the state is not expressible: there is no second boolean
+ * left for it to read. The blocked states below deliberately share the
+ * "upcoming" circle: no fill, no ring, nothing that reads as progress.
+ */
+const RAIL_SEGMENT_STYLES: Record<RailSegmentState, RailSegmentStyle> = {
+  "not-built": { circle: "opacity-70", label: "italic opacity-70", ariaCurrent: false, suffix: null },
+  upcoming: { circle: "", label: "", ariaCurrent: false, suffix: null },
+  completed: {
+    circle:
+      "border-[var(--color-primary)] bg-[var(--color-primary)] text-[var(--color-primary-foreground)]",
+    label: "text-[var(--color-foreground)]",
+    ariaCurrent: false,
+    suffix: null,
+  },
+  current: {
+    circle: "border-2 border-[var(--color-primary)] text-[var(--color-primary)]",
+    label: "font-medium text-[var(--color-foreground)]",
+    ariaCurrent: true,
+    suffix: null,
+  },
+  // THE BLOCKED FOUR. Each keeps its own distinct reason on screen -- an
+  // operator told nothing when a read has actually failed keeps waiting for a
+  // state that is never coming -- and NONE of them gets the ring or the fill,
+  // because the step they name cannot be completed from where the operator is.
+  // UNREACHABLE, AND STILL EXHAUSTIVE. A segment only takes a readiness value
+  // while that step is BLOCKING, and blocking is false exactly when the value
+  // is "resolved" -- so this row is never looked up. It is written as the
+  // no-claim style rather than omitted, because omitting it would mean typing
+  // the table as a partial record, and a partial record is how a future state
+  // gets added with no style and renders as whatever the base class happens to
+  // be. If it is ever reached, it claims nothing.
+  resolved: { circle: "", label: "", ariaCurrent: false, suffix: null },
+  loading: { circle: "", label: "", ariaCurrent: true, suffix: " (loading)" },
+  failed: {
+    circle: "border-[var(--color-destructive)] text-[var(--color-destructive)]",
+    label: "text-[var(--color-destructive)]",
+    ariaCurrent: true,
+    suffix: " (failed to load)",
+  },
+  "tags-unresolved": { circle: "", label: "", ariaCurrent: true, suffix: " (tags still loading)" },
+  unselected: { circle: "", label: "", ariaCurrent: true, suffix: " (not chosen yet)" },
+};
 
 function StepRail({
   current,
@@ -829,12 +911,30 @@ function StepRail({
           job -- and it printed the FRAME HEADING text, which ruling 15 assigns
           to the screen heading, in the one place the short labels are
           canonical. Both halves are corrected here. */}
+      {/* ONE ROW, ALWAYS, SCROLLED RATHER THAN WRAPPED -- and that is the fix
+          for the orphaned connectors, not a styling preference. With
+          `flex-wrap`, a connector travels with the step that follows it, so
+          the first step on every row after the first opened with a line
+          coming out of empty space. CSS gives a flex item no way to know it
+          begins a visual row, so no "hide it at the start of a row" rule is
+          writable; the alternatives are a fixed grid (which would fight the
+          deck's variable-width labels) or drawing the connector as a trailing
+          element (which moves the same orphan to the END of every row and
+          leaves it pointing at nothing). Removing wrapping removes the whole
+          class of defect instead of relocating it: ten segments stay on one
+          line at every width, and the line scrolls when it does not fit.
+          `snap` keeps a partly-scrolled rail landing on a segment rather than
+          mid-label. */}
       <ol
         aria-label="Connection setup steps"
-        className="mb-1 flex flex-wrap items-center gap-y-2"
+        data-testid="step-rail"
+        className="mb-1 flex snap-x snap-mandatory flex-nowrap items-center overflow-x-auto pb-1"
       >
         {SPEC_STEPS.map((s, i) => {
-          const isCurrent = s.n === effectiveCurrentSpec;
+          // POSITION ONLY. This is an input to `state` below and to nothing
+          // else -- see the comment on RAIL_SEGMENT_STYLES for why no visual
+          // may read it directly.
+          const positionallyCurrent = s.n === effectiveCurrentSpec;
           // Completed means "earlier in the order this wizard actually
           // visits built steps in," never "a smaller specified number" --
           // see the comment on BUILT_ORDER above for why those disagree here.
@@ -849,30 +949,26 @@ function StepRail({
           // actually failed keeps waiting for a state that is never coming,
           // and one told "loading" for their own unmade selection is told
           // something false about themselves.
-          const state:
-            | "not-built"
-            | "current"
-            | "completed"
-            | "upcoming"
-            | SiteScopeReadiness
-            | CapabilityReadiness = !s.built
+          const state: RailSegmentState = !s.built
             ? "not-built"
             : s.n === SITE_SCOPE_SPEC_N && siteScopeBlocking
               ? siteScopeState
               : s.n === CAPABILITY_SPEC_N && capabilityBlocking
                 ? capabilityState
-                : isCurrent
+                : positionallyCurrent
                   ? "current"
                   : isCompleted
                     ? "completed"
                     : "upcoming";
-          // NOT FAKED PROGRESS, IN EITHER DIRECTION. A filled circle is the
-          // strongest "this is finished" signal on the screen, so it is drawn
-          // from `state` alone: an unbuilt step has no section behind it to
-          // have completed, and a built step the mint would still refuse gets
-          // neither the filled nor the ringed circle.
-          const isDone = state === "completed";
-          const isFailed = state === "failed";
+          // EVERY VISUAL FROM THE ONE STATE VALUE, VIA THE TABLE. There is no
+          // second boolean here for a style to read, so the ring cannot
+          // appear on a step whose state says it is blocked -- that was the
+          // FIFTH instance of this component's one defect family (the rail
+          // saying a thing is fine while the action it gates is refused), and
+          // it happened because `isCurrent` was positional and the style read
+          // it directly. Position is now an input to `state` and to nothing
+          // else.
+          const style = RAIL_SEGMENT_STYLES[state];
           return (
             <li key={s.n} className="flex items-center">
               {i > 0 ? (
@@ -888,24 +984,19 @@ function StepRail({
                 />
               ) : null}
               <span
-                aria-current={isCurrent ? "step" : undefined}
+                aria-current={style.ariaCurrent ? "step" : undefined}
                 // A plain data attribute rather than only a class, so a test
                 // can assert the state this rail believes it is in without
                 // coupling to Tailwind class names.
                 data-step-n={s.n}
                 data-step-state={state}
-                className="flex items-center gap-2"
+                className="flex snap-start items-center gap-2"
               >
                 <span
                   data-testid={`step-circle-${s.n}`}
                   className={cn(
                     "inline-flex size-[22px] flex-none items-center justify-center rounded-full border-[1.5px] border-[var(--color-border)] font-mono text-[11px] leading-none text-[var(--color-muted-foreground)]",
-                    isDone &&
-                      "border-[var(--color-primary)] bg-[var(--color-primary)] text-[var(--color-primary-foreground)]",
-                    isCurrent &&
-                      "border-2 border-[var(--color-primary)] text-[var(--color-primary)]",
-                    isFailed && "border-[var(--color-destructive)] text-[var(--color-destructive)]",
-                    !s.built && "opacity-70",
+                    style.circle,
                   )}
                 >
                   {s.n}
@@ -913,19 +1004,13 @@ function StepRail({
                 <span
                   data-testid={`step-label-${s.n}`}
                   className={cn(
-                    "text-[12.5px] text-[var(--color-muted-foreground)]",
-                    !s.built && "italic opacity-70",
-                    isCurrent && "font-medium text-[var(--color-foreground)]",
-                    isDone && "text-[var(--color-foreground)]",
-                    isFailed && "text-[var(--color-destructive)]",
+                    "whitespace-nowrap text-[12.5px] text-[var(--color-muted-foreground)]",
+                    style.label,
                   )}
                 >
                   {s.rail}
+                  {style.suffix}
                   {!s.built ? <span className="sr-only"> (not yet available)</span> : null}
-                  {state === "loading" ? " (loading)" : null}
-                  {state === "failed" ? " (failed to load)" : null}
-                  {state === "tags-unresolved" ? " (tags still loading)" : null}
-                  {state === "unselected" ? " (not chosen yet)" : null}
                 </span>
               </span>
             </li>
@@ -987,26 +1072,35 @@ export function recommendationFor(
  * that is not a specified step, so a section cannot be numbered off the spine
  * at all.
  *
- * The heading keeps this section's OWN title rather than the deck's long frame
- * title, where the two differ: the built section for specified step 2 asks for
- * the client and not yet the name (the name field is still down in the setup
- * section), and printing "Name it, pick the AI client" over it would promise a
- * field that is not there. Ruling 15 governs which text is canonical for a
- * heading; it does not license a heading that describes an unbuilt screen.
+ * THE HEADING IS THE SPEC ENTRY'S OWN `heading`, NOT A SECOND STRING PASSED IN
+ * BESIDE IT. A `title` prop next to a canonical `heading` field is two places
+ * one step's name is written with nothing making them agree, which is the
+ * exact shape capabilities.ts documents at length as the reason its vocabulary
+ * is one list -- and drift between them is precisely the defect this component
+ * was reported for.
+ *
+ * `narrowerTitle` is the one deliberate escape, and it is visible at the call
+ * site with its reason. It exists for a built section that does LESS than the
+ * deck's frame title claims: specified step 2 is "Name it, pick the AI client"
+ * and the built section only picks the client (the name field is still down in
+ * the setup section), so printing the deck's title over it would promise a
+ * field that is not on the screen. Ruling 15 says which text is canonical; it
+ * does not license a heading that describes an unbuilt screen.
  */
 function Section({
   specN,
-  title,
+  narrowerTitle,
   hint,
   children,
 }: {
   specN: number;
-  title: string;
+  narrowerTitle?: string;
   hint: string;
   children: ReactNode;
 }) {
   const spec = SPEC_STEPS.find((s) => s.n === specN);
   if (spec === undefined) throw new Error(`section numbered off the spine: ${specN}`);
+  const title = narrowerTitle ?? spec.heading;
   return (
     <section aria-label={title} className="space-y-3">
       <div className="space-y-0.5">

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -860,10 +860,17 @@ function StepRail({
   // THE OTHER HALF OF "ONE ROW THAT SCROLLS". Ten segments do not fit on a
   // phone, so on a narrow screen the step the operator is actually on can sit
   // off the right-hand edge -- a rail whose current step is invisible is no
-  // better than the paragraph this replaced. The current segment is scrolled
-  // into view whenever it changes. `scrollIntoView` is absent in jsdom, so the
-  // guard is what keeps the unit suite from throwing on a browser API it does
-  // not implement; `block: "nearest"` keeps this from scrolling the PAGE.
+  // better than the paragraph this replaced.
+  //
+  // THE RAIL'S OWN CONTAINER IS SCROLLED, AND NOTHING ELSE IS. `scrollIntoView`
+  // is the obvious call and it is the wrong one: it moves whatever ancestors it
+  // must to satisfy the request, and `block: "nearest"` does not save this
+  // rail, which sits at the top of a long page. An operator ticking
+  // capabilities near the bottom, whose action changes the current step, is
+  // dragged back up to a rail they were not looking at. Setting `scrollLeft`
+  // from the segment's own offset means the horizontal axis is the only one
+  // that can move, because it is the only one written.
+  const railScroller = useRef<HTMLOListElement | null>(null);
   const currentSegment = useRef<HTMLLIElement | null>(null);
   const currentSpec = specStepFor(current);
   const currentPos = BUILT_ORDER.findIndex(([, spec]) => spec === currentSpec);
@@ -899,9 +906,26 @@ function StepRail({
       ? capabilityBuiltPos
       : currentPos;
   useEffect(() => {
-    const el = currentSegment.current;
-    if (el !== null && typeof el.scrollIntoView === "function") {
-      el.scrollIntoView({ block: "nearest", inline: "center" });
+    const rail = railScroller.current;
+    const segment = currentSegment.current;
+    if (rail === null || segment === null) return;
+    // Centre the segment in the rail's own viewport, clamped to the scrollable
+    // range so the first and last steps sit flush rather than half off.
+    const centred = segment.offsetLeft + segment.offsetWidth / 2 - rail.clientWidth / 2;
+    const left = Math.max(0, Math.min(centred, rail.scrollWidth - rail.clientWidth));
+    // A motion preference is a real answer about how a person's body responds
+    // to movement, so smooth is the default and never the only option. jsdom
+    // implements neither `matchMedia` nor element scroll methods, hence both
+    // guards: without them the unit suite throws on browser APIs that are
+    // simply absent there, and `scrollLeft` is the assignment that still works
+    // when `scrollTo` is missing.
+    const reduceMotion =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (typeof rail.scrollTo === "function") {
+      rail.scrollTo({ left, behavior: reduceMotion ? "auto" : "smooth" });
+    } else {
+      rail.scrollLeft = left;
     }
   }, [effectiveCurrentSpec]);
   return (
@@ -929,6 +953,7 @@ function StepRail({
           mid-label. */}
       <ol
         aria-label="Connection setup steps"
+        ref={railScroller}
         data-testid="step-rail"
         className="mb-1 flex snap-x snap-mandatory flex-nowrap items-center overflow-x-auto pb-1"
       >

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { UseMutationResult } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
 import { AlertTriangle, Check, ExternalLink, Lock } from "lucide-react";
@@ -869,6 +869,14 @@ function StepRail({
    */
   capabilityState: CapabilityReadiness;
 }) {
+  // THE OTHER HALF OF "ONE ROW THAT SCROLLS". Ten segments do not fit on a
+  // phone, so on a narrow screen the step the operator is actually on can sit
+  // off the right-hand edge -- a rail whose current step is invisible is no
+  // better than the paragraph this replaced. The current segment is scrolled
+  // into view whenever it changes. `scrollIntoView` is absent in jsdom, so the
+  // guard is what keeps the unit suite from throwing on a browser API it does
+  // not implement; `block: "nearest"` keeps this from scrolling the PAGE.
+  const currentSegment = useRef<HTMLLIElement | null>(null);
   const currentSpec = specStepFor(current);
   const currentPos = BUILT_ORDER.findIndex(([, spec]) => spec === currentSpec);
   const siteScopeBuiltPos = BUILT_ORDER.findIndex(([, spec]) => spec === SITE_SCOPE_SPEC_N);
@@ -902,6 +910,12 @@ function StepRail({
     : capabilityBlocking
       ? capabilityBuiltPos
       : currentPos;
+  useEffect(() => {
+    const el = currentSegment.current;
+    if (el !== null && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "nearest", inline: "center" });
+    }
+  }, [effectiveCurrentSpec]);
   return (
     <div className="space-y-2">
       {/* THE STEPPER, AS THE DECK DRAWS IT: numbered circles, connector lines,
@@ -970,7 +984,14 @@ function StepRail({
           // else.
           const style = RAIL_SEGMENT_STYLES[state];
           return (
-            <li key={s.n} className="flex items-center">
+            <li
+              key={s.n}
+              // The ref goes on whichever segment the rail is pointing at,
+              // blocked or not: the operator needs to see the step they are
+              // held on just as much as one they have finished.
+              ref={style.ariaCurrent ? currentSegment : undefined}
+              className="flex items-center"
+            >
               {i > 0 ? (
                 // THE CONNECTOR, AND THE DECK'S OWN BREAKPOINT. 44px wide
                 // above 640px, 16px below it, margins shrinking with it. `sm:`

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -967,14 +967,11 @@ function StepRail({
                   : isCompleted
                     ? "completed"
                     : "upcoming";
-          // EVERY VISUAL FROM THE ONE STATE VALUE, VIA THE TABLE. There is no
-          // second boolean here for a style to read, so the ring cannot
-          // appear on a step whose state says it is blocked -- that was the
-          // FIFTH instance of this component's one defect family (the rail
-          // saying a thing is fine while the action it gates is refused), and
-          // it happened because `isCurrent` was positional and the style read
-          // it directly. Position is now an input to `state` and to nothing
-          // else.
+          // EVERY VISUAL FROM THE ONE STATE VALUE, VIA THE TABLE. No style
+          // reads a second boolean, so the ring cannot appear on a step whose
+          // state says its action is blocked: a rail that presents a step as
+          // in hand while the mint button refuses it is this component's
+          // recurring defect, and one input is what makes it inexpressible.
           const style = RAIL_SEGMENT_STYLES[state];
           return (
             <li
@@ -1079,10 +1076,11 @@ export function recommendationFor(
 
 /**
  * ONE SECTION, NUMBERED WITH THE SPECIFIED STEP IT ANSWERS -- never with its
- * position on this page. That disagreement is the defect the owner reported:
- * the rail called the setup section step 6 while the heading over it said "4.
- * Set it up", so two numbering systems were on screen at once and contradicted
- * each other. `specN` is looked up in SPEC_STEPS, which throws for a number
+ * position on this page. Numbering by position puts two numbering systems on
+ * one screen -- the rail calling a section step 6 while the heading over it
+ * says "4. Set it up" -- and they contradict each other as soon as the page
+ * order stops matching the spine, which here it deliberately does not.
+ * `specN` is looked up in SPEC_STEPS, which throws for a number
  * that is not a specified step, so a section cannot be numbered off the spine
  * at all.
  *
@@ -1479,10 +1477,10 @@ function mintScopeRequest(
  *       -> mint N/A; NextSteps is unconditionally actionable the moment
  *          client and method are picked, so step 3 reads by POSITION alone
  *          (the ordinary completed/upcoming logic) and step 6 stays current.
- *   Getting this wrong the other way was Greptile's P1 on :639: dragging
- *   `aria-current` back to step 3 while an OAuth operator sits in an
- *   already-actionable step 6, because the predicate could not tell "no
- *   button exists here" from "the button here is disabled."
+ *   The over-fire this avoids: dragging `aria-current` back to step 3 while
+ *   an OAuth operator sits in an already-actionable step 6, because the
+ *   predicate could not tell "no button exists here" from "the button here
+ *   is disabled."
  *
  * THE ONE PLACE THIS IS DECIDED. `mintBlockedReason` below and the step
  * rail's `siteScopeState` (ConnectWizard) both call this and nothing else, so

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -141,7 +141,22 @@ function specStepFor(step: Step): number {
 interface SpecStepDef {
   /** The specified step number (design S29), 1 through 10. */
   readonly n: number;
-  readonly label: string;
+  /**
+   * THE RAIL LABEL, AND IT IS THE SHORT ONE. Ruling 15 on the deck: "The
+   * stepper's short labels (Start, Client, Sites, Capabilities, Auth, Setup,
+   * Authorize, Confirm, Test, Done) are canonical for the rail; the long frame
+   * titles are canonical for the screen heading." We shipped the long titles
+   * in the rail, slash-separated, which is the frame heading standing in a
+   * place it does not belong and reads as a paragraph rather than a stepper.
+   */
+  readonly rail: string;
+  /**
+   * The long frame title, canonical for the screen heading. Held here so the
+   * rail and the section heading are two renderings of ONE row, and cannot
+   * drift into naming the same step differently -- which is exactly the defect
+   * reported: the rail called a section step 5 while its own heading said 2.
+   */
+  readonly heading: string;
   /** True when this specified step has a built, reachable section today. */
   readonly built: boolean;
 }
@@ -150,20 +165,22 @@ interface SpecStepDef {
 // starting. Only five are `built: true`; the rest render as not-yet-available
 // rather than being omitted or, worse, made to look done.
 const SPEC_STEPS: readonly SpecStepDef[] = [
-  { n: 1, label: "Start a connection", built: false },
-  { n: 2, label: "Name it, pick the AI client", built: true },
-  { n: 3, label: "Choose which sites", built: true },
+  { n: 1, rail: "Start", heading: "Start a connection", built: false },
+  { n: 2, rail: "Client", heading: "Name it, pick the AI client", built: true },
+  { n: 3, rail: "Sites", heading: "Choose which sites", built: true },
   // Built on the TOKEN path only -- see the file-top comment on the OAuth
   // split. `built: true` still means "reachable on at least one path", the
   // same standard site-scope and setup already meet even though the sites
   // page's copy names its own limits per method.
-  { n: 4, label: "Choose what it may do", built: true },
-  { n: 5, label: "Choose how it authenticates", built: true },
-  { n: 6, label: "Get the setup artefact", built: true },
-  { n: 7, label: "Connect and authorize", built: false },
-  { n: 8, label: "WPMgr confirms connection is live", built: false },
-  { n: 9, label: "Verify with a first read", built: false },
-  { n: 10, label: "Done: tool list and first prompt", built: false },
+  { n: 4, rail: "Capabilities", heading: "Choose what it may do", built: true },
+  { n: 5, rail: "Auth", heading: "Choose how it authenticates", built: true },
+  { n: 6, rail: "Setup", heading: "Get the setup artefact", built: true },
+  { n: 7, rail: "Authorize", heading: "Connect and authorize", built: false },
+  { n: 8, rail: "Confirm", heading: "WPMgr confirms connection is live", built: false },
+  // "Test" in the rail, "Verify with a first read" as the heading -- ruling 15
+  // names this pair explicitly, because the deck uses both words for step 9.
+  { n: 9, rail: "Test", heading: "Verify with a first read", built: false },
+  { n: 10, rail: "Done", heading: "Done: tool list and first prompt", built: false },
 ];
 
 /**
@@ -485,7 +502,7 @@ export function ConnectWizard({
       ) : null}
 
       <Section
-        n={1}
+        specN={2}
         title="Pick your client"
         hint="Everything after this is computed from your answer, so nothing asks you twice."
       >
@@ -505,7 +522,7 @@ export function ConnectWizard({
 
       {client !== null ? (
         <Section
-          n={2}
+          specN={5}
           title="How it signs in"
           hint={`Computed from ${client.name}. A method it cannot use is disabled with the reason.`}
         >
@@ -576,7 +593,7 @@ export function ConnectWizard({
 
       {client !== null && method !== null ? (
         <Section
-          n={3}
+          specN={3}
           title="Sites this connection may reach"
           hint="Chosen before capabilities, on purpose. What a connection may do is only meaningful once you have fixed what it may do it to."
         >
@@ -609,7 +626,7 @@ export function ConnectWizard({
           choice is actually made. */}
       {client !== null && method === "token" ? (
         <Section
-          n={4}
+          specN={4}
           title="Choose what it may do"
           hint="Every capability here is read-only. Nothing on this list can change WordPress content or configuration."
         >
@@ -682,7 +699,7 @@ export function ConnectWizard({
 
       {client !== null && method !== null ? (
         <Section
-          n={5}
+          specN={6}
           title="Set it up"
           hint="Generated for this client. Every difference below is a real difference between clients."
         >
@@ -804,8 +821,18 @@ function StepRail({
       ? capabilityBuiltPos
       : currentPos;
   return (
-    <div className="space-y-1">
-      <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--color-muted-foreground)]">
+    <div className="space-y-2">
+      {/* THE STEPPER, AS THE DECK DRAWS IT: numbered circles, connector lines,
+          done / current / upcoming states, and the 640px breakpoint that
+          shortens the connectors. What shipped instead was the ten long frame
+          titles run together with slashes, which is a paragraph doing a rail's
+          job -- and it printed the FRAME HEADING text, which ruling 15 assigns
+          to the screen heading, in the one place the short labels are
+          canonical. Both halves are corrected here. */}
+      <ol
+        aria-label="Connection setup steps"
+        className="mb-1 flex flex-wrap items-center gap-y-2"
+      >
         {SPEC_STEPS.map((s, i) => {
           const isCurrent = s.n === effectiveCurrentSpec;
           // Completed means "earlier in the order this wizard actually
@@ -839,9 +866,27 @@ function StepRail({
                   : isCompleted
                     ? "completed"
                     : "upcoming";
+          // NOT FAKED PROGRESS, IN EITHER DIRECTION. A filled circle is the
+          // strongest "this is finished" signal on the screen, so it is drawn
+          // from `state` alone: an unbuilt step has no section behind it to
+          // have completed, and a built step the mint would still refuse gets
+          // neither the filled nor the ringed circle.
+          const isDone = state === "completed";
+          const isFailed = state === "failed";
           return (
-            <li key={s.n} className="flex items-center gap-2">
-              {i > 0 ? <span aria-hidden="true">/</span> : null}
+            <li key={s.n} className="flex items-center">
+              {i > 0 ? (
+                // THE CONNECTOR, AND THE DECK'S OWN BREAKPOINT. 44px wide
+                // above 640px, 16px below it, margins shrinking with it. `sm:`
+                // IS that 640px boundary: Tailwind's default `sm` is 640px and
+                // globals.css never redefines it, which the stepper test
+                // asserts rather than assumes.
+                <span
+                  aria-hidden="true"
+                  data-testid={`step-line-${s.n}`}
+                  className="mx-1.5 h-px w-4 shrink-0 bg-[var(--color-border)] sm:mx-2.5 sm:w-11"
+                />
+              ) : null}
               <span
                 aria-current={isCurrent ? "step" : undefined}
                 // A plain data attribute rather than only a class, so a test
@@ -849,24 +894,39 @@ function StepRail({
                 // coupling to Tailwind class names.
                 data-step-n={s.n}
                 data-step-state={state}
-                // NOT FAKED PROGRESS, IN EITHER DIRECTION. An unbuilt step
-                // gets none of the "current" or "completed" styling below,
-                // because it has no section behind it to have completed; a
-                // built step mint would still refuse gets neither "current"
-                // nor "completed" either, for the same reason.
-                className={cn(
-                  !s.built && "italic opacity-70",
-                  state === "current" && "font-medium text-[var(--color-foreground)]",
-                  state === "completed" && "text-[var(--color-foreground)]",
-                  state === "failed" && "text-[var(--color-destructive)]",
-                )}
+                className="flex items-center gap-2"
               >
-                {s.n}. {s.label}
-                {!s.built ? <span className="sr-only"> (not yet available)</span> : null}
-                {state === "loading" ? " (loading)" : null}
-                {state === "failed" ? " (failed to load)" : null}
-                {state === "tags-unresolved" ? " (tags still loading)" : null}
-                {state === "unselected" ? " (not chosen yet)" : null}
+                <span
+                  data-testid={`step-circle-${s.n}`}
+                  className={cn(
+                    "inline-flex size-[22px] flex-none items-center justify-center rounded-full border-[1.5px] border-[var(--color-border)] font-mono text-[11px] leading-none text-[var(--color-muted-foreground)]",
+                    isDone &&
+                      "border-[var(--color-primary)] bg-[var(--color-primary)] text-[var(--color-primary-foreground)]",
+                    isCurrent &&
+                      "border-2 border-[var(--color-primary)] text-[var(--color-primary)]",
+                    isFailed && "border-[var(--color-destructive)] text-[var(--color-destructive)]",
+                    !s.built && "opacity-70",
+                  )}
+                >
+                  {s.n}
+                </span>
+                <span
+                  data-testid={`step-label-${s.n}`}
+                  className={cn(
+                    "text-[12.5px] text-[var(--color-muted-foreground)]",
+                    !s.built && "italic opacity-70",
+                    isCurrent && "font-medium text-[var(--color-foreground)]",
+                    isDone && "text-[var(--color-foreground)]",
+                    isFailed && "text-[var(--color-destructive)]",
+                  )}
+                >
+                  {s.rail}
+                  {!s.built ? <span className="sr-only"> (not yet available)</span> : null}
+                  {state === "loading" ? " (loading)" : null}
+                  {state === "failed" ? " (failed to load)" : null}
+                  {state === "tags-unresolved" ? " (tags still loading)" : null}
+                  {state === "unselected" ? " (not chosen yet)" : null}
+                </span>
               </span>
             </li>
           );
@@ -918,22 +978,40 @@ export function recommendationFor(
     : "The documented headless path";
 }
 
+/**
+ * ONE SECTION, NUMBERED WITH THE SPECIFIED STEP IT ANSWERS -- never with its
+ * position on this page. That disagreement is the defect the owner reported:
+ * the rail called the setup section step 6 while the heading over it said "4.
+ * Set it up", so two numbering systems were on screen at once and contradicted
+ * each other. `specN` is looked up in SPEC_STEPS, which throws for a number
+ * that is not a specified step, so a section cannot be numbered off the spine
+ * at all.
+ *
+ * The heading keeps this section's OWN title rather than the deck's long frame
+ * title, where the two differ: the built section for specified step 2 asks for
+ * the client and not yet the name (the name field is still down in the setup
+ * section), and printing "Name it, pick the AI client" over it would promise a
+ * field that is not there. Ruling 15 governs which text is canonical for a
+ * heading; it does not license a heading that describes an unbuilt screen.
+ */
 function Section({
-  n,
+  specN,
   title,
   hint,
   children,
 }: {
-  n: number;
+  specN: number;
   title: string;
   hint: string;
   children: ReactNode;
 }) {
+  const spec = SPEC_STEPS.find((s) => s.n === specN);
+  if (spec === undefined) throw new Error(`section numbered off the spine: ${specN}`);
   return (
     <section aria-label={title} className="space-y-3">
       <div className="space-y-0.5">
         <h2 className="text-sm font-semibold text-[var(--color-foreground)]">
-          {n}. {title}
+          {spec.n}. {title}
         </h2>
         <p className="text-xs text-[var(--color-muted-foreground)]">{hint}</p>
       </div>


### PR DESCRIPTION
The shipped rail is neither a stepper nor a wizard: it prints the ten long frame titles slash-separated, which is heading text standing in the rail's place, and it disagrees with the numbers on the sections below it.

**Stage 1 (this commit).** The rail is now the component the wireframes draw: numbered circles, connector lines, done / current / upcoming states, and the 640px breakpoint that shortens the connectors, in the project's own tokens and utilities. Rail labels are the short ones ruling 15 makes canonical (Start, Client, Sites, Capabilities, Auth, Setup, Authorize, Confirm, Test, Done). Sections are numbered with the specified step they answer, not their position on the page, so the rail and a section heading can no longer name the same step differently.

Every guard already proven on rail state is untouched: `siteScopeReadiness` stays the single predicate the rail and the mint button both read, unbuilt steps still render as neither current nor done, and the deck's non-monotonic on-screen order is preserved rather than renumbered.

Draft while the tests and the remaining gates run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the AI connection wizard with numbered progress circles, connector lines, and clear states for completed, current, upcoming, and blocked steps.
  * Added concise step labels and canonical section headings for easier navigation.
  * Improved responsive behavior with a single-row, horizontally scrollable progress rail on smaller screens.

* **Bug Fixes**
  * Corrected setup section numbering to remain consistent with the wizard’s progress rail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->