### PR TITLE
fix(agent): survive hosts without the native libsodium extension (#709)

### DIFF
--- a/apps/agent/includes/class-keystore.php
+++ b/apps/agent/includes/class-keystore.php
@@ -51,6 +51,7 @@ declare(strict_types=1);
 namespace WPMgr\Agent;
 
 use WPMgr\Agent\Email\EmailKeystoreInterface;
+use WPMgr\Agent\Support\SecureMemory;
 
 /**
  * Encrypted keystore backed by wp-options + a file-based master key.
@@ -265,7 +266,7 @@ final class Keystore implements EmailKeystoreInterface
         update_option(self::OPTION_SITE_KEYPAIR, $this->encrypt($keypair), false);
 
         // Wipe the in-memory keypair as soon as it is persisted.
-        sodium_memzero($keypair);
+        SecureMemory::wipe($keypair);
 
         return $publicKey;
     }
@@ -696,7 +697,7 @@ final class Keystore implements EmailKeystoreInterface
 
         // HKDF-SHA256 with a fixed info string yields a stable 32-byte key.
         $key = hash_hkdf('sha256', $ikm, self::KEY_BYTES, self::HKDF_INFO, '');
-        sodium_memzero($ikm);
+        SecureMemory::wipe($ikm);
 
         return $key;
     }
@@ -749,7 +750,7 @@ final class Keystore implements EmailKeystoreInterface
 
         // Lost the race: another request's add_option() already won.
         // Discard this key and adopt whichever key actually got persisted.
-        sodium_memzero($key);
+        SecureMemory::wipe($key);
 
         return $this->readDatabaseKey();
     }
@@ -850,7 +851,7 @@ final class Keystore implements EmailKeystoreInterface
 
         if ($written !== self::KEY_BYTES) {
             // Partial write: never pin a key that was not fully persisted.
-            sodium_memzero($key);
+            SecureMemory::wipe($key);
             wp_delete_file($path);
             return null;
         }

--- a/apps/agent/includes/class-signer.php
+++ b/apps/agent/includes/class-signer.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent;
 
+use WPMgr\Agent\Support\SecureMemory;
+
 /**
  * Produces Ed25519-signed request headers for the control plane.
  */
@@ -102,14 +104,14 @@ final class Signer implements \WPMgr\Agent\Security\RequestSigner
 
         $secretKey = sodium_crypto_sign_secretkey($keypair);
         $publicKey = sodium_crypto_sign_publickey($keypair);
-        sodium_memzero($keypair);
+        SecureMemory::wipe($keypair);
 
         $timestamp = (string) ($now ?? time());
         $nonce     = bin2hex(random_bytes(16));
 
         $message   = self::canonicalMessage($method, $path, $timestamp, $nonce, $body);
         $signature = sodium_crypto_sign_detached($message, $secretKey);
-        sodium_memzero($secretKey);
+        SecureMemory::wipe($secretKey);
 
         return [
             self::HEADER_KEY       => base64_encode($publicKey),
@@ -133,7 +135,7 @@ final class Signer implements \WPMgr\Agent\Security\RequestSigner
         }
 
         $publicKey = sodium_crypto_sign_publickey($keypair);
-        sodium_memzero($keypair);
+        SecureMemory::wipe($keypair);
 
         return $publicKey;
     }

--- a/apps/agent/includes/support/class-age-crypto.php
+++ b/apps/agent/includes/support/class-age-crypto.php
@@ -158,7 +158,7 @@ class AgeCrypto
         $header  = $this->buildHeader($fileKey, $recipientKey);
         $payload = $this->encryptPayload($fileKey, $plaintext);
 
-        sodium_memzero($fileKey);
+        SecureMemory::wipe($fileKey);
 
         return $header . $payload;
     }
@@ -182,7 +182,7 @@ class AgeCrypto
         try {
             return $this->decryptPayload($fileKey, substr($ciphertext, $payloadOffset));
         } finally {
-            sodium_memzero($fileKey);
+            SecureMemory::wipe($fileKey);
         }
     }
 
@@ -203,11 +203,11 @@ class AgeCrypto
         $ephShare  = sodium_crypto_scalarmult_base($ephSecret);
 
         $shared  = sodium_crypto_scalarmult($ephSecret, $recipientKey);
-        sodium_memzero($ephSecret);
+        SecureMemory::wipe($ephSecret);
 
         $salt    = $ephShare . $recipientKey;
         $wrapKey = hash_hkdf('sha256', $shared, 32, 'age-encryption.org/v1/X25519', $salt);
-        sodium_memzero($shared);
+        SecureMemory::wipe($shared);
 
         // Wrap the file key: ChaCha20-Poly1305-IETF, 12x 0x00 nonce, no AAD.
         $wrapped = sodium_crypto_aead_chacha20poly1305_ietf_encrypt(
@@ -216,7 +216,7 @@ class AgeCrypto
             str_repeat("\0", SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES),
             $wrapKey
         );
-        sodium_memzero($wrapKey);
+        SecureMemory::wipe($wrapKey);
 
         $stanza = '-> X25519 ' . self::b64($ephShare) . "\n"
             . self::wrap64(self::b64($wrapped)) . "\n";
@@ -225,7 +225,7 @@ class AgeCrypto
 
         $macKey = hash_hkdf('sha256', $fileKey, 32, 'header', '');
         $mac    = hash_hmac('sha256', $macInput, $macKey, true);
-        sodium_memzero($macKey);
+        SecureMemory::wipe($macKey);
 
         return $macInput . ' ' . self::b64($mac) . "\n";
     }
@@ -275,11 +275,11 @@ class AgeCrypto
         // Verify header MAC with the recovered file key.
         $macKey   = hash_hkdf('sha256', $fileKey, 32, 'header', '');
         $expected = hash_hmac('sha256', $macInput, $macKey, true);
-        sodium_memzero($macKey);
+        SecureMemory::wipe($macKey);
 
         $got = self::b64Decode($macB64);
         if ($got === null || !hash_equals($expected, $got)) {
-            sodium_memzero($fileKey);
+            SecureMemory::wipe($fileKey);
             throw new \RuntimeException('WPMgr Agent: age header MAC mismatch.');
         }
 
@@ -353,7 +353,7 @@ class AgeCrypto
         $shared    = sodium_crypto_scalarmult($secret, $ephShare);
         $salt      = $ephShare . $publicKey;
         $wrapKey   = hash_hkdf('sha256', $shared, 32, 'age-encryption.org/v1/X25519', $salt);
-        sodium_memzero($shared);
+        SecureMemory::wipe($shared);
 
         $fileKey = sodium_crypto_aead_chacha20poly1305_ietf_decrypt(
             $wrapped,
@@ -361,7 +361,7 @@ class AgeCrypto
             str_repeat("\0", SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES),
             $wrapKey
         );
-        sodium_memzero($wrapKey);
+        SecureMemory::wipe($wrapKey);
 
         if ($fileKey === false || strlen($fileKey) !== self::FILE_KEY_BYTES) {
             return null;
@@ -407,7 +407,7 @@ class AgeCrypto
             $chunk++;
         } while ($offset < $len);
 
-        sodium_memzero($payloadKey);
+        SecureMemory::wipe($payloadKey);
 
         return $out;
     }
@@ -461,7 +461,7 @@ class AgeCrypto
                 $chunk++;
             } while ($offset < $bodyLen);
         } finally {
-            sodium_memzero($payloadKey);
+            SecureMemory::wipe($payloadKey);
         }
 
         return $out;

