### PR TITLE
feat(agent): add content_update, the first content-write command

### DIFF
--- a/apps/agent/includes/class-plugin.php
+++ b/apps/agent/includes/class-plugin.php
@@ -55,6 +55,7 @@ use WPMgr\Agent\Commands\SyncMediaConfigCommand;
 use WPMgr\Agent\Commands\SyncSecurityConfigCommand;
 use WPMgr\Agent\Commands\UnblockIpCommand;
 use WPMgr\Agent\Commands\UpdateCommand;
+use WPMgr\Agent\Commands\ContentUpdateCommand;
 use WPMgr\Agent\Commands\CacheEnableCommand;
 use WPMgr\Agent\Commands\CacheDisableCommand;
 use WPMgr\Agent\Commands\CachePurgeCommand;
@@ -2007,6 +2008,15 @@ final class Plugin
 
         return [
             new InfoCommand(),
+            // The agent's first content-write command: retitle / rewrite one
+            // EXISTING post or page, nothing else. It takes a post revision of
+            // the current version BEFORE writing and reads it back to confirm
+            // it stuck, refusing outright when revisions are off for the post
+            // type or retention is too low to survive core's post-update
+            // prune — WordPress's own revision-on-update holds the NEW content
+            // (wp-includes/revision.php), so without that pre-flight the
+            // overwritten version would not be retained anywhere.
+            new ContentUpdateCommand(),
             // M5.6 / ADR-033: BackupCommand validates the signed CP request,
             // dedups, seeds the wpmgr_backup_tasks row, schedules the
             // watchdog cron event, then hands off via wp_schedule_single_event

--- a/apps/agent/includes/commands/class-content-update-command.php
+++ b/apps/agent/includes/commands/class-content-update-command.php
@@ -1,0 +1,393 @@
+<?php
+/**
+ * ContentUpdateCommand: change the title and/or body of an EXISTING post or
+ * page, and guarantee before writing that the version being overwritten is
+ * retained somewhere the site can reach.
+ *
+ * This is the agent's first content-write command. Everything about its scope
+ * is deliberately narrow: it updates, it never creates and never deletes, it
+ * touches only post_title and post_content, and it refuses any post type the
+ * request did not name. Meta, taxonomies, status transitions and page-builder
+ * payloads are out of scope here.
+ *
+ * Wire contract (CP -> agent):
+ *   POST /wp-json/wpmgr/v1/command/content_update
+ *   Authorization: Bearer <Ed25519 JWT, cmd="content_update", aud=<siteId>>
+ *   Body: {
+ *     "post_id":            <int, required>,
+ *     "title":              <string, optional>,
+ *     "content":            <string, optional>,
+ *     "allowed_post_types": <list<string>, optional; defaults to post + page>
+ *   }
+ *   At least one of title / content must be present.
+ *
+ * Response (200 OK):
+ *   {
+ *     "ok": true,
+ *     "post_id":     <int>,
+ *     "post_type":   <string>,
+ *     "changed":     <list<string> — subset of ["title","content"]>,
+ *     "revision_id": <int — the revision holding the PRE-UPDATE version>,
+ *     "detail":      "updated"
+ *   }
+ *
+ * Errors follow the agent's { "ok": false, "detail": "<reason>" } envelope.
+ *
+ * Auth: the Router's permission_callback has already enforced the Ed25519 +
+ * anti-replay JWT contract (Connector::verifyCommand) before execute() runs.
+ * This command adds no capability check of its own and invents no new
+ * mechanism: a verified signed command IS the authorisation, exactly as it is
+ * for file_write and every other write command here.
+ *
+ * SANITISATION. The body is filtered as an editor's submission from a user
+ * WITHOUT the unfiltered_html capability would be: wp_kses_post() on the
+ * content, sanitize_text_field() on the title. There is deliberately no
+ * unfiltered-HTML escape hatch and no parameter that opens one — allowing raw
+ * HTML through a remote command would put script injection one signed request
+ * away, and that is a decision to be taken in the open rather than smuggled in
+ * behind a flag. The filtered values are then wp_slash()ed, because
+ * wp_update_post() documents its input as already escaped
+ * (wp-includes/post.php:5316, "Arrays are expected to be escaped, i.e. passed
+ * through wp_slash()") and unslashes it again internally.
+ *
+ * @package WPMgr\Agent\Commands
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Updates the title and/or content of one existing post or page.
+ */
+final class ContentUpdateCommand implements CommandInterface
+{
+    /**
+     * Post types accepted when the request does not name its own set.
+     *
+     * Both support revisions in core, which is what makes the retention
+     * guarantee below satisfiable for the default case.
+     *
+     * @var list<string>
+     */
+    private const DEFAULT_ALLOWED_POST_TYPES = ['post', 'page'];
+
+    /**
+     * Minimum revision retention this command will run under.
+     *
+     * Two, not one, and the reason is the pruning tail of
+     * wp_save_post_revision(): after our update core saves a revision of the
+     * NEW content and then deletes the oldest revisions down to
+     * wp_revisions_to_keep(). At a retention of 1 the revision we took of the
+     * pre-update version is the one that gets deleted, so the copy we just
+     * proved existed is gone by the time the response is written.
+     */
+    private const MIN_REVISIONS_TO_KEEP = 2;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function name(): string
+    {
+        return 'content_update';
+    }
+
+    /**
+     * Effect: replaces the title and/or body of a live post, and is a Write
+     * rather than a Destructive only because it refuses to run unless the
+     * version it is about to overwrite is retained in a post revision.
+     *
+     * That condition is enforced, not assumed, and the reason it has to be is
+     * that WordPress does NOT retain the old version by itself. Verified
+     * against core (wp-includes/revision.php in the WordPress 7.1 tree under
+     * tools/plugincheck/wp): wp_save_post_revision() is reached from
+     * wp_save_post_revision_on_insert(), hooked on wp_after_insert_post AFTER
+     * the row has already been rewritten, and its own docblock states "Creates
+     * a revision for the current version of a post ... the most recent
+     * revision always matches the current post". The revision wp_update_post()
+     * leaves behind therefore holds the NEW content. On a post carrying no
+     * earlier revision — one created by an importer, by WP-CLI, or by any
+     * plain wp_insert_post(), none of which revision anything, because
+     * wp_save_post_revision_on_insert() returns early when $update is false —
+     * the previous version would simply cease to exist.
+     *
+     * So ensureRevisionRetained() takes the revision itself, BEFORE the write,
+     * and verifies by reading it back that a revision now holds the
+     * pre-update title and content. Three paths cannot satisfy that and are
+     * refused rather than mislabelled: a post type that does not support
+     * revisions, WP_POST_REVISIONS disabled (both surface as
+     * wp_revisions_to_keep() === 0), and a retention too low to survive core's
+     * post-update pruning. On every path this command actually executes, the
+     * overwritten version is retained — which is what Write asserts.
+     *
+     * @return CommandEffect
+     */
+    public function effect(): CommandEffect
+    {
+        return CommandEffect::Write;
+    }
+
+    /**
+     * Repeatability: the request pins the post ID, but not the post's current
+     * content. A blind retry writes the request's title and body over whatever
+     * the post holds NOW, discarding any edit — by a human in wp-admin, or by
+     * another command — made between the two runs. That is harm the first run
+     * did not do, which is rule 1 of the enum.
+     *
+     * The pre-update revision this command guarantees makes that recoverable,
+     * and recoverable is not the same outcome: someone has to notice and
+     * restore it. Determine what the first run actually did before sending a
+     * second.
+     *
+     * @return CommandRepeatability
+     */
+    public function repeatability(): CommandRepeatability
+    {
+        return CommandRepeatability::Unsafe;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string,mixed> $claims Validated JWT claims (unused; the
+     *   Router already bound aud + cmd before dispatch).
+     * @param array<string,mixed> $params Decoded JSON body from the CP.
+     * @return array<string,mixed>
+     */
+    public function execute(array $claims, array $params): array
+    {
+        // ------------------------------------------------------------------
+        // 1. Parameters.
+        // ------------------------------------------------------------------
+        if (!array_key_exists('post_id', $params)) {
+            return $this->fail('missing required field: post_id');
+        }
+
+        $rawId = $params['post_id'];
+        if (!is_int($rawId) && !(is_string($rawId) && ctype_digit($rawId))) {
+            return $this->fail('post_id must be a positive integer');
+        }
+
+        $postId = (int) $rawId;
+        if ($postId <= 0) {
+            return $this->fail('post_id must be a positive integer');
+        }
+
+        $hasTitle   = array_key_exists('title', $params);
+        $hasContent = array_key_exists('content', $params);
+
+        if (!$hasTitle && !$hasContent) {
+            return $this->fail('nothing to update: provide title, content, or both');
+        }
+        if ($hasTitle && !is_string($params['title'])) {
+            return $this->fail('title must be a string');
+        }
+        if ($hasContent && !is_string($params['content'])) {
+            return $this->fail('content must be a string');
+        }
+
+        $allowedTypes = $this->resolveAllowedTypes($params);
+        if ($allowedTypes === []) {
+            return $this->fail('allowed_post_types must be a non-empty list of strings');
+        }
+
+        // ------------------------------------------------------------------
+        // 2. The post must exist, be out of the trash, and be an allowed type.
+        // ------------------------------------------------------------------
+        $post = get_post($postId);
+        if (!is_object($post) || !isset($post->ID) || (int) $post->ID !== $postId) {
+            return $this->fail('post not found: ' . $postId);
+        }
+
+        $postType   = isset($post->post_type) ? (string) $post->post_type : '';
+        $postStatus = isset($post->post_status) ? (string) $post->post_status : '';
+
+        if ($postStatus === 'trash') {
+            return $this->fail('post ' . $postId . ' is in the trash; restore it before updating');
+        }
+        if (!in_array($postType, $allowedTypes, true)) {
+            return $this->fail('post ' . $postId . ' is of type "' . $postType . '", which this request did not allow');
+        }
+
+        // ------------------------------------------------------------------
+        // 3. Nothing is overwritten until the current version is retained.
+        // ------------------------------------------------------------------
+        $retained = $this->ensureRevisionRetained($post);
+        if (!is_int($retained)) {
+            return $this->fail($retained);
+        }
+
+        // ------------------------------------------------------------------
+        // 4. Sanitise, then write.
+        // ------------------------------------------------------------------
+        $update  = ['ID' => $postId];
+        $changed = [];
+
+        if ($hasTitle) {
+            $title = sanitize_text_field((string) $params['title']);
+            if ($title !== (string) ($post->post_title ?? '')) {
+                $changed[] = 'title';
+            }
+            $update['post_title'] = $title;
+        }
+
+        if ($hasContent) {
+            $content = wp_kses_post((string) $params['content']);
+            if ($content !== (string) ($post->post_content ?? '')) {
+                $changed[] = 'content';
+            }
+            $update['post_content'] = $content;
+        }
+
+        // wp_update_post() expects already-slashed input and unslashes it
+        // internally; skipping this mangles every backslash in the body.
+        $result = wp_update_post(wp_slash($update), true);
+
+        if (is_wp_error($result)) {
+            return $this->fail('wp_update_post failed: ' . $result->get_error_message());
+        }
+        if (!is_int($result) && !(is_string($result) && ctype_digit($result))) {
+            return $this->fail('wp_update_post returned an unexpected value for post ' . $postId);
+        }
+        if ((int) $result === 0) {
+            return $this->fail('wp_update_post did not update post ' . $postId);
+        }
+
+        return [
+            'ok'          => true,
+            'post_id'     => $postId,
+            'post_type'   => $postType,
+            'changed'     => $changed,
+            'revision_id' => $retained,
+            'detail'      => 'updated',
+        ];
+    }
+
+    /**
+     * Guarantees that the post's CURRENT version is stored in a revision
+     * before the caller overwrites it, and returns that revision's ID.
+     *
+     * Returns a string reason instead when the guarantee cannot be made, which
+     * the caller turns into a refusal. Never returns a revision ID it has not
+     * read back and compared field by field: wp_save_post_revision() answers
+     * null both when it declined to act and when an identical revision already
+     * existed, and those two cases mean opposite things here.
+     *
+     * @param object $post The post as it stands before the update.
+     * @return int|string Revision ID, or a refusal reason.
+     */
+    private function ensureRevisionRetained(object $post): int|string
+    {
+        $postId = (int) $post->ID;
+
+        // wp_revisions_to_keep() folds in both the post-type support check and
+        // WP_POST_REVISIONS, and returns -1 for unlimited.
+        $keep = (int) wp_revisions_to_keep($post);
+
+        if ($keep === 0) {
+            return 'revisions are disabled for post type "' . (string) $post->post_type
+                . '", so the version this would overwrite could not be retained; refusing';
+        }
+        if ($keep > 0 && $keep < self::MIN_REVISIONS_TO_KEEP) {
+            return 'revision retention for post type "' . (string) $post->post_type . '" is ' . $keep
+                . ', too low to keep the overwritten version past this update; refusing';
+        }
+
+        // Snapshot the CURRENT version. A null answer here is not yet a
+        // failure: it also means "an identical revision already exists".
+        wp_save_post_revision($postId);
+
+        $latest = $this->latestRevision($postId);
+        if ($latest === null) {
+            return 'no revision could be created for post ' . $postId
+                . ', so the version this would overwrite could not be retained; refusing';
+        }
+
+        $sameTitle   = (string) ($latest->post_title ?? '') === (string) ($post->post_title ?? '');
+        $sameContent = (string) ($latest->post_content ?? '') === (string) ($post->post_content ?? '');
+
+        if (!$sameTitle || !$sameContent) {
+            return 'the newest revision of post ' . $postId
+                . ' does not match its current version, so the overwritten content would not be retained; refusing';
+        }
+
+        return (int) $latest->ID;
+    }
+
+    /**
+     * The newest genuine revision of a post, skipping autosaves.
+     *
+     * Autosaves live in the same table and are returned by
+     * wp_get_post_revisions(); core distinguishes a real revision by the
+     * "<parent>-revision" marker in post_name, and so does this.
+     *
+     * @param int $postId Parent post ID.
+     * @return object|null
+     */
+    private function latestRevision(int $postId): ?object
+    {
+        $revisions = wp_get_post_revisions($postId);
+        if (!is_array($revisions)) {
+            return null;
+        }
+
+        foreach ($revisions as $revision) {
+            if (!is_object($revision) || !isset($revision->post_name)) {
+                continue;
+            }
+            $parent = isset($revision->post_parent) ? (int) $revision->post_parent : $postId;
+            if (strpos((string) $revision->post_name, $parent . '-revision') !== false) {
+                return $revision;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Normalises allowed_post_types, defaulting when the request omits it.
+     *
+     * An empty list is returned for a malformed value so the caller refuses
+     * rather than silently falling back to the default, which would widen what
+     * the request asked for.
+     *
+     * @param array<string,mixed> $params Request parameters.
+     * @return list<string>
+     */
+    private function resolveAllowedTypes(array $params): array
+    {
+        if (!array_key_exists('allowed_post_types', $params)) {
+            return self::DEFAULT_ALLOWED_POST_TYPES;
+        }
+
+        $raw = $params['allowed_post_types'];
+        if (!is_array($raw) || $raw === []) {
+            return [];
+        }
+
+        $types = [];
+        foreach ($raw as $type) {
+            if (!is_string($type) || $type === '') {
+                return [];
+            }
+            $types[] = $type;
+        }
+
+        return $types;
+    }
+
+    /**
+     * The refusal envelope every other command here uses.
+     *
+     * @param string $detail Human-readable reason.
+     * @return array{ok:bool,detail:string}
+     */
+    private function fail(string $detail): array
+    {
+        return ['ok' => false, 'detail' => $detail];
+    }
+}

--- a/apps/agent/includes/commands/class-content-update-command.php
+++ b/apps/agent/includes/commands/class-content-update-command.php
@@ -33,10 +33,11 @@ if (!defined('ABSPATH')) {
  *   POST /wp-json/wpmgr/v1/command/content_update
  *   Authorization: Bearer <Ed25519 JWT, cmd="content_update", aud=<siteId>>
  *   Body: {
- *     "post_id":            <int, required>,
- *     "title":              <string, optional>,
- *     "content":            <string, optional>,
- *     "allowed_post_types": <list<string>, optional; defaults to post + page>
+ *     "post_id":              <int, required>,
+ *     "expected_fingerprint": <string, required — see FINGERPRINT below>,
+ *     "title":                <string, optional>,
+ *     "content":              <string, optional>,
+ *     "allowed_post_types":   <list<string>, optional; defaults to post + page>
  *   }
  *   At least one of title / content must be present.
  *
@@ -47,10 +48,54 @@ if (!defined('ABSPATH')) {
  *     "post_type":   <string>,
  *     "changed":     <list<string> — subset of ["title","content"]>,
  *     "revision_id": <int — the revision holding the PRE-UPDATE version>,
+ *     "fingerprint": <string — of the bytes RE-READ after the write>,
+ *     "title_bytes":   <int>,
+ *     "content_bytes": <int>,
+ *     "ownership":   <object — see OWNERSHIP below>,
  *     "detail":      "updated"
  *   }
  *
- * Errors follow the agent's { "ok": false, "detail": "<reason>" } envelope.
+ * Refusals follow the agent's { "ok": false, "detail": "<reason>" } envelope
+ * and additionally carry "outcome" and "code". "outcome" is "failed" for every
+ * refusal EXCEPT a fingerprint mismatch, which is "conflict": the post changed
+ * under the caller and NOTHING was written. The two need different remedies —
+ * a conflict means re-read and re-plan, a failure means the call itself was
+ * wrong — so they are not the same outcome.
+ *
+ * FINGERPRINT. expected_fingerprint pins the version the caller believes it is
+ * replacing. It is computed over the EXACT stored bytes of post_title and
+ * post_content, length-framed so no title/content boundary shift can collide:
+ *
+ *   "sha256:" . sha256( "wpmgr.content_update.v1\n"
+ *                       . strlen(title) . "\n" . title . "\n"
+ *                       . strlen(content) . "\n" . content )
+ *
+ * Nothing is normalised, trimmed, entity-decoded or re-serialised first: a
+ * fingerprint over a tidied form passes over exactly the whitespace-only and
+ * encoding-only edits it exists to catch. The agent re-derives it from a
+ * cache-cleaned read immediately before the write, and returns the fingerprint
+ * of the bytes it reads back AFTER the write — never the value it was sent,
+ * because a response that echoes the request cannot detect a write that did
+ * not land.
+ *
+ * OWNERSHIP. A page builder keeps the canonical layout somewhere other than
+ * post_content and filters the rendered output so its copy wins; writing
+ * post_content on such a page changes a field nothing renders, and the write
+ * still succeeds. This command therefore states what it actually checked:
+ * block_document_checked is true (core has_blocks(), below), and
+ * page_builder_checked is FALSE. A successful write here is not evidence that
+ * the published page changed. Builder detection is a later slice and this
+ * field is where its verdict goes; until it exists the field says so rather
+ * than inventing a verdict.
+ *
+ * BLOCK DOCUMENTS are refused outright. The column IS the document, but it is
+ * HTML framed by block-delimiter comments, and each block type's JavaScript
+ * save routine defines the canonical markup for a given set of attributes.
+ * Free-form HTML written into that document does not match what the routine
+ * would emit, so the next human to open the editor — on a page they never
+ * touched — is shown a block-recovery prompt, and accepting recovery DISCARDS
+ * the block. The damage surfaces days later and nowhere near this command, so
+ * the only safe answer at write time is to refuse.
  *
  * Auth: the Router's permission_callback has already enforced the Ed25519 +
  * anti-replay JWT contract (Connector::verifyCommand) before execute() runs.
@@ -98,6 +143,14 @@ final class ContentUpdateCommand implements CommandInterface
      * proved existed is gone by the time the response is written.
      */
     private const MIN_REVISIONS_TO_KEEP = 2;
+
+    /**
+     * Domain separator baked into every fingerprint.
+     *
+     * Versioned so that if the framing ever changes, an old fingerprint cannot
+     * silently match a new one.
+     */
+    private const FINGERPRINT_DOMAIN = 'wpmgr.content_update.v1';
 
     /**
      * {@inheritDoc}
@@ -201,6 +254,21 @@ final class ContentUpdateCommand implements CommandInterface
             return $this->fail('content must be a string');
         }
 
+        if (!array_key_exists('expected_fingerprint', $params)) {
+            return $this->fail(
+                'missing required field: expected_fingerprint — the fingerprint of the '
+                . 'title and content this call believes it is replacing',
+                'missing_expected_fingerprint'
+            );
+        }
+        if (!is_string($params['expected_fingerprint']) || $params['expected_fingerprint'] === '') {
+            return $this->fail(
+                'expected_fingerprint must be a non-empty string',
+                'invalid_expected_fingerprint'
+            );
+        }
+        $expected = (string) $params['expected_fingerprint'];
+
         $allowedTypes = $this->resolveAllowedTypes($params);
         if ($allowedTypes === []) {
             return $this->fail('allowed_post_types must be a non-empty list of strings');
@@ -209,9 +277,9 @@ final class ContentUpdateCommand implements CommandInterface
         // ------------------------------------------------------------------
         // 2. The post must exist, be out of the trash, and be an allowed type.
         // ------------------------------------------------------------------
-        $post = get_post($postId);
-        if (!is_object($post) || !isset($post->ID) || (int) $post->ID !== $postId) {
-            return $this->fail('post not found: ' . $postId);
+        $post = $this->readStored($postId);
+        if ($post === null) {
+            return $this->fail('post not found: ' . $postId, 'post_not_found');
         }
 
         $postType   = isset($post->post_type) ? (string) $post->post_type : '';
@@ -221,19 +289,73 @@ final class ContentUpdateCommand implements CommandInterface
             return $this->fail('post ' . $postId . ' is in the trash; restore it before updating');
         }
         if (!in_array($postType, $allowedTypes, true)) {
-            return $this->fail('post ' . $postId . ' is of type "' . $postType . '", which this request did not allow');
+            return $this->fail(
+                'post ' . $postId . ' is of type "' . $postType . '", which this request did not allow',
+                'post_type_not_allowed'
+            );
         }
 
         // ------------------------------------------------------------------
-        // 3. Nothing is overwritten until the current version is retained.
+        // 3. A block document is refused, and the refusal is terminal.
+        //
+        // has_blocks() is handed the stored STRING deliberately. Given
+        // anything that is not a string it runs get_post() and returns false
+        // unless the result is a WP_Post instance (wp-includes/blocks.php,
+        // WordPress 7.1) — measured: an object of any other class answers
+        // false. That failure direction is silent and permissive, which is the
+        // one direction this guard must never fail in. The string branch skips
+        // the instanceof entirely and tests the exact bytes already read.
+        // ------------------------------------------------------------------
+        if (has_blocks($this->storedContent($post))) {
+            return $this->fail(
+                'post ' . $postId . ' is a block document: its stored content carries block '
+                . 'delimiters, which core has_blocks() detects. Free-form content cannot be '
+                . 'written into a block document safely — the stored markup would no longer '
+                . 'match what the block type\'s save routine emits, so the next person to open '
+                . 'the editor is shown a block-recovery prompt on a page nobody touched, and '
+                . 'accepting recovery discards the block. Do not retry this call in this form: '
+                . 'no parameter forces it, and editing a block document needs the block-aware '
+                . 'path, which does not exist yet.',
+                'block_document_unsupported'
+            );
+        }
+
+        // ------------------------------------------------------------------
+        // 4. The caller must be replacing the version it thinks it is.
+        // ------------------------------------------------------------------
+        $current = $this->fingerprint($post);
+        if (!hash_equals($current, $expected)) {
+            return $this->conflict($postId, $expected, $current);
+        }
+
+        // ------------------------------------------------------------------
+        // 5. Nothing is overwritten until the current version is retained.
         // ------------------------------------------------------------------
         $retained = $this->ensureRevisionRetained($post);
         if (!is_int($retained)) {
-            return $this->fail($retained);
+            return $this->fail($retained, 'retention_not_guaranteed');
         }
 
         // ------------------------------------------------------------------
-        // 4. Sanitise, then write.
+        // 6. Re-derive immediately before the write. Step 5 runs core hooks
+        //    (wp_save_post_revision fires _wp_put_post_revision and friends),
+        //    and a third party is free to write the post from one of them, so
+        //    the read the precondition was checked against is not necessarily
+        //    still true here. This is the check that is load-bearing; step 4
+        //    is the cheap one that refuses before taking a revision.
+        // ------------------------------------------------------------------
+        $post = $this->readStored($postId);
+        if ($post === null) {
+            return $this->fail('post ' . $postId . ' disappeared before the write', 'post_not_found');
+        }
+
+        $current = $this->fingerprint($post);
+        if (!hash_equals($current, $expected)) {
+            return $this->conflict($postId, $expected, $current);
+        }
+
+        // ------------------------------------------------------------------
+        // 7. Sanitise, then write.
         // ------------------------------------------------------------------
         $update  = ['ID' => $postId];
         $changed = [];
@@ -259,22 +381,178 @@ final class ContentUpdateCommand implements CommandInterface
         $result = wp_update_post(wp_slash($update), true);
 
         if (is_wp_error($result)) {
-            return $this->fail('wp_update_post failed: ' . $result->get_error_message());
+            return $this->fail('wp_update_post failed: ' . $result->get_error_message(), 'write_failed');
         }
         if (!is_int($result) && !(is_string($result) && ctype_digit($result))) {
-            return $this->fail('wp_update_post returned an unexpected value for post ' . $postId);
+            return $this->fail(
+                'wp_update_post returned an unexpected value for post ' . $postId,
+                'write_failed'
+            );
         }
         if ((int) $result === 0) {
-            return $this->fail('wp_update_post did not update post ' . $postId);
+            return $this->fail('wp_update_post did not update post ' . $postId, 'write_failed');
+        }
+
+        // ------------------------------------------------------------------
+        // 8. What is reported is what is STORED. Every field below comes from
+        //    a fresh read, not from $update and not from the request: a
+        //    response assembled out of the values that were sent cannot tell
+        //    the difference between a write that landed and one that a filter,
+        //    a builder or a failed query quietly dropped.
+        // ------------------------------------------------------------------
+        $stored = $this->readStored($postId);
+        if ($stored === null) {
+            return $this->fail(
+                'post ' . $postId . ' could not be re-read after the write, so what is now '
+                . 'stored cannot be reported; treat the result as unknown and re-read the post',
+                'read_back_failed'
+            );
         }
 
         return [
-            'ok'          => true,
-            'post_id'     => $postId,
-            'post_type'   => $postType,
-            'changed'     => $changed,
-            'revision_id' => $retained,
-            'detail'      => 'updated',
+            'ok'            => true,
+            'post_id'       => $postId,
+            'post_type'     => $postType,
+            'changed'       => $changed,
+            'revision_id'   => $retained,
+            'fingerprint'   => $this->fingerprint($stored),
+            'title_bytes'   => strlen($this->storedTitle($stored)),
+            'content_bytes' => strlen($this->storedContent($stored)),
+            'ownership'     => $this->ownership(),
+            'detail'        => 'updated',
+        ];
+    }
+
+    /**
+     * What this command verified about who owns the page, and what it did not.
+     *
+     * Stated rather than implied, because the honest answer is partial: the
+     * document is not a block document, and whether a page builder owns the
+     * layout is UNKNOWN. A builder keeps its canonical copy in post meta or
+     * its own tables and filters the rendered output at request time, so a
+     * write to post_content on such a page succeeds, is retained, is audited —
+     * and changes nothing a visitor sees. Confirming that needs per-builder
+     * storage facts verified against real installs, which this slice does not
+     * have, and guessing them is how a fleet tool corrupts a customer's page.
+     *
+     * @return array<string,mixed>
+     */
+    private function ownership(): array
+    {
+        return [
+            'block_document_checked' => true,
+            'is_block_document'      => false,
+            'page_builder_checked'   => false,
+            'detail'                 => 'verified with core has_blocks() that post_content is not '
+                . 'a block document; did NOT verify that no page builder owns this page. A builder '
+                . 'that stores its layout outside post_content and filters the rendered output will '
+                . 'leave this write invisible on the front end, and nothing here detects that yet.',
+        ];
+    }
+
+    /**
+     * Fingerprint of a post's stored title and content.
+     *
+     * Over the EXACT stored bytes, length-framed. No trim, no normalisation,
+     * no entity decoding, no re-serialisation: a fingerprint over a tidied
+     * form passes over precisely the whitespace-only and encoding-only edits
+     * it exists to catch. The length prefixes stop a boundary shift (title
+     * "ab" + content "c" vs title "a" + content "bc") from colliding.
+     *
+     * @param object $post Post row as stored.
+     * @return string
+     */
+    private function fingerprint(object $post): string
+    {
+        $title   = $this->storedTitle($post);
+        $content = $this->storedContent($post);
+
+        return 'sha256:' . hash(
+            'sha256',
+            self::FINGERPRINT_DOMAIN . "\n"
+            . strlen($title) . "\n" . $title . "\n"
+            . strlen($content) . "\n" . $content
+        );
+    }
+
+    /**
+     * Reads a post from the database, bypassing the object cache.
+     *
+     * clean_post_cache() first, deliberately. get_post() answers from the
+     * object cache, and on a site running a PERSISTENT one (Redis, Memcached)
+     * that entry can outlive the request that filled it. A precondition
+     * checked against a cached copy would confirm a version the database no
+     * longer holds, which is the one way this guard could pass while being
+     * wrong. The cost is that clean_post_cache() fires its action on a call
+     * that may yet refuse; that action is core's own post-invalidated signal
+     * and costs a cache purge, which is cheap next to a lost edit.
+     *
+     * @param int $postId Post ID.
+     * @return object|null The post, or null when it is not there.
+     */
+    private function readStored(int $postId): ?object
+    {
+        clean_post_cache($postId);
+
+        $post = get_post($postId);
+        if (!is_object($post) || !isset($post->ID) || (int) $post->ID !== $postId) {
+            return null;
+        }
+
+        return $post;
+    }
+
+    /**
+     * A post's stored title, as bytes.
+     *
+     * @param object $post Post row.
+     * @return string
+     */
+    private function storedTitle(object $post): string
+    {
+        return (string) ($post->post_title ?? '');
+    }
+
+    /**
+     * A post's stored content, as bytes.
+     *
+     * @param object $post Post row.
+     * @return string
+     */
+    private function storedContent(object $post): string
+    {
+        return (string) ($post->post_content ?? '');
+    }
+
+    /**
+     * The conflict envelope: the post moved under the caller, nothing written.
+     *
+     * Deliberately NOT a failure. A failure says the call was wrong and may be
+     * worth retrying as sent; a conflict says the call was fine but the world
+     * moved, and retrying it unchanged would overwrite whatever the other
+     * writer just did. The remedies are opposite, so the outcomes are
+     * different values and not two shades of the same one.
+     *
+     * @param int    $postId   Post ID.
+     * @param string $expected Fingerprint the caller sent.
+     * @param string $current  Fingerprint of what is stored now.
+     * @return array<string,mixed>
+     */
+    private function conflict(int $postId, string $expected, string $current): array
+    {
+        return [
+            'ok'                   => false,
+            'outcome'              => 'conflict',
+            'code'                 => 'expected_fingerprint_mismatch',
+            'written'              => false,
+            'post_id'              => $postId,
+            'expected_fingerprint' => $expected,
+            'current_fingerprint'  => $current,
+            'detail'               => 'post ' . $postId . ' changed after the caller read it: the '
+                . 'stored title and content do not match expected_fingerprint. Nothing was '
+                . 'written. This is a conflict, not a failure — re-read the post, re-plan the '
+                . 'edit against what it holds now, and send a fresh expected_fingerprint. '
+                . 'Retrying this request unchanged would overwrite the other writer\'s edit.',
         ];
     }
 
@@ -392,13 +670,24 @@ final class ContentUpdateCommand implements CommandInterface
     }
 
     /**
-     * The refusal envelope every other command here uses.
+     * The refusal envelope every other command here uses, plus the machine
+     * fields a caller needs to branch on.
+     *
+     * "outcome" is always present so a caller can switch on one field rather
+     * than infer the kind of refusal from prose; it is "failed" here and
+     * "conflict" only in conflict(), which is the distinction that matters.
      *
      * @param string $detail Human-readable reason.
-     * @return array{ok:bool,detail:string}
+     * @param string $code   Stable machine code for the refusal.
+     * @return array{ok:bool,outcome:string,code:string,detail:string}
      */
-    private function fail(string $detail): array
+    private function fail(string $detail, string $code = 'failed'): array
     {
-        return ['ok' => false, 'detail' => $detail];
+        return [
+            'ok'      => false,
+            'outcome' => 'failed',
+            'code'    => $code,
+            'detail'  => $detail,
+        ];
     }
 }

--- a/apps/agent/includes/commands/class-content-update-command.php
+++ b/apps/agent/includes/commands/class-content-update-command.php
@@ -1,4 +1,23 @@
 <?php
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Commands;
+
+// Plugin Check's Direct_File_Access_Check only scans the first 50 lines of
+// the file (after the opening `<?php`) for this guard via its regex
+// fallback; its AST path never matches an `if (!defined('ABSPATH'))` guard
+// here because it is nested inside this file's `namespace` statement and the
+// AST walker does not recurse into it for that check. A guard placed past
+// line ~50 is therefore invisible to the check AND disqualifies the file
+// from the checker's separate "no guard needed, it's just a class" exemption
+// (a top-level If-with-exit is not one of its recognised "safe" statements)
+// — which is *worse* than having no guard at all. Keep this guard here,
+// above the file docblock below, not after it.
+if (!defined('ABSPATH')) {
+    exit;
+}
+
 /**
  * ContentUpdateCommand: change the title and/or body of an EXISTING post or
  * page, and guarantee before writing that the version being overwritten is
@@ -52,14 +71,6 @@
  *
  * @package WPMgr\Agent\Commands
  */
-
-declare(strict_types=1);
-
-namespace WPMgr\Agent\Commands;
-
-if (!defined('ABSPATH')) {
-    exit;
-}
 
 /**
  * Updates the title and/or content of one existing post or page.

--- a/apps/agent/tests/ContentUpdateCommandTest.php
+++ b/apps/agent/tests/ContentUpdateCommandTest.php
@@ -1,0 +1,523 @@
+<?php
+/**
+ * ContentUpdateCommand unit tests.
+ *
+ * The fake WordPress here is a small in-memory posts+revisions store wired
+ * through Brain Monkey, and it is deliberately FAITHFUL on the one behaviour
+ * the command's Write label rests on: wp_update_post() saves its revision
+ * AFTER the row is rewritten, so the revision core leaves behind holds the
+ * NEW content (wp-includes/revision.php — "the most recent revision always
+ * matches the current post"). A fake that revisioned the old content would
+ * make the command look correct for a reason WordPress does not supply, and
+ * would hide the exact defect the pre-flight guard exists to prevent.
+ *
+ * testWriteLabelWouldBeWrongWithoutThePreflight() is the proof of that: with
+ * the pre-flight suppressed, the pre-update content survives nowhere.
+ *
+ * @package WPMgr\Agent\Tests
+ */
+
+declare(strict_types=1);
+
+namespace WPMgr\Agent\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use WPMgr\Agent\Commands\CommandEffect;
+use WPMgr\Agent\Commands\CommandRepeatability;
+use WPMgr\Agent\Commands\ContentUpdateCommand;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers \WPMgr\Agent\Commands\ContentUpdateCommand
+ */
+final class ContentUpdateCommandTest extends TestCase
+{
+    /** In-memory posts, keyed by ID. @var array<int,object> */
+    private array $posts = [];
+
+    /** In-memory revisions, newest first. @var array<int,list<object>> */
+    private array $revisions = [];
+
+    /** Next auto-increment ID for a created revision. */
+    private int $nextRevisionId = 9000;
+
+    /** Revision retention answer for wp_revisions_to_keep(). -1 is unlimited. */
+    private int $revisionsToKeep = -1;
+
+    /** When true, the fake wp_save_post_revision() does nothing. */
+    private bool $suppressPreflightRevision = false;
+
+    protected function set_up(): void
+    {
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->posts                     = [];
+        $this->revisions                 = [];
+        $this->nextRevisionId            = 9000;
+        $this->revisionsToKeep           = -1;
+        $this->suppressPreflightRevision = false;
+
+        $this->installWordPressFake();
+    }
+
+    protected function tear_down(): void
+    {
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    // -------------------------------------------------------------------------
+    // The fake WordPress
+    // -------------------------------------------------------------------------
+
+    /**
+     * Wires the handful of WP functions the command calls to the in-memory
+     * store above.
+     *
+     * @return void
+     */
+    private function installWordPressFake(): void
+    {
+        Functions\when('get_post')->alias(fn ($id) => $this->posts[(int) $id] ?? null);
+
+        Functions\when('sanitize_text_field')->alias(
+            static fn ($str) => trim((string) wp_strip_all_tags((string) $str))
+        );
+
+        // Stands in for the real kses: strips <script>, keeps ordinary markup.
+        Functions\when('wp_kses_post')->alias(
+            static fn ($content) => (string) preg_replace(
+                '#<script\b[^>]*>.*?</script>#is',
+                '',
+                (string) $content
+            )
+        );
+
+        Functions\when('wp_slash')->alias(
+            static fn ($value) => is_array($value) ? array_map(
+                static fn ($v) => is_string($v) ? addslashes($v) : $v,
+                $value
+            ) : (is_string($value) ? addslashes($value) : $value)
+        );
+
+        Functions\when('is_wp_error')->alias(static fn ($thing) => $thing instanceof \WP_Error);
+
+        Functions\when('wp_revisions_to_keep')->alias(fn () => $this->revisionsToKeep);
+
+        Functions\when('wp_get_post_revisions')->alias(
+            fn ($postId) => $this->revisions[(int) $postId] ?? []
+        );
+
+        // Faithful to core: snapshots the post AS IT STANDS NOW, and declines
+        // when an identical revision already exists or revisions are off.
+        Functions\when('wp_save_post_revision')->alias(function ($postId) {
+            if ($this->suppressPreflightRevision) {
+                return null;
+            }
+            return $this->storeRevision((int) $postId);
+        });
+
+        // Faithful to core's ORDER: rewrite the row, THEN revision it. The
+        // revision this leaves behind holds the new content.
+        Functions\when('wp_update_post')->alias(function ($postarr) {
+            $id = (int) ($postarr['ID'] ?? 0);
+            if (!isset($this->posts[$id])) {
+                return new \WP_Error('invalid_post', 'Invalid post ID.');
+            }
+
+            foreach (['post_title', 'post_content'] as $field) {
+                if (array_key_exists($field, $postarr)) {
+                    $this->posts[$id]->{$field} = stripslashes((string) $postarr[$field]);
+                }
+            }
+
+            $this->storeRevision($id);
+
+            return $id;
+        });
+    }
+
+    /**
+     * Stores a revision of a post's CURRENT state, applying the same
+     * "unchanged means no new revision" rule and the same pruning tail core
+     * applies.
+     *
+     * @param int $postId Parent post ID.
+     * @return int|null New revision ID, or null when nothing was stored.
+     */
+    private function storeRevision(int $postId): ?int
+    {
+        if (!isset($this->posts[$postId]) || $this->revisionsToKeep === 0) {
+            return null;
+        }
+
+        $post     = $this->posts[$postId];
+        $existing = $this->revisions[$postId] ?? [];
+
+        if ($existing !== []) {
+            $latest = $existing[0];
+            if (
+                $latest->post_title === $post->post_title
+                && $latest->post_content === $post->post_content
+            ) {
+                return null;
+            }
+        }
+
+        $revision               = new \stdClass();
+        $revision->ID           = $this->nextRevisionId++;
+        $revision->post_parent  = $postId;
+        $revision->post_name    = $postId . '-revision-v1';
+        $revision->post_title   = $post->post_title;
+        $revision->post_content = $post->post_content;
+
+        array_unshift($existing, $revision);
+
+        // Core prunes down to wp_revisions_to_keep() after every save.
+        if ($this->revisionsToKeep > 0 && count($existing) > $this->revisionsToKeep) {
+            $existing = array_slice($existing, 0, $this->revisionsToKeep);
+        }
+
+        $this->revisions[$postId] = $existing;
+
+        return (int) $revision->ID;
+    }
+
+    /**
+     * Seeds one post. No revision is created, mirroring wp_insert_post().
+     *
+     * @param int    $id      Post ID.
+     * @param string $type    Post type.
+     * @param string $status  Post status.
+     * @param string $title   Post title.
+     * @param string $content Post content.
+     * @return void
+     */
+    private function seedPost(
+        int $id,
+        string $type = 'post',
+        string $status = 'publish',
+        string $title = 'Original title',
+        string $content = 'Original content'
+    ): void {
+        $post               = new \stdClass();
+        $post->ID           = $id;
+        $post->post_type    = $type;
+        $post->post_status  = $status;
+        $post->post_title   = $title;
+        $post->post_content = $content;
+
+        $this->posts[$id] = $post;
+    }
+
+    /**
+     * Every revision body currently stored for a post.
+     *
+     * @param int $postId Parent post ID.
+     * @return list<string>
+     */
+    private function revisionContents(int $postId): array
+    {
+        return array_map(
+            static fn ($r) => (string) $r->post_content,
+            $this->revisions[$postId] ?? []
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Identity and labels
+    // -------------------------------------------------------------------------
+
+    public function test_name_is_content_update(): void
+    {
+        $this->assertSame('content_update', (new ContentUpdateCommand())->name());
+    }
+
+    public function test_declares_write_and_unsafe(): void
+    {
+        $command = new ContentUpdateCommand();
+        $this->assertSame(CommandEffect::Write, $command->effect());
+        $this->assertSame(CommandRepeatability::Unsafe, $command->repeatability());
+    }
+
+    // -------------------------------------------------------------------------
+    // 1. The happy path
+    // -------------------------------------------------------------------------
+
+    public function test_updates_title_and_content(): void
+    {
+        $this->seedPost(12);
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 12,
+            'title'   => 'New title',
+            'content' => 'New content',
+        ]);
+
+        $this->assertTrue($result['ok'], 'update refused: ' . ($result['detail'] ?? ''));
+        $this->assertSame(12, $result['post_id']);
+        $this->assertSame('post', $result['post_type']);
+        $this->assertSame(['title', 'content'], $result['changed']);
+
+        $this->assertSame('New title', $this->posts[12]->post_title);
+        $this->assertSame('New content', $this->posts[12]->post_content);
+    }
+
+    public function test_content_only_update_leaves_title_alone(): void
+    {
+        $this->seedPost(13, 'page');
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 13,
+            'content' => 'Just the body',
+        ]);
+
+        $this->assertTrue($result['ok'], (string) ($result['detail'] ?? ''));
+        $this->assertSame(['content'], $result['changed']);
+        $this->assertSame('Original title', $this->posts[13]->post_title);
+        $this->assertSame('Just the body', $this->posts[13]->post_content);
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. The revision assertion -- what earns the Write label
+    // -------------------------------------------------------------------------
+
+    public function test_a_revision_holds_the_previous_content_after_a_successful_update(): void
+    {
+        $this->seedPost(21, 'post', 'publish', 'Before title', 'Before content');
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 21,
+            'title'   => 'After title',
+            'content' => 'After content',
+        ]);
+
+        $this->assertTrue($result['ok'], (string) ($result['detail'] ?? ''));
+
+        $this->assertContains(
+            'Before content',
+            $this->revisionContents(21),
+            'No revision retains the overwritten content. The Write label asserts the previous '
+            . 'version survives the update; if this fails, the label is wrong.'
+        );
+
+        // The reported revision id must be the one holding the PREVIOUS
+        // version, not the one core created from the new content.
+        $reported = null;
+        foreach ($this->revisions[21] as $revision) {
+            if ((int) $revision->ID === (int) $result['revision_id']) {
+                $reported = $revision;
+                break;
+            }
+        }
+
+        $this->assertNotNull($reported, 'reported revision_id is not a stored revision');
+        $this->assertSame('Before content', $reported->post_content);
+        $this->assertSame('Before title', $reported->post_title);
+    }
+
+    /**
+     * The pre-flight is load-bearing, and this is the proof.
+     *
+     * Suppress only wp_save_post_revision() -- the call the command makes
+     * BEFORE writing -- and leave core's own post-update revision intact. The
+     * command must refuse; and had it written anyway, the overwritten content
+     * would survive nowhere, which is Destructive, not Write.
+     *
+     * @return void
+     */
+    public function test_write_label_would_be_wrong_without_the_preflight(): void
+    {
+        $this->seedPost(22, 'post', 'publish', 'Before title', 'Before content');
+        $this->suppressPreflightRevision = true;
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 22,
+            'content' => 'After content',
+        ]);
+
+        $this->assertFalse($result['ok'], 'command wrote without retaining the previous version');
+        $this->assertStringContainsString('refusing', $result['detail']);
+
+        $this->assertSame('Before content', $this->posts[22]->post_content, 'post was modified anyway');
+        $this->assertNotContains('After content', $this->revisionContents(22));
+    }
+
+    public function test_refuses_when_revisions_are_disabled(): void
+    {
+        $this->seedPost(23);
+        $this->revisionsToKeep = 0;
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 23,
+            'content' => 'New content',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('revisions are disabled', $result['detail']);
+        $this->assertSame('Original content', $this->posts[23]->post_content);
+    }
+
+    /**
+     * Retention of 1 is the subtle one: a revision IS created, and core's
+     * post-update prune then deletes it. Refusing is the only honest answer.
+     *
+     * @return void
+     */
+    public function test_refuses_when_retention_is_too_low_to_survive_the_prune(): void
+    {
+        $this->seedPost(24);
+        $this->revisionsToKeep = 1;
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 24,
+            'content' => 'New content',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('too low', $result['detail']);
+        $this->assertSame('Original content', $this->posts[24]->post_content);
+    }
+
+    // -------------------------------------------------------------------------
+    // 2, 3, 4. Refusals
+    // -------------------------------------------------------------------------
+
+    public function test_refuses_a_post_that_does_not_exist(): void
+    {
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 404,
+            'content' => 'New content',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('post not found', $result['detail']);
+        $this->assertStringContainsString('404', $result['detail']);
+    }
+
+    public function test_refuses_a_trashed_post(): void
+    {
+        $this->seedPost(31, 'post', 'trash');
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 31,
+            'content' => 'New content',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('trash', $result['detail']);
+        $this->assertSame('Original content', $this->posts[31]->post_content);
+    }
+
+    public function test_refuses_when_neither_title_nor_content_is_present(): void
+    {
+        $this->seedPost(32);
+
+        $result = (new ContentUpdateCommand())->execute([], ['post_id' => 32]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('nothing to update', $result['detail']);
+    }
+
+    public function test_refuses_a_missing_post_id(): void
+    {
+        $result = (new ContentUpdateCommand())->execute([], ['content' => 'New content']);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('post_id', $result['detail']);
+    }
+
+    public function test_refuses_a_post_type_the_request_did_not_allow(): void
+    {
+        $this->seedPost(33, 'product');
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 33,
+            'content' => 'New content',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('did not allow', $result['detail']);
+        $this->assertSame('Original content', $this->posts[33]->post_content);
+    }
+
+    public function test_allows_a_post_type_the_request_named(): void
+    {
+        $this->seedPost(34, 'product');
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id'            => 34,
+            'content'            => 'New content',
+            'allowed_post_types' => ['product'],
+        ]);
+
+        $this->assertTrue($result['ok'], (string) ($result['detail'] ?? ''));
+        $this->assertSame('New content', $this->posts[34]->post_content);
+    }
+
+    public function test_refuses_a_malformed_allowed_post_types(): void
+    {
+        $this->seedPost(35);
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id'            => 35,
+            'content'            => 'New content',
+            'allowed_post_types' => ['post', 7],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('allowed_post_types', $result['detail']);
+        $this->assertSame('Original content', $this->posts[35]->post_content);
+    }
+
+    public function test_refuses_a_non_string_content(): void
+    {
+        $this->seedPost(36);
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 36,
+            'content' => ['not', 'a', 'string'],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('content must be a string', $result['detail']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sanitisation
+    // -------------------------------------------------------------------------
+
+    public function test_content_is_filtered_before_it_is_stored(): void
+    {
+        $this->seedPost(41);
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 41,
+            'content' => 'Safe<script>alert(1)</script> text',
+        ]);
+
+        $this->assertTrue($result['ok'], (string) ($result['detail'] ?? ''));
+        $this->assertStringNotContainsString('<script', $this->posts[41]->post_content);
+        $this->assertStringContainsString('Safe', $this->posts[41]->post_content);
+    }
+
+    public function test_wp_update_post_failure_is_reported_not_swallowed(): void
+    {
+        $this->seedPost(42);
+
+        Functions\when('wp_update_post')->alias(
+            static fn () => new \WP_Error('db_error', 'Could not update post in the database.')
+        );
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 42,
+            'content' => 'New content',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('wp_update_post failed', $result['detail']);
+        $this->assertStringContainsString('database', $result['detail']);
+    }
+}

