### PR TITLE
test(mcp): wire the context resolver into the integration fixtures #684 missed

### DIFF
--- a/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
+++ b/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
 
@@ -72,7 +73,17 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 	siteURL := "https://" + uuid.NewString()[:8] + ".example.test"
 	siteID := seedSite(t, pool, tenantID, siteURL)
 
-	svc := auditedMCPService(pool, mcp.NewRepo(pool))
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := auditedMCPService(pool, mcp.NewRepo(pool)).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 	// An ORG-scoped operator: the only scope /consent admits. The role is
 	// load-bearing too, and not decoration -- /consent and POST
 	// /api/v1/mcp/connections require the same permission to create a

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 	"github.com/mosamlife/wpmgr/apps/api/internal/site"
 )
@@ -149,7 +150,17 @@ func TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo)
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcpRepo).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	tenant := seedTenant(t, pool, "mcp-s7-caps-"+uuid.NewString()[:8])
 
@@ -304,7 +315,17 @@ func TestS7UntickedCapabilityRefusesByNameAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo)
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcpRepo).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	tenant := seedTenant(t, pool, "mcp-s7-cap-"+uuid.NewString()[:8])
 
@@ -521,7 +542,17 @@ func TestS7CapabilityOutsideTheOrgCeilingIsNotListedAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo)
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcpRepo).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	tenant := seedTenant(t, pool, "mcp-s7-ceil-"+uuid.NewString()[:8])
 

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
 
@@ -116,7 +117,17 @@ func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T)
 	seedSite(t, pool, tenantID, siteURL)
 
 	rec := audit.NewRecorder(pool, domain.SystemClock{})
-	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	// An org-scoped admin: the role RegisterConnections' PermAPIKeyManage
 	// requires for revoke, and the only scope /consent admits.

--- a/apps/api/tests/mcp_audit_fail_closed_integration_test.go
+++ b/apps/api/tests/mcp_audit_fail_closed_integration_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
 
@@ -140,7 +141,17 @@ func TestMCPAuditFailClosed_NoAnswerIsServedWhenTheAppendCannotCommit(t *testing
 	t.Logf("seeded tenant=%s site=%s", tenantID, siteID)
 
 	rec := audit.NewRecorder(pool, domain.SystemClock{})
-	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	principal := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
 	connEng := mountConnectionsLikeProduction(t, svc, principal)

--- a/apps/api/tests/mcp_connection_token_mint_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 	"github.com/mosamlife/wpmgr/apps/api/internal/sitetag"
 )
@@ -79,7 +80,17 @@ func TestMCPMintedTokenAuthenticatesAndIsTenantBoundAsAppRole(t *testing.T) {
 	seedSite(t, pool, tenantB, siteBURL)
 
 	rec := audit.NewRecorder(pool, domain.SystemClock{})
-	svc := auditedMCPService(pool, mcp.NewRepo(pool)).WithAudit(rec)
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := auditedMCPService(pool, mcp.NewRepo(pool)).WithAudit(rec).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	adminA := domain.Principal{
 		Type: domain.PrincipalUser, UserID: userA, TenantID: tenantA,

--- a/apps/api/tests/mcp_layer3_hiding_integration_test.go
+++ b/apps/api/tests/mcp_layer3_hiding_integration_test.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 	"github.com/mosamlife/wpmgr/apps/api/internal/site"
 )
@@ -106,7 +107,17 @@ func TestMCPLayer3OutOfScopeSiteIsAbsentAndNotInferableAsAppRole(t *testing.T) {
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{})).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	tenant := seedTenant(t, pool, "mcp-l3-"+uuid.NewString()[:8])
 
@@ -345,9 +356,19 @@ func TestMCPPageBoundDoesNotDiscloseTenantSizeAsAppRole(t *testing.T) {
 	mcpRepo := mcp.NewRepo(pool)
 	siteRepo := site.NewRepo(pool)
 	// WithPageBound(3) is what makes this proof non-vacuous. See the note above.
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
 	svc := mcp.NewService(mcpRepo).
 		WithAudit(audit.NewRecorder(pool, domain.SystemClock{})).
-		WithPageBound(3)
+		WithPageBound(3).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	tenant := seedTenant(t, pool, "mcp-pb-"+uuid.NewString()[:8])
 

--- a/apps/api/tests/mcp_refusal_audit_integration_test.go
+++ b/apps/api/tests/mcp_refusal_audit_integration_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
 
@@ -126,7 +127,17 @@ func TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole(t *testing.T) {
 	seedSite(t, pool, tenantID, "https://"+suffix+".example.test")
 
 	rec := audit.NewRecorder(pool, domain.SystemClock{})
-	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec)
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcp.NewRepo(pool)).WithAudit(rec).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	admin := domain.Principal{UserID: userID, TenantID: tenantID, Role: "admin", Scope: domain.ScopeOrg}
 	connEng := mountConnectionsLikeProduction(t, svc, admin)

--- a/apps/api/tests/mcp_scoped_site_read_integration_test.go
+++ b/apps/api/tests/mcp_scoped_site_read_integration_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/mosamlife/wpmgr/apps/api/internal/db"
 	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+	"github.com/mosamlife/wpmgr/apps/api/internal/govcontext"
 	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
 )
 
