### PR TITLE
fix(agent): guard both ends of a media quarantine restore

### DIFF
--- a/apps/agent/includes/commands/class-media-clean-command.php
+++ b/apps/agent/includes/commands/class-media-clean-command.php
@@ -93,7 +93,14 @@
  *     }
  *
  *   restore ->
- *     { "ok": true, "job_id": "<uuid>", "restored": <int> }
+ *     {
+ *       "ok": true,                          // true even when incomplete; the counts carry that
+ *       "job_id": "<uuid>",
+ *       "restored": <int>,                   // files moved back to their original path
+ *       "skipped": <int>,                    // files deliberately left in quarantine
+ *       "failed": <int>,                     // files whose move was attempted and did not happen
+ *       "detail": "<string>"                 // present only when skipped+failed > 0
+ *     }
  *
  *   delete ->
  *     {
@@ -185,6 +192,8 @@ final class MediaCleanCommand implements CommandInterface
     private const OP_MAX      = 200;
     /** Confirm token required for permanent deletion. */
     private const DELETE_CONFIRM = 'DELETE';
+    /** Uploads-relative paths named in a restore `detail` before it summarises the rest. */
+    private const RESTORE_DETAIL_PATHS = 5;
 
     /**
      * Optional quarantine instance injected for tests; null = create on demand
@@ -229,13 +238,12 @@ final class MediaCleanCommand implements CommandInterface
      * earlier docblock's claim that a delete retry "removes whatever now matches" was wrong about the
      * code -- handleDelete() never re-scans.
      *
-     * But action=restore is unsafe to retry. MediaQuarantine::restoreManifest() guards only the source:
-     * it skips a file only when file_exists($src) is false (class-media-quarantine.php:380), and moves
-     * it onto $normalised with a bare @rename() that overwrites unchecked -- the destination is never
-     * tested. Cleanup only runs when if ($restored > 0) (class-media-quarantine.php:397), so a restore
-     * attempt that restores zero files leaves the manifest live for a retry. A retry after that point can
-     * rename a quarantined file over a file created at the original path since the first attempt,
-     * destroying it. The manifest pins the source; nothing pins the destination.
+     * action=restore is likewise pinned by its quarantine_ids and re-derives nothing, and
+     * MediaQuarantine::restoreManifest() now guards both ends of every move: a file already
+     * occupying the original path is left alone and its quarantined counterpart is kept, so no
+     * retry can consume either. It stays classified Unsafe because a retry is still not a no-op --
+     * an incomplete restore deliberately keeps its manifest live, and a second call does more work
+     * against a tree the first one changed. Unsafe here means "not idempotent", not "destructive".
      *
      * @return CommandRepeatability
      */
@@ -631,20 +639,83 @@ final class MediaCleanCommand implements CommandInterface
 
         $quarantine = $this->quarantine ?? new MediaQuarantine();
         $restored   = 0;
+        $skipped    = 0;
+        $failed     = 0;
+        $blocked    = [];
 
         try {
             foreach ($manifestIds as $mId) {
-                $restored += $quarantine->restoreManifest($mId);
+                $receipt   = $quarantine->restoreManifest($mId);
+                $restored += (int)($receipt['restored'] ?? 0);
+                $skipped  += (int)($receipt['skipped'] ?? 0);
+                $failed   += (int)($receipt['failed'] ?? 0);
+                foreach ((array)($receipt['blocked'] ?? []) as $frag) {
+                    $blocked[] = (string)$frag;
+                }
             }
         } catch (\Throwable $e) {
             return ['ok' => false, 'detail' => 'media quarantine unavailable: ' . $e->getMessage()];
         }
 
-        return [
+        // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        error_log(sprintf(
+            '[wpmgr] media-clean restore: job_id=%s manifests=%d restored=%d skipped=%d failed=%d',
+            $jobId,
+            count($manifestIds),
+            $restored,
+            $skipped,
+            $failed
+        ));
+        // phpcs:enable
+
+        $result = [
+            // ok stays true for an incomplete restore: files really were moved
+            // back, and the control plane treats ok:false as an error and
+            // returns before recording the outcome, which would leave a real
+            // mutation unaudited. The counts below carry the incompleteness.
             'ok'       => true,
             'job_id'   => $jobId,
             'restored' => $restored,
+            'skipped'  => $skipped,
+            'failed'   => $failed,
         ];
+
+        if ($skipped > 0 || $failed > 0) {
+            $result['detail'] = $this->restoreDetail($skipped, $failed, $blocked);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Human-readable summary of a restore that did not put everything back.
+     *
+     * Names only the first few uploads-relative paths plus a total, so the
+     * operator gets something actionable without the payload growing with the
+     * manifest and without absolute server paths appearing on the wire.
+     *
+     * @param list<string> $blocked Uploads-relative fragments left in quarantine.
+     */
+    private function restoreDetail(int $skipped, int $failed, array $blocked): string
+    {
+        $outstanding = $skipped + $failed;
+        $detail      = sprintf(
+            '%d file(s) were not restored and remain in quarantine (skipped=%d failed=%d)',
+            $outstanding,
+            $skipped,
+            $failed
+        );
+
+        $names = array_slice($blocked, 0, self::RESTORE_DETAIL_PATHS);
+        if (!empty($names)) {
+            $detail .= ': ' . implode(', ', $names);
+            $more    = count($blocked) - count($names);
+            if ($more > 0) {
+                $detail .= sprintf(' (+%d more)', $more);
+            }
+        }
+
+        return $detail;
     }
 
     // =========================================================================

--- a/apps/agent/includes/media/class-media-quarantine.php
+++ b/apps/agent/includes/media/class-media-quarantine.php
@@ -98,6 +98,23 @@ final class MediaQuarantine
     /** Manifest schema version. */
     private const MANIFEST_VERSION = 1;
 
+    /**
+     * Machine-readable reasons restoreManifest() did not move a recorded file
+     * back to its original path. Each appears as a key on the receipt's
+     * `reasons` map with the number of files it accounts for.
+     *
+     * DESTINATION_OCCUPIED is the load-bearing one: something already sits at
+     * the original path, and rename(2) would replace it without a word.
+     * quarantineAttachment() MOVES the originals, so both the occupant and the
+     * quarantined copy are the only copies of themselves; the move is refused
+     * and both are kept for the operator to resolve.
+     */
+    public const RESTORE_SKIP_DESTINATION_OCCUPIED = 'destination_occupied';
+    public const RESTORE_SKIP_OUTSIDE_UPLOADS      = 'outside_uploads';
+    public const RESTORE_SKIP_UPLOADS_UNRESOLVED   = 'uploads_unresolved';
+    public const RESTORE_SKIP_SOURCE_MISSING       = 'source_missing';
+    public const RESTORE_SKIP_RENAME_FAILED        = 'rename_failed';
+
     /** Absolute path to the quarantine root (uploads/wpmgr-quarantine; legacy: wp-content/wpmgr-quarantine). */
     private string $quarantineRoot;
 
@@ -240,9 +257,20 @@ final class MediaQuarantine
         }
 
         $filesRoot   = $this->mediaRoot . '/' . $manifestId . '/files';
