### PR TITLE
feat(mcp): read a grant's OAuth scopes instead of a constant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,33 @@ minify-and-rewrite technique", never "as used by X".
 implementation". They imply the question arose, which reads worse than saying
 nothing.
 
+**A comment that justifies a safety label describes the shipped contract, never
+a live defect's mechanism.** If the honest reason for a classification is a bug
+that is still unpatched, write the label and what it means for a caller, and
+stop. The file, the line and the trigger sequence go to `~/.wpmgr/worklog/`, and
+the mechanism is cited only once the fix is merged **and** released to the
+fleet.
+
+This bites hardest on label and classification work, where naming the mechanism
+feels like rigour. It has happened here: a docblock was written to justify a
+label by describing how the unsafe thing worked, so the next reader could check
+the claim without re-deriving it, and it merged while the fix did not yet exist.
+About an hour later the same session correctly refused to open a *public issue*
+on that defect, for the reason that already applied to the commit it had just
+merged. The worklog rule below covers worklogs, issues and PR bodies; nobody had
+made a code comment into a disclosure before, and the reason applies
+identically. A commit cannot be recalled, and rewriting history to remove one
+orphans every release tag.
+
+Note what this paragraph does not say. Naming the method, the file or the lines
+would point a reader at the mechanism, which is the thing the rule exists to
+keep private — an example is subject to its own rule, and the first draft of
+this one was not.
+
+The publishable form states the consequence and no more: "Unsafe on retry: a
+retry can overwrite a file that now occupies an original path." True, useful to
+a caller, not a recipe.
+
 **Never name a local reference directory in a tracked ignore file**, not
 `.gitignore`, not `.gcloudignore`, not `.dockerignore`. Those files are
 committed, so the line publishes the reference. References are used and then
@@ -339,3 +366,24 @@ status list here is exactly the kind of fact this file already bans
 hard-coding, because it goes stale within days. On 2026-09-01 the session
 rebuilt the wizard roadmap from the code after every compaction instead,
 got it wrong each time, and the owner had to correct it repeatedly.
+
+## The write surface
+
+The plan for giving the AI the ability to change a site — the two independent
+tracks, what is done, what is decided and must not be relitigated, and the
+build order — lives in `~/.wpmgr/worklog/WRITE-SURFACE-TRACKS.md`. That path is
+outside this repository and stays there, same as every other worklog; this file
+only names it. **Read it before deciding what to work on next, and never
+reconstruct the tracks by reading the code.**
+
+It exists because the work is easy to lose across a compaction and was, on
+2026-09-11, easy to lose behind defects found while doing something else. The
+distinction that file turns on is worth repeating here: a **blocker** stops the
+feature and is worked first; an **incidental defect found along the way** does
+not, and runs in parallel or waits. Incidental is the load-bearing word — a
+blocker can perfectly well be found while doing something else, and "I found it
+along the way" is not a reason to defer something that leaves the feature
+inoperable. Before sequencing anything ahead of a track in that file,
+ask whether the feature literally does not work until the new thing lands. If it
+does work, it was not a blocker, and putting it first is a choice being made on
+the owner's behalf.

--- a/apps/agent/includes/commands/class-media-clean-command.php
+++ b/apps/agent/includes/commands/class-media-clean-command.php
@@ -93,7 +93,14 @@
  *     }
  *
  *   restore ->
- *     { "ok": true, "job_id": "<uuid>", "restored": <int> }
+ *     {
+ *       "ok": true,                          // true even when incomplete; the counts carry that
+ *       "job_id": "<uuid>",
+ *       "restored": <int>,                   // files moved back to their original path
+ *       "skipped": <int>,                    // files deliberately left in quarantine
+ *       "failed": <int>,                     // files whose move was attempted and did not happen
+ *       "detail": "<string>"                 // present only when skipped+failed > 0
+ *     }
  *
  *   delete ->
  *     {
@@ -185,6 +192,8 @@ final class MediaCleanCommand implements CommandInterface
     private const OP_MAX      = 200;
     /** Confirm token required for permanent deletion. */
     private const DELETE_CONFIRM = 'DELETE';
+    /** Uploads-relative paths named in a restore `detail` before it summarises the rest. */
+    private const RESTORE_DETAIL_PATHS = 5;
 
     /**
      * Optional quarantine instance injected for tests; null = create on demand
@@ -229,13 +238,12 @@ final class MediaCleanCommand implements CommandInterface
      * earlier docblock's claim that a delete retry "removes whatever now matches" was wrong about the
      * code -- handleDelete() never re-scans.
      *
-     * But action=restore is unsafe to retry. MediaQuarantine::restoreManifest() guards only the source:
-     * it skips a file only when file_exists($src) is false (class-media-quarantine.php:380), and moves
-     * it onto $normalised with a bare @rename() that overwrites unchecked -- the destination is never
-     * tested. Cleanup only runs when if ($restored > 0) (class-media-quarantine.php:397), so a restore
-     * attempt that restores zero files leaves the manifest live for a retry. A retry after that point can
-     * rename a quarantined file over a file created at the original path since the first attempt,
-     * destroying it. The manifest pins the source; nothing pins the destination.
+     * action=restore is likewise pinned by its quarantine_ids and re-derives nothing, and
+     * MediaQuarantine::restoreManifest() now guards both ends of every move: a file already
+     * occupying the original path is left alone and its quarantined counterpart is kept, so no
+     * retry can consume either. It stays classified Unsafe because a retry is still not a no-op --
+     * an incomplete restore deliberately keeps its manifest live, and a second call does more work
+     * against a tree the first one changed. Unsafe here means "not idempotent", not "destructive".
      *
      * @return CommandRepeatability
      */
@@ -631,20 +639,83 @@ final class MediaCleanCommand implements CommandInterface
 
         $quarantine = $this->quarantine ?? new MediaQuarantine();
         $restored   = 0;
+        $skipped    = 0;
+        $failed     = 0;
+        $blocked    = [];
 
         try {
             foreach ($manifestIds as $mId) {
-                $restored += $quarantine->restoreManifest($mId);
+                $receipt   = $quarantine->restoreManifest($mId);
+                $restored += (int)($receipt['restored'] ?? 0);
+                $skipped  += (int)($receipt['skipped'] ?? 0);
+                $failed   += (int)($receipt['failed'] ?? 0);
+                foreach ((array)($receipt['blocked'] ?? []) as $frag) {
+                    $blocked[] = (string)$frag;
+                }
             }
         } catch (\Throwable $e) {
             return ['ok' => false, 'detail' => 'media quarantine unavailable: ' . $e->getMessage()];
         }
 
-        return [
+        // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        error_log(sprintf(
+            '[wpmgr] media-clean restore: job_id=%s manifests=%d restored=%d skipped=%d failed=%d',
+            $jobId,
+            count($manifestIds),
+            $restored,
+            $skipped,
+            $failed
+        ));
+        // phpcs:enable
+
+        $result = [
+            // ok stays true for an incomplete restore: files really were moved
+            // back, and the control plane treats ok:false as an error and
+            // returns before recording the outcome, which would leave a real
+            // mutation unaudited. The counts below carry the incompleteness.
             'ok'       => true,
             'job_id'   => $jobId,
             'restored' => $restored,
+            'skipped'  => $skipped,
+            'failed'   => $failed,
         ];
+
+        if ($skipped > 0 || $failed > 0) {
+            $result['detail'] = $this->restoreDetail($skipped, $failed, $blocked);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Human-readable summary of a restore that did not put everything back.
+     *
+     * Names only the first few uploads-relative paths plus a total, so the
+     * operator gets something actionable without the payload growing with the
+     * manifest and without absolute server paths appearing on the wire.
+     *
+     * @param list<string> $blocked Uploads-relative fragments left in quarantine.
+     */
+    private function restoreDetail(int $skipped, int $failed, array $blocked): string
+    {
+        $outstanding = $skipped + $failed;
+        $detail      = sprintf(
+            '%d file(s) were not restored and remain in quarantine (skipped=%d failed=%d)',
+            $outstanding,
+            $skipped,
+            $failed
+        );
+
+        $names = array_slice($blocked, 0, self::RESTORE_DETAIL_PATHS);
+        if (!empty($names)) {
+            $detail .= ': ' . implode(', ', $names);
+            $more    = count($blocked) - count($names);
+            if ($more > 0) {
+                $detail .= sprintf(' (+%d more)', $more);
+            }
+        }
+
+        return $detail;
     }
 
     // =========================================================================

--- a/apps/agent/includes/media/class-media-quarantine.php
+++ b/apps/agent/includes/media/class-media-quarantine.php
@@ -98,6 +98,23 @@ final class MediaQuarantine
     /** Manifest schema version. */
     private const MANIFEST_VERSION = 1;
 
+    /**
+     * Machine-readable reasons restoreManifest() did not move a recorded file
+     * back to its original path. Each appears as a key on the receipt's
+     * `reasons` map with the number of files it accounts for.
+     *
+     * DESTINATION_OCCUPIED is the load-bearing one: something already sits at
+     * the original path, and rename(2) would replace it without a word.
+     * quarantineAttachment() MOVES the originals, so both the occupant and the
+     * quarantined copy are the only copies of themselves; the move is refused
+     * and both are kept for the operator to resolve.
+     */
+    public const RESTORE_SKIP_DESTINATION_OCCUPIED = 'destination_occupied';
+    public const RESTORE_SKIP_OUTSIDE_UPLOADS      = 'outside_uploads';
+    public const RESTORE_SKIP_UPLOADS_UNRESOLVED   = 'uploads_unresolved';
+    public const RESTORE_SKIP_SOURCE_MISSING       = 'source_missing';
+    public const RESTORE_SKIP_RENAME_FAILED        = 'rename_failed';
+
     /** Absolute path to the quarantine root (uploads/wpmgr-quarantine; legacy: wp-content/wpmgr-quarantine). */
     private string $quarantineRoot;
 
@@ -240,9 +257,20 @@ final class MediaQuarantine
         }
 
         $filesRoot   = $this->mediaRoot . '/' . $manifestId . '/files';
-        $uploadsBase = $this->uploadsBase();
         $movedPaths  = [];
         $moved       = 0;
+
+        // Without a resolvable uploads base nothing can be shown to be inside
+        // uploads, so nothing is moved. The manifest entry is still recorded
+        // below with an empty files[] — that is the same shape an attachment
+        // with no on-disk files produces, and it keeps the post deletable.
+        try {
+            $uploadsBase = $this->uploadsBase();
+        } catch (\RuntimeException $e) {
+            unset($e);
+            $absPaths = [];
+            $uploadsBase = '';
+        }
 
         foreach ($absPaths as $src) {
             // Containment: only move files that are inside the uploads dir.
@@ -321,24 +349,75 @@ final class MediaQuarantine
     /**
      * Move all files in a manifest back to their original paths.
      *
+     * Returns an instrumented receipt rather than a bare count, so a caller can
+     * tell a complete restore from a partial one and so the cleanup decision
+     * below rests on evidence instead of on "at least one file moved":
+     *
+     *   [
+     *     'restored'   => int,  // files moved back to their original path
+     *     'skipped'    => int,  // files deliberately left in quarantine
+     *     'failed'     => int,  // files whose move was attempted and did not happen
+     *     'files_seen' => int,  // file records read from the manifest
+     *     'complete'   => bool, // DERIVED, never passed in — see below
+     *     'reasons'    => array<string,int>,  // RESTORE_SKIP_* => count
+     *     'blocked'    => list<string>,       // uploads-relative fragments not restored
+     *   ]
+     *
+     * A file already occupying the original path is never overwritten, and the
+     * quarantined copy it displaced is never deleted. Both are the only copies
+     * of themselves — quarantineAttachment() MOVES the originals — so the move
+     * is refused, both survive, and the manifest stays live for the operator.
+     *
+     * `complete` is derived from three independent conditions, all required:
+     * the manifest loaded at all, AND every recorded file is accounted for
+     * (nothing skipped, nothing failed), AND no regular file remains anywhere
+     * under media/<manifest_id>. The counters cannot see a file left behind by
+     * a fragment-derivation branch, and the physical scan cannot say why one
+     * is there; only together do they license removing the quarantine copy.
+     *
+     * `complete` is internal to this class today: it gates the cleanup below
+     * and no caller reads it. It is documented because it is returned, not
+     * because anything outside consumes it.
+     *
+     * `blocked` carries uploads-relative fragments only. Absolute server paths
+     * are treated as disclosure here for the same reason finaliseManifest()
+     * keeps the manifest JSON outside the web-served media/ tree.
+     *
      * @param string $manifestId
-     * @return int Number of files successfully restored.
+     * @return array{restored:int,skipped:int,failed:int,files_seen:int,complete:bool,reasons:array<string,int>,blocked:list<string>}
      */
-    public function restoreManifest(string $manifestId): int
+    public function restoreManifest(string $manifestId): array
     {
+        $restored  = 0;
+        $skipped   = 0;
+        $failed    = 0;
+        $filesSeen = 0;
+        $reasons   = [];
+        $blocked   = [];
+
         $manifest = $this->loadManifest($manifestId);
         if ($manifest === null) {
-            return 0;
+            return $this->restoreReceipt($manifestId, false, 0, 0, 0, 0, [], []);
         }
 
-        $filesRoot   = $this->mediaRoot . '/' . $manifestId . '/files';
-        $uploadsBase = $this->uploadsBase();
-        $restored    = 0;
+        $filesRoot = $this->mediaRoot . '/' . $manifestId . '/files';
+
+        // An unresolvable uploads base is not a reason to relax containment;
+        // it is a reason to move nothing. Every recorded file is reported as
+        // skipped so the caller can say why, and nothing is cleaned up.
+        $uploadsBase = null;
+        try {
+            $uploadsBase = $this->uploadsBase();
+        } catch (\RuntimeException $e) {
+            unset($e);
+        }
 
         foreach ($manifest['entries'] as $entry) {
             $files = is_array($entry['files']) ? $entry['files'] : [];
 
             foreach ($files as $fileRecord) {
+                $filesSeen++;
+
                 // Support both the current {"orig","frag"} object format and the
                 // legacy plain-string format written by agent versions < 0.25.9.
                 if (is_array($fileRecord)) {
@@ -349,9 +428,17 @@ final class MediaQuarantine
                     $fragment        = '';
                 }
 
+                if ($uploadsBase === null) {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_UPLOADS_UNRESOLVED, $fragment);
+                    continue;
+                }
+
                 // Containment: restore target must be inside uploads.
                 $normalised = $this->normalisePath($originalAbsPath, $uploadsBase);
                 if ($normalised === '') {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_OUTSIDE_UPLOADS, $fragment);
                     continue;
                 }
 
@@ -364,6 +451,8 @@ final class MediaQuarantine
                 if ($fragment === '') {
                     $uploadsReal = realpath($uploadsBase);
                     if ($uploadsReal === false) {
+                        $skipped++;
+                        $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_UPLOADS_UNRESOLVED, '');
                         continue;
                     }
                     $uploadsBaseNorm = rtrim(str_replace('\\', '/', $uploadsBase), '/');
@@ -378,6 +467,36 @@ final class MediaQuarantine
                 $src = $filesRoot . '/' . $fragment;
 
                 if (!file_exists($src)) {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_SOURCE_MISSING, $fragment);
+                    continue;
+                }
+
+                // Destination guard. POSIX rename(2) unlinks an existing
+                // destination silently and the '@' would eat any warning, so
+                // the destination is stat'd first — the check the source side
+                // has always had. is_link() is paired with file_exists()
+                // because a broken symlink is not an empty slot; the pair is
+                // the one FilesRestorer::revertSingleItem() uses.
+                //
+                // The stat and the rename below are not one atomic operation,
+                // and PHP offers no rename-if-absent, so a residual window
+                // stays open between them. Something can create the
+                // destination inside it and the rename will still clobber it:
+                // in-process, DiskWriter::write() (class-disk-writer.php:74)
+                // renames onto live uploads paths, driven by the
+                // wp_generate_attachment_metadata filter registered at
+                // class-plugin.php:806.
+                //
+                // Narrowing is the whole available fix, and it is strictly
+                // better than what it replaces: before this guard existed
+                // every restore clobbered its destination unconditionally, so
+                // the losing window was the entire operation rather than the
+                // gap between two adjacent syscalls. Nothing worse than the
+                // pre-guard behaviour can happen inside what is left.
+                if (file_exists($normalised) || is_link($normalised)) {
+                    $skipped++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_DESTINATION_OCCUPIED, $fragment);
                     continue;
                 }
 
@@ -389,16 +508,204 @@ final class MediaQuarantine
 
                 if (@rename($src, $normalised)) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename,WordPress.WP.AlternativeFunctions.file_system_operations_rename,PluginCheck.CodeAnalysis.WriteFile.ABSPATHDetected -- restore/quarantine engine intentionally writes under ABSPATH (the live WP tree); relocating would defeat the restore
                     $restored++;
+                } else {
+                    // A move that did not happen must never read as one that
+                    // was never attempted: the quarantined copy is still the
+                    // only copy and cleanup must not run behind it.
+                    $failed++;
+                    $this->noteRestoreSkip($reasons, $blocked, self::RESTORE_SKIP_RENAME_FAILED, $fragment);
                 }
             }
         }
 
