### PR TITLE
fix(api): rate-limit interactive login per account and address

### DIFF
--- a/apps/api/internal/auth/clientaddr_limiter_key_test.go
+++ b/apps/api/internal/auth/clientaddr_limiter_key_test.go
@@ -2,10 +2,11 @@ package auth
 
 // Regression pins for the address the authentication rate limiters key on.
 //
-// Two auth limiters make a DECISION from the requesting address:
+// Three auth limiters make a DECISION from the requesting address:
 //
-//   - reset.go  "pwreset-consume:"+ip  (resetPerMinute)
-//   - twofa.go  "2fa-ip:"+ip           (twoFAIPLockoutPerMinute)
+//   - reset.go   "pwreset-consume:"+ip  (resetPerMinute)
+//   - twofa.go   "2fa-ip:"+ip           (twoFAIPLockoutPerMinute)
+//   - service.go "login-ip:"+ip         (loginIPPerMinute)
 //
 // Both must key on limiterAddr, which selects the entry the infrastructure
 // appended (see proxyHops in handler.go), not on clientAddr, which resolves the
@@ -18,7 +19,7 @@ package auth
 //  2. The registered route — TestResetPasswordRouteKeysOnAppendedClient drives
 //     the real gin route through h.Register into the real Service and the real
 //     limiter, so the wiring is covered and not just the helper.
-//  3. TestDecisionSitesUseLimiterAddr parses the source and pins that all four
+//  3. TestDecisionSitesUseLimiterAddr parses the source and pins that all five
 //     decision sites call limiterAddr. Layer 2 cannot reach the three 2FA sites
 //     without a database (their limiter sits behind a challenge lookup), so
 //     without this a revert of those three would be silent.
@@ -467,7 +468,7 @@ func TestTwoFAPerIPLimiterKeysOnAppendedClient(t *testing.T) {
 
 // decisionSites are the handlers whose address feeds a rate-limit decision.
 var decisionSites = map[string][]string{
-	"handler.go":       {"resetPassword"},
+	"handler.go":       {"resetPassword", "login"},
 	"twofa_handler.go": {"twoFATOTPComplete", "twoFARecoveryComplete", "twoFAWebAuthnFinish"},
 }
 
@@ -536,7 +537,7 @@ func TestDecisionSitesUseLimiterAddr(t *testing.T) {
 		}
 	}
 
-	if checked != 4 {
-		t.Fatalf("checked %d decision sites, want 4; the pin is not covering what it claims", checked)
+	if checked != 5 {
+		t.Fatalf("checked %d decision sites, want 5; the pin is not covering what it claims", checked)
 	}
 }

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -168,7 +168,9 @@ func (h *Handler) login(c *gin.Context) {
 		httpx.Error(c, domain.Validation("invalid_body", "request body is not valid JSON"))
 		return
 	}