-        $uploadsBase = $this->uploadsBase();
         $movedPaths  = [];
         $moved       = 0;
+
+        // Without a resolvable uploads base nothing can be shown to be inside
+        // uploads, so nothing is moved. The manifest entry is still recorded
+        // below with an empty files[] — that is the same shape an attachment
+        // with no on-disk files produces, and it keeps the post deletable.
+        try {
+            $uploadsBase = $this->uploadsBase();
+        } catch (\RuntimeException $e) {
+            unset($e);
+            $absPaths = [];
+            $uploadsBase = '';
+        }
 
         foreach ($absPaths as $src) {
             // Containment: only move files that are inside the uploads dir.
@@ -321,24 +349,71 @@ final class MediaQuarantine
     /**
      * Move all files in a manifest back to their original paths.
      *
+     * Returns an instrumented receipt rather than a bare count, so a caller can
+     * tell a complete restore from a partial one and so the cleanup decision
+     * below rests on evidence instead of on "at least one file moved":
+     *
+     *   [
+     *     'restored'   => int,  // files moved back to their original path
+     *     'skipped'    => int,  // files deliberately left in quarantine
+     *     'failed'     => int,  // files whose move was attempted and did not happen
+     *     'files_seen' => int,  // file records read from the manifest
+     *     'complete'   => bool, // DERIVED, never passed in — see below
+     *     'reasons'    => array<string,int>,  // RESTORE_SKIP_* => count
+     *     'blocked'    => list<string>,       // uploads-relative fragments not restored
+     *   ]
+     *
+     * A file already occupying the original path is never overwritten, and the
+     * quarantined copy it displaced is never deleted. Both are the only copies
+     * of themselves — quarantineAttachment() MOVES the originals — so the move
+     * is refused, both survive, and the manifest stays live for the operator.
+     *
+     * `complete` is derived from two independent conditions, both required:
+     * every recorded file is accounted for (nothing skipped, nothing failed),
+     * AND no regular file remains anywhere under media/<manifest_id>/files. The
+     * counters cannot see a file left behind by a fragment-derivation branch,
+     * and the physical scan cannot say why one is there; only together do they
+     * license removing the quarantine copy.
+     *
+     * `blocked` carries uploads-relative fragments only. Absolute server paths
+     * are treated as disclosure here for the same reason finaliseManifest()
+     * keeps the manifest JSON outside the web-served media/ tree.
+     *
      * @param string $manifestId
-     * @return int Number of files successfully restored.
+     * @return array{restored:int,skipped:int,failed:int,files_seen:int,complete:bool,reasons:array<string,int>,blocked:list<string>}
      */
-    public function restoreManifest(string $manifestId): int
+    public function restoreManifest(string $manifestId): array
     {
+        $restored  = 0;
+        $skipped   = 0;
+        $failed    = 0;
+        $filesSeen = 0;
+        $reasons   = [];
+        $blocked   = [];
+
         $manifest = $this->loadManifest($manifestId);
         if ($manifest === null) {
-            return 0;
+            return $this->restoreReceipt($manifestId, 0, 0, 0, 0, [], []);
         }
 
-        $filesRoot   = $this->mediaRoot . '/' . $manifestId . '/files';
-        $uploadsBase = $this->uploadsBase();
-        $restored    = 0;
+        $filesRoot = $this->mediaRoot . '/' . $manifestId . '/files';
+
+        // An unresolvable uploads base is not a reason to relax containment;
+        // it is a reason to move nothing. Every recorded file is reported as
+        // skipped so the caller can say why, and nothing is cleaned up.
+        $uploadsBase = null;
+        try {
+            $uploadsBase = $this->uploadsBase();
+        } catch (\RuntimeException $e) {
+            unset($e);
+        }
 
         foreach ($manifest['entries'] as $entry) {
             $files = is_array($entry['files']) ? $entry['files'] : [];
 
             foreach ($files as $fileRecord) {
+                $filesSeen++;
+
                 // Support both the current {"orig","frag"} object format and the
                 // legacy plain-string format written by agent versions < 0.25.9.
                 if (is_array($fileRecord)) {
@@ -349,9 +424,17 @@ final class MediaQuarantine
                     $fragment        = '';
                 }
 
+                if ($uploadsBase === null) {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_UPLOADS_UNRESOLVED, $fragment);
+                    continue;
+                }
+
                 // Containment: restore target must be inside uploads.
                 $normalised = $this->normalisePath($originalAbsPath, $uploadsBase);
                 if ($normalised === '') {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_OUTSIDE_UPLOADS, $fragment);
                     continue;
                 }
 
@@ -364,6 +447,8 @@ final class MediaQuarantine
                 if ($fragment === '') {
                     $uploadsReal = realpath($uploadsBase);
                     if ($uploadsReal === false) {
+                        $skipped++;
+                        $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_UPLOADS_UNRESOLVED, '');
                         continue;
                     }
                     $uploadsBaseNorm = rtrim(str_replace('\\', '/', $uploadsBase), '/');
@@ -378,6 +463,20 @@ final class MediaQuarantine
                 $src = $filesRoot . '/' . $fragment;
 
                 if (!file_exists($src)) {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_SOURCE_MISSING, $fragment);
+                    continue;
+                }
+
+                // Destination guard. POSIX rename(2) unlinks an existing
+                // destination silently and the '@' would eat any warning, so
+                // the destination is stat'd first — the check the source side
+                // has always had. is_link() is paired with file_exists()
+                // because a broken symlink is not an empty slot; the pair is
+                // the one FilesRestorer::revertSingleItem() uses.
+                if (file_exists($normalised) || is_link($normalised)) {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_DESTINATION_OCCUPIED, $fragment);
                     continue;
                 }
 
