### PR TITLE
release: 0.61.159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.159] - 2026-09-02
+
+### Added
+
+- The AI connection wizard now walks all ten steps in order, one at a time, with Back and Continue. Previously it was a single scrolling page whose sections appeared out of order, with the progress rail and the section headings disagreeing about which step you were on.
+- Steps that do not apply to the sign-in method you picked are shown struck through with the reason, instead of disappearing, so the wizard never changes length partway through.
+- The permissions step has two shortcuts, "Read everything" and "Just the basics", with a Custom state shown when your selection diverges from both.
+- The final step lists the tools that connection can actually call.
+
+### Security
+
+- Site names and other site-supplied text reaching the assistant are now marked before they arrive, so a crafted site name cannot be read as an instruction.
+- The connections list, and a connection's status and tools, now send Cache-Control: no-store. Their responses vary by who is asking, and without this a shared cache could serve one identity's answer to another.
+
 ## [0.61.158] - 2026-09-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.158**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.159**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.158
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.158
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.158
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.159
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.159
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.159
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.158   # omit to track :latest
+export WPMGR_VERSION=v0.61.159   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,38 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.159",
+    date: "2026-09-02",
+    summary:
+      "The AI connection wizard now walks all ten steps in order, one at a time, with Back and Continue.",
+    items: [
+      {
+        tag: "Added",
+        text: "The AI connection wizard now walks all ten steps in order, one at a time, with Back and Continue. Previously it was a single scrolling page whose sections appeared out of order, with the progress rail and the section headings disagreeing about which step you were on.",
+      },
+      {
+        tag: "Added",
+        text: "Steps that do not apply to the sign-in method you picked are shown struck through with the reason, instead of disappearing, so the wizard never changes length partway through.",
+      },
+      {
+        tag: "Added",
+        text: "The permissions step has two shortcuts, \"Read everything\" and \"Just the basics\", with a Custom state shown when your selection diverges from both.",
+      },
+      {
+        tag: "Added",
+        text: "The final step lists the tools that connection can actually call.",
+      },
+      {
+        tag: "Security",
+        text: "Site names and other site-supplied text reaching the assistant are now marked before they arrive, so a crafted site name cannot be read as an instruction.",
+      },
+      {
+        tag: "Security",
+        text: "The connections list, and a connection's status and tools, now send Cache-Control: no-store. Their responses vary by who is asking, and without this a shared cache could serve one identity's answer to another.",
+      },
+    ],
+  },
+  {
     version: "0.61.158",
     date: "2026-09-02",
     summary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.158   # omit to track :latest
+export WPMGR_VERSION=v0.61.159   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.158
+  version: 0.61.159
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

- The AI connection wizard now has all ten steps and walks them in order, one at a time, with Back and Continue. Previously it was one scrolling page whose sections appeared out of order, and the progress rail and section headings disagreed about which step you were on.
- Steps that do not apply to the chosen sign-in method are shown struck through with the reason, instead of disappearing, so the wizard never changes length partway through.
- The permissions step gains two shortcuts, Read everything and Just the basics, with a Custom state when the selection diverges from both.
- The final step lists the tools a connection can actually call.
- Security: site-supplied text (site names, plugin/theme names, versions) reaching the assistant is now marked before it arrives, so a crafted name cannot be read as an instruction. Three connection endpoints whose answers vary by caller (list, status, tools) now send Cache-Control: no-store.

Dropped from the changelog as internal, not operator-facing: the CI script scoring ADR-061's internal readiness checklist (its job fails red by design and is not required), review-thread fixes, and test hardening.

The agent version does not move in this release. The marketing hero badge stays at 0.61.147, matching `apps/agent/wpmgr-agent.php`.

## Test plan

- [x] `make check-versions-test` (self-test first): 76 passed, 0 failed
- [x] `make check-versions`: all surfaces consistent, agent badge untouched at 0.61.147
- [x] `node apps/marketing/scripts/check-copy.mjs`: passed, 390 files
- [x] Docs vocabulary check run verbatim from `ci.yml`: no hits
- [x] `git grep -n "0.61.158"`: two hits, both correct as historical (CHANGELOG.md prior entry, marketing changelog prior entry) plus one unrelated test fixture literal in `apps/api/internal/mcp/fence_test.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI connection setup now guides you through ten steps with Back and Continue controls.
  * Unavailable steps remain visible with explanations.
  * Choose “Read everything,” “Just the basics,” or customize permissions.
  * The final step shows which tools each connection can use.

* **Security**
  * Site-provided text is clearly separated before being sent to the assistant.
  * Connection data is prevented from being stored in shared caches.

* **Documentation**
  * Updated installation examples and release information for version 0.61.159.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->