### PR TITLE
fix(api): reject non-http(s) site URLs on manual create

### DIFF
--- a/apps/api/internal/site/service.go
+++ b/apps/api/internal/site/service.go
@@ -96,6 +96,12 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (Site, error) {
 	if err := s.validator.Struct(in); err != nil {
 		return Site{}, err
 	}
+	// Reject site URLs whose scheme isn't http/https, mirroring Enroll: the
+	// `url` validator tag accepts javascript:/file:/gopher: URLs, and the
+	// stored value is rendered as a clickable link in the client portal.
+	if u, err := url.Parse(in.URL); err != nil || u == nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return Site{}, domain.Validation("site_url_scheme", "url must be an http or https URL")
+	}
 	return s.repo.Create(ctx, in)
 }
 

--- a/apps/api/internal/site/service_test.go
+++ b/apps/api/internal/site/service_test.go
@@ -199,6 +199,24 @@ func TestServiceCreate(t *testing.T) {
 			wantErr:  true,
 			wantKind: domain.KindConflict,
 		},
+		{
+			// The `url` validator tag accepts any scheme, so the explicit
+			// http/https gate (mirroring Enroll) must catch these.
+			name:     "javascript scheme rejected",
+			in:       CreateInput{TenantID: tenant, URL: "javascript://example.com/%0aalert(1)", Name: "Example"},
+			wantErr:  true,
+			wantKind: domain.KindValidation,
+		},
+		{
+			name:     "file scheme rejected",
+			in:       CreateInput{TenantID: tenant, URL: "file:///etc/passwd", Name: "Example"},
+			wantErr:  true,
+			wantKind: domain.KindValidation,
+		},
+		{
+			name: "plain http accepted",
+			in:   CreateInput{TenantID: tenant, URL: "http://example.com", Name: "Example"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`POST /api/v1/sites` validates the URL only with the go-playground `url` tag, which accepts `javascript://…`, `file://…` and any other scheme. The public enroll path already rejects non-http(s) schemes (`site/service.go`, `Enroll`); manual create was the one gap. The stored value renders as a clickable `href={site.url}` in the client portal (`portal-site-card.tsx` and friends), so an operator could store a `javascript:` link that their client clicks.

This applies the exact same scheme gate to `Service.Create`, with the same `site_url_scheme` validation error.

Deliberately not covered here: the five portal/admin sinks still render pre-existing rows unguarded. `safeExternalHref` exists in `features/security/use-vuln.ts` — happy to apply it at those sinks as a follow-up, but where that helper should live is your structural call.

**Tests:** two new rejection cases + one acceptance case in `TestServiceCreate`. Red without the fix (`expected error, got nil` for the javascript/file cases), green with it. `go build` / `go vet` / unit tests pass with the CI-equivalent package set (`CGO_ENABLED=0`, media-encoder packages excluded).

Part of the security review I sent by email; the smaller findings first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Site creation now rejects URLs using unsupported schemes, such as `javascript:` and `file:`.
  - Standard `http://` and `https://` site URLs continue to be accepted.
  - Invalid URL schemes return a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->