### PR TITLE
fix(ci): revive the agent object-cache E2E gate (40 consecutive scheduled failures)

### DIFF
--- a/.github/workflows/e2e-agent.yml
+++ b/.github/workflows/e2e-agent.yml
@@ -52,11 +52,15 @@ jobs:
           # Suppress interactive prompts; no version stamp needed for E2E.
           VERSION: "0.0.0-e2e"
 
+      # No PLUGIN_ZIP override. run.sh asks `make -s print-agent-wporg-zip` for
+      # the path, so the workflow and the build agree by construction. The line
+      # this replaces pinned a previous slug and overrode the harness's own
+      # default with it, which is why every scheduled run failed on a missing
+      # zip while `make agent-e2e-objectcache` passed locally.
       - name: Run E2E harness
         run: |
           chmod +x apps/agent/tests-e2e/run.sh
-          PLUGIN_ZIP="${PWD}/release/fleet-agent-for-wpmgr.zip" \
-            apps/agent/tests-e2e/run.sh
+          apps/agent/tests-e2e/run.sh
         env:
           DOCKER_BUILDKIT: "1"
 

--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,28 @@ check-assistant-gate-test: ## Run the assistant ship-gate guard's regression sui
 #          a Linux CI runner and a macOS workstation agree.
 #
 # $(1) working dir, $(2) directory to package, $(3) output archive name.
+# The wordpress.org distribution slug, and the zip that carries it. THIS IS THE
+# ONE PLACE EITHER NAME IS WRITTEN. The slug is also the top-level directory
+# inside the archive, which is what WordPress names the installed plugin folder,
+# so a rename moves the zip path and the install path together.
+#
+# Consumers outside this file must NOT restate the literal — they ask make:
+#   PLUGIN_ZIP="$$(make -s print-agent-wporg-zip)"
+# `.github/workflows/e2e-agent.yml` and `apps/agent/tests-e2e/run.sh` both do
+# that. They used to hard-code a previous slug; the rename to the current one
+# updated this file and not them, and the nightly E2E workflow then failed 40
+# runs in a row on a missing zip while `make` kept working locally.
+AGENT_WPORG_SLUG := fleet-agent-site-manager
+AGENT_WPORG_ZIP  := release/$(AGENT_WPORG_SLUG).zip
+
+.PHONY: print-agent-wporg-zip
+print-agent-wporg-zip: ## Print the absolute path of the wp.org agent zip (machine-readable; use with `make -s`)
+	@echo "$(PWD)/$(AGENT_WPORG_ZIP)"
+
+.PHONY: print-agent-wporg-slug
+print-agent-wporg-slug: ## Print the wp.org agent slug (machine-readable; use with `make -s`)
+	@echo "$(AGENT_WPORG_SLUG)"
+
 define reproducible_zip
 	find $(1)/$(2) -exec touch -h -t 200001010000.00 {} +
 	cd $(1) && find $(2) -print | LC_ALL=C sort | zip -X -q -@ $(3)
@@ -437,11 +459,11 @@ agent-zip: agent-vendor ## Package the WordPress agent plugin as a zip (with ifs
 	@echo "agent zip: $$(du -sh release/wpmgr-agent.zip | cut -f1)"
 
 .PHONY: agent-zip-wporg
-agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fleet-agent-site-manager identity; self-hosted identity untouched)
+agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip ($(AGENT_WPORG_SLUG) identity; self-hosted identity untouched)
 	mkdir -p release
-	rm -f release/fleet-agent-site-manager.zip
-	rm -rf release/fleet-agent-site-manager
-	# Stage under fleet-agent-site-manager/ — the permanent wp.org slug. The self-updater
+	rm -f $(AGENT_WPORG_ZIP)
+	rm -rf release/$(AGENT_WPORG_SLUG)
+	# Stage under $(AGENT_WPORG_SLUG)/ — the permanent wp.org slug. The self-updater
 	# (class-update-checker.php) is physically excluded so PCP cannot match the
 	# site_transient_update_plugins hook (B2 / G8). NOTICE.md and README.md are
 	# excluded because wp.org rejects unexpected Markdown files (B4 / C8).
@@ -465,21 +487,21 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 		--exclude 'NOTICE.md' --exclude 'README.md' \
 		--exclude 'patchwork.json' \
 		--exclude 'includes/support/class-update-checker.php' \
