### PR TITLE
release: 0.61.160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.160] - 2026-09-05
+
+### Fixed
+
+- Clearing the alert recipient list now works. It previously showed a validation error and never sent the request, because of a client-side-only rule that rejected an empty list; the server, the database default and the dispatcher already accepted zero recipients. The dashboard also now exposes the master on/off switch for alerts, so you can stop alert email entirely without deleting the recipient list.
+- Sites on hosts without the native libsodium PHP extension can now complete Enroll. The plugin previously showed a white screen on any such host, because a memory-wiping call was made unconditionally and WordPress's bundled polyfill throws instead of performing it. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin could not be installed at all. **Requires updating the plugin to pick up the fix.**
+- Removed a settings-screen section that asked operators to paste a minted connection key into a dashboard flow that was never built. The underlying mechanism is unchanged; only that dead, confusing step is gone.
+
 ## [0.61.159] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 ### Fixed
 
 - Clearing the alert recipient list now works. It previously showed a validation error and never sent the request, because of a client-side-only rule that rejected an empty list; the server, the database default and the dispatcher already accepted zero recipients. The dashboard also now exposes the master on/off switch for alerts, so you can stop alert email entirely without deleting the recipient list.
-- Sites on hosts without the native libsodium PHP extension can now complete Enroll. The plugin previously showed a white screen on any such host, because a memory-wiping call was made unconditionally and WordPress's bundled polyfill throws instead of performing it. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin could not be installed at all. **Requires updating the plugin to pick up the fix.**
+- Sites on hosts without the native libsodium PHP extension can now complete Enroll. The plugin previously showed a white screen on any such host, because a memory-wiping call was made unconditionally and WordPress's bundled polyfill throws instead of performing it. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin installed and activated normally but enrollment could not be completed. **Requires updating the plugin to pick up the fix.**
 - Removed a settings-screen section that asked operators to paste a minted connection key into a dashboard flow that was never built. The underlying mechanism is unchanged; only that dead, confusing step is gone.
 
 ## [0.61.159] - 2026-09-02

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.159**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.160**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -317,15 +317,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.159
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.159
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.159
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.160
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.160
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.160
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.159   # omit to track :latest
+export WPMGR_VERSION=v0.61.160   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, security, performance, updates, site management
 Requires at least: 6.2
 Tested up to: 7.1
 Requires PHP: 8.1
-Stable tag: 0.61.147
+Stable tag: 0.61.148
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -286,6 +286,10 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.31.1. This project ships frequently and not every intermediate patch release is listed here. Full history: https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md
 
+= 0.61.148 =
+* Fixed: this plugin no longer fatals with a white screen on Enroll on a host without the native libsodium PHP extension. A memory-wiping call was made unconditionally, and WordPress's bundled polyfill throws rather than perform it; every call site now degrades to a best-effort overwrite instead. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin could not be installed at all.
+* Changed: removed a settings-screen section that asked you to paste a minted connection key into a dashboard flow that was never built. The underlying mechanism is unchanged; only that dead, confusing step is gone.
+
 = 0.61.147 =
 * Fixed: on a multisite network, a plugin activated for the whole network is now reported as active in this site's metadata. It was reported inactive, so it was missing from the plugin inventory and from everything that reads it, including update and vulnerability checks.
 * Changed: this plugin is licensed MIT, and now says so consistently on every surface that declares a licence (the plugin header, the mu-plugin headers, this readme, composer.json and the bundled licence file). Some of those previously declared GPLv2 or later. No functional change.
@@ -446,6 +450,9 @@ The entries below summarize the notable changes since 0.31.1. This project ships
 * New: WOFF2 font transcoding. TTF, OTF and WOFF are converted on the control plane; the flag defaults to off.
 
 == Upgrade Notice ==
+
+= 0.61.148 =
+Fixes a white screen on Enroll on hosts without the native libsodium PHP extension, common on shared hosting, cPanel and CloudLinux in particular, where the plugin previously could not be installed at all. Update to complete setup on those hosts. Also removes a settings section that referenced a dashboard flow that was never built.
 
 = 0.61.147 =
 On a multisite network, plugins activated for the whole network are now reported as active, so they stop being missing from the plugin inventory and from the update and vulnerability checks that read it. This plugin's licence is also now declared as MIT consistently across every surface that states one. Safe to update in place.

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -287,7 +287,7 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 The entries below summarize the notable changes since 0.31.1. This project ships frequently and not every intermediate patch release is listed here. Full history: https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md
 
 = 0.61.148 =
-* Fixed: this plugin no longer fatals with a white screen on Enroll on a host without the native libsodium PHP extension. A memory-wiping call was made unconditionally, and WordPress's bundled polyfill throws rather than perform it; every call site now degrades to a best-effort overwrite instead. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin could not be installed at all.
+* Fixed: this plugin no longer fatals with a white screen on Enroll on a host without the native libsodium PHP extension. A memory-wiping call was made unconditionally, and WordPress's bundled polyfill throws rather than perform it; every call site now degrades to a best-effort overwrite instead. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin installed and activated normally but enrollment could not be completed.
 * Changed: removed a settings-screen section that asked you to paste a minted connection key into a dashboard flow that was never built. The underlying mechanism is unchanged; only that dead, confusing step is gone.
 
 = 0.61.147 =
