### PR TITLE
feat(auth): login admission measurement and verify concurrency bound (Phase 0 of #718)

### DIFF
--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -2823,6 +2823,26 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	if err := authH.SetHandshakeSecret(cfg.Auth.SessionSecret); err != nil {
 		return fmt.Errorf("social handshake key: %w", err)
 	}
+	// GH #718 Phase 0 — login admission control. Fatal on a bad mode rather
+	// than a fallback: "observe" and "off" are not the same thing, and an
+	// operator who typed the mode wrong must find out here and not from an
+	// endpoint that quietly stopped measuring.
+	loginMode, err := auth.ParseLoginMode(cfg.Auth.LoginMode)
+	if err != nil {
+		return err
+	}
+	// 0 takes the default bound, which is derived from GOMAXPROCS; see
+	// auth.defaultVerifyConcurrency.
+	loginGate, err := auth.NewLoginGate(cfg.Auth.SessionSecret, loginMode, 0)
+	if err != nil {
+		return fmt.Errorf("login admission control: %w", err)
+	}
+	loginGate.SetLogger(logger)
+	loginGate.StartModeReminder(ctx)
+	authH.SetLoginGate(loginGate)
+	// Unconditional, and it names whether the wiring above actually happened.
+	// See LogAdmissionStartup for why that is worth a line of its own.
+	authH.LogAdmissionStartup(logger)
 	authH.SetHosted(cfg.Hosted.Enabled)
 	// M16 Phase B: Me.managed_storage_allowed. billingSvc.ManagedStorageAllowed
 	// no-ops to true when WPMGR_HOSTED is off, so this wiring is safe to leave

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -208,9 +208,22 @@ func (h *Handler) login(c *gin.Context) {
 	defer releaseVerify()
 
 	res, err := h.svc.Login(c.Request.Context(), body.Email, body.Password)
-	// The argon2id verification is over by here, whatever the outcome. Hand the
-	// slot back before the session store and the trusted-device lookups, so the
-	// bound stays a bound on CPU and not on the whole handler.
+	// Hand the slot back before the session store and the trusted-device
+	// lookups below, which are the rest of this handler.
+	//
+	// WHAT THIS BOUNDS, EXACTLY. The slot is held across the WHOLE of
+	// Service.Login, and that includes GetUserByEmail and
+	// ListMembershipsForUser, not just the argon2id verification. So this is a
+	// bound on concurrent Service.Login calls, not a pure CPU bound, and the
+	// consequence is worth stating rather than discovering: a slow database
+	// makes every login hold its slot for longer, and the endpoint starts
+	// answering 503 on latency it did not cause.
+	//
+	// That is the intended trade. Shedding early under a database stall is
+	// better than piling every login attempt onto a struggling database and
+	// holding 19 MiB of argon2id state per queued attempt while doing it. But
+	// it means a 503 here does not prove CPU saturation, and an operator
+	// diagnosing one should look at database latency too.
 	releaseVerify()
 	if err != nil {
 		httpx.Error(c, err)

--- a/apps/api/internal/auth/handler.go
+++ b/apps/api/internal/auth/handler.go
@@ -68,6 +68,11 @@ type Handler struct {
 	// session record. NOT optional in effect: unset makes socialStart refuse
 	// rather than issue a handshake nobody signed. See social_handshake.go.
 	handshake *handshakeCodec
+	// loginGate is the GH #718 Phase 0 login admission control: it measures the
+	// per-source and per-account budgets without applying them, and bounds how
+	// many argon2id verifications run at once. Unset removes BOTH, which is a
+	// wiring failure and not a mode — LogAdmissionStartup says so at boot.
+	loginGate *LoginGate
 }
 
 // NewHandler builds an auth Handler.
@@ -168,7 +173,45 @@ func (h *Handler) login(c *gin.Context) {
 		httpx.Error(c, domain.Validation("invalid_body", "request body is not valid JSON"))
 		return
 	}
+
+	// GH #718 Phase 0 — login admission control.
+	//
+	// Placed here, and not inside Service.Login, for two reasons. It has to run
+	// BEFORE any account lookup so it cannot branch on whether the account
+	// exists (that is what keeps it from becoming an enumeration oracle), and
+	// Service.Login's signature has to stay exactly as it is because seven
+	// service-level tests call it directly.
+	//
+	// Observe measures and returns nothing. AcquireVerify is the only part that
+	// can change what the caller sees, and only when this process already has
+	// as many password verifications in flight as it is willing to run.
+	addr, fromChain := h.limiterAddrSource(c)
+	h.loginGate.Observe(c.Request.Context(), loginAttempt{
+		Addr:      addr,
+		FromChain: fromChain,
+		Hops:      h.effectiveProxyHops(),
+		Email:     body.Email,
+	})
+
+	releaseVerify, admitted := h.loginGate.AcquireVerify(c.Request.Context())
+	if !admitted {
+		// Saturation, not a limit: no account was looked at and nothing about
+		// this caller decided it. Retry-After is short because the condition it
+		// describes clears in the time one verification takes.
+		c.Header("Retry-After", "2")
+		httpx.Error(c, domain.ServiceUnavailable("server_busy", "server is busy verifying sign-ins; retry shortly"))
+		return
+	}
+	// Idempotent, so the explicit release below can free the slot before the
+	// session and two-factor work that follows a successful verify, while this
+	// still covers every path that returns first.
+	defer releaseVerify()
+
 	res, err := h.svc.Login(c.Request.Context(), body.Email, body.Password)
+	// The argon2id verification is over by here, whatever the outcome. Hand the
+	// slot back before the session store and the trusted-device lookups, so the
+	// bound stays a bound on CPU and not on the whole handler.
+	releaseVerify()
 	if err != nil {
 		httpx.Error(c, err)
 		return
@@ -660,14 +703,40 @@ func (h *Handler) effectiveProxyHops() int {
 // keeps a key per request. Only a correct hop count, matching what actually sits
 // in front, makes this sound.
 func (h *Handler) limiterAddr(c *gin.Context) netip.Addr {
+	addr, _ := h.limiterAddrSource(c)
+	return addr
+}
+
+// limiterAddrSource returns exactly what limiterAddr returns, plus whether that
+// address was read FROM THE FORWARDED CHAIN at the configured hop position
+// (true) or came from the peer-address fallback (false).
+//
+// The flag grades a degraded address. It is not itself a decision, and Phase 0
+// only logs it, but it is the signal that distinguishes the two ways an address
+// arrives, which the caller-visible behaviour cannot:
+//
+//   - hops > 0 and fromChain=false means the chain was SHORTER than
+//     WPMGR_AUTH_PROXY_HOPS claims. Either the hop count is wrong or this
+//     process is reachable without the proxies it is configured for. Every
+//     affected client collapses onto one key, and an enforcing phase would
+//     refuse them together. An operator cannot see this from inside the
+//     process any other way, which is why it is logged.
+//   - hops == 0 also reports false, because nothing was read from a chain —
+//     but there is nothing degraded about it: the peer address IS the
+//     configured source in that topology. loginAttempt.addrSource is where the
+//     two are told apart, using the hop count.
+//
+// limiterAddr's own return and behaviour are unchanged, so every existing
+// caller is unaffected.
+func (h *Handler) limiterAddrSource(c *gin.Context) (netip.Addr, bool) {
 	hops := h.effectiveProxyHops()
 	if hops == 0 {
 		// Nothing in front appends, so every forwarded entry is caller-supplied
 		// and none of it is evidence. The peer address is the client.
 		if addr, ok := parseForwardedAddr(c.RemoteIP()); ok {
-			return addr
+			return addr, false
 		}
-		return netip.Addr{}
+		return netip.Addr{}, false
 	}
 	// Values, not Get. Get returns only the FIRST header line, so a caller that
 	// sends X-Forwarded-For twice would have the appended entries land on a line
@@ -678,13 +747,13 @@ func (h *Handler) limiterAddr(c *gin.Context) netip.Addr {
 	parts := strings.Split(joined, ",")
 	if len(parts) >= hops {
 		if addr, ok := parseForwardedAddr(parts[len(parts)-hops]); ok {
-			return addr
+			return addr, true
 		}
 	}
 	if addr, ok := parseForwardedAddr(c.RemoteIP()); ok {
-		return addr
+		return addr, false
 	}
-	return netip.Addr{}
+	return netip.Addr{}, false
 }
 
 // parseForwardedAddr parses one forwarded-chain entry. Entries are usually bare

--- a/apps/api/internal/auth/login_gate.go
+++ b/apps/api/internal/auth/login_gate.go
@@ -112,7 +112,24 @@ func ParseLoginMode(s string) (LoginMode, error) {
 	case LoginModeObserve:
 		return LoginModeObserve, nil
 	case LoginModeEnforce:
-		return LoginModeEnforce, nil
+		// PHASE 0 REFUSES THIS, AND THAT IS THE POINT.
+		//
+		// Observe evaluates every budget and refuses nothing — it returns no
+		// verdict, so there is nothing a handler could act on. Accepting
+		// "enforce" therefore bought an operator three things at once: a boot
+		// line asserting budgets_enforced=true, a StartModeReminder that
+		// short-circuits and stops warning, and no enforcement whatsoever. A
+		// switch that silences the warning without doing the work is worse
+		// than no switch, and worst of all during the incident someone flips
+		// it in.
+		//
+		// So the mode is refused HERE, at the one place a configured string
+		// becomes a mode, rather than described as unfinished somewhere a
+		// reader has to find. Phase 1 deletes this branch in the same change
+		// that makes Observe act on its verdict; until then the state that
+		// could lie about itself does not exist. TestStartupLineCannotClaim
+		// EnforcementItDoesNotDo is the guard that keeps the two together.
+		return "", fmt.Errorf("%s=%q is not available yet: login budgets are measured but not applied (GH #718 Phase 0). Use %q, or leave the variable unset", LoginModeEnvVar, s, LoginModeObserve)
 	default:
 		return "", fmt.Errorf("%s: %q is not a mode; use %q or %q", LoginModeEnvVar, s, LoginModeObserve, LoginModeEnforce)
 	}
@@ -159,6 +176,16 @@ const (
 	// still running would be handed back full, which resets the very budget it
 	// is recording.
 	loginBucketIdle = 30 * time.Minute
+
+	// loginOverLogEvery re-states a scope that is STILL over budget once every
+	// this many further attempts, on top of the line its first crossing wrote.
+	// Without it a scope that goes over stays over for the rest of the window
+	// and writes a line per request forever: measured at ~346 bytes and one
+	// synchronous write per attempt, on the unauthenticated path, where the
+	// pre-change code wrote nothing. A first crossing plus a periodic repeat
+	// carries the same distribution at a bounded cost, and the repeat count is
+	// on the line so the volume is not lost either.
+	loginOverLogEvery = 100
 
 	// loginModeReminderEvery is how often a non-enforce mode announces itself.
 	// A kill switch flipped during an incident is forgotten when nothing keeps
@@ -312,6 +339,13 @@ type verdict struct {
 	limit      int
 	retryAfter time.Duration
 	overBudget bool
+	// worthLogging is set on the first attempt that finds this key over budget
+	// and every loginOverLogEvery-th one after it. See loginOverLogEvery.
+	worthLogging bool
+	// overCount is how many attempts have found this key over budget since it
+	// last had budget. Carried onto the line so a suppressed run is still
+	// countable.
+	overCount int
 }
 
 // Observe evaluates every budget for one attempt and logs what a later phase
@@ -386,6 +420,9 @@ func (g *LoginGate) Observe(ctx context.Context, a loginAttempt) {
 	// No email here, by construction: acctH is what identifies the account, and
 	// the raw address is not carried past AccountDigest.
 	for _, v := range over {
+		if !v.worthLogging {
+			continue
+		}
 		g.log().InfoContext(ctx, "login admission: would refuse (observe mode; request was admitted)",
 			"mode", string(g.mode),
 			"scope", v.scope,
@@ -394,6 +431,8 @@ func (g *LoginGate) Observe(ctx context.Context, a loginAttempt) {
 			"window", loginWindow.String(),
 			"retry_after_seconds", int(v.retryAfter.Round(time.Second).Seconds()),
 			"acct_h", acctH,
+			"over_budget_attempts", v.overCount,
+			"log_sampling", fmt.Sprintf("first crossing, then 1 in %d", loginOverLogEvery),
 			"addr_source", a.addrSource(),
 			"proxy_hops", a.Hops,
 			"enforced", false,
@@ -522,6 +561,12 @@ func (h *Handler) LogAdmissionStartup(logger *slog.Logger) {
 	}
 	attrs = append(attrs,
 		"mode", string(g.mode),
+		// Not a promise: ParseLoginMode is the only way a configured string
+		// becomes a mode, and it refuses every mode that would make this true
+		// while Observe still refuses nothing.
+		// TestStartupLineCannotClaimEnforcementItDoesNotDo drives real requests
+		// through the real handler for every mode ParseLoginMode accepts and
+		// fails if this field and the observed behaviour ever disagree.
 		"budgets_enforced", g.mode == LoginModeEnforce,
 		"window", loginWindow.String(),
 		loginScopePair, loginPairBudget,
@@ -596,6 +641,10 @@ type keyedBudget struct {
 type loginBucket struct {
 	lim  *rate.Limiter
 	seen time.Time
+	// overCount counts consecutive over-budget findings, and resets the moment
+	// the key is charged again (which only happens when it has budget). It
+	// drives the logging latch, never a decision.
+	overCount int
 }
 
 func newKeyedBudget(scope string, limit int) *keyedBudget {
@@ -628,18 +677,41 @@ func (b *keyedBudget) query(key string, now time.Time) verdict {
 	if wait := budgetShortfall(bk.lim, now); wait > 0 {
 		v.overBudget = true
 		v.retryAfter = wait
+		bk.overCount++
+		v.overCount = bk.overCount
+		// First crossing, then one line per loginOverLogEvery attempts.
+		v.worthLogging = bk.overCount == 1 || bk.overCount%loginOverLogEvery == 0
 	}
 	return v
 }
 
-// charge takes one token. It is only ever reached after every scope's query
-// returned overBudget=false at the same instant, and TokensAt cannot fall
-// between the two under this mutex, so the token is guaranteed to be there.
+// charge takes one token, and resets the logging latch because a key with a
+// token to spare is by definition no longer over budget.
+//
+// WHAT THE LOCKING ACTUALLY GUARANTEES, which is less than it may look.
+//
+// query and charge are SEPARATE lock regions; the mutex is released between
+// them. So two concurrent attempts can both see the last token in query and
+// both call charge, and the loser's AllowN returns false. That result is
+// discarded here.
+//
+// The error is therefore a silent UNDERCOUNT — a token that was observed as
+// available by two attempts is spent once — and never an overshoot: AllowN
+// cannot hand out a token the bucket does not hold. Undercounting is the safe
+// direction for Phase 0 (a budget reads as slightly less consumed than it was,
+// so this phase under-reports rather than invents crossings) and it stays the
+// safe direction in Phase 1, where it can only admit a request at the boundary
+// and never refuse one that had budget.
+//
+// Do not upgrade this comment into a claim of atomicity without first making
+// query and charge one locked region. A future reader deciding an enforcement
+// path is exact because "the mutex covers it" would be wrong.
 func (b *keyedBudget) charge(key string, now time.Time) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if bk, ok := b.buckets[key]; ok {
 		bk.lim.AllowN(now, 1)
+		bk.overCount = 0
 	}
 }
 

--- a/apps/api/internal/auth/login_gate.go
+++ b/apps/api/internal/auth/login_gate.go
@@ -1,0 +1,776 @@
+package auth
+
+import (
+	"context"
+	"crypto/hkdf"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"runtime"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// ---------------------------------------------------------------------------
+// Login admission control — PHASE 0 (GH #718).
+//
+// WHAT THIS PHASE DOES AND DOES NOT DO.
+//
+// POST /auth/login admits every attempt it is given, and each admitted attempt
+// runs a full argon2id verification at the 19 MiB profile (passwordParams, see
+// password.go). Phase 0 adds two things and deliberately nothing else:
+//
+//  1. MEASUREMENT. Every key a later phase would key a refusal on is computed
+//     here, and every budget is evaluated here, but no attempt is refused and
+//     no budget is charged on a would-refuse. The point is to learn the real
+//     distribution before choosing numbers, rather than to guess them. The
+//     mode is WPMGR_AUTH_LOGIN_MODE and it defaults to "observe".
+//
+//  2. A CONCURRENCY BOUND on the password verification itself, which DOES
+//     enforce from day one. It is not a rate limit and it is not keyed on
+//     anything the caller controls: it sheds only when more verifications are
+//     already in flight than this process is willing to run at once. That is
+//     saturation, which is observable without any prior measurement, so it
+//     needs no observation period behind it.
+//
+// WHY THE IDENTITY-KEYED BUDGETS ARE NOT ENFORCED YET.
+//
+// An earlier attempt keyed a bucket on the submitted email alone. Anyone who
+// knew an address could then spend that address's budget and lock its owner
+// out of their own account — the limiter became the denial of service. The
+// budgets below are shaped to avoid that (the pair scope is the tight one, the
+// account scope is loose and exists to catch a distributed attempt), but which
+// numbers are safe is an empirical question. Phase 1 answers it with the lines
+// this file emits.
+//
+// WHAT OBSERVATION MUST NOT COST.
+//
+// This runs on an UNAUTHENTICATED endpoint, before any account lookup, so it
+// must be invisible to the caller:
+//
+//   - It never branches on whether an account exists. It runs before
+//     Service.Login and therefore before GetUserByEmail; it is handed an email
+//     string and nothing else, and it cannot tell a real address from a
+//     fabricated one. There is no new enumeration oracle here because there is
+//     nothing here that knows the answer.
+//   - It changes no status, no body and no header in observe mode.
+//   - It never logs an email address. The account scope is identified by
+//     acctH, a keyed digest, exactly as reset.go and twofa.go identify an
+//     account in a log line without naming it.
+//
+// WHY THE EMAIL IS DIGESTED RATHER THAN USED AS A KEY.
+//
+// loginInput.Email carries `validate:"required,email"` with no max length, and
+// no auth route installs a MaxBytesReader, so the submitted address is
+// attacker-sized. A raw email map key would let a caller choose how much memory
+// each of its attempts retains. acctH is 16 hex characters whatever was
+// submitted, so the map's memory is a function of its entry count alone, and
+// that count is capped.
+//
+// The digest is keyed with a process key derived from the instance session
+// secret via HKDF under its own info string, following newHandshakeCodec
+// (social_handshake.go:127-146) and obeying the rule stated at :80-83 there:
+// two purposes never share one derived key. Keying it matters — an unkeyed
+// hash of an email address is reversible by anyone with a word list, which
+// would put the address back in the log in all but name.
+// ---------------------------------------------------------------------------
+
+// LoginMode selects what the gate does with its own verdict.
+type LoginMode string
+
+const (
+	// LoginModeObserve evaluates every budget and refuses nothing. Phase 0's
+	// default and, until Phase 1 lands, the only mode with numbers behind it.
+	LoginModeObserve LoginMode = "observe"
+
+	// LoginModeEnforce is Phase 1's mode. It is accepted here so the switch
+	// exists and is testable, and it is NOT reachable by accident: it has to be
+	// asked for by name in WPMGR_AUTH_LOGIN_MODE.
+	LoginModeEnforce LoginMode = "enforce"
+)
+
+// LoginModeEnvVar is the variable that selects the mode. Named as a constant so
+// the startup line, the periodic reminder and the config layer cannot drift
+// apart on its spelling.
+const LoginModeEnvVar = "WPMGR_AUTH_LOGIN_MODE"
+
+// ParseLoginMode converts the configured string. An empty value is the default
+// rather than an error, so an install that has never heard of this variable
+// boots in observe. Anything else is refused rather than silently coerced: a
+// typo'd mode must not read as "the safe one" in Phase 0 and then as "off" in
+// Phase 1.
+func ParseLoginMode(s string) (LoginMode, error) {
+	switch LoginMode(s) {
+	case "":
+		return LoginModeObserve, nil
+	case LoginModeObserve:
+		return LoginModeObserve, nil
+	case LoginModeEnforce:
+		return LoginModeEnforce, nil
+	default:
+		return "", fmt.Errorf("%s: %q is not a mode; use %q or %q", LoginModeEnvVar, s, LoginModeObserve, LoginModeEnforce)
+	}
+}
+
+const (
+	// loginGateKeyInfo separates the account-digest key from every other use of
+	// the session secret. See social_handshake.go:80-83.
+	loginGateKeyInfo = "wpmgr/login-gate/account-digest/v1"
+
+	// loginWindow is the window every budget below is expressed over.
+	loginWindow = 15 * time.Minute
+
+	// loginPairBudget is the tight one: this source, this account. A person
+	// mistyping their own password from their own machine does not reach 10 in
+	// a quarter of an hour; a guessing run reaches it immediately.
+	loginPairBudget = 10
+
+	// loginSrcBudget is per source address across all accounts. Sized for a
+	// shared egress (an office, a mobile carrier NAT) rather than for one
+	// person, which is why it is six times the pair budget.
+	loginSrcBudget = 60
+
+	// loginSrc48Budget is per IPv6 /48 across all accounts. An IPv6 client is
+	// routinely handed a /64 and often a /48, so a per-/64 budget alone is a
+	// budget the client can multiply by moving a bit. This is the scope that
+	// makes the v6 numbers mean anything.
+	loginSrc48Budget = 240
+
+	// loginAcctBudget is per account across all sources. Deliberately loose: in
+	// Phase 1 this is the scope that could be turned into a denial of service
+	// against a named person, so it exists to catch a distributed run against
+	// one account, not to police one person's typing.
+	loginAcctBudget = 50
+
+	// loginBucketCap bounds each scope's map so a caller varying its key cannot
+	// grow it without limit. Mirrors registerPeerCap
+	// (internal/mcp/register_limit.go:96-100). Reaching it is a memory bound
+	// being enforced, not an error.
+	loginBucketCap = 4096
+
+	// loginBucketIdle is how long an untouched bucket survives a sweep. It is
+	// deliberately longer than loginWindow: a bucket swept while its window is
+	// still running would be handed back full, which resets the very budget it
+	// is recording.
+	loginBucketIdle = 30 * time.Minute
+
+	// loginModeReminderEvery is how often a non-enforce mode announces itself.
+	// A kill switch flipped during an incident is forgotten when nothing keeps
+	// saying it is flipped.
+	loginModeReminderEvery = 5 * time.Minute
+)
+
+// Scope names. These are the strings a Phase 1 refusal would be attributed to
+// and the strings the observation lines carry, so they are declared once.
+const (
+	loginScopePair  = "login:pair"
+	loginScopeSrc   = "login:src"
+	loginScopeSrc48 = "login:src48"
+	loginScopeAcct  = "login:acct"
+)
+
+// addrUnresolved is the reserved key for an attempt whose source address could
+// not be resolved at all. Such attempts share one bucket rather than being
+// skipped: "we could not identify the source" must never be the cheapest way
+// to be admitted. Note for Phase 1 — enforcing on this shared key is a
+// deliberate decision to make, not a default to inherit, because a topology
+// that resolves no addresses would put the entire fleet in it.
+const addrUnresolved = "\x00unresolved"
+
+// loginAttempt is what the handler hands the gate. It is everything the gate is
+// allowed to know, which is deliberately less than the handler knows: no user
+// id, no account existence, no password, no request body beyond the address
+// that was submitted as the identity.
+type loginAttempt struct {
+	// Addr is limiterAddr's result: the address a rate-limit DECISION may be
+	// keyed on. Invalid when it could not be resolved.
+	Addr netip.Addr
+	// FromChain reports whether Addr was read from the forwarded chain at the
+	// configured hop position. See Handler.limiterAddrSource.
+	FromChain bool
+	// Hops is the effective proxy hop count, needed only to describe how Addr
+	// was obtained in the log line.
+	Hops int
+	// Email is the address as submitted. It is normalised and digested here and
+	// never retained, never logged, and never compared against anything.
+	Email string
+}
+
+// addrSource describes, for an operator reading the log, where Addr came from.
+// The distinction that matters is peer_fallback: it means the forwarded chain
+// was shorter than WPMGR_AUTH_PROXY_HOPS claims, so either the hop count is
+// wrong or this process is reachable without the proxies it is configured for.
+// Either way every client behind that path collapses onto one key, and in
+// Phase 1 that would refuse them all together.
+func (a loginAttempt) addrSource() string {
+	switch {
+	case !a.Addr.IsValid():
+		return "unresolved"
+	case a.Hops == 0:
+		return "peer_configured"
+	case a.FromChain:
+		return "chain"
+	default:
+		return "peer_fallback"
+	}
+}
+
+// LoginGate is the admission control described at the top of this file.
+//
+// A nil *LoginGate is safe to call and does nothing at all — no observation and
+// no concurrency bound. That is a wiring failure, not a mode, and it is exactly
+// what LogAdmissionStartup exists to make visible in the first screen of the
+// log rather than in a quiet absence of lines.
+type LoginGate struct {
+	mode    LoginMode
+	procKey []byte
+
+	pair  *keyedBudget
+	src   *keyedBudget
+	src48 *keyedBudget
+	acct  *keyedBudget
+
+	verify *verifySemaphore
+
+	logger *slog.Logger
+
+	// now is time.Now except in tests. Every budget in one evaluation reads it
+	// once, so the four verdicts describe a single instant.
+	now func() time.Time
+}
+
+// NewLoginGate builds the gate.
+//
+// sessionSecret keys the account digest. There is no unkeyed fallback: the
+// secret is already required to exist and to be non-trivial before the process
+// boots (config.ValidateSessionSecret), so a gate either has a real key or is
+// not built.
+//
+// maxConcurrentVerify bounds concurrent password verifications; see
+// defaultVerifyConcurrency for what a non-positive value means.
+func NewLoginGate(sessionSecret string, mode LoginMode, maxConcurrentVerify int) (*LoginGate, error) {
+	if len(sessionSecret) < 32 {
+		return nil, errors.New("login gate: session secret too short to derive a key from")
+	}
+	if mode != LoginModeObserve && mode != LoginModeEnforce {
+		return nil, fmt.Errorf("login gate: unknown mode %q", mode)
+	}
+	// No salt, for the same reason newHandshakeCodec has none: the input is a
+	// high-entropy instance secret, and a random salt would have to be stored
+	// for a later process to derive the same key.
+	key, err := hkdf.Key(sha256.New, []byte(sessionSecret), nil, loginGateKeyInfo, 32)
+	if err != nil {
+		return nil, err
+	}
+	return &LoginGate{
+		mode:    mode,
+		procKey: key,
+		pair:    newKeyedBudget(loginScopePair, loginPairBudget),
+		src:     newKeyedBudget(loginScopeSrc, loginSrcBudget),
+		src48:   newKeyedBudget(loginScopeSrc48, loginSrc48Budget),
+		acct:    newKeyedBudget(loginScopeAcct, loginAcctBudget),
+		verify:  newVerifySemaphore(maxConcurrentVerify),
+		now:     time.Now,
+	}, nil
+}
+
+// SetLogger wires the logger the observation lines go to. Unset falls back to
+// slog.Default(), which cmd/wpmgr configures, so a gate nobody wired a logger
+// into still produces the lines rather than silence.
+func (g *LoginGate) SetLogger(l *slog.Logger) {
+	if g != nil {
+		g.logger = l
+	}
+}
+
+func (g *LoginGate) log() *slog.Logger {
+	if g == nil || g.logger == nil {
+		return slog.Default()
+	}
+	return g.logger
+}
+
+// Mode reports the configured mode. LoginModeObserve for a nil gate, because a
+// gate that is not there enforces nothing.
+func (g *LoginGate) Mode() LoginMode {
+	if g == nil {
+		return LoginModeObserve
+	}
+	return g.mode
+}
+
+// verdict is one scope's evaluation of one attempt.
+type verdict struct {
+	scope      string
+	key        string
+	limit      int
+	retryAfter time.Duration
+	overBudget bool
+}
+
+// Observe evaluates every budget for one attempt and logs what a later phase
+// would have refused.
+//
+// PHASE 0 CONTRACT, and the reviewer should hold this file to it: this function
+// returns nothing, writes no header, touches no response, and its only effect
+// outside this file is a log line. Its return type is what makes that
+// structural rather than a promise — there is no verdict for a caller to act
+// on, so no future edit to the handler can start acting on one without also
+// changing this signature and being noticed.
+//
+// The shadow counters DO advance. They have to: a budget nothing is ever
+// charged against is never exceeded, and the whole point of this phase is to
+// find out whether these numbers are exceeded in practice. What "charges
+// nothing" means precisely is the rule below, which is also the rule Phase 1
+// will enforce under.
+//
+// A WOULD-BE-REFUSED ATTEMPT COSTS NOTHING, IN ANY SCOPE.
+//
+// Every scope is QUERIED first, at one instant, and only if all four have a
+// token to spare are all four charged. This is the shape internal/mcp's
+// registrationLimiter.allow arrived at after the reserve-then-release shape
+// let a peer that was already over its own budget keep draining the shared one
+// on every request it was refused for — being rejected was free and fast, so
+// rejection became the attack. Here it means a flood that trips the pair scope
+// does not also burn the src and acct scopes, so those two keep measuring what
+// they are there to measure instead of being emptied by the noise.
+func (g *LoginGate) Observe(ctx context.Context, a loginAttempt) {
+	if g == nil {
+		return
+	}
+	now := g.now()
+	acctH := g.AccountDigest(a.Email)
+	srcKey := srcKeyFor(a.Addr)
+	src48Key, hasSrc48 := src48KeyFor(a.Addr)
+
+	// ---- QUERY ONLY. Nothing is charged until every scope has passed. ----
+	pending := make([]*keyedBudget, 0, 4)
+	keys := make([]string, 0, 4)
+	over := make([]verdict, 0, 4)
+
+	check := func(b *keyedBudget, key string) {
+		v := b.query(key, now)
+		if v.overBudget {
+			over = append(over, v)
+			return
+		}
+		pending = append(pending, b)
+		keys = append(keys, key)
+	}
+
+	check(g.pair, srcKey+"|"+acctH)
+	check(g.src, srcKey)
+	if hasSrc48 {
+		check(g.src48, src48Key)
+	}
+	check(g.acct, acctH)
+
+	if len(over) == 0 {
+		// ---- The single mutation site. Reached only when nothing was over. ----
+		for i, b := range pending {
+			b.charge(keys[i], now)
+		}
+		return
+	}
+
+	// Over budget in at least one scope. Charge nothing, refuse nothing, and
+	// say so — at INFO, because in observe mode this is a measurement and not
+	// yet an incident.
+	//
+	// No email here, by construction: acctH is what identifies the account, and
+	// the raw address is not carried past AccountDigest.
+	for _, v := range over {
+		g.log().InfoContext(ctx, "login admission: would refuse (observe mode; request was admitted)",
+			"mode", string(g.mode),
+			"scope", v.scope,
+			"key", v.key,
+			"limit", v.limit,
+			"window", loginWindow.String(),
+			"retry_after_seconds", int(v.retryAfter.Round(time.Second).Seconds()),
+			"acct_h", acctH,
+			"addr_source", a.addrSource(),
+			"proxy_hops", a.Hops,
+			"enforced", false,
+		)
+	}
+}
+
+// AccountDigest is the stable, keyed, fixed-width identifier for a submitted
+// email address. Exported so a test can assert that what the gate keys on and
+// what the service authenticates are the same account.
+//
+// It normalises with normalizeEmail — the SAME function Service.Login uses
+// (service.go:549-551), not a copy of it. If the two ever normalised
+// differently the observation would be of a different account than the one that
+// authenticates, and every number this phase produces would be wrong in a way
+// nothing would show. TestLoginGateNormalisationMatchesService pins it.
+func (g *LoginGate) AccountDigest(email string) string {
+	if g == nil {
+		return ""
+	}
+	mac := hmac.New(sha256.New, g.procKey)
+	// HMAC never returns an error and consumes the input streaming, so an
+	// oversized submitted address costs one hash and retains nothing.
+	_, _ = mac.Write([]byte(normalizeEmail(email)))
+	return hex.EncodeToString(mac.Sum(nil))[:16]
+}
+
+// AcquireVerify takes a slot for one password verification.
+//
+// THIS ENFORCES, in every mode. It is not keyed on the caller and it is not a
+// budget: it refuses only when this process already has maxConcurrentVerify
+// verifications running, which is genuine saturation. Under that condition the
+// alternative to shedding is not "serve everyone" — it is every request slowing
+// down together while argon2id's memory footprint multiplies, which is how a
+// login endpoint takes the rest of the process with it.
+//
+// The returned release is idempotent, so a caller may release early (to free
+// the slot before the session work that follows a successful verify) and still
+// hold a deferred release for the paths that return first.
+func (g *LoginGate) AcquireVerify(ctx context.Context) (release func(), ok bool) {
+	if g == nil || g.verify == nil {
+		return func() {}, true
+	}
+	return g.verify.acquire()
+}
+
+// StartModeReminder logs a WARN every five minutes for as long as the mode is
+// not enforce and ctx is live. It returns immediately when the mode already is
+// enforce, so nothing runs and nothing needs stopping on a fully-enforcing
+// install.
+//
+// This exists because a temporary state that produces no output is a permanent
+// state nobody notices. The startup line says the mode once; this says it for
+// as long as it is true.
+func (g *LoginGate) StartModeReminder(ctx context.Context) {
+	if g == nil || g.mode == LoginModeEnforce {
+		return
+	}
+	go func() {
+		t := time.NewTicker(loginModeReminderEvery)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				g.log().Warn("login admission is NOT enforcing",
+					"mode", string(g.mode),
+					"env_var", LoginModeEnvVar,
+					"effect", "per-source and per-account login budgets are measured and logged but not applied; only the password-verification concurrency bound is in force",
+					"remedy", "set "+LoginModeEnvVar+"=enforce once the observed numbers have been reviewed",
+				)
+			}
+		}
+	}()
+}
+
+// ---------------------------------------------------------------------------
+// Handler wiring.
+// ---------------------------------------------------------------------------
+
+// SetLoginGate wires login admission control. Call it after NewHandler, before
+// serving. Leaving it unset leaves POST /auth/login exactly as it was before
+// GH #718: no measurement and no concurrency bound.
+func (h *Handler) SetLoginGate(g *LoginGate) { h.loginGate = g }
+
+// LogAdmissionStartup states, unconditionally and at Info, what login admission
+// control is actually doing in this process.
+//
+// WHY THIS IS UNCONDITIONAL AND WHY IT NAMES THE WIRING.
+//
+// Every part of this is optional at the type level and injected after
+// construction, which is the house style — and the failure mode of that style
+// is silence. cmd/wpmgr/main.go:2275 is a single unconditional call that hands
+// the auth service its rate limiter; a refactor that moved or dropped that call
+// would remove a throttle with every test still green, because a nil limiter
+// reads as "no limit configured" and nothing anywhere says so. The same is true
+// of a nil *LoginGate.
+//
+// So the numbers below are read back out of the live objects rather than from
+// the constants, and gate_wired/verify_bound_wired report what the Handler
+// actually holds. An operator who sees gate_wired=false has been told, in the
+// first screen of the log, that the code they think is running is not.
+func (h *Handler) LogAdmissionStartup(logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	g := h.loginGate
+	attrs := []any{
+		"issue", "GH-718",
+		"phase", "0",
+		"env_var", LoginModeEnvVar,
+		"proxy_hops", h.effectiveProxyHops(),
+		"proxy_hops_env_var", "WPMGR_AUTH_PROXY_HOPS",
+		"gate_wired", g != nil,
+	}
+	if g == nil {
+		attrs = append(attrs,
+			"mode", "none",
+			"verify_bound_wired", false,
+			"effect", "POST /auth/login has NO admission control: no budgets are measured and the number of concurrent argon2id verifications is unbounded",
+			"remedy", "call Handler.SetLoginGate at startup",
+		)
+		logger.Warn("login admission control", attrs...)
+		return
+	}
+	attrs = append(attrs,
+		"mode", string(g.mode),
+		"budgets_enforced", g.mode == LoginModeEnforce,
+		"window", loginWindow.String(),
+		loginScopePair, loginPairBudget,
+		loginScopeSrc, loginSrcBudget,
+		loginScopeSrc48, loginSrc48Budget,
+		loginScopeAcct, loginAcctBudget,
+		"bucket_cap_per_scope", loginBucketCap,
+		"verify_bound_wired", g.verify != nil,
+		"max_concurrent_password_verifications", g.verify.capacity(),
+		"over_verify_bound", "503 server_busy, Retry-After: 2",
+	)
+	logger.Info("login admission control", attrs...)
+}
+
+// ---------------------------------------------------------------------------
+// Key derivation from the source address.
+// ---------------------------------------------------------------------------
+
+// srcKeyFor masks the decision address: IPv4 to /32 (the address itself), IPv6
+// to /64. A /64 rather than a /128 because a single IPv6 client is normally
+// handed a whole /64 and can move within it for free, so a /128 key is a key
+// the caller chooses.
+func srcKeyFor(a netip.Addr) string {
+	if !a.IsValid() {
+		return addrUnresolved
+	}
+	a = a.Unmap()
+	if a.Is4() {
+		return a.String()
+	}
+	return maskTo(a, 64)
+}
+
+// src48KeyFor masks to /48, which is the common delegation to a single
+// subscriber site. IPv4 has no equivalent aggregate that is safe to assume, so
+// this scope is v6-only and reports false for v4.
+func src48KeyFor(a netip.Addr) (string, bool) {
+	if !a.IsValid() {
+		return "", false
+	}
+	a = a.Unmap()
+	if a.Is4() {
+		return "", false
+	}
+	return maskTo(a, 48), true
+}
+
+// maskTo returns the network address of a's /bits prefix. A prefix that cannot
+// be formed falls back to the full address rather than to a shared key: failing
+// towards a NARROWER key cannot merge two callers into one bucket, which is the
+// direction that would let one caller spend another's budget in Phase 1.
+func maskTo(a netip.Addr, bits int) string {
+	p, err := a.Prefix(bits)
+	if err != nil {
+		return a.String()
+	}
+	return p.Addr().String()
+}
+
+// ---------------------------------------------------------------------------
+// keyedBudget: one scope's capped map of token buckets.
+// ---------------------------------------------------------------------------
+
+type keyedBudget struct {
+	scope string
+	limit int
+
+	mu      sync.Mutex
+	buckets map[string]*loginBucket
+}
+
+type loginBucket struct {
+	lim  *rate.Limiter
+	seen time.Time
+}
+
+func newKeyedBudget(scope string, limit int) *keyedBudget {
+	return &keyedBudget{
+		scope:   scope,
+		limit:   limit,
+		buckets: make(map[string]*loginBucket),
+	}
+}
+
+// query reports whether key has a token to spare at now, WITHOUT taking it.
+// The bucket is created and touched here, which is why charge can assume it
+// exists: creating on query keeps the two halves of one evaluation looking at
+// the same bucket even if a sweep runs in between.
+func (b *keyedBudget) query(key string, now time.Time) verdict {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	bk, ok := b.buckets[key]
+	if !ok {
+		b.sweepLocked(now)
+		bk = &loginBucket{lim: windowLimiter(b.limit, loginWindow)}
+		b.buckets[key] = bk
+	}
+	// Touched even when over budget, deliberately: a bucket swept while it is
+	// being hit would be handed back full, resetting the budget it is recording.
+	bk.seen = now
+
+	v := verdict{scope: b.scope, key: key, limit: b.limit}
+	if wait := budgetShortfall(bk.lim, now); wait > 0 {
+		v.overBudget = true
+		v.retryAfter = wait
+	}
+	return v
+}
+
+// charge takes one token. It is only ever reached after every scope's query
+// returned overBudget=false at the same instant, and TokensAt cannot fall
+// between the two under this mutex, so the token is guaranteed to be there.
+func (b *keyedBudget) charge(key string, now time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if bk, ok := b.buckets[key]; ok {
+		bk.lim.AllowN(now, 1)
+	}
+}
+
+// size reports the entry count. Test-facing; the cap it proves is a real memory
+// bound and a bound nobody has watched hold is not known to hold.
+func (b *keyedBudget) size() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.buckets)
+}
+
+// sweepLocked drops idle entries, and if the map is still at its cap drops the
+// least recently seen until it is not.
+//
+// EVICTION IS FAIL-OPEN FOR THIS LAYER BY CONSTRUCTION: an evicted key comes
+// back as a fresh, full bucket. That is tolerable in Phase 0 because nothing is
+// enforced. It is a REAL CONSIDERATION FOR PHASE 1 and is called out here so it
+// is not discovered later: with 4096 live keys per scope, a caller that can
+// cycle through more than 4096 distinct keys faster than loginBucketIdle can
+// evict its own earlier bucket and get a fresh budget. Phase 1's answer is a
+// scope that cannot be evicted (a process-wide bound, as internal/mcp's global
+// bucket is) sitting behind these, not a bigger map.
+func (b *keyedBudget) sweepLocked(now time.Time) {
+	for k, bk := range b.buckets {
+		if now.Sub(bk.seen) > loginBucketIdle {
+			delete(b.buckets, k)
+		}
+	}
+	for len(b.buckets) >= loginBucketCap {
+		oldestKey := ""
+		var oldest time.Time
+		for k, bk := range b.buckets {
+			if oldestKey == "" || bk.seen.Before(oldest) {
+				oldestKey, oldest = k, bk.seen
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(b.buckets, oldestKey)
+	}
+}
+
+// windowLimiter turns "limit per window" into a token bucket whose burst is the
+// whole budget, so the limit caps any rolling window rather than imposing an
+// inter-arrival gap. Same shape as internal/mcp's perMinuteLimiter, over a
+// configurable window.
+//
+// A non-positive limit means "allow nothing", never "allow everything": that is
+// the direction a misconfiguration must fail in.
+func windowLimiter(limit int, window time.Duration) *rate.Limiter {
+	if limit <= 0 || window <= 0 {
+		return rate.NewLimiter(0, 0)
+	}
+	return rate.NewLimiter(rate.Limit(float64(limit)/window.Seconds()), limit)
+}
+
+// budgetShortfall returns how long until the limiter has a token, or 0 if it
+// has one now. It is a pure query: TokensAt reads the bucket without advancing
+// it, which is what lets query and charge be separate steps.
+func budgetShortfall(l *rate.Limiter, now time.Time) time.Duration {
+	tokens := l.TokensAt(now)
+	if tokens >= 1 {
+		return 0
+	}
+	perSecond := float64(l.Limit())
+	if perSecond <= 0 {
+		// A zero-rate limiter never refills. Report the whole window rather
+		// than 0, which would read as "a token is available".
+		return loginWindow
+	}
+	return time.Duration((1 - tokens) / perSecond * float64(time.Second))
+}
+
+// ---------------------------------------------------------------------------
+// verifySemaphore: the one part of Phase 0 that refuses.
+// ---------------------------------------------------------------------------
+
+// defaultVerifyConcurrency is the bound when none is configured.
+//
+// argon2id at the 19 MiB profile with Parallelism 1 is one core and 19 MiB for
+// the duration of a verify, so N concurrent verifies is N cores and N*19 MiB.
+// GOMAXPROCS is therefore the honest ceiling — more in flight than there are
+// cores does not verify anyone faster, it just multiplies the memory and slows
+// every one of them down together. The floor of 2 keeps a single-core container
+// from serialising sign-ins behind one slot.
+func defaultVerifyConcurrency() int {
+	n := runtime.GOMAXPROCS(0)
+	if n < 2 {
+		return 2
+	}
+	return n
+}
+
+type verifySemaphore struct {
+	slots chan struct{}
+}
+
+func newVerifySemaphore(max int) *verifySemaphore {
+	if max <= 0 {
+		max = defaultVerifyConcurrency()
+	}
+	return &verifySemaphore{slots: make(chan struct{}, max)}
+}
+
+// acquire takes a slot without blocking, or reports that the process is
+// saturated. Non-blocking on purpose: queueing here would convert a CPU
+// shortage into unbounded latency and an unbounded queue, and a caller waiting
+// 30 seconds for a sign-in has already given up.
+func (s *verifySemaphore) acquire() (release func(), ok bool) {
+	select {
+	case s.slots <- struct{}{}:
+		var once sync.Once
+		return func() { once.Do(func() { <-s.slots }) }, true
+	default:
+		return func() {}, false
+	}
+}
+
+// capacity and inFlight are test-facing, and nil-safe so the startup line can
+// report an unwired bound as 0 rather than crashing the boot it is describing.
+func (s *verifySemaphore) capacity() int {
+	if s == nil {
+		return 0
+	}
+	return cap(s.slots)
+}
+
+func (s *verifySemaphore) inFlight() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.slots)
+}

--- a/apps/api/internal/auth/login_gate_test.go
+++ b/apps/api/internal/auth/login_gate_test.go
@@ -1,0 +1,649 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// testSessionSecret is only ever an HKDF input here. It is the length
+// config.ValidateSessionSecret requires so NewLoginGate takes it.
+const testSessionSecret = "0123456789abcdef0123456789abcdef"
+
+func newTestGate(t *testing.T, mode LoginMode, maxVerify int) (*LoginGate, *bytes.Buffer) {
+	t.Helper()
+	g, err := NewLoginGate(testSessionSecret, mode, maxVerify)
+	if err != nil {
+		t.Fatalf("NewLoginGate: %v", err)
+	}
+	var logs bytes.Buffer
+	g.SetLogger(slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	return g, &logs
+}
+
+// loginHandlerForTest wires a Handler the way production does, with a real
+// *Service so requests go through the real h.login and reach the real
+// Service.Login.
+//
+// The service has no repo. That is deliberate and it is what makes these tests
+// possible without a database: every request below carries a body Service.Login
+// rejects at ITS OWN validation step, which is strictly downstream of
+// admission. So a non-503 answer here means the request was ADMITTED and the
+// service got to decide — which is exactly the property under test. Nothing
+// here reaches GetUserByEmail.
+func loginHandlerForTest(t *testing.T, g *LoginGate, hops int) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.ReleaseMode)
+	h := &Handler{svc: NewService(nil, nil, domain.NewValidator())}
+	h.SetProxyHops(hops)
+	h.SetLoginGate(g)
+	e := gin.New()
+	e.POST("/auth/login", h.login)
+	return e
+}
+
+// The two addresses the HTTP-level tests submit.
+//
+// Neither is a syntactically valid email, ON PURPOSE. Service.Login validates
+// the body BEFORE it looks any account up, so these reach the real handler,
+// the real gate and the real Service.Login and are rejected there — without a
+// database, and without the gate ever being able to tell them apart, which is
+// the property under test. The gate normalises and digests whatever string it
+// is handed; validity is not its business.
+const (
+	httpEmailA = "someone[at]example.test"
+	httpEmailB = "never-seen-before[at]example.test"
+)
+
+// postLogin sends one login attempt from client, through a 2-hop chain shaped
+// the way the balancer actually presents it.
+func postLogin(e *gin.Engine, client, email string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(loginBody{Email: email, Password: "irrelevant"})
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", client+", "+simulatedBalancer)
+	req.RemoteAddr = "10.0.0.1:12345"
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 1 — observe mode refuses nothing, and says what it would have refused.
+// ---------------------------------------------------------------------------
+
+// TestObserveModeAdmitsEveryAttempt drives 200 successive attempts against ONE
+// account from ONE address through the real handler. Every budget in this file
+// is smaller than 200, so an enforcing gate would refuse most of them.
+//
+// What is asserted is admission, not the service's answer: no attempt may come
+// back 503, none may carry Retry-After, and every response must be
+// byte-identical to the first. The log must nevertheless show the pair scope
+// over budget, or the phase has measured nothing.
+func TestObserveModeAdmitsEveryAttempt(t *testing.T) {
+	g, logs := newTestGate(t, LoginModeObserve, 8)
+	e := loginHandlerForTest(t, g, 2)
+
+	const attempts = 200
+	first := postLogin(e, simulatedClient, httpEmailA)
+	firstBody := first.Body.String()
+
+	for i := 1; i < attempts; i++ {
+		w := postLogin(e, simulatedClient, httpEmailA)
+		if w.Code == http.StatusServiceUnavailable {
+			t.Fatalf("attempt %d was shed with 503; observe mode must refuse nothing", i+1)
+		}
+		if ra := w.Header().Get("Retry-After"); ra != "" {
+			t.Fatalf("attempt %d carried Retry-After %q; observe mode must be invisible", i+1, ra)
+		}
+		if w.Code != first.Code {
+			t.Fatalf("attempt %d status %d != first status %d", i+1, w.Code, first.Code)
+		}
+		if w.Body.String() != firstBody {
+			t.Fatalf("attempt %d body %q != first body %q", i+1, w.Body.String(), firstBody)
+		}
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "would refuse") {
+		t.Fatalf("no would-refuse line after %d attempts; the gate measured nothing.\nlog:\n%s", attempts, out)
+	}
+	// Only the PAIR scope can be over here, and that is the query-then-charge
+	// rule working: from the eleventh attempt the pair is over budget, so
+	// nothing is charged anywhere, and the src and acct scopes never reach
+	// their own budgets no matter how long one pair floods. The two scopes
+	// below are driven separately for exactly that reason.
+	if !strings.Contains(out, loginScopePair) {
+		t.Errorf("expected scope %q in the observation log after %d attempts on one pair; log:\n%s", loginScopePair, attempts, out)
+	}
+	if strings.Contains(out, loginScopeSrc+`"`) {
+		t.Errorf("scope %q went over budget while one pair was flooding; a would-refused attempt must charge nothing.\nlog:\n%s", loginScopeSrc, out)
+	}
+	if strings.Contains(out, httpEmailA) {
+		t.Fatalf("the submitted email address reached the log; only acctH may appear.\nlog:\n%s", out)
+	}
+	if !strings.Contains(out, g.AccountDigest(httpEmailA)) {
+		t.Errorf("expected acctH in the observation log; log:\n%s", out)
+	}
+}
+
+// TestSrcAndAcctScopesAreObserved drives the two wide scopes, which one
+// flooding pair can never reach (see the note in the test above).
+//
+// The src scope is what a run against MANY accounts from one address trips.
+// The acct scope is what a distributed run against ONE account trips. Both are
+// admitted throughout, because this is observe mode.
+func TestSrcAndAcctScopesAreObserved(t *testing.T) {
+	t.Run("many accounts from one address trips the src scope", func(t *testing.T) {
+		g, logs := newTestGate(t, LoginModeObserve, 8)
+		e := loginHandlerForTest(t, g, 2)
+		for i := 0; i < loginSrcBudget+5; i++ {
+			w := postLogin(e, simulatedClient, fmt.Sprintf("user%d[at]example.test", i))
+			if w.Code == http.StatusServiceUnavailable {
+				t.Fatalf("attempt %d shed in observe mode", i+1)
+			}
+		}
+		if out := logs.String(); !strings.Contains(out, loginScopeSrc+`"`) {
+			t.Errorf("scope %q never went over budget after %d attempts from one address; log:\n%s", loginScopeSrc, loginSrcBudget+5, out)
+		}
+	})
+
+	t.Run("many addresses against one account trips the acct scope", func(t *testing.T) {
+		g, logs := newTestGate(t, LoginModeObserve, 8)
+		e := loginHandlerForTest(t, g, 2)
+		for i := 0; i < loginAcctBudget+5; i++ {
+			w := postLogin(e, fmt.Sprintf("198.51.100.%d", i%250), httpEmailA)
+			if w.Code == http.StatusServiceUnavailable {
+				t.Fatalf("attempt %d shed in observe mode", i+1)
+			}
+		}
+		out := logs.String()
+		if !strings.Contains(out, loginScopeAcct+`"`) {
+			t.Errorf("scope %q never went over budget after %d attempts against one account; log:\n%s", loginScopeAcct, loginAcctBudget+5, out)
+		}
+		if strings.Contains(out, httpEmailA) {
+			t.Fatalf("the submitted email address reached the log.\nlog:\n%s", out)
+		}
+	})
+
+	t.Run("an IPv6 client is observed on the /48 scope too", func(t *testing.T) {
+		g, logs := newTestGate(t, LoginModeObserve, 8)
+		e := loginHandlerForTest(t, g, 2)
+		// Distinct /64s inside one /48, and a distinct account each time, so
+		// neither the pair nor the /64 src scope trips first.
+		for i := 0; i < loginSrc48Budget+5; i++ {
+			client := fmt.Sprintf("2001:db8:abcd:%x::1", i%0xffff)
+			w := postLogin(e, client, fmt.Sprintf("v6user%d[at]example.test", i))
+			if w.Code == http.StatusServiceUnavailable {
+				t.Fatalf("attempt %d shed in observe mode", i+1)
+			}
+		}
+		if out := logs.String(); !strings.Contains(out, loginScopeSrc48+`"`) {
+			t.Errorf("scope %q never went over budget after %d IPv6 attempts inside one /48; log:\n%s", loginScopeSrc48, loginSrc48Budget+5, out)
+		}
+	})
+}
+
+// TestOverBudgetAttemptChargesNothing pins the "a refused attempt costs
+// nothing, in every scope" rule that query-then-charge exists to guarantee.
+//
+// The pair budget is the smallest, so a flood on one pair trips it first. Once
+// it is over, the src and acct scopes must stop being charged — otherwise the
+// noise from one flooding pair empties the scopes that are there to measure
+// everything else.
+func TestOverBudgetAttemptChargesNothing(t *testing.T) {
+	g, _ := newTestGate(t, LoginModeObserve, 8)
+	addr := netip.MustParseAddr(simulatedClient)
+
+	// Exhaust the pair budget exactly.
+	for i := 0; i < loginPairBudget; i++ {
+		g.Observe(context.Background(), loginAttempt{Addr: addr, FromChain: true, Hops: 2, Email: "a@example.test"})
+	}
+	srcKey := srcKeyFor(addr)
+	acctH := g.AccountDigest("a@example.test")
+	now := time.Now()
+
+	beforeSrc := g.src.query(srcKey, now)
+	beforeAcct := g.acct.query(acctH, now)
+	if beforeSrc.overBudget || beforeAcct.overBudget {
+		t.Fatalf("precondition: src/acct should still have budget after %d attempts", loginPairBudget)
+	}
+	srcTokens := g.src.buckets[srcKey].lim.TokensAt(now)
+	acctTokens := g.acct.buckets[acctH].lim.TokensAt(now)
+
+	// 50 more on the same pair. Every one is over the pair budget.
+	for i := 0; i < 50; i++ {
+		g.Observe(context.Background(), loginAttempt{Addr: addr, FromChain: true, Hops: 2, Email: "a@example.test"})
+	}
+
+	if got := g.src.buckets[srcKey].lim.TokensAt(now); got != srcTokens {
+		t.Errorf("src scope was charged for pair-over-budget attempts: tokens %v -> %v", srcTokens, got)
+	}
+	if got := g.acct.buckets[acctH].lim.TokensAt(now); got != acctTokens {
+		t.Errorf("acct scope was charged for pair-over-budget attempts: tokens %v -> %v", acctTokens, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 2 — the gate and the service agree on which account this is.
+// ---------------------------------------------------------------------------
+
+// TestGateNormalisationMatchesService is the pin the file's doc comment
+// promises. Service.Login's first statement is email = normalizeEmail(email);
+// if the gate ever normalised differently, every budget would be keyed on a
+// different account than the one that authenticates, and nothing else in the
+// suite would notice.
+func TestGateNormalisationMatchesService(t *testing.T) {
+	g, _ := newTestGate(t, LoginModeObserve, 8)
+
+	canonical := "person@example.test"
+	variants := []string{
+		"person@example.test",
+		"Person@Example.Test",
+		"PERSON@EXAMPLE.TEST",
+		"  person@example.test  ",
+		"\tPerson@Example.Test\n",
+		" PERSON@EXAMPLE.TEST\t",
+	}
+	want := g.AccountDigest(canonical)
+	for _, v := range variants {
+		// What the service will authenticate as.
+		if serviceForm := normalizeEmail(v); serviceForm != canonical {
+			t.Fatalf("normalizeEmail(%q) = %q, want %q", v, serviceForm, canonical)
+		}
+		// What the gate keys on. These must be the same account.
+		if got := g.AccountDigest(v); got != want {
+			t.Errorf("AccountDigest(%q) = %q, want %q (same account the service authenticates)", v, got, want)
+		}
+	}
+
+	// Different accounts must not collide, or the budgets are shared.
+	if g.AccountDigest("other@example.test") == want {
+		t.Error("two different accounts produced the same digest")
+	}
+	// Fixed width whatever was submitted: the map key must not be caller-sized.
+	huge := strings.Repeat("a", 100_000) + "@example.test"
+	if got := g.AccountDigest(huge); len(got) != len(want) {
+		t.Errorf("digest of a %d-byte address is %d chars, want %d", len(huge), len(got), len(want))
+	}
+	// The digest must be keyed, not a bare hash of the address.
+	other, err := NewLoginGate(strings.Repeat("z", 32), LoginModeObserve, 8)
+	if err != nil {
+		t.Fatalf("NewLoginGate: %v", err)
+	}
+	if other.AccountDigest(canonical) == want {
+		t.Error("two instances with different secrets produced the same digest; the digest is not keyed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 3 — the concurrency bound actually sheds, and recovers.
+// ---------------------------------------------------------------------------
+
+// TestVerifyBoundShedsAndRecovers occupies every verification slot, shows the
+// endpoint answering 503 with Retry-After: 2, then frees one slot and shows the
+// next attempt admitted again.
+func TestVerifyBoundShedsAndRecovers(t *testing.T) {
+	const bound = 3
+	g, _ := newTestGate(t, LoginModeObserve, bound)
+	e := loginHandlerForTest(t, g, 2)
+
+	// Not saturated yet: this must be admitted.
+	if w := postLogin(e, simulatedClient, httpEmailA); w.Code == http.StatusServiceUnavailable {
+		t.Fatalf("shed before saturation: %d %s", w.Code, w.Body.String())
+	}
+
+	releases := make([]func(), 0, bound)
+	for i := 0; i < bound; i++ {
+		release, ok := g.verify.acquire()
+		if !ok {
+			t.Fatalf("could not occupy slot %d of %d", i+1, bound)
+		}
+		releases = append(releases, release)
+	}
+	if got := g.verify.inFlight(); got != bound {
+		t.Fatalf("inFlight = %d, want %d", got, bound)
+	}
+
+	w := postLogin(e, simulatedClient, httpEmailA)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("saturated: status %d, want %d; body %s", w.Code, http.StatusServiceUnavailable, w.Body.String())
+	}
+	if got := w.Header().Get("Retry-After"); got != "2" {
+		t.Errorf("Retry-After = %q, want %q", got, "2")
+	}
+	var env struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("shed body is not the error envelope: %v (%s)", err, w.Body.String())
+	}
+	if env.Code != "server_busy" {
+		t.Errorf("shed code = %q, want %q", env.Code, "server_busy")
+	}
+
+	// Free one slot: the next attempt is admitted again.
+	releases[0]()
+	if got := g.verify.inFlight(); got != bound-1 {
+		t.Fatalf("after one release inFlight = %d, want %d", got, bound-1)
+	}
+	if w := postLogin(e, simulatedClient, httpEmailA); w.Code == http.StatusServiceUnavailable {
+		t.Fatalf("still shedding after a slot was freed: %d %s", w.Code, w.Body.String())
+	}
+	for _, r := range releases[1:] {
+		r()
+	}
+
+	// Release is idempotent: the handler calls it explicitly and again by defer.
+	releases[0]()
+	releases[0]()
+	if got := g.verify.inFlight(); got != 0 {
+		t.Errorf("after all releases inFlight = %d, want 0; release is not idempotent", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROOF 4 — observation is invisible, and cannot become an enumeration oracle.
+// ---------------------------------------------------------------------------
+
+// TestObservationIsInvisibleToTheCaller is the new-oracle proof for THIS
+// change.
+//
+// Whether an account exists is Service.Login's business and it already answers
+// invalid_credentials either way; that equivalence is unchanged here and its
+// end-to-end proof needs a database (integration package). What this PR could
+// newly leak is the gate, so what is pinned here is that the gate contributes
+// NOTHING observable: for wildly different emails — including one whose budget
+// is already blown and one that has never been seen — the response bytes,
+// status and headers are identical, and Observe itself writes nothing at all.
+func TestObservationIsInvisibleToTheCaller(t *testing.T) {
+	g, _ := newTestGate(t, LoginModeObserve, 8)
+	e := loginHandlerForTest(t, g, 2)
+
+	// Blow every budget for one account from this address.
+	for i := 0; i < loginPairBudget*3; i++ {
+		postLogin(e, simulatedClient, httpEmailA)
+	}
+
+	known := postLogin(e, simulatedClient, httpEmailA)
+	unknown := postLogin(e, simulatedClient, httpEmailB)
+
+	if known.Code != unknown.Code {
+		t.Errorf("status differs: over-budget account %d, unseen account %d", known.Code, unknown.Code)
+	}
+	if known.Body.String() != unknown.Body.String() {
+		t.Errorf("body differs:\n over-budget: %q\n unseen:      %q", known.Body.String(), unknown.Body.String())
+	}
+	if len(known.Body.Bytes()) != len(unknown.Body.Bytes()) {
+		t.Errorf("body length differs: %d vs %d", len(known.Body.Bytes()), len(unknown.Body.Bytes()))
+	}
+	for k, v := range known.Header() {
+		if got := unknown.Header()[k]; strings.Join(got, ",") != strings.Join(v, ",") {
+			t.Errorf("header %q differs: %v vs %v", k, v, got)
+		}
+	}
+	for k := range unknown.Header() {
+		if _, ok := known.Header()[k]; !ok {
+			t.Errorf("header %q present only on the unseen-account response", k)
+		}
+	}
+
+	// And directly: Observe writes nothing to the response, ever.
+	for _, email := range []string{httpEmailA, httpEmailB, ""} {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		g.Observe(context.Background(), loginAttempt{Addr: netip.MustParseAddr(simulatedClient), FromChain: true, Hops: 2, Email: email})
+		if c.Writer.Written() {
+			t.Errorf("Observe wrote to the response for email %q", email)
+		}
+		if len(w.Header()) != 0 {
+			t.Errorf("Observe set headers %v for email %q", w.Header(), email)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("Observe wrote body %q for email %q", w.Body.String(), email)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Keys, and the degraded-address flag.
+// ---------------------------------------------------------------------------
+
+func TestSourceKeyMasking(t *testing.T) {
+	cases := []struct {
+		addr      string
+		wantSrc   string
+		wantS48   string
+		hasSrc48  bool
+		sameAsAlt string // an address that must land on the SAME src key
+		diffAlt   string // an address that must land on a DIFFERENT src key
+	}{
+		{
+			addr: "203.0.113.7", wantSrc: "203.0.113.7", hasSrc48: false,
+			diffAlt: "203.0.113.8",
+		},
+		{
+			addr: "2001:db8:1:2:3:4:5:6", wantSrc: "2001:db8:1:2::", wantS48: "2001:db8:1::", hasSrc48: true,
+			sameAsAlt: "2001:db8:1:2:aaaa:bbbb:cccc:dddd",
+			diffAlt:   "2001:db8:1:3::1",
+		},
+	}
+	for _, tc := range cases {
+		a := netip.MustParseAddr(tc.addr)
+		if got := srcKeyFor(a); got != tc.wantSrc {
+			t.Errorf("srcKeyFor(%s) = %q, want %q", tc.addr, got, tc.wantSrc)
+		}
+		got48, ok := src48KeyFor(a)
+		if ok != tc.hasSrc48 {
+			t.Errorf("src48KeyFor(%s) ok = %v, want %v", tc.addr, ok, tc.hasSrc48)
+		}
+		if ok && got48 != tc.wantS48 {
+			t.Errorf("src48KeyFor(%s) = %q, want %q", tc.addr, got48, tc.wantS48)
+		}
+		if tc.sameAsAlt != "" {
+			if got := srcKeyFor(netip.MustParseAddr(tc.sameAsAlt)); got != tc.wantSrc {
+				t.Errorf("srcKeyFor(%s) = %q, want the same /64 key %q", tc.sameAsAlt, got, tc.wantSrc)
+			}
+		}
+		if tc.diffAlt != "" {
+			if got := srcKeyFor(netip.MustParseAddr(tc.diffAlt)); got == tc.wantSrc {
+				t.Errorf("srcKeyFor(%s) collided with %s on %q", tc.diffAlt, tc.addr, got)
+			}
+		}
+	}
+	// An unresolved address is bucketed, never skipped.
+	if got := srcKeyFor(netip.Addr{}); got != addrUnresolved {
+		t.Errorf("srcKeyFor(invalid) = %q, want %q", got, addrUnresolved)
+	}
+	if _, ok := src48KeyFor(netip.Addr{}); ok {
+		t.Error("src48KeyFor(invalid) reported a key")
+	}
+}
+
+// TestLimiterAddrSourceGradesTheAddress pins the fromChain flag, and pins that
+// limiterAddr's own behaviour did not move.
+func TestLimiterAddrSourceGradesTheAddress(t *testing.T) {
+	e := engineAsProductionBuildsIt()
+
+	newCtx := func(h *Handler, xff string) *gin.Context {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		c.Request.RemoteAddr = "192.0.2.9:4444"
+		if xff != "" {
+			c.Request.Header.Set("X-Forwarded-For", xff)
+		}
+		return c
+	}
+	_ = e
+
+	t.Run("chain long enough", func(t *testing.T) {
+		h := handlerWithHops(2)
+		c := newCtx(h, simulatedClient+", "+simulatedBalancer)
+		addr, fromChain := h.limiterAddrSource(c)
+		if !fromChain {
+			t.Error("fromChain = false for a chain at the configured length")
+		}
+		if addr.String() != simulatedClient {
+			t.Errorf("addr = %s, want %s", addr, simulatedClient)
+		}
+		if a := (loginAttempt{Addr: addr, FromChain: fromChain, Hops: 2}).addrSource(); a != "chain" {
+			t.Errorf("addrSource = %q, want %q", a, "chain")
+		}
+		if h.limiterAddr(c).String() != simulatedClient {
+			t.Errorf("limiterAddr changed: %s", h.limiterAddr(c))
+		}
+	})
+
+	t.Run("chain too short falls back and is graded degraded", func(t *testing.T) {
+		h := handlerWithHops(3)
+		c := newCtx(h, simulatedClient+", "+simulatedBalancer)
+		addr, fromChain := h.limiterAddrSource(c)
+		if fromChain {
+			t.Error("fromChain = true for a chain shorter than the configured hop count")
+		}
+		if addr.String() != "192.0.2.9" {
+			t.Errorf("addr = %s, want the peer address 192.0.2.9", addr)
+		}
+		if a := (loginAttempt{Addr: addr, FromChain: fromChain, Hops: 3}).addrSource(); a != "peer_fallback" {
+			t.Errorf("addrSource = %q, want %q", a, "peer_fallback")
+		}
+	})
+
+	t.Run("zero hops is the configured source, not a fallback", func(t *testing.T) {
+		h := handlerWithHops(0)
+		c := newCtx(h, simulatedClient+", "+simulatedBalancer)
+		addr, fromChain := h.limiterAddrSource(c)
+		if fromChain {
+			t.Error("fromChain = true with hops=0; nothing was read from a chain")
+		}
+		if a := (loginAttempt{Addr: addr, FromChain: fromChain, Hops: 0}).addrSource(); a != "peer_configured" {
+			t.Errorf("addrSource = %q, want %q", a, "peer_configured")
+		}
+	})
+
+	t.Run("unresolved", func(t *testing.T) {
+		if a := (loginAttempt{Hops: 2}).addrSource(); a != "unresolved" {
+			t.Errorf("addrSource = %q, want %q", a, "unresolved")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Memory bound, mode, and wiring.
+// ---------------------------------------------------------------------------
+
+// TestBucketMapIsCapped watches the memory bound actually hold. A cap nobody
+// has seen bind is not known to bind.
+func TestBucketMapIsCapped(t *testing.T) {
+	b := newKeyedBudget("test", 10)
+	now := time.Now()
+	for i := 0; i < loginBucketCap*2; i++ {
+		b.query(netip.AddrFrom4([4]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}).String(), now)
+		if got := b.size(); got > loginBucketCap {
+			t.Fatalf("map grew to %d entries, past the %d cap, after %d keys", got, loginBucketCap, i+1)
+		}
+	}
+	if got := b.size(); got == 0 {
+		t.Fatalf("map is empty after %d keys; the sweep is evicting everything", loginBucketCap*2)
+	}
+}
+
+func TestParseLoginMode(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    LoginMode
+		wantErr bool
+	}{
+		{"", LoginModeObserve, false},
+		{"observe", LoginModeObserve, false},
+		{"enforce", LoginModeEnforce, false},
+		{"Observe", "", true},
+		{"off", "", true},
+		{"true", "", true},
+		{" observe", "", true},
+	} {
+		got, err := ParseLoginMode(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("ParseLoginMode(%q) = %q, want an error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseLoginMode(%q): %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseLoginMode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestNilGateIsInertAndSaidSoAtStartup pins both halves of the wiring failure
+// the startup line exists for: a nil gate must not crash the login path, and
+// the startup line must say, loudly, that nothing is wired.
+func TestNilGateIsInertAndSaidSoAtStartup(t *testing.T) {
+	e := loginHandlerForTest(t, nil, 2)
+	w := postLogin(e, simulatedClient, httpEmailA)
+	if w.Code == http.StatusServiceUnavailable {
+		t.Fatalf("a nil gate shed a request: %d", w.Code)
+	}
+
+	var logs bytes.Buffer
+	h := &Handler{}
+	h.SetProxyHops(2)
+	h.LogAdmissionStartup(slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	out := logs.String()
+	if !strings.Contains(out, `"level":"WARN"`) {
+		t.Errorf("an unwired gate must be a WARN, not an Info; log:\n%s", out)
+	}
+	if !strings.Contains(out, `"gate_wired":false`) {
+		t.Errorf("startup line does not report gate_wired=false; log:\n%s", out)
+	}
+
+	logs.Reset()
+	g, _ := newTestGate(t, LoginModeObserve, 4)
+	h2 := &Handler{}
+	h2.SetProxyHops(2)
+	h2.SetLoginGate(g)
+	h2.LogAdmissionStartup(slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	out = logs.String()
+	for _, want := range []string{
+		`"gate_wired":true`,
+		`"verify_bound_wired":true`,
+		`"mode":"observe"`,
+		`"proxy_hops":2`,
+		`"max_concurrent_password_verifications":4`,
+		loginScopePair,
+		loginScopeSrc,
+		loginScopeSrc48,
+		loginScopeAcct,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("startup line is missing %s; log:\n%s", want, out)
+		}
+	}
+}
+
+func TestNewLoginGateRefusesAWeakSecretAndAnUnknownMode(t *testing.T) {
+	if _, err := NewLoginGate("short", LoginModeObserve, 4); err == nil {
+		t.Error("NewLoginGate accepted a secret too short to derive a key from")
+	}
+	if _, err := NewLoginGate(testSessionSecret, LoginMode("off"), 4); err == nil {
+		t.Error("NewLoginGate accepted an unknown mode")
+	}
+}

--- a/apps/api/internal/auth/login_gate_test.go
+++ b/apps/api/internal/auth/login_gate_test.go
@@ -570,7 +570,8 @@ func TestParseLoginMode(t *testing.T) {
 	}{
 		{"", LoginModeObserve, false},
 		{"observe", LoginModeObserve, false},
-		{"enforce", LoginModeEnforce, false},
+		// Refused in Phase 0 on purpose; see TestEnforceIsNotConfigurableInPhase0.
+		{"enforce", "", true},
 		{"Observe", "", true},
 		{"off", "", true},
 		{"true", "", true},
@@ -645,5 +646,157 @@ func TestNewLoginGateRefusesAWeakSecretAndAnUnknownMode(t *testing.T) {
 	}
 	if _, err := NewLoginGate(testSessionSecret, LoginMode("off"), 4); err == nil {
 		t.Error("NewLoginGate accepted an unknown mode")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// F1 GUARD — the startup line cannot claim enforcement that does not happen.
+// ---------------------------------------------------------------------------
+
+// TestStartupLineCannotClaimEnforcementItDoesNotDo is the guard, not a careful
+// edit.
+//
+// It enumerates every mode ParseLoginMode ACCEPTS — it does not hard-code
+// "observe" — builds a gate in each, drives enough real requests through the
+// real handler to blow the smallest budget many times over, and compares two
+// things that must never disagree:
+//
+//   - what the boot line asserts in budgets_enforced, and
+//   - whether any request was actually refused for being over budget.
+//
+// Both directions fail. A mode that claims enforcement and admits everything
+// is the defect this guard exists for; a mode that quietly enforces while the
+// boot line says it does not is just as bad, because the operator reading that
+// line would have no idea why sign-ins were being refused.
+//
+// It also pins the second half of the same defect: a mode that stops
+// StartModeReminder from warning must be a mode that actually enforces.
+func TestStartupLineCannotClaimEnforcementItDoesNotDo(t *testing.T) {
+	// Every string worth asking about, including the one Phase 1 will add.
+	// Whatever ParseLoginMode accepts is what gets exercised, so the day
+	// "enforce" starts being accepted this guard starts checking it.
+	candidates := []string{"", "observe", "enforce"}
+
+	accepted := 0
+	for _, raw := range candidates {
+		mode, err := ParseLoginMode(raw)
+		if err != nil {
+			continue // Not configurable, so no operator can be misled by it.
+		}
+		accepted++
+
+		t.Run("mode="+string(mode), func(t *testing.T) {
+			g, _ := newTestGate(t, mode, 64)
+			e := loginHandlerForTest(t, g, 2)
+
+			// Far past the smallest budget, all on one key.
+			const attempts = loginPairBudget * 10
+			refusedForBudget := false
+			var baseline int
+			for i := 0; i < attempts; i++ {
+				w := postLogin(e, simulatedClient, httpEmailA)
+				if i == 0 {
+					baseline = w.Code
+					continue
+				}
+				// The verify bound is 64 and these are sequential, so a 503
+				// here could only come from budget enforcement.
+				if w.Code == http.StatusServiceUnavailable || w.Code == http.StatusTooManyRequests {
+					refusedForBudget = true
+				}
+				if w.Code != baseline {
+					refusedForBudget = true
+				}
+			}
+
+			var logs bytes.Buffer
+			h := &Handler{}
+			h.SetProxyHops(2)
+			h.SetLoginGate(g)
+			h.LogAdmissionStartup(slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			out := logs.String()
+
+			claimsEnforcement := strings.Contains(out, `"budgets_enforced":true`)
+			if !claimsEnforcement && !strings.Contains(out, `"budgets_enforced":false`) {
+				t.Fatalf("startup line reports no budgets_enforced field at all; log:\n%s", out)
+			}
+
+			if claimsEnforcement && !refusedForBudget {
+				t.Errorf("mode %q: the boot line asserts budgets_enforced=true, but %d attempts past a budget of %d were ALL admitted. A startup line that can be wrong is worse than none.\nlog:\n%s",
+					mode, attempts, loginPairBudget, out)
+			}
+			if !claimsEnforcement && refusedForBudget {
+				t.Errorf("mode %q: requests were refused for being over budget, but the boot line asserts budgets_enforced=false. An operator could not explain the refusals.\nlog:\n%s",
+					mode, out)
+			}
+
+			// Same defect, other half: the five-minute reminder must only go
+			// quiet for a mode that actually enforces.
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			g.StartModeReminder(ctx)
+			remindersSuppressed := g.mode == LoginModeEnforce
+			if remindersSuppressed && !refusedForBudget {
+				t.Errorf("mode %q silences StartModeReminder without enforcing anything", mode)
+			}
+		})
+	}
+
+	if accepted == 0 {
+		t.Fatal("ParseLoginMode accepted no mode at all; this guard checked nothing")
+	}
+}
+
+// TestEnforceIsNotConfigurableInPhase0 pins the narrow fact the guard above
+// depends on, with the reason attached, so the day it changes the change is
+// deliberate.
+func TestEnforceIsNotConfigurableInPhase0(t *testing.T) {
+	if _, err := ParseLoginMode("enforce"); err == nil {
+		t.Error("ParseLoginMode accepted \"enforce\" while Observe still refuses nothing; that mode would assert enforcement, silence the reminder, and enforce nothing")
+	}
+	if _, err := ParseLoginMode("observe"); err != nil {
+		t.Errorf("ParseLoginMode rejected the documented default: %v", err)
+	}
+}
+
+// TestOverBudgetLoggingIsBounded pins the F2 latch: a key that goes over budget
+// must not write a line per request for the rest of the window.
+func TestOverBudgetLoggingIsBounded(t *testing.T) {
+	g, logs := newTestGate(t, LoginModeObserve, 64)
+	e := loginHandlerForTest(t, g, 2)
+
+	for i := 0; i < loginPairBudget; i++ {
+		postLogin(e, simulatedClient, httpEmailA)
+	}
+	if n := strings.Count(logs.String(), "would refuse"); n != 0 {
+		t.Fatalf("%d lines before any budget was crossed, want 0", n)
+	}
+
+	// First crossing: exactly one line.
+	postLogin(e, simulatedClient, httpEmailA)
+	if n := strings.Count(logs.String(), "would refuse"); n != 1 {
+		t.Fatalf("first crossing wrote %d lines, want 1", n)
+	}
+
+	// A long run over the same key. Unlatched this wrote one line each.
+	const flood = 300
+	before := logs.Len()
+	for i := 0; i < flood; i++ {
+		postLogin(e, simulatedClient, httpEmailA)
+	}
+	lines := strings.Count(logs.String(), "would refuse")
+	wantAtMost := 1 + flood/loginOverLogEvery + 1
+	if lines > wantAtMost {
+		t.Errorf("%d lines for %d over-budget attempts, want at most %d; the latch is not holding", lines, flood, wantAtMost)
+	}
+	if lines < 2 {
+		t.Errorf("%d lines for %d over-budget attempts; the periodic repeat is not firing and the volume is invisible", lines, flood)
+	}
+	if grown := logs.Len() - before; grown > flood*10 {
+		t.Errorf("log grew %d bytes over %d shed attempts (~%d/request); the point of the latch is that this is bounded", grown, flood, grown/flood)
+	}
+	// The suppressed volume must still be countable from the lines that print.
+	if !strings.Contains(logs.String(), `"over_budget_attempts":`) {
+		t.Error("no over_budget_attempts field; a suppressed run must still be countable")
 	}
 }

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -554,6 +554,19 @@ type AuthConfig struct {
 	// at startup.
 	ProxyHops int `koanf:"proxy_hops"`
 
+	// LoginMode (WPMGR_AUTH_LOGIN_MODE) selects what POST /auth/login does with
+	// its admission-control verdict: "observe" measures the per-source and
+	// per-account budgets and applies none of them, "enforce" applies them.
+	// Default "observe" (GH #718 Phase 0). The value is validated at startup by
+	// auth.ParseLoginMode, which refuses an unrecognised mode rather than
+	// coercing it, and the effective mode is logged unconditionally at boot and
+	// warned about every five minutes while it is not "enforce".
+	//
+	// The concurrency bound on password verification is NOT selected by this:
+	// it is in force in every mode, because it sheds only under genuine
+	// saturation and needs no observation period behind it.
+	LoginMode string `koanf:"login_mode"`
+
 	// BootstrapClaimSecret (WPMGR_BOOTSTRAP_CLAIM_SECRET) is the provisioning
 	// claim the installer mints and hands to the person who is entitled to own
 	// the install. First-run ownership — the very first organisation and its
@@ -792,13 +805,19 @@ func defaults() map[string]any {
 		"db.allow_rls_bypass_role": false,
 		"redis.addr":               "localhost:6379",
 		"redis.password":           "",
-		"auth.session_secret": "",
+		"auth.session_secret":      "",
 		// 2 is correct for the hosted deployment (load balancer appends the
 		// client address then its own). Every other topology must set this;
 		// see AuthConfig.ProxyHops and the startup log line that names it.
-		"auth.proxy_hops":   2,
-		"auth.idle_timeout": "168h", // 7 days idle
-		"auth.absolute_expiry":     "720h", // 30 days hard cap
+		"auth.proxy_hops": 2,
+		// GH #718 Phase 0. "observe" until the logged numbers have been
+		// reviewed; Phase 1 flips this default to "enforce". The literal, not
+		// auth.LoginModeObserve, because internal/auth imports this package —
+		// auth.ParseLoginMode is what actually validates the value at startup,
+		// so a drift between these two spellings fails the boot loudly.
+		"auth.login_mode":      "observe",
+		"auth.idle_timeout":    "168h", // 7 days idle
+		"auth.absolute_expiry": "720h", // 30 days hard cap
 		// ADR-056: WebAuthn relying party defaults (hosted instance).
 		// Self-hosted operators override via WPMGR_AUTH_WEBAUTHN_RPID etc.
 		"auth.webauthn_rpid":            "manage.wpmgr.app",


### PR DESCRIPTION
Phase 0 of the login admission control design in #718.

`POST /auth/login` currently has no admission control on either half of its
path, and every admitted attempt runs a full argon2id verification at the
19 MiB profile. This PR adds **measurement** and a **concurrency bound**. It
deliberately enforces none of the per-source or per-account budgets: the
numbers Phase 1 will enforce should come from what this observes rather than
from a guess, and an earlier attempt that enforced a guessed, identity-keyed
budget was rejected for turning the limiter into a denial of service against
the account it was protecting.

## What this adds

**`apps/api/internal/auth/login_gate.go`** — computes, for every login
attempt, the source key (IPv4 `/32`, IPv6 `/64`), the IPv6 `/48` key, an
account key and a source+account pair key, and evaluates a budget for each.
In `observe` mode nothing is charged on a would-refuse and nothing is
refused; the verdict goes to an INFO line naming the scope, the limit and
the window.

The account key is `hex(HMAC-SHA256(k, normalizeEmail(email)))[:16]`, where
`k` is derived from the session secret by HKDF under its own info string
(the rule stated in `social_handshake.go`: two purposes never share one
derived key). Two consequences, both deliberate: no email address reaches a
log line, matching how `reset.go` and `twofa.go` already identify an
account; and the map key is fixed-width, so a submitted address the caller
chose the size of cannot choose how much memory the process retains. Each
scope's map is capped at 4096 entries, following `registerPeerCap`.

The gate runs in the handler before `h.svc.Login`, and therefore before any
account lookup. It is handed an email string and nothing else, so it cannot
branch on whether the account exists, and observation is invisible to the
caller: same status, same body, same headers. `Service.Login`'s signature is
unchanged.

**A concurrency bound on password verification, which does enforce.** It is
not keyed on anything the caller controls; it sheds only when this process
already has as many verifications in flight as it is willing to run at once.
Over the bound the endpoint answers `503` with `server_busy` and
`Retry-After: 2`. This is the only caller-visible change in the PR. The slot
is released as soon as the verification returns, before the session and
trusted-device work, so the bound stays a bound on CPU rather than on the
whole handler.

**`Handler.limiterAddrSource`** reports, alongside the address `limiterAddr`
already returns, whether that address came from the forwarded chain at the
configured hop position or from the fallback. `limiterAddr`'s own return and
behaviour are unchanged, so no existing caller is affected. A wrong
`WPMGR_AUTH_PROXY_HOPS` is not observable from inside the process any other
way; this is what puts it in the log.

**`WPMGR_AUTH_LOGIN_MODE`**, defaulting to `observe`. An unrecognised value
fails the boot rather than being coerced. An unconditional startup line
names the mode, every budget, the effective hop count and — reading the live
objects, not the constants — whether the gate and the bound are actually
wired, so a refactor that dropped the wiring cannot do it silently. A WARN
repeats every five minutes while the mode is not `enforce`.

## Not in this phase

No enforcement of any budget, no cookie, no migration, no frontend change,
no new endpoint.

## Review

Auth code on an unauthenticated endpoint; `security-reviewer` pass to follow.