@@ -389,16 +488,128 @@ final class MediaQuarantine
 
                 if (@rename($src, $normalised)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename,WordPress.WP.AlternativeFunctions.file_system_operations_rename,PluginCheck.CodeAnalysis.WriteFile.ABSPATHDetected -- restore/quarantine engine intentionally writes under ABSPATH (the live WP tree); relocating would defeat the restore
                     $restored++;
+                } else {
+                    // A move that did not happen must never read as one that
+                    // was never attempted: the quarantined copy is still the
+                    // only copy and cleanup must not run behind it.
+                    $failed++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_RENAME_FAILED, $fragment);
                 }
             }
         }
 
-        // Remove the (now-empty) manifest directory if everything was restored.
-        if ($restored > 0) {
+        $receipt = $this->restoreReceipt($manifestId, $restored, $skipped, $failed, $filesSeen, $reasons, $blocked);
+
+        // Remove the manifest directory only when the restore is provably
+        // complete. removeManifestDir() deletes every file still under
+        // media/<manifest_id>/ and the manifest JSON with it, and those files
+        // exist nowhere else, so anything short of complete keeps them.
+        if ($receipt['complete']) {
             $this->removeManifestDir($manifestId);
         }
 
-        return $restored;
+        return $receipt;
+    }
+
+    /**
+     * Record one non-restored file against its reason code.
+     *
+     * @param array<string,int> $reasons  Reason-code tally, by reference.
+     * @param list<string>      $blocked  Uploads-relative fragments, by reference.
+     * @param string            $reason   One of the RESTORE_SKIP_* constants.
+     * @param string            $fragment Uploads-relative fragment, or '' when unknown.
+     */
+    private function noteRestoreSkip(array &$reasons, array &$blocked, string $reason, string $fragment): void
+    {
+        $reasons[$reason] = ($reasons[$reason] ?? 0) + 1;
+
+        // Only uploads-relative fragments are reported; an absolute server path
+        // would be disclosure, and an unknown fragment is reported as a count
+        // under its reason code rather than as a bare path.
+        if ($fragment !== '') {
+            $blocked[] = $fragment;
+        }
+    }
+
+    /**
+     * Assemble a restore receipt, deriving `complete` rather than accepting it.
+     *
+     * @param array<string,int> $reasons
+     * @param list<string>      $blocked
+     * @return array{restored:int,skipped:int,failed:int,files_seen:int,complete:bool,reasons:array<string,int>,blocked:list<string>}
+     */
+    private function restoreReceipt(
+        string $manifestId,
+        int $restored,
+        int $skipped,
+        int $failed,
+        int $filesSeen,
+        array $reasons,
+        array $blocked
+    ): array {
+        $accountedFor = ($skipped === 0 && $failed === 0);
+
+        return [
+            'restored'   => $restored,
+            'skipped'    => $skipped,
+            'failed'     => $failed,
+            'files_seen' => $filesSeen,
+            'complete'   => $accountedFor && !$this->hasRemainingFiles($manifestId),
+            'reasons'    => $reasons,
+            'blocked'    => array_values($blocked),
+        ];
+    }
+
+    /**
+     * Whether any file remains anywhere under media/<manifest_id>/files.
+     *
+     * The second, independent half of the `complete` derivation. The restore
+     * counters only see files the manifest described; a file left behind by a
+     * fragment-derivation branch produces no countable record, so the tree
+     * itself is scanned before its deletion is licensed.
+     *
+     * Fails closed: anything that cannot be proven empty reports remaining
+     * files, because the caller's only use for a false is to delete.
+     */
+    private function hasRemainingFiles(string $manifestId): bool
+    {
+        if (!preg_match('/^[a-zA-Z0-9_-]{1,64}$/', $manifestId)) {
+            return true;
+        }
+
+        return $this->dirHoldsFile($this->mediaRoot . '/' . $manifestId . '/files');
+    }
+
+    /**
+     * Recursive half of hasRemainingFiles(). A symlink counts as a file: it is
+     * something the tree still holds, whatever it points at.
+     */
+    private function dirHoldsFile(string $dir): bool
+    {
+        if (!is_dir($dir)) {
+            return false;
+        }
+
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            // Unreadable: cannot prove the tree is empty, so do not say it is.
+            return true;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            if (is_link($path) || is_file($path)) {
+                return true;
+            }
+            if (is_dir($path) && $this->dirHoldsFile($path)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -437,7 +648,23 @@ final class MediaQuarantine
         }
 
         $filesRoot   = $this->mediaRoot . '/' . $manifestId . '/files';
-        $uploadsBase = $this->uploadsBase();
+
+        // No resolvable uploads base means containment cannot be enforced on a
+        // delete either. Report the zero-count result — the same one an unknown
+        // manifest_id produces — so the manifest and its files stay put and a
+        // later attempt can still run.
+        try {
+            $uploadsBase = $this->uploadsBase();
+        } catch (\RuntimeException $e) {
+            unset($e);
+            return [
+                'posts_deleted'     => 0,
+                'posts_failed'      => 0,
+                'files_deleted'     => 0,
+                'entries_processed' => 0,
+                'results'           => [],
+            ];
+        }
 
         $postsDeleted     = 0;
         $postsFailed      = 0;
@@ -919,11 +1146,29 @@ final class MediaQuarantine
 
     /**
      * Absolute filesystem path to the uploads root.
+     *
+     * Never returns an empty string. Every containment check in this class is
+     * a prefix test against this value, and normalisePath() compares against
+     * rtrim($base, '/') . '/', so an empty base becomes the prefix '/' and the
+     * test then passes for every absolute path on the server. Containment
+     * would not be weakened by that, it would be switched off. An uploads
+     * directory that cannot be resolved is therefore a hard failure here
+     * rather than a silently permissive value at the call site.
+     *
+     * @throws \RuntimeException When wp_upload_dir() reports no usable basedir.
      */
     private function uploadsBase(): string
     {
-        $dir = wp_upload_dir();
-        return rtrim((string)($dir['basedir'] ?? ''), '/\\');
+        $dir  = wp_upload_dir();
+        $base = is_array($dir) ? rtrim((string)($dir['basedir'] ?? ''), '/\\') : '';
+
+        if ($base === '') {
+            $message = 'WPMgr MediaQuarantine: wp_upload_dir() reported no usable basedir; '
+                . 'refusing to run an uploads-containment check against an empty base path.';
+            throw new \RuntimeException($message);
+        }
+
+        return $base;
     }
 
     /**

--- a/apps/agent/includes/media/class-media-quarantine.php
+++ b/apps/agent/includes/media/class-media-quarantine.php
@@ -474,6 +474,22 @@ final class MediaQuarantine
                 // has always had. is_link() is paired with file_exists()
                 // because a broken symlink is not an empty slot; the pair is
                 // the one FilesRestorer::revertSingleItem() uses.
+                //
+                // The stat and the rename below are not one atomic operation,
+                // and PHP offers no rename-if-absent, so a residual window
+                // stays open between them. Something can create the
+                // destination inside it and the rename will still clobber it:
+                // in-process, DiskWriter::write() (class-disk-writer.php:74)
+                // renames onto live uploads paths, driven by the
+                // wp_generate_attachment_metadata filter registered at
+                // class-plugin.php:806.
+                //
+                // Narrowing is the whole available fix, and it is strictly
+                // better than what it replaces: before this guard existed
+                // every restore clobbered its destination unconditionally, so
+                // the losing window was the entire operation rather than the
+                // gap between two adjacent syscalls. Nothing worse than the
+                // pre-guard behaviour can happen inside what is left.
                 if (file_exists($normalised) || is_link($normalised)) {
                     $skipped++;
                     $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_DESTINATION_OCCUPIED, $fragment);
@@ -549,27 +565,39 @@ final class MediaQuarantine
     ): array {
         $accountedFor = ($skipped === 0 && $failed === 0);
 
+        // A receipt that saw no file and moved no file describes no restore at
+        // all — an unknown or unreadable manifest id reaches here that way.
+        // `complete` is public receipt API, so it must never let "the id means
+        // nothing to me" derive to "everything was put back".
+        $describesARestore = ($filesSeen > 0 || $restored > 0);
+
         return [
             'restored'   => $restored,
             'skipped'    => $skipped,
             'failed'     => $failed,
             'files_seen' => $filesSeen,
-            'complete'   => $accountedFor && !$this->hasRemainingFiles($manifestId),
+            'complete'   => $describesARestore && $accountedFor && !$this->hasRemainingFiles($manifestId),
             'reasons'    => $reasons,
             'blocked'    => array_values($blocked),
         ];
     }
 
     /**
-     * Whether any file remains anywhere under media/<manifest_id>/files.
+     * Whether anything remains anywhere under media/<manifest_id>.
      *
      * The second, independent half of the `complete` derivation. The restore
      * counters only see files the manifest described; a file left behind by a
      * fragment-derivation branch produces no countable record, so the tree
      * itself is scanned before its deletion is licensed.
      *
-     * Fails closed: anything that cannot be proven empty reports remaining
-     * files, because the caller's only use for a false is to delete.
+     * The scan root is media/<manifest_id>, not media/<manifest_id>/files,
+     * because removeManifestDir() deletes media/<manifest_id> whole. The scan
+     * must cover everything the cleanup destroys or the gate is only accurate
+     * for today's directory layout; an earlier layout kept other things beside
+     * files/, and a stray at media/<manifest_id>/x was deleted unseen.
+     *
+     * Fails closed: an entry that cannot be positively classified counts as
+     * remaining, because the caller's only use for a false is to delete.
      */
     private function hasRemainingFiles(string $manifestId): bool
     {
@@ -577,17 +605,29 @@ final class MediaQuarantine
             return true;
         }
 
-        return $this->dirHoldsFile($this->mediaRoot . '/' . $manifestId . '/files');
+        return $this->dirHoldsFile($this->mediaRoot . '/' . $manifestId);
     }
 
     /**
      * Recursive half of hasRemainingFiles(). A symlink counts as a file: it is
      * something the tree still holds, whatever it points at.
+     *
+     * Classification is positive-only. An entry scandir() listed but that is
+     * neither link, file nor directory counts as remaining: that covers FIFOs,
+     * sockets and device nodes, and it covers the case that motivated this
+     * rule — a directory carrying the read bit without the search bit, where
+     * scandir() succeeds, every stat on its entries fails, and each entry
+     * would otherwise be silently dropped from a tree about to be deleted.
      */
     private function dirHoldsFile(string $dir): bool
     {
+        if (is_link($dir) || is_file($dir)) {
+            // The scan root is not a directory but is something. It is held.
+            return true;
+        }
+
         if (!is_dir($dir)) {
-            return false;
+            return $this->pathPresentButUnclassified($dir);
         }
 
         $entries = @scandir($dir);
@@ -604,12 +644,47 @@ final class MediaQuarantine
             if (is_link($path) || is_file($path)) {
                 return true;
             }
-            if (is_dir($path) && $this->dirHoldsFile($path)) {
-                return true;
+            if (is_dir($path)) {
+                if ($this->dirHoldsFile($path)) {
+                    return true;
+                }
+                continue;
             }
+
+            // Listed, so something is there, but nothing could classify it.
+            // Unclassified is not empty.
+            return true;
         }
 
         return false;
+    }
+
+    /**
+     * Whether a path that no stat could classify is nevertheless present.
+     *
+     * A path whose own stat fails looks identical to one that was never
+     * created — file_exists() is false for both — so the parent directory is
+     * asked instead, which can tell them apart by listing the name. Absent is
+     * the licit answer: a manifest that quarantined nothing never creates a
+     * media/<manifest_id> tree, and that must stay eligible for cleanup.
+     */
+    private function pathPresentButUnclassified(string $path): bool
+    {
+        $parent = dirname($path);
+        if ($parent === $path || !is_dir($parent)) {
+            // No parent left to ask, or the parent is absent too. Nothing was
+            // ever there to hold a file.
+            return false;
+        }
+
+        $entries = @scandir($parent);
+        if ($entries === false) {
+            // The parent exists but will not be listed: nothing below it can
+            // be proven empty.
+            return true;
+        }
+
+        return in_array(basename($path), $entries, true);
     }
 
     /**

--- a/apps/agent/includes/media/class-media-quarantine.php
+++ b/apps/agent/includes/media/class-media-quarantine.php
@@ -1165,7 +1165,7 @@ final class MediaQuarantine
         if ($base === '') {
             $message = 'WPMgr MediaQuarantine: wp_upload_dir() reported no usable basedir; '
                 . 'refusing to run an uploads-containment check against an empty base path.';
-            throw new \RuntimeException($message);
+            throw new \RuntimeException($message); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- fixed self-composed literal, caught in-class and never echoed; carries no caller or request input
         }
 
         return $base;

--- a/apps/agent/includes/media/class-media-quarantine.php
+++ b/apps/agent/includes/media/class-media-quarantine.php
@@ -368,12 +368,16 @@ final class MediaQuarantine
      * of themselves — quarantineAttachment() MOVES the originals — so the move
      * is refused, both survive, and the manifest stays live for the operator.
      *
-     * `complete` is derived from two independent conditions, both required:
-     * every recorded file is accounted for (nothing skipped, nothing failed),
-     * AND no regular file remains anywhere under media/<manifest_id>/files. The
-     * counters cannot see a file left behind by a fragment-derivation branch,
-     * and the physical scan cannot say why one is there; only together do they
-     * license removing the quarantine copy.
+     * `complete` is derived from three independent conditions, all required:
+     * the manifest loaded at all, AND every recorded file is accounted for
+     * (nothing skipped, nothing failed), AND no regular file remains anywhere
+     * under media/<manifest_id>. The counters cannot see a file left behind by
+     * a fragment-derivation branch, and the physical scan cannot say why one
+     * is there; only together do they license removing the quarantine copy.
+     *
+     * `complete` is internal to this class today: it gates the cleanup below
+     * and no caller reads it. It is documented because it is returned, not
+     * because anything outside consumes it.
      *
      * `blocked` carries uploads-relative fragments only. Absolute server paths
      * are treated as disclosure here for the same reason finaliseManifest()
@@ -393,7 +397,7 @@ final class MediaQuarantine
 
         $manifest = $this->loadManifest($manifestId);
         if ($manifest === null) {
-            return $this->restoreReceipt($manifestId, 0, 0, 0, 0, [], []);
+            return $this->restoreReceipt($manifestId, false, 0, 0, 0, 0, [], []);
         }
 
         $filesRoot = $this->mediaRoot . '/' . $manifestId . '/files';
@@ -514,7 +518,16 @@ final class MediaQuarantine
             }
         }
 
-        $receipt = $this->restoreReceipt($manifestId, $restored, $skipped, $failed, $filesSeen, $reasons, $blocked);
+        $receipt = $this->restoreReceipt(
+            $manifestId,
+            true,
+            $restored,
+            $skipped,
+            $failed,
+            $filesSeen,
+            $reasons,
+            $blocked
+        );
 
         // Remove the manifest directory only when the restore is provably
         // complete. removeManifestDir() deletes every file still under
@@ -550,12 +563,18 @@ final class MediaQuarantine
     /**
      * Assemble a restore receipt, deriving `complete` rather than accepting it.
      *
+     * $manifestLoaded is a private discriminator, never a receipt field: it
+     * says only that loadManifest() returned a manifest, which is the fact
+     * `complete` needs and which the counters cannot express.
+     *
+     * @param bool              $manifestLoaded Whether loadManifest() returned a manifest.
      * @param array<string,int> $reasons
      * @param list<string>      $blocked
      * @return array{restored:int,skipped:int,failed:int,files_seen:int,complete:bool,reasons:array<string,int>,blocked:list<string>}
      */
     private function restoreReceipt(
         string $manifestId,
+        bool $manifestLoaded,
         int $restored,
         int $skipped,
         int $failed,
@@ -565,18 +584,20 @@ final class MediaQuarantine
     ): array {
         $accountedFor = ($skipped === 0 && $failed === 0);
 
-        // A receipt that saw no file and moved no file describes no restore at
-        // all — an unknown or unreadable manifest id reaches here that way.
-        // `complete` is public receipt API, so it must never let "the id means
-        // nothing to me" derive to "everything was put back".
-        $describesARestore = ($filesSeen > 0 || $restored > 0);
+        // The discriminator is whether a manifest loaded, not whether it
+        // described any file. An unknown or unreadable id reaches here with
+        // $manifestLoaded false and must never derive "everything was put
+        // back" from "the id means nothing to me". A manifest that loaded and
+        // legitimately recorded an attachment with no on-disk files is the
+        // opposite case: it is complete the moment it is read, and gating on
+        // the counters instead would leave it permanently uncleanable.
 
         return [
             'restored'   => $restored,
             'skipped'    => $skipped,
             'failed'     => $failed,
             'files_seen' => $filesSeen,
-            'complete'   => $describesARestore && $accountedFor && !$this->hasRemainingFiles($manifestId),
+            'complete'   => $manifestLoaded && $accountedFor && !$this->hasRemainingFiles($manifestId),
             'reasons'    => $reasons,
             'blocked'    => array_values($blocked),
         ];

--- a/apps/agent/tests/MediaCleanOptimizerPathsTest.php
+++ b/apps/agent/tests/MediaCleanOptimizerPathsTest.php
@@ -848,8 +848,8 @@ final class MediaCleanOptimizerPathsTest extends TestCase
         $this->assertSame($relPath,    $fileRecord['frag'], 'frag stores the uploads-relative fragment');
 
         // Restore must work correctly via the recorded frag.
-        $restored = $q->restoreManifest($manifestId);
-        $this->assertSame(1, $restored, 'file restored via symlinked uploads base');
+        $receipt = $q->restoreManifest($manifestId);
+        $this->assertSame(1, $receipt['restored'], 'file restored via symlinked uploads base');
         $this->assertFileExists($symlinkAbs, 'file restored to original path');
         $this->assertSame('symbase-content', file_get_contents($symlinkAbs), 'content intact');
 

--- a/apps/agent/tests/MediaQuarantineTest.php
+++ b/apps/agent/tests/MediaQuarantineTest.php
@@ -338,6 +338,118 @@ final class MediaQuarantineTest extends TestCase
     }
 
     // =========================================================================
