### PR TITLE
fix(web): correct false backup encryption claims across both privacy copies

### DIFF
--- a/apps/web/public/privacy.html
+++ b/apps/web/public/privacy.html
@@ -259,7 +259,10 @@
             destination provides it, encryption at rest. Client-side encryption of backup
             archives is planned.
           </li>
-          <li>All network traffic uses TLS.</li>
+          <li>
+            All network traffic uses TLS. A backup sent to a folder on the site's own server does
+            not cross the network at all.
+          </li>
         </ul>
       </section>
 

--- a/apps/web/public/privacy.html
+++ b/apps/web/public/privacy.html
@@ -138,7 +138,7 @@
 
     <article>
       <h1>Privacy Policy</h1>
-      <p class="meta">Last updated: 8 June 2026</p>
+      <p class="meta">Last updated: 10 September 2026</p>
 
       <p class="intro">
         WPMgr is open-source, self-hostable software for managing a fleet of WordPress sites —
@@ -181,11 +181,17 @@
             <strong>Update inventory</strong> — the list of available core, plugin, and theme updates.
           </li>
           <li>
-            <strong>Backup archives (encrypted)</strong>
+            <strong>Backup archives</strong>
             — when you run or schedule a backup, the agent creates an archive of your database
-            and/or files, encrypts it, and uploads it to the storage destination your control plane
-            configures. Archive contents may include your site's content and personal data; they are
-            encrypted before they leave your server.
+            and/or files and stores it at the destination configured for that site: a
+            control-plane-managed bucket, your own S3-compatible bucket, or a local folder on the
+            WordPress host. The control-plane-managed bucket is available only on plans with
+            managed backup storage; without that entitlement, one of the other two must be
+            configured before backups will run. A bucket destination receives the archive over the
+            network; a local folder keeps it on your own server, written there directly by the
+            agent. Archive contents may include your site's content and personal data; the agent
+            does not encrypt them beforehand, so protection comes from your chosen destination's
+            own access controls and at-rest encryption, if any.
           </li>
           <li>
             <strong>Rendered HTML</strong> — for
@@ -221,8 +227,10 @@
             management features you use.
           </li>
           <li>
-            <strong>Encrypted backup archives</strong>,
-            stored in cloud object storage.
+            <strong>Backup archives</strong>: for sites on a plan with managed backup storage
+            using the control-plane-managed bucket, stored in our cloud object storage with the
+            provider's encryption at rest. Free-plan sites, and any site pointed at your own
+            S3-compatible bucket or a local folder instead, keep backup data off our storage.
           </li>
           <li>
             <strong>Operational logs</strong> needed to run and secure the service.
@@ -245,7 +253,12 @@
         <h2>Security</h2>
         <ul>
           <li>Agent-to-control-plane requests are Ed25519-signed and replay-protected.</li>
