### PR TITLE
docs: a safety label's comment states the contract, not a live defect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,15 +183,20 @@ the mechanism is cited only once the fix is merged **and** released to the
 fleet.
 
 This bites hardest on label and classification work, where naming the mechanism
-feels like rigour. On 2026-09-11 a `repeatability()` docblock was written to
-name the two exact lines of an unpatched data-loss path, the missing guard and
-the sequence that triggers it, explicitly so the next reader could check the
-claim without re-deriving it. It merged. About an hour later the same session
-correctly refused to open a *public issue* on that defect, for the reason that
-already applied to the commit it had just merged. The worklog rule below covers
-worklogs, issues and PR bodies; nobody had made a code comment into a
-disclosure before, and the reason applies identically. A commit cannot be
-recalled, and rewriting history to remove one orphans every release tag.
+feels like rigour. It has happened here: a docblock was written to justify a
+label by describing how the unsafe thing worked, so the next reader could check
+the claim without re-deriving it, and it merged while the fix did not yet exist.
+About an hour later the same session correctly refused to open a *public issue*
+on that defect, for the reason that already applied to the commit it had just
+merged. The worklog rule below covers worklogs, issues and PR bodies; nobody had
+made a code comment into a disclosure before, and the reason applies
+identically. A commit cannot be recalled, and rewriting history to remove one
+orphans every release tag.
+
+Note what this paragraph does not say. Naming the method, the file or the lines
+would point a reader at the mechanism, which is the thing the rule exists to
+keep private — an example is subject to its own rule, and the first draft of
+this one was not.
 
 The publishable form states the consequence and no more: "Unsafe on retry: a
 retry can overwrite a file that now occupies an original path." True, useful to
@@ -374,8 +379,11 @@ reconstruct the tracks by reading the code.**
 It exists because the work is easy to lose across a compaction and was, on
 2026-09-11, easy to lose behind defects found while doing something else. The
 distinction that file turns on is worth repeating here: a **blocker** stops the
-feature and is worked first; a **defect found along the way** does not, and runs
-in parallel or waits. Before sequencing anything ahead of a track in that file,
+feature and is worked first; an **incidental defect found along the way** does
+not, and runs in parallel or waits. Incidental is the load-bearing word — a
+blocker can perfectly well be found while doing something else, and "I found it
+along the way" is not a reason to defer something that leaves the feature
+inoperable. Before sequencing anything ahead of a track in that file,
 ask whether the feature literally does not work until the new thing lands. If it
 does work, it was not a blocker, and putting it first is a choice being made on
 the owner's behalf.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,28 @@ minify-and-rewrite technique", never "as used by X".
 implementation". They imply the question arose, which reads worse than saying
 nothing.
 
+**A comment that justifies a safety label describes the shipped contract, never
+a live defect's mechanism.** If the honest reason for a classification is a bug
+that is still unpatched, write the label and what it means for a caller, and
+stop. The file, the line and the trigger sequence go to `~/.wpmgr/worklog/`, and
+the mechanism is cited only once the fix is merged **and** released to the
+fleet.
+
+This bites hardest on label and classification work, where naming the mechanism
+feels like rigour. On 2026-09-11 a `repeatability()` docblock was written to
+name the two exact lines of an unpatched data-loss path, the missing guard and
+the sequence that triggers it, explicitly so the next reader could check the
+claim without re-deriving it. It merged. About an hour later the same session
+correctly refused to open a *public issue* on that defect, for the reason that
+already applied to the commit it had just merged. The worklog rule below covers
+worklogs, issues and PR bodies; nobody had made a code comment into a
+disclosure before, and the reason applies identically. A commit cannot be
+recalled, and rewriting history to remove one orphans every release tag.
+
+The publishable form states the consequence and no more: "Unsafe on retry: a
+retry can overwrite a file that now occupies an original path." True, useful to
+a caller, not a recipe.
+
 **Never name a local reference directory in a tracked ignore file**, not
 `.gitignore`, not `.gcloudignore`, not `.dockerignore`. Those files are
 committed, so the line publishes the reference. References are used and then
@@ -339,3 +361,21 @@ status list here is exactly the kind of fact this file already bans
 hard-coding, because it goes stale within days. On 2026-09-01 the session
 rebuilt the wizard roadmap from the code after every compaction instead,
 got it wrong each time, and the owner had to correct it repeatedly.
+
+## The write surface
+
+The plan for giving the AI the ability to change a site — the two independent
+tracks, what is done, what is decided and must not be relitigated, and the
+build order — lives in `~/.wpmgr/worklog/WRITE-SURFACE-TRACKS.md`. That path is
+outside this repository and stays there, same as every other worklog; this file
+only names it. **Read it before deciding what to work on next, and never
+reconstruct the tracks by reading the code.**
+
+It exists because the work is easy to lose across a compaction and was, on
+2026-09-11, easy to lose behind defects found while doing something else. The
+distinction that file turns on is worth repeating here: a **blocker** stops the
+feature and is worked first; a **defect found along the way** does not, and runs
+in parallel or waits. Before sequencing anything ahead of a track in that file,
+ask whether the feature literally does not work until the new thing lands. If it
+does work, it was not a blocker, and putting it first is a choice being made on
+the owner's behalf.


### PR DESCRIPTION
Two additions to the working agreements, both from things that went wrong today.

**A comment that justifies a safety label describes the shipped contract, never a live defect's mechanism.** If the honest reason for a classification is a bug that is still unpatched, write the label and what it means for a caller, and stop. The file, the line and the trigger go to the worklog; the mechanism is cited only once the fix is merged and released to the fleet.

The existing worklog rule covers worklogs, issues and PR bodies. Nobody had made a code comment into a disclosure before, so nothing said "and also code comments" — and the reason, that this repository is public and a commit cannot be recalled, applies identically. This bites hardest on label and classification work, where naming the mechanism feels like rigour.

**A pointer to the write surface plan**, which lives in the worklog beside the wizard spec. This file only names the path, same as the wizard section. It also restates the distinction that plan turns on, because that is the part that goes first under pressure: a blocker stops the feature and is worked first; a defect found along the way does not, and runs in parallel or waits.

No behaviour change. Root markdown, no competitor names, and the em/en dash gate covers marketing and the agent's public copy rather than this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for documenting safety labels using general incident context without exposing implementation-specific details.
  * Clarified write-surface planning guidance, including how incidental defects relate to blockers and feature operability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->