### PR TITLE
fix(agent): re-jail nearest existing ancestor in file_mkdir

### DIFF
--- a/apps/agent/includes/commands/class-file-mkdir-command.php
+++ b/apps/agent/includes/commands/class-file-mkdir-command.php
@@ -16,6 +16,9 @@
  *
  * Security:
  *   - Path jail via FileListCommand::jailPath() (segment checks + realpath containment).
+ *   - F3: nearest existing ancestor re-jailed via realpath before wp_mkdir_p()
+ *     (jailPath() is lexical for not-yet-existing targets; a pre-existing
+ *     in-jail symlink parent must not redirect the mkdir outside the jail).
  *   - T3: jail root resolved or error before any FS write.
  *   - Directory is hardened via StoragePaths::ensureHardenedPath() (.htaccess + index.php guard).
  *   - 'exists' error if the path is already present (any type).
@@ -82,13 +85,46 @@ final class FileMkdirCommand implements CommandInterface {
 
 		// ------------------------------------------------------------------
 		// 4. Check for pre-existing entry.
+		//    file_exists() follows symlinks, so a dangling symlink at the
+		//    target slips past it — the is_link() check below catches it.
 		// ------------------------------------------------------------------
 		if ( file_exists( $absPath ) ) {
 			return $this->error( 'exists', 'path already exists: ' . $resolvedRel );
 		}
 
 		// ------------------------------------------------------------------
-		// 5. Create and harden the directory.
+		// 5. F3: Re-jail the nearest existing ancestor before creating.
+		//    jailPath() returns a LEXICAL path when the target does not exist
+		//    yet, so a pre-existing in-jail symlink in a parent segment would
+		//    let wp_mkdir_p() (which follows symlinks) create the directory
+		//    outside the jail. Walk up to the deepest ancestor that exists (or
+		//    is a dangling symlink) and require its realpath to stay inside
+		//    the jail root — the same parent re-jail the other write commands
+		//    perform before touching the filesystem.
+		// ------------------------------------------------------------------
+		if ( is_link( $absPath ) ) {
+			return $this->error( 'outside_root', 'mkdir denied: destination is a symbolic link' );
+		}
+
+		$ancestor = dirname( $absPath );
+		while ( ! file_exists( $ancestor ) && ! is_link( $ancestor ) ) {
+			$parent = dirname( $ancestor );
+			if ( $parent === $ancestor ) {
+				break;
+			}
+			$ancestor = $parent;
+		}
+
+		$ancestorReal = realpath( $ancestor );
+		if ( $ancestorReal === false
+			|| ( strncmp( str_replace( '\\', '/', $ancestorReal ), $jailRoot . '/', strlen( $jailRoot ) + 1 ) !== 0
+				&& str_replace( '\\', '/', $ancestorReal ) !== $jailRoot )
+		) {
+			return $this->error( 'outside_root', 'mkdir denied: parent directory resolves outside the jail root' );
+		}
+
+		// ------------------------------------------------------------------
+		// 6. Create and harden the directory.
 		//    StoragePaths::ensureHardenedPath() creates the directory with
 		//    wp_mkdir_p() and drops a deny-all .htaccess + index.php guard.
 		// ------------------------------------------------------------------

--- a/apps/agent/tests/FileManagerWriteCommandsTest.php
+++ b/apps/agent/tests/FileManagerWriteCommandsTest.php
@@ -493,6 +493,64 @@ final class FileManagerWriteCommandsTest extends TestCase {
 		$this->assertSame( 'invalid_path', $result['error']['code'] );
 	}
 
+	public function test_file_mkdir_symlink_parent_escape_rejected(): void {
+		// Regression: jailPath() returns a lexical path when the target does
+		// not exist yet, so a pre-existing in-jail symlink pointing outside
+		// the jail must not let file_mkdir create directories outside the
+		// jail root (wp_mkdir_p follows symlinks).
+		$outside = sys_get_temp_dir() . '/wpmgr-mkdir-escape-' . bin2hex( random_bytes( 6 ) );
+		mkdir( $outside, 0755, true );
+
+		try {
+			symlink( $outside, $this->testAbsDir . '/link' );
+
+			$cmd    = new FileMkdirCommand();
+			$result = $cmd->execute( [], [ 'path' => $this->testSubDir . '/link/pwned' ] );
+
+			$this->assertArrayHasKey( 'error', $result, json_encode( $result ) );
+			$this->assertSame( 'outside_root', $result['error']['code'] );
+			$this->assertDirectoryDoesNotExist( $outside . '/pwned' );
+		} finally {
+			$this->rmdir_r( $outside );
+		}
+	}
+
+	public function test_file_mkdir_dangling_symlink_target_rejected(): void {
+		// file_exists() follows symlinks, so a dangling symlink at the target
+		// passes the 'exists' check; the is_link() guard must reject it.
+		symlink( $this->testAbsDir . '/nonexistent-target', $this->testAbsDir . '/dangling' );
+
+		$cmd    = new FileMkdirCommand();
+		$result = $cmd->execute( [], [ 'path' => $this->testSubDir . '/dangling' ] );
+
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( 'outside_root', $result['error']['code'] );
+	}
+
+	public function test_file_mkdir_nested_path_still_created(): void {
+		// The ancestor re-jail walk must not break legitimate nested creation
+		// (wp_mkdir_p creates intermediate directories).
+		$jailPath = $this->testSubDir . '/a/b/c';
+		$cmd      = new FileMkdirCommand();
+		$result   = $cmd->execute( [], [ 'path' => $jailPath ] );
+
+		$this->assertArrayNotHasKey( 'error', $result, json_encode( $result ) );
+		$this->assertDirectoryExists( $this->testAbsDir . '/a/b/c' );
+	}
+
+	public function test_file_mkdir_in_jail_symlink_parent_still_allowed(): void {
+		// A symlink parent that RESOLVES inside the jail is legitimate: the
+		// guard keys on realpath containment, not on symlink presence.
+		$this->makeDir( 'real-dir' );
+		symlink( $this->testAbsDir . '/real-dir', $this->testAbsDir . '/in-jail-link' );
+
+		$cmd    = new FileMkdirCommand();
+		$result = $cmd->execute( [], [ 'path' => $this->testSubDir . '/in-jail-link/child' ] );
+
+		$this->assertArrayNotHasKey( 'error', $result, json_encode( $result ) );
+		$this->assertDirectoryExists( $this->testAbsDir . '/real-dir/child' );
+	}
+
 	// ==================================================================
 	// FileRenameCommand — POSITIVE + NEGATIVE TESTS
 	// ==================================================================


### PR DESCRIPTION
`FileListCommand::jailPath()` intentionally returns a lexical path when the target does not exist yet, and delegates new-path containment to each write command's own realpath re-check. Every write command has that re-check — except `file_mkdir`. With a pre-existing in-jail symlink pointing outside the jail (e.g. an uploads dir symlinked to external storage), a signed `file_mkdir` for a path through that symlink makes `wp_mkdir_p()` (which follows symlinks) create the directory — plus the `.htaccess`/`index.php` hardening files — outside `WPMGR_FILE_JAIL_ROOT`.

The fix walks up from the target to the nearest existing ancestor (mirroring the F3 parent re-jail in `file_write`) and requires its `realpath()` to stay inside the jail root before `ensureHardenedPath()` runs. A dangling symlink at the target itself (which `file_exists()` misses) is rejected explicitly.

**Tests** (`FileManagerWriteCommandsTest`): symlink-parent escape (on unfixed code the directory really lands outside the jail), dangling-symlink target, plus two must-not-over-fire cases (nested `a/b/c` creation, and a symlink parent that resolves *inside* the jail). Red without the fix (2 failures), green with it (8/8 mkdir tests). Full agent suite: 3491 tests OK; PHPStan level 8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory creation security by rejecting symbolic links that could escape the permitted storage area.
  * Prevented directories from being created outside the allowed location through external or dangling symlink paths.
  * Continued supporting valid nested directory creation and symlink paths that resolve within the permitted area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->