-		apps/agent/ release/fleet-agent-site-manager/
+		apps/agent/ release/$(AGENT_WPORG_SLUG)/
 	# Remove CLI entrypoints, LICENSE files, data-scripts dirs, and Python files
 	# that wp.org does not permit. rsync --exclude patterns for vendor/*/bin/ do not
 	# recurse into arbitrary depth (e.g. vendor/matthiasmullie/minify/bin/ is 3 levels
 	# deep), so a post-stage find+delete is more reliable than path-based excludes.
-	find release/fleet-agent-site-manager/vendor/bin -mindepth 0 -maxdepth 0 -type d -exec rm -rf {} + 2>/dev/null || true
-	find release/fleet-agent-site-manager/vendor -mindepth 2 -type d -name bin -exec rm -rf {} + 2>/dev/null || true
-	find release/fleet-agent-site-manager/vendor -mindepth 2 -type f -name LICENSE -delete 2>/dev/null || true
-	find release/fleet-agent-site-manager/vendor -type d -name data-scripts -exec rm -rf {} + 2>/dev/null || true
-	find release/fleet-agent-site-manager/vendor -type f -name "*.py" -delete 2>/dev/null || true
+	find release/$(AGENT_WPORG_SLUG)/vendor/bin -mindepth 0 -maxdepth 0 -type d -exec rm -rf {} + 2>/dev/null || true
+	find release/$(AGENT_WPORG_SLUG)/vendor -mindepth 2 -type d -name bin -exec rm -rf {} + 2>/dev/null || true
+	find release/$(AGENT_WPORG_SLUG)/vendor -mindepth 2 -type f -name LICENSE -delete 2>/dev/null || true
+	find release/$(AGENT_WPORG_SLUG)/vendor -type d -name data-scripts -exec rm -rf {} + 2>/dev/null || true
+	find release/$(AGENT_WPORG_SLUG)/vendor -type f -name "*.py" -delete 2>/dev/null || true
 	# Rename the main plugin file to match the wp.org slug. WordPress derives the
 	# plugin's displayed name, slug, and update identity from the top-level .php
 	# filename inside the archive folder — renaming is mandatory for the wp.org slug.
-	mv release/fleet-agent-site-manager/wpmgr-agent.php \
-		release/fleet-agent-site-manager/fleet-agent-site-manager.php
+	mv release/$(AGENT_WPORG_SLUG)/wpmgr-agent.php \
+		release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php
 	# VERSION override: same mechanism as agent-zip — stamp ONLY the staged copy.
 	# Two lines: the plugin header "Version:" and the WPMGR_AGENT_VERSION constant.
 	@if [ -n "$(VERSION)" ]; then \
@@ -494,20 +516,20 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 		esac; \
 		_v_esc=$$(printf '%s' "$$_v" | sed -e 's/[\/&|]/\\&/g'); \
 		echo "agent-zip-wporg: stamping staged copy with version $$_v"; \
-		sed -i.bak -E "s/^( \* Version:[ \t]+)[0-9]+\.[0-9]+\.[0-9].*/\1$$_v_esc/" release/fleet-agent-site-manager/fleet-agent-site-manager.php; \
-		sed -i.bak -E "s/^(define\('WPMGR_AGENT_VERSION', *')[^']+(')/\1$$_v_esc\2/" release/fleet-agent-site-manager/fleet-agent-site-manager.php; \
-		rm -f release/fleet-agent-site-manager/fleet-agent-site-manager.php.bak; \
+		sed -i.bak -E "s/^( \* Version:[ \t]+)[0-9]+\.[0-9]+\.[0-9].*/\1$$_v_esc/" release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php; \
+		sed -i.bak -E "s/^(define\('WPMGR_AGENT_VERSION', *')[^']+(')/\1$$_v_esc\2/" release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php; \
+		rm -f release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php.bak; \
 	fi
 	# Stamp readme.txt Stable tag to match the plugin header Version. Mirrors the
 	# VERSION block above; reads the stamped Version from the staged main file so
 	# the two values always agree regardless of the VERSION variable.
