### PR TITLE
fix(web): correct false backup encryption claims in the dashboard

### DIFF
--- a/apps/web/src/components/layout/auth-layout.tsx
+++ b/apps/web/src/components/layout/auth-layout.tsx
@@ -47,7 +47,7 @@ export function AuthLayout({ children }: { children: React.ReactNode }) {
 
 const PROOF = [
   "Connect a site in about a minute",
-  "Backups encrypted before they leave the site",
+  "Agent commands are signed and allow-listed",
   "Open source, and self-hostable for free",
 ];
 

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -130,8 +130,9 @@ export function BackupsSection({
           <div className="space-y-1.5">
             <CardTitle>Backups</CardTitle>
             <CardDescription>
-              Encrypted snapshots of this site. Chunks are encrypted on the
-              agent; the control plane cannot read your data.
+              Snapshots of this site, uploaded to the destination you configure: a
+              control-plane-managed bucket by default, or your own S3-compatible bucket or local
+              folder from Destinations.
             </CardDescription>
           </div>
           {canOperate ? <BackupNowControl siteId={siteId} /> : null}

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -131,8 +131,8 @@ export function BackupsSection({
             <CardTitle>Backups</CardTitle>
             <CardDescription>
               Snapshots of this site, uploaded to the destination you configure: a
-              control-plane-managed bucket by default, or your own S3-compatible bucket or local
-              folder from Destinations.
+              control-plane-managed bucket on plans with managed backup storage, or your own
+              S3-compatible bucket or local folder from Destinations otherwise.
             </CardDescription>
           </div>
           {canOperate ? <BackupNowControl siteId={siteId} /> : null}

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -130,7 +130,7 @@ export function BackupsSection({
           <div className="space-y-1.5">
             <CardTitle>Backups</CardTitle>
             <CardDescription>
-              Snapshots of this site, uploaded to the destination you configure: a
+              Snapshots of this site, stored at the destination you configure: a
               control-plane-managed bucket on plans with managed backup storage, or your own
               S3-compatible bucket or local folder from Destinations otherwise.
             </CardDescription>

--- a/apps/web/src/features/backups/backups-section.tsx
+++ b/apps/web/src/features/backups/backups-section.tsx
@@ -131,8 +131,8 @@ export function BackupsSection({
             <CardTitle>Backups</CardTitle>
             <CardDescription>
               Snapshots of this site, stored at the destination you configure: a
-              control-plane-managed bucket on plans with managed backup storage, or your own
-              S3-compatible bucket or local folder from Destinations otherwise.
+              control-plane-managed bucket, your own S3-compatible bucket, or a local folder
+              from Destinations.
             </CardDescription>
           </div>
           {canOperate ? <BackupNowControl siteId={siteId} /> : null}

--- a/apps/web/src/features/backups/format-progress.ts
+++ b/apps/web/src/features/backups/format-progress.ts
@@ -56,9 +56,9 @@ export const PHASE_LABEL: Record<PhaseId, string> = {
   dumping_db: "Dumping database",
   archiving_files: "Archiving files",
   compressing_files: "Compressing files",
-  encrypting: "Encrypting",
+  encrypting: "Uploading",
   uploading: "Uploading",
-  encrypting_uploading: "Encrypting & uploading",
+  encrypting_uploading: "Uploading",
   submitting_manifest: "Finalising",
   // Incremental backup (ADR-048)
   fetching_file_index: "Fetching file index",

--- a/apps/web/src/features/backups/format-progress.ts
+++ b/apps/web/src/features/backups/format-progress.ts
@@ -56,9 +56,9 @@ export const PHASE_LABEL: Record<PhaseId, string> = {
   dumping_db: "Dumping database",
   archiving_files: "Archiving files",
   compressing_files: "Compressing files",
-  encrypting: "Uploading",
+  encrypting: "Processing backup chunks",
   uploading: "Uploading",
-  encrypting_uploading: "Uploading",
+  encrypting_uploading: "Processing backup chunks",
   submitting_manifest: "Finalising",
   // Incremental backup (ADR-048)
   fetching_file_index: "Fetching file index",

--- a/apps/web/src/features/backups/format-progress.ts
+++ b/apps/web/src/features/backups/format-progress.ts
@@ -57,13 +57,13 @@ export const PHASE_LABEL: Record<PhaseId, string> = {
   archiving_files: "Archiving files",
   compressing_files: "Compressing files",
   encrypting: "Processing backup chunks",
-  uploading: "Uploading",
+  uploading: "Processing backup chunks",
   encrypting_uploading: "Processing backup chunks",
   submitting_manifest: "Finalising",
   // Incremental backup (ADR-048)
   fetching_file_index: "Fetching file index",
   scanning_files: "Scanning changes",
-  uploading_incremental: "Uploading changed files",
+  uploading_incremental: "Storing changed files",
   incremental_fallback: "Switching to full backup",
   // Restore (phase names match the agent's task-runner)
   preflight: "Pre-flight checks",

--- a/apps/web/src/features/tools/DbSnapshotPanel.tsx
+++ b/apps/web/src/features/tools/DbSnapshotPanel.tsx
@@ -119,8 +119,8 @@ export function DbSnapshotPanel({ siteId, canOperate }: Props) {
         <p className="mt-1 text-sm text-muted-foreground">
           Capture the database before a risky change, such as a plugin update,
           search-replace, or bulk edit. Revert in one click if something breaks.
-          Snapshots are stored locally on the WP server; they are separate from
-          this site's off-site backups.
+          Snapshots are stored locally on the WP server, separate from this
+          site's regular backups.
         </p>
       </div>
 

--- a/apps/web/src/features/tools/DbSnapshotPanel.tsx
+++ b/apps/web/src/features/tools/DbSnapshotPanel.tsx
@@ -117,9 +117,10 @@ export function DbSnapshotPanel({ siteId, canOperate }: Props) {
       <div>
         <h2 className="text-base font-semibold">Database Snapshots</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Capture the database before a risky change — plugin update, search-replace,
-          or bulk edit. Revert in one click if something breaks. Snapshots are
-          stored locally on the WP server (not encrypted off-site backups).
+          Capture the database before a risky change, such as a plugin update,
+          search-replace, or bulk edit. Revert in one click if something breaks.
+          Snapshots are stored locally on the WP server; they are separate from
+          this site's off-site backups.
         </p>
       </div>
 

--- a/apps/web/src/features/tools/use-db-snapshots.ts
+++ b/apps/web/src/features/tools/use-db-snapshots.ts
@@ -20,9 +20,9 @@ import { toError } from "@/features/auth/use-auth";
 // useDbSnapshots — local database snapshot hooks (#189).
 //
 // Snapshots are a fast LOCAL safety-net stored on the WP server filesystem.
-// They are distinct from durable backups (encrypted, off-site). Use them to
-// capture the DB state before a risky change (plugin update, search-replace,
-// bulk edit) and revert in one click if something goes wrong.
+// They are distinct from durable backups (off-site, unencrypted client side).
+// Use them to capture the DB state before a risky change (plugin update,
+// search-replace, bulk edit) and revert in one click if something goes wrong.
 //
 // Data flow:
 //   useDbSnapshotList  — GET  /api/v1/sites/{siteId}/perf/db/snapshots

--- a/apps/web/src/features/tools/use-db-snapshots.ts
+++ b/apps/web/src/features/tools/use-db-snapshots.ts
@@ -20,9 +20,10 @@ import { toError } from "@/features/auth/use-auth";
 // useDbSnapshots — local database snapshot hooks (#189).
 //
 // Snapshots are a fast LOCAL safety-net stored on the WP server filesystem.
-// They are distinct from durable backups (off-site, unencrypted client side).
-// Use them to capture the DB state before a risky change (plugin update,
-// search-replace, bulk edit) and revert in one click if something goes wrong.
+// They are distinct from durable backups (unencrypted client side, stored at
+// whatever destination the site configures). Use them to capture the DB state
+// before a risky change (plugin update, search-replace, bulk edit) and revert
+// in one click if something goes wrong.
 //
 // Data flow:
 //   useDbSnapshotList  — GET  /api/v1/sites/{siteId}/perf/db/snapshots

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -73,10 +73,12 @@ function PrivacyPage() {
                 <strong className="text-[var(--color-foreground)]">Backup archives:</strong>{" "}
                 when you run or schedule a backup, the agent creates an archive of your database
                 and/or files and uploads it to the storage destination your control plane
-                configures: a control-plane-managed bucket by default, or a customer-owned bucket or
-                local folder you point it at instead. Archive contents may include your site's content
-                and personal data; the agent does not encrypt them before upload, so protection comes
-                from your chosen destination's own access controls and at-rest encryption, if any.
+                configures. The default is a control-plane-managed bucket on plans with managed
+                backup storage; otherwise a customer-owned bucket or local folder must be
+                configured before backups will run. Archive contents may include your site's
+                content and personal data; the agent does not encrypt them before upload, so
+                protection comes from your chosen destination's own access controls and at-rest
+                encryption, if any.
               </li>
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Rendered HTML</strong> — for
@@ -112,10 +114,10 @@ function PrivacyPage() {
               </li>
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Backup archives:</strong> for sites
-                using the control-plane-managed bucket (the default), stored in our cloud object storage
-                with the provider's encryption at rest. If you configure your own S3-compatible bucket or
-                a local folder on the WordPress host instead, backup data does not pass through our
-                storage.
+                on a plan with managed backup storage using the control-plane-managed bucket, stored in
+                our cloud object storage with the provider's encryption at rest. Free-plan sites, and any
+                site pointed at your own S3-compatible bucket or a local folder instead, keep backup data
+                off our storage.
               </li>
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Operational logs</strong> needed to

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -72,13 +72,15 @@ function PrivacyPage() {
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Backup archives:</strong>{" "}
                 when you run or schedule a backup, the agent creates an archive of your database
-                and/or files and uploads it to the storage destination your control plane
-                configures. The default is a control-plane-managed bucket on plans with managed
-                backup storage; otherwise a customer-owned bucket or local folder must be
-                configured before backups will run. Archive contents may include your site's
-                content and personal data; the agent does not encrypt them before upload, so
-                protection comes from your chosen destination's own access controls and at-rest
-                encryption, if any.
+                and/or files and stores it at the destination your control plane configures. The
+                default is a control-plane-managed bucket on plans with managed backup storage;
+                otherwise a customer-owned bucket or local folder must be configured before
+                backups will run. A control-plane-managed or customer-owned bucket receives the
+                archive over the network; a local folder keeps it on your own server, written
+                there directly by the agent. Archive contents may include your site's content and
+                personal data; the agent does not encrypt them beforehand, so protection comes
+                from your chosen destination's own access controls and at-rest encryption, if
+                any.
               </li>
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Rendered HTML</strong> — for
@@ -142,9 +144,10 @@ function PrivacyPage() {
                 Agent-to-control-plane requests are Ed25519-signed and replay-protected.
               </li>
               <li className="leading-relaxed">
-                Backup archives are not encrypted client side before upload; protection comes from
-                your chosen destination's access controls and, where the destination provides it,
-                encryption at rest. Client-side encryption of backup archives is planned.
+                Backup archives are not encrypted client side before they reach the destination;
+                protection comes from your chosen destination's access controls and, where the
+                destination provides it, encryption at rest. Client-side encryption of backup
+                archives is planned.
               </li>
               <li className="leading-relaxed">All network traffic uses TLS.</li>
             </ul>

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -72,12 +72,13 @@ function PrivacyPage() {
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Backup archives:</strong>{" "}
                 when you run or schedule a backup, the agent creates an archive of your database
-                and/or files and stores it at the destination your control plane configures. The
-                default is a control-plane-managed bucket on plans with managed backup storage;
-                otherwise a customer-owned bucket or local folder must be configured before
-                backups will run. A control-plane-managed or customer-owned bucket receives the
-                archive over the network; a local folder keeps it on your own server, written
-                there directly by the agent. Archive contents may include your site's content and
+                and/or files and stores it at the destination configured for that site: a
+                control-plane-managed bucket, your own S3-compatible bucket, or a local folder on
+                the WordPress host. The control-plane-managed bucket is available only on plans
+                with managed backup storage; without that entitlement, one of the other two must
+                be configured before backups will run. A bucket destination receives the archive
+                over the network; a local folder keeps it on your own server, written there
+                directly by the agent. Archive contents may include your site's content and
                 personal data; the agent does not encrypt them beforehand, so protection comes
                 from your chosen destination's own access controls and at-rest encryption, if
                 any.

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -70,11 +70,13 @@ function PrivacyPage() {
                 of available core, plugin, and theme updates.
               </li>
               <li className="leading-relaxed">
-                <strong className="text-[var(--color-foreground)]">Backup archives (encrypted)</strong>{" "}
-                — when you run or schedule a backup, the agent creates an archive of your database
-                and/or files, encrypts it, and uploads it to the storage destination your control plane
-                configures. Archive contents may include your site's content and personal data; they are
-                encrypted before they leave your server.
+                <strong className="text-[var(--color-foreground)]">Backup archives:</strong>{" "}
+                when you run or schedule a backup, the agent creates an archive of your database
+                and/or files and uploads it to the storage destination your control plane
+                configures: a control-plane-managed bucket by default, or a customer-owned bucket or
+                local folder you point it at instead. Archive contents may include your site's content
+                and personal data; the agent does not encrypt them before upload, so protection comes
+                from your chosen destination's own access controls and at-rest encryption, if any.
               </li>
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Rendered HTML</strong> — for
@@ -109,8 +111,11 @@ function PrivacyPage() {
                 management features you use.
               </li>
               <li className="leading-relaxed">
-                <strong className="text-[var(--color-foreground)]">Encrypted backup archives</strong>,
-                stored in cloud object storage.
+                <strong className="text-[var(--color-foreground)]">Backup archives:</strong> for sites
+                using the control-plane-managed bucket (the default), stored in our cloud object storage
+                with the provider's encryption at rest. If you configure your own S3-compatible bucket or
+                a local folder on the WordPress host instead, backup data does not pass through our
+                storage.
               </li>
               <li className="leading-relaxed">
                 <strong className="text-[var(--color-foreground)]">Operational logs</strong> needed to
@@ -134,7 +139,11 @@ function PrivacyPage() {
               <li className="leading-relaxed">
                 Agent-to-control-plane requests are Ed25519-signed and replay-protected.
               </li>
-              <li className="leading-relaxed">Backups are encrypted before they leave your server.</li>
+              <li className="leading-relaxed">
+                Backup archives are not encrypted client side before upload; protection comes from
+                your chosen destination's access controls and, where the destination provides it,
+                encryption at rest. Client-side encryption of backup archives is planned.
+              </li>
               <li className="leading-relaxed">All network traffic uses TLS.</li>
             </ul>
           </Section>


### PR DESCRIPTION
## Summary
Backups are not encrypted client side in any shipped build: `apps/agent/includes/backup/class-encrypt-and-upload.php:105` is `public const ENCRYPT_CHUNKS = false;`, a compile-time constant nothing at runtime can flip. This is the sixth surface carrying the same false claim; README.md, SECURITY.md, docs/, docs/legal/privacy.md and apps/marketing were corrected separately. This PR corrects apps/web, the one surface missed.

## Occurrences found and fixed
- `apps/web/src/components/layout/auth-layout.tsx:50` - sign-in screen selling point claimed backups are encrypted before leaving the site. Replaced with a different true security property (agent commands are signed and allow-listed), since an inverted bullet on a sign-in screen reads as a confession.
- `apps/web/src/routes/privacy.tsx` (three spots) - "What the agent sends", "The hosted service", and "Security" sections all asserted client-side backup encryption. Reworded to describe the actual destination model (control-plane-managed bucket by default, or a customer-owned bucket / local folder) and that protection comes from the destination's own access controls and at-rest encryption, not from the agent. The Security section now states plainly that client-side encryption is not implemented today and is planned, per instruction not to promise a date.
- `apps/web/src/features/backups/backups-section.tsx:133-134` - the Backups card description claimed "Chunks are encrypted on the agent; the control plane cannot read your data." This was the most severe instance (an explicit zero-knowledge claim, false for every destination). Replaced with a factual description of the configurable destination.
- `apps/web/src/features/tools/DbSnapshotPanel.tsx:122` and `use-db-snapshots.ts:23` - DB snapshot copy/comment implied durable off-site backups are encrypted by contrast. Corrected.
- `apps/web/src/features/backups/format-progress.ts:59,61` - the live progress labels shown during every backup run ("Encrypting" / "Encrypting & uploading") asserted an encryption step that never executes. Relabeled "Uploading" to match actual behavior. The underlying phase ids are unchanged (they mirror the agent's wire protocol, out of scope here).

Reviewed and left unchanged (different subsystem, not the same claim): `use-admin-vuln-feed.ts:13` (server-side age-encrypted API key storage for the vuln feed, unrelated to backups), `CdnSection.tsx:248` (CDN provider credential storage, unrelated to backups), the "Encryption recipient" field in the snapshot detail page (already renders empty/undefined since `age_recipient` is never populated while `ENCRYPT_CHUNKS` is false, so it asserts nothing false today).

## Verification
- `grep -rniE "encrypted before|client-side encrypt|only ciphertext|never holds a decryption key" apps/web/src` - one surviving hit, `privacy.tsx`: "Client-side encryption of backup archives is planned." (a true, forward-looking statement, not a present-tense claim).
- `pnpm --filter @wpmgr/web typecheck` - passes.

## Test plan
- [x] `pnpm --filter @wpmgr/web typecheck`
- [ ] `pnpm --filter @wpmgr/web test`
- [ ] `pnpm --filter @wpmgr/web build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the privacy policy to clarify backup destinations, network transmission, access controls, and encryption practices.
  - Clarified the distinction between local database snapshots and durable backups.
  - Updated backup descriptions to explain supported storage destinations and retention behavior.

- **User Interface**
  - Updated backup progress labels to use “Processing backup chunks” and “Storing changed files.”
  - Refreshed authentication page security messaging.
  - Improved database snapshot wording to clarify risks and local storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->