### PR TITLE
release: agent 0.61.149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ House rules: no em dashes, no en dashes, no competitor names. Use "to" for range
 
 ## [Unreleased]
 
+### Added
+
+- Every agent command now declares two facts about itself: what a successful run does to the site (read, write or destructive) and whether running it again is safe (idempotent, repeatable or unsafe). Nothing in the agent reads these to allow or refuse a command; they exist so an approval screen, a read-only connection or an audit trail can be built on a declared fact rather than a guess made from a command name. A command that declares neither is refused at build time (#734). Agent 0.61.149.
+
+### Fixed
+
+- Restoring a file from the agent's media quarantine no longer overwrites a file that has since been recreated at the same path, and a file the restore declines to move is no longer removed from quarantine afterwards. Quarantine moves the original rather than copying it, so a file removed without being restored existed nowhere else. Restore now reports a per-file outcome with a reason instead of a bare count, and the quarantine folder is cleared only once every file it recorded is accounted for and a scan of the folder confirms nothing remains; anything the scan cannot positively classify counts as remaining (#737). **Requires updating the plugin to pick up the fix.**
+- The agent's page cache now keeps every path it builds inside the cache root (#719). **Requires updating the plugin to pick up the fix.**
+- The agent's pre-update snapshot now distinguishes a source directory that did not exist from a snapshot that could not be taken. Both previously produced the same empty result, and every rollback gate reads that result, so the two outcomes could not be told apart: a rollback could be skipped when one was available, or attempted when there was nothing to restore. An absent source is now a first-class before-state that a rollback undoes by removing whatever was created in its place, a capture failure is reported with a machine-readable code, and a partial snapshot left by a failed capture is deleted rather than left looking like a snapshot (#733). **Requires updating the plugin to pick up the fix.**
+
 ## [0.61.161] - 2026-09-10
 
 ### Security

--- a/apps/agent/readme.txt
+++ b/apps/agent/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, security, performance, updates, site management
 Requires at least: 6.2
 Tested up to: 7.1
 Requires PHP: 8.1
-Stable tag: 0.61.148
+Stable tag: 0.61.149
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -286,6 +286,13 @@ This plugin ships two minified JavaScript files. Their human-readable source and
 
 The entries below summarize the notable changes since 0.31.1. This project ships frequently and not every intermediate patch release is listed here. Full history: https://github.com/mosamlife/wpmgr/blob/main/CHANGELOG.md
 
+= 0.61.149 =
+* Fixed: restoring a file from media quarantine no longer overwrites a file that has since been recreated at the same path. A file that cannot be put back safely is now left in quarantine and reported with a reason, instead of being removed after a restore that did not happen, so nothing is lost when a restore cannot complete in full. The quarantine folder is now cleared only once every file it recorded has been accounted for and a scan confirms nothing is left behind.
+* Fixed: every path the page cache reads or writes is now kept inside the cache folder.
+* Fixed: creating a folder on this site now stays inside the WordPress installation even when the parent folder does not exist yet.
+* Fixed: the snapshot taken before an update now tells apart "nothing was here before" from "the snapshot could not be taken". Both previously looked the same to the code that decides whether an automatic rollback is possible, so a rollback could be skipped when it was available, or attempted when there was nothing to restore. A snapshot that could not be completed is also no longer left behind as a partial copy.
+* Changed: every command this plugin accepts now declares what a successful run does to the site and whether running it again is safe. This is descriptive information for the dashboard's approval and audit screens; no command behaves differently because of it.
+
 = 0.61.148 =
 * Fixed: this plugin no longer fatals with a white screen on Enroll on a host without the native libsodium PHP extension. A memory-wiping call was made unconditionally, and WordPress's bundled polyfill throws rather than perform it; every call site now degrades to a best-effort overwrite instead. This affected shared hosting broadly, cPanel and CloudLinux hosts especially, where the plugin installed and activated normally but enrollment could not be completed.
 * Changed: removed a settings-screen section that asked you to paste a minted connection key into a dashboard flow that was never built. The underlying mechanism is unchanged; only that dead, confusing step is gone.
@@ -450,6 +457,9 @@ The entries below summarize the notable changes since 0.31.1. This project ships
 * New: WOFF2 font transcoding. TTF, OTF and WOFF are converted on the control plane; the flag defaults to off.
 
 == Upgrade Notice ==
+
+= 0.61.149 =
+Fixes a media quarantine restore that could overwrite a file recreated at the same path, and could remove a quarantined file it had declined to restore. Also tightens where the page cache and folder creation may write. Update if this site uses the unused-image quarantine.
 
 = 0.61.148 =
 Fixes a white screen on Enroll on hosts without the native libsodium PHP extension, common on shared hosting, cPanel and CloudLinux in particular, where the plugin installed and activated normally but enrollment could not be completed. Update to complete setup on those hosts. Also removes a settings section that referenced a dashboard flow that was never built.

--- a/apps/agent/wpmgr-agent.php
+++ b/apps/agent/wpmgr-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WPMgr Agent
  * Plugin URI:        https://github.com/mosamlife/wpmgr
  * Description:        Connects this WordPress site to a WPMgr control plane for backups, updates, monitoring, and security scanning.
- * Version:           0.61.148
+ * Version:           0.61.149
  * Requires at least: 6.2
  * Requires PHP:      8.1
  * Author:            WPMgr contributors
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
     exit; // No direct access.
 }
 