-	@_stamped_v=$$(grep -E '^ \* Version:' release/fleet-agent-site-manager/fleet-agent-site-manager.php | sed -E 's/.*Version:[ \t]+//'); \
+	@_stamped_v=$$(grep -E '^ \* Version:' release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php | sed -E 's/.*Version:[ \t]+//'); \
 	echo "agent-zip-wporg: stamping readme.txt Stable tag: $$_stamped_v"; \
-	sed -i.bak -E "s/^(Stable tag:[ \t]+).*/\1$$_stamped_v/" release/fleet-agent-site-manager/readme.txt; \
-	rm -f release/fleet-agent-site-manager/readme.txt.bak
+	sed -i.bak -E "s/^(Stable tag:[ \t]+).*/\1$$_stamped_v/" release/$(AGENT_WPORG_SLUG)/readme.txt; \
+	rm -f release/$(AGENT_WPORG_SLUG)/readme.txt.bak
 	# Rewrite plugin-identity header fields in the staged main file:
 	#   Plugin Name  -> Fleet Agent Site Manager  (reviewer-accepted display name; no "WP" prefix)
-	#   Text Domain  -> fleet-agent-site-manager  (matches new slug)
+	#   Text Domain  -> $(AGENT_WPORG_SLUG)  (matches new slug)
 	#   WPMGR_AGENT_DISPLAY_NAME -> Fleet Agent Site Manager (admin menu/page
 	#   title constant; keeps the wp.org admin screen name consistent with the
 	#   listing identity above instead of showing the self-hosted "WPMgr Agent")
@@ -527,10 +549,10 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# license value could live.
 	sed -i.bak \
 		-e "s|^ \* Plugin Name:.*| * Plugin Name:       Fleet Agent Site Manager|" \
-		-e "s|^ \* Text Domain:.*| * Text Domain:       fleet-agent-site-manager|" \
+		-e "s|^ \* Text Domain:.*| * Text Domain:       $(AGENT_WPORG_SLUG)|" \
 		-e "s|define('WPMGR_AGENT_DISPLAY_NAME', 'WPMgr Agent');|define('WPMGR_AGENT_DISPLAY_NAME', 'Fleet Agent Site Manager');|" \
-		release/fleet-agent-site-manager/fleet-agent-site-manager.php
-	rm -f release/fleet-agent-site-manager/fleet-agent-site-manager.php.bak
+		release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php
+	rm -f release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php.bak
 	# Inject the WPMGR_WPORG_BUILD constant immediately after the WPMGR_AGENT_VERSION
 	# define line. This guards the self-updater boot hook (class-plugin.php:522) so
 	# it never binds in the wp.org build, satisfying G8 / B2 (the file exclusion
@@ -538,34 +560,34 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# Use awk to insert the line immediately after the WPMGR_AGENT_VERSION define,
 	# avoiding the multi-line sed /a\ syntax which is non-portable across BSD/GNU sed.
 	awk "/^define\('WPMGR_AGENT_VERSION',/{print; print \"define('WPMGR_WPORG_BUILD', true);\"; next}1" \
-		release/fleet-agent-site-manager/fleet-agent-site-manager.php \
-		> release/fleet-agent-site-manager/fleet-agent-site-manager.php.tmp
-	mv release/fleet-agent-site-manager/fleet-agent-site-manager.php.tmp \
-		release/fleet-agent-site-manager/fleet-agent-site-manager.php
-	# Rewrite the text-domain literal 'wpmgr-agent' -> 'fleet-agent-site-manager' across
+		release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php \
+		> release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php.tmp
+	mv release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php.tmp \
+		release/$(AGENT_WPORG_SLUG)/$(AGENT_WPORG_SLUG).php
+	# Rewrite the text-domain literal 'wpmgr-agent' -> '$(AGENT_WPORG_SLUG)' across
 	# all staged PHP files. This covers both __()/__e() text-domain args AND the
 	# plugin-identity constants (PAGE_SLUG, exclude-dir lists) that reference the
-	# plugin folder name — in the wp.org install the folder IS fleet-agent-site-manager,
+	# plugin folder name — in the wp.org install the folder IS $(AGENT_WPORG_SLUG),
 	# so all references must agree. class-update-checker.php is already excluded above
 	# and is never present in the staged tree.
 	# GREP FIRST — surface every occurrence so the caller can audit non-text-domain hits.
 	@echo "--- grep of 'wpmgr-agent' in staged tree (before rewrite) ---"; \