--- a/apps/agent/includes/support/class-age-identity.php
+++ b/apps/agent/includes/support/class-age-identity.php
@@ -58,14 +58,14 @@ class AgeIdentity
             $pair   = $this->age->generateIdentity();
             $this->keystore->storeAgeIdentity($pair['secret']);
             $recipient = $pair['recipient'];
-            sodium_memzero($pair['secret']);
-            sodium_memzero($pair['identity']);
+            SecureMemory::wipe($pair['secret']);
+            SecureMemory::wipe($pair['identity']);
 
             return $recipient;
         }
 
         $recipient = $this->age->recipientForSecret($secret);
-        sodium_memzero($secret);
+        SecureMemory::wipe($secret);
 
         return $recipient;
     }
@@ -83,7 +83,7 @@ class AgeIdentity
             return '';
         }
         $recipient = $this->age->recipientForSecret($secret);
-        sodium_memzero($secret);
+        SecureMemory::wipe($secret);
 
         return $recipient;
     }
@@ -134,7 +134,7 @@ class AgeIdentity
         try {
             return $this->age->decrypt($ciphertext, $secret);
         } finally {
-            sodium_memzero($secret);
+            SecureMemory::wipe($secret);
         }
     }
 }

--- a/apps/agent/includes/support/class-secure-memory.php
+++ b/apps/agent/includes/support/class-secure-memory.php
@@ -65,7 +65,15 @@ final class SecureMemory
 
     /**
      * Wipe a sensitive value, by reference, as thoroughly as this platform
-     * allows. Never throws, and never leaves the value readable.
+     * allows. Never throws, and always clears the variable: on every host,
+     * $value is null once this returns.
+     *
+     * That is a guarantee about the variable, not about the bytes. It does
+     * not promise the secret is gone from the process: when the native wipe
+     * is unavailable and the string is shared, PHP's copy-on-write separates
+     * it and overwrite() scrubs only the separated copy, so the original
+     * bytes may still be resident elsewhere in memory (see overwrite()
+     * below). This is hygiene, not a security boundary.
      *
      * Accepts the value untyped and by reference so that it is a drop-in for
      * sodium_memzero() at every existing call site, including array elements
@@ -92,7 +100,14 @@ final class SecureMemory
      * the capability probe and the real work, so a capable platform pays no
      * extra cost. Once the platform has refused, no further attempt is made.
      *
-     * @param string $value Value to wipe. Modified in place on success.
+     * Takes a string in and, on success, leaves null behind: that is what the
+     * native sodium_memzero() writes back into its by-reference argument. PHP
+     * has no syntax for an out-type that differs from the in-type, so the
+     * out-type is declared with @param-out; without it the null this method
+     * genuinely produces contradicts the string it genuinely requires.
+     *
+     * @param string $value Value to wipe. Set to null in place on success.
+     * @param-out string|null $value
      * @return bool True when the native wipe was performed.
      */
     private static function supportsNativeWipe(string &$value): bool

--- a/apps/agent/includes/support/class-secure-memory.php
+++ b/apps/agent/includes/support/class-secure-memory.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Best-effort wiping of sensitive values from PHP memory.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * sodium_memzero() is not universally callable. When a host has no native
+ * libsodium PHP extension, WordPress falls back to its bundled pure-PHP
+ * polyfill (wp-includes/sodium_compat), and that polyfill's memzero()
+ * deliberately throws SodiumException rather than pretend to have wiped
+ * anything -- PHP genuinely cannot scrub a buffer it does not own.
+ *
+ * Calling sodium_memzero() unguarded therefore turns a best-effort hygiene
+ * step into an uncaught fatal on an entire class of host. CloudLinux/cPanel
+ * shared hosting commonly ships with the extension off by default, so on
+ * those sites the agent could not enrol at all: the first key derivation
+ * fataled and the admin screen went white.
+ *
+ * WHAT THIS DOES
+ * --------------
+ * wipe() calls the real sodium_memzero() whenever the platform can actually
+ * perform it, and degrades to the best overwrite PHP itself can manage when
+ * it cannot. The wipe is hygiene, not a security boundary: no key material
+ * is handled differently, no algorithm is weakened, and nothing about the
+ * cryptography changes. Only the post-use scrub degrades, on precisely the
+ * hosts where PHP was never able to do it in the first place.
+ *
+ * CAPABILITY DETECTION, NOT ENVIRONMENT SNIFFING
+ * ----------------------------------------------
+ * supportsNativeWipe() probes the capability by attempting it once and
+ * remembering the answer for the rest of the request. It does not test a PHP
+ * version, a host name, or a SAPI, and it deliberately does not test
+ * extension_loaded('sodium') either: a host carrying the older PECL
+ * "libsodium" extension has no 'sodium' extension yet still wipes
+ * successfully, because sodium_compat routes memzero() through
+ * \Sodium\memzero() when that is present. Asking the platform to do the work
+ * is the only check that is right on every host.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+/**
+ * Platform-aware, never-fatal replacement for a bare sodium_memzero() call.
+ */
+final class SecureMemory
+{
+    /**
+     * Tri-state cache of whether this platform can perform a real
+     * sodium_memzero(): true = yes, false = no, null = not yet probed.
+     *
+     * Cached per request so the SodiumException raised by the polyfill is
+     * constructed at most once, no matter how many secrets are wiped.
+     *
+     * @var bool|null
+     */
+    private static ?bool $nativeWipe = null;
+
+    /**
+     * Wipe a sensitive value, by reference, as thoroughly as this platform
+     * allows. Never throws, and never leaves the value readable.
+     *
+     * Accepts the value untyped and by reference so that it is a drop-in for
+     * sodium_memzero() at every existing call site, including array elements
+     * such as $pair['secret']. It is untyped on purpose: this function exists
+     * to remove a fatal from the key paths, so it must not be capable of
+     * introducing a different one via an argument type error.
+     *
+     * @param mixed $value Value to wipe. Modified in place.
+     * @return void
+     */
+    public static function wipe(&$value): void
+    {
+        if (is_string($value) && self::supportsNativeWipe($value)) {
+            return;
+        }
+
+        self::overwrite($value);
+    }
+
+    /**
+     * Attempt the native wipe, caching whether this platform supports it.
+     *
+     * On the first call the wipe is genuinely attempted; that attempt is both
+     * the capability probe and the real work, so a capable platform pays no
+     * extra cost. Once the platform has refused, no further attempt is made.
+     *
+     * @param string $value Value to wipe. Modified in place on success.
+     * @return bool True when the native wipe was performed.
+     */
+    private static function supportsNativeWipe(string &$value): bool
+    {
+        if (self::$nativeWipe === false) {
+            return false;
+        }
+
+        if (!function_exists('sodium_memzero')) {
+            self::$nativeWipe = false;
+
+            return false;
+        }
+
+        try {
+            sodium_memzero($value);
+            self::$nativeWipe = true;
+
+            return true;
+        } catch (\SodiumException $e) {
+            // sodium_compat refusing the call: PHP has no native libsodium and
+            // cannot securely wipe memory. Remember it and fall back. Not
+            // logged -- it is an expected property of the host, not a fault,
+            // and it would otherwise repeat on every key operation forever.
+            self::$nativeWipe = false;
+
+            return false;
+        }
+    }
+
+    /**
+     * The best overwrite PHP can perform without libsodium.
+     *
+     * Zeroing byte-by-byte first is not ceremony: PHP mutates a string in
+     * place through offset assignment when nothing else references it, so on
+     * that path the original bytes really are overwritten. When the string is
+     * shared, PHP separates it first and the loop scrubs only the copy, which
+     * is exactly as good as the plain reassignment that follows and no worse.
+     * Note that WordPress's bundled sodium_compat throws *without* clearing
+     * the variable, so this overwrite is doing real work rather than
+     * repeating something the polyfill already did.
+     *
+     * @param mixed $value Value to overwrite. Modified in place.
+     * @return void
+     */
+    private static function overwrite(&$value): void
+    {
+        if (is_string($value)) {
+            $length = strlen($value);
+            for ($i = 0; $i < $length; $i++) {
+                $value[$i] = "\0";
+            }
+
+            $value = '';
+
+            return;
+        }
+
+        $value = null;
+    }
+
+    /**
+     * Whether this platform can perform a real sodium_memzero().
+     *
+     * Reported as a plain environment fact on the agent's admin screen, and
+     * used by the tests. Probing here uses a throwaway string so that asking
+     * the question never touches a caller's value.
+     *
+     * @return bool
+     */
+    public static function hasNativeWipe(): bool
+    {
+        if (self::$nativeWipe === null) {
+            $probe = 'wpmgr-probe';
+            self::supportsNativeWipe($probe);
+        }
+
+        return (bool) self::$nativeWipe;
+    }
+
+    /**
+     * Discard the cached capability answer.
+     *
+     * Exists for tests, which need to re-probe after simulating a host
+     * without native libsodium. Harmless in production: the next wipe simply
+     * probes again.
+     *
+     * @return void
+     */
+    public static function resetCapabilityCache(): void
+    {
+        self::$nativeWipe = null;
+    }
+}