-        // Remove the (now-empty) manifest directory if everything was restored.
-        if ($restored > 0) {
+        $receipt = $this->restoreReceipt(
+            $manifestId,
+            true,
+            $restored,
+            $skipped,
+            $failed,
+            $filesSeen,
+            $reasons,
+            $blocked
+        );
+
+        // Remove the manifest directory only when the restore is provably
+        // complete. removeManifestDir() deletes every file still under
+        // media/<manifest_id>/ and the manifest JSON with it, and those files
+        // exist nowhere else, so anything short of complete keeps them.
+        if ($receipt['complete']) {
             $this->removeManifestDir($manifestId);
         }
 
-        return $restored;
+        return $receipt;
+    }
+
+    /**
+     * Record one non-restored file against its reason code.
+     *
+     * @param array<string,int> $reasons  Reason-code tally, by reference.
+     * @param list<string>      $blocked  Uploads-relative fragments, by reference.
+     * @param string            $reason   One of the RESTORE_SKIP_* constants.
+     * @param string            $fragment Uploads-relative fragment, or '' when unknown.
+     */
+    private function noteRestoreSkip(array &$reasons, array &$blocked, string $reason, string $fragment): void
+    {
+        $reasons[$reason] = ($reasons[$reason] ?? 0) + 1;
+
+        // Only uploads-relative fragments are reported; an absolute server path
+        // would be disclosure, and an unknown fragment is reported as a count
+        // under its reason code rather than as a bare path.
+        if ($fragment !== '') {
+            $blocked[] = $fragment;
+        }
+    }
+
+    /**
+     * Assemble a restore receipt, deriving `complete` rather than accepting it.
+     *
+     * $manifestLoaded is a private discriminator, never a receipt field: it
+     * says only that loadManifest() returned a manifest, which is the fact
+     * `complete` needs and which the counters cannot express.
+     *
+     * @param bool              $manifestLoaded Whether loadManifest() returned a manifest.
+     * @param array<string,int> $reasons
+     * @param list<string>      $blocked
+     * @return array{restored:int,skipped:int,failed:int,files_seen:int,complete:bool,reasons:array<string,int>,blocked:list<string>}
+     */
+    private function restoreReceipt(
+        string $manifestId,
+        bool $manifestLoaded,
+        int $restored,
+        int $skipped,
+        int $failed,
+        int $filesSeen,
+        array $reasons,
+        array $blocked
+    ): array {
+        $accountedFor = ($skipped === 0 && $failed === 0);
+
+        // The discriminator is whether a manifest loaded, not whether it
+        // described any file. An unknown or unreadable id reaches here with
+        // $manifestLoaded false and must never derive "everything was put
+        // back" from "the id means nothing to me". A manifest that loaded and
+        // legitimately recorded an attachment with no on-disk files is the
+        // opposite case: it is complete the moment it is read, and gating on
+        // the counters instead would leave it permanently uncleanable.
+
+        return [
+            'restored'   => $restored,
+            'skipped'    => $skipped,
+            'failed'     => $failed,
+            'files_seen' => $filesSeen,
+            'complete'   => $manifestLoaded && $accountedFor && !$this->hasRemainingFiles($manifestId),
+            'reasons'    => $reasons,
+            'blocked'    => array_values($blocked),
+        ];
+    }
+
+    /**
+     * Whether anything remains anywhere under media/<manifest_id>.
+     *
+     * The second, independent half of the `complete` derivation. The restore
+     * counters only see files the manifest described; a file left behind by a
+     * fragment-derivation branch produces no countable record, so the tree
+     * itself is scanned before its deletion is licensed.
+     *
+     * The scan root is media/<manifest_id>, not media/<manifest_id>/files,
+     * because removeManifestDir() deletes media/<manifest_id> whole. The scan
+     * must cover everything the cleanup destroys or the gate is only accurate
+     * for today's directory layout; an earlier layout kept other things beside
+     * files/, and a stray at media/<manifest_id>/x was deleted unseen.
+     *
+     * Fails closed: an entry that cannot be positively classified counts as
+     * remaining, because the caller's only use for a false is to delete.
+     */
+    private function hasRemainingFiles(string $manifestId): bool
+    {
+        if (!preg_match('/^[a-zA-Z0-9_-]{1,64}$/', $manifestId)) {
+            return true;
+        }
+
+        return $this->dirHoldsFile($this->mediaRoot . '/' . $manifestId);
+    }
+
+    /**
+     * Recursive half of hasRemainingFiles(). A symlink counts as a file: it is
+     * something the tree still holds, whatever it points at.
+     *
+     * Classification is positive-only. An entry scandir() listed but that is
+     * neither link, file nor directory counts as remaining: that covers FIFOs,
+     * sockets and device nodes, and it covers the case that motivated this
+     * rule — a directory carrying the read bit without the search bit, where
+     * scandir() succeeds, every stat on its entries fails, and each entry
+     * would otherwise be silently dropped from a tree about to be deleted.
+     */
+    private function dirHoldsFile(string $dir): bool
+    {
+        if (is_link($dir) || is_file($dir)) {
+            // The scan root is not a directory but is something. It is held.
+            return true;
+        }
+
+        if (!is_dir($dir)) {
+            return $this->pathPresentButUnclassified($dir);
+        }
+
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            // Unreadable: cannot prove the tree is empty, so do not say it is.
+            return true;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            if (is_link($path) || is_file($path)) {
+                return true;
+            }
+            if (is_dir($path)) {
+                if ($this->dirHoldsFile($path)) {
+                    return true;
+                }
+                continue;
+            }
+
+            // Listed, so something is there, but nothing could classify it.
+            // Unclassified is not empty.
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether a path that no stat could classify is nevertheless present.
+     *
+     * A path whose own stat fails looks identical to one that was never
+     * created — file_exists() is false for both — so the parent directory is
+     * asked instead, which can tell them apart by listing the name. Absent is
+     * the licit answer: a manifest that quarantined nothing never creates a
+     * media/<manifest_id> tree, and that must stay eligible for cleanup.
+     */
+    private function pathPresentButUnclassified(string $path): bool
+    {
+        $parent = dirname($path);
+        if ($parent === $path || !is_dir($parent)) {
+            // No parent left to ask, or the parent is absent too. Nothing was
+            // ever there to hold a file.
+            return false;
+        }
+
+        $entries = @scandir($parent);
+        if ($entries === false) {
+            // The parent exists but will not be listed: nothing below it can
+            // be proven empty.
+            return true;
+        }
+
+        return in_array(basename($path), $entries, true);
     }
 
     /**
@@ -437,7 +744,23 @@ final class MediaQuarantine
         }
 
         $filesRoot   = $this->mediaRoot . '/' . $manifestId . '/files';
-        $uploadsBase = $this->uploadsBase();
+
+        // No resolvable uploads base means containment cannot be enforced on a
+        // delete either. Report the zero-count result — the same one an unknown
+        // manifest_id produces — so the manifest and its files stay put and a
+        // later attempt can still run.
+        try {
+            $uploadsBase = $this->uploadsBase();
+        } catch (\RuntimeException $e) {
+            unset($e);
+            return [
+                'posts_deleted'     => 0,
+                'posts_failed'      => 0,
+                'files_deleted'     => 0,
+                'entries_processed' => 0,
+                'results'           => [],
+            ];
+        }
 
         $postsDeleted     = 0;
         $postsFailed      = 0;
@@ -919,11 +1242,29 @@ final class MediaQuarantine
 
     /**
      * Absolute filesystem path to the uploads root.
+     *
+     * Never returns an empty string. Every containment check in this class is
+     * a prefix test against this value, and normalisePath() compares against
+     * rtrim($base, '/') . '/', so an empty base becomes the prefix '/' and the
+     * test then passes for every absolute path on the server. Containment
+     * would not be weakened by that, it would be switched off. An uploads
+     * directory that cannot be resolved is therefore a hard failure here
+     * rather than a silently permissive value at the call site.
+     *
+     * @throws \RuntimeException When wp_upload_dir() reports no usable basedir.
      */
     private function uploadsBase(): string
     {
-        $dir = wp_upload_dir();
-        return rtrim((string)($dir['basedir'] ?? ''), '/\\');
+        $dir  = wp_upload_dir();
+        $base = is_array($dir) ? rtrim((string)($dir['basedir'] ?? ''), '/\\') : '';
+
+        if ($base === '') {
+            $message = 'WPMgr MediaQuarantine: wp_upload_dir() reported no usable basedir; '
+                . 'refusing to run an uploads-containment check against an empty base path.';
+            throw new \RuntimeException($message); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- fixed self-composed literal, caught in-class and never echoed; carries no caller or request input
+        }
+
+        return $base;
     }
 
     /**

--- a/apps/agent/tests/MediaCleanOptimizerPathsTest.php
+++ b/apps/agent/tests/MediaCleanOptimizerPathsTest.php
@@ -848,8 +848,8 @@ final class MediaCleanOptimizerPathsTest extends TestCase
         $this->assertSame($relPath,    $fileRecord['frag'], 'frag stores the uploads-relative fragment');
 
         // Restore must work correctly via the recorded frag.
-        $restored = $q->restoreManifest($manifestId);
-        $this->assertSame(1, $restored, 'file restored via symlinked uploads base');
+        $receipt = $q->restoreManifest($manifestId);
+        $this->assertSame(1, $receipt['restored'], 'file restored via symlinked uploads base');
         $this->assertFileExists($symlinkAbs, 'file restored to original path');
         $this->assertSame('symbase-content', file_get_contents($symlinkAbs), 'content intact');
 

--- a/apps/agent/tests/MediaQuarantineTest.php
+++ b/apps/agent/tests/MediaQuarantineTest.php
@@ -15,6 +15,14 @@
  *   - finaliseManifest() — media/ subtree contains only image files (no JSON).
  *   - restoreManifest() returns 0 for an unknown manifest_id.
  *   - restoreManifest() moves files back and removes the manifest dir.
+ *   - restoreManifest() never moves a quarantined file onto an original path that
+ *     something else now occupies, and reports the skip with a reason code.
+ *   - restoreManifest() does not delete a quarantined file it refused to restore —
+ *     cleanup runs only on a complete restore, so a partial one keeps every copy.
+ *   - restoreManifest() withholds `complete` while the quarantine tree still holds
+ *     anything the counters cannot see: an unrecorded file, an entry no stat can
+ *     classify, or a stray beside files/ that cleanup would delete unseen.
+ *   - restoreManifest() never reports `complete` for a manifest id that named nothing.
  *   - restoreManifest() handles entries with empty files[] cleanly (0 files back, no error).
  *   - deleteManifest() returns a zero-count result for an unknown manifest_id.
  *   - deleteManifest() removes quarantined files, calls wp_delete_attachment,
@@ -304,7 +312,9 @@ final class MediaQuarantineTest extends TestCase
         // Ensure the quarantine root exists (needed for realpath in loadManifest).
         $q->beginManifest('warmup');
 
-        $this->assertSame(0, $q->restoreManifest('00000000000000000000000000000000'));
+        $receipt = $q->restoreManifest('00000000000000000000000000000000');
+
+        $this->assertSame(0, $receipt['restored']);
     }
 
     // =========================================================================
@@ -324,9 +334,10 @@ final class MediaQuarantineTest extends TestCase
         // Confirm file is gone from uploads.
         $this->assertFileDoesNotExist($srcAbs);
 
-        $restored = $q->restoreManifest($manifestId);
+        $receipt = $q->restoreManifest($manifestId);
 
-        $this->assertSame(1, $restored);
+        $this->assertSame(1, $receipt['restored']);
+        $this->assertTrue($receipt['complete'], 'a restore that put everything back is complete');
 
         // File is back in uploads.
         $this->assertFileExists($srcAbs);
@@ -335,6 +346,254 @@ final class MediaQuarantineTest extends TestCase
         // Manifest dir is removed after successful restore.
         $manifestDir = $this->mediaRoot() . '/' . $manifestId;
         $this->assertDirectoryDoesNotExist($manifestDir);
+    }
+
+    // =========================================================================
+    // restoreManifest() — never moves a quarantined file over a file that
+    // occupies the original path
+    // =========================================================================
+
+    public function testRestoreManifestDoesNotOverwriteANewerFileAtTheOriginalPath(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'quarantined-bytes');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-restore-occupied');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // The original path is empty: quarantineAttachment() MOVES the bytes,
+        // so the quarantined copy is the only copy that exists.
+        $this->assertFileDoesNotExist($srcAbs);
+
+        // A different file comes to occupy that exact path while the
+        // attachment is isolated.
+        $this->createUploadFile($relPath, 'newer-bytes-written-after-isolation');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        // Load-bearing: the occupant is the only copy of its own bytes.
+        $this->assertSame(
+            'newer-bytes-written-after-isolation',
+            file_get_contents($srcAbs),
+            'restore must not move a quarantined file onto an occupied original path'
+        );
+
+        // The refused file is likewise the only copy of itself, so it must
+        // survive the refusal rather than be cleaned up behind it.
+        $quarantinedCopy = $this->mediaRoot() . '/' . $manifestId . '/files/' . $relPath;
+        $this->assertFileExists($quarantinedCopy, 'the refused file stays in quarantine');
+        $this->assertSame('quarantined-bytes', file_get_contents($quarantinedCopy));
+
+        $this->assertFileExists(
+            $this->manifestsRoot() . '/' . $manifestId . '.json',
+            'the manifest survives an incomplete restore so the operator can retry'
+        );
+
+        $this->assertSame(0, $receipt['restored'], 'nothing was restored');
+        $this->assertSame(1, $receipt['skipped'], 'the contested file counts as skipped');
+        $this->assertSame(
+            1,
+            $receipt['reasons'][MediaQuarantine::RESTORE_SKIP_DESTINATION_OCCUPIED] ?? 0,
+            'the skip is attributed to the occupied destination'
+        );
+        $this->assertFalse($receipt['complete'], 'an incomplete restore never reports complete');
+    }
+
+    // =========================================================================
+    // restoreManifest() — a file it refused to restore is never then deleted
+    // by the cleanup gate
+    // =========================================================================
+
+    public function testRestoreManifestDoesNotDeleteAQuarantinedFileItRefusedToRestore(): void
+    {
+        $mainRel  = '2024/01/gallery.jpg';
+        $thumbRel = '2024/01/gallery-150x150.jpg';
+
+        $mainAbs  = $this->createUploadFile($mainRel,  'main-bytes');
+        $thumbAbs = $this->createUploadFile($thumbRel, 'thumb-bytes');
+
+        // One entry, two files — the shape isolate produces for an attachment
+        // with sub-sizes.
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-restore-partial');
+        $q->quarantineAttachment($manifestId, 42, $mainRel, [$mainAbs, $thumbAbs]);
+        $q->finaliseManifest($manifestId);
+
+        $this->assertFileDoesNotExist($mainAbs);
+        $this->assertFileDoesNotExist($thumbAbs);
+
+        // Only the main file's original path is taken.
+        $this->createUploadFile($mainRel, 'newer-main-bytes');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(
+            'newer-main-bytes',
+            file_get_contents($mainAbs),
+            'the occupant survives'
+        );
+
+        // The guard must not block correct work: the uncontested file still
+        // goes back, with its original content.
+        $this->assertFileExists($thumbAbs, 'the uncontested file is still restored');
+        $this->assertSame('thumb-bytes', file_get_contents($thumbAbs), 'restored content intact');
+
+        // Load-bearing: cleanup must not delete the copy restore declined to
+        // move. A partial restore that then removes the manifest directory
+        // destroys the only remaining copy of the refused file.
+        $refusedCopy = $this->mediaRoot() . '/' . $manifestId . '/files/' . $mainRel;
+        $this->assertFileExists(
+            $refusedCopy,
+            'a quarantined file restore refused to move must not then be deleted'
+        );
+        $this->assertSame('main-bytes', file_get_contents($refusedCopy));
+
+        $this->assertFileExists(
+            $this->manifestsRoot() . '/' . $manifestId . '.json',
+            'the manifest survives so the refused file can still be recovered'
+        );
+
+        $this->assertSame(1, $receipt['restored'], 'the uncontested file counts as restored');
+        $this->assertSame(1, $receipt['skipped'], 'the contested file counts as skipped');
+        $this->assertFalse($receipt['complete'], 'a partial restore never reports complete');
+    }
+
+    // =========================================================================
+    // restoreManifest() — the physical scan, the half of `complete` the
+    // restore counters cannot see
+    //
+    // Every test below leaves something in the quarantine tree that no
+    // manifest entry describes, so the counters read clean and only the scan
+    // can withhold `complete`. Delete the hasRemainingFiles() term from
+    // restoreReceipt() and each of them fails.
+    // =========================================================================
+
+    public function testRestoreManifestIsNotCompleteWhileAnUnrecordedFileRemains(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'restore-me');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-unrecorded');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // A file under files/ that no manifest entry names. A fragment
+        // derivation that went down a different branch leaves exactly this:
+        // bytes in the tree with no countable record anywhere.
+        $orphan = $this->mediaRoot() . '/' . $manifestId . '/files/2024/01/orphan.jpg';
+        file_put_contents($orphan, 'orphan-bytes');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        // The counters are clean: every file the manifest described went back.
+        $this->assertSame(1, $receipt['restored'], 'the recorded file is restored');
+        $this->assertSame(0, $receipt['skipped'], 'nothing was skipped');
+        $this->assertSame(0, $receipt['failed'], 'nothing failed');
+        $this->assertFileExists($srcAbs, 'the guard does not block correct work');
+
+        // Load-bearing: only the physical scan knows the orphan is there.
+        $this->assertFalse(
+            $receipt['complete'],
+            'a tree that still holds an unrecorded file is not a complete restore'
+        );
+        $this->assertFileExists($orphan, 'the unrecorded file is not deleted behind the counters');
+        $this->assertSame('orphan-bytes', file_get_contents($orphan));
+        $this->assertFileExists(
+            $this->manifestsRoot() . '/' . $manifestId . '.json',
+            'the manifest stays, so the leftover still has something naming it'
+        );
+    }
+
+    public function testRestoreManifestIsNotCompleteWhileAnUnclassifiableEntryRemains(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'restore-me');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-unclassifiable');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // An entry scandir() lists but that is neither link, file nor
+        // directory. A FIFO is the portable way to produce one: unlike the
+        // read-bit-without-search-bit directory that motivated this rule, it
+        // behaves the same for root, so it is reproducible in a CI container.
+        $oddball = $this->mediaRoot() . '/' . $manifestId . '/files/2024/01/oddball';
+        if (!function_exists('posix_mkfifo') || !@posix_mkfifo($oddball, 0644)) {
+            $this->markTestSkipped('posix_mkfifo() unavailable: cannot create an unclassifiable entry');
+        }
+
+        // Refuse to pass vacuously: if the entry is classifiable after all,
+        // this test proves nothing about the hazard and must not report green.
+        $this->assertTrue(file_exists($oddball), 'the planted entry exists');
+        $this->assertFalse(is_link($oddball), 'precondition: not a link');
+        $this->assertFalse(is_file($oddball), 'precondition: not a file');
+        $this->assertFalse(is_dir($oddball), 'precondition: not a directory');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(1, $receipt['restored'], 'the recorded file is restored');
+        $this->assertSame(0, $receipt['skipped'], 'nothing was skipped');
+        $this->assertSame(0, $receipt['failed'], 'nothing failed');
+
+        // Load-bearing: an entry no stat can classify is not an empty tree.
+        $this->assertFalse(
+            $receipt['complete'],
+            'an entry that cannot be positively classified counts as remaining'
+        );
+        $this->assertTrue(file_exists($oddball), 'the unclassified entry is not deleted behind the scan');
+    }
+
+    public function testRestoreManifestIsNotCompleteWhileAStrayOutsideFilesRemains(): void
+    {
+        $relPath = '2024/01/hero.jpg';
+        $srcAbs  = $this->createUploadFile($relPath, 'restore-me');
+
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-stray');
+        $q->quarantineAttachment($manifestId, 42, $relPath, [$srcAbs]);
+        $q->finaliseManifest($manifestId);
+
+        // Beside files/, not under it. removeManifestDir() deletes the whole
+        // media/<manifest_id> tree, so the scan has to cover the whole of it
+        // rather than the one sub-directory today's layout happens to use.
+        $stray = $this->mediaRoot() . '/' . $manifestId . '/stray.dat';
+        file_put_contents($stray, 'stray-bytes');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(1, $receipt['restored'], 'the recorded file is restored');
+        $this->assertSame(0, $receipt['skipped'], 'nothing was skipped');
+        $this->assertSame(0, $receipt['failed'], 'nothing failed');
+
+        $this->assertFalse(
+            $receipt['complete'],
+            'a stray beside files/ is inside what the cleanup deletes, so it withholds complete'
+        );
+        $this->assertFileExists($stray, 'the stray is not deleted unseen');
+        $this->assertSame('stray-bytes', file_get_contents($stray));
+    }
+
+    public function testRestoreManifestUnknownIdIsNeverComplete(): void
+    {
+        $q = $this->makeQuarantine();
+        $q->beginManifest('warmup');
+
+        $receipt = $q->restoreManifest('00000000000000000000000000000000');
+
+        $this->assertSame(0, $receipt['files_seen'], 'an unknown id describes no files');
+        $this->assertSame(0, $receipt['restored'], 'and restores none');
+
+        // `complete` gates the cleanup that deletes the quarantine copy, and
+        // it must never read "this id means nothing to me" as "everything was
+        // put back".
+        $this->assertFalse(
+            $receipt['complete'],
+            'a receipt for a manifest that never existed is not a complete restore'
+        );
     }
 
     // =========================================================================
@@ -465,9 +724,46 @@ final class MediaQuarantineTest extends TestCase
         $q->finaliseManifest($manifestId);
 
         // restoreManifest must handle empty files[] without error and return 0.
-        $restored = $q->restoreManifest($manifestId);
+        $receipt = $q->restoreManifest($manifestId);
 
-        $this->assertSame(0, $restored, 'Nothing to restore when files array is empty.');
+        $this->assertSame(0, $receipt['restored'], 'Nothing to restore when files array is empty.');
+    }
+
+    // =========================================================================
+    // restoreManifest() — a manifest that loaded and legitimately recorded no
+    // on-disk file is complete, and is cleaned up
+    // =========================================================================
+
+    public function testRestoreManifestWithOnlyEmptyFilesEntriesIsCompleteAndCleansUp(): void
+    {
+        $q          = $this->makeQuarantine();
+        $manifestId = $q->beginManifest('job-restore-empty-complete');
+
+        // A broken attachment with no on-disk files: quarantineAttachment()
+        // deliberately records the entry with files => [].
+        $q->quarantineAttachment($manifestId, 12, '2024/01/ghost.jpg', []);
+        $q->finaliseManifest($manifestId);
+
+        $manifestFile = $this->manifestsRoot() . '/' . $manifestId . '.json';
+        $manifestDir  = $this->mediaRoot() . '/' . $manifestId;
+        $this->assertFileExists($manifestFile, 'the manifest exists before the restore');
+
+        $receipt = $q->restoreManifest($manifestId);
+
+        $this->assertSame(0, $receipt['files_seen'], 'the manifest described no file');
+        $this->assertSame(0, $receipt['restored'], 'so nothing was moved back');
+
+        // The discriminator is "did a manifest load", not "did it describe
+        // files". Deriving this from the counters makes a zero-file manifest
+        // permanently uncleanable: complete never becomes true, so the JSON
+        // and the directory tree are retained for ever.
+        $this->assertTrue(
+            $receipt['complete'],
+            'a manifest that loaded and held nothing to restore is a complete restore'
+        );
+
+        $this->assertFileDoesNotExist($manifestFile, 'the manifest JSON is cleaned up');
+        $this->assertDirectoryDoesNotExist($manifestDir, 'and the media directory with it');
     }
 
     // =========================================================================
@@ -483,7 +779,7 @@ final class MediaQuarantineTest extends TestCase
 
         foreach ($traversalIds as $id) {
             $result = $q->restoreManifest($id);
-            $this->assertSame(0, $result, "Path-traversal id '{$id}' must be rejected (returns 0).");
+            $this->assertSame(0, $result['restored'], "Path-traversal id '{$id}' must be rejected (restores 0).");
         }
     }
 
@@ -520,11 +816,16 @@ final class MediaQuarantineTest extends TestCase
         file_put_contents($manifestFile, $crafted);
 
         // restoreManifest must skip the crafted entry (returns 0 restored).
-        $restored = $q->restoreManifest($manifestId);
+        $receipt = $q->restoreManifest($manifestId);
         $this->assertSame(
             0,
-            $restored,
+            $receipt['restored'],
             'normalisePath() must reject paths containing "/.." — 0 files restored.'
+        );
+        $this->assertSame(
+            1,
+            $receipt['reasons'][MediaQuarantine::RESTORE_SKIP_OUTSIDE_UPLOADS] ?? 0,
+            'the rejected entry is attributed to the containment check, not silently dropped'
         );
     }
 }

--- a/apps/api/db/query/mcp_connections.sql
+++ b/apps/api/db/query/mcp_connections.sql
@@ -310,12 +310,27 @@ RETURNING *;
 -- setup_client from this list would silently discard the operator's step-2
 -- choice on every create; omitting any m127 column would mint a credential
 -- nobody chose the terms of. Both failures compile and generate cleanly.
+--
+-- m136 ADDS oauth_scopes AND IT OBEYS THE SAME RULE AS THE m127 COLUMNS: NOT
+-- NULL, no DEFAULT, so a caller that omits it gets 23502 rather than a grant
+-- whose scope set the schema chose. It is named here for that reason and not
+-- because the generator needed it -- CreateMCPGrantParams is a named-field
+-- literal at every call site, so omitting the field would have compiled and
+-- left it nil, which is NULL, which is the 23502 m136 DECISION 3 designed.
+--
+-- IT IS THE COLUMN THE CAPABILITY CEILING IS DERIVED FROM, so a wrong value
+-- here is not a wrong label: it is the wrong ceiling on every request that
+-- grant ever makes. The two creation paths pass different things on purpose --
+-- the OAuth path passes the scope set the client requested and the operator
+-- consented to, the token path passes DefaultGrantScopes() because no client
+-- asked for anything -- and both are validated against recognisedScopes in Go
+-- before they arrive, on top of the vocabulary CHECK here.
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
     client_id, created_by_user_id, capabilities, expires_at,
-    idle_expire_after_days, setup_client
+    idle_expire_after_days, setup_client, oauth_scopes
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 )
 RETURNING *;
 
@@ -576,6 +591,12 @@ SELECT
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
     g.capabilities                AS grant_capabilities,
+    -- g.oauth_scopes is returned for the SAME REASON g.capabilities is: the
+    -- CEILING the stored capability set is narrowed against is derived from
+    -- these scopes, and deriving it from a constant instead makes it a guess
+    -- that agrees with the row only while the registry holds one entry. Read
+    -- from the same row and the same transaction as the `authorized` verdict.
+    g.oauth_scopes                AS grant_oauth_scopes,
     g.expires_at                  AS grant_expires_at,
     g.idle_expire_after_days      AS grant_idle_expire_after_days,
     g.last_used_at                AS grant_last_used_at,

--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -5708,10 +5708,21 @@ CREATE TABLE mcp_grants (
     -- middle segment is the OUTCOME an operator ticks on Step 4 and never the
     -- mechanism that serves it.
     --
-    -- EVERY MEMBER ENDS IN '.read', and that is checkable by pattern rather
-    -- than by trust. No write capability is seated: the write side uses
-    -- '.propose' and '.write', and the first migration to add a member not
-    -- ending in '.read' is the one that owes the write review.
+    -- m135 SEATED THE FIRST NON-READ MEMBER, 'mcp.cache.purge', which is the
+    -- write review m131 DECISION 2 said the next non-'.read' member would owe.
+    -- It authorises purging a site's page cache: the agent-side `cache_purge`
+    -- command, Write / Idempotent, whose retry converges and whose worst case is
+    -- a slower page load rather than lost authored state. m135 DECISION 1 gives
+    -- the full argument and DECISION 2 gives the naming rule -- the suffix is
+    -- the OPERATION where a domain has exactly one, which is why it is neither
+    -- '.write' (broader than the grant) nor '.propose' (there is no approval
+    -- step and none is wanted).
+    --
+    -- 'EVERY MEMBER ENDS IN .read' WAS TRUE UNTIL m135 AND IS NOW FALSE. m131
+    -- offered that as a property checkable by pattern; after m135 the pattern
+    -- answers "a write is seated" and cannot say which, so it must not be reused
+    -- as a safety property. Read the enumeration below instead, and do not grep
+    -- for '.read' to decide what this vocabulary permits.
     --
     -- 'mcp.content.read' is seated DELIBERATELY AND UNREACHABLE -- there is no
     -- post or page table here and no agent command returns post content, and
@@ -5726,6 +5737,7 @@ CREATE TABLE mcp_grants (
         CHECK (capabilities <@ ARRAY[
             'mcp.activity.read',
             'mcp.backups.read',
+            'mcp.cache.purge',
             'mcp.content.read',
             'mcp.diagnostics.read',
             'mcp.performance.read',

--- a/apps/api/internal/db/sqlc/mcp_connections.sql.go
+++ b/apps/api/internal/db/sqlc/mcp_connections.sql.go
@@ -203,9 +203,9 @@ const createMCPGrant = `-- name: CreateMCPGrant :one
 INSERT INTO mcp_grants (
     tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids,
     client_id, created_by_user_id, capabilities, expires_at,
-    idle_expire_after_days, setup_client
+    idle_expire_after_days, setup_client, oauth_scopes
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 )
 RETURNING id, tenant_id, name, status, site_scope_mode, scope_tag_ids, scope_site_ids, capabilities, oauth_scopes, client_id, client_name, client_version, protocol_version, client_identity_recorded_at, setup_client, created_by_user_id, created_at, last_used_at, revoked_at, expires_at, idle_expire_after_days
 `
@@ -223,6 +223,7 @@ type CreateMCPGrantParams struct {
 	ExpiresAt           time.Time   `json:"expires_at"`
 	IdleExpireAfterDays *int32      `json:"idle_expire_after_days"`
 	SetupClient         *string     `json:"setup_client"`
+	OauthScopes         []string    `json:"oauth_scopes"`
 }
 
 // ===========================================================================
@@ -292,6 +293,21 @@ type CreateMCPGrantParams struct {
 // setup_client from this list would silently discard the operator's step-2
 // choice on every create; omitting any m127 column would mint a credential
 // nobody chose the terms of. Both failures compile and generate cleanly.
+//
+// m136 ADDS oauth_scopes AND IT OBEYS THE SAME RULE AS THE m127 COLUMNS: NOT
+// NULL, no DEFAULT, so a caller that omits it gets 23502 rather than a grant
+// whose scope set the schema chose. It is named here for that reason and not
+// because the generator needed it -- CreateMCPGrantParams is a named-field
+// literal at every call site, so omitting the field would have compiled and
+// left it nil, which is NULL, which is the 23502 m136 DECISION 3 designed.
+//
+// IT IS THE COLUMN THE CAPABILITY CEILING IS DERIVED FROM, so a wrong value
+// here is not a wrong label: it is the wrong ceiling on every request that
+// grant ever makes. The two creation paths pass different things on purpose --
+// the OAuth path passes the scope set the client requested and the operator
+// consented to, the token path passes DefaultGrantScopes() because no client
+// asked for anything -- and both are validated against recognisedScopes in Go
+// before they arrive, on top of the vocabulary CHECK here.
 func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error) {
 	row := q.db.QueryRow(ctx, createMCPGrant,
 		arg.TenantID,
@@ -306,6 +322,7 @@ func (q *Queries) CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) 
 		arg.ExpiresAt,
 		arg.IdleExpireAfterDays,
 		arg.SetupClient,
+		arg.OauthScopes,
 	)
 	var i McpGrant
 	err := row.Scan(
@@ -681,6 +698,12 @@ SELECT
     g.scope_site_ids              AS scope_site_ids,
     g.client_id                   AS client_id,
     g.capabilities                AS grant_capabilities,
+    -- g.oauth_scopes is returned for the SAME REASON g.capabilities is: the
+    -- CEILING the stored capability set is narrowed against is derived from
+    -- these scopes, and deriving it from a constant instead makes it a guess
+    -- that agrees with the row only while the registry holds one entry. Read
+    -- from the same row and the same transaction as the ` + "`" + `authorized` + "`" + ` verdict.
+    g.oauth_scopes                AS grant_oauth_scopes,
     g.expires_at                  AS grant_expires_at,
     g.idle_expire_after_days      AS grant_idle_expire_after_days,
     g.last_used_at                AS grant_last_used_at,
@@ -778,6 +801,7 @@ type ReCheckMCPRequestAuthorizationInTenantTxRow struct {
 	ScopeSiteIds                []uuid.UUID        `json:"scope_site_ids"`
 	ClientID                    *string            `json:"client_id"`
 	GrantCapabilities           []string           `json:"grant_capabilities"`
+	GrantOauthScopes            []string           `json:"grant_oauth_scopes"`
 	GrantExpiresAt              time.Time          `json:"grant_expires_at"`
 	GrantIdleExpireAfterDays    *int32             `json:"grant_idle_expire_after_days"`
 	GrantLastUsedAt             pgtype.Timestamptz `json:"grant_last_used_at"`
@@ -844,6 +868,7 @@ func (q *Queries) ReCheckMCPRequestAuthorizationInTenantTx(ctx context.Context, 
 		&i.ScopeSiteIds,
 		&i.ClientID,
 		&i.GrantCapabilities,
+		&i.GrantOauthScopes,
 		&i.GrantExpiresAt,
 		&i.GrantIdleExpireAfterDays,
 		&i.GrantLastUsedAt,

--- a/apps/api/internal/db/sqlc/querier.go
+++ b/apps/api/internal/db/sqlc/querier.go
@@ -670,6 +670,21 @@ type Querier interface {
 	// setup_client from this list would silently discard the operator's step-2
 	// choice on every create; omitting any m127 column would mint a credential
 	// nobody chose the terms of. Both failures compile and generate cleanly.
+	//
+	// m136 ADDS oauth_scopes AND IT OBEYS THE SAME RULE AS THE m127 COLUMNS: NOT
+	// NULL, no DEFAULT, so a caller that omits it gets 23502 rather than a grant
+	// whose scope set the schema chose. It is named here for that reason and not
+	// because the generator needed it -- CreateMCPGrantParams is a named-field
+	// literal at every call site, so omitting the field would have compiled and
+	// left it nil, which is NULL, which is the 23502 m136 DECISION 3 designed.
+	//
+	// IT IS THE COLUMN THE CAPABILITY CEILING IS DERIVED FROM, so a wrong value
+	// here is not a wrong label: it is the wrong ceiling on every request that
+	// grant ever makes. The two creation paths pass different things on purpose --
+	// the OAuth path passes the scope set the client requested and the operator
+	// consented to, the token path passes DefaultGrantScopes() because no client
+	// asked for anything -- and both are validated against recognisedScopes in Go
+	// before they arrive, on top of the vocabulary CHECK here.
 	CreateMCPGrant(ctx context.Context, arg CreateMCPGrantParams) (McpGrant, error)
 	// ---------------------------------------------------------------------------
 	// backup_manifest_entries

--- a/apps/api/internal/mcp/authenticate_scope_column_test.go
+++ b/apps/api/internal/mcp/authenticate_scope_column_test.go
@@ -1,0 +1,149 @@
+// The failure direction m136's read exists to close, executed through
+// Service.Authenticate rather than argued about in a comment.
+//
+// WHY THESE PLANT THROUGH THE FAKE STORE AND NOT THROUGH POSTGRES. The value
+// under test is UNSTORABLE: mcp_grants_oauth_scopes_vocabulary_check refuses an
+// unrecognised scope and mcp_grants_oauth_scopes_not_empty_check refuses an
+// empty set, and the integration suite proves both of those refusals are live
+// as wpmgr_app. That is exactly why the Go half has to be tested here: m136
+// DECISION 5(d) says the read "must not depend on the database being the only
+// writer", and a test that can only plant what the database permits cannot
+// check what happens when something else writes the row. The fake store is the
+// only place a row the CHECK forbids can be put in front of the code that reads
+// it.
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db/sqlc"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// authWithStoredScopes builds a live, authorized recheck row carrying an
+// arbitrary oauth_scopes column, and returns the service in front of it. Every
+// other field is the ordinary healthy connection, so the only variable across
+// the tests below is the scope column.
+func authWithStoredScopes(storedScopes []string) *Service {
+	tenantID := uuid.New()
+	tok := liveToken(tenantID)
+	return NewService(&fakeStore{
+		tokenOK: true, token: tok,
+		recheckOK: true,
+		recheck: sqlc.ReCheckMCPRequestAuthorizationInTenantTxRow{
+			GrantID: tok.GrantID, GrantStatus: "active",
+			SiteScopeMode: "all", TokenID: tok.ID, TokenStatus: "active",
+			TokenExpiresAt:    tok.ExpiresAt,
+			GrantCapabilities: []string{string(CapSitesRead)},
+			GrantOauthScopes:  storedScopes,
+			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
+			Authorized:        true,
+		},
+		scopeSites: []uuid.UUID{uuid.New()},
+	})
+}
+
+// TestAuthenticateRefusesAGrantHoldingAnUnrecognisedScope IS THE PROOF THAT
+// MATTERS, because it is the direction where the wrong answer still works.
+//
+// The row holds {mcp:read, mcp:not-a-scope}. The tempting implementation trims
+// the unknown entry and authenticates the connection on {mcp:read} alone: it is
+// fail-closed relative to the row, every client keeps working, and NOBODY EVER
+// LEARNS that the credential's stored terms and its resolved authority
+// disagree. That is the failure. A scope this build does not recognise is a
+// grant this build cannot correctly evaluate, and the honest answer to "I
+// cannot tell what this grant may do" is to refuse it.
+//
+// It is the same stance one layer up: ParseRequestedScopes refuses the WHOLE
+// request on an unrecognised scope rather than dropping the token from it, and
+// NarrowTo refuses a capability the ceiling does not hold rather than
+// intersecting it away.
+func TestAuthenticateRefusesAGrantHoldingAnUnrecognisedScope(t *testing.T) {
+	svc := authWithStoredScopes([]string{string(ScopeRead), "mcp:not-a-scope"})
+
+	auth, err := svc.Authenticate(context.Background(), "the-bearer-token")
+	if err == nil {
+		t.Fatalf("a grant whose oauth_scopes column holds an unrecognised scope "+
+			"AUTHENTICATED, resolving to %v.\n"+
+			"The row says {mcp:read, mcp:not-a-scope} and the connection was "+
+			"admitted as though it said {mcp:read}. That is grantScopes having "+
+			"trimmed the unknown entry, or OrgDefaultCapabilities having skipped "+
+			"it -- either way the stored terms and the granted authority "+
+			"disagree and nothing anywhere says so.", auth.Capabilities.Sorted())
+	}
+
+	// AND IT IS THE RIGHT REFUSAL, not an incidental one. A 500 here would also
+	// make the assertion above pass while telling the operator nothing, so the
+	// domain error is checked by code.
+	de, ok := domain.AsDomain(err)
+	if !ok {
+		t.Fatalf("the refusal is not a domain error (%v), so it renders as a 500 "+
+			"and names nothing the operator can act on", err)
+	}
+	if de.Code != ErrCodeCapabilityUnmapped {
+		t.Fatalf("refusal code = %q, want %q", de.Code, ErrCodeCapabilityUnmapped)
+	}
+	t.Logf("a grant holding an unrecognised scope was refused: %v", err)
+}
+
+// TestAuthenticateRefusesAGrantWhoseScopeColumnIsEmpty covers the other
+// direction absence can fail in. An empty or nil column must mean NO AUTHORITY;
+// the bug it guards against is a future reader deciding that "no scope
+// restriction recorded" means "no restriction".
+//
+// mcp_grants_oauth_scopes_not_empty_check makes the value unrepresentable, so
+// reaching this state means a writer outside that constraint -- which is
+// precisely the case the Go read may not assume away.
+func TestAuthenticateRefusesAGrantWhoseScopeColumnIsEmpty(t *testing.T) {
+	for name, stored := range map[string][]string{"nil": nil, "empty": {}} {
+		t.Run(name, func(t *testing.T) {
+			auth, err := authWithStoredScopes(stored).
+				Authenticate(context.Background(), "the-bearer-token")
+			if err == nil {
+				t.Fatalf("a grant with a %s oauth_scopes column authenticated, "+
+					"resolving to %v. Absence must never widen.",
+					name, auth.Capabilities.Sorted())
+			}
+			de, ok := domain.AsDomain(err)
+			if !ok || de.Code != ErrCodeCapabilityUnmapped {
+				t.Fatalf("refusal = %v, want a %q domain error",
+					err, ErrCodeCapabilityUnmapped)
+			}
+		})
+	}
+}
+
+// TestAuthenticateGivesTheDefaultGrantExactlyWhatItHasToday is the
+// no-regression pin, and it is the reason the three tests above are safe to
+// assert: a change that refuses too much would be caught here rather than in
+// production.
+//
+// Every grant this surface has ever minted holds {mcp:read} on the scope axis
+// and {mcp.sites.read} on the capability axis, and m136's backfill wrote the
+// first of those onto every existing row. This asserts the resolved set is
+// EXACTLY that -- not merely that it contains it. A wider resolved set would be
+// the widening this whole commit exists to make impossible, arriving at read
+// time instead of at write time.
+func TestAuthenticateGivesTheDefaultGrantExactlyWhatItHasToday(t *testing.T) {
+	svc := authWithStoredScopes(scopeNames(DefaultGrantScopes()))
+
+	auth, err := svc.Authenticate(context.Background(), "the-bearer-token")
+	if err != nil {
+		t.Fatalf("the ordinary grant every live connection is no longer "+
+			"authenticates: %v", err)
+	}
+	if !auth.Capabilities.Allows(CapSitesRead) {
+		t.Fatalf("resolved capabilities = %v, want to hold %q",
+			auth.Capabilities.Sorted(), CapSitesRead)
+	}
+	if auth.Capabilities.Len() != 1 {
+		t.Fatalf("a grant whose row holds {mcp:read} on the scope axis and "+
+			"{mcp.sites.read} on the capability axis resolved to %v.\n"+
+			"Exactly one, or this commit has widened a credential nobody "+
+			"re-consented to.", auth.Capabilities.Sorted())
+	}
+}

--- a/apps/api/internal/mcp/authenticate_scope_column_test.go
+++ b/apps/api/internal/mcp/authenticate_scope_column_test.go
@@ -4,8 +4,10 @@
 // WHY THESE PLANT THROUGH THE FAKE STORE AND NOT THROUGH POSTGRES. The value
 // under test is UNSTORABLE: mcp_grants_oauth_scopes_vocabulary_check refuses an
 // unrecognised scope and mcp_grants_oauth_scopes_not_empty_check refuses an
-// empty set, and the integration suite proves both of those refusals are live
-// as wpmgr_app. That is exactly why the Go half has to be tested here: m136
+// empty set. Both refusals are executed as wpmgr_app, by constraint name, in
+// tests/mcp_m136_scope_column_constraints_test.go -- which also proves the
+// honest value is still accepted, so the refusals are not a column that says
+// no to everything. That is exactly why the Go half has to be tested here: m136
 // DECISION 5(d) says the read "must not depend on the database being the only
 // writer", and a test that can only plant what the database permits cannot
 // check what happens when something else writes the row. The fake store is the

--- a/apps/api/internal/mcp/capability_default_test.go
+++ b/apps/api/internal/mcp/capability_default_test.go
@@ -1,9 +1,13 @@
 // The three sets this package keeps separate, and the tests that keep them
 // separate.
 //
-//	capabilityVocabulary       what may be spelled at all      -- 8
+//	capabilityVocabulary       what may be spelled at all      -- 9
 //	scopeCapabilities          what a scope confers, a CEILING -- 7
 //	DefaultGrantCapabilities   what an unasked grant receives  -- 1
+//
+// The gap between 9 and 7 is two deliberately unreachable members,
+// mcp.content.read (m131) and mcp.cache.purge (m135). Neither is conferred by
+// any scope, so neither can be minted or authenticated; see policy.go.
 //
 // Before m131 all three held one member, so all three were the same list and
 // nothing in the tree could tell them apart. The identity was TRUE, and every
@@ -147,14 +151,21 @@ func TestMintWithNoRequestedCapabilitiesGetsThePresetNotTheCeiling(t *testing.T)
 // The vocabulary and the ceiling, pinned by value.
 // ---------------------------------------------------------------------------
 
-// TestVocabularyIsM131sEight pins the Go half of the two-place closed set by
+// TestVocabularyIsM135sNine pins the Go half of the two-place closed set by
 // value. The DATABASE half is proved separately and against the live
 // constraint, by TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole in
 // apps/api/tests -- this one cannot see the database and does not pretend to.
-func TestVocabularyIsM131sEight(t *testing.T) {
+//
+// It was TestVocabularyIsM131sEight until m135 seated mcp.cache.purge. The
+// rename is deliberate rather than a silent edit of the literal: the name of
+// this test is the only place the vocabulary's SIZE is asserted in prose, and a
+// test called "IsM131sEight" passing over nine members is the drift this
+// project keeps finding.
+func TestVocabularyIsM135sNine(t *testing.T) {
 	want := []Capability{
 		CapActivityRead,
 		CapBackupsRead,
+		CapCachePurge,
 		CapContentRead,
 		CapDiagnosticsRead,
 		CapPerformanceRead,
@@ -163,42 +174,148 @@ func TestVocabularyIsM131sEight(t *testing.T) {
 		CapUptimeRead,
 	}
 	if !sameCaps(AllCapabilities(), want) {
-		t.Fatalf("AllCapabilities() = %v, want exactly %v (m131's seated vocabulary, "+
+		t.Fatalf("AllCapabilities() = %v, want exactly %v (m135's seated vocabulary, "+
 			"alphabetical, which is the order the constraint lists them in)",
 			capsToStrings(AllCapabilities()), capsToStrings(want))
 	}
 }
 
-// TestEveryCapabilityIsARead makes "this build seats no write capability" a
-// property that is checked rather than claimed. m131 DECISION 2 froze the
-// three-segment form specifically so this is a pattern test: the write side of
-// the design uses '.propose' and '.write', and the first member that does not
-// end in '.read' is the one that needs the write review.
+// nonReadCapabilities is the ENUMERATED allowlist of vocabulary members that
+// are not reads. It is a literal and not a pattern, so seating a second write
+// capability is a diff that has to name it here.
+//
+// It exists because m135 ended the pure pattern test below it. Until then
+// "this build seats no write capability" was checkable by suffix, which was
+// exactly as strong as it was true; the honest successor is not a weaker
+// pattern but a named exception list, so the property becomes "the only
+// non-read members are the ones a reviewer wrote down".
+var nonReadCapabilities = map[Capability]struct{}{
+	CapCachePurge: {},
+}
+
+// TestEveryCapabilityIsAReadOrAnEnumeratedWrite makes "this build seats no
+// UNREVIEWED write capability" a property that is checked rather than claimed.
+// m131 DECISION 2 froze the three-segment form specifically so this could be a
+// suffix test; m135 seated the first member that fails it, so the suffix rule
+// now has one enumerated exception and gains nothing else.
+//
+// It was TestEveryCapabilityIsARead. The rename is deliberate: the old name
+// asserts something this build no longer does, and a test whose name is a false
+// claim is worse than no test, because the next session greps for the claim and
+// believes it.
 //
 // It also fails on an empty vocabulary, because a loop over an empty set passes
 // having checked nothing -- the exact shape this brief names as failure mode 3
 // on the database side.
-func TestEveryCapabilityIsARead(t *testing.T) {
+func TestEveryCapabilityIsAReadOrAnEnumeratedWrite(t *testing.T) {
 	all := AllCapabilities()
 	if len(all) == 0 {
 		t.Fatal("the vocabulary is empty, so this test ranged over nothing and " +
 			"would have reported a pass having checked no capability at all")
 	}
+	if len(nonReadCapabilities) == 0 {
+		t.Fatal("nonReadCapabilities is empty, so the exception arm below checked " +
+			"nothing; if the last write capability was removed, delete the arm " +
+			"rather than leaving it to pass vacuously")
+	}
+	reads := 0
 	for _, c := range all {
-		if !strings.HasSuffix(string(c), ".read") {
-			t.Fatalf("capability %q does not end in '.read'.\n"+
-				"If this is the first write capability, it needs the review m124 "+
-				"DECISION 1 built the closed CHECK to force -- and it must not be "+
-				"conferred by ScopeRead, which is a read scope.", c)
-		}
 		if !strings.HasPrefix(string(c), "mcp.") {
 			t.Fatalf("capability %q does not carry the frozen 'mcp.' prefix. The "+
 				"wireframes' 'site.*' labels are the SCREEN's, not the stored "+
 				"string's; adopting one here strands every live grant.", c)
 		}
+		if strings.HasSuffix(string(c), ".read") {
+			reads++
+			if _, listed := nonReadCapabilities[c]; listed {
+				t.Fatalf("capability %q ends in '.read' and is ALSO listed in "+
+					"nonReadCapabilities. One of the two is wrong, and while they "+
+					"disagree the exception list is not describing the vocabulary.", c)
+			}
+			continue
+		}
+		if _, listed := nonReadCapabilities[c]; !listed {
+			t.Fatalf("capability %q does not end in '.read' and is not named in "+
+				"nonReadCapabilities.\n"+
+				"If this is a new write capability, it needs the review m124 "+
+				"DECISION 1 built the closed CHECK to force -- and it must not be "+
+				"conferred by ScopeRead, which is a read scope. Name it in "+
+				"nonReadCapabilities in the same diff that seats it.", c)
+		}
 	}
-	t.Logf("all %d seated capabilities carry the mcp. prefix and the .read suffix: %v",
-		len(all), capsToStrings(all))
+
+	// EVERY NAMED EXCEPTION MUST STILL BE IN THE VOCABULARY. Without this arm a
+	// capability could be deleted from the vocabulary and left in the list, and
+	// the list would go on describing a member that no longer exists.
+	for c := range nonReadCapabilities {
+		if !KnownCapability(c) {
+			t.Fatalf("nonReadCapabilities names %q, which is not in the vocabulary. "+
+				"Remove it here in the diff that removes it there.", c)
+		}
+	}
+	t.Logf("%d seated capabilities: %d reads and %d enumerated writes (%v)",
+		len(all), reads, len(nonReadCapabilities), capsToStrings(all))
+}
+
+// TestCachePurgeIsKnownButConferredByNoScope is the m135 ceiling decision, held
+// as a test. It is the sibling of TestContentReadIsKnownButConferredByNoScope
+// and it is deliberately a SEPARATE test rather than a second arm of that one:
+// the two members are unreachable for different reasons, and a shared test
+// would let one reason be deleted while the other kept it green.
+//
+// WHOEVER CONFERS mcp.cache.purge MUST DELETE THIS TEST, not edit it. That is
+// the point of pinning the refusal by name: conferring the first write
+// capability cannot then happen as a quiet one-line map edit, because the diff
+// that does it also has to remove a test whose comment says why it was there.
+//
+// The prerequisite that blocks the conferral today is NOT a missing line in
+// scopeCapabilities. It is that grantScopes() is a constant -- mcp_grants has
+// no scopes column -- so a second scope added to recognisedScopes would hand
+// ScopeRead's capabilities to a grant that never requested them. See the
+// CapCachePurge note on scopeCapabilities in policy.go.
+func TestCachePurgeIsKnownButConferredByNoScope(t *testing.T) {
+	// KNOWN: the database CHECK holds it, so this map must too, or a name the
+	// database accepts is refused at a different layer with a different error.
+	if !KnownCapability(CapCachePurge) {
+		t.Fatalf("%q is not in capabilityVocabulary, but m135 seats it in "+
+			"mcp_grants_capabilities_vocabulary_check; the two closed sets must "+
+			"agree exactly", CapCachePurge)
+	}
+
+	// NOT CONFERRED: no scope hands it out, so no grant can be minted holding
+	// it and no stored row carrying it can authenticate.
+	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	if err != nil {
+		t.Fatalf("OrgDefaultCapabilities(grantScopes()): %v", err)
+	}
+	if ceiling.Allows(CapCachePurge) {
+		t.Fatalf("the organisation ceiling confers %q -- the FIRST WRITE capability "+
+			"on this surface. Every live grant holds ScopeRead by construction, so "+
+			"conferring this widens every grant ever minted with no second consent. "+
+			"Confer it only alongside a real per-grant scope read (mcp_grants has no "+
+			"scopes column today), in that diff, under that review.", CapCachePurge)
+	}
+
+	// AND THE REFUSAL IS LOUD. An operator asking for it is told by name rather
+	// than handed a quietly smaller connection -- and critically, the whole
+	// request is refused rather than trimmed down to the read capabilities.
+	if _, err := ceiling.NarrowTo([]Capability{CapSitesRead, CapCachePurge}); err == nil {
+		t.Fatalf("a mint request naming %q was accepted; it must be refused whole, "+
+			"not trimmed down to the capabilities the ceiling does hold", CapCachePurge)
+	}
+
+	// THE DEFAULT DOES NOT CARRY IT EITHER. This is the m135 note (3)(a) arm:
+	// asserted here as well as in the preset test, because that test pins the
+	// whole set by value and this one says WHICH member must never appear in it
+	// and why -- so a future widening fails with the reason attached.
+	for _, c := range DefaultGrantCapabilities() {
+		if c == CapCachePurge {
+			t.Fatalf("DefaultGrantCapabilities() hands out %q. A grant minted with no "+
+				"explicit request would be stamped with the power to purge a live "+
+				"site's cache, which is exactly the widening m135 note (3)(a) and "+
+				"m131 DECISION 3 both forbid.", CapCachePurge)
+		}
+	}
 }
 
 // TestScopeReadConfersTheSevenReachableGroups pins the CEILING by value, and it

--- a/apps/api/internal/mcp/capability_default_test.go
+++ b/apps/api/internal/mcp/capability_default_test.go
@@ -268,11 +268,19 @@ func TestEveryCapabilityIsAReadOrAnEnumeratedWrite(t *testing.T) {
 // capability cannot then happen as a quiet one-line map edit, because the diff
 // that does it also has to remove a test whose comment says why it was there.
 //
-// The prerequisite that blocks the conferral today is NOT a missing line in
-// scopeCapabilities. It is that grantScopes() is a constant -- mcp_grants has
-// no scopes column -- so a second scope added to recognisedScopes would hand
-// ScopeRead's capabilities to a grant that never requested them. See the
-// CapCachePurge note on scopeCapabilities in policy.go.
+// THE PREREQUISITE THIS COMMENT NAMED HAS BEEN MET, and what remains is not
+// the same thing. It used to read that grantScopes() was a constant because
+// mcp_grants had no scopes column, so a second entry in recognisedScopes would
+// hand ScopeRead's capabilities to a grant that never requested them. m136
+// added the column and grantScopes is now a per-grant read, so that widening is
+// no longer the blocker.
+//
+// What blocks the conferral now is that no scope confers it: a second scope has
+// to arrive in recognisedScopes, be mapped in scopeCapabilities, and -- see the
+// note at service.go's Approve -- have the STORED scope set bound to what the
+// authorize call actually carried, which today is unnecessary only because the
+// registry holds one member. See the CapCachePurge note on scopeCapabilities in
+// policy.go.
 func TestCachePurgeIsKnownButConferredByNoScope(t *testing.T) {
 	// KNOWN: the database CHECK holds it, so this map must too, or a name the
 	// database accepts is refused at a different layer with a different error.
@@ -284,9 +292,9 @@ func TestCachePurgeIsKnownButConferredByNoScope(t *testing.T) {
 
 	// NOT CONFERRED: no scope hands it out, so no grant can be minted holding
 	// it and no stored row carrying it can authenticate.
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	ceiling, err := OrgDefaultCapabilities(DefaultGrantScopes())
 	if err != nil {
-		t.Fatalf("OrgDefaultCapabilities(grantScopes()): %v", err)
+		t.Fatalf("OrgDefaultCapabilities(DefaultGrantScopes()): %v", err)
 	}
 	if ceiling.Allows(CapCachePurge) {
 		t.Fatalf("the organisation ceiling confers %q -- the FIRST WRITE capability "+

--- a/apps/api/internal/mcp/capability_default_test.go
+++ b/apps/api/internal/mcp/capability_default_test.go
@@ -93,9 +93,9 @@ func TestDefaultGrantCapabilitiesIsThePresetNotTheVocabulary(t *testing.T) {
 	// request authenticates and then reaches nothing -- the half-working
 	// connection m127 DECISION 3 forbids. Checked against the ceiling, which is
 	// what Authenticate narrows the stored column against.
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	ceiling, err := OrgDefaultCapabilities(DefaultGrantScopes())
 	if err != nil {
-		t.Fatalf("OrgDefaultCapabilities(grantScopes()): %v", err)
+		t.Fatalf("OrgDefaultCapabilities(DefaultGrantScopes()): %v", err)
 	}
 	if _, err := ceiling.NarrowTo(got); err != nil {
 		t.Fatalf("the default preset %v is not held by the organisation ceiling %v: %v.\n"+
@@ -118,7 +118,7 @@ func TestMintWithNoRequestedCapabilitiesGetsThePresetNotTheCeiling(t *testing.T)
 	// honest fixture rather than a stub standing in for one.
 	svc := &Service{}
 
-	set, err := svc.resolveGrantCapabilities(nil)
+	set, err := svc.resolveGrantCapabilities(DefaultGrantScopes(), nil)
 	if err != nil {
 		t.Fatalf("resolveGrantCapabilities(nil): %v", err)
 	}
@@ -133,7 +133,7 @@ func TestMintWithNoRequestedCapabilitiesGetsThePresetNotTheCeiling(t *testing.T)
 	// The ceiling is still reachable BY ASKING, which is the other half of the
 	// decision: this is a narrower default, not a narrower surface.
 	wider := []Capability{CapSitesRead, CapUptimeRead, CapBackupsRead}
-	asked, err := svc.resolveGrantCapabilities(&wider)
+	asked, err := svc.resolveGrantCapabilities(DefaultGrantScopes(), &wider)
 	if err != nil {
 		t.Fatalf("resolveGrantCapabilities(%v): %v -- an operator who explicitly asks "+
 			"for a seated, conferred capability must receive it", capsToStrings(wider), err)
@@ -258,9 +258,9 @@ func TestContentReadIsKnownButConferredByNoScope(t *testing.T) {
 	}
 
 	// NOT CONFERRED: no scope hands it out, so no grant can be minted holding it.
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	ceiling, err := OrgDefaultCapabilities(DefaultGrantScopes())
 	if err != nil {
-		t.Fatalf("OrgDefaultCapabilities(grantScopes()): %v", err)
+		t.Fatalf("OrgDefaultCapabilities(DefaultGrantScopes()): %v", err)
 	}
 	if ceiling.Allows(CapContentRead) {
 		t.Fatalf("the organisation ceiling confers %q. Nothing serves it: the tool "+

--- a/apps/api/internal/mcp/connection_status_race_test.go
+++ b/apps/api/internal/mcp/connection_status_race_test.go
@@ -386,6 +386,7 @@ func seedSnapshotGrant(t *testing.T, pool *db.Pool, p domain.Principal, name str
 			ClientID:            nil,
 			CreatedByUserID:     uuidToPG(p.UserID),
 			Capabilities:        capabilityNames(DefaultGrantCapabilities()),
+			OauthScopes:         scopeNames(DefaultGrantScopes()),
 			ExpiresAt:           time.Now().UTC().Add(grantAbsoluteTTL),
 			IdleExpireAfterDays: nil,
 			SetupClient:         nil,

--- a/apps/api/internal/mcp/connection_tools.go
+++ b/apps/api/internal/mcp/connection_tools.go
@@ -75,7 +75,21 @@ func (s *Service) ConnectionTools(ctx context.Context, p domain.Principal, grant
 	// grant does not hold is LISTED and annotated. Passing the stored set as
 	// both would collapse the two boundaries into one and quietly hide every
 	// tool the operator unticked -- which is the D1 ruling backwards.
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	//
+	// THE SCOPES ARE THE GRANT'S OWN (m136), read off the row already fetched
+	// above rather than recomputed from the registry. An empty column is
+	// refused by name for the reason Authenticate gives: it is the state
+	// mcp_grants_oauth_scopes_not_empty_check makes unrepresentable, so it
+	// means a writer outside that constraint, and rendering it as an empty tool
+	// list would put "this connection has no tools" on the screen for a
+	// credential that is in fact refused on every request.
+	scopes := grantScopes(grant.OauthScopes)
+	if len(scopes) == 0 {
+		return nil, domain.Forbidden(ErrCodeCapabilityUnmapped,
+			"this connection holds no scope, so it confers no capability")
+	}
+
+	ceiling, err := OrgDefaultCapabilities(scopes)
 	if err != nil {
 		// A ceiling that cannot be resolved is a REFUSAL, never an empty list.
 		// An empty list here reads as "this connection can call nothing",

--- a/apps/api/internal/mcp/connection_tools_test.go
+++ b/apps/api/internal/mcp/connection_tools_test.go
@@ -42,6 +42,12 @@ func grantHolding(id uuid.UUID, caps ...Capability) sqlc.McpGrant {
 		Status:        string(GrantStatusActive),
 		SiteScopeMode: string(SiteScopeModeAll),
 		Capabilities:  capabilityNames(caps),
+		// The scope column the CEILING is derived from (m136), distinct from
+		// the capability column above, which is what the ceiling NARROWS. Every
+		// grant this surface has minted holds exactly this, so it is what a
+		// stored row looks like; an empty column is refused rather than
+		// defaulted, which is why a fixture has to say it.
+		OauthScopes: scopeNames(DefaultGrantScopes()),
 	}
 }
 
@@ -64,7 +70,7 @@ func TestConnectionToolsAnswersWithTheGrantsOwnList(t *testing.T) {
 		t.Fatalf("ConnectionTools: %v", err)
 	}
 
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	ceiling, err := OrgDefaultCapabilities(DefaultGrantScopes())
 	if err != nil {
 		t.Fatalf("OrgDefaultCapabilities: %v", err)
 	}

--- a/apps/api/internal/mcp/consent_capability_test.go
+++ b/apps/api/internal/mcp/consent_capability_test.go
@@ -72,7 +72,7 @@ func TestApproveStoresTheOperatorsNarrowedChoice(t *testing.T) {
 	}
 	// And it is genuinely narrower than the ceiling, or the assertion above
 	// would be satisfied by an implementation that stores everything.
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	ceiling, err := OrgDefaultCapabilities(DefaultGrantScopes())
 	if err != nil {
 		t.Fatalf("OrgDefaultCapabilities: %v", err)
 	}

--- a/apps/api/internal/mcp/mint.go
+++ b/apps/api/internal/mcp/mint.go
@@ -415,7 +415,13 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 	// widened past it. NarrowTo REFUSES a capability the ceiling does not hold
 	// rather than dropping it, for the reason written on that method: a
 	// silently-dropped capability is a grant the operator did not ask for.
-	caps, err := s.resolveGrantCapabilities(req.Capabilities)
+	//
+	// THE SCOPES ARE DefaultGrantScopes() ON THIS PATH AND THE SAME SLICE IS
+	// STORED BELOW. A connection token has no RFC 7591 client behind it and so
+	// no `scope` request parameter to honour; the answer to "nobody asked" is
+	// the preset, which is the read scope and nothing else.
+	grantedScopes := DefaultGrantScopes()
+	caps, err := s.resolveGrantCapabilities(grantedScopes, req.Capabilities)
 	if err != nil {
 		return MintedConnection{}, err
 	}
@@ -464,7 +470,15 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 			// field is 23502 at the INSERT rather than an unrestricted or
 			// never-expiring connection.
 			Capabilities: capabilityNames(caps.Sorted()),
-			ExpiresAt:    now.Add(grantAbsoluteTTL),
+
+			// m136's column, SUPPLIED EXPLICITLY and NOT NULL with no DEFAULT,
+			// so a forgotten field is 23502 rather than a grant whose scope set
+			// the schema chose. It is the SAME slice the ceiling above was
+			// derived from -- see resolveGrantCapabilities -- so the row and
+			// the ceiling cannot disagree about what this grant holds.
+			OauthScopes: scopeNames(grantedScopes),
+
+			ExpiresAt: now.Add(grantAbsoluteTTL),
 
 			// NULL means "never idle-expire" (m127 DECISION 4), and NULL is the
 			// answer rather than a placeholder. Nothing asks the operator for a
@@ -597,8 +611,17 @@ func (s *Service) MintConnection(ctx context.Context, req MintConnectionRequest)
 // first gets the preset. The second is handed to NarrowTo, which refuses it in
 // so many words -- an empty narrowing is not a way to ask for the default, and
 // treating it as one would grant a capability the operator had just removed.
-func (s *Service) resolveGrantCapabilities(requested *[]Capability) (CapabilitySet, error) {
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+// THE SCOPES ARE A PARAMETER AND NOT A CONSTANT, AND THAT IS m136's CHANGE
+// HERE. This function runs BEFORE the grant row exists, so there is no row to
+// read: the caller passes the scope set the grant is ABOUT TO BE STORED WITH,
+// and the ceiling is derived from that. The two creation paths pass different
+// things and both are honest -- Approve passes the client's re-parsed request,
+// MintConnection passes DefaultGrantScopes() because no client asked -- and
+// each then writes the SAME slice into oauth_scopes. Deriving the ceiling from
+// one value and storing another is the divergence this signature makes
+// impossible to write by accident.
+func (s *Service) resolveGrantCapabilities(scopes []Scope, requested *[]Capability) (CapabilitySet, error) {
+	ceiling, err := OrgDefaultCapabilities(scopes)
 	if err != nil {
 		return CapabilitySet{}, fmt.Errorf("resolve organisation capabilities: %w", err)
 	}

--- a/apps/api/internal/mcp/oauth_test.go
+++ b/apps/api/internal/mcp/oauth_test.go
@@ -1045,6 +1045,10 @@ func TestAuthenticateHandsTheChokepointAnUnscopedPrincipal(t *testing.T) {
 			SiteScopeMode: "all", TokenID: tok.ID, TokenStatus: "active",
 			TokenExpiresAt:    tok.ExpiresAt,
 			GrantCapabilities: []string{string(CapSitesRead)},
+			// The scope column the ceiling is now DERIVED from (m136). Set to
+			// what every live grant holds, because a nil column is refused --
+			// correctly -- as "no scope, so no capability".
+			GrantOauthScopes: []string{string(ScopeRead)},
 			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
 			Authorized:        true,
 		},
@@ -1085,6 +1089,10 @@ func TestAuthenticate_RevocationBitesOnTheNextRequest(t *testing.T) {
 			SiteScopeMode: "all", TokenID: tok.ID, TokenStatus: "active",
 			TokenExpiresAt:    tok.ExpiresAt,
 			GrantCapabilities: []string{string(CapSitesRead)},
+			// The scope column the ceiling is now DERIVED from (m136). Set to
+			// what every live grant holds, because a nil column is refused --
+			// correctly -- as "no scope, so no capability".
+			GrantOauthScopes: []string{string(ScopeRead)},
 			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
 			Authorized:        true,
 		},
@@ -1167,6 +1175,10 @@ func TestAuthenticate_EmptyResolvedScopeGrantsNoSites(t *testing.T) {
 			TokenID: tok.ID, TokenStatus: "active",
 			TokenExpiresAt:    tok.ExpiresAt,
 			GrantCapabilities: []string{string(CapSitesRead)},
+			// The scope column the ceiling is now DERIVED from (m136). Set to
+			// what every live grant holds, because a nil column is refused --
+			// correctly -- as "no scope, so no capability".
+			GrantOauthScopes: []string{string(ScopeRead)},
 			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
 			Authorized:        true,
 		},

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -237,13 +237,20 @@ func AllCapabilities() []Capability {
 // conferred by no scope is not "mint-only", it is UNREACHABLE -- unstorable at
 // mint, and fatal to the whole connection if a row ever holds it.
 //
-// Conferring it therefore requires a second scope, and a second scope cannot be
-// added here alone. grantScopes() is a CONSTANT because mcp_grants has no
-// scopes column, so a second entry in recognisedScopes would hand ScopeRead's
-// capabilities to a grant that never asked for them -- the widening
-// TestGrantScopesIsExactOnlyWhileOneScopeExists exists to force someone to fix
-// by replacing that constant with a real per-grant read. That read needs the
-// column, and the column is a migration, which is not this diff's to write.
+// Conferring it therefore requires a second scope. WHEN THIS PARAGRAPH WAS
+// WRITTEN the blocker was that grantScopes() was a constant -- mcp_grants had
+// no scopes column -- so a second entry in recognisedScopes would have handed
+// ScopeRead's capabilities to a grant that never asked for them. m136 added the
+// column and grantScopes is now a real per-grant read, so THAT widening is
+// closed and this is no longer the thing standing in the way.
+//
+// What stands in the way now is one step further on, and it is smaller but not
+// nothing: the scope set STORED at consent is the approval body re-parsed, not
+// a restatement of the registry, and the two coincide only while
+// recognisedScopes has a single member. The note at Service.Approve in
+// service.go says what has to be bound before a second scope is recognised.
+// That binding, the write scope and the tool behind it belong in one diff,
+// under one review.
 //
 // SO THE CAPABILITY IS SEATED AND NO TOOL IS REGISTERED BEHIND IT YET.
 // registryTools() is unchanged by this diff, and that is the honest ordering

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -198,23 +198,77 @@ var scopeCapabilities = map[Scope][]Capability{
 	},
 }
 
-// grantScopes returns the OAuth scopes a live grant holds.
+// grantScopes reads mcp_grants.oauth_scopes back into the domain type. IT IS A
+// PER-GRANT READ AND NO LONGER A CONSTANT.
 //
-// IT IS A CONSTANT, AND THAT IS THE WHOLE REASON THIS FUNCTION EXISTS RATHER
-// THAN A LITERAL AT THE CALL SITE. mcp_grants has no scopes column (m124
-// DECISION 1 declines to mint one), so there is nothing per-grant to read; every
-// grant that can authenticate holds ScopeRead, because ParseRequestedScopes
-// refuses anything recognisedScopes does not carry and recognisedScopes carries
-// exactly one entry.
+// IT USED TO RETURN []Scope{ScopeRead} UNCONDITIONALLY, and the comment that
+// stood here argued the constant was exact because recognisedScopes held one
+// entry and ParseRequestedScopes refuses anything outside it. That argument was
+// true and it was also the reason the first write capability could never be
+// reached: a capability no scope confers is unstorable at mint AND narrowed
+// away by Authenticate, so seating one in the vocabulary shipped nothing. m136
+// added the column; this function is the read it exists for.
 //
-// That reasoning is load-bearing and it EXPIRES the moment a second scope is
-// recognised: a connection granted only the new scope would still be handed
-// ScopeRead's capabilities, which is a widening rather than a narrowing and is
-// therefore the direction that matters. Naming it here gives
-// TestGrantScopesIsExactOnlyWhileOneScopeExists something to point at, and gives
-// whoever adds that scope one obvious place to replace with a real per-grant
-// read.
-func grantScopes() []Scope {
+// IT DOES NOT FILTER, and the omission is capabilitiesFromColumn's, verbatim
+// and for the same reason. Dropping an unknown name here would hand
+// OrgDefaultCapabilities a set that had already been quietly reduced, so a row
+// carrying a scope outside this build's registry would authenticate as though
+// it carried ONLY the known ones -- the widening wearing the shape of a
+// narrowing. The refusal belongs at OrgDefaultCapabilities, where an unmapped
+// scope rejects the WHOLE set instead of being trimmed out of it, exactly as
+// ParseRequestedScopes refuses an unrecognised scope rather than ignoring it.
+//
+// A NIL OR EMPTY COLUMN YIELDS AN EMPTY SLICE, WHICH MEANS NO AUTHORITY AND
+// NEVER "UNRESTRICTED". That is the one direction this surface must never fail
+// in. mcp_grants_oauth_scopes_not_empty_check makes the value unrepresentable
+// (m136 DECISION 4), so an empty read means something is wrong rather than
+// something is permissive -- and the Go read does not depend on the database
+// being the only writer. OrgDefaultCapabilities refuses an empty scope list by
+// name, and Authenticate refuses it again by name before it gets there.
+func grantScopes(stored []string) []Scope {
+	out := make([]Scope, 0, len(stored))
+	for _, s := range stored {
+		out = append(out, Scope(s))
+	}
+	return out
+}
+
+// scopeNames renders scopes for the text[] column. capabilityNames' twin.
+func scopeNames(scopes []Scope) []string {
+	out := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		out = append(out, string(s))
+	}
+	return out
+}
+
+// DefaultGrantScopes is the scope set stamped onto mcp_grants.oauth_scopes when
+// a new grant is created and NO CLIENT ASKED FOR ONE -- the operator-facing
+// connection-token path (Service.MintConnection), which has no RFC 7591 client
+// behind it and therefore no `scope` request parameter to honour.
+//
+// IT IS NOT grantScopes' OLD CONSTANT MOVED. The old constant answered "what
+// does THIS LIVE GRANT hold", for every grant, without reading it; this answers
+// "what does a grant nobody stated terms for RECEIVE", once, at creation, and
+// is then written to the row that grantScopes reads. The OAuth path does not
+// call it at all: Approve passes the scope set the client requested and the
+// operator consented to, re-parsed from the approval body.
+//
+// IT IS DELIBERATELY THE READ SCOPE AND NOTHING ELSE, and that is the same
+// stance DefaultGrantCapabilities takes one function down: the answer to
+// "nobody asked" is never "everything". It moves no floor -- every grant this
+// surface has ever minted holds exactly {mcp:read}, which is what m136's
+// backfill wrote down -- and it raises no ceiling.
+//
+// A FUNCTION, NOT A PACKAGE VARIABLE, for DefaultGrantCapabilities' reason: a
+// shared slice is one append away from widening every grant this surface has
+// ever minted.
+//
+// WHEN A WRITE SCOPE EXISTS this is where the operator's choice replaces the
+// preset on the token path, and it is NOT where the write scope gets added to
+// the preset. See recognisedScopes in scope.go: a write scope arrives with its
+// own migration and its own review.
+func DefaultGrantScopes() []Scope {
 	return []Scope{ScopeRead}
 }
 

--- a/apps/api/internal/mcp/policy.go
+++ b/apps/api/internal/mcp/policy.go
@@ -67,10 +67,11 @@ const ErrCodeCapabilityWiderThanDefault = "mcp_capability_wider_than_default"
 // something this path enforces. See ToolPolicy.OperatorPermission.
 type Capability string
 
-// The v1 READ vocabulary, one constant per outcome group. m131 seated these
+// The v1 vocabulary, one constant per outcome group. m131 seated the first
 // eight in mcp_grants_capabilities_vocabulary_check and its DECISION 1 is the
 // argument for each name and each boundary; it is not restated here, because a
-// second copy of that argument is a second thing that can drift.
+// second copy of that argument is a second thing that can drift. m135 seated
+// the ninth, CapCachePurge, which is the first member that is not a read.
 //
 // Three properties of the set that this file DOES have to hold:
 //
@@ -78,9 +79,13 @@ type Capability string
 //     render the operator-facing form as `site.*`; those are the SCREEN's
 //     labels and the picker may render whatever label it likes above these
 //     strings.
-//   - EVERY MEMBER ENDS IN `.read`, which is what makes "no write capability is
-//     reachable from this build" checkable by pattern rather than by claim.
-//     TestEveryCapabilityIsARead pins it.
+//   - EVERY MEMBER EXCEPT CapCachePurge ENDS IN `.read`, and the exception is
+//     enumerated rather than pattern-matched. This used to be a pure pattern
+//     test ("no write capability is reachable from this build"), which was
+//     checkable precisely while it was true. It is no longer true, so the
+//     property is now stated as a named allowlist of non-read members:
+//     TestEveryCapabilityIsAReadOrAnEnumeratedWrite pins it, and a second
+//     non-read member arriving without being named there goes red.
 //   - The set is CLOSED, for the same reason recognisedScopes is closed: an
 //     unrecognised capability must be a refusal, never a token quietly dropped
 //     from a set that is then honoured.
@@ -102,6 +107,17 @@ const (
 	// agree exactly (m131 DECISION 5), and it is in NO scope's capability list
 	// so no grant can be minted holding it. See scopeCapabilities.
 	CapContentRead Capability = "mcp.content.read"
+
+	// CapCachePurge is THE FIRST NON-READ MEMBER OF THIS VOCABULARY, seated by
+	// m135. It gates one operation: clear a site's page cache.
+	//
+	// IT IS SEATED AND, LIKE CapContentRead, IT IS CONFERRED BY NO SCOPE -- so
+	// no grant can currently be minted holding it and no connection can
+	// currently call the tool behind it. That is not an oversight and it is not
+	// the same stance for the same reason; see the CapCachePurge paragraph on
+	// scopeCapabilities for the argument, and the ceiling note there for what
+	// has to land before it can be conferred at all.
+	CapCachePurge Capability = "mcp.cache.purge"
 )
 
 // capabilityVocabulary is the CLOSED set of capabilities this surface knows.
@@ -110,7 +126,7 @@ const (
 //
 // IT IS THE GO HALF OF A SET THAT IS CLOSED IN TWO PLACES. The other half is
 // mcp_grants_capabilities_vocabulary_check, and the two must hold the same
-// eight names: a name the database accepts and this map does not is refused at
+// NINE names: a name the database accepts and this map does not is refused at
 // a different layer with a different error, and a name this map accepts and the
 // database does not is a 23514 at INSERT on a path an operator reached through
 // a wizard. TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole (in
@@ -119,15 +135,21 @@ const (
 // KNOWING a capability is not CONFERRING it and is not DEFAULTING to it. Those
 // are three separate sets and this is the widest of them:
 //
-//	capabilityVocabulary   -- what may be spelled at all           (8)
-//	scopeCapabilities      -- what a scope confers, the CEILING    (7)
+//	capabilityVocabulary     -- what may be spelled at all         (9)
+//	scopeCapabilities        -- what a scope confers, the CEILING  (7)
 //	DefaultGrantCapabilities -- what an unasked grant receives     (1)
 //
+// THE GAP BETWEEN 9 AND 7 IS TWO DELIBERATELY UNREACHABLE MEMBERS, and it is
+// the shape of this design rather than a backlog: CapContentRead (m131
+// DECISION 3) and CapCachePurge (m135). Both are spellable, neither is
+// conferred, so NarrowTo refuses either by name and no mint path can store one.
+//
 // Widening this map alone widens NOTHING a grant receives, and that separation
-// is the whole point of this commit. See DefaultGrantCapabilities.
+// is the whole point. See DefaultGrantCapabilities.
 var capabilityVocabulary = map[Capability]struct{}{
 	CapActivityRead:    {},
 	CapBackupsRead:     {},
+	CapCachePurge:      {},
 	CapContentRead:     {},
 	CapDiagnosticsRead: {},
 	CapPerformanceRead: {},
@@ -186,6 +208,61 @@ func AllCapabilities() []Capability {
 // consent, arriving as a side effect of a registry edit. Adding it to this list
 // is a one-line change at the moment the content tools ship, in that diff,
 // under that review. TestContentReadIsKnownButConferredByNoScope pins it.
+//
+// ---------------------------------------------------------------------------
+// CapCachePurge IS ALSO ABSENT, AND THAT IS THE m135 CEILING DECISION.
+//
+// THE CHOICE MADE: mcp.cache.purge is conferred by NO SCOPE. ScopeRead does not
+// confer it and no second scope is added here.
+//
+// WHY NOT ScopeRead. It is a read scope. The paragraph above already states the
+// rule this map encodes -- "the read scope confers the READ capabilities, and a
+// member that does not end in `.read` is not conferred by it until someone
+// writes that line and defends it" -- and mcp.cache.purge is the first member
+// that tests it. The line cannot be defended: every live grant holds ScopeRead
+// by construction (see grantScopes), and every operator who consented to it
+// consented to a screen describing reads. Adding one entry here would hand the
+// power to purge a live site's cache to EVERY GRANT THIS SURFACE HAS EVER
+// MINTED, retroactively, with no second consent -- a write capability arriving
+// through a scope the operator did not read, which is the exact failure m135's
+// own note (3)(a) and m131 DECISION 3 both name.
+//
+// WHY NOT A SECOND SCOPE EITHER, WHICH IS THE PART THAT BLOCKS THE TOOL.
+// "Mint-only" is not a mechanism this package has, and reading it as one is the
+// trap here. There is no mint path that bypasses this ceiling: BOTH creation
+// paths resolve through Service.resolveGrantCapabilities (mint.go:600), which
+// calls ceiling.NarrowTo for the explicit request AND for the preset, and
+// Service.Authenticate (service.go:1408) re-derives the same ceiling and
+// NarrowTo's the STORED column against it on every request. So a capability
+// conferred by no scope is not "mint-only", it is UNREACHABLE -- unstorable at
+// mint, and fatal to the whole connection if a row ever holds it.
+//
+// Conferring it therefore requires a second scope, and a second scope cannot be
+// added here alone. grantScopes() is a CONSTANT because mcp_grants has no
+// scopes column, so a second entry in recognisedScopes would hand ScopeRead's
+// capabilities to a grant that never asked for them -- the widening
+// TestGrantScopesIsExactOnlyWhileOneScopeExists exists to force someone to fix
+// by replacing that constant with a real per-grant read. That read needs the
+// column, and the column is a migration, which is not this diff's to write.
+//
+// SO THE CAPABILITY IS SEATED AND NO TOOL IS REGISTERED BEHIND IT YET.
+// registryTools() is unchanged by this diff, and that is the honest ordering
+// rather than a shortfall: a tool requiring this capability would be dropped
+// from every tools/list by withinOrgCeiling and answered as an unregistered
+// name by AuthorizeTool, for every connection, so registering it would ship an
+// authorisation path -- site-scope enforcement, agent dispatch, audit -- that
+// no test could exercise end to end through Authenticate, because no grant can
+// hold the capability that reaches it. An unreachable write path is exactly the
+// thing that gets reviewed once and then quietly goes wrong.
+//
+// The tool, its site-scope check and its dispatch belong in the SAME diff as
+// the scopes column and the write scope, where all three can be proved
+// together. That is the same seated-and-unreachable stance CapContentRead has
+// held since m131, and for a write capability it is the direction that fails
+// safe. TestCachePurgeIsKnownButConferredByNoScope pins it, and it is the test
+// that must be DELETED -- not edited -- by whoever confers this, so the
+// conferral cannot happen quietly.
+// ---------------------------------------------------------------------------
 var scopeCapabilities = map[Scope][]Capability{
 	ScopeRead: {
 		CapActivityRead,

--- a/apps/api/internal/mcp/policy_test.go
+++ b/apps/api/internal/mcp/policy_test.go
@@ -122,34 +122,115 @@ func TestEveryRecognisedScopeHasACapabilityMapping(t *testing.T) {
 	}
 }
 
-// TestGrantScopesIsExactOnlyWhileOneScopeExists is a TRIPWIRE, not a property
-// test. It asserts the precondition that makes grantScopes' constant honest.
+// TestGrantScopesIsAPerGrantReadAndNeverAConstant IS THE RENAMED TRIPWIRE.
 //
-// Authenticate hands OrgDefaultCapabilities a constant instead of the grant's
-// own scopes, which is exact only while every live grant holds the same single
-// scope. Adding a second recognised scope silently converts that constant into
-// a WIDENING: a connection granted only the new scope keeps being handed
-// ScopeRead's capabilities, and no other test in this package notices, because
-// TestEveryRecognisedScopeHasACapabilityMapping pins the map's totality rather
-// than Authenticate's input.
+// It used to be TestGrantScopesIsExactOnlyWhileOneScopeExists, and it was a
+// tripwire rather than a property test: it asserted `len(recognisedScopes) == 1`
+// so that adding a second scope went red and forced whoever did it to replace
+// grantScopes' constant with a real per-grant read. m136 added
+// mcp_grants.oauth_scopes and that read now exists, so the precondition the old
+// name asserted is no longer the thing being defended -- and a test whose name
+// asserts something the build no longer does is worse than no test.
 //
-// So this fails the moment recognisedScopes grows. The fix when it does is NOT
-// to update the number here: it is to store the grant's scopes and read them,
-// then delete this test.
-func TestGrantScopesIsExactOnlyWhileOneScopeExists(t *testing.T) {
-	if len(recognisedScopes) != 1 {
-		t.Fatalf("recognisedScopes now holds %d scopes, so grantScopes()'s constant is no longer "+
-			"exact: a connection granted only one of them is still handed %v's capabilities by "+
-			"Authenticate, which WIDENS it. Read the grant's own scopes instead of a constant "+
-			"(mcp_grants needs the column first -- see m124 DECISION 1), then delete this test. "+
-			"Do not just update the count.", len(recognisedScopes), ScopeRead)
+// IT IS NOT DELETED AND IT IS NOT WEAKER. The old test's own instructions said
+// to delete it once the read landed; that would have left the read itself
+// unpinned, and the read is where the failure direction lives. So it is
+// renamed and repointed at the property the constant's removal bought:
+// grantScopes ANSWERS FROM ITS ARGUMENT. Every case below fails against the old
+// `return []Scope{ScopeRead}` body.
+func TestGrantScopesIsAPerGrantReadAndNeverAConstant(t *testing.T) {
+	// 1. IT REFLECTS THE ROW. A constant returns {mcp:read} for every input,
+	// so a row holding something else proves the argument is read at all.
+	got := grantScopes([]string{"mcp:write-someday"})
+	if len(got) != 1 || got[0] != Scope("mcp:write-someday") {
+		t.Fatalf("grantScopes([mcp:write-someday]) = %v, want exactly "+
+			"[mcp:write-someday].\nIf this returned [%v] the function is still "+
+			"answering from a constant and every grant shares one ceiling.",
+			got, ScopeRead)
 	}
-	got := grantScopes()
+
+	// 2. IT DOES NOT FILTER. This is the failure direction that matters and it
+	// is capabilitiesFromColumn's rule verbatim: trimming the unknown entry
+	// would hand OrgDefaultCapabilities {mcp:read} alone, and the grant would
+	// authenticate as though its row carried only the known scope.
+	mixed := grantScopes([]string{string(ScopeRead), "mcp:not-a-scope"})
+	if len(mixed) != 2 {
+		t.Fatalf("grantScopes dropped an unrecognised scope: got %v from "+
+			"{mcp:read, mcp:not-a-scope}.\nA trimmed read is a WIDENING wearing "+
+			"the shape of a narrowing: the row says two things, the ceiling is "+
+			"computed from one, and nobody learns the two disagreed.", mixed)
+	}
+
+	// 3. AND THE UNKNOWN ENTRY REFUSES THE WHOLE SET rather than shrinking it.
+	// Step 2 only proves the read carried it; this proves carrying it matters.
+	if set, err := OrgDefaultCapabilities(mixed); err == nil {
+		t.Fatalf("a scope set containing an unrecognised scope resolved to %v.\n"+
+			"It must REFUSE. Resolving it means a row carrying a scope outside "+
+			"this build's registry authenticates holding the known scopes' "+
+			"capabilities, which is exactly what not filtering the read exists "+
+			"to prevent.", set.Sorted())
+	}
+
+	// 4. NIL AND EMPTY ARE NO AUTHORITY, NEVER UNRESTRICTED. The database makes
+	// the value unrepresentable (m136 DECISION 4), so reaching either means a
+	// writer outside that constraint -- and the answer to "I cannot tell what
+	// this grant may do" is nothing at all.
+	for _, stored := range [][]string{nil, {}} {
+		if sc := grantScopes(stored); len(sc) != 0 {
+			t.Fatalf("grantScopes(%v) = %v, want an empty slice", stored, sc)
+		}
+		if set, err := OrgDefaultCapabilities(grantScopes(stored)); err == nil {
+			t.Fatalf("an empty scope column resolved to %v instead of refusing.\n"+
+				"Absence must never widen.", set.Sorted())
+		}
+	}
+}
+
+// TestDefaultGrantScopesIsTheReadScopeAndNothingElse pins what a grant nobody
+// stated terms for RECEIVES, so a future edit cannot widen it silently.
+//
+// This is the pin the old tripwire's `len(recognisedScopes) == 1` assertion
+// used to provide by accident, moved to the thing it was actually protecting.
+// recognisedScopes may now grow -- that is what m136 made safe -- but a wider
+// REGISTRY must not become a wider DEFAULT: every grant this surface has ever
+// minted holds exactly {mcp:read}, which is what m136's backfill wrote down,
+// and the answer to "nobody asked" is never "everything we have".
+func TestDefaultGrantScopesIsTheReadScopeAndNothingElse(t *testing.T) {
+	got := DefaultGrantScopes()
 	if len(got) != 1 || got[0] != ScopeRead {
-		t.Fatalf("grantScopes() = %v, want exactly [%v]", got, ScopeRead)
+		t.Fatalf("DefaultGrantScopes() = %v, want exactly [%v].\n"+
+			"Widening the default hands new authority to every grant minted "+
+			"without an explicit request, with no second consent from anyone. A "+
+			"new scope belongs in recognisedScopes and in an operator's explicit "+
+			"choice, not in the preset.", got, ScopeRead)
 	}
 	if _, ok := recognisedScopes[got[0]]; !ok {
-		t.Fatalf("grantScopes() returns %v, which is not a recognised scope", got[0])
+		t.Fatalf("DefaultGrantScopes() returns %v, which is not a recognised scope", got[0])
+	}
+
+	// It must also be REACHABLE: a preset that resolves to no capability mints
+	// a credential that authenticates and reaches nothing.
+	set, err := OrgDefaultCapabilities(got)
+	if err != nil {
+		t.Fatalf("the default scope set %v confers no capability: %v", got, err)
+	}
+	if set.IsEmpty() {
+		t.Fatalf("the default scope set %v resolved to an empty ceiling", got)
+	}
+}
+
+// TestScopeNamesRoundTripsThroughTheColumn pins the pair that crosses the
+// database boundary. scopeNames writes the column and grantScopes reads it, and
+// a mismatch between them is invisible to the compiler.
+func TestScopeNamesRoundTripsThroughTheColumn(t *testing.T) {
+	in := []Scope{ScopeRead}
+	out := grantScopes(scopeNames(in))
+	if len(out) != len(in) || out[0] != in[0] {
+		t.Fatalf("scopeNames -> grantScopes round trip changed %v into %v", in, out)
+	}
+	if names := scopeNames(nil); len(names) != 0 {
+		t.Fatalf("scopeNames(nil) = %v, want an empty slice -- a nil column is "+
+			"refused by the not-empty CHECK, not repaired here", names)
 	}
 }
 

--- a/apps/api/internal/mcp/registry_test.go
+++ b/apps/api/internal/mcp/registry_test.go
@@ -51,7 +51,7 @@ func nonEmptyRegistry(t *testing.T) []ToolPolicy {
 // A test that needs a NARROWER ceiling than the vocabulary -- the org-switched-
 // off case -- must say so, and authWithCeiling is how.
 func authWith(caps CapabilitySet, siteIDs ...uuid.UUID) AuthorizedRequest {
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	ceiling, err := OrgDefaultCapabilities(DefaultGrantScopes())
 	if err != nil {
 		// Not t.Fatal: authWith has no *testing.T and this is unreachable while
 		// scopeCapabilities is total over recognisedScopes, which

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -821,15 +821,40 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 
 	// Re-run the exit gate on the approval too. The consent screen's scope list
 	// arrives back over the wire and a resubmitted form is caller input like
-	// any other; re-parsing means a tampered approval cannot widen what the
-	// authorize call already refused.
+	// any other, so it is re-parsed rather than trusted.
+	//
 	// THE RESULT IS KEPT NOW, NOT DISCARDED. m136 gave the grant an
 	// oauth_scopes column and this is the only place on the OAuth path that
-	// knows what the client asked for and the operator consented to. Storing
-	// the re-parsed value rather than a preset is what makes the stored set the
-	// consent rather than a restatement of the registry -- and it is the same
-	// value the ceiling below is computed from, so the row and the ceiling
-	// cannot disagree.
+	// carries what the client asked for and the operator saw. The stored value
+	// is this re-parsed set rather than a preset, and it is the same value the
+	// ceiling below is computed from, so the row and the ceiling cannot
+	// disagree.
+	//
+	// BUT BE EXACT ABOUT WHAT THE RE-PARSE ESTABLISHES, BECAUSE IT IS LESS THAN
+	// IT LOOKS. Authorize mints nothing: the whole consent context round-trips
+	// through the browser and comes back here as caller input, and
+	// ParseRequestedScopes checks only that every member is in recognisedScopes.
+	// It does NOT check that this set is the set the authorize call carried. So
+	// the stored set is the approval BODY, constrained by registry membership,
+	// and calling it "the consent rather than a restatement of the registry"
+	// overstates it -- the two are the same thing only while the registry has a
+	// single member, which is why nothing is reachable here today: a tampered
+	// body can produce exactly {mcp:read} and nothing else, which is what the
+	// old hard-coded constant produced anyway.
+	//
+	// WHOEVER ADDS THE SECOND RECOGNISED SCOPE MUST FIX THIS FIRST, and this
+	// comment is the only thing left pointing at it. The branch that introduced
+	// the column removed TestGrantScopesIsExactOnlyWhileOneScopeExists, which
+	// asserted len(recognisedScopes) == 1; removing it was right, because m136
+	// exists to make the registry safe to grow -- but that assertion was the
+	// tripwire that would have forced a visit to this line. The moment a second
+	// scope is recognised, an approval body naming it is accepted here on the
+	// strength of registry membership alone, and the grant is stored holding a
+	// scope the authorize call need never have requested. Bind the stored set
+	// to what that call actually carried -- the authorize request has to leave
+	// behind something server-side to compare against -- before recognising the
+	// second scope, not in the diff after it. That binding is the write-scope
+	// PR's prerequisite and is deliberately not built here.
 	grantedScopes, err := ParseRequestedScopes(scopesToString(req.Consent.Scopes))
 	if err != nil {
 		return Approval{}, err

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -823,7 +823,15 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 	// arrives back over the wire and a resubmitted form is caller input like
 	// any other; re-parsing means a tampered approval cannot widen what the
 	// authorize call already refused.
-	if _, err := ParseRequestedScopes(scopesToString(req.Consent.Scopes)); err != nil {
+	// THE RESULT IS KEPT NOW, NOT DISCARDED. m136 gave the grant an
+	// oauth_scopes column and this is the only place on the OAuth path that
+	// knows what the client asked for and the operator consented to. Storing
+	// the re-parsed value rather than a preset is what makes the stored set the
+	// consent rather than a restatement of the registry -- and it is the same
+	// value the ceiling below is computed from, so the row and the ceiling
+	// cannot disagree.
+	grantedScopes, err := ParseRequestedScopes(scopesToString(req.Consent.Scopes))
+	if err != nil {
 		return Approval{}, err
 	}
 	if err := ValidateSiteScopeRequest(req.SiteScope); err != nil {
@@ -868,7 +876,7 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 	// organisation's ceiling refuses the whole approval here -- no code, no
 	// grant, no half-made connection -- rather than being narrowed to the
 	// intersection behind the operator's back.
-	caps, err := s.resolveGrantCapabilities(req.Capabilities)
+	caps, err := s.resolveGrantCapabilities(grantedScopes, req.Capabilities)
 	if err != nil {
 		return Approval{}, err
 	}
@@ -911,7 +919,20 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 			// applied it -- refusing a set wider than the organisation
 			// ceiling rather than quietly intersecting it.
 			Capabilities: capabilityNames(caps.Sorted()),
-			ExpiresAt:    s.now().UTC().Add(grantAbsoluteTTL),
+
+			// m136's column, SUPPLIED EXPLICITLY for the same reason and with
+			// the same failure mode: NOT NULL, no DEFAULT, so omitting this
+			// field would compile, leave it nil, and take 23502 at the INSERT
+			// rather than mint a grant whose scope set the schema chose.
+			//
+			// IT IS THE CLIENT'S REQUEST, RE-PARSED FROM THIS APPROVAL, and not
+			// DefaultGrantScopes(). The preset is what the token path uses
+			// because no client asked it anything; here one did, the operator
+			// consented to it on the screen, and the value the ceiling above
+			// was computed from is the value written down.
+			OauthScopes: scopeNames(grantedScopes),
+
+			ExpiresAt: s.now().UTC().Add(grantAbsoluteTTL),
 
 			// IDLE EXPIRY IS WRITTEN NULL, AND NULL IS THE ANSWER, NOT A
 			// PLACEHOLDER. NULL means "never idle-expire" (m127 DECISION 4).
@@ -1390,22 +1411,35 @@ func (s *Service) Authenticate(ctx context.Context, bearer string) (AuthorizedRe
 	// honoured, and not quietly dropped. Dropping would be fail-closed and
 	// still wrong, for the reason written on NarrowTo.
 	//
-	// ONE GAP SURVIVES m127, AND IT IS A LATENT WIDENING RATHER THAN A MISSING
-	// NARROWING: the scope list below is a CONSTANT, not the grant's own
-	// scopes. mcp_grants still has no scopes column, so there is nothing
-	// per-grant to read; grantScopes() returns the one scope every live grant
-	// holds by construction. That is exact TODAY and only because
-	// recognisedScopes holds exactly one entry. The day a second scope joins
-	// it, a connection granted ONLY that scope would still be handed
-	// ScopeRead's capabilities as its CEILING here -- a widening, and one no
-	// existing test catches, because
-	// TestEveryRecognisedScopeHasACapabilityMapping pins the map's totality and
-	// not this function's input.
+	// THE SCOPES ARE THE GRANT'S OWN, READ OFF THE SAME ROW AND THE SAME
+	// TRANSACTION, AND THAT IS WHAT m136 CHANGED. This line used to pass
+	// grantScopes() -- a hard-coded {ScopeRead} -- because mcp_grants had no
+	// scopes column. The constant was exact only while recognisedScopes held one
+	// entry, and it was exact in the direction that matters least: the day a
+	// second scope joined the registry, a connection granted ONLY that scope
+	// would still have been handed ScopeRead's capabilities as its CEILING here.
+	// A ceiling computed from a constant is a guess that agrees with the row by
+	// coincidence.
 	//
-	// TestGrantScopesIsExactOnlyWhileOneScopeExists goes red the moment
-	// recognisedScopes grows, so whoever adds the second scope is forced to
-	// come here and read a grant's scopes instead of a constant.
-	ceiling, err := OrgDefaultCapabilities(grantScopes())
+	// AN EMPTY SCOPE COLUMN IS REFUSED BY NAME AND IS NEVER READ AS
+	// UNRESTRICTED. mcp_grants_oauth_scopes_not_empty_check makes '{}'
+	// unrepresentable (m136 DECISION 4), so reaching this with an empty set means
+	// a writer outside that constraint, and the fail-closed answer to "I cannot
+	// tell what this grant may do" is nothing at all. OrgDefaultCapabilities
+	// refuses it too; it is refused here first so the message names the SCOPE
+	// column rather than the capability one, which is the difference between an
+	// operator looking at the right row and the wrong one.
+	//
+	// IT IS 403, NOT 401, for the reason spelled out on the empty-capabilities
+	// refusal below: an MCP client that receives 401 re-runs the OAuth handshake,
+	// which cannot repair a stored column.
+	scopes := grantScopes(chk.GrantOauthScopes)
+	if len(scopes) == 0 {
+		return AuthorizedRequest{}, domain.Forbidden(ErrCodeCapabilityUnmapped,
+			"this connection holds no scope, so it confers no capability")
+	}
+
+	ceiling, err := OrgDefaultCapabilities(scopes)
 	if err != nil {
 		// A capability set that cannot be resolved is a REFUSAL, never an
 		// empty-but-proceeding one. An AuthorizedRequest with a zero-value
@@ -2297,20 +2331,20 @@ func (s *Service) RevokeConnection(ctx context.Context, p domain.Principal, gran
 // date in the year 1 and would render as "last used 1 Jan 0001" for a
 // connection that has never been used.
 //
-// Scopes is DERIVED, not read. mcp_grants has no scopes column (m124 Decision
-// 1 declines to add one, so that a write capability cannot appear without a
-// migration), and grantScopes() returns the one scope every live grant holds by
-// construction. That is exact only while recognisedScopes has one entry, which
-// is what TestGrantScopesIsExactOnlyWhileOneScopeExists pins -- when a second
-// scope is added, that test goes red and this line has to start reading the
-// grant instead of a constant.
+// Scopes is READ, not derived, and m136 is what made that possible. It used to
+// be grantScopes() -- a constant -- on the reasoning that every live grant held
+// {mcp:read} by construction. That rendered the same answer for every row
+// whether or not the row agreed, which on an operator console is worse than no
+// column at all: the screen would have kept saying "mcp:read" for a grant whose
+// stored scope set had changed. It is now grantScopes(g.OauthScopes), the same
+// unfiltered reader Authenticate uses, so the console shows what the row holds.
 func connectionFromGrant(g sqlc.McpGrant) Connection {
 	return Connection{
 		ID:            g.ID,
 		Name:          g.Name,
 		Status:        GrantStatus(g.Status),
 		SiteScopeMode: SiteScopeMode(g.SiteScopeMode),
-		Scopes:        grantScopes(),
+		Scopes:        grantScopes(g.OauthScopes),
 		// Read straight off the row via capabilitiesFromColumn -- the same
 		// reader Authenticate uses on chk.GrantCapabilities -- and never
 		// recomputed. See Connection.Capabilities.

--- a/apps/api/internal/mcp/toolcall_limit_test.go
+++ b/apps/api/internal/mcp/toolcall_limit_test.go
@@ -109,6 +109,9 @@ func (s *twoTenantStore) ReCheckAuthorization(
 		GrantID:           grant,
 		TokenID:           uuid.New(),
 		GrantCapabilities: []string{string(CapSitesRead)},
+		// The scope column the ceiling is now DERIVED from (m136). A nil
+		// column is refused as "no scope, so no capability".
+		GrantOauthScopes: []string{string(ScopeRead)},
 		GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
 	}, nil
 }

--- a/apps/api/internal/mcp/transport_test.go
+++ b/apps/api/internal/mcp/transport_test.go
@@ -84,6 +84,10 @@ func liveGrantStore(siteIDs ...uuid.UUID) *fakeStore {
 			// the service was still computing capabilities instead of reading
 			// them.
 			GrantCapabilities: []string{string(CapSitesRead)},
+			// The scope column the ceiling is now DERIVED from (m136). Set to
+			// what every live grant holds, because a nil column is refused --
+			// correctly -- as "no scope, so no capability".
+			GrantOauthScopes: []string{string(ScopeRead)},
 			GrantExpiresAt:    time.Now().UTC().Add(90 * 24 * time.Hour),
 		},
 		scopeSites: siteIDs,

--- a/apps/api/migrations/20260906000000_m135_mcp_cache_purge_capability.sql
+++ b/apps/api/migrations/20260906000000_m135_mcp_cache_purge_capability.sql
@@ -1,0 +1,279 @@
+-- m135 - seat the FIRST NON-READ capability: 'mcp.cache.purge'.
+--
+-- This migration CORRECTS NOTHING. It edits no applied migration and re-runs no
+-- earlier backfill. m131 is correct and every decision it records is preserved
+-- here in full; this file is the event m131 DECISION 2 said would come.
+--
+-- m131 DECISION 2, verbatim:
+--
+--     "Every member of this vocabulary ends in '.read'. The next migration that
+--      adds a member not ending in '.read' is the one that needs the write
+--      review."
+--
+-- THIS IS THAT MIGRATION. The '.read' invariant m131 made checkable by pattern
+-- ends here, deliberately and on its own diff, which is precisely the shape
+-- m124 DECISION 1 built the closed CHECK to force.
+--
+-- CONVERGE PATH. Every database in every state converges by applying this file
+-- and nothing else. There is no separate converge migration owed and no
+-- operator step, for the identical reason m131 gave: the only object this
+-- migration changes is a CHECK constraint whose definition is a literal, so the
+-- constraint's post-state is a function of THIS FILE ALONE and not of what the
+-- database held before. Step (1) drops the constraint by name whatever its
+-- current definition; step (2) re-adds the definition written here. A database
+-- that ran m127, a database that ran m131, and a database created after this
+-- file all end with the identical constraint.
+--
+-- That property is what makes the ordinal collision in DECISION 4 dangerous
+-- rather than merely untidy, and DECISION 4 is the part of this file a reviewer
+-- must not skip.
+--
+-- ===========================================================================
+-- DECISION 1: WHY 'mcp.cache.purge' IS THE FIRST WRITE
+-- ===========================================================================
+--
+-- It is the safest available write in the product, and "safest" here is a
+-- property of the operation rather than a judgement about it:
+--
+--   a. IT IS IDEMPOTENT AND CONVERGENT. The agent-side command is `cache_purge`,
+--      labelled Write / Idempotent. A retry converges and loses nothing; a
+--      second purge of an already-purged cache is indistinguishable from the
+--      first. Every other write on the roadmap has a retry story that has to be
+--      argued. This one does not.
+--
+--   b. IT DESTROYS NO AUTHORED STATE. A page cache is derived data, regenerated
+--      from the site's own content on the next request. There is no version of
+--      this operation that loses something a human wrote. Contrast the write
+--      group the wireframes draw next to it -- content editing -- which is
+--      exactly a write over authored state and is why that one arrives as
+--      '.propose' with an approval step rather than as a bare '.write'.
+--
+--   c. ITS BLAST RADIUS IS A SLOWER PAGE LOAD. The worst outcome of an
+--      unwanted purge is that the next few requests miss cache and the site
+--      rebuilds it. That is a performance event, not a data event, and it is
+--      self-healing on the timescale of one page view.
+--
+-- WHY IT IS STILL A REVIEWED EVENT DESPITE ALL THAT. It changes a live site on
+-- purpose. m131 DECISION 2 does not say "the first DANGEROUS write gets the
+-- review"; it says the first member not ending in '.read' does, because the
+-- boundary being defended is read-versus-write and not safe-versus-unsafe. A
+-- capability that is nearly harmless is the correct first crossing of that
+-- boundary -- it is the crossing itself that is being reviewed here, and doing
+-- it with the mildest possible member is the point rather than a loophole.
+--
+-- ===========================================================================
+-- DECISION 2: THE NAME
+-- ===========================================================================
+--
+--   mcp.cache.purge   MAY I CLEAR THIS SITE'S PAGE CACHE. Purging the cached
+--                     copies of a site's pages so the next visitor gets a fresh
+--                     render.
+--
+-- THE THREE SEGMENTS, following m131 DECISION 1 exactly:
+--
+--   a. THE `mcp.` PREFIX IS FROZEN, not chosen. m131 records why: every grant
+--      this surface has ever minted is spelled with it, and the operator-facing
+--      labels on the Step 4 screen are the frontend's business. One prefix.
+--
+--   b. `cache` IS THE OUTCOME DOMAIN, in the operator's words. It is what a
+--      human ticks on a checkbox and recognises without being taught. It is NOT
+--      mechanism-shaped: there is no 'mcp.wp_cli.run', no 'mcp.agent.command'
+--      and no 'mcp.http.post' here, and m131 DECISION 1 forbids all three
+--      shapes by name. An operator grants "clear my cache", never "run a
+--      command on my site that happens to clear my cache".
+--
+--   c. `.purge` IS THE VERB, AND IT IS NEITHER '.read' NOR '.write' NOR
+--      '.propose'. m131 named '.propose' and '.write' as the write side's
+--      suffixes. This is a third, and that is deliberate rather than a drift:
+--
+--        - '.propose' would be a lie. A propose-shaped capability means the
+--          assistant drafts a change and a human approves it before it lands.
+--          There is no approval step here and none is wanted for an operation
+--          whose worst case is a slow page load; wiring a proposal queue for it
+--          would train operators to click through approvals that never matter,
+--          which is how an approval step stops being read at all.
+--
+--        - '.write' would be broader than the thing. '.write' on a domain reads
+--          as "may change what is in it". This capability confers exactly one
+--          operation, purge, and cannot create, edit or configure a cache. A
+--          name wider than its grant is a name that will be widened in code
+--          later without a migration, because the string already sounds like it
+--          covers the new thing.
+--
+--      The suffix is the OPERATION when the domain has exactly one, and the
+--      general verb when it has several. That rule is stated here so the next
+--      write capability has something to follow rather than a precedent to
+--      guess at.
+--
+-- THE '.read' PATTERN CHECK IS NOW DEAD, AND ITS OBITUARY BELONGS HERE. m131
+-- offered "no write capability is seated" as a property checkable by pattern:
+-- every member ends in '.read'. After this file that check answers "a write is
+-- seated" and it can no longer say WHICH, so it must not be reused as a safety
+-- property. What replaces it is enumeration: the nine members below, read by a
+-- human. Nothing in the tree should grep for '.read' to decide what this
+-- vocabulary permits.
+--
+-- ===========================================================================
+-- DECISION 3: EXACTLY ONE MEMBER IS ADDED, AND NOTHING IS BACKFILLED
+-- ===========================================================================
+--
+-- WIDENING A CONTAINMENT CHECK CANNOT INVALIDATE AN EXISTING ROW. The
+-- constraint is `capabilities <@ ARRAY[...]`, array containment, and widening
+-- the right-hand array is MONOTONE: a row contained by the smaller array is
+-- contained by every superset. The empty array '{}' -- zero capabilities, the
+-- restrictive value -- is contained by every array and still passes, as m127
+-- intended. Step (2) re-adds WITHOUT `NOT VALID`, so PostgreSQL scans the table
+-- and would refuse this migration outright rather than leave an unchecked row.
+--
+-- WHAT THIS MIGRATION DOES NOT DO: it does not widen a single existing grant.
+-- Every grant that held '{mcp.sites.read}' before this file holds exactly
+-- '{mcp.sites.read}' after it. The CHECK is a CEILING on what a grant MAY hold,
+-- not a floor and not a default; raising a ceiling moves nothing under it.
+-- There is no backfill here and none is wanted -- a backfill would hand the
+-- power to change a live site to credentials whose operators consented only to
+-- reads, which is the exact failure m127 DECISION 1 and m131 DECISION 4 both
+-- refuse.
+--
+-- Nine members against the 64-element ceiling m127's shape check imposes, so
+-- the ceiling is not in play and the shape check is untouched.
+--
+-- ===========================================================================
+-- DECISION 4: ORDINAL COLLISION -- READ THIS BEFORE MERGING EITHER BRANCH
+-- ===========================================================================
+--
+-- THIS ORDINAL IS 20260906000000/m135 AND NOT 20260905000000/m134, BECAUSE
+-- m134 IS ALREADY TAKEN ON AN UNMERGED BRANCH. At the time this file was
+-- written, `pr675` carries:
+--
+--     apps/api/migrations/20260905000000_m134_mcp_updates_propose_capability.sql
+--
+-- which drops and re-adds THIS SAME CONSTRAINT, by the same name, over a
+-- nine-member list that is m131's eight plus 'mcp.updates.propose'. It is not
+-- in HEAD and it is not assumed here.
+--
+-- THE HAZARD IS NOT THE FILENAME. Taking a free ordinal avoids a collision on
+-- disk and avoids nothing else. Both files DROP the constraint by name and
+-- re-add a LITERAL list, and that literal is the whole post-state -- the same
+-- property the CONVERGE PATH note above relies on. So if both files ever apply
+-- to one database, THE ONE WITH THE HIGHER ORDINAL APPLIES SECOND AND ITS LIST
+-- WINS ENTIRELY. This file's ordinal is higher. On a database that applies
+-- both, in order:
+--
+--     m134 seats  ...+ 'mcp.updates.propose'   -> nine members
+--     m135 re-adds ...+ 'mcp.cache.purge'      -> nine members, and
+--                                                 'mcp.updates.propose' IS GONE
+--
+-- The loss is SILENT. Containment is monotone in the widening direction only;
+-- NARROWING it is not, and step (2) re-adds WITHOUT `NOT VALID`, so a grant row
+-- already holding 'mcp.updates.propose' makes the table scan fail and this
+-- migration errors inside main() at boot -- a control-plane outage on every
+-- install that had minted such a grant. If no such grant exists yet, the scan
+-- passes, the member vanishes from the vocabulary with no error at all, and the
+-- first symptom is a 23514 at INSERT on the wizard path some days later.
+--
+-- WHAT IS OWED, AND BY WHOM. Whichever of the two branches merges SECOND owes a
+-- reconciling migration, at a fresh ordinal, whose literal list names BOTH
+-- writes alongside m131's eight. Neither branch may quietly adopt the other's
+-- member: 'mcp.updates.propose' is a proposal-gated write over update runs and
+-- is a different review from this one, and seating it here to dodge the
+-- reconcile would spend that review to save a migration -- which m131 DECISION
+-- 2 already calls exactly backwards. This file therefore states the nine
+-- members it has reviewed and names the collision rather than resolving it
+-- unilaterally.
+--
+-- ===========================================================================
+-- DECISION 5: THE VOCABULARY IS STILL CLOSED IN TWO PLACES
+-- ===========================================================================
+--
+-- capabilityVocabulary in apps/api/internal/mcp/policy.go is the other closed
+-- set, and m131 DECISION 5's hazard is unchanged: a capability the database
+-- accepts and Go does not is refused at a different layer with a different
+-- error, and a capability Go accepts and the database does not is a 23514 at
+-- INSERT on a path an operator reached through a wizard.
+--
+-- TestCapabilityVocabularyMatchesTheDatabaseCheckAsAppRole
+-- (apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go) executes that
+-- comparison, reading this constraint at runtime by NAME via
+-- pg_get_constraintdef. THE NAME IS THEREFORE KEPT, unchanged, exactly as m131
+-- kept it: one stable name means one lookup that works against an m127-era, an
+-- m131-era and a post-m135 database alike.
+--
+-- THAT TEST FAILS THE MOMENT THIS FILE APPLIES, AND THAT IS CORRECT. The
+-- database now holds nine members and Go holds eight, so the test's FAILURE
+-- MODE 2 arm fires: "in the CHECK but NOT in Go: [mcp.cache.purge]". The
+-- migration lands first and the Go code that depends on the member follows;
+-- the red test is the handoff, and the next engineer makes it green.
+--
+-- ===========================================================================
+-- (1) DROP THE EIGHT-MEMBER CONSTRAINT
+-- ===========================================================================
+--
+-- By name, unconditionally, whatever definition it currently carries. A CHECK
+-- constraint's expression cannot be altered in place, so widening is a drop and
+-- a re-add; there is no window in which the column is unconstrained, because
+-- both statements run in the one transaction the runner wraps this file in.
+
+ALTER TABLE "public"."mcp_grants"
+    DROP CONSTRAINT IF EXISTS "mcp_grants_capabilities_vocabulary_check";
+
+-- ===========================================================================
+-- (2) RE-ADD IT OVER m131'S EIGHT READS PLUS THE FIRST WRITE
+-- ===========================================================================
+--
+-- Validated on add, not NOT VALID. See DECISION 3.
+--
+-- Alphabetical, which is also the order AllCapabilities() sorts into, so the
+-- two lists can be read side by side without either being re-sorted first.
+-- Note that alphabetical order no longer groups the reads together --
+-- 'mcp.cache.purge' sorts into the middle of them. That is a consequence of
+-- sorting by string and not a grouping claim; DECISION 2's obituary for the
+-- '.read' pattern check is the reason nothing should infer a member's kind from
+-- its position or its suffix any more.
+--
+-- KEEP IN LOCKSTEP with capabilityVocabulary in apps/api/internal/mcp/policy.go.
+-- Extending this list is still a migration.
+
+ALTER TABLE "public"."mcp_grants"
+    ADD CONSTRAINT "mcp_grants_capabilities_vocabulary_check"
+    CHECK ("capabilities" <@ ARRAY[
+        'mcp.activity.read',
+        'mcp.backups.read',
+        'mcp.cache.purge',
+        'mcp.content.read',
+        'mcp.diagnostics.read',
+        'mcp.performance.read',
+        'mcp.security.read',
+        'mcp.sites.read',
+        'mcp.uptime.read'
+    ]::text[]);
+
+-- ===========================================================================
+-- (3) WHAT THE GO LAYER MUST NOW DO -- READ THIS BEFORE WIDENING policy.go
+-- ===========================================================================
+--
+-- A note to the next engineer, not work this file performs. It is here because
+-- the hazard is created by widening the OTHER closed set, and whoever widens it
+-- will be reading this file.
+--
+--   a. THE DEFAULT MUST NOT INHERIT THIS MEMBER. m131 DECISION 3's warning
+--      applies with more force now, because the member being handed out is no
+--      longer a read. If DefaultGrantCapabilities() still returns
+--      AllCapabilities() when capabilityVocabulary is widened, EVERY NEWLY
+--      MINTED GRANT IS STAMPED WITH THE POWER TO PURGE A LIVE SITE'S CACHE,
+--      silently, as a consequence of a one-line map edit. Decouple the default
+--      from the vocabulary in the SAME commit that widens the map, not after
+--      it. The v1 preset is READ EVERYTHING, CHANGE NOTHING, and this member is
+--      not in it.
+--
+--   b. A CAPABILITY IS NOT A TOOL AND IS NOT AN AUTHORISATION TO DISPATCH. The
+--      capability gates whether the tool is offered and callable. Whether the
+--      `cache_purge` command may be sent to a particular site is still the
+--      site-scope decision the grant's own scope columns make, and the two
+--      checks are separate. Neither substitutes for the other.
+--
+--   c. THE STEP 4 PICKER NOW HAS TWO KINDS OF ROW. Every checkbox on that
+--      screen has until now been a read. One of them is now an operation that
+--      changes a live site, and rendering it identically to its neighbours
+--      makes the operator's consent to it indistinguishable from consent to a
+--      read. That is a frontend decision and this file does not make it -- it
+--      is named here only so it is not discovered after the fact.

--- a/apps/api/migrations/20260907000000_m136_mcp_grant_oauth_scopes.sql
+++ b/apps/api/migrations/20260907000000_m136_mcp_grant_oauth_scopes.sql
@@ -16,14 +16,16 @@
 -- run every migration since m1 end with the identical column and the identical
 -- four constraints.
 --
--- ORDINAL. 20260907000000 / m136. origin/main's migrations end at m133
--- (20260904000000). m134 (20260905000000) exists only on a local unpushed
--- branch whose PR merged WITHOUT it -- 'mcp.updates.propose' is in neither
--- db/schema.sql nor internal/mcp/policy.go, so it is not live. m135
--- (20260906000000) is on a branch and seats 'mcp.cache.purge' in the CAPABILITY
--- vocabulary. THIS FILE IS INDEPENDENT OF BOTH: it touches no capability
--- constraint and adds a column neither of them mentions, so it applies
--- correctly whether it lands before m135, after it, or without it ever landing.
+-- ORDINAL. 20260907000000 / m136. origin/main's migrations end at m135
+-- (20260906000000), merged by #738 as 0f84ca3d, which seats 'mcp.cache.purge'
+-- in the CAPABILITY vocabulary. This file is the only migration on this branch
+-- that origin/main does not already carry. m134 (20260905000000) never reached
+-- origin/main -- it was authored in the same commit as m133 and only m133
+-- landed -- and 'mcp.updates.propose' is in neither db/schema.sql nor
+-- internal/mcp/policy.go, so it is not live. THIS FILE IS INDEPENDENT OF BOTH:
+-- it touches no capability constraint and adds a column neither of them
+-- mentions. m135's lower ordinal settles the order -- it applies first, on
+-- every database -- and nothing below depends on that.
 --
 -- ===========================================================================
 -- WHY IT EXISTS

--- a/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
+++ b/apps/api/tests/adr064_s6b2_mcp_transport_rls_test.go
@@ -90,6 +90,9 @@ func mcpSeedGrant(t *testing.T, repo *mcp.Repo, tenantID uuid.UUID, mode string,
 		// fixture. idle_expire_after_days is left NULL -- "never idle-expire" --
 		// which is what Service.Approve writes.
 		Capabilities:        []string{"mcp.sites.read"},
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:         []string{"mcp:read"},
 		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
 		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {

--- a/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
+++ b/apps/api/tests/adr064_s7_mcp_tool_registry_rls_test.go
@@ -96,6 +96,9 @@ func s7GrantWithBearer(
 		ClientID:      &clientID,
 		// m127: both NOT NULL with no default. See the s6b2 fixture.
 		Capabilities:        []string{"mcp.sites.read"},
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:         []string{"mcp:read"},
 		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
 		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -341,6 +341,9 @@ func TestMCPAuditEvents_RolledBackGrantCreationLeavesNoAuditRow_AsAppRole(t *tes
 		// would roll the same transaction back for the wrong reason -- which
 		// would make the assertion pass while proving nothing.
 		Capabilities:        []string{"mcp.sites.read"},
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:         []string{"mcp:read"},
 		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
 		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {

--- a/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
+++ b/apps/api/tests/mcp_connection_token_mint_layers_integration_test.go
@@ -528,6 +528,9 @@ func mintProbeGrant(tenantID uuid.UUID, name string) sqlc.CreateMCPGrantParams {
 		ScopeSiteIds:  []uuid.UUID{},
 		ClientID:      nil,
 		Capabilities:  []string{"mcp.sites.read"},
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:   []string{"mcp:read"},
 		ExpiresAt:     time.Now().UTC().Add(24 * time.Hour),
 	}
 }

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -320,6 +320,9 @@ func TestMCPCreateGrantWithCodeRefusesASiteScopedPrincipalAsAppRole(t *testing.T
 		// m127: both NOT NULL with no default. Supplied so this proof fails on
 		// the RLS refusal it is actually about, not on a 23502.
 		Capabilities:        []string{"mcp.sites.read"},
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:         []string{"mcp:read"},
 		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
 		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {

--- a/apps/api/tests/mcp_m127_m128_merge_roundtrip_integration_test.go
+++ b/apps/api/tests/mcp_m127_m128_merge_roundtrip_integration_test.go
@@ -95,6 +95,9 @@ func TestMCPMergedGrantCarriesBothMigrationsColumnsAsAppRole(t *testing.T) {
 		ScopeSiteIds: []uuid.UUID{},
 		// m127.
 		Capabilities:        []string{"mcp.sites.read"},
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:         []string{"mcp:read"},
 		ExpiresAt:           expires,
 		IdleExpireAfterDays: &idleDays,
 		// m128.
@@ -164,6 +167,9 @@ func TestMCPMergedGrantOmittingSetupClientIsNullAsAppRole(t *testing.T) {
 		ScopeTagIds:   []uuid.UUID{},
 		ScopeSiteIds:  []uuid.UUID{},
 		Capabilities:  []string{"mcp.sites.read"},
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:   []string{"mcp:read"},
 		ExpiresAt:     expires,
 		// IdleExpireAfterDays and SetupClient both deliberately omitted. Both are
 		// nullable; leaving the fields zero is exactly what a caller that does

--- a/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
+++ b/apps/api/tests/mcp_m131_capability_vocabulary_parity_test.go
@@ -231,6 +231,9 @@ func m131GrantWithBearer(
 		ScopeSiteIds:        []uuid.UUID{},
 		ClientID:            &clientID,
 		Capabilities:        caps,
+		// m136: NOT NULL with no DEFAULT, so a fixture that omits it takes
+		// 23502 rather than minting a grant whose scope set the schema chose.
+		OauthScopes:         []string{"mcp:read"},
 		ExpiresAt:           time.Now().UTC().Add(90 * 24 * time.Hour),
 		IdleExpireAfterDays: nil,
 	}, func(grantID uuid.UUID) sqlc.CreateMCPAuthorizationCodeParams {

--- a/apps/api/tests/mcp_m136_scope_column_constraints_test.go
+++ b/apps/api/tests/mcp_m136_scope_column_constraints_test.go
@@ -1,0 +1,320 @@
+// m136 put four refusals on mcp_grants.oauth_scopes -- NOT NULL, a not-empty
+// CHECK, a shape CHECK and a closed-vocabulary CHECK -- and until this file
+// existed NOTHING EXECUTED ANY OF THEM.
+//
+// THE GAP THIS CLOSES, STATED PLAINLY. The scope vocabulary parity test one
+// file over reads pg_get_constraintdef and compares two closed sets; it never
+// inserts, so it proves the constraint's TEXT matches Go and not that the
+// database refuses anything. Every other fixture in this package that names
+// oauth_scopes passes the happy value {mcp:read}, so it exercises the accept
+// path and no refusal. The comment on internal/mcp/authenticate_scope_column_test.go
+// asserted this suite proved those refusals live as wpmgr_app. It did not.
+// This file is that proof, written so the claim can be true.
+//
+// WHY IT MATTERS THAT THE REFUSALS ARE REAL. internal/mcp/policy.go's grantScopes
+// deliberately does NOT filter: an unrecognised scope is carried through to
+// OrgDefaultCapabilities, which refuses the WHOLE set rather than trimming it
+// down. That design is only safe because the row is hard to write wrong in the
+// first place -- and "hard to write wrong" is a property of the database, not
+// of a comment about the database. A dropped or renamed constraint would leave
+// every Go test in this repository green.
+//
+// THE ACCEPT ARM IS NOT OPTIONAL. A constraint set that refuses everything
+// guards nothing, because the first legitimate write turns it off. The honest
+// value is inserted last and must land.
+//
+// ON THE ROLE. Every transaction below is opened by db.Pool.RunTenantTx -- the
+// same dispatch the grant insert uses -- and asserts current_user=wpmgr_app
+// with neither rolsuper nor rolbypassrls INSIDE the transaction that runs the
+// INSERT. A CHECK is enforced identically against any role, but RLS is not, and
+// a fixture that reached this table as a superuser would prove nothing about
+// the database an install actually connects to.
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/db"
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// The four constraint names this file holds the database to. They are listed
+// here once, as constants, for the m136 parity test's reason: a failure message
+// naming a constraint the test did not look for sends the reader to the wrong
+// place.
+//
+// m136 chose these names to be STABLE. A later migration widening the scope
+// vocabulary must drop and re-add THESE names rather than introduce new ones,
+// exactly as m131 did for capabilities.
+const (
+	m136ScopesNotEmptyConstraint   = "mcp_grants_oauth_scopes_not_empty_check"
+	m136ScopesShapeConstraint      = "mcp_grants_oauth_scopes_shape_check"
+	m136ScopesVocabularyConstraint = "mcp_grants_oauth_scopes_vocabulary_check"
+)
+
+// m136InsertGrantScopes runs ONE insert of a grant carrying the given
+// oauth_scopes value and returns the raw error. Everything except the scope
+// column is an ordinary healthy grant, so the scope value is the only variable.
+//
+// IT IS A DIRECT INSERT AND THAT IS DELIBERATE, not a shortcut past the repo.
+// Three of the five refusals below are UNREACHABLE through mcp.Repo: an
+// unrecognised scope is refused by ParseRequestedScopes before any SQL runs,
+// and a nil or 17-member column cannot be expressed by CreateMCPGrantParams at
+// all. A test that can only plant what the Go layer permits cannot check what
+// the database does when something else writes the row -- which is precisely
+// the independence m136 DECISION 5(d) asks for. The transaction is still the
+// production dispatch and the role is still asserted inside it.
+func m136InsertGrantScopes(
+	t *testing.T, pool *db.Pool, tenantID uuid.UUID, where string, scopes any,
+) error {
+	t.Helper()
+	ctx := context.Background()
+	principal := domain.Principal{TenantID: tenantID, Scope: domain.ScopeOrg}
+
+	return pool.RunTenantTx(ctx, principal, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "RunTenantTx ("+where+")")
+		_, err := tx.Exec(ctx, `
+			INSERT INTO mcp_grants
+			    (tenant_id, name, status, site_scope_mode,
+			     capabilities, oauth_scopes, expires_at)
+			VALUES ($1, $2, 'active', 'all', ARRAY['mcp.sites.read']::text[],
+			        $3::text[], $4)`,
+			tenantID, "m136 "+where, scopes,
+			time.Now().UTC().Add(90*24*time.Hour))
+		return err
+	})
+}
+
+// TestScopeColumnConstraintsRefuseAsAppRole is the proof.
+func TestScopeColumnConstraintsRefuseAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "m136-constraints-"+uuid.NewString()[:8])
+
+	// -----------------------------------------------------------------------
+	// THE INDETERMINATE ARM, CHECKED FIRST, BEFORE ANY INSERT.
+	//
+	// Every assertion below identifies a refusal by CONSTRAINT NAME. If a
+	// constraint has been renamed or dropped, the insert it was meant to trip
+	// either succeeds -- caught -- or trips a DIFFERENT constraint whose name
+	// this file would then report as a mismatch, which is a confusing way to
+	// learn that the subject is gone. So the subject is confirmed to exist
+	// first, by name, and a missing one fails HERE with the reason attached.
+	//
+	// This is also the arm that makes the file honest as a guard: point any
+	// constant above at a name the database does not carry and this test goes
+	// RED rather than passing by matching nothing.
+	// -----------------------------------------------------------------------
+	wantConstraints := []string{
+		m136ScopesNotEmptyConstraint,
+		m136ScopesShapeConstraint,
+		m136ScopesVocabularyConstraint,
+	}
+	for _, name := range wantConstraints {
+		var found bool
+		if err := pool.RunTenantTx(ctx,
+			domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg},
+			func(tx pgx.Tx) error {
+				return tx.QueryRow(ctx, `
+					SELECT EXISTS (
+						SELECT 1 FROM pg_constraint
+						WHERE conrelid = 'public.mcp_grants'::regclass
+						  AND contype  = 'c'
+						  AND conname  = $1)`, name).Scan(&found)
+			}); err != nil {
+			t.Fatalf("probe for constraint %q: %v", name, err)
+		}
+		if !found {
+			t.Fatalf("INDETERMINATE: public.mcp_grants carries no CHECK named %q, "+
+				"so the refusal this file attributes to it cannot be attributed to "+
+				"anything.\nThis is NOT a pass. Either the constraint was renamed or "+
+				"dropped -- m136 requires a widening migration to drop and re-add "+
+				"THIS name -- or this file is pointed at a name that never existed. "+
+				"Fix the constraint or fix the constant; do not read this as "+
+				"'the database refuses it'.", name)
+		}
+		t.Logf("subject confirmed: public.mcp_grants carries CHECK %q", name)
+	}
+
+	// NOT NULL is not a named CHECK, so it has no pg_constraint row to probe
+	// by name. Its subject is confirmed the other way: attnotnull on the
+	// column itself. Same purpose -- if the column stopped being NOT NULL this
+	// would say so instead of the insert quietly succeeding.
+	var notNull bool
+	if err := pool.RunTenantTx(ctx,
+		domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg},
+		func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `
+				SELECT attnotnull FROM pg_attribute
+				WHERE attrelid = 'public.mcp_grants'::regclass
+				  AND attname  = 'oauth_scopes'
+				  AND NOT attisdropped`).Scan(&notNull)
+		}); err != nil {
+		t.Fatalf("probe mcp_grants.oauth_scopes for NOT NULL: %v", err)
+	}
+	if !notNull {
+		t.Fatal("INDETERMINATE: mcp_grants.oauth_scopes is nullable. m136 DECISION 4 " +
+			"makes the absent value unrepresentable precisely so an empty read means " +
+			"'something is wrong' rather than 'no narrowing applied, therefore " +
+			"everything'. The 23502 arm below would prove nothing.")
+	}
+	t.Log("subject confirmed: mcp_grants.oauth_scopes is NOT NULL")
+
+	// -----------------------------------------------------------------------
+	// THE REFUSALS. One transaction each, role asserted inside each.
+	//
+	// ON CONSTRAINT ORDERING, BECAUSE ONE CASE DEPENDS ON IT. ARRAY[''] is
+	// refused by the shape CHECK (no empty string) AND by the vocabulary CHECK
+	// ('' is not a recognised scope), and Postgres reports the violated CHECK
+	// it reaches first, which is creation order. m136 creates shape before
+	// vocabulary, so shape is the name reported. That is asserted rather than
+	// papered over: if a later migration re-adds them in the other order this
+	// test says so, and the reader is told the refusal is still live but the
+	// attribution moved. Every other case below violates exactly one.
+	// -----------------------------------------------------------------------
+	cases := []struct {
+		where       string
+		scopes      any
+		wantCode    string
+		wantSubject string
+		why         string
+	}{
+		{
+			where:       "nil",
+			scopes:      nil,
+			wantCode:    "23502", // not_null_violation
+			wantSubject: "oauth_scopes",
+			why: "a NULL scope column is the 'unknown, therefore unrestricted' " +
+				"read m136 DECISION 4 exists to make unrepresentable",
+		},
+		{
+			where:       "the empty array",
+			scopes:      []string{},
+			wantCode:    "23514", // check_violation
+			wantSubject: m136ScopesNotEmptyConstraint,
+			why: "a grant holding no scope at all authenticates nowhere and " +
+				"fails at no write, so it is refused at the write instead",
+		},
+		{
+			where:       "an unrecognised scope",
+			scopes:      []string{"mcp:write-someday"},
+			wantCode:    "23514",
+			wantSubject: m136ScopesVocabularyConstraint,
+			why: "grantScopes does not filter, so a scope outside this build's " +
+				"registry would reach OrgDefaultCapabilities and 403 a live " +
+				"credential rather than failing at write time",
+		},
+		{
+			where:       "an empty-string member",
+			scopes:      []string{""},
+			wantCode:    "23514",
+			wantSubject: m136ScopesShapeConstraint,
+			why: "an empty element is a scope name nothing can match and " +
+				"nothing reports, which is the m120 shape trap one column over",
+		},
+		{
+			where:       "17 members",
+			scopes:      m136RepeatScope("mcp:read", 17),
+			wantCode:    "23514",
+			wantSubject: m136ScopesShapeConstraint,
+			why: "the cardinality ceiling is 16; a scope list longer than the " +
+				"credential's stated shape is refused whole",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.where, func(t *testing.T) {
+			err := m136InsertGrantScopes(t, pool, tenant, tc.where, tc.scopes)
+			if err == nil {
+				t.Fatalf("oauth_scopes = %v was ACCEPTED. It must be refused with "+
+					"SQLSTATE %s by %q -- %s.",
+					tc.scopes, tc.wantCode, tc.wantSubject, tc.why)
+			}
+
+			var pgErr *pgconn.PgError
+			if !errors.As(err, &pgErr) {
+				t.Fatalf("oauth_scopes = %v was refused, but not by the database: %v.\n"+
+					"A refusal from some other layer is not the proof this file "+
+					"makes -- the whole point is that the column is hard to write "+
+					"wrong even when Go is not the writer.", tc.scopes, err)
+			}
+			if pgErr.Code != tc.wantCode {
+				t.Fatalf("oauth_scopes = %v took SQLSTATE %s (%s), want %s.",
+					tc.scopes, pgErr.Code, pgErr.ConstraintName, tc.wantCode)
+			}
+
+			// NOT NULL names a COLUMN, every CHECK names a CONSTRAINT. Both are
+			// asserted by name so a refusal can never be credited to the wrong
+			// guard.
+			got := pgErr.ConstraintName
+			if tc.wantCode == "23502" {
+				got = pgErr.ColumnName
+			}
+			if got != tc.wantSubject {
+				t.Fatalf("oauth_scopes = %v was refused with SQLSTATE %s by %q, "+
+					"want %q.\nThe refusal is live but it is being credited to the "+
+					"wrong guard, which means one of the two is not doing the job "+
+					"this file says it does.", tc.scopes, pgErr.Code, got, tc.wantSubject)
+			}
+			t.Logf("refused as wpmgr_app: oauth_scopes = %v -> SQLSTATE %s by %q",
+				tc.scopes, pgErr.Code, got)
+		})
+	}
+
+	// -----------------------------------------------------------------------
+	// AND IT DOES NOT OVER-FIRE. The honest value lands.
+	//
+	// This arm is what keeps the five above meaningful. A column that refused
+	// every value would pass all of them and the first real connection would
+	// fail, so the guard would be removed and then it would guard nothing.
+	// -----------------------------------------------------------------------
+	honest := []string{"mcp:read"}
+	if err := m136InsertGrantScopes(t, pool, tenant, "the honest value", honest); err != nil {
+		t.Fatalf("oauth_scopes = %v was REFUSED: %v.\nThis is the value m136's "+
+			"backfill wrote onto every grant this surface has ever minted and the "+
+			"value DefaultGrantScopes() stamps on new ones. A constraint set that "+
+			"refuses it refuses the whole product.", honest, err)
+	}
+
+	// Read it back through the same dispatch, so the accept is a stored row and
+	// not merely an INSERT that did not raise.
+	var stored []string
+	if err := pool.RunTenantTx(ctx,
+		domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg},
+		func(tx pgx.Tx) error {
+			mcpAssertAndReportRole(t, tx, "RunTenantTx (read the accepted row back)")
+			return tx.QueryRow(ctx, `
+				SELECT oauth_scopes FROM mcp_grants
+				WHERE tenant_id = $1 AND name = $2`,
+				tenant, "m136 the honest value").Scan(&stored)
+		}); err != nil {
+		t.Fatalf("read the accepted grant back: %v", err)
+	}
+	if len(stored) != 1 || stored[0] != "mcp:read" {
+		t.Fatalf("stored oauth_scopes = %v, want [mcp:read]", stored)
+	}
+	t.Logf("accepted as wpmgr_app and read back: oauth_scopes = %v", stored)
+}
+
+// m136RepeatScope builds an n-member scope list. Every member is a RECOGNISED
+// scope, so the only thing wrong with the value is its length -- otherwise the
+// vocabulary CHECK could be the one refusing it and the cardinality ceiling
+// would go untested behind a passing assertion.
+func m136RepeatScope(scope string, n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, scope)
+	}
+	if len(out) != n {
+		panic(fmt.Sprintf("m136RepeatScope built %d members, want %d", len(out), n))
+	}
+	return out
+}

--- a/apps/api/tests/mcp_m136_scope_vocabulary_parity_test.go
+++ b/apps/api/tests/mcp_m136_scope_vocabulary_parity_test.go
@@ -1,0 +1,173 @@
+// m136 added mcp_grants.oauth_scopes and closed its vocabulary with a CHECK.
+// recognisedScopes in apps/api/internal/mcp/scope.go is the other closed set,
+// and m136 DECISION 2(c) and DECISION 5 owe this file: two closed sets with two
+// answers is worse than one open set unless something EXECUTES the comparison.
+//
+// THE HAZARD IS m131 DECISION 5's, ONE COLUMN OVER. A scope the database
+// accepts and Go does not is stored and then refused at a different layer with
+// a different error -- and because grantScopes deliberately does NOT filter, it
+// is refused as a WHOLE-SET refusal at OrgDefaultCapabilities, which is correct
+// but is a 403 on a live credential rather than a failure at write time. A
+// scope Go accepts and the database does not is a 23514 at INSERT, on the
+// consent path, after the operator already approved the connection.
+//
+// THE EXTRACTION IS m131's, VERBATIM AND NOT A REWRITE. It is the same query
+// against a different constraint name -- that is exactly what m136 DECISION
+// 2(c) chose text[]-plus-CHECK to buy, one mechanism covering two constraints
+// rather than a second catalogue query for an enum. pg_get_constraintdef
+// renders the STORED expression tree, so this reads what the database enforces
+// and cannot be fooled by editing the migration file's text or its comments.
+//
+// THE FAILURE MODE THAT LOOKS LIKE A PASS IS CHECKED FIRST. Rename or drop the
+// constraint and the extraction matches nothing: both difference arms come back
+// empty and "no differences" reads as "the sets agree" while nothing has been
+// compared. That is INDETERMINATE and it fails, before either difference is
+// computed. A guard that cannot find its subject must go red.
+package tests
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/mcp"
+)
+
+// m136ScopeConstraint is the name the extraction looks up AND the name the
+// INDETERMINATE message prints. One constant, bound as $1 rather than
+// interpolated, for m131's reason: a failure message naming a constraint the
+// query did not look for sends the reader to the wrong place, and the whole
+// point of the INDETERMINATE arm is that the reader believes it.
+//
+// m136 chose this name to be STABLE: a later migration widening the vocabulary
+// must drop and re-add THIS name, exactly as m131 did for capabilities.
+const m136ScopeConstraint = "mcp_grants_oauth_scopes_vocabulary_check"
+
+// TestScopeVocabularyMatchesTheDatabaseCheckAsAppRole is the parity proof.
+//
+// ON THE ROLE, PLAINLY, AND WITHOUT OVERCLAIMING -- the sibling capability
+// parity test says the same and it is still true here: pg_constraint and
+// pg_get_constraintdef are readable by every role, carry no RLS, and a CHECK is
+// enforced identically against a superuser and against wpmgr_app, so this
+// particular read would return the same strings connected as anyone. It is
+// asserted and printed anyway, for two reasons that are real. First, it proves
+// the constraint exists in the database the application actually connects to
+// rather than in some other one a privileged fixture reached. Second, the tests
+// this file sits beside INSERT and AUTHENTICATE, where the role is entirely
+// load-bearing, and a file whose evidence is uniform is one where nobody has to
+// work out which transaction was the honest one.
+func TestScopeVocabularyMatchesTheDatabaseCheckAsAppRole(t *testing.T) {
+	ctx := context.Background()
+	pool := startPostgres(t)
+	tenant := seedTenant(t, pool, "m136-parity-"+uuid.NewString()[:8])
+
+	var inDB []string
+	// Through InTenantTx -- a production dispatch -- and not a connection this
+	// test opened. A test that dials its own connection proves something about
+	// a database, not about the one the request path reaches.
+	if err := pool.InTenantTx(ctx, tenant, func(tx pgx.Tx) error {
+		mcpAssertAndReportRole(t, tx, "InTenantTx (scope vocabulary parity)")
+		rows, err := tx.Query(ctx, m131VocabularyExtraction, m136ScopeConstraint)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var s string
+			if err := rows.Scan(&s); err != nil {
+				return err
+			}
+			inDB = append(inDB, s)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("read %s: %v", m136ScopeConstraint, err)
+	}
+
+	// THE INDETERMINATE ARM, CHECKED BEFORE EITHER DIFFERENCE.
+	//
+	// Zero rows means the constraint was not found or its definition no longer
+	// renders as quoted ::text literals -- a rename, a drop, a schema change,
+	// or an extraction that has stopped matching. Every arm below would then be
+	// empty and this test would report a pass having compared nothing against
+	// nothing.
+	if len(inDB) == 0 {
+		t.Fatalf("INDETERMINATE: the extraction returned no rows, so this test "+
+			"compared nothing.\n"+
+			"Looked for constraint %q on public.mcp_grants.\n"+
+			"This is NOT 'the sets agree' -- both difference arms are empty "+
+			"because there is nothing to difference against. Either the "+
+			"constraint was renamed or dropped, or pg_get_constraintdef no "+
+			"longer renders the vocabulary as quoted ::text literals. Fix the "+
+			"extraction or the constraint; do not read this as a pass.",
+			m136ScopeConstraint)
+	}
+
+	sort.Strings(inDB)
+	inGo := append([]string(nil), mcp.SupportedScopes()...)
+	sort.Strings(inGo)
+
+	// A SECOND EMPTY-SET GUARD, ON THE OTHER SIDE. SupportedScopes ranges over
+	// recognisedScopes, so an emptied registry would make the "in Go but not in
+	// the database" arm vacuously empty in exactly the same way.
+	if len(inGo) == 0 {
+		t.Fatal("INDETERMINATE: mcp.SupportedScopes() is empty, so the Go half " +
+			"of this comparison contributed nothing")
+	}
+
+	dbSet := map[string]struct{}{}
+	for _, s := range inDB {
+		dbSet[s] = struct{}{}
+	}
+	goSet := map[string]struct{}{}
+	for _, s := range inGo {
+		goSet[s] = struct{}{}
+	}
+
+	// FAILURE MODE 1: Go recognises a scope the CHECK does not. ParseRequested-
+	// Scopes accepts it at the authorize endpoint and the operator approves the
+	// connection; the INSERT then takes 23514, after consent was given.
+	var goOnly []string
+	for _, s := range inGo {
+		if _, ok := dbSet[s]; !ok {
+			goOnly = append(goOnly, s)
+		}
+	}
+
+	// FAILURE MODE 2: the CHECK holds a scope Go does not recognise. The
+	// database stores it, and grantScopes carries it through UNFILTERED, so
+	// OrgDefaultCapabilities refuses the whole set -- a live credential that
+	// authenticates nowhere, with no write-time failure anywhere to point at.
+	var dbOnly []string
+	for _, s := range inDB {
+		if _, ok := goSet[s]; !ok {
+			dbOnly = append(dbOnly, s)
+		}
+	}
+
+	if len(goOnly) > 0 || len(dbOnly) > 0 {
+		t.Fatalf("the two closed scope vocabularies disagree.\n"+
+			"  in Go but NOT in the CHECK: %v\n"+
+			"      -> the authorize endpoint accepts it and the INSERT takes "+
+			"23514, after the operator approved the connection\n"+
+			"  in the CHECK but NOT in Go:  %v\n"+
+			"      -> the row stores it, grantScopes carries it through "+
+			"unfiltered, and OrgDefaultCapabilities refuses the WHOLE set: a "+
+			"credential that authenticates nowhere and fails at no write\n"+
+			"  Go:       %v\n"+
+			"  database: %v\n"+
+			"Widening either set is a change to the other. The database half is "+
+			"a migration (database-engineer); the Go half is recognisedScopes "+
+			"in apps/api/internal/mcp/scope.go -- and a scope that is not a read "+
+			"scope owes its own review before either moves.",
+			goOnly, dbOnly, inGo, inDB)
+	}
+
+	t.Logf("scope vocabularies agree on %d scopes, read from "+
+		"pg_get_constraintdef inside InTenantTx: %s",
+		len(inDB), strings.Join(inDB, " "))
+}


### PR DESCRIPTION
Stacked on #740 (m136). Makes `grantScopes()` a real per-grant read of `mcp_grants.oauth_scopes`, and makes `CreateMCPGrant` name the column so grant creation stops taking 23502.

Confers no write capability: `recognisedScopes` and `scopeCapabilities` are untouched.

Draft while the proofs run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)