-	grep -rn "'wpmgr-agent'" release/fleet-agent-site-manager/ --include="*.php" || true; \
+	grep -rn "'wpmgr-agent'" release/$(AGENT_WPORG_SLUG)/ --include="*.php" || true; \
 	echo "--- end grep ---"
-	find release/fleet-agent-site-manager -name "*.php" -print0 | \
-		xargs -0 sed -i.bak "s/'wpmgr-agent'/'fleet-agent-site-manager'/g"
-	find release/fleet-agent-site-manager -name "*.php.bak" -delete
+	find release/$(AGENT_WPORG_SLUG) -name "*.php" -print0 | \
+		xargs -0 sed -i.bak "s/'wpmgr-agent'/'$(AGENT_WPORG_SLUG)'/g"
+	find release/$(AGENT_WPORG_SLUG) -name "*.php.bak" -delete
 	# ASSERT the rewrite above reached the self-target guard's own constant.
 	# tests/ is excluded from the staged tree, so nothing else checks that the
 	# wp.org build recognises its OWN slug as the agent; a refactor of that
 	# constant to double quotes or string concatenation would silently leave the
 	# wp.org build guarding the self-hosted slug only.
-	@if ! grep -q "SELF_PLUGIN_FOLDER = 'fleet-agent-site-manager';" \
-		release/fleet-agent-site-manager/includes/commands/class-update-command.php; then \
-		echo "agent-zip-wporg: FAILED. SELF_PLUGIN_FOLDER in the staged tree is not 'fleet-agent-site-manager', so the self-target guard would not recognise the wp.org slug. Check the 'wpmgr-agent' rewrite above and the constant in apps/agent/includes/commands/class-update-command.php" >&2; \
+	@if ! grep -q "SELF_PLUGIN_FOLDER = '$(AGENT_WPORG_SLUG)';" \
+		release/$(AGENT_WPORG_SLUG)/includes/commands/class-update-command.php; then \
+		echo "agent-zip-wporg: FAILED. SELF_PLUGIN_FOLDER in the staged tree is not '$(AGENT_WPORG_SLUG)', so the self-target guard would not recognise the wp.org slug. Check the 'wpmgr-agent' rewrite above and the constant in apps/agent/includes/commands/class-update-command.php" >&2; \
 		exit 1; \
 	fi
-	@echo "agent-zip-wporg: self-target guard constant OK (SELF_PLUGIN_FOLDER = 'fleet-agent-site-manager')"
+	@echo "agent-zip-wporg: self-target guard constant OK (SELF_PLUGIN_FOLDER = '$(AGENT_WPORG_SLUG)')"
 	# ASSERT no staged file resolves the (now absent) self-updater class outside a
 	# guard. includes/class-plugin.php SURVIVES the rsync above and holds two hard
 	# class fetches, `new UpdateChecker(...)` and `UpdateChecker::HOOK_APPLY`, each
@@ -578,10 +600,10 @@ agent-zip-wporg: agent-vendor ## Package the wp.org-distributable plugin zip (fl
 	# against the artifact that actually ships. Mirrors the SELF_PLUGIN_FOLDER
 	# assertion above. tools/ is excluded from the staged tree, so the checker is
 	# invoked from the source tree.
-	php apps/agent/tools/assert-wporg-updatechecker-guard.php release/fleet-agent-site-manager
-	$(call reproducible_zip,release,fleet-agent-site-manager,fleet-agent-site-manager.zip)
-	rm -rf release/fleet-agent-site-manager
-	@echo "agent wporg zip: $$(du -sh release/fleet-agent-site-manager.zip | cut -f1)"
+	php apps/agent/tools/assert-wporg-updatechecker-guard.php release/$(AGENT_WPORG_SLUG)
+	$(call reproducible_zip,release,$(AGENT_WPORG_SLUG),$(AGENT_WPORG_SLUG).zip)
+	rm -rf release/$(AGENT_WPORG_SLUG)
+	@echo "agent wporg zip: $$(du -sh $(AGENT_WPORG_ZIP) | cut -f1)"
 
 .PHONY: agent-check
 agent-check: ## Fast phpcs pass over apps/agent (committed phpcs.xml.dist). NOT the authoritative gate.
