### PR TITLE
fix(agent): make the snapshot before-state explicit

### DIFF
--- a/apps/agent/includes/commands/class-file-write-command.php
+++ b/apps/agent/includes/commands/class-file-write-command.php
@@ -60,6 +60,18 @@ final class FileWriteCommand implements CommandInterface {
 	private const MAX_BYTES = 262144;
 
 	/**
+	 * Before-state kinds reported on a successful write's response, mirroring
+	 * SnapshotManager's BEFORE_STATE_* vocabulary.
+	 *
+	 * A write that creates a NEW file has a real before-state ("this path did
+	 * not exist"), whose undo is a delete — it is not the same thing as a
+	 * staging failure, and reporting both as silence was the defect.
+	 */
+	private const BEFORE_STATE_CAPTURED = 'captured';
+	private const BEFORE_STATE_ABSENT   = 'absent';
+	private const BEFORE_STATE_FAILED   = 'failed';
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function name(): string {
@@ -155,9 +167,26 @@ final class FileWriteCommand implements CommandInterface {
 
 		// ------------------------------------------------------------------
 		// 7. T11: Pre-write backup — if target exists, copy to staging area.
+		//
+		// The outcome is RECORDED, not swallowed. Staging stays best-effort
+		// and still does not block the write (see stageBackup()'s doc), but
+		// the caller no longer has to assume a backup exists: the response
+		// reports which before-state this write has, using the same
+		// vocabulary as SnapshotManager.
+		//   'captured' — the previous bytes are in the staging area.
+		//   'absent'   — the target did not exist; the undo is to delete the
+		//                file this write creates. A real before-state, not a
+		//                missing one.
+		//   'failed'   — the target existed and could not be staged. The
+		//                write still proceeds, but a caller that needs an undo
+		//                can now see that it does not have one.
 		// ------------------------------------------------------------------
 		if ( file_exists( $absPath ) && ! is_dir( $absPath ) ) {
-			$this->stageBackup( $absPath, $resolvedRel );
+			$beforeState = $this->stageBackup( $absPath, $resolvedRel )
+				? self::BEFORE_STATE_CAPTURED
+				: self::BEFORE_STATE_FAILED;
+		} else {
+			$beforeState = self::BEFORE_STATE_ABSENT;
 		}
 
 		// ------------------------------------------------------------------
@@ -234,10 +263,14 @@ final class FileWriteCommand implements CommandInterface {
 		$mode  = $lstat !== false ? (int) ( $lstat['mode'] ?? 0 ) : 0;
 
 		return [
-			'path'  => $resolvedRel,
-			'size'  => $size,
-			'mtime' => $mtime,
-			'mode'  => sprintf( '%04o', $mode & 07777 ),
+			'path'         => $resolvedRel,
+			'size'         => $size,
+			'mtime'        => $mtime,
+			'mode'         => sprintf( '%04o', $mode & 07777 ),
+			// Which before-state this write has, so the caller can tell an
+			// undoable write from one with no undo. Additive: existing
+			// consumers that read only path/size/mtime/mode are unaffected.
+			'before_state' => $beforeState,
 		];
 	}
 
@@ -254,17 +287,21 @@ final class FileWriteCommand implements CommandInterface {
 	 * unreadable without the agent's master key. The key is derived from wp-config
 	 * salts (or a site-specific file), same as all other Keystore-protected data.
 	 *
-	 * Errors are silenced — failure here does NOT block the write; the backup is
-	 * best-effort so that a later "restore previous version" is possible.
+	 * Errors do NOT block the write; the backup is best-effort so that a later
+	 * "restore previous version" is possible. They are, however, REPORTED: the
+	 * return value says whether the previous bytes actually reached the staging
+	 * area, and the caller surfaces that on the response. Silently swallowing a
+	 * staging failure left the caller unable to tell "I have an undo" from "I
+	 * have none", which is the whole defect this return value closes.
 	 *
 	 * @param string $absPath     Absolute path to the current target file.
 	 * @param string $resolvedRel Site-relative path of the target.
-	 * @return void
+	 * @return bool True when the encrypted backup was written.
 	 */
-	private function stageBackup( string $absPath, string $resolvedRel ): void {
+	private function stageBackup( string $absPath, string $resolvedRel ): bool {
 		$stagingBase = StoragePaths::ensureHardened( 'file-backups' );
 		if ( $stagingBase === '' ) {
-			return;
+			return false;
 		}
 
 		// Per-op directory: <staging_base>/<sanitized_rel>/<timestamp>-<rand>.bak
@@ -279,7 +316,7 @@ final class FileWriteCommand implements CommandInterface {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_get_contents -- headless agent; WP_Filesystem never initialized; reading source file for encrypted backup
 		$plaintext = @file_get_contents( $absPath );
 		if ( $plaintext === false ) {
-			return; // Unreadable source — skip silently.
+			return false; // Unreadable source — no before-state captured.
 		}
 
 		// F4: Encrypt the backup bytes with the existing Keystore AES-256-GCM cipher.
@@ -288,12 +325,17 @@ final class FileWriteCommand implements CommandInterface {
 			$keystore   = new Keystore();
 			$ciphertext = $keystore->encrypt( $plaintext );
 		} catch ( \Throwable $e ) {
-			return; // Encryption failed — skip backup rather than writing plaintext.
+			return false; // Encryption failed — skip backup rather than writing plaintext.
 		}
 
 		$backupFile = $backupDir . '/' . time() . '-' . bin2hex( random_bytes( 4 ) ) . '.bak';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- headless agent; WP_Filesystem never initialized; writing AES-256-GCM-encrypted backup file
-		@file_put_contents( $backupFile, $ciphertext, LOCK_EX );
+		$written = @file_put_contents( $backupFile, $ciphertext, LOCK_EX );
+
+		// A short write is a failed backup: a truncated ciphertext will not
+		// decrypt, so it is not an undo, and reporting it as one would be the
+		// same nominal-not-real claim this change exists to prevent.
+		return $written !== false && $written === strlen( $ciphertext );
 	}
 
 	// ------------------------------------------------------------------

--- a/apps/agent/includes/commands/class-update-command.php
+++ b/apps/agent/includes/commands/class-update-command.php
@@ -604,6 +604,20 @@ final class UpdateCommand implements CommandInterface
                 // wpmgr-snapshots. `core` keeps the original opt-in behavior:
                 // there is no directory to snapshot/restore for core, and D3
                 // deliberately does not build one (see UpdateRunner::isComplete()).
+                //
+                // capture() is deliberately the best-effort entry point here,
+                // not SnapshotManager::captureRequired(). Now that a missing
+                // source directory is recorded as a real before-state
+                // (BEFORE_STATE_ABSENT) rather than a failed capture, the only
+                // outcomes left with no before-state are an unwritable
+                // snapshot store and a failed copy — both real errors — so
+                // captureRequired() here would be defensible. It is not taken
+                // because it would turn those two cases from a best-effort
+                // apply into a refused update across the live fleet, which is
+                // exactly the S8 regression documented above and needs its own
+                // decision rather than arriving as a side effect. The receipt
+                // capture() returns (`before_state`, `restorable`, `files`,
+                // `bytes`) is what a caller that DOES need the guarantee reads.
                 $shouldSnapshot = $type === 'core' ? $snapshot : true;
                 if ($shouldSnapshot) {
                     $snap        = $this->snapshots->capture($type, $slug, $fromVersion);

--- a/apps/agent/includes/support/class-snapshot-capture-failed.php
+++ b/apps/agent/includes/support/class-snapshot-capture-failed.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * SnapshotCaptureFailed: thrown by SnapshotManager::captureRequired() when no
+ * restorable before-state could be recorded.
+ *
+ * This exists so a caller whose only undo is the snapshot can DEMAND one
+ * instead of receiving an empty snapshot id it has to remember to check.
+ * SnapshotManager::capture() stays best-effort and keeps returning a receipt
+ * — UpdateCommand deliberately degrades to an unprotected apply rather than
+ * refusing an update outright, and that behaviour is unchanged.
+ *
+ * `failureCode()` is one of SnapshotManager's CAPTURE_FAILURE_* constants, so
+ * a handler can distinguish an environment problem (no writable snapshot
+ * store) from a real copy error. Neither is the same as a legitimately absent
+ * source, which is a SUCCESSFUL capture with before_state = absent and never
+ * reaches this exception.
+ *
+ * @package WPMgr\Agent\Support
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Support;
+
+/**
+ * No restorable before-state could be captured.
+ */
+class SnapshotCaptureFailed extends \RuntimeException
+{
+    /**
+     * One of SnapshotManager's CAPTURE_FAILURE_* constants.
+     *
+     * @var string
+     */
+    private string $failureCode;
+
+    /**
+     * The full capture receipt, for a handler that wants to log or report it.
+     *
+     * @var array<string,mixed>
+     */
+    private array $receipt;
+
+    /**
+     * @param string              $message     Human-readable log line from the receipt.
+     * @param string              $failureCode One of SnapshotManager's CAPTURE_FAILURE_* constants.
+     * @param array<string,mixed> $receipt     The receipt capture() returned.
+     */
+    public function __construct(string $message, string $failureCode, array $receipt = [])
+    {
+        parent::__construct($message);
+        $this->failureCode = $failureCode;
+        $this->receipt     = $receipt;
+    }
+
+    /**
+     * Machine-readable reason the capture recorded nothing.
+     *
+     * @return string
+     */
+    public function failureCode(): string
+    {
+        return $this->failureCode;
+    }
+
+    /**
+     * The capture receipt behind this failure.
+     *
+     * @return array<string,mixed>
+     */
+    public function receipt(): array
+    {
+        return $this->receipt;
+    }
+}

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -353,10 +353,16 @@ class SnapshotManager
         $receipt = $this->capture($type, $slug, $fromVersion);
 
         if (!self::isRestorable($receipt)) {
+            // The three arguments below are this class's own receipt values
+            // (a log line it composed, one of its own CAPTURE_FAILURE_*
+            // constants, and the receipt array), never request input, and
+            // this exception is never echoed — the headless agent turns it
+            // into a JSON command response, which escapes at its own output
+            // boundary.
             throw new SnapshotCaptureFailed(
-                $receipt['log'],
-                $receipt['failure'] !== '' ? $receipt['failure'] : self::CAPTURE_FAILURE_NOT_RESTORABLE,
-                $receipt
+                $receipt['log'], // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- self-composed log line; never echoed (JSON response escapes at its own boundary)
+                $receipt['failure'] !== '' ? $receipt['failure'] : self::CAPTURE_FAILURE_NOT_RESTORABLE, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- one of this class's own CAPTURE_FAILURE_* constants; never echoed
+                $receipt // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- structured receipt array for the handler; never echoed
             );
         }
 

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -144,22 +144,80 @@ class SnapshotManager
     private const OPTION_GC_LAST = 'wpmgr_snapshot_gc_last';
 
     /**
+     * Before-state kinds, recorded in each snapshot's meta.json as
+     * `before_state` and reported back on capture()'s receipt.
+     *
+     * The whole point of naming them is that "the source directory was not
+     * there" and "the copy failed" stop being the same outcome. They never
+     * were the same thing: the first is a complete before-state whose undo is
+     * a delete, the second is an error with no before-state at all.
+     *
+     *   DIRECTORY    — a full copy of the live directory sits in payload/.
+     *   ABSENT       — the live path did not exist; rollback deletes whatever
+     *                  was created in its place. No payload/ directory.
+     *   CORE_VERSION — only the prior core version string was recorded;
+     *                  rollback is a downgrade-by-version (see D3).
+     *   NONE         — nothing was recorded. Always paired with a
+     *                  CAPTURE_FAILURE_* code and an empty snapshot id.
+     *
+     * A snapshot written before this constant existed has no `before_state`
+     * key at all; readMeta() consumers therefore treat a missing/unknown
+     * value as DIRECTORY, which is what every pre-existing snapshot is (the
+     * only other pre-existing kind, core, has no payload and is never passed
+     * to restore()).
+     */
+    public const BEFORE_STATE_DIRECTORY    = 'directory';
+    public const BEFORE_STATE_ABSENT       = 'absent';
+    public const BEFORE_STATE_CORE_VERSION = 'core_version';
+    public const BEFORE_STATE_NONE         = 'none';
+
+    /**
+     * Machine-readable reasons a capture recorded no before-state at all.
+     * Reported on the receipt's `failure` key and carried by
+     * SnapshotCaptureFailed, so a caller can tell an environment problem
+     * (no writable store) from a real copy error, and neither from the
+     * legitimate absence that is BEFORE_STATE_ABSENT.
+     */
+    public const CAPTURE_FAILURE_STORE_UNAVAILABLE = 'store_unavailable';
+    public const CAPTURE_FAILURE_COPY_FAILED       = 'copy_failed';
+    public const CAPTURE_FAILURE_NOT_RESTORABLE    = 'not_restorable';
+
+    /**
      * Capture a pre-update snapshot for an item.
      *
      * For plugin/theme the live source directory is copied into the snapshot
-     * store. For core only the prior version is recorded (no copy).
+     * store. For core only the prior version is recorded (no copy). When the
+     * live source directory does not exist, the ABSENCE ITSELF is recorded as
+     * a first-class before-state (see BEFORE_STATE_ABSENT) rather than being
+     * reported as "no snapshot".
+     *
+     * The returned array is a RECEIPT, not just an id: `before_state` says
+     * which kind of before-state was recorded, `restorable` says whether
+     * rollback() can put the item back the way it was, and `files`/`bytes`
+     * quantify a directory payload so a caller can tell a real capture from a
+     * nominal one. `failure` carries a machine-readable reason (one of the
+     * CAPTURE_FAILURE_* constants) whenever nothing was recorded, so a copy
+     * failure — an error — is distinguishable from a legitimate absence.
      *
      * @param string $type        plugin|theme|core.
      * @param string $slug        Sanitized slug.
      * @param string $fromVersion Currently installed version (recorded for core).
-     * @return array{snapshot_id:string,log:string}
+     * @return array{snapshot_id:string,log:string,before_state:string,restorable:bool,files:int,bytes:int,failure:string}
      */
     public function capture(string $type, string $slug, string $fromVersion): array
     {
         $snapshotId = $this->newSnapshotId();
         $base       = $this->snapshotBaseDir();
         if ($base === '') {
-            return ['snapshot_id' => '', 'log' => 'Snapshot store unavailable; proceeding without snapshot.'];
+            return $this->receipt(
+                '',
+                'Snapshot store unavailable; proceeding without snapshot.',
+                self::BEFORE_STATE_NONE,
+                false,
+                0,
+                0,
+                self::CAPTURE_FAILURE_STORE_UNAVAILABLE
+            );
         }
 
         $this->protectBaseDir($base);
@@ -174,23 +232,248 @@ class SnapshotManager
 
         if ($type === 'core') {
             // Record the prior version for downgrade-by-version on rollback.
-            $this->writeMeta($dest, $type, $slug, $fromVersion);
+            $this->writeMeta($dest, $type, $slug, $fromVersion, self::BEFORE_STATE_CORE_VERSION);
 
-            return ['snapshot_id' => $snapshotId, 'log' => 'Recorded core version ' . $fromVersion . ' for rollback.'];
+            return $this->receipt(
+                $snapshotId,
+                'Recorded core version ' . $fromVersion . ' for rollback.',
+                self::BEFORE_STATE_CORE_VERSION,
+                true,
+                0,
+                0,
+                ''
+            );
         }
 
         $source = $this->liveDir($type, $slug);
         if ($source === '' || !is_dir($source)) {
-            return ['snapshot_id' => '', 'log' => 'Source directory not found; proceeding without snapshot.'];
+            // A MISSING SOURCE IS NOT A FAILED CAPTURE. "This path did not
+            // exist" is a complete, perfectly recoverable before-state: the
+            // undo is to delete whatever gets created. Recording it as a real
+            // snapshot (with a real, non-empty id) is what lets every
+            // downstream rollback gate — all of which key on a non-empty
+            // snapshot id — treat it as the genuine before-state it is,
+            // instead of throwing the information away and running unguarded.
+            //
+            // liveDir() returning '' lands here too, deliberately: its own
+            // anchored fallback requires is_dir(), so a path that does not
+            // exist yet legitimately resolves to '' on the hosts that
+            // fallback exists for (open_basedir, relocated/symlinked
+            // wp-content). restore() re-resolves the live path itself at
+            // rollback time and treats an unresolvable/absent path as
+            // "already in the recorded state" — never as a licence to delete
+            // something it could not identify.
+            $this->writeMeta($dest, $type, $slug, $fromVersion, self::BEFORE_STATE_ABSENT);
+
+            return $this->receipt(
+                $snapshotId,
+                'Recorded absent-source before-state ' . $snapshotId . '; rollback removes whatever is created.',
+                self::BEFORE_STATE_ABSENT,
+                true,
+                0,
+                0,
+                ''
+            );
         }
 
         if (!$this->copyDir($source, $dest . '/payload')) {
-            return ['snapshot_id' => '', 'log' => 'Snapshot copy failed; proceeding without snapshot.'];
+            // A COPY FAILURE IS AN ERROR, not an absence: disk full,
+            // permissions, or a half-written tree. Two things follow.
+            //
+            // First, the partial payload is deleted rather than left behind.
+            // copyDir() creates directories as it descends, so a failure
+            // leaves a truncated tree on disk; without meta.json nothing
+            // would restore FROM it today, but leaving a directory that looks
+            // like a snapshot is exactly the "nominal, not real" state this
+            // receipt exists to make impossible. Best effort — a delete that
+            // itself fails still leaves an id-less, meta-less directory the
+            // GC backstop reclaims.
+            //
+            // Second, the receipt says so: BEFORE_STATE_NONE plus
+            // CAPTURE_FAILURE_COPY_FAILED, so a caller can distinguish this
+            // from the absent case above and refuse to proceed (see
+            // captureRequired()). Existing callers that only read
+            // `snapshot_id` see the same empty id, and the same log intent,
+            // that they saw before this change.
+            $this->deleteDir($dest);
+
+            return $this->receipt(
+                '',
+                'Snapshot copy failed; no before-state was captured.',
+                self::BEFORE_STATE_NONE,
+                false,
+                0,
+                0,
+                self::CAPTURE_FAILURE_COPY_FAILED
+            );
         }
 
-        $this->writeMeta($dest, $type, $slug, $fromVersion);
+        $measured = $this->measureDir($dest . '/payload');
 
-        return ['snapshot_id' => $snapshotId, 'log' => 'Captured snapshot ' . $snapshotId . '.'];
+        $this->writeMeta(
+            $dest,
+            $type,
+            $slug,
+            $fromVersion,
+            self::BEFORE_STATE_DIRECTORY,
+            $measured['files'],
+            $measured['bytes']
+        );
+
+        return $this->receipt(
+            $snapshotId,
+            'Captured snapshot ' . $snapshotId . '.',
+            self::BEFORE_STATE_DIRECTORY,
+            true,
+            $measured['files'],
+            $measured['bytes'],
+            ''
+        );
+    }
+
+    /**
+     * capture(), for a caller that will NOT proceed without a real before-state.
+     *
+     * This is the demand-a-guarantee entry point. capture() itself stays
+     * best-effort on purpose — UpdateCommand deliberately degrades to an
+     * unprotected apply rather than refusing an update outright (see its
+     * class doc, S8 revised), and that behaviour is unchanged. A caller that
+     * cannot make that trade — anything whose only undo is the snapshot —
+     * calls this instead and gets an exception rather than an empty id it
+     * has to remember to check.
+     *
+     * @param string $type        plugin|theme|core.
+     * @param string $slug        Sanitized slug.
+     * @param string $fromVersion Currently installed version.
+     * @return array{snapshot_id:string,log:string,before_state:string,restorable:bool,files:int,bytes:int,failure:string}
+     * @throws SnapshotCaptureFailed When no restorable before-state was recorded.
+     */
+    public function captureRequired(string $type, string $slug, string $fromVersion): array
+    {
+        $receipt = $this->capture($type, $slug, $fromVersion);
+
+        if (!self::isRestorable($receipt)) {
+            throw new SnapshotCaptureFailed(
+                $receipt['log'],
+                $receipt['failure'] !== '' ? $receipt['failure'] : self::CAPTURE_FAILURE_NOT_RESTORABLE,
+                $receipt
+            );
+        }
+
+        return $receipt;
+    }
+
+    /**
+     * Whether a capture receipt describes a before-state rollback can actually
+     * return to.
+     *
+     * Both halves are required and neither implies the other: an id with no
+     * recorded before-state is a bookkeeping artefact, and a before-state kind
+     * with no id cannot be addressed by any rollback path (they all key on the
+     * id). A directory before-state additionally has to have copied at least
+     * one file — a zero-file payload for a source directory that existed is
+     * nominal, not real.
+     *
+     * Accepts a loose array so a receipt that has been round-tripped through
+     * JSON (an in-flight marker, a command response) can still be checked.
+     *
+     * @param array<string,mixed> $receipt Receipt from capture().
+     * @return bool
+     */
+    public static function isRestorable(array $receipt): bool
+    {
+        $id    = isset($receipt['snapshot_id']) && is_string($receipt['snapshot_id']) ? $receipt['snapshot_id'] : '';
+        $state = isset($receipt['before_state']) && is_string($receipt['before_state']) ? $receipt['before_state'] : '';
+
+        if ($id === '') {
+            return false;
+        }
+
+        if ($state === self::BEFORE_STATE_DIRECTORY) {
+            $files = isset($receipt['files']) && is_int($receipt['files']) ? $receipt['files'] : 0;
+
+            return $files > 0;
+        }
+
+        return $state === self::BEFORE_STATE_ABSENT || $state === self::BEFORE_STATE_CORE_VERSION;
+    }
+
+    /**
+     * Build a capture receipt.
+     *
+     * @param string $snapshotId  Snapshot id ('' when nothing was recorded).
+     * @param string $log         Human-readable log line.
+     * @param string $beforeState One of the BEFORE_STATE_* constants.
+     * @param bool   $restorable  Whether rollback can return to this state.
+     * @param int    $files       Files copied into the payload.
+     * @param int    $bytes       Bytes copied into the payload.
+     * @param string $failure     One of the CAPTURE_FAILURE_* constants, or ''.
+     * @return array{snapshot_id:string,log:string,before_state:string,restorable:bool,files:int,bytes:int,failure:string}
+     */
+    private function receipt(
+        string $snapshotId,
+        string $log,
+        string $beforeState,
+        bool $restorable,
+        int $files,
+        int $bytes,
+        string $failure
+    ): array {
+        return [
+            'snapshot_id'  => $snapshotId,
+            'log'          => $log,
+            'before_state' => $beforeState,
+            'restorable'   => $restorable,
+            'files'        => $files,
+            'bytes'        => $bytes,
+            'failure'      => $failure,
+        ];
+    }
+
+    /**
+     * Count the files and bytes under a directory, so a receipt can prove a
+     * payload is real rather than nominal.
+     *
+     * Symlinks are skipped, matching copyDir()'s own refusal to follow them
+     * out of the tree, so the count describes exactly what was copied.
+     *
+     * @param string $dir Directory to measure.
+     * @return array{files:int,bytes:int}
+     */
+    private function measureDir(string $dir): array
+    {
+        $files = 0;
+        $bytes = 0;
+
+        if (!is_dir($dir)) {
+            return ['files' => $files, 'bytes' => $bytes];
+        }
+
+        $items = @scandir($dir);
+        if ($items === false) {
+            return ['files' => $files, 'bytes' => $bytes];
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                continue;
+            }
+            if (is_dir($path)) {
+                $nested = $this->measureDir($path);
+                $files += $nested['files'];
+                $bytes += $nested['bytes'];
+                continue;
+            }
+            ++$files;
+            $size   = @filesize($path);
+            $bytes += $size === false ? 0 : (int) $size;
+        }
+
+        return ['files' => $files, 'bytes' => $bytes];
     }
 
     /**
@@ -214,6 +497,14 @@ class SnapshotManager
         $snapshotDir = $this->resolveSnapshotDir($base, $snapshotId);
         if ($snapshotDir === '') {
             return ['ok' => false, 'log' => 'Invalid snapshot id.'];
+        }
+
+        $meta = $this->readMeta($snapshotDir);
+        if (is_array($meta)
+            && isset($meta['before_state'])
+            && $meta['before_state'] === self::BEFORE_STATE_ABSENT
+        ) {
+            return $this->restoreAbsent($type, $slug, $snapshotId, $meta);
         }
 
         $payload = $snapshotDir . '/payload';
@@ -331,6 +622,78 @@ class SnapshotManager
         }
 
         return ['ok' => true, 'log' => 'Restored ' . $slug . ' from snapshot ' . $snapshotId . '.'];
+    }
+
+    /**
+     * Roll back to a BEFORE_STATE_ABSENT snapshot: the recorded before-state
+     * is "this path did not exist", so the undo is to remove what was created
+     * in its place.
+     *
+     * This is the only rollback path in this class that DELETES rather than
+     * copies, so it is deliberately narrow. It runs only when the snapshot's
+     * own meta.json says `before_state: absent` — a key this class writes and
+     * nothing else does — and only after three further checks:
+     *
+     *   1. The meta's type and slug must match the ones the caller asked to
+     *      roll back. A snapshot id addresses one item; a mismatch means the
+     *      caller and the snapshot disagree about what is being undone, and
+     *      the safe response to that disagreement is to delete nothing.
+     *   2. liveDir() must resolve the path, with the same containment rules
+     *      every other path in this class goes through. An unresolvable path
+     *      is reported as already-absent, never guessed at.
+     *   3. The resolved path must have a real parent (dirname() !== itself)
+     *      and a non-empty final segment, so a degenerate slug can never make
+     *      this the plugin root, the theme root, or the filesystem root.
+     *
+     * An already-absent live path is a SUCCESS, not a failure: the site is
+     * already in the state this snapshot records, which makes rollback
+     * idempotent and safe to retry (the watchdog and the in-flight reconcile
+     * can both re-enter it).
+     *
+     * @param string              $type       plugin|theme.
+     * @param string              $slug       Sanitized slug.
+     * @param string              $snapshotId Snapshot identifier.
+     * @param array<string,mixed> $meta       The snapshot's decoded meta.json.
+     * @return array{ok:bool,log:string}
+     */
+    private function restoreAbsent(string $type, string $slug, string $snapshotId, array $meta): array
+    {
+        $metaType = isset($meta['type']) && is_string($meta['type']) ? $meta['type'] : '';
+        $metaSlug = isset($meta['slug']) && is_string($meta['slug']) ? $meta['slug'] : '';
+        if ($metaType !== $type || $metaSlug !== $slug) {
+            return [
+                'ok'  => false,
+                'log' => 'Snapshot ' . $snapshotId . ' records an absent before-state for a different item; refusing to remove anything.',
+            ];
+        }
+
+        $live = $this->liveDir($type, $slug);
+        if ($live === '' || !is_dir($live)) {
+            return [
+                'ok'  => true,
+                'log' => 'Nothing to remove for ' . $slug . '; already in the absent before-state recorded by snapshot ' . $snapshotId . '.',
+            ];
+        }
+
+        $parent = dirname($live);
+        if ($parent === $live || $parent === '' || basename($live) === '') {
+            return [
+                'ok'  => false,
+                'log' => 'Refusing to remove ' . $slug . ': the resolved live path has no distinct parent directory.',
+            ];
+        }
+
+        if (!$this->deleteDir($live)) {
+            return [
+                'ok'  => false,
+                'log' => 'Could not remove ' . $slug . ' to restore the absent before-state recorded by snapshot ' . $snapshotId . '.',
+            ];
+        }
+
+        return [
+            'ok'  => true,
+            'log' => 'Removed ' . $slug . ', restoring the absent before-state recorded by snapshot ' . $snapshotId . '.',
+        ];
     }
 
     /**
@@ -1290,10 +1653,20 @@ class SnapshotManager
      * @param string $type        Item type.
      * @param string $slug        Slug.
      * @param string $fromVersion Recorded version.
+     * @param string $beforeState One of the BEFORE_STATE_* constants.
+     * @param int    $files       Files in the payload (0 when there is none).
+     * @param int    $bytes       Bytes in the payload (0 when there is none).
      * @return void
      */
-    private function writeMeta(string $dir, string $type, string $slug, string $fromVersion): void
-    {
+    private function writeMeta(
+        string $dir,
+        string $type,
+        string $slug,
+        string $fromVersion,
+        string $beforeState = self::BEFORE_STATE_DIRECTORY,
+        int $files = 0,
+        int $bytes = 0
+    ): void {
         if (!is_dir($dir)) {
             wp_mkdir_p($dir);
         }
@@ -1301,6 +1674,15 @@ class SnapshotManager
             'type'         => $type,
             'slug'         => $slug,
             'from_version' => $fromVersion,
+            // The recorded before-state kind. restore() reads this to decide
+            // whether rollback means "copy the payload back" or "delete what
+            // was created", so it is written for EVERY snapshot, including
+            // the ones that have a payload.
+            'before_state' => $beforeState,
+            // Payload size, for a reader that wants to confirm the snapshot
+            // is real rather than nominal without walking it again.
+            'files'        => $files,
+            'bytes'        => $bytes,
             // M1 (issue #131 adversarial review) — microtime(true), not
             // time(): pruneForSlug() orders same-slug snapshots by this
             // field to decide which to keep, and two captures for the same

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -673,6 +673,32 @@ class SnapshotManager
             ];
         }
 
+        // Validate the slug HERE, in the method that deletes, rather than
+        // inheriting the guarantee from UpdateCommand::sanitizeSlug().
+        // liveDir()'s containment argument is explicitly "the slug was already
+        // sanitized upstream" — sound for the update path, but restore() is
+        // reachable by callers holding nothing but a snapshot id, and that
+        // guarantee lives in a class this one never calls. A delete must not
+        // rest on a promise made somewhere else.
+        //
+        // The concrete case this closes, which the positional checks below
+        // cannot see: an EMPTY slug on the plugin branch makes liveDir() build
+        // "<plugins root>/", so is_dir() is true, basename() returns the
+        // root's own name rather than '', and dirname() differs from the path
+        // — all three positional guards pass and deleteDir() would be handed
+        // the entire plugins directory. It is not reachable today (an empty
+        // slug at capture time finds a real directory, so capture() records
+        // BEFORE_STATE_DIRECTORY and never reaches this method), but the guard
+        // must not depend on that reasoning continuing to hold.
+        $folder = $this->itemFolderSegment($type, $slug);
+        if ($folder === '') {
+            return [
+                'ok'  => false,
+                'log' => 'Refusing to remove the item recorded by snapshot ' . $snapshotId
+                    . ': its slug is not a single plain path segment.',
+            ];
+        }
+
         $live = $this->liveDir($type, $slug);
         if ($live === '' || !is_dir($live)) {
             return [
@@ -689,6 +715,19 @@ class SnapshotManager
             ];
         }
 
+        // Strictly BELOW the item's own root, not merely somewhere under
+        // wp-content: the final segment of the path about to be deleted must
+        // be the item's own folder name. liveDir() builds "<root>/<folder>",
+        // so a resolved path whose last segment is anything else — a root
+        // directory, a parent, a path some future liveDir() change resolved
+        // differently — is not this item's directory and is not deleted.
+        if (basename($live) !== $folder) {
+            return [
+                'ok'  => false,
+                'log' => 'Refusing to remove ' . $slug . ': the resolved live path is not that item\'s own directory.',
+            ];
+        }
+
         if (!$this->deleteDir($live)) {
             return [
                 'ok'  => false,
@@ -700,6 +739,55 @@ class SnapshotManager
             'ok'  => true,
             'log' => 'Removed ' . $slug . ', restoring the absent before-state recorded by snapshot ' . $snapshotId . '.',
         ];
+    }
+
+    /**
+     * The single directory segment an item's live path must end in, or '' when
+     * the slug cannot safely name one.
+     *
+     * Used only by restoreAbsent() — the one rollback path in this class that
+     * deletes — so it is deliberately stricter than the update path needs. A
+     * plugin slug is "<folder>/<file>.php" (or a bare single-file plugin
+     * name); a theme slug is the theme directory name. Either way the part
+     * that names a DIRECTORY is one plain segment, and anything else ('', '.',
+     * '..', a nested path, a Windows drive letter, an embedded null byte, a
+     * segment of nothing but dots) is refused rather than normalized: for a
+     * delete, "I cannot tell exactly which directory this is" has to end the
+     * operation, not start a best guess.
+     *
+     * @param string $type plugin|theme.
+     * @param string $slug Recorded slug.
+     * @return string The folder segment, or '' when the slug is unusable here.
+     */
+    private function itemFolderSegment(string $type, string $slug): string
+    {
+        if ($type !== 'plugin' && $type !== 'theme') {
+            return '';
+        }
+        if ($slug === '' || strpos($slug, "\0") !== false) {
+            return '';
+        }
+
+        $normalized = str_replace('\\', '/', $slug);
+
+        $folder = $normalized;
+        if ($type === 'plugin') {
+            $separator = strpos($normalized, '/');
+            if ($separator !== false) {
+                $folder = substr($normalized, 0, $separator);
+            }
+        }
+
+        if ($folder === '' || strpos($folder, '/') !== false || strpos($folder, ':') !== false) {
+            return '';
+        }
+
+        // Rejects '.', '..' and any all-dots segment in one check.
+        if (trim($folder, '.') === '') {
+            return '';
+        }
+
+        return $folder;
     }
 
     /**

--- a/apps/agent/includes/support/class-snapshot-manager.php
+++ b/apps/agent/includes/support/class-snapshot-manager.php
@@ -183,6 +183,33 @@ class SnapshotManager
     public const CAPTURE_FAILURE_NOT_RESTORABLE    = 'not_restorable';
 
     /**
+     * The live path resolved to something that is not a directory — a
+     * single-file plugin such as `hello.php`, or a symlink standing in for
+     * one. This class snapshots DIRECTORIES; it must not record such a source
+     * as absent, because "absent" promises a rollback (delete what was
+     * created) that would silently do nothing for a file that already exists.
+     * An honest non-restorable failure leaves the item visibly unprotected,
+     * which is exactly what it was before this class learned about absence.
+     */
+    public const CAPTURE_FAILURE_UNSUPPORTED_SOURCE = 'unsupported_source';
+
+    /**
+     * liveDir() could not resolve the item's path at all (open_basedir, a
+     * relocated wp-content tree, an unknown type). Nothing is known about the
+     * path, so nothing can be claimed about it — recording "absent" here would
+     * be a before-state asserted about a path this class never saw.
+     */
+    public const CAPTURE_FAILURE_UNRESOLVED_SOURCE = 'unresolved_source';
+
+    /**
+     * The copy succeeded but the payload measured zero files. isRestorable()
+     * refuses a directory before-state with nothing in it, so this is the
+     * failure code that goes with that refusal — distinct from a copy failure
+     * (which copied nothing because it broke) and from an unavailable store.
+     */
+    public const CAPTURE_FAILURE_EMPTY_PAYLOAD = 'empty_payload';
+
+    /**
      * Capture a pre-update snapshot for an item.
      *
      * For plugin/theme the live source directory is copied into the snapshot
@@ -213,7 +240,6 @@ class SnapshotManager
                 '',
                 'Snapshot store unavailable; proceeding without snapshot.',
                 self::BEFORE_STATE_NONE,
-                false,
                 0,
                 0,
                 self::CAPTURE_FAILURE_STORE_UNAVAILABLE
@@ -238,7 +264,6 @@ class SnapshotManager
                 $snapshotId,
                 'Recorded core version ' . $fromVersion . ' for rollback.',
                 self::BEFORE_STATE_CORE_VERSION,
-                true,
                 0,
                 0,
                 ''
@@ -246,7 +271,50 @@ class SnapshotManager
         }
 
         $source = $this->liveDir($type, $slug);
-        if ($source === '' || !is_dir($source)) {
+
+        if ($source === '') {
+            // Not absence — ignorance. liveDir() returning '' means the path
+            // could not be resolved (open_basedir, a relocated wp-content
+            // tree), so this class never saw it and cannot testify that it
+            // does not exist. Recording BEFORE_STATE_ABSENT here would promise
+            // a rollback for a path we could not identify.
+            return $this->receipt(
+                '',
+                'Live path could not be resolved; no before-state was captured.',
+                self::BEFORE_STATE_NONE,
+                0,
+                0,
+                self::CAPTURE_FAILURE_UNRESOLVED_SOURCE
+            );
+        }
+
+        if (!is_dir($source) && (file_exists($source) || is_link($source))) {
+            // A SINGLE-FILE PLUGIN (hello.php and friends) resolves to a FILE,
+            // not a directory. It exists, so it is not absent, and this class
+            // snapshots directories, so it cannot be captured either.
+            //
+            // Classifying it as absent would be strictly worse than having no
+            // snapshot: the receipt would claim a valid before-state, a
+            // rollback would be attempted, restoreAbsent() would find no
+            // directory, report "already in the absent before-state" and
+            // return success having restored nothing. A silent successful
+            // no-op is the exact failure shape this class exists to remove.
+            //
+            // An honest non-restorable failure instead returns the empty
+            // snapshot id this branch returned before absence was modelled at
+            // all, so a single-file plugin update behaves precisely as it does
+            // on main: unprotected, and visibly so.
+            return $this->receipt(
+                '',
+                'Live path is a file, not a directory; no before-state was captured.',
+                self::BEFORE_STATE_NONE,
+                0,
+                0,
+                self::CAPTURE_FAILURE_UNSUPPORTED_SOURCE
+            );
+        }
+
+        if (!is_dir($source)) {
             // A MISSING SOURCE IS NOT A FAILED CAPTURE. "This path did not
             // exist" is a complete, perfectly recoverable before-state: the
             // undo is to delete whatever gets created. Recording it as a real
@@ -269,7 +337,6 @@ class SnapshotManager
                 $snapshotId,
                 'Recorded absent-source before-state ' . $snapshotId . '; rollback removes whatever is created.',
                 self::BEFORE_STATE_ABSENT,
-                true,
                 0,
                 0,
                 ''
@@ -301,7 +368,6 @@ class SnapshotManager
                 '',
                 'Snapshot copy failed; no before-state was captured.',
                 self::BEFORE_STATE_NONE,
-                false,
                 0,
                 0,
                 self::CAPTURE_FAILURE_COPY_FAILED
@@ -322,12 +388,16 @@ class SnapshotManager
 
         return $this->receipt(
             $snapshotId,
-            'Captured snapshot ' . $snapshotId . '.',
+            $measured['files'] > 0
+                ? 'Captured snapshot ' . $snapshotId . '.'
+                : 'Captured snapshot ' . $snapshotId . ', but its payload is empty.',
             self::BEFORE_STATE_DIRECTORY,
-            true,
             $measured['files'],
             $measured['bytes'],
-            ''
+            // isRestorable() refuses a directory before-state that copied
+            // nothing, so the receipt names that case rather than leaving a
+            // caller to infer it from a zero.
+            $measured['files'] > 0 ? '' : self::CAPTURE_FAILURE_EMPTY_PAYLOAD
         );
     }
 
@@ -407,10 +477,16 @@ class SnapshotManager
     /**
      * Build a capture receipt.
      *
+     * `restorable` is DERIVED, never passed in: it is isRestorable() applied
+     * to the receipt being built. A hand-passed flag could disagree with the
+     * predicate every reader uses — a zero-file directory payload is the case
+     * that actually did disagree — and a receipt whose own fields contradict
+     * each other is worse than no receipt, because both halves look
+     * authoritative. Deriving it makes the contradiction unrepresentable.
+     *
      * @param string $snapshotId  Snapshot id ('' when nothing was recorded).
      * @param string $log         Human-readable log line.
      * @param string $beforeState One of the BEFORE_STATE_* constants.
-     * @param bool   $restorable  Whether rollback can return to this state.
      * @param int    $files       Files copied into the payload.
      * @param int    $bytes       Bytes copied into the payload.
      * @param string $failure     One of the CAPTURE_FAILURE_* constants, or ''.
@@ -420,20 +496,23 @@ class SnapshotManager
         string $snapshotId,
         string $log,
         string $beforeState,
-        bool $restorable,
         int $files,
         int $bytes,
         string $failure
     ): array {
-        return [
+        $receipt = [
             'snapshot_id'  => $snapshotId,
             'log'          => $log,
             'before_state' => $beforeState,
-            'restorable'   => $restorable,
+            'restorable'   => false,
             'files'        => $files,
             'bytes'        => $bytes,
             'failure'      => $failure,
         ];
+
+        $receipt['restorable'] = self::isRestorable($receipt);
+
+        return $receipt;
     }
 
     /**
@@ -700,10 +779,13 @@ class SnapshotManager
         }
 
         $live = $this->liveDir($type, $slug);
-        if ($live === '' || !is_dir($live)) {
+        if ($live === '') {
+            // Unresolvable is not "already absent": claiming success for a
+            // state that could not be verified is the silent no-op this class
+            // exists to avoid.
             return [
-                'ok'  => true,
-                'log' => 'Nothing to remove for ' . $slug . '; already in the absent before-state recorded by snapshot ' . $snapshotId . '.',
+                'ok'  => false,
+                'log' => 'Could not resolve the live path for ' . $slug . '; the absent before-state could not be verified.',
             ];
         }
 
@@ -725,6 +807,36 @@ class SnapshotManager
             return [
                 'ok'  => false,
                 'log' => 'Refusing to remove ' . $slug . ': the resolved live path is not that item\'s own directory.',
+            ];
+        }
+
+        // Checked AFTER the guards above, so an unmatched or degenerate path
+        // is refused rather than reported as "nothing to do".
+        if (!file_exists($live) && !is_link($live)) {
+            return [
+                'ok'  => true,
+                'log' => 'Nothing to remove for ' . $slug . '; already in the absent before-state recorded by snapshot ' . $snapshotId . '.',
+            ];
+        }
+
+        // What was created in place of the absence may be a FILE, not a
+        // directory — a single-file plugin is the obvious case. Deleting only
+        // directories here would leave the file in place and still report
+        // success, which is the same silent no-op the capture side now refuses
+        // to set up.
+        if (!is_dir($live) || is_link($live)) {
+            wp_delete_file($live);
+
+            if (file_exists($live) || is_link($live)) {
+                return [
+                    'ok'  => false,
+                    'log' => 'Could not remove the file created for ' . $slug . ' to restore the absent before-state recorded by snapshot ' . $snapshotId . '.',
+                ];
+            }
+
+            return [
+                'ok'  => true,
+                'log' => 'Removed ' . $slug . ', restoring the absent before-state recorded by snapshot ' . $snapshotId . '.',
             ];
         }
 

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -1399,12 +1399,15 @@ final class SnapshotManagerTest extends TestCase
 
         $res = $mgr->restore('plugin', '', $snap['snapshot_id']);
 
-        $this->assertFalse($res['ok'], 'a degenerate slug must be refused');
-        $this->assertDirectoryExists($pluginsRoot);
+        // Asserted FIRST, deliberately: "nothing was deleted" is the property
+        // that matters, and asserting the return value first would abort the
+        // test before it could report a destroyed plugins directory.
         $this->assertFileExists(
             $pluginsRoot . '/innocent-neighbour/plugin.php',
             'a refused rollback must delete nothing'
         );
+        $this->assertDirectoryExists($pluginsRoot);
+        $this->assertFalse($res['ok'], 'a degenerate slug must be refused');
     }
 
     /**
@@ -1427,8 +1430,11 @@ final class SnapshotManagerTest extends TestCase
 
         $res = $mgr->restore($type, $slug, $snap['snapshot_id']);
 
-        $this->assertFalse($res['ok'], 'slug ' . var_export($slug, true) . ' must not reach the delete');
-        $this->assertFileExists($root . '/bystander/keep.php');
+        $this->assertFileExists(
+            $root . '/bystander/keep.php',
+            'slug ' . var_export($slug, true) . ' must not reach the delete'
+        );
+        $this->assertFalse($res['ok'], 'slug ' . var_export($slug, true) . ' must be refused');
     }
 
     /**
@@ -1467,8 +1473,8 @@ final class SnapshotManagerTest extends TestCase
 
         $res = $mgr->restore('plugin', 'well-formed/well-formed.php', $snap['snapshot_id']);
 
+        $this->assertFileExists($elsewhere . '/keep.php', 'an unmatched path must not be deleted');
         $this->assertFalse($res['ok']);
-        $this->assertFileExists($elsewhere . '/keep.php');
     }
 
     public function test_failed_copy_is_distinguishable_and_never_presents_as_a_successful_capture(): void

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -36,6 +36,7 @@ namespace WPMgr\Agent\Tests;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use WPMgr\Agent\Support\SnapshotCaptureFailed;
 use WPMgr\Agent\Support\SnapshotManager;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
@@ -1294,5 +1295,216 @@ final class SnapshotManagerTest extends TestCase
         $paths = $mgr->resolvedRestorePaths('plugin', 'watchdog-demo2/watchdog-demo2.php', $snap['snapshot_id']);
 
         $this->assertSame(['live' => '', 'payload' => ''], $paths);
+    }
+
+    // =========================================================================
+    // Explicit before-state: an absent source is a before-state, a failed copy
+    // is an error, and the two stop being the same empty snapshot id.
+    // =========================================================================
+
+    public function test_absent_source_records_a_real_before_state_whose_rollback_removes_what_was_created(): void
+    {
+        $live = $this->root . '/plugins-src/brand-new';
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $live; // Resolvable, but nothing is there yet.
+
+        $this->assertDirectoryDoesNotExist($live);
+
+        $snap = $mgr->capture('plugin', 'brand-new/brand-new.php', '');
+
+        // A real, non-empty id: every downstream rollback gate keys on this,
+        // so an absent before-state has to produce one or it is not a
+        // before-state at all.
+        $this->assertNotSame('', $snap['snapshot_id'], 'an absent source must still yield a snapshot id');
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $snap['before_state']);
+        $this->assertTrue($snap['restorable']);
+        $this->assertSame('', $snap['failure']);
+        $this->assertTrue(SnapshotManager::isRestorable($snap));
+
+        // No payload directory is written for an absent before-state.
+        $this->assertDirectoryDoesNotExist($this->snapshotsBase . '/' . $snap['snapshot_id'] . '/payload');
+        $this->assertFileExists($this->snapshotsBase . '/' . $snap['snapshot_id'] . '/meta.json');
+
+        // Now something creates the directory that did not exist.
+        mkdir($live . '/nested', 0755, true);
+        file_put_contents($live . '/created.php', "<?php\n// new\n");
+        file_put_contents($live . '/nested/also-created.txt', 'new');
+
+        $res = $mgr->restore('plugin', 'brand-new/brand-new.php', $snap['snapshot_id']);
+
+        $this->assertTrue($res['ok'], $res['log']);
+        $this->assertDirectoryDoesNotExist($live, 'rollback of an absent before-state must remove what was created');
+    }
+
+    public function test_rollback_of_an_absent_before_state_is_idempotent_when_nothing_was_created(): void
+    {
+        $live              = $this->root . '/plugins-src/never-created';
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'never-created/never-created.php', '');
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $snap['before_state']);
+
+        // Nothing was ever created: the site is already in the recorded
+        // state, so rollback succeeds rather than reporting a failure the
+        // watchdog / in-flight reconcile would have to interpret.
+        $res = $mgr->restore('plugin', 'never-created/never-created.php', $snap['snapshot_id']);
+
+        $this->assertTrue($res['ok'], $res['log']);
+    }
+
+    public function test_rollback_of_an_absent_before_state_refuses_a_mismatched_item(): void
+    {
+        $live              = $this->root . '/plugins-src/mismatch';
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'mismatch/mismatch.php', '');
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $snap['before_state']);
+
+        // Something now exists at the live path, and a caller asks to roll
+        // back a DIFFERENT slug against this snapshot's id. The only
+        // rollback path in this class that deletes must refuse.
+        mkdir($live, 0755, true);
+        file_put_contents($live . '/keep-me.php', "<?php\n");
+
+        $res = $mgr->restore('plugin', 'some-other-plugin/other.php', $snap['snapshot_id']);
+
+        $this->assertFalse($res['ok']);
+        $this->assertFileExists($live . '/keep-me.php', 'a mismatched rollback must delete nothing');
+    }
+
+    public function test_failed_copy_is_distinguishable_and_never_presents_as_a_successful_capture(): void
+    {
+        $source = $this->root . '/plugins-src/copy-fails';
+        mkdir($source, 0755, true);
+        file_put_contents($source . '/copy-fails.php', "<?php\n// v1\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $source;
+        $mgr->failCopy     = true;
+
+        $snap = $mgr->capture('plugin', 'copy-fails/copy-fails.php', '1.0');
+
+        // An error, not an absence, and not a capture.
+        $this->assertSame('', $snap['snapshot_id']);
+        $this->assertSame(SnapshotManager::BEFORE_STATE_NONE, $snap['before_state']);
+        $this->assertNotSame(
+            SnapshotManager::BEFORE_STATE_ABSENT,
+            $snap['before_state'],
+            'a failed copy must not be reported as a legitimate absence'
+        );
+        $this->assertSame(SnapshotManager::CAPTURE_FAILURE_COPY_FAILED, $snap['failure']);
+        $this->assertFalse($snap['restorable']);
+        $this->assertFalse(SnapshotManager::isRestorable($snap));
+
+        // The partial payload the failed copy left behind is gone, so
+        // nothing on disk looks like a snapshot that is not one.
+        $leftovers = array_values(array_diff((array) scandir($this->snapshotsBase), ['.', '..']));
+        foreach ($leftovers as $entry) {
+            $this->assertDirectoryDoesNotExist(
+                $this->snapshotsBase . '/' . $entry . '/payload',
+                'a failed copy must not leave a payload directory behind'
+            );
+        }
+    }
+
+    public function test_capture_required_throws_on_a_failed_copy_but_accepts_an_absent_source(): void
+    {
+        $source = $this->root . '/plugins-src/demanding';
+        mkdir($source, 0755, true);
+        file_put_contents($source . '/demanding.php', "<?php\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $source;
+        $mgr->failCopy     = true;
+
+        $threw = null;
+        try {
+            $mgr->captureRequired('plugin', 'demanding/demanding.php', '1.0');
+        } catch (SnapshotCaptureFailed $e) {
+            $threw = $e;
+        }
+
+        $this->assertNotNull($threw, 'a caller demanding a guarantee must not receive an empty id');
+        $this->assertSame(SnapshotManager::CAPTURE_FAILURE_COPY_FAILED, $threw->failureCode());
+
+        // An absent source is a REAL before-state, so the same demanding
+        // caller is served rather than refused.
+        $mgr->failCopy     = false;
+        $mgr->liveOverride = $this->root . '/plugins-src/demanding-absent';
+
+        $receipt = $mgr->captureRequired('plugin', 'demanding-absent/demanding-absent.php', '');
+
+        $this->assertNotSame('', $receipt['snapshot_id']);
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $receipt['before_state']);
+    }
+
+    // =========================================================================
+    // Non-regression: the shipped update snapshot + auto-rollback path.
+    // =========================================================================
+
+    public function test_update_snapshot_path_is_unchanged_for_a_source_that_exists(): void
+    {
+        $live = $this->root . '/plugins-src/regression';
+        mkdir($live . '/inc', 0755, true);
+        file_put_contents($live . '/regression.php', "<?php\n// v1\n");
+        file_put_contents($live . '/inc/lib.php', "<?php\n// lib v1\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $live;
+
+        $snap = $mgr->capture('plugin', 'regression/regression.php', '1.0');
+
+        // Same contract as before this change: a real id and a full payload.
+        $this->assertNotSame('', $snap['snapshot_id']);
+        $this->assertStringContainsString('Captured snapshot', $snap['log']);
+        $this->assertSame(SnapshotManager::BEFORE_STATE_DIRECTORY, $snap['before_state']);
+        $this->assertTrue($snap['restorable']);
+        $this->assertSame(2, $snap['files'], 'the receipt must count what was actually copied');
+        $this->assertGreaterThan(0, $snap['bytes']);
+        $this->assertTrue(SnapshotManager::isRestorable($snap));
+
+        $payload = $this->snapshotsBase . '/' . $snap['snapshot_id'] . '/payload';
+        $this->assertFileExists($payload . '/regression.php');
+        $this->assertFileExists($payload . '/inc/lib.php');
+
+        // The update lands and breaks the plugin.
+        file_put_contents($live . '/regression.php', "<?php\n// v2 broken\n");
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test-only fixture mutation
+        @unlink($live . '/inc/lib.php');
+
+        // Auto-rollback: the shipped safety property.
+        $res = $mgr->restore('plugin', 'regression/regression.php', $snap['snapshot_id']);
+
+        $this->assertTrue($res['ok'], $res['log']);
+        $this->assertStringContainsString('Restored', $res['log']);
+        $this->assertSame("<?php\n// v1\n", (string) file_get_contents($live . '/regression.php'));
+        $this->assertFileExists($live . '/inc/lib.php');
+        $this->assertSame("<?php\n// lib v1\n", (string) file_get_contents($live . '/inc/lib.php'));
+    }
+
+    public function test_core_capture_records_only_a_version_and_stays_restorable_by_downgrade(): void
+    {
+        $mgr = $this->manager();
+
+        $snap = $mgr->capture('core', 'core', '6.5.2');
+
+        $this->assertNotSame('', $snap['snapshot_id']);
+        $this->assertStringContainsString('Recorded core version 6.5.2', $snap['log']);
+        $this->assertSame(SnapshotManager::BEFORE_STATE_CORE_VERSION, $snap['before_state']);
+        $this->assertTrue($snap['restorable']);
+        $this->assertSame(0, $snap['files']);
+
+        // Core takes the version-downgrade path, never a directory copy.
+        $this->assertDirectoryDoesNotExist($this->snapshotsBase . '/' . $snap['snapshot_id'] . '/payload');
+        $this->assertSame('6.5.2', $mgr->recordedVersion($snap['snapshot_id']));
+
+        // And it is never a delete: a core snapshot is not an absent
+        // before-state, so restore() does not take restoreAbsent().
+        $res = $mgr->restore('core', 'core', $snap['snapshot_id']);
+        $this->assertFalse($res['ok']);
+        $this->assertSame('Snapshot payload missing.', $res['log']);
     }
 }

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -1375,6 +1375,102 @@ final class SnapshotManagerTest extends TestCase
         $this->assertFileExists($live . '/keep-me.php', 'a mismatched rollback must delete nothing');
     }
 
+    public function test_rollback_of_an_absent_before_state_refuses_a_degenerate_slug_and_deletes_nothing(): void
+    {
+        // The exact shape the delete guard must survive: an EMPTY slug makes
+        // the real liveDir() build "<plugins root>/", whose is_dir() is true,
+        // whose basename() is the root's own name (not ''), and whose
+        // dirname() differs from itself — so every positional check passes and
+        // deleteDir() would receive the whole plugins directory.
+        $pluginsRoot = $this->root . '/plugins-root';
+        mkdir($pluginsRoot . '/innocent-neighbour', 0755, true);
+        file_put_contents($pluginsRoot . '/innocent-neighbour/plugin.php', "<?php\n");
+
+        $mgr = $this->manager();
+
+        // Capture while the path is absent...
+        $mgr->liveOverride = $this->root . '/not-there-yet';
+        $snap              = $mgr->capture('plugin', '', '');
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $snap['before_state']);
+
+        // ...then roll back when the resolved path is the plugins ROOT, with
+        // its trailing separator, exactly as liveDir() would build it.
+        $mgr->liveOverride = $pluginsRoot . '/';
+
+        $res = $mgr->restore('plugin', '', $snap['snapshot_id']);
+
+        $this->assertFalse($res['ok'], 'a degenerate slug must be refused');
+        $this->assertDirectoryExists($pluginsRoot);
+        $this->assertFileExists(
+            $pluginsRoot . '/innocent-neighbour/plugin.php',
+            'a refused rollback must delete nothing'
+        );
+    }
+
+    /**
+     * @dataProvider provide_unusable_delete_slugs
+     */
+    public function test_rollback_of_an_absent_before_state_refuses_any_slug_that_is_not_one_plain_segment(
+        string $type,
+        string $slug
+    ): void {
+        $root = $this->root . '/segment-root';
+        mkdir($root . '/bystander', 0755, true);
+        file_put_contents($root . '/bystander/keep.php', "<?php\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $this->root . '/absent-at-capture';
+        $snap              = $mgr->capture($type, $slug, '');
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $snap['before_state']);
+
+        $mgr->liveOverride = $root;
+
+        $res = $mgr->restore($type, $slug, $snap['snapshot_id']);
+
+        $this->assertFalse($res['ok'], 'slug ' . var_export($slug, true) . ' must not reach the delete');
+        $this->assertFileExists($root . '/bystander/keep.php');
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function provide_unusable_delete_slugs(): array
+    {
+        return [
+            'empty plugin slug'        => ['plugin', ''],
+            'plugin parent traversal'  => ['plugin', '../evil/evil.php'],
+            'plugin dot folder'        => ['plugin', './evil.php'],
+            'plugin all-dots folder'   => ['plugin', '.../evil.php'],
+            'plugin null byte'         => ['plugin', "evil\0/evil.php"],
+            'empty theme slug'         => ['theme', ''],
+            'theme nested path'        => ['theme', 'twentytwenty/subdir'],
+            'theme parent traversal'   => ['theme', '..'],
+            'theme drive letter'       => ['theme', 'C:evil'],
+        ];
+    }
+
+    public function test_a_resolved_live_path_that_is_not_the_items_own_directory_is_refused(): void
+    {
+        // The slug is perfectly well formed, but the path resolution does not
+        // land on that item's directory. A delete must not proceed on a path
+        // it cannot match back to the item it was asked to roll back.
+        $elsewhere = $this->root . '/elsewhere';
+        mkdir($elsewhere, 0755, true);
+        file_put_contents($elsewhere . '/keep.php', "<?php\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $this->root . '/plugins-src/well-formed';
+        $snap              = $mgr->capture('plugin', 'well-formed/well-formed.php', '');
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $snap['before_state']);
+
+        $mgr->liveOverride = $elsewhere;
+
+        $res = $mgr->restore('plugin', 'well-formed/well-formed.php', $snap['snapshot_id']);
+
+        $this->assertFalse($res['ok']);
+        $this->assertFileExists($elsewhere . '/keep.php');
+    }
+
     public function test_failed_copy_is_distinguishable_and_never_presents_as_a_successful_capture(): void
     {
         $source = $this->root . '/plugins-src/copy-fails';

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -1558,6 +1558,27 @@ final class SnapshotManagerTest extends TestCase
 
         $snap = $mgr->capture('plugin', 'hello.php', '1.0');
 
+        // The update lands on the single-file plugin.
+        file_put_contents($pluginFile, "<?php\n// Hello Dolly v2\n");
+
+        $res = $mgr->restore('plugin', 'hello.php', $snap['snapshot_id']);
+
+        // Asserted FIRST, and on the filesystem rather than a returned flag.
+        // Misclassifying this plugin as absent records a before-state that
+        // says "nothing was here", and rolling THAT back means "delete what
+        // is here" — so the plugin file is destroyed, and the caller is told
+        // the rollback succeeded. The live plugin surviving a rollback that
+        // never had a before-state is the property under test.
+        $this->assertFileExists(
+            $pluginFile,
+            'a rollback with no real before-state deleted the live plugin file'
+        );
+        $this->assertSame(
+            "<?php\n// Hello Dolly v2\n",
+            (string) file_get_contents($pluginFile),
+            'the live plugin file must be left exactly as the update left it'
+        );
+
         $this->assertNotSame(
             SnapshotManager::BEFORE_STATE_ABSENT,
             $snap['before_state'],
@@ -1571,20 +1592,7 @@ final class SnapshotManagerTest extends TestCase
         // absence was modelled, so the rollback gates stay shut and the item
         // is visibly unprotected rather than falsely protected.
         $this->assertSame('', $snap['snapshot_id'], 'no id means the rollback gates never fire');
-
-        // The update lands on the single-file plugin.
-        file_put_contents($pluginFile, "<?php\n// Hello Dolly v2\n");
-
-        // Nothing claims to be able to undo it, and nothing silently reports
-        // that it did.
-        $res = $mgr->restore('plugin', 'hello.php', $snap['snapshot_id']);
-
         $this->assertFalse($res['ok'], 'there is no snapshot to restore from');
-        $this->assertSame(
-            "<?php\n// Hello Dolly v2\n",
-            (string) file_get_contents($pluginFile),
-            'the file is untouched by a rollback that never had a before-state'
-        );
     }
 
     public function test_an_absent_before_state_rollback_removes_a_file_created_in_its_place(): void

--- a/apps/agent/tests/SnapshotManagerTest.php
+++ b/apps/agent/tests/SnapshotManagerTest.php
@@ -1543,6 +1543,195 @@ final class SnapshotManagerTest extends TestCase
         $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $receipt['before_state']);
     }
 
+    public function test_an_existing_single_file_plugin_is_never_recorded_as_absent(): void
+    {
+        // hello.php and friends: liveDir() resolves to the FILE, so is_dir()
+        // is false even though the plugin plainly exists. Recording that as
+        // absent would hand the caller a snapshot id promising a rollback
+        // that, on a file, silently restores nothing.
+        $pluginFile = $this->root . '/plugins-src/hello.php';
+        mkdir($this->root . '/plugins-src', 0755, true);
+        file_put_contents($pluginFile, "<?php\n// Hello Dolly v1\n");
+
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $pluginFile;
+
+        $snap = $mgr->capture('plugin', 'hello.php', '1.0');
+
+        $this->assertNotSame(
+            SnapshotManager::BEFORE_STATE_ABSENT,
+            $snap['before_state'],
+            'a plugin file that exists must never be recorded as absent'
+        );
+        $this->assertSame(SnapshotManager::BEFORE_STATE_NONE, $snap['before_state']);
+        $this->assertSame(SnapshotManager::CAPTURE_FAILURE_UNSUPPORTED_SOURCE, $snap['failure']);
+        $this->assertFalse($snap['restorable']);
+
+        // The empty id is the point: it is what this branch returned before
+        // absence was modelled, so the rollback gates stay shut and the item
+        // is visibly unprotected rather than falsely protected.
+        $this->assertSame('', $snap['snapshot_id'], 'no id means the rollback gates never fire');
+
+        // The update lands on the single-file plugin.
+        file_put_contents($pluginFile, "<?php\n// Hello Dolly v2\n");
+
+        // Nothing claims to be able to undo it, and nothing silently reports
+        // that it did.
+        $res = $mgr->restore('plugin', 'hello.php', $snap['snapshot_id']);
+
+        $this->assertFalse($res['ok'], 'there is no snapshot to restore from');
+        $this->assertSame(
+            "<?php\n// Hello Dolly v2\n",
+            (string) file_get_contents($pluginFile),
+            'the file is untouched by a rollback that never had a before-state'
+        );
+    }
+
+    public function test_an_absent_before_state_rollback_removes_a_file_created_in_its_place(): void
+    {
+        // The absence was real, and what filled it is a FILE. Removing only
+        // directories would leave it behind and still report success.
+        $pluginFile        = $this->root . '/plugins-src/newcomer.php';
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $pluginFile;
+        mkdir($this->root . '/plugins-src', 0755, true);
+
+        $snap = $mgr->capture('plugin', 'newcomer.php', '');
+        $this->assertSame(SnapshotManager::BEFORE_STATE_ABSENT, $snap['before_state']);
+
+        file_put_contents($pluginFile, "<?php\n// created\n");
+
+        $res = $mgr->restore('plugin', 'newcomer.php', $snap['snapshot_id']);
+
+        $this->assertFileDoesNotExist($pluginFile, 'rollback must remove the file created in place of the absence');
+        $this->assertTrue($res['ok'], $res['log']);
+    }
+
+    public function test_an_unresolvable_live_path_is_not_recorded_as_an_absent_before_state(): void
+    {
+        // liveDir() returning '' is ignorance, not absence: nothing can be
+        // claimed about a path this class never resolved.
+        $mgr               = $this->manager();
+        $mgr->liveOverride = '';
+
+        $snap = $mgr->capture('plugin', 'unresolvable/unresolvable.php', '1.0');
+
+        $this->assertSame(SnapshotManager::BEFORE_STATE_NONE, $snap['before_state']);
+        $this->assertSame(SnapshotManager::CAPTURE_FAILURE_UNRESOLVED_SOURCE, $snap['failure']);
+        $this->assertFalse($snap['restorable']);
+        $this->assertSame('', $snap['snapshot_id']);
+    }
+
+    // =========================================================================
+    // The receipt can never contradict the predicate that reads it.
+    // =========================================================================
+
+    public function test_every_receipt_agrees_with_is_restorable_and_every_before_state_is_covered(): void
+    {
+        $produced = [];
+
+        foreach ($this->everyCaptureScenario() as $label => $receipt) {
+            // The invariant, pinned rather than the instance: whatever
+            // capture() returns, its own `restorable` field must equal what
+            // isRestorable() says about it. A future before-state that gets
+            // this wrong fails here without anyone remembering to add a case.
+            $this->assertSame(
+                SnapshotManager::isRestorable($receipt),
+                $receipt['restorable'],
+                $label . ': the receipt contradicts isRestorable()'
+            );
+
+            // A receipt is either restorable or it says why not.
+            if ($receipt['restorable'] === false) {
+                $this->assertNotSame(
+                    '',
+                    $receipt['failure'],
+                    $label . ': a non-restorable receipt must carry a failure code'
+                );
+            } else {
+                $this->assertSame('', $receipt['failure'], $label . ': a restorable receipt carries no failure code');
+                $this->assertNotSame('', $receipt['snapshot_id'], $label . ': a restorable receipt needs an id');
+            }
+
+            $produced[$receipt['before_state']] = true;
+        }
+
+        // Every BEFORE_STATE_* the class declares must have been exercised
+        // above, so adding a new one without covering it fails this test
+        // rather than sliding through untested.
+        $reflected = new \ReflectionClass(SnapshotManager::class);
+        foreach ($reflected->getConstants() as $name => $value) {
+            if (strpos($name, 'BEFORE_STATE_') !== 0) {
+                continue;
+            }
+            $this->assertArrayHasKey(
+                $value,
+                $produced,
+                'before-state ' . $name . ' is declared but no capture scenario produces it'
+            );
+        }
+    }
+
+    /**
+     * One capture receipt per outcome capture() can produce.
+     *
+     * @return array<string,array<string,mixed>>
+     */
+    private function everyCaptureScenario(): array
+    {
+        $scenarios = [];
+
+        // BEFORE_STATE_DIRECTORY, with content.
+        $full = $this->root . '/scenarios/full';
+        mkdir($full, 0755, true);
+        file_put_contents($full . '/plugin.php', "<?php\n");
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $full;
+        $scenarios['directory with content'] = $mgr->capture('plugin', 'full/full.php', '1.0');
+
+        // BEFORE_STATE_DIRECTORY, empty — the case that contradicted itself.
+        $empty = $this->root . '/scenarios/empty';
+        mkdir($empty, 0755, true);
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $empty;
+        $scenarios['empty directory'] = $mgr->capture('plugin', 'empty/empty.php', '1.0');
+
+        // BEFORE_STATE_ABSENT.
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $this->root . '/scenarios/not-there';
+        $scenarios['absent source'] = $mgr->capture('plugin', 'not-there/not-there.php', '');
+
+        // BEFORE_STATE_CORE_VERSION.
+        $mgr = $this->manager();
+        $scenarios['core version'] = $mgr->capture('core', 'core', '6.5.2');
+
+        // BEFORE_STATE_NONE via a failed copy.
+        $broken = $this->root . '/scenarios/broken';
+        mkdir($broken, 0755, true);
+        file_put_contents($broken . '/plugin.php', "<?php\n");
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $broken;
+        $mgr->failCopy     = true;
+        $scenarios['failed copy'] = $mgr->capture('plugin', 'broken/broken.php', '1.0');
+
+        // BEFORE_STATE_NONE via a single-file plugin.
+        $file = $this->root . '/scenarios/single.php';
+        if (!is_dir($this->root . '/scenarios')) {
+            mkdir($this->root . '/scenarios', 0755, true);
+        }
+        file_put_contents($file, "<?php\n");
+        $mgr               = $this->manager();
+        $mgr->liveOverride = $file;
+        $scenarios['single-file plugin'] = $mgr->capture('plugin', 'single.php', '1.0');
+
+        // BEFORE_STATE_NONE via an unresolvable path.
+        $mgr               = $this->manager();
+        $mgr->liveOverride = '';
+        $scenarios['unresolvable path'] = $mgr->capture('plugin', 'gone/gone.php', '1.0');
+
+        return $scenarios;
+    }
+
     // =========================================================================
     // Non-regression: the shipped update snapshot + auto-rollback path.
     // =========================================================================


### PR DESCRIPTION
## What

`SnapshotManager::capture()` returned an empty snapshot id for two unrelated outcomes: a live source directory that did not exist, and a copy that failed. Every downstream rollback gate keys on a non-empty snapshot id, so both outcomes meant "no rollback is possible", and the caller could not tell them apart.

They are not the same thing. A source directory that does not exist is a complete, perfectly recoverable before-state — the undo is to delete whatever gets created. A copy that failed is an error with no before-state at all.

## Changes

- **`BEFORE_STATE_ABSENT` is a first-class before-state.** An absent source now writes a real snapshot with a real, non-empty id and `before_state: absent` in its `meta.json`. `restore()` on it removes what was created in its place, so every gate that keys on a non-empty id treats it as the genuine before-state it is.
- **A copy failure is distinguishable.** It returns `before_state: none` plus a machine-readable `failure` code (`copy_failed` vs `store_unavailable`), and the partial payload is deleted so nothing on disk looks like a snapshot that is not one.
- **`capture()` returns a receipt, not just an id**: `snapshot_id`, `before_state`, `restorable`, `files`, `bytes`, `failure`. The file/byte counts are what make a payload provably real rather than nominal — `isRestorable()` refuses a directory before-state that copied zero files.
- **`captureRequired()` throws `SnapshotCaptureFailed`** for a caller that will not proceed without a real before-state. `capture()` itself stays best-effort.
- **`FileWriteCommand`'s pre-write staging keeps its best-effort semantics** but stops swallowing its outcome: `stageBackup()` now returns whether the previous bytes were staged, and the response reports `before_state` as `captured` / `absent` / `failed`.

## Behaviour that did not change

`UpdateCommand` is untouched. A plugin/theme update whose source directory exists still captures a directory snapshot and still arms the watchdog; an update that cannot capture still degrades to an unprotected apply rather than refusing the item (the S8-revised behaviour). No existing caller became strict.

The `restoreAbsent()` path is the only rollback in this class that deletes rather than copies, so it is narrow by construction: it runs only on a snapshot whose own `meta.json` records `before_state: absent`, only when the meta's type and slug match what the caller asked to roll back, only on a path `liveDir()` resolves under its existing containment rules, and only when that path has a distinct parent and a non-empty final segment. An already-absent path is a success, which makes it idempotent and safe for the watchdog and the in-flight reconcile to re-enter.

## Tests

### Gates

All run from `apps/agent/`, every exit status read from `$?` directly.

| Command | Exit | Result |
|---|---|---|
| `php -d memory_limit=1G vendor/bin/phpunit` | 0 | `Tests: 3565, Assertions: 18702, Deprecations: 59, PHPUnit Deprecations: 1, Skipped: 11` |
| `vendor/bin/phpcs --no-cache -p` | 0 | `........ 8 / 8 (100%)` |
| `php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress` | 0 | `[OK] No errors` |
| `make agent-plugincheck` | 0 | `Plugin Check: 0 errors.` |

Plugin Check warnings are all pre-existing: the readme name/upgrade-notice/trademark rows, and `WriteFile.ABSPATHDetected` on the file commands' atomic write + rename (`class-file-write-command.php` lines 218 and 251 are the pre-existing `file_put_contents`/`rename` pair, shifted by the added comment block, not new writes).

### Mutation proofs

Each defect planted in `includes/support/class-snapshot-manager.php`, run, then reverted with `git checkout --`.

**1. Absent source falls back to the old empty id** — `--filter 'absent_before_state|absent_source_records|capture_required'`
- RED, exit 2: `Tests: 4, Assertions: 6, Errors: 1, Failures: 3` — `-'absent' +'none'`, and `captureRequired()` threw on a source it should have served.
- GREEN, exit 0: `Tests: 4, Assertions: 19`.

**2. Copy failure masquerades as an absent before-state** — `--filter 'failed_copy_is_distinguishable|capture_required_throws'`
- RED, exit 1: `Tests: 2, Assertions: 2, Failures: 2` — `-'' +'snap_030ecfa12be6a230eb5c0ad6'`, and "a caller demanding a guarantee must not receive an empty id".
- GREEN, exit 0: `Tests: 2, Assertions: 12`.

**3. A present source is treated as absent** (`if (true)` in place of the `is_dir()` test) — `--filter 'update_snapshot_path_is_unchanged|core_capture_records_only'`
- RED, exit 1: `Tests: 2, Assertions: 11, Failures: 1` — `'Recorded absent-source before-state ...' does not contain "Captured snapshot"`.

**4. Every rollback takes the delete path** (the `before_state === absent` condition dropped from `restore()`) — `--filter 'update_snapshot_path_is_unchanged'`
- RED, exit 1: `Tests: 1, Assertions: 11, Failures: 1` — `'Removed regression/regression.php, restoring the absent before-state ...' does not contain "Restored"`. This is the shipped auto-rollback safety property going red.
- GREEN for 3 and 4, exit 0: `Tests: 2, Assertions: 23`.

### Cases it must not break

Covered by the same file and green: a normal plugin update snapshot and its rollback (`test_update_snapshot_path_is_unchanged_for_a_source_that_exists` — receipt reports `directory`, 2 files, >0 bytes, and the restore returns both files byte-for-byte), a core update recording only a version (`test_core_capture_records_only_a_version_and_stays_restorable_by_downgrade` — no payload, `recordedVersion()` returns `6.5.2`, and it does **not** take the delete path), an absent rollback with nothing created (idempotent success), and an absent rollback asked for a mismatched slug (refused, deletes nothing). The pre-existing prune/GC/restore suite in `SnapshotManagerTest.php` is unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GrXyBzNHmi6Q8wUR6WDaY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File-write responses now indicate whether the previous state was captured, absent, or unavailable.
  - Snapshot handling now distinguishes existing content, missing content, and capture failures.
  - Rollbacks can restore items that were previously absent by removing newly created content safely.
  - Required snapshot operations now report clear failures when a restorable backup cannot be created.

- **Bug Fixes**
  - Improved protection against unsafe or mismatched rollback targets.
  - Partial snapshot data is cleaned up after copy failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->