+    // restoreManifest() — never moves a quarantined file over a file that
+    // occupies the original path
+    // =========================================================================
+
+    public function testRestoreManifestDoesNotOverwriteANewerFileAtTheOriginalPath(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'quarantined-bytes');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-restore-occupied');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // The original path is empty: quarantineAttachment() MOVES the bytes,
+        // so the quarantined copy is the only copy that exists.
+        $this->assertFileDoesNotExist($srcAbs);
+
+        // A different file comes to occupy that exact path while the
+        // attachment is isolated.
+        $this->createUploadFile($relPath, 'newer-bytes-written-after-isolation');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        // Load-bearing: the occupant is the only copy of its own bytes.
+        $this->assertSame(
+            'newer-bytes-written-after-isolation',
+            file_get_contents($srcAbs),
+            'restore must not move a quarantined file onto an occupied original path'
+        );
+
+        // The refused file is likewise the only copy of itself, so it must
+        // survive the refusal rather than be cleaned up behind it.
+        $quarantinedCopy = $this->mediaRoot() . '/' . $manifestId . '/files/' . $relPath;
+        $this->assertFileExists($quarantinedCopy, 'the refused file stays in quarantine');
+        $this->assertSame('quarantined-bytes', file_get_contents($quarantinedCopy));
+
+        $this->assertFileExists(
+            $this->manifestsRoot() . '/' . $manifestId . '.json',
+            'the manifest survives an incomplete restore so the operator can retry'
+        );
+
+        $this->assertSame(0, $receipt['restored'], 'nothing was restored');
+        $this->assertSame(1, $receipt['skipped'], 'the contested file counts as skipped');
+        $this->assertSame(
+            1,
+            $receipt['reasons'][MediaQuarantine::RESTORE_SKIP_DESTINATION_OCCUPIED] ?? 0,
+            'the skip is attributed to the occupied destination'
+        );
+        $this->assertFalse($receipt['complete'], 'an incomplete restore never reports complete');
+    }
+
+    // =========================================================================
+    // restoreManifest() — a file it refused to restore is never then deleted
+    // by the cleanup gate
+    // =========================================================================
+
+    public function testRestoreManifestDoesNotDeleteAQuarantinedFileItRefusedToRestore(): void
+    {
+        $mainRel  = '2024/01/gallery.jpg';
+        $thumbRel = '2024/01/gallery-150x150.jpg';
+
+        $mainAbs  = $this->createUploadFile($mainRel,  'main-bytes');
+        $thumbAbs = $this->createUploadFile($thumbRel, 'thumb-bytes');
+
+        // One entry, two files — the shape isolate produces for an attachment
+        // with sub-sizes.
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-restore-partial');
+        $q->quarantineAttachment($manifestId, 42, $mainRel, [$mainAbs, $thumbAbs]);
+        $q->finaliseManifest($manifestId);
+
+        $this->assertFileDoesNotExist($mainAbs);
+        $this->assertFileDoesNotExist($thumbAbs);
+
+        // Only the main file's original path is taken.
+        $this->createUploadFile($mainRel, 'newer-main-bytes');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(
+            'newer-main-bytes',
+            file_get_contents($mainAbs),
+            'the occupant survives'
+        );
+
+        // The guard must not block correct work: the uncontested file still
+        // goes back, with its original content.
+        $this->assertFileExists($thumbAbs, 'the uncontested file is still restored');
+        $this->assertSame('thumb-bytes', file_get_contents($thumbAbs), 'restored content intact');
+
+        // Load-bearing: cleanup must not delete the copy restore declined to
+        // move. A partial restore that then removes the manifest directory
+        // destroys the only remaining copy of the refused file.
+        $refusedCopy = $this->mediaRoot() . '/' . $manifestId . '/files/' . $mainRel;
+        $this->assertFileExists(
+            $refusedCopy,
+            'a quarantined file restore refused to move must not then be deleted'
+        );
+        $this->assertSame('main-bytes', file_get_contents($refusedCopy));
+
+        $this->assertFileExists(
+            $this->manifestsRoot() . '/' . $manifestId . '.json',
+            'the manifest survives so the refused file can still be recovered'
+        );
+
+        $this->assertSame(1, $receipt['restored'], 'the uncontested file counts as restored');
+        $this->assertSame(1, $receipt['skipped'], 'the contested file counts as skipped');
+        $this->assertFalse($receipt['complete'], 'a partial restore never reports complete');
+    }
+
+    // =========================================================================
     // deleteManifest() — unknown manifest_id returns 0
     // =========================================================================
 