@@ -619,18 +641,20 @@ agent-format: ## phpcbf auto-fix over apps/agent, then re-lint
 
 .PHONY: agent-plugincheck
 agent-plugincheck: agent-zip-wporg ## AUTHORITATIVE: `wp plugin check` on real WordPress via Docker (mariadb + wordpress:cli)
-	# Always tests the wp.org-identity build (fleet-agent-site-manager) so the META
+	# Always tests the wp.org-identity build ($(AGENT_WPORG_SLUG)) so the META
 	# trademark/updater/readme checks key off the right slug. Exits non-zero on any ERROR row.
-	cd tools/plugincheck && PLUGIN_ZIP="$(PWD)/release/fleet-agent-site-manager.zip" ./run.sh
+	cd tools/plugincheck && PLUGIN_ZIP="$(PWD)/$(AGENT_WPORG_ZIP)" ./run.sh
 
 .PHONY: agent-e2e-objectcache
-agent-e2e-objectcache: agent-zip ## Run the object-cache E2E harness (Docker; Redis + WordPress + phpredis)
+agent-e2e-objectcache: agent-zip-wporg ## Run the object-cache E2E harness (Docker; Redis + WordPress + phpredis)
 	# Spins a full Docker environment: WordPress 6.8 + MariaDB 11 + Redis 7 + phpredis.
 	# Exercises provision → assert-cli → cross-request persistence (FIX A net) →
 	# freshness guard → cron-check → negative-check → disable.
-	# Requires Docker. PLUGIN_ZIP can be overridden; defaults to the wporg build.
+	# Requires Docker. Depends on agent-zip-wporg because the zip passed below IS
+	# the wp.org build; the old `agent-zip` dependency built release/wpmgr-agent.zip
+	# and then handed the harness a path that target never produces.
 	chmod +x apps/agent/tests-e2e/run.sh
-	PLUGIN_ZIP="$(PWD)/release/fleet-agent-site-manager.zip" apps/agent/tests-e2e/run.sh
+	PLUGIN_ZIP="$(PWD)/$(AGENT_WPORG_ZIP)" apps/agent/tests-e2e/run.sh
 
 .PHONY: agent-release
 agent-release: agent-zip ## Publish the agent release (zip + latest.json) to object storage for CP-driven self-update (ADR-042)

--- a/apps/agent/tests-e2e/Dockerfile
+++ b/apps/agent/tests-e2e/Dockerfile
@@ -1,8 +1,35 @@
 FROM wordpress:6.8-php8.3-apache
 