-	res, err := h.svc.Login(c.Request.Context(), body.Email, body.Password)
+	// limiterAddr, not clientAddr: Login rate-limits on this value (see the
+	// decision-site pins in clientaddr_limiter_key_test.go).
+	res, err := h.svc.Login(c.Request.Context(), body.Email, body.Password, h.limiterAddr(c))
 	if err != nil {
 		httpx.Error(c, err)
 		return

--- a/apps/api/internal/auth/login_ratelimit_test.go
+++ b/apps/api/internal/auth/login_ratelimit_test.go
@@ -1,0 +1,124 @@
+package auth
+
+// Regression pins for the login brute-force throttle. Interactive login was
+// the sole unthrottled credential endpoint (reset, 2FA and verify-resend all
+// had limiters), leaving password spray and argon2 CPU exhaustion open.
+//
+// The throttle runs BEFORE input validation and the account lookup, which is
+// what lets these tests drive it without a database: an under-cap attempt
+// with an empty password returns a validation error before any repo access,
+// an over-cap attempt returns KindRateLimited. The wiring of the handler's
+// address derivation is pinned by TestDecisionSitesUseLimiterAddr; the
+// behaviour of limiterAddr itself by the tests alongside it.
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"testing"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/autologin"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+func throttleTestService(lim *autologin.MemoryLimiter) *Service {
+	return &Service{limiter: lim, validator: domain.NewValidator()}
+}
+
+func kindOf(t *testing.T, err error) domain.Kind {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("expected a domain error, got %T: %v", err, err)
+	}
+	return de.Kind
+}
+
+func TestLoginPerUserThrottleFires(t *testing.T) {
+	lim := autologin.NewMemoryLimiter()
+	defer lim.Stop()
+	svc := throttleTestService(lim)
+	ctx := context.Background()
+
+	var last error
+	for i := 0; i < loginUserPerMinute+1; i++ {
+		_, last = svc.Login(ctx, "victim@example.com", "", netip.Addr{})
+	}
+	if kind := kindOf(t, last); kind != domain.KindRateLimited {
+		t.Fatalf("attempt %d on one account: kind = %v, want KindRateLimited",
+			loginUserPerMinute+1, kind)
+	}
+}
+
+func TestLoginPerUserThrottleSeparatesAccounts(t *testing.T) {
+	// Over-fire control: exhausting one account's budget must not refuse a
+	// different account (distinct emails get distinct buckets).
+	lim := autologin.NewMemoryLimiter()
+	defer lim.Stop()
+	svc := throttleTestService(lim)
+	ctx := context.Background()
+
+	for i := 0; i < loginUserPerMinute+1; i++ {
+		_, _ = svc.Login(ctx, "victim@example.com", "", netip.Addr{})
+	}
+	_, err := svc.Login(ctx, "bystander@example.com", "", netip.Addr{})
+	if kind := kindOf(t, err); kind != domain.KindValidation {
+		t.Fatalf("other account after victim's budget spent: kind = %v, want KindValidation", kind)
+	}
+}
+
+func TestLoginPerIPThrottleFires(t *testing.T) {
+	// Spraying distinct accounts from one address must trip the per-IP cap
+	// even though no single account reaches the per-user cap.
+	lim := autologin.NewMemoryLimiter()
+	defer lim.Stop()
+	svc := throttleTestService(lim)
+	ctx := context.Background()
+	ip := netip.MustParseAddr("203.0.113.200")
+
+	var last error
+	for i := 0; i < loginIPPerMinute+1; i++ {
+		_, last = svc.Login(ctx, fmt.Sprintf("user%d@example.com", i), "", ip)
+	}
+	if kind := kindOf(t, last); kind != domain.KindRateLimited {
+		t.Fatalf("attempt %d from one address: kind = %v, want KindRateLimited",
+			loginIPPerMinute+1, kind)
+	}
+}
+
+func TestLoginPerIPThrottleSeparatesClients(t *testing.T) {
+	// Over-fire control: distinct addresses get distinct buckets — a second
+	// client is not refused by the first client's spray.
+	lim := autologin.NewMemoryLimiter()
+	defer lim.Stop()
+	svc := throttleTestService(lim)
+	ctx := context.Background()
+
+	for i := 0; i < loginIPPerMinute+1; i++ {
+		_, _ = svc.Login(ctx, fmt.Sprintf("user%d@example.com", i), "", netip.MustParseAddr("203.0.113.200"))
+	}
+	_, err := svc.Login(ctx, "fresh@example.com", "", netip.MustParseAddr("203.0.113.201"))
+	if kind := kindOf(t, err); kind != domain.KindValidation {
+		t.Fatalf("distinct client after spray: kind = %v, want KindValidation", kind)
+	}
+}
+
+func TestLoginZeroIPSkipsPerIPLimit(t *testing.T) {
+	// A zero netip.Addr must skip the per-IP limit (matching
+	// checkCrossChallengeLimits), not key every caller onto one bucket.
+	lim := autologin.NewMemoryLimiter()
+	defer lim.Stop()
+	svc := throttleTestService(lim)
+	ctx := context.Background()
+
+	for i := 0; i < loginIPPerMinute+1; i++ {
+		if _, err := svc.Login(ctx, fmt.Sprintf("user%d@example.com", i), "", netip.Addr{}); err != nil {
+			if kind := kindOf(t, err); kind == domain.KindRateLimited {
+				t.Fatalf("attempt %d with zero addr rate limited; zero addr must skip the per-IP limit", i+1)
+			}
+		}
+	}
+}