@@ -98,7 +99,17 @@ func TestMCPSiteReadReturnsTheLastSortingInScopeSiteAsAppRole(t *testing.T) {
 	ctx := context.Background()
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{})).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	tenant := seedTenant(t, pool, "mcp-ssr-"+uuid.NewString()[:8])
 	const lastName = "zzz-sorts-last"
@@ -314,7 +325,17 @@ func TestMCPSiteReadArchivedInScopeSiteIsAccountedAsAppRole(t *testing.T) {
 	ctx := context.Background()
 	pool := startPostgres(t)
 	mcpRepo := mcp.NewRepo(pool)
-	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{}))
+	// THE CONTEXT RESOLVER IS WIRED BECAUSE PRODUCTION WIRES IT: both non-test
+	// call sites of mcp.NewService (cmd/wpmgr/main.go, cmd/dump-routes/routes.go)
+	// chain WithContextResolver, and a Service without one refuses every fleet
+	// tool call rather than serving with the operator's governance silently
+	// absent. Omitting it here would make the tools/call below refuse and this
+	// test would prove nothing about what it is named for. It is the REAL
+	// govcontext.Repo over the same pool, so the organisation-context read runs
+	// through InTenantTx as wpmgr_app under the same RLS policies as every other
+	// read in this file.
+	svc := mcp.NewService(mcpRepo).WithAudit(audit.NewRecorder(pool, domain.SystemClock{})).
+		WithContextResolver(&govcontext.Resolver{Store: govcontext.NewRepo(pool)})
 
 	tenant := seedTenant(t, pool, "mcp-arch-"+uuid.NewString()[:8])
 	liveID := seedSitesBulk(t, pool, tenant, 2, "aaa-live")


### PR DESCRIPTION
`main`'s integration gate has been red since #684. Twelve tests in
`apps/api/tests` fail with

    this connection cannot be served because its organisation's context
    cannot be resolved

`ci.yml` does not run that package, so #684 merged green.

## Root cause

`apps/api/internal/mcp/govcontext.go:62` — the nil-resolver branch of
`Service.operatorContext`:

```go
if s.context == nil {
    return "", domain.Internal(ErrCodeContextUnavailable,
        "this connection cannot be served because its organisation's context cannot be resolved")
}
```

That string is unique to this branch; every refusal `internal/govcontext`
raises itself is worded `"effective context could not be resolved: …"`. The
twelve failing tests build `mcp.NewService(...)` without
`.WithContextResolver(...)`, so `s.context` is nil and #684's fence refuses
every fleet tool call before the test reaches what it is named for.

Reproduced against a real Postgres as `wpmgr_app`:

```
--- FAIL: TestS7CapabilitiesAreResolvedByAuthenticateAsAppRole (1.97s)
    adr064_s7_mcp_tool_registry_rls_test.go:211: ListSitesForModel for a fully-scoped
      connection: this connection cannot be served because its organisation's context
      cannot be resolved
```

## Fixture gap, not a live refusal

Three checks, because the two diagnoses have opposite fixes:

1. **Production cannot reach a nil resolver.** `mcp.NewService` has exactly two
   non-test call sites — `cmd/wpmgr/main.go:553` and
   `cmd/dump-routes/routes.go:289` — and both chain `WithContextResolver`.
2. **A fresh organisation is not refused.** An org that has authored nothing
   resolves *successfully*: `internal/govcontext/repo.go:155` maps `ErrNotFound`
   to `(Snapshot{}, false, nil)`, a legitimate empty layer 2. The refusal is not
   about a missing row.
3. **#684 already fixed one of the thirteen the same way**
   (`tests/mcp_connection_status_integration_test.go:212`), with a comment
   saying production wires it. It found one fixture and missed the rest.

## The fix, and what it deliberately does not do

The resolver is wired **at each of the twelve sites**, not folded into the
`auditedMCPService` helper. A helper that silently hands every `Service` a
resolver would turn all twelve green while making the fence invisible at every
call site, and the next fixture that needs to prove a refusal would have to
fight the helper to get one. Each site is the real `govcontext.Repo` over the
same pool, so the organisation-context read runs through `InTenantTx` as
`wpmgr_app` under the same policies as every other read in its file.

The fence's own refusal stays proven where it belongs, in
`internal/mcp/govcontext_test.go`, which asserts a `Service` built without a
resolver refuses. #684's audit guarantee is untouched: a refusal still writes
its `mcp.tool.denied` row and a healthy call still writes exactly one
`mcp.tool.called` row and no denial row — asserted by
`TestMCPRefusalAudit_EveryRefusalWritesItsRow_AsAppRole` and
`TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole`, both in the
twelve.

No production code changes.

## Verification

See the comment below for the full `make test-integration` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DP2DoMnepVgtDZize9ecV7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded integration coverage for MCP authorization, tenant isolation, scoped access, refusal auditing, and token authentication.
  - Added verification that grant creation, tool usage, and revocation generate the expected audit records.
  - Confirmed failed transactions leave no partial grant or audit data.
  - Updated test scenarios to use production-equivalent organization-context resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->