--- a/apps/agent/tests/MediaQuarantineTest.php
+++ b/apps/agent/tests/MediaQuarantineTest.php
@@ -15,6 +15,10 @@
  *   - finaliseManifest() — media/ subtree contains only image files (no JSON).
  *   - restoreManifest() returns 0 for an unknown manifest_id.
  *   - restoreManifest() moves files back and removes the manifest dir.
+ *   - restoreManifest() never moves a quarantined file onto an original path that
+ *     something else now occupies, and reports the skip with a reason code.
+ *   - restoreManifest() does not delete a quarantined file it refused to restore —
+ *     cleanup runs only on a complete restore, so a partial one keeps every copy.
  *   - restoreManifest() handles entries with empty files[] cleanly (0 files back, no error).
  *   - deleteManifest() returns a zero-count result for an unknown manifest_id.
  *   - deleteManifest() removes quarantined files, calls wp_delete_attachment,
@@ -304,7 +308,9 @@ final class MediaQuarantineTest extends TestCase
         // Ensure the quarantine root exists (needed for realpath in loadManifest).
         $q->beginManifest('warmup');
 
-        $this->assertSame(0, $q->restoreManifest('00000000000000000000000000000000'));
+        $receipt = $q->restoreManifest('00000000000000000000000000000000');
+
+        $this->assertSame(0, $receipt['restored']);
     }
 
     // =========================================================================