--- a/apps/api/internal/auth/service.go
+++ b/apps/api/internal/auth/service.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"log/slog"
 	"net/netip"
 	"strings"
 
@@ -132,11 +133,44 @@ type loginInput struct {
 	Password string `validate:"required"`
 }
 
+// Login brute-force caps, mirroring the 2FA cross-challenge limits (S2).
+// Interactive login was the sole unthrottled credential endpoint: password
+// reset, 2FA and verify-resend were already limited. The per-account cap
+// stops a targeted brute-force; the per-IP cap stops a single host spraying
+// across accounts.
+const (
+	loginUserPerMinute = 10
+	loginIPPerMinute   = 30
+)
+
 // Login verifies an email+password and returns the user with their memberships.
 // It records a login success/failure audit event against the user's first
 // tenant (failures with no resolvable tenant are not chained to any tenant).
-func (s *Service) Login(ctx context.Context, email, password string) (LoginResult, error) {
+func (s *Service) Login(ctx context.Context, email, password string, ip netip.Addr) (LoginResult, error) {
 	email = normalizeEmail(email)
+
+	// Brute-force throttle, checked before validation, the account lookup and
+	// the argon2 verify, so a spray burns neither CPU nor DB round-trips. Keyed
+	// on the submitted email whether or not the account exists — the 429 must
+	// not leak account existence. ip may be a zero netip.Addr (limit skipped
+	// for IP), matching checkCrossChallengeLimits.
+	if s.limiter != nil {
+		if ok, _ := s.limiter.Allow(ctx, "login-user:"+email, loginUserPerMinute); !ok {
+			return LoginResult{}, domain.RateLimited("too_many_attempts", "too many login attempts; wait before trying again")
+		}
+		if ip.IsValid() {
+			if ok, _ := s.limiter.Allow(ctx, "login-ip:"+ip.String(), loginIPPerMinute); !ok {
+				// Logged because the refusal is otherwise invisible (see the
+				// matching 2FA per-address limit): if the address this keys on
+				// ever stops distinguishing callers, every login in the fleet
+				// is refused and this line is the only thing that says so.
+				slog.WarnContext(ctx, "login per-address rate limited",
+					"key", "login-ip", "addr", ip.String(), "limit_per_minute", loginIPPerMinute)
+				return LoginResult{}, domain.RateLimited("too_many_attempts", "too many requests from this address; wait before trying again")
+			}
+		}
+	}
+
 	if err := s.validator.Struct(loginInput{Email: email, Password: password}); err != nil {
 		return LoginResult{}, err
 	}

--- a/apps/api/tests/account_settings_test.go
+++ b/apps/api/tests/account_settings_test.go
@@ -8,6 +8,7 @@ package tests
 
 import (
 	"context"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -171,7 +172,7 @@ func TestChangePassword(t *testing.T) {
 			t.Fatalf("ChangePassword: %v", err)
 		}
 		// Verify new password works at login.
-		res, err := svc.Login(ctx, "pwchange@example.com", newPwd)
+		res, err := svc.Login(ctx, "pwchange@example.com", newPwd, netip.Addr{})
 		if err != nil {
 			t.Fatalf("login with new password: %v", err)
 		}
@@ -179,7 +180,7 @@ func TestChangePassword(t *testing.T) {
 			t.Fatal("login returned unexpected user")
 		}
 		// Old password should no longer work.
-		if _, err := svc.Login(ctx, "pwchange@example.com", originalPwd); err == nil {
+		if _, err := svc.Login(ctx, "pwchange@example.com", originalPwd, netip.Addr{}); err == nil {
 			t.Fatal("old password should no longer be valid")
 		}
 	})

--- a/apps/api/tests/auth_first_run_ownership_integration_test.go
+++ b/apps/api/tests/auth_first_run_ownership_integration_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"net/netip"
 	"strings"
 	"sync"
 	"testing"
@@ -181,7 +182,7 @@ func TestFirstRunOwnership_CorrectClaimStillWorks(t *testing.T) {
 
 	// The session-issuing half of the existing behaviour: the owner can log in
 	// immediately, with no verification step.
-	if _, err := svc.Login(ctx, "owner@example.com", "a-very-strong-password"); err != nil {
+	if _, err := svc.Login(ctx, "owner@example.com", "a-very-strong-password", netip.Addr{}); err != nil {
 		t.Fatalf("owner login after bootstrap: %v", err)
 	}
 

--- a/apps/api/tests/auth_integration_test.go
+++ b/apps/api/tests/auth_integration_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	"github.com/google/uuid"
@@ -52,7 +53,7 @@ func TestBootstrapAndLogin(t *testing.T) {
 	}
 
 	// Login success.
-	login, err := svc.Login(ctx, "owner@example.com", "a-very-strong-password")
+	login, err := svc.Login(ctx, "owner@example.com", "a-very-strong-password", netip.Addr{})
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}
@@ -61,14 +62,14 @@ func TestBootstrapAndLogin(t *testing.T) {
 	}
 
 	// Login failure: wrong password.
-	if _, err := svc.Login(ctx, "owner@example.com", "wrong"); err == nil {
+	if _, err := svc.Login(ctx, "owner@example.com", "wrong", netip.Addr{}); err == nil {
 		t.Fatal("login with wrong password should fail")
 	} else if de, ok := domain.AsDomain(err); !ok || de.Kind != domain.KindUnauthorized {
 		t.Fatalf("want unauthorized, got %v", err)
 	}
 
 	// Login failure: unknown user (must not reveal existence).
-	if _, err := svc.Login(ctx, "nobody@example.com", "whatever"); err == nil {
+	if _, err := svc.Login(ctx, "nobody@example.com", "whatever", netip.Addr{}); err == nil {
 		t.Fatal("login with unknown user should fail")
 	} else if de, ok := domain.AsDomain(err); !ok || de.Kind != domain.KindUnauthorized {
 		t.Fatalf("want unauthorized, got %v", err)

--- a/apps/api/tests/social_writes_integration_test.go
+++ b/apps/api/tests/social_writes_integration_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	"github.com/google/uuid"
@@ -328,7 +329,7 @@ func TestSocialSignInDoesNotMintAnOrgDuringTheDeleteGraceWindow(t *testing.T) {
 	// now (the first-run call set one), so this is the stronger form of the
 	// original check: the two paths are compared on the same account, and both
 	// must report zero visible memberships rather than one merely failing.
-	pw, lerr := svc.Login(ctx, "sarah@acme.com", "a-very-strong-password")
+	pw, lerr := svc.Login(ctx, "sarah@acme.com", "a-very-strong-password", netip.Addr{})
 	if lerr != nil {
 		t.Fatalf("password login: %v", lerr)
 	}


### PR DESCRIPTION
`POST /auth/login` was the sole unthrottled credential endpoint — password reset (5/10 per min), 2FA (10/user + 30/IP per min) and verify-resend are all limited, but interactive login had no cap. An install reachable without an upstream rate-limiting proxy allows unbounded password spray, and each attempt costs an argon2 verification (CPU DoS).

This adds the same throttle shape 2FA uses (`checkCrossChallengeLimits`), inside `Service.Login`:

- `login-user:<email>` at 10/min — keyed on the submitted email whether or not the account exists, so the 429 cannot be used for account enumeration.
- `login-ip:<limiterAddr>` at 30/min — logged on refusal, like the 2FA per-address limit, since the refusal is otherwise invisible.

The throttle runs before validation, the account lookup and the argon2 verify, so a spray burns neither CPU nor DB round-trips. The handler passes `limiterAddr(c)` (never `clientAddr`), and the login site is added to the `decisionSites` AST pin (now 5 sites) — flipping it to `clientAddr` fails `TestDecisionSitesUseLimiterAddr` (verified).

Uses the existing `autologin.MemoryLimiter` already wired via `SetMailer` at boot, so production gets the limiter unconditionally; a nil limiter (tests) skips, matching reset/2FA. Same per-replica caveat as the existing limiters. `Service.Login` gained an `ip netip.Addr` parameter; the five integration-test call sites are updated.

**Tests:** `login_ratelimit_test.go` — per-user fires / separates accounts, per-IP fires / separates clients, zero-addr skips per-IP. Build/vet/unit tests green (CI-equivalent set), including `./tests/contract`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
