### PR TITLE
release: 0.61.158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.158] - 2026-09-02
+
+### Fixed
+
+- The connection wizard's capability step showed the "no capability is selected" refusal twice, stacked in two panels. It now shows once.
+
 ## [0.61.157] - 2026-09-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.157**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.158**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.157
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.157
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.157
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.158
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.158
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.158
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.157   # omit to track :latest
+export WPMGR_VERSION=v0.61.158   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,18 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.158",
+    date: "2026-09-02",
+    summary:
+      "The connection wizard's capability step showed its refusal message twice; it now shows once.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "The connection wizard's capability step showed the \"no capability is selected\" refusal twice, stacked in two panels. It now shows once.",
+      },
+    ],
+  },
+  {
     version: "0.61.157",
     date: "2026-09-02",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.157   # omit to track :latest
+export WPMGR_VERSION=v0.61.158   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.157
+  version: 0.61.158
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Web-only release. #704 fixed a doubled refusal render on the connection wizard's capability step: the "no capability is selected" message was shown once beside the picker and once again in the mint panel, both reading the same underlying value. It now shows once.

This is a small, cosmetic-adjacent defect that shipped and was fixed within hours of the previous release. It is included as one plain Fixed line because it was visible on screen and an operator who saw it doubled deserves the correction on record; it is not dressed up as anything more than a duplicate-render fix.

No security entry. Agent version does not move: the marketing hero badge stays at 0.61.147, matching `apps/agent/wpmgr-agent.php`.

## Test plan

- [x] `make check-versions-test` (self-test, 76 passed, 0 failed)
- [x] `make check-versions` (all surfaces OK)
- [x] `node apps/marketing/scripts/check-copy.mjs` (passed)
- [x] Docs vocabulary check from `ci.yml` run verbatim (no hits)
- [x] `git grep -n "0.61.157"` audited: both hits are historical (previous CHANGELOG heading and marketing changelog entry), correctly unchanged
- [x] CHANGELOG.md and the marketing changelog page agree
- [x] No tag created