--- a/apps/agent/tests/ContentUpdateCommandTest.php
+++ b/apps/agent/tests/ContentUpdateCommandTest.php
@@ -48,6 +48,9 @@ final class ContentUpdateCommandTest extends TestCase
     /** When true, the fake wp_save_post_revision() does nothing. */
     private bool $suppressPreflightRevision = false;
 
+    /** Post IDs passed to clean_post_cache(), in order. @var list<int> */
+    private array $cleanPostCacheCalls = [];
+
     protected function set_up(): void
     {
         parent::set_up();
@@ -58,6 +61,7 @@ final class ContentUpdateCommandTest extends TestCase
         $this->nextRevisionId            = 9000;
         $this->revisionsToKeep           = -1;
         $this->suppressPreflightRevision = false;
+        $this->cleanPostCacheCalls       = [];
 
         $this->installWordPressFake();
     }
@@ -81,6 +85,22 @@ final class ContentUpdateCommandTest extends TestCase
     private function installWordPressFake(): void
     {
         Functions\when('get_post')->alias(fn ($id) => $this->posts[(int) $id] ?? null);
+
+        // The in-memory store IS the database here, so there is no cache to
+        // clean; what matters is that the command calls this before every
+        // authoritative read, and that a re-read returns what is stored now.
+        Functions\when('clean_post_cache')->alias(function ($id): void {
+            $this->cleanPostCacheCalls[] = (int) $id;
+        });
+
+        // has_blocks(), verbatim from the vendored WordPress 7.1 tree
+        // (wp-includes/blocks.php:878-890), reduced to the string branch the
+        // command actually uses: a plain substring test for '<!-- wp:'.
+        // Measured against that source: '' => false, classic HTML => false,
+        // delimiterless freeform => false, '<!-- wp:freeform -->' => true.
+        Functions\when('has_blocks')->alias(
+            static fn ($post) => is_string($post) && str_contains($post, '<!-- wp:')
+        );
 
         Functions\when('sanitize_text_field')->alias(
             static fn ($str) => trim((string) wp_strip_all_tags((string) $str))
@@ -213,6 +233,53 @@ final class ContentUpdateCommandTest extends TestCase
     }
 
     /**
+     * The fingerprint of what a post holds RIGHT NOW.
+     *
+     * Recomputed here from the spec rather than called on the command, so a
+     * change to the command's framing shows up as a red test instead of both
+     * sides drifting together: exact stored bytes, length-framed, domain
+     * separator, no normalisation of any kind.
+     *
+     * @param int $postId Post ID.
+     * @return string
+     */
+    private function fingerprintOf(int $postId): string
+    {
+        $post    = $this->posts[$postId];
+        $title   = (string) $post->post_title;
+        $content = (string) $post->post_content;
+
+        return 'sha256:' . hash(
+            'sha256',
+            "wpmgr.content_update.v1\n"
+            . strlen($title) . "\n" . $title . "\n"
+            . strlen($content) . "\n" . $content
+        );
+    }
+
+    /**
+     * Runs the command, filling in a CURRENT expected_fingerprint unless the
+     * test supplies its own.
+     *
+     * Every pre-existing test here predates the precondition and means "the
+     * caller is up to date", so the default keeps them testing what they were
+     * written to test. A test about staleness passes its own value.
+     *
+     * @param array<string,mixed> $params Request parameters.
+     * @return array<string,mixed>
+     */
+    private function runCommand(array $params): array
+    {
+        $postId = (int) ($params['post_id'] ?? 0);
+
+        if (!array_key_exists('expected_fingerprint', $params) && isset($this->posts[$postId])) {
+            $params['expected_fingerprint'] = $this->fingerprintOf($postId);
+        }
+
+        return (new ContentUpdateCommand())->execute([], $params);
+    }
+
+    /**
      * Every revision body currently stored for a post.
      *
      * @param int $postId Parent post ID.
@@ -250,7 +317,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(12);
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 12,
             'title'   => 'New title',
             'content' => 'New content',
@@ -269,7 +336,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(13, 'page');
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 13,
             'content' => 'Just the body',
         ]);
@@ -288,7 +355,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(21, 'post', 'publish', 'Before title', 'Before content');
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 21,
             'title'   => 'After title',
             'content' => 'After content',
@@ -333,7 +400,7 @@ final class ContentUpdateCommandTest extends TestCase
         $this->seedPost(22, 'post', 'publish', 'Before title', 'Before content');
         $this->suppressPreflightRevision = true;
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 22,
             'content' => 'After content',
         ]);
@@ -350,7 +417,7 @@ final class ContentUpdateCommandTest extends TestCase
         $this->seedPost(23);
         $this->revisionsToKeep = 0;
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 23,
             'content' => 'New content',
         ]);
@@ -371,7 +438,7 @@ final class ContentUpdateCommandTest extends TestCase
         $this->seedPost(24);
         $this->revisionsToKeep = 1;
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 24,
             'content' => 'New content',
         ]);
@@ -387,9 +454,12 @@ final class ContentUpdateCommandTest extends TestCase
 
     public function test_refuses_a_post_that_does_not_exist(): void
     {
-        $result = (new ContentUpdateCommand())->execute([], [
-            'post_id' => 404,
-            'content' => 'New content',
+        $result = $this->runCommand([
+            'post_id'              => 404,
+            'content'              => 'New content',
+            // There is no post to fingerprint; any well-formed value is fine,
+            // and "post not found" must win over anything about this field.
+            'expected_fingerprint' => 'sha256:' . str_repeat('0', 64),
         ]);
 
         $this->assertFalse($result['ok']);
@@ -401,7 +471,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(31, 'post', 'trash');
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 31,
             'content' => 'New content',
         ]);
@@ -415,7 +485,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(32);
 
-        $result = (new ContentUpdateCommand())->execute([], ['post_id' => 32]);
+        $result = $this->runCommand(['post_id' => 32]);
 
         $this->assertFalse($result['ok']);
         $this->assertStringContainsString('nothing to update', $result['detail']);
@@ -423,7 +493,7 @@ final class ContentUpdateCommandTest extends TestCase
 
     public function test_refuses_a_missing_post_id(): void
     {
-        $result = (new ContentUpdateCommand())->execute([], ['content' => 'New content']);
+        $result = $this->runCommand(['content' => 'New content']);
 
         $this->assertFalse($result['ok']);
         $this->assertStringContainsString('post_id', $result['detail']);
@@ -433,7 +503,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(33, 'product');
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 33,
             'content' => 'New content',
         ]);
@@ -447,7 +517,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(34, 'product');
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id'            => 34,
             'content'            => 'New content',
             'allowed_post_types' => ['product'],
@@ -461,7 +531,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(35);
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id'            => 35,
             'content'            => 'New content',
             'allowed_post_types' => ['post', 7],
@@ -476,7 +546,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(36);
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 36,
             'content' => ['not', 'a', 'string'],
         ]);
@@ -493,7 +563,7 @@ final class ContentUpdateCommandTest extends TestCase
     {
         $this->seedPost(41);
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 41,
             'content' => 'Safe<script>alert(1)</script> text',
         ]);
@@ -511,7 +581,7 @@ final class ContentUpdateCommandTest extends TestCase
             static fn () => new \WP_Error('db_error', 'Could not update post in the database.')
         );
 
-        $result = (new ContentUpdateCommand())->execute([], [
+        $result = $this->runCommand([
             'post_id' => 42,
             'content' => 'New content',
         ]);
@@ -519,5 +589,266 @@ final class ContentUpdateCommandTest extends TestCase
         $this->assertFalse($result['ok']);
         $this->assertStringContainsString('wp_update_post failed', $result['detail']);
         $this->assertStringContainsString('database', $result['detail']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Block documents
+    //
+    // Writing free-form HTML into a block document leaves markup that no
+    // longer matches what the block type's save routine emits. Nothing fails
+    // at write time; the damage surfaces when a human next opens the editor,
+    // is offered block recovery on a page they never touched, and accepts it,
+    // which discards the block. So the write must not happen at all.
+    // -------------------------------------------------------------------------
+
+    public function test_refuses_a_block_document_and_leaves_it_byte_for_byte_unchanged(): void
+    {
+        $blockContent = "<!-- wp:paragraph -->\n<p>Canonical markup.</p>\n<!-- /wp:paragraph -->";
+        $this->seedPost(51, 'page', 'publish', 'Block page', $blockContent);
+
+        $before = $this->fingerprintOf(51);
+
+        $result = $this->runCommand([
+            'post_id' => 51,
+            'title'   => 'Rewritten title',
+            'content' => '<p>Free-form HTML.</p>',
+        ]);
+
+        $this->assertFalse($result['ok'], 'a block document was written');
+        $this->assertSame('failed', $result['outcome']);
+        $this->assertSame('block_document_unsupported', $result['code']);
+
+        // The refusal has to be actionable, or an automated caller retries the
+        // identical call until its budget is gone.
+        $this->assertStringContainsString('block document', $result['detail']);
+        $this->assertStringContainsString('Do not retry', $result['detail']);
+
+        $this->assertSame($blockContent, $this->posts[51]->post_content);
+        $this->assertSame('Block page', $this->posts[51]->post_title);
+        $this->assertSame($before, $this->fingerprintOf(51), 'the post changed');
+        $this->assertSame([], $this->revisionContents(51), 'a refused call left a revision behind');
+    }
+
+    /**
+     * The over-fire test, and it matters as much as the refusals: a guard that
+     * blocks correct work gets switched off, and then it guards nothing.
+     *
+     * @return void
+     */
+    public function test_a_classic_document_with_a_matching_fingerprint_still_succeeds(): void
+    {
+        $this->seedPost(52, 'page', 'publish', 'Classic page', '<p>Plain old HTML.</p>');
+
+        $result = $this->runCommand([
+            'post_id' => 52,
+            'content' => '<p>Replacement HTML.</p>',
+        ]);
+
+        $this->assertTrue($result['ok'], 'correct work was refused: ' . ($result['detail'] ?? ''));
+        $this->assertSame('<p>Replacement HTML.</p>', $this->posts[52]->post_content);
+        $this->assertSame(['content'], $result['changed']);
+    }
+
+    public function test_a_stale_fingerprint_is_a_conflict_not_a_failure_and_writes_nothing(): void
+    {
+        $this->seedPost(53, 'post', 'publish', 'Title as read', 'Content as read');
+
+        $stale = $this->fingerprintOf(53);
+
+        // Somebody else edits the post between the caller's read and its write.
+        $this->posts[53]->post_content = 'Content as it is NOW';
+
+        $result = $this->runCommand([
+            'post_id'              => 53,
+            'content'              => 'Content the caller planned',
+            'expected_fingerprint' => $stale,
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('conflict', $result['outcome'], 'a conflict was reported as a failure');
+        $this->assertSame('expected_fingerprint_mismatch', $result['code']);
+        $this->assertFalse($result['written']);
+        $this->assertSame($stale, $result['expected_fingerprint']);
+        $this->assertSame($this->fingerprintOf(53), $result['current_fingerprint']);
+
+        // A conflict is not a failure, and the response must say which it is:
+        // the remedies are opposite -- re-read and re-plan, versus retry.
+        $this->assertStringContainsString('conflict, not a failure', $result['detail']);
+
+        $this->assertSame('Content as it is NOW', $this->posts[53]->post_content, 'the other writer was overwritten');
+    }
+
+    /**
+     * The failure outcome and the conflict outcome must not be the same value,
+     * asserted side by side so a future "simplification" that collapses them
+     * cannot pass.
+     *
+     * @return void
+     */
+    public function test_conflict_and_failure_are_distinguishable_outcomes(): void
+    {
+        $this->seedPost(54);
+        $this->revisionsToKeep = 0;
+
+        $failure = $this->runCommand(['post_id' => 54, 'content' => 'New content']);
+
+        $this->seedPost(55);
+        $conflict = $this->runCommand([
+            'post_id'              => 55,
+            'content'              => 'New content',
+            'expected_fingerprint' => 'sha256:' . str_repeat('f', 64),
+        ]);
+
+        $this->assertFalse($failure['ok']);
+        $this->assertFalse($conflict['ok']);
+        $this->assertSame('failed', $failure['outcome']);
+        $this->assertSame('conflict', $conflict['outcome']);
+        $this->assertNotSame($failure['outcome'], $conflict['outcome']);
+    }
+
+    /**
+     * The reported fingerprint must be of the bytes that are STORED, which is
+     * not the same thing as the bytes that were sent.
+     *
+     * The proof is a filter that quietly rewrites the content on its way into
+     * the database, standing in for the real thing: a page builder, a kses
+     * variant, a sanitising plugin. A response echoing the request's value
+     * reports a fingerprint the database does not hold, and the caller has no
+     * way to see that its write did not land as asked.
+     *
+     * @return void
+     */
+    public function test_the_returned_fingerprint_is_the_re_read_stored_value(): void
+    {
+        $this->seedPost(56, 'post', 'publish', 'Title', 'Before');
+
+        $sent = 'After';
+
+        // Something between the command and the row rewrites the content.
+        Functions\when('wp_update_post')->alias(function ($postarr) {
+            $id                              = (int) $postarr['ID'];
+            $this->posts[$id]->post_content  = 'SOMETHING ELSE ENTIRELY';
+            return $id;
+        });
+
+        $result = $this->runCommand(['post_id' => 56, 'content' => $sent]);
+
+        $this->assertTrue($result['ok'], (string) ($result['detail'] ?? ''));
+        $this->assertSame(
+            $this->fingerprintOf(56),
+            $result['fingerprint'],
+            'the reported fingerprint is not the fingerprint of what is stored'
+        );
+        $this->assertNotSame(
+            'sha256:' . hash('sha256', "wpmgr.content_update.v1\n5\nTitle\n5\n" . $sent),
+            $result['fingerprint'],
+            'the response echoed the request instead of re-reading the row'
+        );
+        $this->assertSame(strlen('SOMETHING ELSE ENTIRELY'), $result['content_bytes']);
+        $this->assertSame(strlen('Title'), $result['title_bytes']);
+
+        // Re-read means re-read: the object cache is dropped first, or a
+        // persistent cache can answer with a version the row no longer holds.
+        $this->assertContains(56, $this->cleanPostCacheCalls);
+    }
+
+    // -------------------------------------------------------------------------
+    // What has_blocks() ACTUALLY does
+    //
+    // Measured against the vendored WordPress 7.1 source
+    // (tools/plugincheck/wp/wp-includes/blocks.php:878-890), which is
+    // str_contains($content, '<!-- wp:') and nothing more:
+    //
+    //   empty string                  => false
+    //   classic HTML                  => false
+    //   freeform, delimiterless       => false   <- what the block editor
+    //                                               stores for classic content
+    //   '<!-- wp:freeform -->' framed => true
+    //
+    // These assert the measured behaviour, not the behaviour one might expect
+    // of something called "has blocks".
+    // -------------------------------------------------------------------------
+
+    public function test_an_empty_post_is_not_a_block_document(): void
+    {
+        $this->seedPost(57, 'post', 'publish', 'Empty', '');
+
+        $result = $this->runCommand(['post_id' => 57, 'content' => 'First body.']);
+
+        $this->assertTrue($result['ok'], 'an empty post was treated as a block document: '
+            . (string) ($result['detail'] ?? ''));
+        $this->assertSame('First body.', $this->posts[57]->post_content);
+        $this->assertFalse($result['ownership']['is_block_document']);
+    }
+
+    /**
+     * Classic content round-tripped through the block editor is stored as a
+     * core/freeform block, and core/freeform serialises WITHOUT delimiters.
+     * has_blocks() therefore answers false and the write is allowed — which is
+     * the measured behaviour, and is also the right answer, since freeform
+     * holds raw HTML and has no save routine to mismatch.
+     *
+     * @return void
+     */
+    public function test_a_delimiterless_freeform_document_is_allowed(): void
+    {
+        $this->seedPost(58, 'page', 'publish', 'Freeform', '<p>Classic content.</p>');
+
+        $result = $this->runCommand(['post_id' => 58, 'content' => '<p>Replaced.</p>']);
+
+        $this->assertTrue($result['ok'], (string) ($result['detail'] ?? ''));
+        $this->assertSame('<p>Replaced.</p>', $this->posts[58]->post_content);
+    }
+
+    /**
+     * The same content WITH an explicit freeform delimiter is refused, because
+     * has_blocks() is a substring test and the delimiter is present.
+     *
+     * @return void
+     */
+    public function test_a_delimited_freeform_document_is_refused(): void
+    {
+        $content = "<!-- wp:freeform -->\n<p>Classic content.</p>\n<!-- /wp:freeform -->";
+        $this->seedPost(59, 'page', 'publish', 'Freeform', $content);
+
+        $result = $this->runCommand(['post_id' => 59, 'content' => '<p>Replaced.</p>']);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('block_document_unsupported', $result['code']);
+        $this->assertSame($content, $this->posts[59]->post_content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Ownership confidence
+    // -------------------------------------------------------------------------
+
+    public function test_the_response_admits_it_did_not_check_for_a_page_builder(): void
+    {
+        $this->seedPost(60, 'page');
+
+        $result = $this->runCommand(['post_id' => 60, 'content' => 'New body']);
+
+        $this->assertTrue($result['ok'], (string) ($result['detail'] ?? ''));
+        $this->assertTrue($result['ownership']['block_document_checked']);
+        $this->assertFalse($result['ownership']['is_block_document']);
+        $this->assertFalse(
+            $result['ownership']['page_builder_checked'],
+            'the response claims a page-builder verdict this slice did not earn'
+        );
+        $this->assertStringContainsString('page builder', $result['ownership']['detail']);
+    }
+
+    public function test_expected_fingerprint_is_required(): void
+    {
+        $this->seedPost(61);
+
+        $result = (new ContentUpdateCommand())->execute([], [
+            'post_id' => 61,
+            'content' => 'New content',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('missing_expected_fingerprint', $result['code']);
+        $this->assertSame('Original content', $this->posts[61]->post_content);
     }
 }


### PR DESCRIPTION
Adds `content_update`: retitle and/or rewrite one **existing** post or page. It does not create, does not delete, touches only `post_title` and `post_content`, and refuses any post type the request did not name.

## The labels

`effect()` → `Write`, `repeatability()` → `Unsafe`.

`Write` is earned, not assumed. WordPress does **not** retain the overwritten version by itself — verified against the WordPress 7.1 tree in `tools/plugincheck/wp`:

- `wp_save_post_revision()` is reached from `wp_save_post_revision_on_insert()`, hooked on `wp_after_insert_post` (`default-filters.php:445`) — i.e. **after** the row has already been rewritten.
- Core’s own docblock: *"Creates a revision for the current version of a post … the most recent revision always matches the current post."* The revision `wp_update_post()` leaves behind holds the **new** content.
- `wp_save_post_revision_on_insert()` returns early when `$update` is false, so a plain `wp_insert_post()` — importer, WP-CLI, programmatic creation — revisions nothing. On such a post the previous version would simply cease to exist.

So the command takes the revision **before** the write and reads it back to confirm the pre-update title and content are in it, and refuses when that guarantee is impossible:

- post type does not support revisions, or `WP_POST_REVISIONS` disabled (both → `wp_revisions_to_keep() === 0`);
- retention below 2 — at 1, the pruning tail of `wp_save_post_revision()` deletes the very revision just taken.

`Unsafe` because the request pins the post ID but not the post’s current content: a blind retry writes the request’s body over whatever the post holds now, discarding an edit made in between.

## Sanitisation

`wp_kses_post()` on content, `sanitize_text_field()` on title — the filtering an editor’s submission gets from a user without `unfiltered_html`. There is deliberately **no** unfiltered-HTML escape hatch. Values are then `wp_slash()`ed, because `wp_update_post()` documents its input as already escaped (`wp-includes/post.php:5316`).

## Scope

Agent side only. No control-plane half. No creation, deletion, meta editing or page-builder payload handling. No existing command modified.