### PR TITLE
fix(web): allow clearing alert recipients, expose enabled switch

### DIFF
--- a/apps/web/src/features/monitoring/alert-config-form.test.tsx
+++ b/apps/web/src/features/monitoring/alert-config-form.test.tsx
@@ -311,6 +311,152 @@ describe("AlertConfigForm — vulnerability alerts severity select", () => {
   });
 });
 
+describe("AlertConfigForm — clearing recipients to zero (GH #706)", () => {
+  // The exact regression: a customer with a SINGLE recipient could not clear
+  // it and resorted to saving a fake address, because a client-only
+  // non-empty refine blocked the submit entirely (no request ever went out).
+  // Removing exactly one seeded recipient to zero is the only scenario that
+  // actually exercises the old refine — a two-address test that drops to one
+  // remaining address would pass against the broken code too.
+  it("sends email_recipients: [] when the single seeded recipient is cleared and saved", async () => {
+    const config = buildAlertConfig({ email_recipients: ["ops@example.com"] });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    const mutateMock = vi.fn();
+    mockPutAlertConfig({ mutate: mutateMock });
+
+    renderForm(<AlertConfigForm />);
+
+    const recipients = await screen.findByLabelText("Email recipients");
+    fireEvent.change(recipients, { target: { value: "" } });
+    fireEvent.blur(recipients);
+
+    // The old refine's error must not appear, and Save must be reachable.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    const [body] = mutateMock.mock.calls[0] as [AlertConfigUpdate];
+    expect(body.email_recipients).toEqual([]);
+  });
+
+  it("shows a plain (non-error) empty state instead of a validation error when recipients are cleared", async () => {
+    const config = buildAlertConfig({ email_recipients: ["ops@example.com"] });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    mockPutAlertConfig();
+
+    renderForm(<AlertConfigForm />);
+
+    const recipients = await screen.findByLabelText("Email recipients");
+    fireEvent.change(recipients, { target: { value: "" } });
+    fireEvent.blur(recipients);
+
+    expect(
+      await screen.findByText(
+        "No recipients configured. Email alerts are off until you add one.",
+      ),
+    ).toBeInTheDocument();
+    // Never rendered as role="alert" — this is valid state, not a mistake.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("round-trips a zero-recipient config after save: a refetch reflecting the save re-seeds the form empty without re-raising the old error", async () => {
+    const config = buildAlertConfig({ email_recipients: ["ops@example.com"] });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    mockPutAlertConfig();
+
+    const { rerender } = renderForm(<AlertConfigForm />);
+
+    // Simulate the server round trip: GET now reflects the saved empty list,
+    // exactly like `useAlertConfig`'s cache after `usePutAlertConfig`
+    // invalidates/refetches on settle.
+    const cleared = buildAlertConfig({ email_recipients: [] });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: cleared }),
+    );
+    rerender(
+      <ShellContext.Provider
+        value={{
+          collapsed: false,
+          toggleCollapsed: vi.fn(),
+          mobileOpen: false,
+          setMobileOpen: vi.fn(),
+        }}
+      >
+        <AlertConfigForm />
+      </ShellContext.Provider>,
+    );
+
+    const recipients = await screen.findByLabelText("Email recipients");
+    await waitFor(() => expect(recipients).toHaveValue(""));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByText("No recipients")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No recipients configured. Email alerts are off until you add one.",
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("AlertConfigForm — alert channel enabled switch (GH #706)", () => {
+  it("reflects an enabled:true config and sends enabled:false when the switch is turned off and saved", async () => {
+    const config = buildAlertConfig({ enabled: true });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    const mutateMock = vi.fn();
+    mockPutAlertConfig({ mutate: mutateMock });
+
+    renderForm(<AlertConfigForm />);
+
+    const enabledSwitch = await screen.findByLabelText("Alert channel enabled");
+    expect(enabledSwitch).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(enabledSwitch);
+    expect(enabledSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+      expect.anything(),
+    );
+  });
+
+  it("reflects an enabled:false config and sends enabled:true when the switch is turned on and saved", async () => {
+    const config = buildAlertConfig({ enabled: false });
+    mockedUseAlertConfig.mockReturnValue(
+      mockQueryResult<AlertConfig | null>({ data: config }),
+    );
+    const mutateMock = vi.fn();
+    mockPutAlertConfig({ mutate: mutateMock });
+
+    renderForm(<AlertConfigForm />);
+
+    const enabledSwitch = await screen.findByLabelText("Alert channel enabled");
+    expect(enabledSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(enabledSwitch);
+    expect(enabledSwitch).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+      expect.anything(),
+    );
+  });
+});
+
 describe("AlertConfigForm — instance mailer warning banner", () => {
   it("shows the 'instance mailer not configured' banner with a link to /settings/smtp when instance email is not configured", async () => {
     mockedUseAlertConfig.mockReturnValue(

--- a/apps/web/src/features/monitoring/alert-config-form.tsx
+++ b/apps/web/src/features/monitoring/alert-config-form.tsx
@@ -63,23 +63,19 @@ const VULN_SEVERITY_OPTIONS: ReadonlyArray<{
 ];
 
 const formSchema = z.object({
-  // A textarea of recipients; validation happens after splitting (below).
-  recipients: z
-    .string()
-    .refine(
-      (raw) => {
-        const list = splitRecipients(raw);
-        return list.length > 0;
-      },
-      { message: "No recipients" },
-    )
-    .refine(
-      (raw) => splitRecipients(raw).every((e) => z.string().email().safeParse(e).success),
-      { message: "Invalid email address" },
-    ),
+  // A textarea of recipients; validation happens after splitting (below). An
+  // empty list is a valid, deliberate configuration (GH #706) — it silences
+  // email delivery for this channel (the dispatcher's own
+  // `no_recipients_configured` skip), so only the format of whatever
+  // addresses ARE present is checked here, never the count.
+  recipients: z.string().refine(
+    (raw) => splitRecipients(raw).every((e) => z.string().email().safeParse(e).success),
+    { message: "Invalid email address" },
+  ),
   webhook_url: z
     .union([z.literal(""), z.string().url("Invalid URL")])
     .optional(),
+  enabled: z.boolean(),
   notify_security: z.boolean(),
   app_alerts_enabled: z.boolean(),
   notify_vulns: z.boolean(),
@@ -121,6 +117,7 @@ export function AlertConfigForm() {
     defaultValues: {
       recipients: "",
       webhook_url: "",
+      enabled: true,
       notify_security: false,
       app_alerts_enabled: false,
       notify_vulns: false,
@@ -131,6 +128,8 @@ export function AlertConfigForm() {
   });
 
   const notifyVulns = useWatch({ control, name: "notify_vulns" });
+  const recipientsRaw = useWatch({ control, name: "recipients" });
+  const hasRecipients = splitRecipients(recipientsRaw ?? "").length > 0;
 
   // Seed the form once the config loads (or stays empty when none configured).
   useEffect(() => {
@@ -138,6 +137,9 @@ export function AlertConfigForm() {
     reset({
       recipients: config ? config.email_recipients.join("\n") : "",
       webhook_url: config?.webhook_url ?? "",
+      // No row yet matches the API's own zero-value default (service.go):
+      // a fresh tenant's alert channel starts enabled.
+      enabled: config?.enabled ?? true,
       notify_security: config?.notify_security ?? false,
       app_alerts_enabled: config?.app_alerts_enabled ?? false,
       notify_vulns: config?.notify_vulns ?? false,
@@ -152,6 +154,7 @@ export function AlertConfigForm() {
       webhook_url: values.webhook_url?.trim() ? values.webhook_url.trim() : "",
       // Always sent explicitly (never omitted) so a save never silently
       // drops a signal the operator didn't touch this time around.
+      enabled: values.enabled,
       notify_security: values.notify_security,
       app_alerts_enabled: values.app_alerts_enabled,
       notify_vulns: values.notify_vulns,
@@ -224,6 +227,33 @@ export function AlertConfigForm() {
                 description="Where every alert in this channel is delivered. Downtime, security events, and vulnerability alerts below all use these recipients and this webhook."
               >
                 <div className="space-y-1">
+                  <div className="flex items-center gap-3">
+                    <Controller
+                      control={control}
+                      name="enabled"
+                      render={({ field }) => (
+                        <Switch
+                          id="alert-channel-enabled"
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      )}
+                    />
+                    <Label
+                      htmlFor="alert-channel-enabled"
+                      className="cursor-pointer"
+                    >
+                      Alert channel enabled
+                    </Label>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Turns off delivery for every signal below — downtime,
+                    application health, security events, and vulnerability
+                    alerts — without discarding your recipients or webhook.
+                  </p>
+                </div>
+
+                <div className="space-y-1">
                   <Label htmlFor="recipients">Email recipients</Label>
                   <textarea
                     id="recipients"
@@ -238,12 +268,19 @@ export function AlertConfigForm() {
                     id="recipients-help"
                     className="text-sm text-muted-foreground"
                   >
-                    One per line, or separated by commas.
+                    One per line, or separated by commas. Leave blank to turn
+                    off email delivery for this channel.
                   </p>
+                  {!errors.recipients && !hasRecipients ? (
+                    <p className="text-sm text-muted-foreground">
+                      No recipients configured. Email alerts are off until
+                      you add one.
+                    </p>
+                  ) : null}
                   <FieldError
                     what={errors.recipients?.message}
-                    why="At least one valid email address is required."
-                    how="Edit the list above."
+                    why="Every recipient must be a valid email address."
+                    how="Fix the invalid address above."
                   />
                 </div>
 
@@ -283,8 +320,10 @@ export function AlertConfigForm() {
                 description="Email and webhook whenever a monitored site goes down or comes back online. Applies to every site in this tenant."
               >
                 <p className="text-sm text-muted-foreground">
-                  Uses the recipients and webhook above. There is no separate
-                  switch for downtime alerts.
+                  Uses the recipients and webhook above. There is no switch
+                  just for downtime alerts — the alert channel switch above
+                  turns this off along with every other signal in this
+                  channel.
                 </p>
               </FormSection>
 

--- a/apps/web/src/features/monitoring/use-uptime.ts
+++ b/apps/web/src/features/monitoring/use-uptime.ts
@@ -148,6 +148,7 @@ export function usePutAlertConfig(): UseMutationResult<
           email_recipients:
             body.email_recipients ?? previous.email_recipients,
           webhook_url: body.webhook_url ?? previous.webhook_url,
+          enabled: body.enabled ?? previous.enabled,
           notify_security: body.notify_security ?? previous.notify_security,
           app_alerts_enabled:
             body.app_alerts_enabled ?? previous.app_alerts_enabled,


### PR DESCRIPTION
## Summary

Fixes #706. A customer could not clear the alert-email recipient list
because the form silently blocked emptying it, and resorted to saving
a fake address.

Root cause: `alert-config-form.tsx` had a client-only Zod refine
requiring at least one recipient. Clearing the textarea failed
validation, `handleSubmit` never called `onSubmit`, and no request was
sent. The backend has always accepted zero recipients — it's the
system's own default for a tenant with no config row, and the alert
dispatcher already has a dedicated `no_recipients_configured` skip
path — so the client-side invariant contradicted the whole backend
stack.

## Changes (apps/web only)

- Remove the non-empty refine on `recipients`; keep per-address
  email-format validation for whatever addresses are present.
- Render an empty recipient list as a plain informational state
  ("No recipients configured. Email alerts are off until you add
  one."), not a red validation error — it's a legitimate
  configuration.
- Add the `enabled` master switch to the form. It already exists in
  the generated `AlertConfig`/`AlertConfigUpdate` types (re-exported
  through `@wpmgr/api`) and is honoured server-side by all four
  dispatch paths (downtime, app health x2, vuln), but no web code
  read or wrote it before this change. This is the real way out for
  the customer: turn the whole channel off instead of faking a
  recipient.
- Correct the now-inaccurate "There is no separate switch for
  downtime alerts" copy in the Downtime section now that the alert
  channel switch exists and does affect it.
- Include `enabled` in `usePutAlertConfig`'s optimistic-update merge
  in `use-uptime.ts` so toggling it doesn't get clobbered by the
  optimistic cache patch before the real response lands.

## Tests

`alert-config-form.test.tsx` grew from 8 to 13 tests:
- clearing the single seeded recipient sends `email_recipients: []`
- the empty state renders as plain text, not `role="alert"`
- a post-save refetch reflecting zero recipients re-seeds empty
  without re-raising the old error
- the `enabled` switch reaches the PUT body in both directions and
  reflects a GET response correctly

Mutation-tested by hand: reverting the refine removal reddens the
submit-path tests in the new recipients describe block; omitting
`enabled` from the PUT body reddens both enabled-switch tests. Both
restored to green.

## Test plan

- [x] `pnpm -C apps/web typecheck`
- [x] `pnpm -C apps/web lint` (0 errors; pre-existing warnings only)
- [x] `pnpm -C apps/web test` (168 files / 2261 tests passed)
- [x] `pnpm -C apps/web build`
- [x] `impeccable detect` on the changed files (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)