-# Install phpredis via PECL and enable it.
-RUN pecl install redis \
-    && docker-php-ext-enable redis
+# Install phpredis and enable it.
+#
+# NOT via `pecl install redis`. pecl.php.net no longer serves this package — its
+# REST endpoint returns a non-XML body, so pecl reports
+#   No releases available for package "pecl.php.net/redis"
+# and `pecl channel-update pecl.php.net` fails first with
+#   XML Error: 'Not well-formed (invalid token)' on line '1'
+# That is an upstream retirement, nothing in this repo, and it bricks the image
+# build before any WordPress or object-cache code runs. Building the extension
+# from the project's own release tarball removes the dependency on that channel.
+#
+# The version is pinned: an unpinned build of a C extension is not reproducible,
+# and this image is the substrate for a gate whose job is to notice change.
+ARG PHPREDIS_VERSION=6.1.0
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $PHPIZE_DEPS; \
+    curl -fsSL "https://github.com/phpredis/phpredis/archive/refs/tags/${PHPREDIS_VERSION}.tar.gz" \
+        -o /tmp/phpredis.tar.gz; \
+    mkdir -p /usr/src/php/ext/redis; \
+    tar -xzf /tmp/phpredis.tar.gz -C /usr/src/php/ext/redis --strip-components=1; \
+    docker-php-ext-install -j"$(nproc)" redis; \
+    rm -rf /tmp/phpredis.tar.gz /usr/src/php/ext/redis; \
+    apt-get purge -y --auto-remove $PHPIZE_DEPS; \
+    rm -rf /var/lib/apt/lists/*
+
+# Assert the extension is actually loadable. `docker-php-ext-install` succeeding
+# is not the same claim, and a silently absent phpredis would make the whole
+# object-cache suite fall back to array mode and report a meaningless pass.
+RUN php -m | grep -x redis
 
 # Install WP-CLI.
 RUN curl -sS -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \

--- a/apps/agent/tests-e2e/assert.php
+++ b/apps/agent/tests-e2e/assert.php
@@ -33,8 +33,20 @@ declare(strict_types=1);
 $stage = $argv[1] ?? '';
 
 $wpRoot    = '/var/www/html';
-$pluginZip = '/tmp/fleet-agent-for-wpmgr.zip';
-$pluginSlug = 'fleet-agent-for-wpmgr';
+// The compose file mounts the zip at this slug-free path; see docker-compose.yml.
+$pluginZip = '/tmp/wpmgr-agent-e2e.zip';
+
+// The installed plugin directory. NOT a literal: run.sh reads it out of the
+// archive's top-level entry (what WordPress names the folder) and compose passes
+// it in. A hard-coded slug here is exactly what stranded this harness on the
+// previous plugin name, so an absent value is a loud failure, never a default.
+$pluginSlug = (string) (getenv('WPMGR_E2E_PLUGIN_SLUG') ?: '');
+if ($pluginSlug === '') {
+    fwrite(STDERR, "assert.php: WPMGR_E2E_PLUGIN_SLUG is empty.\n"
+        . "assert.php: run.sh derives it from the plugin archive and docker-compose.yml\n"
+        . "assert.php: passes it through; run this harness via tests-e2e/run.sh.\n");
+    exit(1);
+}
 
 /**
  * Run a shell command, print stdout/stderr, return exit code.

--- a/apps/agent/tests-e2e/docker-compose.yml
+++ b/apps/agent/tests-e2e/docker-compose.yml
@@ -38,6 +38,14 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_TABLE_PREFIX: wp_
+      # The installed plugin directory name, read by run.sh out of the archive's
+      # top-level entry (which is what WordPress names the folder). assert.php
+      # takes it from here rather than carrying a literal that a slug rename can
+      # strand. Unset means run.sh was bypassed; assert.php fails loudly on that
+      # rather than guessing a name.
+      WPMGR_E2E_PLUGIN_SLUG: ${PLUGIN_SLUG:-}
     volumes:
-      # Mount the agent zip read-only so assert.php can install it.
-      - ${PLUGIN_ZIP}:/tmp/fleet-agent-for-wpmgr.zip:ro
+      # Mount the agent zip read-only so assert.php can install it. The container
+      # path is deliberately slug-free: the archive's own top-level directory is
+      # what decides the install folder, so nothing here needs to spell the slug.
+      - ${PLUGIN_ZIP}:/tmp/wpmgr-agent-e2e.zip:ro

--- a/apps/agent/tests-e2e/run.sh
+++ b/apps/agent/tests-e2e/run.sh
@@ -25,11 +25,20 @@
 # 18.  EXIT trap: docker compose down -v.
 #
 # Usage:
-#   PLUGIN_ZIP=/path/to/fleet-agent-for-wpmgr.zip ./tests-e2e/run.sh
+#   ./tests-e2e/run.sh                    # asks make where the zip is
+#   PLUGIN_ZIP=/path/to/agent.zip ./tests-e2e/run.sh   # explicit override
 #
-# The PLUGIN_ZIP default is derived from `make agent-zip` output location when
-# run from the repo root (release/fleet-agent-for-wpmgr.zip is the wporg build,
-# but we use the standard build zip here since we only need the plugin installed).
+# THE ZIP NAME IS NOT WRITTEN IN THIS FILE. The Makefile owns the wp.org slug
+# (AGENT_WPORG_SLUG) and the zip path built from it, and this script asks for it
+# with `make -s print-agent-wporg-zip`. The same goes for the INSTALLED plugin
+# directory: it is read out of the archive itself (its top-level entry, which is
+# what WordPress names the folder), never assumed.
+#
+# Both used to be hard-coded here under a previous slug. The rename updated the
+# Makefile and not this script, so `make agent-e2e-objectcache` kept working on a
+# developer machine (it passes PLUGIN_ZIP explicitly) while the nightly workflow,
+# which restated the old literal too, failed 40 consecutive runs before a single
+# assertion ran.
 
 set -euo pipefail
 
@@ -37,8 +46,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 AGENT_ROOT="${REPO_ROOT}/apps/agent"
 
-# Default zip location: the wporg build, since it is the one tested by plugincheck.
-: "${PLUGIN_ZIP:=${REPO_ROOT}/release/fleet-agent-for-wpmgr.zip}"
+# Default zip location: whatever the Makefile says the wp.org build is. Ask, do
+# not restate. `make` is required for that, so a missing make is a hard failure
+# with a usable message, never a silent fallback to a guessed path.
+if [ -z "${PLUGIN_ZIP:-}" ]; then
+    if ! command -v make >/dev/null 2>&1; then
+        echo "[e2e] ERROR: 'make' not found, so the wp.org zip path cannot be resolved." >&2
+        echo "[e2e]        Install make, or pass PLUGIN_ZIP=/abs/path/to/agent.zip explicitly." >&2
+        exit 1
+    fi
+    PLUGIN_ZIP="$(make -s -C "${REPO_ROOT}" print-agent-wporg-zip)"
+    if [ -z "${PLUGIN_ZIP}" ]; then
+        echo "[e2e] ERROR: 'make -s -C ${REPO_ROOT} print-agent-wporg-zip' printed nothing." >&2
+        echo "[e2e]        That target is the single source of the wp.org zip path; an empty" >&2
+        echo "[e2e]        answer means it was renamed or removed. Fix the Makefile." >&2
+        exit 1
+    fi
+fi
 
 # Compose project directory is the tests-e2e directory.
 COMPOSE_DIR="${SCRIPT_DIR}"
@@ -59,13 +83,11 @@ trap cleanup EXIT
 # -----------------------------------------------------------------------
 echo "[e2e] Step 1: Ensure agent zip exists at ${PLUGIN_ZIP}"
 if [ ! -f "${PLUGIN_ZIP}" ]; then
-    echo "[e2e] Zip not found; building via make agent-zip..."
-    make -C "${REPO_ROOT}" agent-zip
-    # agent-zip produces release/wpmgr-agent.zip; for e2e we need the wporg build.
-    if [ ! -f "${PLUGIN_ZIP}" ]; then
-        echo "[e2e] Building wporg zip via make agent-zip-wporg..."
-        make -C "${REPO_ROOT}" agent-zip-wporg
-    fi
+    # Build the wp.org zip directly. This used to run `make agent-zip` first,
+    # which produces a DIFFERENT archive (the self-hosted identity) and could
+    # never satisfy the path above, then fall through to agent-zip-wporg anyway.
+    echo "[e2e] Zip not found; building via make agent-zip-wporg..."
+    make -C "${REPO_ROOT}" agent-zip-wporg
 fi
 
 if [ ! -f "${PLUGIN_ZIP}" ]; then
@@ -73,6 +95,30 @@ if [ ! -f "${PLUGIN_ZIP}" ]; then
     exit 1
 fi
 echo "[e2e] Plugin zip: ${PLUGIN_ZIP}"
+
+# -----------------------------------------------------------------------
+# Step 1b: Derive the INSTALLED plugin directory name from the archive.
+#
+# WordPress names a plugin's folder after the archive's top-level directory, so
+# that entry — not the zip filename, and not any literal in this repo — is the
+# authority on where the installed files land. Reading it here means a slug
+# rename cannot desynchronise the harness from the artifact again.
+# -----------------------------------------------------------------------
+if ! command -v unzip >/dev/null 2>&1; then
+    echo "[e2e] ERROR: 'unzip' not found; cannot read the plugin slug out of ${PLUGIN_ZIP}." >&2
+    exit 1
+fi
+PLUGIN_SLUG="$(unzip -Z1 "${PLUGIN_ZIP}" | awk -F/ 'NF>1 && $1!="" {print $1; exit}')"
+if [ -z "${PLUGIN_SLUG}" ]; then
+    echo "[e2e] ERROR: ${PLUGIN_ZIP} has no top-level directory." >&2
+    echo "[e2e]        WordPress would then name the install folder after the zip FILENAME," >&2
+    echo "[e2e]        which is not what this harness (or the wp.org build) expects." >&2
+    echo "[e2e]        Archive listing:" >&2
+    unzip -Z1 "${PLUGIN_ZIP}" | head -5 >&2
+    exit 1
+fi
+export PLUGIN_SLUG
+echo "[e2e] Installed plugin directory (from the archive's top-level entry): ${PLUGIN_SLUG}"
 
 # -----------------------------------------------------------------------
 # Step 2: Export PLUGIN_ZIP for docker compose.
@@ -292,7 +338,7 @@ INSTALLED_VER="$(docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
 ASSET_VER="$(docker compose -f "${COMPOSE_DIR}/docker-compose.yml" \
     --project-name wpmgr-agent-e2e \
     exec -T wordpress grep -m1 'Version:' \
-    /var/www/html/wp-content/plugins/fleet-agent-for-wpmgr/assets/wpmgr-object-cache-dropin.php \
+    "/var/www/html/wp-content/plugins/${PLUGIN_SLUG}/assets/wpmgr-object-cache-dropin.php" \
     | awk '{print $NF}')"
 echo "[e2e] Drop-in installer state: ${INSTALLED_VER}"
 echo "[e2e] Asset version: ${ASSET_VER}"

--- a/apps/agent/tests-e2e/run.sh
+++ b/apps/agent/tests-e2e/run.sh
@@ -108,7 +108,10 @@ if ! command -v unzip >/dev/null 2>&1; then
     echo "[e2e] ERROR: 'unzip' not found; cannot read the plugin slug out of ${PLUGIN_ZIP}." >&2
     exit 1
 fi
-PLUGIN_SLUG="$(unzip -Z1 "${PLUGIN_ZIP}" | awk -F/ 'NF>1 && $1!="" {print $1; exit}')"
+# awk deliberately reads the WHOLE listing rather than `exit`-ing on the first
+# match: exiting early closes the pipe, unzip dies on SIGPIPE, and `set -o
+# pipefail` turns a correct read into exit 141.
+PLUGIN_SLUG="$(unzip -Z1 "${PLUGIN_ZIP}" | awk -F/ 'NF>1 && $1!="" && !seen {print $1; seen=1}')"
 if [ -z "${PLUGIN_SLUG}" ]; then
     echo "[e2e] ERROR: ${PLUGIN_ZIP} has no top-level directory." >&2
     echo "[e2e]        WordPress would then name the install folder after the zip FILENAME," >&2


### PR DESCRIPTION
The nightly **E2E — Agent Object Cache** workflow has failed every scheduled run since the agent plugin was renamed for wordpress.org, dying before a single assertion ran:

```
[e2e] ERROR: Plugin zip not found at .../release/fleet-agent-for-wpmgr.zip
```

The rename updated `Makefile`. The workflow, `run.sh`, `docker-compose.yml` and `assert.php` each restated the old literal and were not updated. It stayed invisible because `make agent-e2e-objectcache` passes the correct path explicitly, so the harness only broke where nothing overrode it — i.e. only in CI.

## Approach

Neither the zip name nor the installed directory name is written in the harness any more.

- `Makefile` gains `AGENT_WPORG_SLUG` / `AGENT_WPORG_ZIP`, substituted through `agent-zip-wporg`, `agent-plugincheck` and `agent-e2e-objectcache`, plus `print-agent-wporg-zip` and `print-agent-wporg-slug` for callers outside the file.
- `run.sh` asks `make -s print-agent-wporg-zip` for the zip path, and reads the **installed plugin directory** out of the archive's own top-level entry — which is what WordPress actually names the folder — rather than assuming it matches the zip filename.
- The workflow drops its `PLUGIN_ZIP` override entirely.
- `docker-compose.yml` mounts the zip at a slug-free container path and forwards the derived slug; `assert.php` exits 1 when that slug is absent rather than defaulting to a guess.

## Two adjacent defects found while tracing this

- `agent-e2e-objectcache` depended on `agent-zip` (the self-hosted archive) then handed the harness a wp.org path that target never produces. Now depends on `agent-zip-wporg`.
- `run.sh`'s missing-zip fallback ran `make agent-zip` first for the same reason. It now builds the wp.org zip directly.

## Fail-loud

Every new failure path exits non-zero with the reason: missing `make`, an empty print target, missing `unzip`, an archive with no top-level directory, and an unset slug inside the container.

No product code under `apps/agent/includes/**` is touched, and no test is deleted or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)