-          <li>Backups are encrypted before they leave your server.</li>
+          <li>
+            Backup archives are not encrypted client side before they reach the destination;
+            protection comes from your chosen destination's access controls and, where the
+            destination provides it, encryption at rest. Client-side encryption of backup
+            archives is planned.
+          </li>
           <li>All network traffic uses TLS.</li>
         </ul>
       </section>

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -150,7 +150,10 @@ function PrivacyPage() {
                 destination provides it, encryption at rest. Client-side encryption of backup
                 archives is planned.
               </li>
-              <li className="leading-relaxed">All network traffic uses TLS.</li>
+              <li className="leading-relaxed">
+                All network traffic uses TLS. A backup sent to a folder on the site's own server
+                does not cross the network at all.
+              </li>
             </ul>
           </Section>
 


### PR DESCRIPTION
## Summary

`apps/web/public/privacy.html` is a tracked static file served live at `https://manage.wpmgr.app/privacy.html`, added in 0d338aaf as a crawlable twin of the React `/privacy` route for a wordpress.org review. When the React route was corrected in #729 (backups are not encrypted client side; `ENCRYPT_CHUNKS` is a compile-time `false` in `apps/agent/includes/backup/class-encrypt-and-upload.php:105`), this static copy was missed because prior sweeps searched `apps/web/src`, not `apps/web/public/`. The live page still claimed backups are "encrypted before they leave your server."

This corrects the static copy to match the wording already merged in `apps/web/src/routes/privacy.tsx`:

- The "Backup archives" bullet under "What the agent sends" now describes the three destination types (control-plane-managed bucket, customer S3-compatible bucket, local folder on the WordPress host), the managed-bucket entitlement gate, and that the agent does not encrypt archives beforehand.
- The hosted-service "Backup archives" bullet now distinguishes the managed bucket (provider encryption at rest) from free-plan/customer-bucket/local-folder sites (kept off WPMgr's storage).
- The Security-section encryption bullet no longer claims "Backups are encrypted before they leave your server"; it states client-side encryption does not happen today, protection comes from the destination's own access controls and at-rest encryption, and client-side encryption is planned.
- Bumped "Last updated" to 10 September 2026.

`apps/web/public/terms.html` was swept for the same language (encrypt/upload/off-site/leaves your server) and had zero hits; no change needed there.

## Follow-up in this same PR: the TLS bullet, widened to `apps/web/src`

A second pass found the Security section's "All network traffic uses TLS." bullet true but incomplete in both web copies. It is not false (a local-folder backup never touches the network, so the sentence holds), but it leaves the exact reader this section exists for, the one asking whether their backup crosses the network protected, to infer an answer, and the natural inference is wrong for the local-folder destination. Confirmed no network hop exists for that destination: `apps/api/internal/blobstore/registry.go:122-123`, `KindLocal` returns "local destinations do not use a Store (chunks go to disk on the agent)".

`docs/legal/privacy.md:118-119` already carries the qualified sentence, added in #723: "All network traffic uses TLS. A backup sent to a folder on the site's own server does not cross the network at all." The two web copies had not picked it up. Rather than fix only the static file (which would leave both web copies agreeing with each other and disagreeing with the docs), this PR now also edits `apps/web/src/routes/privacy.tsx` to match the docs wording verbatim, so all three copies of this document now say the same thing about TLS.

## Verification

`grep -niE "encrypt|upload|off-site|leaves your server" apps/web/public/privacy.html apps/web/src/routes/privacy.tsx docs/legal/privacy.md apps/web/public/terms.html`: every surviving hit across all four files is a true statement consistent with the others (does-not-encrypt, at-rest encryption, GCP encrypted-storage sub-processor note, planned client-side encryption); `terms.html` is 0 hits before and after.

Diff of the corrected sections reviewed against `apps/web/src/routes/privacy.tsx` (backup-archive wording) and against `docs/legal/privacy.md` (TLS wording); not byte-identical (JSX vs HTML vs Markdown) but no difference in meaning.

`pnpm -C apps/web typecheck` exits 0. `pnpm -C apps/web lint` exits 0 (16 pre-existing warnings unrelated to this change, 0 errors). `pnpm --filter @wpmgr/web build` exits 0; `apps/web/dist/privacy.html` (gitignored build output, not tracked, confirmed via an empty `git ls-files apps/web/dist` and `git check-ignore -v apps/web/dist/privacy.html` matching `.gitignore` line 13) picks up both rounds of wording changes. `routeTree.gen.ts` is untouched (`git status` after the build shows no diff to it), as expected since no route was added, removed or moved.

HTML tag balance checked on `privacy.html` (li/ul/section/p/strong all open/close matched, both rounds). No em or en dashes introduced in any added line (checked the diff's added lines only in both rounds).

## Does this drift again?

Nothing in this repo prevents these three copies (`docs/legal/privacy.md`, `apps/web/src/routes/privacy.tsx`, `apps/web/public/privacy.html`) from drifting apart again, and this PR is itself evidence: the docs copy got the TLS qualification in #723, the React route did not, and the static file inherited the gap a second time. A generator or a byte-identity/content-equivalence CI check (the shape used for the page-cache path-normalization fix in #719) is a real option, but it is out of scope here by design, since these pages are live and wrong today and the fix should not wait on building a guard. Whether it is worth building is a separate call: a Markdown/JSX/HTML triple can't be byte-identical, so any guard would need to diff normalized, semantically-tagged content (e.g. extract the prose behind a shared set of markers in all three, or generate two of the three from one source) rather than raw bytes, which is real engineering effort for a document that changes rarely. Given this is the second same-shaped drift found today (after the page-cache path-normalization one in #719), I'd lean toward it being worth doing, but as a deliberate follow-up, not folded into this fix.

## Test plan

- [x] grep sweep across all four files (privacy.html, privacy.tsx, docs/legal/privacy.md, terms.html), before and after both rounds (reported above)
- [x] `pnpm -C apps/web typecheck` exits 0
- [x] `pnpm -C apps/web lint` exits 0
- [x] `pnpm --filter @wpmgr/web build` exits 0
- [x] Manual diff of corrected sections against `apps/web/src/routes/privacy.tsx` and `docs/legal/privacy.md`
