### PR TITLE
release: 0.61.157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.157] - 2026-09-02
+
+### Changed
+
+- The AI connection wizard now shows one step at a time, with Back and Continue, instead of every section stacked on one scrolling page. The progress rail marks the step you are actually on. Continue refuses to advance while the current step's answer is missing or unresolved, and says why; Back keeps every answer already given. On the browser sign-in path, the step where you choose what the assistant may do is shown in the rail as not asked on that path, because permissions are chosen on the approval screen instead, rather than being silently removed and shortening the flow.
+
 ## [0.61.156] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.156**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.157**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.156
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.156
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.156
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.157
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.157
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.157
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.156   # omit to track :latest
+export WPMGR_VERSION=v0.61.157   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,18 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.157",
+    date: "2026-09-02",
+    summary:
+      "The AI connection wizard now walks one step at a time, with Back and Continue, instead of stacking every section on one scrolling page.",
+    items: [
+      {
+        tag: "Changed",
+        text: "The AI connection wizard now shows one step at a time, with Back and Continue, instead of every section stacked on one scrolling page. The progress rail marks the step you are actually on. Continue refuses to advance while the current step's answer is missing or unresolved, and says why; Back keeps every answer already given. On the browser sign-in path, the step where you choose what the assistant may do is shown in the rail as not asked on that path, because permissions are chosen on the approval screen instead, rather than being silently removed and shortening the flow.",
+      },
+    ],
+  },
+  {
     version: "0.61.156",
     date: "2026-09-02",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.156   # omit to track :latest
+export WPMGR_VERSION=v0.61.157   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.156
+  version: 0.61.157
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Web-only release for 0.61.157. Version surfaces and CHANGELOG only, no code changes.

- The AI connection wizard now shows one step at a time, with Back and Continue, instead of every section stacked on one scrolling page (#702). The progress rail marks the step you are actually on. Continue refuses to advance while the current step's answer is missing or unresolved, and says why; Back keeps every answer already given. On the browser sign-in path, the step where you choose what the assistant may do is shown in the rail as not asked on that path, because permissions are chosen on the approval screen instead.
- The agent version does not move in this release, so the marketing hero badge stays at 0.61.147.

## Test plan

- [x] `make check-versions-test` — 76 passed, 0 failed
- [x] `make check-versions` — all surfaces consistent at 0.61.157, agent badge unmoved at 0.61.147
- [x] `node apps/marketing/scripts/check-copy.mjs` — passed
- [x] Docs vocabulary check (copied verbatim from ci.yml) — clean
- [x] `git grep -n "0.61.156"` — remaining hits are historical CHANGELOG/marketing-changelog entries only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated the AI connection wizard to guide users through one step at a time with Back and Continue controls.
  * Added progress indicators for the current step.
  * Continue now explains when an answer is missing or unresolved and prevents advancement.
  * Browser sign-in flows show permissions as “not asked” when selected on the approval screen.
* **Documentation**
  * Updated installation instructions and release references to version 0.61.157.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->