--- a/apps/agent/includes/support/class-secure-memory.php
+++ b/apps/agent/includes/support/class-secure-memory.php
@@ -43,6 +43,10 @@ declare(strict_types=1);
 
 namespace WPMgr\Agent\Support;
 
+if (!defined('ABSPATH')) {
+    exit; // No direct access.
+}
+
 /**
  * Platform-aware, never-fatal replacement for a bare sodium_memzero() call.
  */

--- a/apps/agent/includes/support/class-secure-memory.php
+++ b/apps/agent/includes/support/class-secure-memory.php
@@ -157,9 +157,12 @@ final class SecureMemory
     /**
      * Whether this platform can perform a real sodium_memzero().
      *
-     * Reported as a plain environment fact on the agent's admin screen, and
-     * used by the tests. Probing here uses a throwaway string so that asking
-     * the question never touches a caller's value.
+     * Nothing in the plugin surfaces this today, by choice: after this class
+     * exists the missing extension no longer costs the operator anything they
+     * can act on. It is public, cheap and side-effect-free so that surfacing
+     * it later -- on the admin screen, or in the info command's payload -- is
+     * one call rather than a second copy of the detection logic. Probing here
+     * uses a throwaway string so asking never touches a caller's value.
      *
      * @return bool
      */

--- a/apps/agent/includes/support/class-secure-memory.php
+++ b/apps/agent/includes/support/class-secure-memory.php
@@ -131,6 +131,10 @@ final class SecureMemory
      * the variable, so this overwrite is doing real work rather than
      * repeating something the polyfill already did.
      *
+     * The value is finally set to null, not to '': that is precisely what the
+     * native sodium_memzero() leaves behind, so every call site sees the same
+     * post-condition it saw before this helper existed, on every host.
+     *
      * @param mixed $value Value to overwrite. Modified in place.
      * @return void
      */
@@ -141,10 +145,6 @@ final class SecureMemory
             for ($i = 0; $i < $length; $i++) {
                 $value[$i] = "\0";
             }
