### PR TITLE
release: 0.61.161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+## [0.61.161] - 2026-09-10
+
+### Security
+
+- The marketing site's `next` dependency is upgraded from 16.2.11 to 16.3.4, closing two published critical advisories, including an unauthenticated remote code execution in the image optimization API. `sharp` and `js-yaml` are also upgraded, closing three published high-severity advisories. Anyone self-hosting the marketing site should update.
+- The manual site-create path now only accepts http and https URLs. It previously accepted any URL scheme a generic validator allowed, so a non-http(s) URL could be stored and later rendered as a link in a client portal. This is not the path a normal install uses to add a site.
+- The agent's `file_mkdir` command now re-checks path containment for a directory that does not yet exist, matching every sibling write command, which already did this check. Previously, a signed command combined with a pre-existing symlink could create a directory outside the WordPress root.
+- Container hardening: Linux capabilities are dropped and privilege escalation is forbidden across the services in `infra/docker-compose.yml`, with nginx keeping only the capabilities it needs.
+
+Thanks to Ines Opifanti (GitHub `wildfang`) for a private security review that found the URL scheme, `file_mkdir` containment, and container capability issues above, reported and fixed in coordination.
+
+### Fixed
+
+- Corrected documentation and marketing copy that claimed backups are encrypted client side before upload. Shipped builds do not perform this encryption; the claim has been removed from the README, SECURITY.md, the docs, the marketing site, the privacy page, and the legal security policy.
+
 ## [0.61.160] - 2026-09-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Thanks to Ines Opifanti (GitHub `wildfang`) for a private security review that f
 
 ### Fixed
 
-- Corrected documentation and marketing copy that claimed backups are encrypted client side before upload. Shipped builds do not perform this encryption; the claim has been removed from the README, SECURITY.md, the docs, the marketing site, the privacy page, and the legal security policy.
+- Corrected documentation, marketing copy, and the dashboard that claimed backups are encrypted client side before upload. Shipped builds do not perform this encryption; the claim has been removed from the README, SECURITY.md, the docs, the marketing site, the dashboard (including the sign-in screen and the backups screen), the privacy pages, and the legal security policy (#723, #724, #729).
+- The dashboard's own backup progress indicator repeated the same false claim live: it labeled a real backup run's upload phase "Encrypting" while nothing was being encrypted. The label now describes what is actually happening (#729).
 
 ## [0.61.160] - 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WPMgr lets you enroll, monitor, update, back up, and secure a fleet of WordPress
 </p>
 
 <!-- wpmgr-install-pins:start (the version below is a required pin; scripts/check-version-surfaces.sh keeps it current) -->
-**v0.61.160**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
+**v0.61.161**: open-source and production-usable for self-hosters. The agent plugin is reviewed and listed in the [WordPress.org plugin directory](https://wordpress.org/plugins/fleet-agent-site-manager/).
 <!-- wpmgr-install-pins:end -->
 
 ---
@@ -316,15 +316,15 @@ The control plane, dashboard, and media encoder are published on GitHub Containe
 <!-- wpmgr-install-pins:start (required pins; scripts/check-version-surfaces.sh keeps them current) -->
 
 ```bash
-docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.160
-docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.160
-docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.160
+docker pull ghcr.io/mosamlife/wpmgr-api:v0.61.161
+docker pull ghcr.io/mosamlife/wpmgr-web:v0.61.161
+docker pull ghcr.io/mosamlife/wpmgr-media-encoder:v0.61.161
 ```
 
 Or bring up the whole stack from the published images (no local build) with the pull-only Compose overlay:
 
 ```bash
-export WPMGR_VERSION=v0.61.160   # omit to track :latest
+export WPMGR_VERSION=v0.61.161   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,7 +305,7 @@ quickstart or a clone), bring up the stack with the pull-only overlay:
 <!-- wpmgr-install-pins:start (required pin; scripts/check-version-surfaces.sh keeps it current) -->
 
 ```bash
-export WPMGR_VERSION=v0.61.160   # omit to track :latest
+export WPMGR_VERSION=v0.61.161   # omit to track :latest
 docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml up -d
 ```
 

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: WPMgr API
-  version: 0.61.160
+  version: 0.61.161
   description: |
     Control-plane REST API for **WPMgr**, the open-source, self-hostable
     WordPress fleet management platform (AGPL-3.0). One control plane enrolls,


### PR DESCRIPTION
## Summary

Version-surface bump for 0.61.161, catching the CHANGELOG and install pins up to a marketing image deploy already in flight ahead of this PR.

- `CHANGELOG.md`: `[Unreleased]` -> `## [0.61.161] - 2026-09-10`, bare `[Unreleased]` heading left behind.
- `packages/openapi/openapi.yaml`: `info.version` 0.61.160 -> 0.61.161.
- `README.md`: the three GHCR pull tags, the `WPMGR_VERSION` export, and the status line inside the `wpmgr-install-pins` regions.
- `docs/install.md`: the `WPMGR_VERSION` export.
- Agent version **unchanged** at 0.61.148 (no agent change in this release), so the marketing hero badge (`AGENT_VERSION` in `apps/marketing/lib/content/home.ts`) is untouched, correctly.

**Not touched, on purpose:** `apps/marketing/app/(marketing)/changelog/page.tsx`. The docs-changelog SOP's release checklist calls for a curated entry there, but this PR's scope was explicitly "do not modify code under `apps/`," and that page is `frontend-architect`'s routed path, not `docs-writer`'s. `check-versions` still passes because the marketing changelog page is 1 release behind the new CHANGELOG top entry, well inside its 5-release tolerance. Flagging this as a real gap for a follow-up, not a silent skip.

## What's in this release

- **#726 (the important one):** `next` 16.2.11 -> 16.3.4, closing two published critical advisories in a dependency, one of them an unauthenticated remote code execution in the image optimization API. `sharp` and `js-yaml` also raised, closing three published high advisories. Anyone self-hosting the marketing site should update.
- **#716:** the manual site-create path now only accepts http and https URLs, closing a stored-link risk on that path.
- **#717:** the agent's `file_mkdir` command now re-checks path containment for a not-yet-existing path, matching its sibling write commands.
- **#720:** container hardening in `infra/docker-compose.yml` (capabilities dropped, privilege escalation forbidden, nginx keeps only what it needs).
- **#723 / #724:** documentation and marketing copy corrected: backups are not encrypted client side in shipped builds.

Thanks to Ines Opifanti (GitHub `wildfang`) for the private security review behind #716, #717, and #720.

## Gate results

- `make check-versions-test`: exit 0 (76 passed, 0 failed)
- `make check-versions`: exit 0, "Version surfaces are consistent."
- `node apps/marketing/scripts/check-copy.mjs`: exit 0
- Docs vocabulary check (copied verbatim from `ci.yml` this turn): exit 0, no output

## What this PR does NOT do

- Does not create the git tag or publish anything. The owner's standing order is that the tag comes last, after the deploy already in flight and after QA.
- Does not touch any generated tree.
- Does not modify agent code or bump the agent version.

## Test plan

- [ ] CI green on this PR (Docs vocabulary check, commit-hygiene, version-surfaces guard, marketing copy check)
- [ ] Owner confirms the marketing image deploy (closing the live vulnerability) has landed
- [ ] Merge, then continue the release: deploy, QA, tag last

🤖 Generated with [Claude Code](https://claude.com/claude-code)