-define('WPMGR_AGENT_VERSION', '0.61.148');
+define('WPMGR_AGENT_VERSION', '0.61.149');
 
 // Display name shown on the admin settings screen (menu label, page title).
 // Kept as its own constant (rather than hard-coded strings in class-admin.php)

--- a/apps/marketing/lib/content/home.ts
+++ b/apps/marketing/lib/content/home.ts
@@ -14,7 +14,7 @@ import { SITE_CONFIG, signupHref } from "@/lib/site";
 // on every release: the agent version deliberately does not track the repo
 // release version, so a control-plane-only release leaves this alone and the
 // badge stays true.
-const AGENT_VERSION = "0.61.148";
+const AGENT_VERSION = "0.61.149";
 
 export const HOME_HERO = {
   badge: `v${AGENT_VERSION} / open source`,


### PR DESCRIPTION
Prepares agent release **0.61.149**. Branched from `main` at `8e31dbb2`.

**Scope: prepare only.** No git tag, no `make agent-release`, no wordpress.org SVN. The order in this project is deploy, then owner QA, then tag.

## Surfaces changed

| Surface | File | Change |
|---|---|---|
| Plugin header | `apps/agent/wpmgr-agent.php:6` | `0.61.148` to `0.61.149` |
| Constant | `apps/agent/wpmgr-agent.php:23` | `WPMGR_AGENT_VERSION` to `0.61.149` |
| wordpress.org | `apps/agent/readme.txt:7` | `Stable tag:` to `0.61.149` |
| Marketing hero badge | `apps/marketing/lib/content/home.ts:17` | `AGENT_VERSION` to `0.61.149` |
| Listing changelog | `apps/agent/readme.txt` | new `= 0.61.149 =` entry and upgrade notice |
| Repo changelog | `CHANGELOG.md` | agent entries under `[Unreleased]` |

## Shipping

Derived with `git log --oneline 8b31bb92..origin/main -- apps/agent/` (there is no `0.61.148` tag; `8b31bb92` is the commit that stamped it). Five commits, matching the brief exactly:

- `f31ef1bd` fix(agent): guard both ends of a media quarantine restore (#737)
- `d574ab29` feat(agent): declare effect and repeatability on every agent command (#734)
- `d4a99a63` fix(agent): make the snapshot before-state explicit (#733)
- `533d2a3e` fix(agent): contain page-cache paths to the cache root (#719)
- `1d014e70` fix(agent): re-jail nearest existing ancestor in file_mkdir (#717)

## Changelog copy

#737 is a data-loss fix and this release is what puts it in front of the fleet, so the entries state the corrected behaviour and the user-visible consequence only. No trigger recipe, no line references, no order of operations. Same restraint for #717 and #719. This follows the "A comment that justifies a safety label" rule in `CLAUDE.md`, which releases the mechanism only once the fix is merged **and** released to the fleet.

The upgrade notice is 272 characters, under the 300-character `upgrade_notice_limit`. The historical entries that exceed it are left alone; that is a separate change.

## Two corrections to the brief

1. **`apps/marketing/app/(marketing)/changelog/page.tsx:333` was not changed.** That line is the *repo* release 0.61.148 entry from 2026-08-30 (the AI connection surface), not an agent surface. That page tracks repo releases against the top `CHANGELOG.md` entry with a tolerance of 5, and `scripts/check-version-surfaces.sh:348` states outright that the hero badge's reference "is the agent plugin, NOT the changelog. Comparing it to the changelog was wrong, and expensively so." Editing it would have been wrong.
2. **#717 is already in `CHANGELOG.md` under 0.61.161** and is not duplicated. It is in the agent readme changelog, which is the surface that had not yet recorded it.

No repo release version is cut here, so the agent entries sit under `[Unreleased]`. `scripts/check-version-surfaces.sh:158` matches only `^## [X.Y.Z]`, so the top released entry stays 0.61.161 and the openapi and marketing-changelog tolerances are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