-
-            $value = '';
-
-            return;
         }
 
         $value = null;

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -1,5 +1,6 @@
 {
   "redefinable-internals": [
+    "sodium_memzero",
     "headers_list",
     "set_time_limit",
     "php_sapi_name",

--- a/apps/agent/patchwork.json
+++ b/apps/agent/patchwork.json
@@ -1,6 +1,5 @@
 {
   "redefinable-internals": [
-    "sodium_memzero",
     "headers_list",
     "set_time_limit",
     "php_sapi_name",

--- a/apps/agent/tests/SecureMemoryTest.php
+++ b/apps/agent/tests/SecureMemoryTest.php
@@ -10,12 +10,19 @@
  * extension, so a test that merely calls the code proves nothing.
  *
  * These tests therefore make the platform behave exactly as an
- * extension-less host does, by redefining sodium_memzero() through Patchwork
- * ("sodium_memzero" is listed in patchwork.json's redefinable-internals) to
- * throw the SodiumException that sodium_compat throws, with the verbatim
- * message taken from wp-includes/sodium_compat/src/Compat.php. Production
- * code is not modified, not parameterised for the test, and not told it is
- * under test: it takes the same branch it takes on a real CloudLinux host.
+ * extension-less host does, via tests/sodium-memzero-shim.php: a namespaced
+ * WPMgr\Agent\Support\sodium_memzero() that shadows the global builtin for
+ * the one namespace SecureMemory lives in, and raises the SodiumException
+ * sodium_compat raises, message verbatim from
+ * wp-includes/sodium_compat/src/Compat.php.
+ *
+ * That file's header explains why this is not a Patchwork redefinable-internal:
+ * Patchwork forwards a wrapped internal's arguments by value, which both emits
+ * a by-reference warning on every wipe in the suite (failOnWarning) and breaks
+ * the very contract sodium_memzero() exists to provide.
+ *
+ * Production code is not modified, not parameterised for the test, and not told
+ * it is under test: it takes the same branch it takes on a real CloudLinux host.
  *
  * @package WPMgr\Agent\Tests
  */
@@ -36,14 +43,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class SecureMemoryTest extends TestCase
 {
-    /**
-     * The message sodium_compat raises, verbatim, from
-     * wp-includes/sodium_compat/src/Compat.php.
-     */
-    private const POLYFILL_MESSAGE = 'This is not implemented in sodium_compat, as it is not possible to '
-        . 'securely wipe memory from PHP. To fix this error, make sure libsodium is installed and the PHP '
-        . 'extension is enabled.';
-
     /** @var array<string,mixed> */
     private array $options = [];
 
@@ -72,8 +71,9 @@ final class SecureMemoryTest extends TestCase
 
     protected function tear_down(): void
     {
-        // Patchwork redefinitions leak across tests unless they are undone.
-        \Patchwork\restoreAll();
+        // The shim is process-wide, so it must be handed back inert or the
+        // next test inherits a platform that refuses to wipe.
+        SodiumPlatform::reset();
         SecureMemory::resetCapabilityCache();
 
         if (is_file($this->keyFile)) {
@@ -87,22 +87,11 @@ final class SecureMemoryTest extends TestCase
      * Make this process behave like a host with no native libsodium: every
      * sodium_memzero() call raises sodium_compat's refusal.
      *
-     * @return \ArrayObject<int,string> Grows by one entry per refusal, so a
-     *                                   test can assert how often the
-     *                                   platform was asked.
+     * @return void
      */
-    private function simulateHostWithoutNativeLibsodium(): \ArrayObject
+    private function simulateHostWithoutNativeLibsodium(): void
     {
-        /** @var \ArrayObject<int,string> $attempts */
-        $attempts = new \ArrayObject();
-
-        \Patchwork\redefine('sodium_memzero', function (&$var) use ($attempts): void {
-            $attempts->append('refused');
-
-            throw new \SodiumException(self::POLYFILL_MESSAGE);
-        });
-
-        return $attempts;
+        SodiumPlatform::refuse();
     }
 
     // -----------------------------------------------------------------
@@ -185,14 +174,14 @@ final class SecureMemoryTest extends TestCase
      */
     public function test_platform_refusal_is_probed_only_once(): void
     {
-        $attempts = $this->simulateHostWithoutNativeLibsodium();
+        $this->simulateHostWithoutNativeLibsodium();
 
         for ($i = 0; $i < 25; $i++) {
             $secret = 'secret-' . $i;
             SecureMemory::wipe($secret);
         }
 
-        $this->assertCount(1, $attempts, 'The platform must be asked once, then the answer reused.');
+        $this->assertSame(1, SodiumPlatform::$calls, 'The platform must be asked once, then the answer reused.');
         $this->assertFalse(SecureMemory::hasNativeWipe());
     }
 
@@ -207,18 +196,19 @@ final class SecureMemoryTest extends TestCase
      */
     public function test_native_wipe_is_still_performed_when_the_platform_supports_it(): void
     {
-        /** @var \ArrayObject<int,string> $calls */
-        $calls = new \ArrayObject();
-        \Patchwork\redefine('sodium_memzero', function (&$var) use ($calls): void {
-            $calls->append((string) $var);
-            $var = '';
-        });
+        SodiumPlatform::reset();
 
         $secret = 'super-secret-key-material';
         SecureMemory::wipe($secret);
 
-        $this->assertCount(1, $calls, 'sodium_memzero() must still be called where the platform supports it.');
-        $this->assertSame('super-secret-key-material', $calls[0], 'It must receive the real value to wipe.');
+        $this->assertSame(1, SodiumPlatform::$calls, 'sodium_memzero() must still be called where supported.');
+        $this->assertSame(
+            'super-secret-key-material',
+            SodiumPlatform::$wiped[0],
+            'It must receive the real value to wipe.'
+        );
+        // The shim delegates to the real builtin, so this is the genuine wipe.
+        $this->assertNull($secret, 'The native wipe must actually have cleared the value.');
         $this->assertTrue(SecureMemory::hasNativeWipe());
     }
 
@@ -228,34 +218,24 @@ final class SecureMemoryTest extends TestCase
      */
     public function test_native_wipe_is_performed_for_every_secret(): void
     {
-        /** @var \ArrayObject<int,string> $calls */
-        $calls = new \ArrayObject();
-        \Patchwork\redefine('sodium_memzero', function (&$var) use ($calls): void {
-            $calls->append((string) $var);
-        });
+        SodiumPlatform::reset();
 
         foreach (['alpha', 'bravo', 'charlie'] as $value) {
             $secret = $value;
             SecureMemory::wipe($secret);
         }
 
-        $this->assertSame(['alpha', 'bravo', 'charlie'], (array) $calls->getArrayCopy());
+        $this->assertSame(['alpha', 'bravo', 'charlie'], SodiumPlatform::$wiped);
     }
 
     /**
      * The same over-fire arm, proven outside this harness.
      *
-     * Listing sodium_memzero in patchwork.json's redefinable-internals is what
-     * makes the polyfill tests above possible, but it has a cost: Patchwork
-     * routes every call to that function through a wrapper, and the wrapper
-     * does not carry the by-reference argument back out. In-process, then, a
-     * native wipe is observably *called* (asserted above) but its clearing
-     * effect cannot be observed. That is an artefact of the instrumentation
-     * and not of the shipped code.
-     *
-     * So this arm runs in a clean subprocess with no Patchwork, no PHPUnit and
-     * no stubs: real PHP, the real class file, the real platform. It is the
-     * assertion that a "fix" which quietly stopped wiping would fail.
+     * Every assertion above still runs through a shim, however thin, and a
+     * shim is a thing that can be wrong. So this arm runs in a clean
+     * subprocess with no shim, no PHPUnit and no stubs: real PHP, the real
+     * class file, the real global sodium_memzero(), the real platform. It is
+     * the assertion a "fix" that quietly stopped wiping would fail.
      */
     public function test_wipe_really_clears_the_value_on_an_uninstrumented_platform(): void
     {

--- a/apps/agent/tests/SecureMemoryTest.php
+++ b/apps/agent/tests/SecureMemoryTest.php
@@ -261,7 +261,7 @@ final class SecureMemoryTest extends TestCase
     {
         $classFile = dirname(__DIR__) . '/includes/support/class-secure-memory.php';
         $script    = sprintf(
-            '<?php require %s; $s = "real-platform-secret"; '
+            '<?php define("ABSPATH", "/wp/"); require %s; $s = "real-platform-secret"; '
                 . '\\WPMgr\\Agent\\Support\\SecureMemory::wipe($s); '
                 . 'echo (extension_loaded("sodium") ? "native" : "polyfill"), "|", var_export($s, true), "|", '
                 . 'var_export(\\WPMgr\\Agent\\Support\\SecureMemory::hasNativeWipe(), true);',

--- a/apps/agent/tests/SecureMemoryTest.php
+++ b/apps/agent/tests/SecureMemoryTest.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Regression tests for GH #709: enrollment fataled with an uncaught
+ * SodiumException on any host without the native libsodium PHP extension.
+ *
+ * HOW THE POLYFILL PATH IS EXERCISED
+ * ----------------------------------
+ * The bug only appears when WordPress's bundled sodium_compat polyfill
+ * services the call, and this machine (like most CI runners) has the native
+ * extension, so a test that merely calls the code proves nothing.
+ *
+ * These tests therefore make the platform behave exactly as an
+ * extension-less host does, by redefining sodium_memzero() through Patchwork
+ * ("sodium_memzero" is listed in patchwork.json's redefinable-internals) to
+ * throw the SodiumException that sodium_compat throws, with the verbatim
+ * message taken from wp-includes/sodium_compat/src/Compat.php. Production
+ * code is not modified, not parameterised for the test, and not told it is
+ * under test: it takes the same branch it takes on a real CloudLinux host.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Keystore;
+use WPMgr\Agent\Signer;
+use WPMgr\Agent\Support\SecureMemory;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Support\SecureMemory
+ */
+final class SecureMemoryTest extends TestCase
+{
+    /**
+     * The message sodium_compat raises, verbatim, from
+     * wp-includes/sodium_compat/src/Compat.php.
+     */
+    private const POLYFILL_MESSAGE = 'This is not implemented in sodium_compat, as it is not possible to '
+        . 'securely wipe memory from PHP. To fix this error, make sure libsodium is installed and the PHP '
+        . 'extension is enabled.';
+
+    /** @var array<string,mixed> */
+    private array $options = [];
+
+    private string $keyFile = '';
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        // The capability answer is cached per request; every test starts by
+        // forgetting it so each one re-probes against its own simulated host.
+        SecureMemory::resetCapabilityCache();
+
+        $this->keyFile = sys_get_temp_dir() . '/wpmgr-secmem-test-' . bin2hex(random_bytes(8)) . '.key';
+        $this->options = [];
+        Functions\when('update_option')->alias(function ($name, $value) {
+            $this->options[$name] = $value;
+
+            return true;
+        });
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+    }
+
+    protected function tear_down(): void
+    {
+        // Patchwork redefinitions leak across tests unless they are undone.
+        \Patchwork\restoreAll();
+        SecureMemory::resetCapabilityCache();
+
+        if (is_file($this->keyFile)) {
+            @unlink($this->keyFile);
+        }
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Make this process behave like a host with no native libsodium: every
+     * sodium_memzero() call raises sodium_compat's refusal.
+     *
+     * @return \ArrayObject<int,string> Grows by one entry per refusal, so a
+     *                                   test can assert how often the
+     *                                   platform was asked.
+     */
+    private function simulateHostWithoutNativeLibsodium(): \ArrayObject
+    {
+        /** @var \ArrayObject<int,string> $attempts */
+        $attempts = new \ArrayObject();
+
+        \Patchwork\redefine('sodium_memzero', function (&$var) use ($attempts): void {
+            $attempts->append('refused');
+
+            throw new \SodiumException(self::POLYFILL_MESSAGE);
+        });
+
+        return $attempts;
+    }
+
+    // -----------------------------------------------------------------
+    // The bug itself.
+    // -----------------------------------------------------------------
+
+    /**
+     * The crux. Before the fix this call site was a bare sodium_memzero()
+     * and this test fataled with an uncaught SodiumException.
+     */
+    public function test_wipe_does_not_throw_when_the_platform_refuses(): void
+    {
+        $this->simulateHostWithoutNativeLibsodium();
+
+        $secret = 'super-secret-key-material';
+        SecureMemory::wipe($secret);
+
+        $this->assertNull($secret, 'The value must still be cleared when the native wipe is unavailable.');
+    }
+
+    /**
+     * The reported crash path end to end: generating the site keypair reaches
+     * Keystore::encrypt() -> masterKey() -> ... -> the wipe. On a host without
+     * native libsodium this fataled, which is why enrollment white-screened.
+     */
+    public function test_site_keypair_generation_completes_without_native_libsodium(): void
+    {
+        $this->simulateHostWithoutNativeLibsodium();
+
+        $keystore  = new Keystore();
+        $publicKey = $keystore->generateSiteKeypair();
+
+        $this->assertSame(
+            SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES,
+            strlen($publicKey),
+            'A full Ed25519 public key must still be produced on a host without native libsodium.'
+        );
+        $this->assertNotSame('', (string) ($this->options[Keystore::OPTION_SITE_KEYPAIR] ?? ''));
+    }
+
+    /**
+     * The enrollment entry point from the issue's backtrace
+     * (Enrollment::buildEnrollPayload -> Signer::agentPublicKeyBase64).
+     */
+    public function test_agent_public_key_base64_completes_without_native_libsodium(): void
+    {
+        $this->simulateHostWithoutNativeLibsodium();
+
+        $signer = new Signer(new Keystore());
+        $base64 = $signer->agentPublicKeyBase64();
+
+        $this->assertNotSame('', $base64);
+        $this->assertSame(
+            SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES,
+            strlen((string) base64_decode($base64, true)),
+            'agentPublicKeyBase64() must return a decodable 32-byte Ed25519 key.'
+        );
+    }
+
+    /**
+     * Request signing shares the same code path and was equally unreachable.
+     */
+    public function test_request_signing_completes_without_native_libsodium(): void
+    {
+        $this->simulateHostWithoutNativeLibsodium();
+
+        $keystore = new Keystore();
+        $signer   = new Signer($keystore);
+        $signer->agentPublicKey();
+
+        $headers = $signer->signHeaders('POST', '/v1/agent/heartbeat', '{}');
+
+        $this->assertNotSame('', $headers[Signer::HEADER_SIGNATURE] ?? '');
+        $this->assertNotSame('', $headers[Signer::HEADER_KEY] ?? '');
+    }
+
+    /**
+     * The refusal is probed once, not on every secret. Without the cache each
+     * key operation would build and throw a fresh exception forever.
+     */
+    public function test_platform_refusal_is_probed_only_once(): void
+    {
+        $attempts = $this->simulateHostWithoutNativeLibsodium();
+
+        for ($i = 0; $i < 25; $i++) {
+            $secret = 'secret-' . $i;
+            SecureMemory::wipe($secret);
+        }
+
+        $this->assertCount(1, $attempts, 'The platform must be asked once, then the answer reused.');
+        $this->assertFalse(SecureMemory::hasNativeWipe());
+    }
+
+    // -----------------------------------------------------------------
+    // The over-fire arm: the wipe must NOT be skipped where it works.
+    // -----------------------------------------------------------------
+
+    /**
+     * On a platform that can wipe, the real sodium_memzero() is still called.
+     * A "fix" that simply stopped wiping would pass every test above and fail
+     * this one.
+     */
+    public function test_native_wipe_is_still_performed_when_the_platform_supports_it(): void
+    {
+        /** @var \ArrayObject<int,string> $calls */
+        $calls = new \ArrayObject();
+        \Patchwork\redefine('sodium_memzero', function (&$var) use ($calls): void {
+            $calls->append((string) $var);
+            $var = '';
+        });
+
+        $secret = 'super-secret-key-material';
+        SecureMemory::wipe($secret);
+
+        $this->assertCount(1, $calls, 'sodium_memzero() must still be called where the platform supports it.');
+        $this->assertSame('super-secret-key-material', $calls[0], 'It must receive the real value to wipe.');
+        $this->assertTrue(SecureMemory::hasNativeWipe());
+    }
+
+    /**
+     * And it keeps being called for every subsequent secret, rather than the
+     * capability cache turning one success into a permanent skip.
+     */
+    public function test_native_wipe_is_performed_for_every_secret(): void
+    {
+        /** @var \ArrayObject<int,string> $calls */
+        $calls = new \ArrayObject();
+        \Patchwork\redefine('sodium_memzero', function (&$var) use ($calls): void {
+            $calls->append((string) $var);
+        });
+
+        foreach (['alpha', 'bravo', 'charlie'] as $value) {
+            $secret = $value;
+            SecureMemory::wipe($secret);
+        }
+
+        $this->assertSame(['alpha', 'bravo', 'charlie'], (array) $calls->getArrayCopy());
+    }
+
+    /**
+     * The same over-fire arm, proven outside this harness.
+     *
+     * Listing sodium_memzero in patchwork.json's redefinable-internals is what
+     * makes the polyfill tests above possible, but it has a cost: Patchwork
+     * routes every call to that function through a wrapper, and the wrapper
+     * does not carry the by-reference argument back out. In-process, then, a
+     * native wipe is observably *called* (asserted above) but its clearing
+     * effect cannot be observed. That is an artefact of the instrumentation
+     * and not of the shipped code.
+     *
+     * So this arm runs in a clean subprocess with no Patchwork, no PHPUnit and
+     * no stubs: real PHP, the real class file, the real platform. It is the
+     * assertion that a "fix" which quietly stopped wiping would fail.
+     */
+    public function test_wipe_really_clears_the_value_on_an_uninstrumented_platform(): void
+    {
+        $classFile = dirname(__DIR__) . '/includes/support/class-secure-memory.php';
+        $script    = sprintf(
+            '<?php require %s; $s = "real-platform-secret"; '
+                . '\\WPMgr\\Agent\\Support\\SecureMemory::wipe($s); '
+                . 'echo (extension_loaded("sodium") ? "native" : "polyfill"), "|", var_export($s, true), "|", '
+                . 'var_export(\\WPMgr\\Agent\\Support\\SecureMemory::hasNativeWipe(), true);',
+            var_export($classFile, true)
+        );
+
+        $scriptFile = sys_get_temp_dir() . '/wpmgr-secmem-subprocess-' . bin2hex(random_bytes(8)) . '.php';
+        file_put_contents($scriptFile, $script);
+
+        $output = (string) shell_exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($scriptFile) . ' 2>&1');
+        @unlink($scriptFile);
+
+        $parts = explode('|', trim($output));
+        $this->assertCount(3, $parts, 'Subprocess did not complete cleanly. Output: ' . $output);
+
+        [$platform, $wiped, $usedNative] = $parts;
+
+        $this->assertSame('NULL', $wiped, 'The secret must be cleared on a real, uninstrumented platform.');
+
+        if ($platform === 'native') {
+            $this->assertSame(
+                'true',
+                $usedNative,
+                'With the native extension present the real sodium_memzero() must still be the one doing the work.'
+            );
+        } else {
+            $this->assertSame('false', $usedNative);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Drop-in equivalence with the sodium_memzero() calls it replaced.
+    // -----------------------------------------------------------------
+
+    /**
+     * Several call sites wipe an array element (AgeIdentity wipes
+     * $pair['secret']), so the by-reference contract must hold for those too.
+     */
+    public function test_wipe_clears_an_array_element_by_reference(): void
+    {
+        $this->simulateHostWithoutNativeLibsodium();
+
+        $pair = ['secret' => 'private-key-bytes', 'recipient' => 'age1public'];
+        SecureMemory::wipe($pair['secret']);
+
+        $this->assertNull($pair['secret']);
+        $this->assertSame('age1public', $pair['recipient'], 'Only the named element may be touched.');
+    }
+
+    /**
+     * The helper replaced a call that fataled; it must not be able to
+     * introduce a fatal of its own on an unexpected argument.
+     */
+    public function test_wipe_tolerates_a_non_string_value(): void
+    {
+        $this->simulateHostWithoutNativeLibsodium();
+
+        $value = null;
+        SecureMemory::wipe($value);
+        $this->assertNull($value);
+
+        $empty = '';
+        SecureMemory::wipe($empty);
+        $this->assertNull($empty);
+    }
+
+    /**
+     * No sodium primitive other than memzero may be guarded away: the sweep
+     * for #709 confirmed sodium_compat implements all of them, so they must
+     * keep being called directly rather than routed through a fallback.
+     */
+    public function test_only_memzero_was_replaced(): void
+    {
+        $dir   = dirname(__DIR__) . '/includes';
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+
+        $helper = $dir . '/support/class-secure-memory.php';
+
+        $found = [];
+        foreach ($files as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            // The helper is the one place allowed to make the raw call: it is
+            // what wraps it in the guard.
+            if ($file->getPathname() === $helper) {
+                continue;
+            }
+            $source = (string) file_get_contents($file->getPathname());
+            if (preg_match('/\bsodium_memzero\s*\(/', $source) === 1) {
+                $found[] = $file->getPathname();
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $found,
+            'sodium_memzero() must not be called directly; use SecureMemory::wipe(). Offenders: '
+                . implode(', ', $found)
+        );
+    }
+}

--- a/apps/agent/tests/SecureMemoryTest.php
+++ b/apps/agent/tests/SecureMemoryTest.php
@@ -24,6 +24,16 @@
  * Production code is not modified, not parameterised for the test, and not told
  * it is under test: it takes the same branch it takes on a real CloudLinux host.
  *
+ * WHAT THE SIMULATION DOES NOT COVER
+ * ----------------------------------
+ * Namespace fallback shadows one namespace, so the simulation reaches
+ * SecureMemory and nothing else. Keystore and Signer are in WPMgr\Agent, and a
+ * bare sodium_memzero() written in either would bypass the shim entirely and
+ * leave every simulated-host test below green. The tests that name a real call
+ * path therefore prove the fallback branch works end to end; they do not guard
+ * against the bug returning. test_only_memzero_was_replaced() does that, by
+ * source grep, and its docblock explains why nothing behavioural can.
+ *
  * @package WPMgr\Agent\Tests
  */
 
@@ -114,10 +124,22 @@ final class SecureMemoryTest extends TestCase
 
     /**
      * The reported crash path end to end: generating the site keypair reaches
-     * Keystore::encrypt() -> masterKey() -> ... -> the wipe. On a host without
-     * native libsodium this fataled, which is why enrollment white-screened.
+     * Keystore::encrypt() -> masterKey() -> ... -> SecureMemory::wipe(). With
+     * the platform refusing the native wipe, this walks the real call chain
+     * over SecureMemory's fallback branch and asserts a usable keypair still
+     * comes out.
+     *
+     * WHAT THIS CANNOT SEE
+     * --------------------
+     * It cannot detect the #709 regression returning. The refusal is injected
+     * by tests/sodium-memzero-shim.php, which works by namespace fallback and
+     * so shadows sodium_memzero() only for calls made from inside
+     * WPMgr\Agent\Support. Keystore is in WPMgr\Agent, so a bare
+     * sodium_memzero() reintroduced there would resolve to the global builtin,
+     * never reach the shim, never be refused, and leave this test green.
+     * test_only_memzero_was_replaced() is the guard for that.
      */
-    public function test_site_keypair_generation_completes_without_native_libsodium(): void
+    public function test_site_keypair_generation_completes_when_secure_memory_falls_back(): void
     {
         $this->simulateHostWithoutNativeLibsodium();
 
@@ -134,9 +156,15 @@ final class SecureMemoryTest extends TestCase
 
     /**
      * The enrollment entry point from the issue's backtrace
-     * (Enrollment::buildEnrollPayload -> Signer::agentPublicKeyBase64).
+     * (Enrollment::buildEnrollPayload -> Signer::agentPublicKeyBase64), driven
+     * with SecureMemory taking its fallback branch.
+     *
+     * Same blind spot as the test above: Signer is in WPMgr\Agent, outside the
+     * one namespace the shim can shadow, so this cannot detect a bare
+     * sodium_memzero() reappearing in Signer. It covers the fallback path, not
+     * the regression. See test_only_memzero_was_replaced().
      */
-    public function test_agent_public_key_base64_completes_without_native_libsodium(): void
+    public function test_agent_public_key_base64_completes_when_secure_memory_falls_back(): void
     {
         $this->simulateHostWithoutNativeLibsodium();
 
@@ -152,9 +180,14 @@ final class SecureMemoryTest extends TestCase
     }
 
     /**
-     * Request signing shares the same code path and was equally unreachable.
+     * Request signing shares the same code path and was equally unreachable
+     * before the fix; this drives it with SecureMemory falling back.
+     *
+     * Blind to a reintroduced bare sodium_memzero() for the same reason as the
+     * two tests above: the shim shadows only WPMgr\Agent\Support, and Signer
+     * and Keystore are in WPMgr\Agent. See test_only_memzero_was_replaced().
      */
-    public function test_request_signing_completes_without_native_libsodium(): void
+    public function test_request_signing_completes_when_secure_memory_falls_back(): void
     {
         $this->simulateHostWithoutNativeLibsodium();
 
@@ -309,9 +342,34 @@ final class SecureMemoryTest extends TestCase
     }
 
     /**
-     * No sodium primitive other than memzero may be guarded away: the sweep
-     * for #709 confirmed sodium_compat implements all of them, so they must
-     * keep being called directly rather than routed through a fallback.
+     * THE REVERSION GUARD FOR #709. Do not delete this test as redundant with
+     * the behavioural ones above; it is the only test in this file that fails
+     * if the bug comes back.
+     *
+     * It asserts by source grep that no file under includes/ outside
+     * SecureMemory itself calls sodium_memzero() directly. Reintroduce a bare
+     * call anywhere -- Keystore, Signer, or a new caller written next year --
+     * and this goes red naming the file.
+     *
+     * WHY A BEHAVIOURAL TEST CANNOT DO THIS JOB
+     * -----------------------------------------
+     * Simulating an extension-less host means intercepting sodium_memzero(),
+     * and the only interception available here is PHP's namespace fallback
+     * (tests/sodium-memzero-shim.php explains why Patchwork is not an option:
+     * it forwards a wrapped internal's arguments by value, breaking the very
+     * by-reference contract the function exists to provide). Namespace
+     * fallback reaches exactly one namespace -- WPMgr\Agent\Support, where
+     * SecureMemory lives. A bare sodium_memzero() written in WPMgr\Agent binds
+     * to the global builtin, which on this machine succeeds silently. Nothing
+     * about that call is observable from PHP: same name, same signature, same
+     * void return, no side effect a test can read back. So no behavioural test
+     * can distinguish the fixed code from the broken code here, and a source
+     * grep is the correct instrument rather than a weaker substitute for one.
+     *
+     * The second thing it pins, from the original sweep: no sodium primitive
+     * other than memzero may be guarded away. sodium_compat implements all the
+     * others, so they must keep being called directly rather than routed
+     * through a fallback.
      */
     public function test_only_memzero_was_replaced(): void
     {

--- a/apps/agent/tests/bootstrap.php
+++ b/apps/agent/tests/bootstrap.php
@@ -29,6 +29,13 @@ if (!function_exists('Patchwork\redefine')) {
 // redefinable. Brain Monkey tests override these defaults via Functions\when().
 require_once __DIR__ . '/wp-stubs.php';
 
+// Namespaced shadow of sodium_memzero(), so the suite can run as if this
+// machine had no native libsodium extension (GH #709). Required here, not from
+// a test case, so the function exists before any call site is first executed.
+// Inert until a test flips WPMgr\Agent\Tests\SodiumPlatform::refuse(); see the
+// file's header for why this is not a Patchwork redefinable-internal.
+require_once __DIR__ . '/sodium-memzero-shim.php';
+
 // ---------------------------------------------------------------------------
 // Constants needed by the object-cache drop-in and engine files.
 // ---------------------------------------------------------------------------

--- a/apps/agent/tests/sodium-memzero-shim.php
+++ b/apps/agent/tests/sodium-memzero-shim.php
@@ -31,6 +31,29 @@
  * existed. It is loaded from bootstrap.php rather than from a test case so the
  * namespaced function is defined before any call site is first executed.
  *
+ * THE LIMIT OF THIS SHIM
+ * ----------------------
+ * Namespace fallback is the mechanism and therefore also the boundary: this
+ * shim shadows unqualified sodium_memzero() calls made from inside
+ * WPMgr\Agent\Support, and nowhere else. Keystore and Signer live in
+ * WPMgr\Agent, so an unqualified sodium_memzero() written there resolves
+ * straight to the global builtin and this file never sees it.
+ *
+ * The consequence is worth stating plainly, because it is easy to assume
+ * otherwise: **no test built on this shim can detect the #709 regression
+ * coming back.** If a bare sodium_memzero() were reintroduced in Keystore or
+ * Signer, every test here would still pass green, because the shim cannot
+ * observe -- let alone refuse -- a call it does not shadow.
+ *
+ * What this shim is for is exercising SecureMemory's fallback path, through
+ * the real call chain, on a machine that does have the extension. The guard
+ * against the regression itself is the source grep in
+ * SecureMemoryTest::test_only_memzero_was_replaced().
+ *
+ * Do not widen this file to shadow WPMgr\Agent as well. Every real call site
+ * routes through SecureMemory::wipe(), so a second shadow would simulate a
+ * call shape the plugin does not make, and would read as coverage it is not.
+ *
  * @package WPMgr\Agent\Tests
  */
 

--- a/apps/agent/tests/sodium-memzero-shim.php
+++ b/apps/agent/tests/sodium-memzero-shim.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Test-only shim that lets the suite run as if this machine had no native
+ * libsodium PHP extension (GH #709).
+ *
+ * WHY NOT PATCHWORK
+ * -----------------
+ * The obvious approach -- listing sodium_memzero in patchwork.json's
+ * redefinable-internals -- does not work. Patchwork wraps a redefinable
+ * internal in a generated function that forwards its arguments by value, so
+ * every call in preprocessed code starts emitting
+ *
+ *   sodium_memzero(): Argument #1 ($string) must be passed by reference
+ *
+ * That is a PHP warning on a by-reference builtin, it fires on all 267 tests
+ * that reach a wipe, and phpunit.xml.dist sets failOnWarning="true". It also
+ * silently breaks the by-reference contract the function exists to provide.
+ *
+ * WHAT THIS DOES INSTEAD
+ * ----------------------
+ * PHP resolves an unqualified function call inside a namespace against that
+ * namespace first and only then against the global scope. SecureMemory lives
+ * in WPMgr\Agent\Support and is the single place in the plugin that calls
+ * sodium_memzero(), so defining WPMgr\Agent\Support\sodium_memzero() here
+ * shadows exactly that one call site -- by reference, with no instrumentation,
+ * and with no effect on any other namespace or on production code, which never
+ * loads this file.
+ *
+ * With SodiumPlatform::$refuses off, the shim simply delegates to the real
+ * global function, so the suite behaves exactly as it did before this file
+ * existed. It is loaded from bootstrap.php rather than from a test case so the
+ * namespaced function is defined before any call site is first executed.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests {
+
+    /**
+     * Switchboard for the shim below.
+     */
+    final class SodiumPlatform
+    {
+        /**
+         * The refusal sodium_compat raises, verbatim, from
+         * wp-includes/sodium_compat/src/Compat.php.
+         */
+        public const REFUSAL_MESSAGE = 'This is not implemented in sodium_compat, as it is not possible to '
+            . 'securely wipe memory from PHP. To fix this error, make sure libsodium is installed and the PHP '
+            . 'extension is enabled.';
+
+        /**
+         * When true, every wipe raises sodium_compat's refusal, exactly as it
+         * does on a host with no native libsodium extension.
+         */
+        public static bool $refuses = false;
+
+        /** Number of times the shim has been entered since the last reset. */
+        public static int $calls = 0;
+
+        /** Values the shim was asked to wipe since the last reset. */
+        public static array $wiped = [];
+
+        /**
+         * Behave like a host with no native libsodium extension.
+         *
+         * @return void
+         */
+        public static function refuse(): void
+        {
+            self::reset();
+            self::$refuses = true;
+        }
+
+        /**
+         * Restore this machine's real behaviour.
+         *
+         * @return void
+         */
+        public static function reset(): void
+        {
+            self::$refuses = false;
+            self::$calls   = 0;
+            self::$wiped   = [];
+        }
+    }
+}
+
+namespace WPMgr\Agent\Support {
+
+    use WPMgr\Agent\Tests\SodiumPlatform;
+
+    /**
+     * Namespaced shadow of the global sodium_memzero().
+     *
+     * @param string $string Value to wipe, by reference.
+     * @return void
+     * @throws \SodiumException When simulating a host without native libsodium.
+     */
+    function sodium_memzero(&$string): void
+    {
+        SodiumPlatform::$calls++;
+        SodiumPlatform::$wiped[] = is_string($string) ? $string : null;
+
+        if (SodiumPlatform::$refuses) {
+            throw new \SodiumException(SodiumPlatform::REFUSAL_MESSAGE);
+        }
+
+        \sodium_memzero($string);
+    }
+}


### PR DESCRIPTION
Fixes #709.

## Root cause, confirmed

`apps/agent/includes/class-keystore.php:699` (pre-fix) called `sodium_memzero($ikm)` unguarded, reached from the enrollment click through `keyFromSalts` → `resolveMasterKey` → `masterKey` → `encrypt` → `generateSiteKeypair` → `agentPublicKey` → `agentPublicKeyBase64` → `buildEnrollPayload`.

The reporter's chain is correct, and I confirmed it rather than assuming it. `wp-includes/sodium_compat/src/Compat.php` — WordPress's bundled polyfill, used whenever the native extension is absent — ends `memzero()` with an unconditional `throw new SodiumException(...)`; it returns early only via `useNewSodiumAPI()` or a `\Sodium\memzero` fallback. So on any host without native libsodium, the first key derivation fatals.

One correction to the issue: it says sodium_compat "already sets `$var = null` immediately before throwing, so catching the exception loses nothing." That is **not** true of the copy WordPress bundles — it throws without clearing the variable. The fallback overwrite here is therefore doing real work, not repeating the polyfill.

## The sweep

Every sodium symbol the shipped plugin references:

```
7 SODIUM_CRYPTO_SCALARMULT_BYTES          2 sodium_crypto_scalarmult
6 SODIUM_CRYPTO_SIGN_BYTES                2 SODIUM_CRYPTO_AEAD_..._NPUBBYTES
5 sodium_crypto_sign_verify_detached      2 ..._chacha20poly1305_ietf_encrypt
4 SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES       2 ..._chacha20poly1305_ietf_decrypt
4 sodium_crypto_scalarmult_base           1 sodium_crypto_sign_secretkey
3 sodium_crypto_sign_publickey            1 sodium_crypto_sign_keypair
3 sodium_crypto_generichash               1 sodium_crypto_sign_detached
24 sodium_memzero
```

Checked each against the bundled polyfill. `memzero` is the **only** one it refuses. The other two refusals in sodium_compat are Argon2i and Scrypt (`crypto_pwhash*`), which the agent does not use; every function above is present in `sodium_compat/lib/php72compat.php` and works. So: **no others** — the 24 `memzero` sites were the whole exposure, across enrollment, request signing and backup encryption.

## The fix

New `WPMgr\Agent\Support\SecureMemory::wipe()`, a never-fatal drop-in, with all 24 sites routed through it.

Capability is detected by **attempting the wipe once** and caching the answer — not a PHP version, a SAPI, or a host name. It deliberately does not use `extension_loaded('sodium')` either: a host carrying the older PECL `libsodium` extension reports no `sodium` extension yet still wipes successfully, because sodium_compat routes `memzero()` through `\Sodium\memzero()` when present. Asking the platform to do the work is the only check that is right on every host.

**The cryptography is unchanged.** No key material is handled differently, no algorithm is weakened, and the native wipe still happens wherever the platform can perform it. Only the post-use scrub degrades, on exactly the hosts where PHP was never capable of it.

The subprocess arm caught a real defect in the first cut: native `sodium_memzero()` leaves the variable **NULL**, while the fallback was leaving `''`. Post-conditions differed by host. The fallback now ends at null too, so every call site sees exactly what it saw before this helper existed.

## Exercising the polyfill path

This machine has the native extension, so a test that merely calls the code proves nothing.

`tests/sodium-memzero-shim.php` defines a namespaced `WPMgr\Agent\Support\sodium_memzero()`. PHP resolves an unqualified function call inside a namespace against that namespace before the global scope, and `SecureMemory` is the single place in the plugin that calls the function, so the shim shadows exactly that one call site — by reference, with no instrumentation, no effect on any other namespace, and never loaded by production code. It delegates to the real builtin until a test calls `SodiumPlatform::refuse()`.

I first tried Patchwork for this and it was wrong; the second commit's message records why. Patchwork wraps a redefinable internal in a generated function that forwards arguments **by value**, which emitted `sodium_memzero(): Argument #1 ($string) must be passed by reference` across 267 tests and, with `failOnWarning="true"`, exited 1 while all 3487 tests passed. CI caught it because my local check piped phpunit into `tail` and read the summary instead of the exit status. Both the mechanism and that habit are fixed; every count below now comes with its exit code.

**Red**, with the pre-fix unguarded call planted in `wipe()`:

```
7) ...::test_wipe_tolerates_a_non_string_value
SodiumException: This is not implemented in sodium_compat, as it is not possible to
securely wipe memory from PHP. ...
  .../tests/sodium-memzero-shim.php:108
  .../includes/support/class-secure-memory.php:83
Tests: 11, Assertions: 9, Errors: 7
```

Every error is the real exception. **Green** once the guard is restored: `Tests: 11, Assertions: 22`, 0 failures.

**The over-fire arm.** Because the shim delegates rather than fakes, the native wipe's clearing effect is observable in-process: the test asserts `sodium_memzero()` is still called, still receives the real secret, and really clears it. It additionally runs in a **clean subprocess** — no shim, no PHPUnit, real global builtin, real platform. A "fix" that quietly stopped wiping fails both.

A repo-wide scan test keeps the raw call from coming back: the helper is the only file permitted to call `sodium_memzero()` directly.

## Telling the operator: I chose not to

After this fix the missing extension no longer degrades anything an operator can act on inside the plugin — enrollment, signing and backups behave identically. What remains is a memory scrub PHP could never perform on that host regardless of this plugin. A notice with no failure and no in-product remedy is noise on an admin screen, and the fleet-wide home for it (the info command payload) is a control-plane contract change this PR is scoped out of. `SecureMemory::hasNativeWipe()` is public, cheap and side-effect-free, so surfacing it later is one call rather than a second copy of the detection logic.

## Gates

| Gate | Command | Result |
|---|---|---|
| Unit suite | `php -d memory_limit=1G vendor/bin/phpunit` | **3487 tests, 18030 assertions, 0 failures, 0 errors**, `PHPUNIT_EXIT=0` |
| phpcs | `vendor/bin/phpcs --no-cache -p` on all 5 changed files | 0 errors, `PHPCS_EXIT=0` |
| Plugin Check | `wp plugin check (Docker)` on this PR | **`Plugin Check: 0 errors.`** |
| `PHP (agent)` | CI on this PR | pass |

Plugin Check's remaining WARNING rows are all pre-existing (readme `mismatched_plugin_name`, `upgrade_notice_limit`, `trademarked_term`, and `WriteFile.ABSPATHDetected` in three file commands). None is in a file this PR touches, and `class-secure-memory.php` produces no row.

`make agent-plugincheck` **could not run locally** — the Docker daemon on this machine is not running and Docker Desktop refuses to launch (`error -1712`). The CI job above is the authoritative run, and it is green. I also added the `ABSPATH` direct-file-access guard to the new file by hand.

Plain `composer test` on this machine hits a 128M `memory_limit` exhaustion in `SqlInspectorTest` (`gzgets` with a 16MB buffer, `class-sql-inspector.php:186`), unrelated to this change, which is why the local run raises the limit; CI's `PHP (agent)` job runs it unmodified and passes.

`ADR-061 assistant pre-ship gate` fails here and is unrelated: it is the only failing job on `main` too, and it scores the AI assistant/MCP surface (dashboard kill switch, quota counter, two missing docs), nothing under `apps/agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DP2DoMnepVgtDZize9ecV7
