### PR TITLE
fix(web): stop rendering the capability step refusal twice

### DIFF
--- a/apps/web/src/features/ai-connections/connect-wizard.test.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.test.tsx
@@ -1487,11 +1487,12 @@ describe("choosing what a token may do (step 4, token path only)", () => {
 
     fireEvent.click(screen.getByRole("checkbox", { name: /^Sites/i }));
 
-    // Rendered TWICE by design -- once beside the picker (an operator working
-    // the checkboxes sees it immediately) and once inside the mint panel
-    // (an operator who scrolled straight to the button sees it there) -- so
-    // this asserts on the plural.
-    expect((await screen.findAllByText(/no capability is selected/i)).length).toBeGreaterThan(0);
+    // EXACTLY ONE, not merely present. WizardNav owns the one refusal panel
+    // for every step; a private panel inside this section rendering the same
+    // sentence a second time shipped to production once and a `findAllByText
+    // .length > 0` assertion here did not catch it, because two matches
+    // satisfy "greater than zero" as easily as one does.
+    expect(await screen.findAllByText(/no capability is selected/i)).toHaveLength(1);
     // REFUSED AT CONTINUE NOW, not at a mint button one step further on. The
     // same predicate makes both refusals, so moving the assertion to the
     // control the operator is standing in front of tests the same guard at the
@@ -1559,6 +1560,57 @@ describe("choosing what a token may do (step 4, token path only)", () => {
 
     const body = capturedBody as Record<string, unknown>;
     expect(body.capabilities).toEqual(["mcp.sites.read", "mcp.uptime.read", "mcp.backups.read"]);
+  });
+});
+
+/**
+ * ONE REFUSAL PER BLOCKED STEP, AS A COUNT, FOR EVERY STEP THAT CAN REFUSE.
+ *
+ * WizardNav (`connect-wizard.tsx`) is the one place a step's `gate.refusal`
+ * is rendered. A step section that also renders its own copy of the same
+ * sentence -- reachable because the section reads the same underlying value
+ * the gate does -- puts the identical text on screen twice. A `getAllByText
+ * / findAllByText .length > 0` assertion is blind to that: a second match
+ * satisfies "at least one" exactly as well as one match does, which is how
+ * the capability step's private panel shipped and stayed unnoticed. Every
+ * test below asserts the exact count instead, on every local step whose gate
+ * can carry a refusal (1, 2, 3 and 4 -- the setup artefact step never
+ * refuses, see `stepGate`'s final branch).
+ */
+describe("a blocked step's refusal renders exactly once, never twice", () => {
+  it("step 1 -- no client chosen", async () => {
+    renderWizard();
+    await screen.findByRole("button", { name: /cursor/i });
+    expect(
+      screen.getAllByText(/pick the client that will connect before going on/i),
+    ).toHaveLength(1);
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it("step 2 -- client chosen, no sign-in method chosen", async () => {
+    renderWizard();
+    await pickClient("Cursor");
+    expect(
+      screen.getAllByText(/choose how this client signs in before going on/i),
+    ).toHaveLength(1);
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it("step 3 -- token path, list mode, no site picked", async () => {
+    loadedFleet(3);
+    renderWizard();
+    await reachSiteScopeStep("Cursor", "token");
+    expect(screen.getAllByText(/no site is picked/i)).toHaveLength(1);
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it("step 4 -- token path, every capability deselected", async () => {
+    loadedFleet(3);
+    renderWizard();
+    await advanceToCapabilityStep();
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Sites/i }));
+    expect(await screen.findAllByText(/no capability is selected/i)).toHaveLength(1);
+    expect(continueButton()).toBeDisabled();
   });
 });
 

--- a/apps/web/src/features/ai-connections/connect-wizard.tsx
+++ b/apps/web/src/features/ai-connections/connect-wizard.tsx
@@ -789,14 +789,13 @@ export function ConnectWizard({
               These are all read-only. No capability on this screen can change WordPress
               content or configuration, whichever ones you pick.
             </p>
-            {!capabilitiesRequest.ok ? (
-              <p
-                role="alert"
-                className="rounded-md border border-[var(--color-border)] bg-[var(--color-muted)]/40 p-3 text-sm text-[var(--color-foreground)]"
-              >
-                {capabilitiesRequest.refusal}
-              </p>
-            ) : null}
+            {/* NO PRIVATE REFUSAL PANEL HERE. `capabilitiesRequest.refusal` is
+                the exact string `stepGate`'s CAPABILITY_LOCAL_STEP branch
+                returns as `gate.refusal`, and WizardNav below already renders
+                that once, next to Continue, for every step that can refuse.
+                A second panel in this section rendered the identical sentence
+                twice on screen; it predates the one-step-at-a-time conversion,
+                from when this step had no Continue to attach a reason to. */}
           </div>
         </Section>
       ) : null}


### PR DESCRIPTION
## Summary
- The step-4 capability section rendered its own refusal panel (`{capabilitiesRequest.refusal}` at what was line 797) in addition to `WizardNav`'s panel (`{gate.refusal}`, line 1009). Both read the exact same string — `stepGate`'s `CAPABILITY_LOCAL_STEP` branch returns `refusal: ctx.capabilitiesRequest.ok ? null : ctx.capabilitiesRequest.refusal` verbatim — so unticking every capability rendered the identical sentence in two stacked bordered panels. The private panel predates the one-step-at-a-time conversion (#702), from when step 4 had no Continue button to attach a reason to.
- Removed the private panel; `WizardNav`'s panel is the one general mechanism and already renders for every step uniformly (steps 1-3 confirmed to have no such private panel).
- No wording changed.

## Why it shipped unnoticed
The existing regression test asserted `(await screen.findAllByText(/no capability is selected/i)).length` with `.toBeGreaterThan(0)`, and even carried a comment claiming the duplicate was "rendered TWICE by design." Two identical matches satisfy "greater than zero" exactly as well as one match does, so the test could never have caught either the original design intent or its later drift into an actual bug.

## Fix to the class of bug, not just the instance
- Replaced that assertion with an exact count (`toHaveLength(1)`).
- Added a new `describe` block asserting an exact single-match count for every local step whose `stepGate` can carry a refusal (steps 1-4; the setup-artefact step never refuses).

## Mutation test
Restored the deleted private panel locally, reran the suite: the new count assertions in both the existing test and the new "exactly once" test went red (`expected [...] to have a length of 1 but got 2`). Reverted to the fix, reran: 119/119 green.

## Test plan
- [x] `pnpm -C apps/web typecheck` — clean
- [x] `pnpm -C apps/web lint` — 0 errors (pre-existing warnings only, unrelated files)
- [x] `pnpm -C apps/web test` — 168 files, 2240 tests passed
- [x] `pnpm -C apps/web build` — succeeds, `routeTree.gen.ts` unaffected
- [x] `apps/web/node_modules/.bin/impeccable detect apps/web/src/features/ai-connections` — clean (verified via `--json`, empty array)
- [x] `pnpm exec playwright test e2e/ai-connect-stepper.spec.ts e2e/ai-connect-wizard.spec.ts` at 390px and 1440px — 5 passed, 2 pre-existing skips (unrelated: a documented known-failing horizontal-scroll test and an env-gated screenshot capture)
- [x] `git status --porcelain` empty, `git grep "MUTATION M" -- apps` exits 1