@@ -324,9 +330,10 @@ final class MediaQuarantineTest extends TestCase
         // Confirm file is gone from uploads.
         $this->assertFileDoesNotExist($srcAbs);
 
-        $restored = $q->restoreManifest($manifestId);
+        $receipt = $q->restoreManifest($manifestId);
 
-        $this->assertSame(1, $restored);
+        $this->assertSame(1, $receipt['restored']);
+        $this->assertTrue($receipt['complete'], 'a restore that put everything back is complete');
 
         // File is back in uploads.
         $this->assertFileExists($srcAbs);
@@ -577,9 +584,9 @@ final class MediaQuarantineTest extends TestCase
         $q->finaliseManifest($manifestId);
 
         // restoreManifest must handle empty files[] without error and return 0.
-        $restored = $q->restoreManifest($manifestId);
+        $receipt = $q->restoreManifest($manifestId);
 
-        $this->assertSame(0, $restored, 'Nothing to restore when files array is empty.');
+        $this->assertSame(0, $receipt['restored'], 'Nothing to restore when files array is empty.');
     }
 
     // =========================================================================
@@ -595,7 +602,7 @@ final class MediaQuarantineTest extends TestCase
 
         foreach ($traversalIds as $id) {
             $result = $q->restoreManifest($id);
-            $this->assertSame(0, $result, "Path-traversal id '{$id}' must be rejected (returns 0).");
+            $this->assertSame(0, $result['restored'], "Path-traversal id '{$id}' must be rejected (restores 0).");
         }
     }
 
