### PR TITLE
fix(api): guard the agent metadata write of a site's backup recipient

### DIFF
--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -534,6 +534,9 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 	siteSvc := site.NewService(site.NewRepo(pool), validator, clock)
 	siteSvc.SetLogger(logger)
 	auditRec := audit.NewRecorder(pool, clock)
+	// The agent metadata path records a first set of, and any refused change
+	// to, a site's backup encryption recipient (sites.age_recipient).
+	siteSvc.SetAuditRecorder(auditRec)
 
 	// S6b — the MCP read surface. Wired UNCONDITIONALLY, not behind a hosted
 	// flag: the endpoint is published on the connect screen, and a nil handler

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -79,6 +79,27 @@ const (
 	ActionPairingCodeCreated = "pairing_code.created"
 	ActionSiteTagsSet        = "site.tags.set"
 
+	// Backup encryption recipient (sites.age_recipient). The column is key
+	// material: it decides which age PUBLIC key future backups are encrypted
+	// to, and the control plane never holds the matching identity, so a change
+	// to it is otherwise only discoverable at restore time. Both events are
+	// recorded with ActorSystem — the writer is the agent channel, not a human
+	// — and carry the FULL recipient values in metadata. Those are public keys,
+	// never secrets, and recording them is the point: the log is where an
+	// operator looks to find which recipient a site's older backups were
+	// written for. audit_log.action is plain text with no CHECK and no enum
+	// (db/schema.sql), so neither of these needed a migration.
+	//
+	// ActionSiteBackupRecipientSet: the FIRST recipient was recorded for a site
+	// (normal enrolment). Metadata: recipient, source ("agent_metadata"),
+	// agent_version.
+	ActionSiteBackupRecipientSet = "site.backup.recipient.set"
+	// ActionSiteBackupRecipientChangeRejected: an agent metadata push carried a
+	// recipient DIFFERENT from the one already recorded, and the change was NOT
+	// applied. Metadata: current_recipient, proposed_recipient, source,
+	// agent_version, reason.
+	ActionSiteBackupRecipientChangeRejected = "site.backup.recipient.change_rejected"
+
 	// GH #230 "rich tags" — tenant-level tag registry (internal/sitetag).
 	ActionTagCreate    = "tag.create"
 	ActionTagUpdate    = "tag.update"

--- a/apps/api/internal/site/age_recipient_guard_test.go
+++ b/apps/api/internal/site/age_recipient_guard_test.go
@@ -1,0 +1,205 @@
+package site
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	agentpkg "github.com/mosamlife/wpmgr/apps/api/internal/agent"
+)
+
+// The agent metadata path writes sites.age_recipient, which names the age
+// PUBLIC key a site's backups are encrypted to. These tests pin the three
+// properties the write must have: a first set still lands, a change to an
+// established recipient is refused AND visible, and a failed persist is not
+// swallowed.
+
+const (
+	recipientA = "age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsaaaaaa"
+	recipientB = "age1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzsbbbbbb"
+)
+
+// logCapture wires a service to a JSON logger writing into a buffer, so a test
+// can assert on what the operator would actually see. The audit recorder needs
+// a live pool, so the log line is the visibility surface a unit test can reach;
+// the service emits it unconditionally, before and independently of the audit
+// write.
+func logCapture(svc *Service) *bytes.Buffer {
+	var buf bytes.Buffer
+	svc.SetLogger(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return &buf
+}
+
+func applyRecipient(t *testing.T, svc *Service, tenantID, siteID uuid.UUID, rec string) error {
+	t.Helper()
+	_, err := svc.ApplyAgentMetadata(context.Background(), tenantID, siteID, agentpkg.Metadata{
+		WPVersion:    "6.7",
+		AgentVersion: "0.61.161",
+		AgeRecipient: rec,
+	})
+	return err
+}
+
+// A first set is the path every normal enrolment takes: the column is empty and
+// the agent's recipient must be recorded, or the site can never back up
+// (internal/backup refuses with age_recipient_missing).
+func TestAgentMetadataRecordsFirstAgeRecipient(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := newSvc(repo)
+	buf := logCapture(svc)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	if err := applyRecipient(t, svc, tenantID, siteID, recipientA); err != nil {
+		t.Fatalf("ApplyAgentMetadata returned error on first set: %v", err)
+	}
+
+	if repo.ageRecipient != recipientA {
+		t.Fatalf("first set was not persisted: column = %q, want %q", repo.ageRecipient, recipientA)
+	}
+	if repo.ifUnsetCalls != 1 {
+		t.Fatalf("expected exactly one guarded write, got %d", repo.ifUnsetCalls)
+	}
+	if repo.unconditionalSets != 0 {
+		t.Fatalf("agent path must never use the unconditional write, got %d calls", repo.unconditionalSets)
+	}
+	if !strings.Contains(buf.String(), "site backup recipient recorded") {
+		t.Fatalf("first set was not logged; log = %s", buf.String())
+	}
+}
+
+// Re-pushing the SAME recipient is the steady state (every metadata beat
+// carries it). It must not re-write the column and must not look like a change.
+func TestAgentMetadataSameRecipientIsANoOp(t *testing.T) {
+	repo := &fakeRepo{ageRecipient: recipientA}
+	svc := newSvc(repo)
+	buf := logCapture(svc)
+
+	if err := applyRecipient(t, svc, uuid.New(), uuid.New(), recipientA); err != nil {
+		t.Fatalf("ApplyAgentMetadata returned error on unchanged recipient: %v", err)
+	}
+	if repo.ifUnsetCalls != 0 || repo.unconditionalSets != 0 {
+		t.Fatalf("unchanged recipient triggered a write: ifUnset=%d unconditional=%d",
+			repo.ifUnsetCalls, repo.unconditionalSets)
+	}
+	if strings.Contains(buf.String(), "rejected agent-pushed change") {
+		t.Fatalf("unchanged recipient was reported as a rejected change; log = %s", buf.String())
+	}
+}
+
+// The defect: a push carrying a DIFFERENT recipient silently replaced an
+// established one. It must now leave the column alone and say so — a refused
+// change that nobody can see is the same silence in a different shape.
+func TestAgentMetadataRefusesAndReportsRecipientChange(t *testing.T) {
+	repo := &fakeRepo{ageRecipient: recipientA}
+	svc := newSvc(repo)
+	buf := logCapture(svc)
+	tenantID, siteID := uuid.New(), uuid.New()
+
+	out, err := svc.ApplyAgentMetadata(context.Background(), tenantID, siteID, agentpkg.Metadata{
+		WPVersion:    "6.7",
+		AgentVersion: "0.61.161",
+		AgeRecipient: recipientB,
+	})
+	if err != nil {
+		// A refused change must not fail the whole metadata push: the rest of
+		// the inventory is legitimate and the agent cannot fix the value by
+		// retrying.
+		t.Fatalf("ApplyAgentMetadata returned error on refused change: %v", err)
+	}
+
+	if repo.ageRecipient != recipientA {
+		t.Fatalf("established recipient was overwritten: column = %q, want %q", repo.ageRecipient, recipientA)
+	}
+	if repo.unconditionalSets != 0 {
+		t.Fatalf("refused change still reached the unconditional write (%d calls)", repo.unconditionalSets)
+	}
+	// The wire type carries no recipient field, so the site the agent gets back
+	// is just the site; what matters is that the stored column is untouched
+	// (asserted above) and the push still succeeded for every other field.
+	if out.ID != siteID {
+		t.Fatalf("returned site %v, want %v", out.ID, siteID)
+	}
+
+	// Visibility: one WARN line naming both recipients, so an operator reading
+	// logs can tell which key the site's existing backups were written for and
+	// which one is now claiming the site.
+	var found bool
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] != "rejected agent-pushed change to an established site backup recipient" {
+			continue
+		}
+		found = true
+		if rec["level"] != "WARN" {
+			t.Fatalf("rejection logged at %v, want WARN", rec["level"])
+		}
+		if rec["current_recipient"] != recipientA || rec["proposed_recipient"] != recipientB {
+			t.Fatalf("rejection log lost the recipients: %v", rec)
+		}
+		if rec["site_id"] != siteID.String() {
+			t.Fatalf("rejection log names site %v, want %s", rec["site_id"], siteID)
+		}
+	}
+	if !found {
+		t.Fatalf("a refused recipient change produced no log line; log = %s", buf.String())
+	}
+}
+
+// The old code did `if err == nil { out = updated }`, so a failed write left the
+// caller believing the recipient was stored. It must surface instead.
+func TestAgentMetadataSurfacesRecipientPersistFailure(t *testing.T) {
+	boom := errors.New("write failed")
+	repo := &fakeRepo{ifUnsetErr: boom}
+	svc := newSvc(repo)
+	buf := logCapture(svc)
+
+	err := applyRecipient(t, svc, uuid.New(), uuid.New(), recipientA)
+	if err == nil {
+		t.Fatalf("a failed recipient write was swallowed: ApplyAgentMetadata returned nil")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("error did not carry the persist failure: %v", err)
+	}
+	if !strings.Contains(buf.String(), "failed to persist site age recipient") {
+		t.Fatalf("persist failure was not logged; log = %s", buf.String())
+	}
+}
+
+// Losing the in-transaction race to a concurrent first set is a refused change
+// too: the column already holds someone else's value and this push must not
+// pretend it won.
+func TestAgentMetadataConcurrentFirstSetLoserIsReported(t *testing.T) {
+	repo := &racingRepo{winner: recipientA}
+	svc := newSvc(repo)
+	buf := logCapture(svc)
+
+	if err := applyRecipient(t, svc, uuid.New(), uuid.New(), recipientB); err != nil {
+		t.Fatalf("ApplyAgentMetadata returned error for the race loser: %v", err)
+	}
+	if !strings.Contains(buf.String(), "concurrent_first_set") {
+		t.Fatalf("race loser was not reported; log = %s", buf.String())
+	}
+}
+
+// racingRepo simulates the other transaction winning the per-site advisory lock
+// and setting the recipient first: the guarded write applies nothing and hands
+// back the winner's row.
+type racingRepo struct {
+	fakeRepo
+	winner string
+}
+
+func (r *racingRepo) SetAgeRecipientIfUnset(_ context.Context, tenantID, siteID uuid.UUID, _ string) (Site, bool, error) {
+	r.ifUnsetCalls++
+	r.ageRecipient = r.winner
+	return Site{ID: siteID, TenantID: tenantID, AgeRecipient: r.winner}, false, nil
+}