@@ -452,7 +452,7 @@ The entries below summarize the notable changes since 0.31.1. This project ships
 == Upgrade Notice ==
 
 = 0.61.148 =
-Fixes a white screen on Enroll on hosts without the native libsodium PHP extension, common on shared hosting, cPanel and CloudLinux in particular, where the plugin previously could not be installed at all. Update to complete setup on those hosts. Also removes a settings section that referenced a dashboard flow that was never built.
+Fixes a white screen on Enroll on hosts without the native libsodium PHP extension, common on shared hosting, cPanel and CloudLinux in particular, where the plugin installed and activated normally but enrollment could not be completed. Update to complete setup on those hosts. Also removes a settings section that referenced a dashboard flow that was never built.
 
 = 0.61.147 =
 On a multisite network, plugins activated for the whole network are now reported as active, so they stop being missing from the plugin inventory and from the update and vulnerability checks that read it. This plugin's licence is also now declared as MIT consistently across every surface that states one. Safe to update in place.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.147
+ * Version:           0.61.148
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.147');
+define('WPMGR_AGENT_VERSION', '0.61.148');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -61,7 +61,7 @@ const RELEASES: ChangeEntry[] = [
       },
       {
         tag: "Fixed",
-        text: "Sites on hosts without the native libsodium PHP extension can now complete Enroll. The plugin previously showed a white screen on any such host, because a memory-wiping call was made unconditionally and WordPress's bundled polyfill throws instead of performing it. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin could not be installed at all. Requires updating the plugin to pick up the fix.",
+        text: "Sites on hosts without the native libsodium PHP extension can now complete Enroll. The plugin previously showed a white screen on any such host, because a memory-wiping call was made unconditionally and WordPress's bundled polyfill throws instead of performing it. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin installed and activated normally but enrollment could not be completed. Requires updating the plugin to pick up the fix.",
       },
       {
         tag: "Fixed",

--- a/apps/marketing/app/(marketing)/changelog/page.tsx
+++ b/apps/marketing/app/(marketing)/changelog/page.tsx
@@ -50,6 +50,26 @@ const TAG_COLOR: Record<ChangeTag, string> = {
 
 const RELEASES: ChangeEntry[] = [
   {
+    version: "0.61.160",
+    date: "2026-09-05",
+    summary:
+      "Clearing the alert recipient list now works, with a master switch to turn alert email off entirely, and sites without native libsodium can complete Enroll again.",
+    items: [
+      {
+        tag: "Fixed",
+        text: "Clearing the alert recipient list now works. It previously showed a validation error and never sent the request, because of a client-side-only rule that rejected an empty list; the server, the database default and the dispatcher already accepted zero recipients. The dashboard also now exposes the master on/off switch for alerts, so you can stop alert email entirely without deleting the recipient list.",
+      },
+      {
+        tag: "Fixed",
+        text: "Sites on hosts without the native libsodium PHP extension can now complete Enroll. The plugin previously showed a white screen on any such host, because a memory-wiping call was made unconditionally and WordPress's bundled polyfill throws instead of performing it. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin could not be installed at all. Requires updating the plugin to pick up the fix.",
+      },
+      {
+        tag: "Fixed",
+        text: "Removed a settings-screen section that asked operators to paste a minted connection key into a dashboard flow that was never built. The underlying mechanism is unchanged; only that dead, confusing step is gone.",
+      },
+    ],
+  },
+  {
     version: "0.61.159",
     date: "2026-09-02",
     summary:

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -14,7 +14,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 // on every release: the agent version deliberately does not track the repo
 // release version, so a control-plane-only release leaves this alone and the
 // badge stays true.
-const AGENT_VERSION = "0.61.147";
+const AGENT_VERSION = "0.61.148";
 
 export const HOME_HERO = {
   badge: `v${AGENT_VERSION} / open source`,

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.159   # omit to track :latest
+export WPMGR_VERSION=v0.61.160   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.159
+  version: 0.61.160
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

- Control plane 0.61.159 to 0.61.160; agent 0.61.147 to 0.61.148 (two of the three fixes are agent changes).
- Bumps every version-lockstep surface: CHANGELOG.md, packages/openapi/openapi.yaml info.version, the marketing /changelog page, the marketing hero badge (AGENT_VERSION in apps/marketing/lib/content/home.ts), the agent plugin header and WPMGR_AGENT_VERSION, apps/agent/readme.txt (Stable tag, Changelog, Upgrade Notice), and the install pins in README.md and docs/install.md.

## What's in this release

- #711 / GH #706 (web): Clearing the alert recipient list now works. Also exposes the master alert on/off switch in the dashboard.
- #712 / GH #709 (agent): The plugin no longer fatals with a white screen on Enroll on hosts without the native libsodium PHP extension.
- #713 (agent): Removed a settings-screen section pointing at a connection-key dashboard flow that was never built.

## Test plan

- make check-versions-test
- make check-versions
- node apps/marketing/scripts/check-copy.mjs
- Docs vocabulary check re-run verbatim

This PR does not create the release tag or publish anything.

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing the alert recipient list now works correctly.
  - Added a master switch for enabling or disabling alert emails.
  - Enrollment now works on hosting environments without the native PHP libsodium extension.
- **User Interface**
  - Removed an obsolete settings section that referenced an unavailable connection-key workflow.
- **Documentation**
  - Updated release notes and installation references for the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->