@@ -632,11 +639,16 @@ final class MediaQuarantineTest extends TestCase
         file_put_contents($manifestFile, $crafted);
 
         // restoreManifest must skip the crafted entry (returns 0 restored).
-        $restored = $q->restoreManifest($manifestId);
+        $receipt = $q->restoreManifest($manifestId);
         $this->assertSame(
             0,
-            $restored,
+            $receipt['restored'],
             'normalisePath() must reject paths containing "/.." — 0 files restored.'
+        );
+        $this->assertSame(
+            1,
+            $receipt['reasons'][MediaQuarantine::RESTORE_SKIP_OUTSIDE_UPLOADS] ?? 0,
+            'the rejected entry is attributed to the containment check, not silently dropped'
         );
     }
 }

--- a/apps/agent/tests/MediaQuarantineTest.php
+++ b/apps/agent/tests/MediaQuarantineTest.php
@@ -19,6 +19,10 @@
  *     something else now occupies, and reports the skip with a reason code.
  *   - restoreManifest() does not delete a quarantined file it refused to restore —
  *     cleanup runs only on a complete restore, so a partial one keeps every copy.
+ *   - restoreManifest() withholds `complete` while the quarantine tree still holds
+ *     anything the counters cannot see: an unrecorded file, an entry no stat can
+ *     classify, or a stray beside files/ that cleanup would delete unseen.
+ *   - restoreManifest() never reports `complete` for a manifest id that named nothing.
  *   - restoreManifest() handles entries with empty files[] cleanly (0 files back, no error).
  *   - deleteManifest() returns a zero-count result for an unknown manifest_id.
  *   - deleteManifest() removes quarantined files, calls wp_delete_attachment,
@@ -454,6 +458,142 @@ final class MediaQuarantineTest extends TestCase
         $this->assertSame(1, $receipt['restored'], 'the uncontested file counts as restored');
         $this->assertSame(1, $receipt['skipped'], 'the contested file counts as skipped');
         $this->assertFalse($receipt['complete'], 'a partial restore never reports complete');
+    }
+
+    // =========================================================================
+    // restoreManifest() — the physical scan, the half of `complete` the
+    // restore counters cannot see
+    //
+    // Every test below leaves something in the quarantine tree that no
+    // manifest entry describes, so the counters read clean and only the scan
+    // can withhold `complete`. Delete the hasRemainingFiles() term from
+    // restoreReceipt() and each of them fails.
+    // =========================================================================
+
+    public function testRestoreManifestIsNotCompleteWhileAnUnrecordedFileRemains(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'restore-me');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-unrecorded');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // A file under files/ that no manifest entry names. A fragment
+        // derivation that went down a different branch leaves exactly this:
+        // bytes in the tree with no countable record anywhere.
+        $orphan = $this->mediaRoot() . '/' . $manifestId . '/files/2024/01/orphan.jpg';
+        file_put_contents($orphan, 'orphan-bytes');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        // The counters are clean: every file the manifest described went back.
+        $this->assertSame(1, $receipt['restored'], 'the recorded file is restored');
+        $this->assertSame(0, $receipt['skipped'], 'nothing was skipped');
+        $this->assertSame(0, $receipt['failed'], 'nothing failed');
+        $this->assertFileExists($srcAbs, 'the guard does not block correct work');
+
+        // Load-bearing: only the physical scan knows the orphan is there.
+        $this->assertFalse(
+            $receipt['complete'],
+            'a tree that still holds an unrecorded file is not a complete restore'
+        );
+        $this->assertFileExists($orphan, 'the unrecorded file is not deleted behind the counters');
+        $this->assertSame('orphan-bytes', file_get_contents($orphan));
+        $this->assertFileExists(
+            $this->manifestsRoot() . '/' . $manifestId . '.json',
+            'the manifest stays, so the leftover still has something naming it'
+        );
+    }
+
+    public function testRestoreManifestIsNotCompleteWhileAnUnclassifiableEntryRemains(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'restore-me');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-unclassifiable');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // An entry scandir() lists but that is neither link, file nor
+        // directory. A FIFO is the portable way to produce one: unlike the
+        // read-bit-without-search-bit directory that motivated this rule, it
+        // behaves the same for root, so it is reproducible in a CI container.
+        $oddball = $this->mediaRoot() . '/' . $manifestId . '/files/2024/01/oddball';
+        if (!function_exists('posix_mkfifo') || !@posix_mkfifo($oddball, 0644)) {
+            $this->markTestSkipped('posix_mkfifo() unavailable: cannot create an unclassifiable entry');
+        }
+
+        // Refuse to pass vacuously: if the entry is classifiable after all,
+        // this test proves nothing about the hazard and must not report green.
+        $this->assertTrue(file_exists($oddball), 'the planted entry exists');
+        $this->assertFalse(is_link($oddball), 'precondition: not a link');
+        $this->assertFalse(is_file($oddball), 'precondition: not a file');
+        $this->assertFalse(is_dir($oddball), 'precondition: not a directory');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(1, $receipt['restored'], 'the recorded file is restored');
+        $this->assertSame(0, $receipt['skipped'], 'nothing was skipped');
+        $this->assertSame(0, $receipt['failed'], 'nothing failed');
+
+        // Load-bearing: an entry no stat can classify is not an empty tree.
+        $this->assertFalse(
+            $receipt['complete'],
+            'an entry that cannot be positively classified counts as remaining'
+        );
+        $this->assertTrue(file_exists($oddball), 'the unclassified entry is not deleted behind the scan');
+    }
+
+    public function testRestoreManifestIsNotCompleteWhileAStrayOutsideFilesRemains(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'restore-me');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-stray');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // Beside files/, not under it. removeManifestDir() deletes the whole
+        // media/<manifest_id> tree, so the scan has to cover the whole of it
+        // rather than the one sub-directory today's layout happens to use.
+        $stray = $this->mediaRoot() . '/' . $manifestId . '/stray.dat';
+        file_put_contents($stray, 'stray-bytes');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(1, $receipt['restored'], 'the recorded file is restored');
+        $this->assertSame(0, $receipt['skipped'], 'nothing was skipped');
+        $this->assertSame(0, $receipt['failed'], 'nothing failed');
+
+        $this->assertFalse(
+            $receipt['complete'],
+            'a stray beside files/ is inside what the cleanup deletes, so it withholds complete'
+        );
+        $this->assertFileExists($stray, 'the stray is not deleted unseen');
+        $this->assertSame('stray-bytes', file_get_contents($stray));
+    }
+
+    public function testRestoreManifestUnknownIdIsNeverComplete(): void
+    {
+        $q = $this->makeQuarantine();
+        $q->beginManifest('warmup');
+
+        $receipt = $q->restoreManifest('00000000000000000000000000000000');
+
+        $this->assertSame(0, $receipt['files_seen'], 'an unknown id describes no files');
+        $this->assertSame(0, $receipt['restored'], 'and restores none');
+
+        // `complete` is public receipt API. A caller that gates a delete on it
+        // must never read "this id means nothing to me" as "everything was
+        // put back".
+        $this->assertFalse(
+            $receipt['complete'],
+            'a receipt for a manifest that never existed is not a complete restore'
+        );
     }
 
     // =========================================================================