--- a/apps/api/internal/site/repo.go
+++ b/apps/api/internal/site/repo.go
@@ -35,6 +35,12 @@ type Repo interface {
 	Delete(ctx context.Context, tenantID, id uuid.UUID) error
 	SetTags(ctx context.Context, in SetTagsInput) (Site, error)
 	SetAgeRecipient(ctx context.Context, tenantID, siteID uuid.UUID, recipient string) (Site, error)
+	// SetAgeRecipientIfUnset is the AGENT path's write: it stores the recipient
+	// only when the site has none yet, and never overwrites an established one.
+	// Returns the site as it stands after the call and whether the write was
+	// applied. SetAgeRecipient (above) stays the deliberate, unconditional
+	// operator path.
+	SetAgeRecipientIfUnset(ctx context.Context, tenantID, siteID uuid.UUID, recipient string) (Site, bool, error)
 
 	// GH #414 m117 — monitoring pause/resume. Bulk by construction (the UI
 	// entry point is a multi-select) and idempotent: see monitoring_repo.go.
@@ -627,6 +633,60 @@ func (r *pgRepo) SetAgeRecipient(ctx context.Context, tenantID, siteID uuid.UUID
 		return nil
 	})
 	return out, err
+}
+
+// ageRecipientLockNamespace is the advisory-lock namespace that serializes the
+// read-then-write in SetAgeRecipientIfUnset. Without it two concurrent agent
+// pushes (the twelve-clones-under-one-identity shape of GH #577) both read an
+// empty column, both decide they are the first set, and the later write wins —
+// which is exactly the silent overwrite this method exists to prevent. The lock
+// is xact-scoped, so it releases on commit or rollback; it is taken per SITE,
+// so it never serializes unrelated sites.
+const ageRecipientLockNamespace = "site_age_recipient"
+
+func (r *pgRepo) SetAgeRecipientIfUnset(ctx context.Context, tenantID, siteID uuid.UUID, recipient string) (Site, bool, error) {
+	var out Site
+	var applied bool
+	err := r.pool.InTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx,
+			"SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))",
+			ageRecipientLockNamespace, siteID.String()); err != nil {
+			return domain.Internal("site_recipient_lock_failed", "failed to lock site age recipient").WithCause(err)
+		}
+		q := sqlc.New(tx)
+		cur, err := q.GetSite(ctx, sqlc.GetSiteParams{ID: siteID, TenantID: tenantID})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.NotFound("site_not_found", "site not found")
+			}
+			return domain.Internal("site_get_failed", "failed to load site").WithCause(err)
+		}
+		// Already set: leave it alone and report the row as it stands. The
+		// caller decides whether that is a no-op (same value) or a refused
+		// change (different value) and records it.
+		if cur.AgeRecipient != "" {
+			out = toModelFromGetSiteRow(cur)
+			return nil
+		}
+		row, err := q.SetSiteAgeRecipient(ctx, sqlc.SetSiteAgeRecipientParams{
+			ID:           siteID,
+			TenantID:     tenantID,
+			AgeRecipient: recipient,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.NotFound("site_not_found", "site not found")
+			}
+			return domain.Internal("site_set_recipient_failed", "failed to set site age recipient").WithCause(err)
+		}
+		out = toModel(row)
+		applied = true
+		return nil
+	})
+	if err != nil {
+		return Site{}, false, err
+	}
+	return out, applied, nil
 }
 
 func (r *pgRepo) CreatePairingCode(ctx context.Context, in CreatePairingCodeInput, codeHash string, expiresAt time.Time) (PairingCode, error) {

--- a/apps/api/internal/site/service.go
+++ b/apps/api/internal/site/service.go
@@ -13,6 +13,7 @@ import (
 	agentpkg "github.com/mosamlife/wpmgr/apps/api/internal/agent"
 	"github.com/mosamlife/wpmgr/apps/api/internal/agentplugin"
 	"github.com/mosamlife/wpmgr/apps/api/internal/api/gen"
+	"github.com/mosamlife/wpmgr/apps/api/internal/audit"
 	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
 	"github.com/mosamlife/wpmgr/apps/api/internal/metrics"
 	"github.com/mosamlife/wpmgr/apps/api/internal/wpversion"
@@ -38,6 +39,17 @@ type Service struct {
 	// deployments see real data (ClickHouse never writes to site_uptime_probes).
 	// nil disables uptime enrichment (tests that don't inject a store).
 	uptimeStore metrics.Store
+	// audit records agent-channel events that change (or are refused from
+	// changing) backup key material on a site. Optional: nil means the audit
+	// entry is skipped, never that the event goes unreported — the structured
+	// log line is unconditional.
+	audit *audit.Recorder
+}
+
+// SetAuditRecorder wires the hash-chained audit recorder. Call once at boot;
+// nil-safe when omitted (dump-routes and unit tests).
+func (s *Service) SetAuditRecorder(rec *audit.Recorder) {
+	s.audit = rec
 }
 
 // NewService builds a site Service.
@@ -392,16 +404,133 @@ func (s *Service) ApplyAgentMetadata(ctx context.Context, tenantID, siteID uuid.
 	if err != nil {
 		return gen.Site{}, err
 	}
-	// Opportunistically register the agent's age recipient (M4 backups need it).
-	// Best-effort: a malformed recipient is silently ignored — the agent will
-	// retry on the next sync, and operators can also set it explicitly elsewhere.
+	// Register the agent's age recipient (M4 backups need it). A malformed
+	// recipient is still ignored — the agent retries on the next sync — but a
+	// well-formed one is now routed through applyAgentAgeRecipient, which
+	// distinguishes a first set from a change to an established value.
 	if rec := strings.TrimSpace(m.AgeRecipient); rec != "" && len(rec) <= 256 &&
 		strings.HasPrefix(rec, "age1") && out.AgeRecipient != rec {
-		if updated, err := s.repo.SetAgeRecipient(ctx, tenantID, siteID, rec); err == nil {
-			out = updated
+		updated, err := s.applyAgentAgeRecipient(ctx, tenantID, siteID, rec, out, m.AgentVersion)
+		if err != nil {
+			return gen.Site{}, err
 		}
+		out = updated
 	}
 	return toAPI(out), nil
+}
+
+// applyAgentAgeRecipient decides what an agent-pushed age recipient may do to
+// sites.age_recipient, which is backup key material: it names the age PUBLIC
+// key the site's future backups are encrypted to, and the control plane never
+// holds the matching identity.
+//
+// FIRST SET (column empty) is applied. That is ordinary enrolment and the
+// column gates backups outright (internal/backup: age_recipient_missing), so
+// breaking it would stop every new site backing up.
+//
+// A CHANGE to an established recipient is NOT applied. The agent channel proves
+// possession of the site's agent credential, and nothing more: a cloned install
+// carries the original's credential (GH #577 reported twelve clones reporting
+// under one identity), so "a different recipient arrived over an authenticated
+// push" does not distinguish a legitimately re-provisioned keystore from a copy
+// of the site speaking for the original. Accepting the change would let
+// whichever install pushed last repoint an established site's backup encryption
+// at a key its owner does not hold — silently, since the CP cannot read either.
+// Refusing leaves the established recipient in force, which is the state the
+// operator already has working backups under.
+//
+// Either way the outcome is now RECORDED: a hash-chained audit entry plus a
+// structured log line. The previous behaviour left a change invisible in every
+// direction — no log, no audit row, no error — and that invisibility, not the
+// overwrite itself, is what made the mismatch undiscoverable until a restore.
+//
+// A refused change is deliberately NOT an error to the agent: the metadata push
+// carries the whole inventory and rejecting it would strand every other field
+// over a value the agent cannot fix by retrying. A failure to PERSIST is a
+// different matter and is returned (see below).
+func (s *Service) applyAgentAgeRecipient(ctx context.Context, tenantID, siteID uuid.UUID, rec string, current Site, agentVersion string) (Site, error) {
+	if current.AgeRecipient != "" {
+		s.recordRecipientChangeRejected(ctx, tenantID, siteID, current.AgeRecipient, rec, agentVersion, "already_set")
+		return current, nil
+	}
+
+	// The read-and-decide above is advisory only: the authoritative first-set
+	// check happens inside the repo's transaction, under a per-site advisory
+	// lock, so two concurrent pushes cannot both conclude they are first.
+	updated, applied, err := s.repo.SetAgeRecipientIfUnset(ctx, tenantID, siteID, rec)
+	if err != nil {
+		// NOT swallowed. The old code dropped this error on the floor and
+		// returned the pre-write site, so a failed write read back to the
+		// caller as a success and the site was left unable to back up with no
+		// signal anywhere. The metadata itself is already committed and this
+		// path is idempotent, so the agent's next push retries cleanly.
+		s.logger.Error("failed to persist site age recipient",
+			"tenant_id", tenantID, "site_id", siteID, "err", err)
+		return Site{}, err
+	}
+	if !applied {
+		// Lost the race to a concurrent first set. If the winner stored the
+		// same value there is nothing to report; a different one is a refused
+		// change like any other.
+		if updated.AgeRecipient != rec {
+			s.recordRecipientChangeRejected(ctx, tenantID, siteID, updated.AgeRecipient, rec, agentVersion, "concurrent_first_set")
+		}
+		return updated, nil
+	}
+
+	s.logger.Info("site backup recipient recorded",
+		"tenant_id", tenantID, "site_id", siteID, "recipient", rec)
+	s.recordAudit(ctx, tenantID, siteID, audit.ActionSiteBackupRecipientSet, map[string]any{
+		"recipient":     rec,
+		"source":        agentMetadataSource,
+		"agent_version": agentVersion,
+	})
+	return updated, nil
+}
+
+// agentMetadataSource names the channel a recipient event arrived on, so the
+// audit log distinguishes it from any future operator-initiated change.
+const agentMetadataSource = "agent_metadata"
+
+func (s *Service) recordRecipientChangeRejected(ctx context.Context, tenantID, siteID uuid.UUID, current, proposed, agentVersion, reason string) {
+	// WARN, not INFO: on a site with backups this means the install that is
+	// reporting cannot decrypt what the site's backups are being written for,
+	// or vice versa, and an operator has to decide which one is right.
+	s.logger.Warn("rejected agent-pushed change to an established site backup recipient",
+		"tenant_id", tenantID,
+		"site_id", siteID,
+		"current_recipient", current,
+		"proposed_recipient", proposed,
+		"agent_version", agentVersion,
+		"reason", reason,
+	)
+	s.recordAudit(ctx, tenantID, siteID, audit.ActionSiteBackupRecipientChangeRejected, map[string]any{
+		"current_recipient":  current,
+		"proposed_recipient": proposed,
+		"source":             agentMetadataSource,
+		"agent_version":      agentVersion,
+		"reason":             reason,
+	})
+}
+
+// recordAudit appends a hash-chained audit entry for an agent-channel event.
+// Best-effort and nil-safe: the recorder is optional (tests and dump-routes
+// construct the service without one), and an audit write failure must not undo
+// a metadata push that already committed. The structured log line above is
+// emitted unconditionally, so the event is never invisible even when the
+// recorder is absent.
+func (s *Service) recordAudit(ctx context.Context, tenantID, siteID uuid.UUID, action string, meta map[string]any) {
+	if s.audit == nil {
+		return
+	}
+	_, _ = s.audit.Record(ctx, audit.Event{
+		TenantID:   tenantID,
+		ActorType:  audit.ActorSystem,
+		Action:     action,
+		TargetType: "site",
+		TargetID:   siteID.String(),
+		Metadata:   meta,
+	})
 }
 
 func fromAgentComponents(cs []agentpkg.Component) []Component {

--- a/apps/api/internal/site/service_test.go
+++ b/apps/api/internal/site/service_test.go
@@ -20,6 +20,13 @@ type fakeRepo struct {
 	getErr      error
 	listErr     error
 	deleteErr   error
+
+	// Backup-recipient state for the agent metadata path. ageRecipient models
+	// the sites.age_recipient column: empty means "never set".
+	ageRecipient      string
+	ifUnsetErr        error
+	ifUnsetCalls      int
+	unconditionalSets int
 }
 
 func (f *fakeRepo) Create(_ context.Context, in CreateInput) (Site, error) {
@@ -55,7 +62,24 @@ func (f *fakeRepo) SetTags(_ context.Context, in SetTagsInput) (Site, error) {
 }
 
 func (f *fakeRepo) SetAgeRecipient(_ context.Context, tenantID, siteID uuid.UUID, recipient string) (Site, error) {
+	f.unconditionalSets++
+	f.ageRecipient = recipient
 	return Site{ID: siteID, TenantID: tenantID, AgeRecipient: recipient}, nil
+}
+
+// SetAgeRecipientIfUnset mirrors the pgRepo contract: first set wins, an
+// established value is never overwritten, and the returned Site is the row as
+// it stands after the call.
+func (f *fakeRepo) SetAgeRecipientIfUnset(_ context.Context, tenantID, siteID uuid.UUID, recipient string) (Site, bool, error) {
+	f.ifUnsetCalls++
+	if f.ifUnsetErr != nil {
+		return Site{}, false, f.ifUnsetErr
+	}
+	if f.ageRecipient != "" {
+		return Site{ID: siteID, TenantID: tenantID, AgeRecipient: f.ageRecipient}, false, nil
+	}
+	f.ageRecipient = recipient
+	return Site{ID: siteID, TenantID: tenantID, AgeRecipient: recipient}, true, nil
 }
 
 func (f *fakeRepo) CreatePairingCode(_ context.Context, in CreatePairingCodeInput, codeHash string, expiresAt time.Time) (PairingCode, error) {
@@ -71,7 +95,9 @@ func (f *fakeRepo) GetByAgentKey(_ context.Context, key string) (Site, error) {
 }
 
 func (f *fakeRepo) UpdateMetadata(_ context.Context, tenantID, siteID uuid.UUID, _ Metadata, _ []byte) (Site, error) {
-	return Site{ID: siteID, TenantID: tenantID}, nil
+	// RETURNING * on the real query carries age_recipient back, so the fake
+	// must too — the service reads it to tell a first set from a change.
+	return Site{ID: siteID, TenantID: tenantID, AgeRecipient: f.ageRecipient}, nil
 }
 
 func (f *fakeRepo) TouchSeen(_ context.Context, _, _ uuid.UUID) error { return nil }


### PR DESCRIPTION
## What

Hardens the agent metadata write path for `sites.age_recipient`.

Before, `ApplyAgentMetadata` wrote the column unconditionally whenever an
agent push carried a different well-formed `age1...` value. There was no
distinction between recording a recipient for the first time and replacing an
established one, no log line, no audit entry, and the write error was dropped
(`if err == nil`), so a failed persist read back to the caller as a success.

The column is not decorative: `internal/backup` refuses to start a backup for a
site that has none (`age_recipient_missing`), and it names the public key future
backups are written for. The control plane never holds the matching identity.

## Change

- **First set (column empty) behaves exactly as before.** That is ordinary
  enrolment and must not break.
- **A change to an established recipient is no longer applied from the agent
  channel.** The agent credential proves possession of a site's key, not which
  physical install is speaking — a cloned install carries the original's
  credential (GH #577) — so an accepted change would let whichever install
  pushed last repoint an established site's backup encryption.
- **Both outcomes are now visible**: a hash-chained audit entry
  (`site.backup.recipient.set` / `site.backup.recipient.change_rejected`,
  `ActorSystem`, target the site) plus a structured log line (`Info` on a first
  set, `Warn` on a refused change). The recorded values are public recipients,
  never key material the CP could decrypt with.
- **The persist error is returned instead of discarded.** A refused *change* is
  deliberately not an error to the agent (the push carries the whole inventory
  and the agent cannot fix the value by retrying); a failure to *write* is.
- The first-set check runs inside the repo transaction under a per-site
  advisory lock, so two concurrent pushes cannot both decide they are first and
  race the column back to a silent overwrite.

`SetAgeRecipient` (the unconditional, deliberate path) is untouched and remains
available for an operator-initiated change.

## No schema change

`audit_log.action` is plain text with no CHECK or enum, and the previous
recipient is recorded in existing audit metadata, so nothing here needs a
migration and no `db/query` or generated tree was touched.

## Scope

No change to plaintext-vs-encrypted behaviour, nothing under `apps/agent`,
`apps/web` or `apps/marketing`, and no OpenAPI movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site backup encryption recipients can now be registered securely on first setup.
  * Attempts to change an established recipient are rejected while preserving the original configuration.
  * Recipient registrations and rejected changes are recorded in the audit history.

* **Bug Fixes**
  * Persistence failures during recipient registration are now reported instead of being silently ignored.
  * Concurrent initial registrations are handled consistently, ensuring only one recipient is saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->