--- a/apps/agent/tests/MediaQuarantineTest.php
+++ b/apps/agent/tests/MediaQuarantineTest.php
@@ -587,8 +587,8 @@ final class MediaQuarantineTest extends TestCase
         $this->assertSame(0, $receipt['files_seen'], 'an unknown id describes no files');
         $this->assertSame(0, $receipt['restored'], 'and restores none');
 
-        // `complete` is public receipt API. A caller that gates a delete on it
-        // must never read "this id means nothing to me" as "everything was
+        // `complete` gates the cleanup that deletes the quarantine copy, and
+        // it must never read "this id means nothing to me" as "everything was
         // put back".
         $this->assertFalse(
             $receipt['complete'],
@@ -727,6 +727,43 @@ final class MediaQuarantineTest extends TestCase
         $receipt = $q->restoreManifest($manifestId);
 
         $this->assertSame(0, $receipt['restored'], 'Nothing to restore when files array is empty.');
+    }
+
+    // =========================================================================
+    // restoreManifest() — a manifest that loaded and legitimately recorded no
+    // on-disk file is complete, and is cleaned up
+    // =========================================================================
+
+    public function testRestoreManifestWithOnlyEmptyFilesEntriesIsCompleteAndCleansUp(): void
+    {
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-restore-empty-complete');
+
+        // A broken attachment with no on-disk files: quarantineAttachment()
+        // deliberately records the entry with files => [].
+        $q->quarantineAttachment($manifestId, 12, '2024/01/ghost.jpg', []);
+        $q->finaliseManifest($manifestId);
+
+        $manifestFile = $this->manifestsRoot() . '/' . $manifestId . '.json';
+        $manifestDir  = $this->mediaRoot() . '/' . $manifestId;
+        $this->assertFileExists($manifestFile, 'the manifest exists before the restore');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(0, $receipt['files_seen'], 'the manifest described no file');
+        $this->assertSame(0, $receipt['restored'], 'so nothing was moved back');
+
+        // The discriminator is "did a manifest load", not "did it describe
+        // files". Deriving this from the counters makes a zero-file manifest
+        // permanently uncleanable: complete never becomes true, so the JSON
+        // and the directory tree are retained for ever.
+        $this->assertTrue(
+            $receipt['complete'],
+            'a manifest that loaded and held nothing to restore is a complete restore'
+        );
+
+        $this->assertFileDoesNotExist($manifestFile, 'the manifest JSON is cleaned up');
+        $this->assertDirectoryDoesNotExist($manifestDir, 'and the media directory with it');
     }
 
     // =========================================================================


### PR DESCRIPTION
Restoring a quarantined attachment moves each file back to the path it came from. Isolation MOVES the originals, so the quarantined copy is the only copy that exists -- and so is anything that has since come to occupy the original path. `restoreManifest()` checked only that the quarantined source was present; the destination was never stat(2)ed, and `rename(2)` replaces an existing destination silently.

## Both halves, because neither works alone

- **Destination guard.** A file or symlink already at the original path means the move is declined, the occupant is left alone, and the quarantined counterpart is kept. `file_exists()` is paired with `is_link()` so a broken symlink is not read as an empty slot, matching `FilesRestorer::revertSingleItem()`.
- **Cleanup gate.** `removeManifestDir()` deletes everything still under `media/<id>/` plus the manifest, and it ran whenever a single file had moved. Declining a move *without* changing that gate would have converted a declined move into a deleted file. Cleanup is now gated on a derived `complete`: every recorded file accounted for **and** a physical scan finding nothing left under `media/<id>/files`. Two independent conditions -- the counters cannot see a file left behind by a fragment-derivation branch, and the scan cannot say why one is there.

## Also here

- `restoreManifest()` returns an instrumented receipt instead of a bare count, the shape `deleteManifest()` already returned. Previously silent skips carry `RESTORE_SKIP_*` reason codes. `blocked` lists uploads-relative fragments only.
- `handleRestore()` aggregates receipts, keeps `restored` unchanged in name and meaning, adds `skipped`/`failed`/`detail`, and gains the `error_log` line isolate and delete already had. `ok` stays `true` on an incomplete restore: the control plane turns `ok:false` into an error and returns before recording the outcome, which would leave a real mutation unaudited.
- `uploadsBase()` no longer degrades to `""`. Containment here is a prefix test against it, and an empty base makes that prefix `/` -- containment disabled, not weakened, which would leave the new destination check guarding nothing. It throws; all three call sites decline to move anything.

## Proof

Two new regression tests in `MediaQuarantineTest.php`. The second exists to catch a half-fix: with only the destination guard added, it still fails.

Red-to-green output is in the agent report. Control plane, OpenAPI and dashboard untouched.
