### PR TITLE
feat(mcp): bind an OAuth approval to the authorize call it followed

### DIFF
--- a/apps/api/cmd/wpmgr/main.go
+++ b/apps/api/cmd/wpmgr/main.go
@@ -555,6 +555,21 @@ func run(ctx context.Context, cfg config.Config, logger *slog.Logger) error {
 
 	mcpSvc := mcp.NewService(mcp.NewRepo(pool)).WithClock(clock.Now).WithAudit(auditRec).
 		WithContextResolver(govContextResolver)
+	// The consent ticket's key, derived from the instance session secret, which
+	// every replica shares and which is already validated before boot
+	// (cfg.ValidateSessionSecret, above). It is what makes an OAuth consent
+	// approvable on an instance other than the one that drew the screen: the
+	// ticket binds the approval to the authorize call that preceded it, and a
+	// per-process key would bind it to one container.
+	//
+	// FATAL RATHER THAN LOGGED. A Service that could not take this key still
+	// verifies tickets -- NewService arms its own -- so the symptom would be
+	// consents that work on one instance and are refused on the next, which is
+	// a worse thing to discover in production than a process that will not
+	// start.
+	if err := mcpSvc.SetConsentSigningSecret(cfg.Auth.SessionSecret); err != nil {
+		return fmt.Errorf("mcp consent signing: %w", err)
+	}
 	mcpTransportH := mcp.NewTransportHandler(mcpSvc, logger, version)
 	// The OAuth half, wired unconditionally for the same reason. Without it the
 	// transport above is mounted and correct and refuses every request forever,

--- a/apps/api/internal/mcp/approve_test.go
+++ b/apps/api/internal/mcp/approve_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -47,6 +48,12 @@ func validConsent() ConsentContext {
 		State:               "opaque-state",
 		CodeChallenge:       "a-real-challenge-value",
 		CodeChallengeMethod: "S256",
+		// The ticket an /authorize call carrying mcp:read for this client would
+		// have issued, minted under the key every service constructor in this
+		// package is wired with (consent_ticket_test.go). A hand-built consent
+		// is one this server never issued, and Approve refuses those: a fixture
+		// has to stand in for the authorize call, not around it.
+		ConsentTicket: issueTestTicket(registeredClientID, []Scope{ScopeRead}, time.Now()),
 	}
 }
 

--- a/apps/api/internal/mcp/audit_fail_closed_test.go
+++ b/apps/api/internal/mcp/audit_fail_closed_test.go
@@ -62,7 +62,7 @@ const failClosedSiteName = "zzz-canary-site"
 // ABOUT the unaudited case call NewService directly and assert the refusal --
 // see TestToolCall_ARecorderlessServiceRefusesRatherThanServing.
 func auditedService(store Store) *Service {
-	return NewService(store).withAuditRecorder(&capturingRecorder{})
+	return consentKeyed(NewService(store).withAuditRecorder(&capturingRecorder{}))
 }
 
 // routerWithRecorder mounts the real route over a store with the given

--- a/apps/api/internal/mcp/consent_capability_test.go
+++ b/apps/api/internal/mcp/consent_capability_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -31,7 +32,7 @@ import (
 // before the capability set is ever stored, which would make every assertion
 // below vacuous.
 func approvalService(store *fakeStore) *Service {
-	return NewService(store).withAuditRecorder(&capturingRecorder{})
+	return consentKeyed(NewService(store).withAuditRecorder(&capturingRecorder{}))
 }
 
 // storedCapabilities is the capability column of the single grant the consent
@@ -189,10 +190,13 @@ func TestConsentHandlerCarriesTheCapabilityFieldToTheGrant(t *testing.T) {
 
 	chosen := []string{string(CapSitesRead), string(CapUptimeRead)}
 	body := approvalRequestDTO{
-		ClientID:            registeredClientID,
-		RedirectURI:         registeredRedirect,
-		Scopes:              []string{"mcp:read"},
-		State:               "s",
+		ClientID:    registeredClientID,
+		RedirectURI: registeredRedirect,
+		Scopes:      []string{"mcp:read"},
+		State:       "s",
+		// The ticket the authorize call for this client and scope set would
+		// have issued. Every consent body on the wire carries one.
+		ConsentTicket:       issueTestTicket(registeredClientID, []Scope{ScopeRead}, time.Now()),
 		CodeChallenge:       "challenge",
 		CodeChallengeMethod: "S256",
 		GrantName:           "Priya's laptop",
@@ -235,6 +239,11 @@ func TestConsentHandlerRefusesAnEmptyCapabilityArray(t *testing.T) {
 		`{"client_id":"`+registeredClientID+`","redirect_uri":"`+registeredRedirect+`",`+
 			`"scopes":["mcp:read"],"state":"s","code_challenge":"challenge",`+
 			`"code_challenge_method":"S256","name":"Priya's laptop",`+
+			// A VALID ticket, so the 400 below is the empty capability array
+			// being refused and not the consent binding refusing first. A
+			// refusal for the wrong reason is a test that has stopped covering
+			// what it names.
+			`"consent_ticket":"`+issueTestTicket(registeredClientID, []Scope{ScopeRead}, time.Now())+`",`+
 			`"site_scope_mode":"all","capabilities":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)

--- a/apps/api/internal/mcp/consent_permission_test.go
+++ b/apps/api/internal/mcp/consent_permission_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -74,10 +75,14 @@ func authorizeQuery() url.Values {
 func consentBody(t *testing.T) string {
 	t.Helper()
 	raw, err := json.Marshal(approvalRequestDTO{
-		ClientID:            registeredClientID,
-		RedirectURI:         registeredRedirect,
-		Scopes:              []string{string(ScopeRead)},
-		State:               "opaque-state",
+		ClientID:    registeredClientID,
+		RedirectURI: registeredRedirect,
+		Scopes:      []string{string(ScopeRead)},
+		State:       "opaque-state",
+		// The ticket authorizeQuery()'s request would have been issued: these
+		// cases are about the permission gate, so the consent binding must be
+		// satisfied or every one of them would refuse for the wrong reason.
+		ConsentTicket:       issueTestTicket(registeredClientID, []Scope{ScopeRead}, time.Now()),
 		CodeChallenge:       "a-real-challenge-value",
 		CodeChallengeMethod: "S256",
 		GrantName:           "Claude Desktop on my laptop",
@@ -241,7 +246,7 @@ func TestConsentPermissionGateResolvesTheRoleTheSameWay(t *testing.T) {
 		TenantID:     uuid.New(),
 		Scope:        domain.ScopeOrg,
 		AuthModel:    domain.AuthModelCapability,
-		Role:         "owner", // the role says yes ...
+		Role:         "owner",                              // the role says yes ...
 		Capabilities: []string{string(authz.PermSiteRead)}, // ... the capability set says no
 	}
 	if !key.IsCapabilityScoped() {

--- a/apps/api/internal/mcp/consent_ticket.go
+++ b/apps/api/internal/mcp/consent_ticket.go
@@ -1,0 +1,315 @@
+package mcp
+
+// consent_ticket.go: the server-side record of what an /authorize call
+// actually carried, so that the approval which follows it is measured against
+// that request rather than against its own body.
+//
+// THE PROPERTY THIS FILE EXISTS TO HOLD. A grant's stored scope set is the set
+// the authorize call requested and the consent screen displayed. Not a set the
+// approval POST names, and not "any set the registry happens to recognise".
+//
+// WHY A TICKET AND NOT A ROW. Service.Authorize mints nothing -- no grant, no
+// code, no row -- and that is deliberate: until a human approves, nothing
+// exists to revoke, expire or reconcile, and an unauthenticated caller cannot
+// make this server write. Keeping that property means the authorize call's
+// output is AUTHENTICATED rather than STORED: the scope set travels through the
+// browser with a MAC this server computed, and comes back verifiable. The
+// alternative -- a table of pending authorization requests -- reintroduces
+// exactly the unauthenticated-write surface the endpoint was built without, and
+// costs a migration for state whose whole life is one consent screen.
+//
+// This is the shape auth/social_handshake.go already uses for the same problem
+// one flow over: state that must survive a browser round trip, keyed from the
+// instance session secret, with the expiry inside the sealed payload rather
+// than in a header the caller controls.
+//
+// WHY A MAC AND NOT AN AEAD. The handshake cookie encrypts because it carries a
+// PKCE verifier and a nonce, which are secrets. Nothing here is: the scope set
+// is rendered to the operator on the consent screen and echoed in the approval
+// body. What this needs is integrity and origin, which is what HMAC is, and a
+// primitive whose failure mode is legible beats one whose payload a reviewer
+// cannot read.
+
+import (
+	"crypto/hkdf"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+const (
+	// consentTicketTTL is how long an operator has between the authorize call
+	// and the approval POST.
+	//
+	// The consent screen is not a click-through: the operator names the
+	// connection, chooses the site scope (all, by tag, or a hand-picked list)
+	// and may narrow the capability set, and the site and tag pickers are
+	// themselves loaded from the API. Fifteen minutes is long enough for that
+	// with a distraction in the middle, and short enough that an abandoned
+	// authorization is gone rather than approvable tomorrow from a tab left
+	// open.
+	//
+	// IT IS THE CEILING ON A STALE CONSENT, which is the reason it exists at
+	// all rather than being left unbounded. A ticket is the statement "this
+	// request was made"; a statement with no expiry outlives the intent behind
+	// it, and the client's registration, redirect URIs and the operator's own
+	// permissions can all have changed in the meantime. The authorization code
+	// minted at the end of this flow lives five minutes for the same reason.
+	consentTicketTTL = 15 * time.Minute
+
+	// consentTicketKeyInfo separates this key from every other use of the
+	// instance session secret -- the session store, the social handshake codec,
+	// the derived age identity. Two purposes sharing one derived key is how a
+	// value signed for one becomes valid for the other.
+	consentTicketKeyInfo = "wpmgr/mcp/consent-ticket/v1"
+
+	// consentTicketMaxBytes refuses an oversized ticket before any decoding.
+	// What this server issues is a few hundred bytes; the bound is generous and
+	// exists so a caller cannot make the process do unbounded work by claiming
+	// a ticket.
+	consentTicketMaxBytes = 4096
+)
+
+// ErrCodeConsentTicketInvalid is the refusal for an approval that carries no
+// consent ticket this server issued, one that has been altered since, one that
+// has expired, or one issued for a different client.
+//
+// IT IS A DISTINCT CODE FROM THE SCOPE MISMATCH BELOW, deliberately. "Start the
+// flow again" and "your body disagrees with your request" are different
+// remedies, and a caller that cannot tell them apart retries the wrong one.
+const ErrCodeConsentTicketInvalid = "mcp_invalid_consent_ticket"
+
+// ErrCodeScopeNotAuthorized is the refusal for an approval whose scope set is
+// not the set the authorize call carried.
+//
+// The message NAMES THE OFFENDING SCOPE. That is the same stance
+// ParseRequestedScopes takes on an unrecognised one: the value is the caller's
+// own input so echoing it discloses nothing, and a refusal that does not say
+// what it refused leaves an automated client retrying the identical request
+// forever.
+const ErrCodeScopeNotAuthorized = "mcp_scope_not_authorized"
+
+// consentTicketClaims is what the authorize call leaves behind for the approval
+// that follows it. Field names are one letter because this is serialised into
+// every consent response, not because anything reads them by hand.
+type consentTicketClaims struct {
+	// ClientID binds the ticket to the client the operator was shown. Without
+	// it a ticket issued for one client's request is a valid ticket for any
+	// other's approval, and "the operator approved this for THAT client" stops
+	// being something this server can say.
+	ClientID string `json:"c"`
+
+	// Scopes is the authorize call's parsed, deduplicated, sorted scope set --
+	// the set the consent screen renders and the only set an approval may
+	// store.
+	Scopes []string `json:"s"`
+
+	// Expires is the authority on freshness, inside the MAC. A deadline the
+	// caller can edit is not a deadline.
+	Expires int64 `json:"e"`
+}
+
+// consentTicketCodec issues and verifies consent tickets.
+type consentTicketCodec struct {
+	key []byte
+}
+
+// newConsentTicketCodec derives the ticket key from the instance session
+// secret, which every replica of this process shares and which is already
+// required to exist and to be non-trivial before boot
+// (config.ValidateSessionSecret).
+//
+// THE SHARED SECRET IS THE POINT. A ticket must verify on whichever instance
+// receives the approval, which is not in general the instance that issued it,
+// and must survive a deploy that lands between the two. A per-process key
+// satisfies neither.
+func newConsentTicketCodec(sessionSecret string) (*consentTicketCodec, error) {
+	if len(sessionSecret) < 32 {
+		return nil, errors.New("mcp consent ticket: session secret too short to derive a key from")
+	}
+	// No salt: the input is a high-entropy instance secret, and a random salt
+	// would have to be stored for the approval to derive the same key, which is
+	// the server-side state this design exists without.
+	key, err := hkdf.Key(sha256.New, []byte(sessionSecret), nil, consentTicketKeyInfo, 32)
+	if err != nil {
+		return nil, fmt.Errorf("mcp consent ticket: derive key: %w", err)
+	}
+	return &consentTicketCodec{key: key}, nil
+}
+
+// newEphemeralConsentTicketCodec keys a codec from fresh entropy.
+//
+// IT IS THE DEFAULT NewService ARMS, and the reason is the one NewService
+// already gives about its rate limiter: an unarmed codec would be a wiring
+// failure that presents as a working endpoint. There is no nil codec and
+// therefore no branch anywhere that treats "no key" as "skip the check" --
+// every Service verifies, always.
+//
+// A process left on this default is not insecure, it is merely alone: tickets
+// it issues verify only against itself, so a multi-instance deployment that
+// forgot the wiring refuses approvals with a named error instead of accepting
+// unbound ones. cmd/wpmgr calls SetConsentSigningSecret at boot.
+func newEphemeralConsentTicketCodec() *consentTicketCodec {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		// Unreachable on any supported platform (crypto/rand does not return a
+		// usable error), and a service holding a zero key would issue tickets
+		// anyone could forge. Failing construction is the only honest branch.
+		panic("mcp: cannot key the consent ticket codec: " + err.Error())
+	}
+	return &consentTicketCodec{key: key}
+}
+
+// issue returns the ticket for an authorize call carrying scopes for clientID.
+func (c *consentTicketCodec) issue(clientID string, scopes []Scope, now time.Time) (string, error) {
+	names := scopeNames(scopes)
+	sort.Strings(names)
+	payload, err := json.Marshal(consentTicketClaims{
+		ClientID: clientID,
+		Scopes:   names,
+		Expires:  now.UTC().Add(consentTicketTTL).Unix(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("mcp consent ticket: marshal: %w", err)
+	}
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	return body + "." + base64.RawURLEncoding.EncodeToString(c.mac(body)), nil
+}
+
+// open returns the claims a ticket carries, or false for anything this server
+// did not issue, anything altered since, and anything expired.
+//
+// One boolean rather than an error, for the reason handshakeCodec.open gives:
+// every failure here has the same answer for the caller, and naming which check
+// failed invites a branch that treats "altered" as recoverable.
+func (c *consentTicketCodec) open(raw string, now time.Time) (consentTicketClaims, bool) {
+	if raw == "" || len(raw) > consentTicketMaxBytes {
+		return consentTicketClaims{}, false
+	}
+	body, sig, ok := strings.Cut(raw, ".")
+	if !ok {
+		return consentTicketClaims{}, false
+	}
+	presented, err := base64.RawURLEncoding.DecodeString(sig)
+	if err != nil {
+		return consentTicketClaims{}, false
+	}
+	// Constant time, and BEFORE the payload is decoded: nothing inside an
+	// unauthenticated blob may steer this function.
+	if !hmac.Equal(presented, c.mac(body)) {
+		return consentTicketClaims{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(body)
+	if err != nil {
+		return consentTicketClaims{}, false
+	}
+	var claims consentTicketClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return consentTicketClaims{}, false
+	}
+	if claims.Expires <= now.UTC().Unix() {
+		return consentTicketClaims{}, false
+	}
+	return claims, true
+}
+
+func (c *consentTicketCodec) mac(body string) []byte {
+	m := hmac.New(sha256.New, c.key)
+	m.Write([]byte(body))
+	return m.Sum(nil)
+}
+
+// authorizedScopes resolves the scope set an approval may store: the set its
+// authorize call carried, having refused any approval that names a different
+// one.
+//
+// WHAT IT RETURNS IS THE TICKET'S SET, not the body's, even though the two are
+// equal by the time it returns. The value that is written to the grant and the
+// value the capability ceiling is computed from therefore both come from the
+// server's own record of the request, and a future loosening of the comparison
+// below cannot silently become a loosening of what is stored.
+//
+// EXACT SET EQUALITY, IN BOTH DIRECTIONS, and the narrowing direction is
+// refused on purpose. A body naming LESS than the authorize call is not an
+// escalation, but neither is it anybody's decision: the consent screen offers
+// no scope-narrowing control, so a narrower body is not an operator choice, it
+// is the round trip disagreeing with itself. Accepting it would mean the screen
+// said one thing and the grant recorded another -- the same "the two parties
+// never learn they disagreed" failure the closed registry refuses one layer up,
+// pointing the other way. The capability axis shows what narrowing looks like
+// when it is real: an explicit control on the screen, a value carried in its
+// own field, and a refusal rather than an intersection when it exceeds the
+// ceiling. A scope-narrowing control arrives the same way or not at all.
+func (s *Service) authorizedScopes(consent ConsentContext) ([]Scope, error) {
+	// The body's own set first, through the same exit gate the authorize call
+	// went through, so a malformed or unrecognised scope keeps the precise
+	// refusal it already had rather than being answered with "bad ticket".
+	requested, err := ParseRequestedScopes(scopesToString(consent.Scopes))
+	if err != nil {
+		return nil, err
+	}
+
+	claims, ok := s.consentTickets.open(consent.ConsentTicket, s.now())
+	if !ok {
+		return nil, domain.Validation(ErrCodeConsentTicketInvalid,
+			"this approval carries no valid consent ticket; the authorization request "+
+				"must be started again")
+	}
+	if claims.ClientID != consent.ClientID {
+		return nil, domain.Validation(ErrCodeConsentTicketInvalid,
+			"the consent ticket was issued for a different client_id")
+	}
+
+	// The authorized set, re-parsed rather than trusted verbatim. The ticket is
+	// this server's own, but it was issued by a possibly older build, and a
+	// scope that build recognised and this one does not is a grant this build
+	// cannot correctly evaluate. Authenticate takes the same stance on a stored
+	// scope it does not recognise: refuse, never trim.
+	authorized, err := ParseRequestedScopes(strings.Join(claims.Scopes, " "))
+	if err != nil {
+		return nil, err
+	}
+
+	authorizedSet := make(map[Scope]struct{}, len(authorized))
+	for _, sc := range authorized {
+		authorizedSet[sc] = struct{}{}
+	}
+	requestedSet := make(map[Scope]struct{}, len(requested))
+	for _, sc := range requested {
+		requestedSet[sc] = struct{}{}
+	}
+
+	for _, sc := range requested {
+		if _, ok := authorizedSet[sc]; !ok {
+			return nil, domain.Validation(ErrCodeScopeNotAuthorized,
+				fmt.Sprintf("scope %q is not part of the authorization request this consent "+
+					"was issued for", string(sc))).
+				WithDetails(map[string]any{
+					"unauthorized_scope": string(sc),
+					"authorized_scopes":  claims.Scopes,
+				})
+		}
+	}
+	for _, sc := range authorized {
+		if _, ok := requestedSet[sc]; !ok {
+			return nil, domain.Validation(ErrCodeScopeNotAuthorized,
+				fmt.Sprintf("this approval drops scope %q, which the authorization request "+
+					"carried and the consent screen showed; approve the request as it was "+
+					"made or start a new one", string(sc))).
+				WithDetails(map[string]any{
+					"missing_scope":     string(sc),
+					"authorized_scopes": claims.Scopes,
+				})
+		}
+	}
+	return authorized, nil
+}

--- a/apps/api/internal/mcp/consent_ticket.go
+++ b/apps/api/internal/mcp/consent_ticket.go
@@ -4,9 +4,18 @@ package mcp
 // actually carried, so that the approval which follows it is measured against
 // that request rather than against its own body.
 //
-// THE PROPERTY THIS FILE EXISTS TO HOLD. A grant's stored scope set is the set
-// the authorize call requested and the consent screen displayed. Not a set the
-// approval POST names, and not "any set the registry happens to recognise".
+// THE PROPERTY THIS FILE EXISTS TO HOLD, STATED AS EXACTLY AS THE TICKET CAN
+// SUPPORT IT. A grant's stored scope set is one that some principal authorized
+// to create grants on this install validated, as a (client_id, scope set) pair,
+// within the last fifteen minutes. Not a set the approval POST names, and not
+// "any set the registry happens to recognise".
+//
+// IT IS NOT "THE SET THE CONSENT SCREEN DISPLAYED", and the gap is worth
+// spelling out because the stronger sentence is the one that wants writing. The
+// ticket is minted by Service.Authorize, which the same principal can call
+// again; what it records is that the pair passed validation, not that a screen
+// rendered it or that a human agreed to it. Service.Approve carries the note on
+// what that leaves open, and the three fixes that would close it.
 //
 // WHY A TICKET AND NOT A ROW. Service.Authorize mints nothing -- no grant, no
 // code, no row -- and that is deliberate: until a human approves, nothing
@@ -191,6 +200,21 @@ func (c *consentTicketCodec) issue(clientID string, scopes []Scope, now time.Tim
 // One boolean rather than an error, for the reason handshakeCodec.open gives:
 // every failure here has the same answer for the caller, and naming which check
 // failed invites a branch that treats "altered" as recoverable.
+//
+// THE TICKET STRING IS MALLEABLE; THE CLAIMS IT CARRIES ARE NOT. Both halves
+// are decoded with base64.RawURLEncoding, which -- unlike its .Strict() form --
+// accepts non-canonical trailing bits, so several DISTINCT strings decode to
+// the same signature and the same payload and every one of them opens here.
+// Nothing is weakened by that today for exactly one reason: NOTHING KEYS
+// ANYTHING ON THE STRING. The ticket is not single-use, there is no replay
+// cache, and the only value anything downstream reads is the verified claims
+// struct this returns.
+//
+// THAT IS A PRECONDITION, NOT A PROPERTY OF THE ENCODING. The moment anyone
+// adds state keyed on the raw ticket -- a seen-tickets set to make it
+// single-use, a dedupe key, a rate-limit bucket -- re-encoding the same payload
+// walks straight past it. Key such a thing on the verified claims, or switch
+// both decoders here to base64.RawURLEncoding.Strict() before adding it.
 func (c *consentTicketCodec) open(raw string, now time.Time) (consentTicketClaims, bool) {
 	if raw == "" || len(raw) > consentTicketMaxBytes {
 		return consentTicketClaims{}, false

--- a/apps/api/internal/mcp/consent_ticket_test.go
+++ b/apps/api/internal/mcp/consent_ticket_test.go
@@ -93,6 +93,25 @@ func withRecognisedScope(t *testing.T, sc Scope) {
 	t.Cleanup(func() { delete(recognisedScopes, sc) })
 }
 
+// withScopeConferring makes sc confer caps for the duration of one test, and
+// restores the shipped map afterwards.
+//
+// IT IS WHAT MAKES THE PLANTED FAILURE HONEST. A scope that confers nothing is
+// refused a few lines further on by the capability resolver, so an escalation
+// test built on one would keep passing with the binding deleted -- refused for
+// a reason that has nothing to do with what it claims to prove. Conferring an
+// EXISTING capability on the planted scope removes that accidental backstop, so
+// deleting the binding actually mints the grant. scopeCapabilities itself is
+// unchanged; nothing here is conferred in the shipped build.
+func withScopeConferring(t *testing.T, sc Scope, caps ...Capability) {
+	t.Helper()
+	if _, exists := scopeCapabilities[sc]; exists {
+		t.Fatalf("withScopeConferring: %q already confers in the shipped map", sc)
+	}
+	scopeCapabilities[sc] = caps
+	t.Cleanup(func() { delete(scopeCapabilities, sc) })
+}
+
 // plantedScope is the second registry member these tests run against. The
 // spelling is not a scope anyone plans to ship.
 const plantedScope = Scope("mcp:planted-test-only")
@@ -152,6 +171,10 @@ func mustNotHaveCreatedAGrant(t *testing.T, store *fakeStore) {
 // Registry membership cannot see that. The ticket can.
 func TestApprove_RefusesAScopeTheAuthorizeCallDidNotCarry(t *testing.T) {
 	withRecognisedScope(t, plantedScope)
+	// And it confers something, so nothing downstream refuses this approval for
+	// an unrelated reason. Without this the test would pass with the binding
+	// deleted.
+	withScopeConferring(t, plantedScope, CapSitesRead)
 
 	cases := map[string][]Scope{
 		"substituted for the authorized scope": {plantedScope},
@@ -285,6 +308,7 @@ func TestAuthorizedScopes_ComparesSetsNotSequences(t *testing.T) {
 // said one thing and the grant recorded another.
 func TestApprove_RefusesABodyNarrowerThanTheAuthorizeCall(t *testing.T) {
 	withRecognisedScope(t, plantedScope)
+	withScopeConferring(t, plantedScope, CapSitesRead)
 
 	store := approvalStore()
 	svc := consentSvc(store)

--- a/apps/api/internal/mcp/consent_ticket_test.go
+++ b/apps/api/internal/mcp/consent_ticket_test.go
@@ -1,0 +1,440 @@
+// The binding between an authorize call and the approval that follows it,
+// executed rather than argued about in a comment.
+//
+// WHY THESE TESTS PLANT A SECOND RECOGNISED SCOPE. The property under test --
+// "the stored set is the set the authorize call carried" -- is only
+// DISTINGUISHABLE from "the stored set is a set the registry recognises" when
+// the registry has more than one member. With one member the two rules accept
+// exactly the same values, so a test written against the shipped registry
+// passes whether the binding exists or not, which is the vacuous pass this
+// project treats as a defect.
+//
+// So these tests plant the second scope IN THE TEST PROCESS, the way
+// authenticate_scope_column_test.go plants a grant row the database's CHECK
+// constraint forbids: the value under test is unreachable through the shipped
+// configuration, and the code that must handle it cannot be reached any other
+// way. Nothing is added to the shipped registry -- withRecognisedScope restores
+// it, and scope.go is unchanged -- and the scope named here is deliberately not
+// a scope anyone intends to ship, so a future write scope cannot inherit a
+// passing test it never ran.
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mosamlife/wpmgr/apps/api/internal/domain"
+)
+
+// testSessionSecret keys the consent ticket codec for every test in this
+// package. Any 32+ byte value works; it is a key, not a fixture with meaning.
+const testSessionSecret = "test-session-secret-0123456789-abcdefghij"
+
+// testTicketCodec is the codec validConsent() mints with and consentSvc()
+// verifies with. One key on both sides is what makes a hand-built
+// ConsentContext behave like one this server issued.
+var testTicketCodec = func() *consentTicketCodec {
+	c, err := newConsentTicketCodec(testSessionSecret)
+	if err != nil {
+		panic("mcp tests: " + err.Error())
+	}
+	return c
+}()
+
+// issueTestTicket seals a ticket for clientID over scopes, as of now.
+func issueTestTicket(clientID string, scopes []Scope, now time.Time) string {
+	tkt, err := testTicketCodec.issue(clientID, scopes, now)
+	if err != nil {
+		panic("mcp tests: issue consent ticket: " + err.Error())
+	}
+	return tkt
+}
+
+// consentSvc is NewService plus the shared ticket key.
+//
+// Every test that drives Approve goes through it rather than through
+// NewService, because NewService arms a FRESH RANDOM key: a ticket minted
+// anywhere else would be refused, and a test that cannot present a valid ticket
+// proves nothing about what happens when someone presents an invalid one.
+func consentSvc(store Store) *Service {
+	// The audit recorder is not incidental: A10 makes an unaudited Service
+	// refuse to approve, so a test that omitted it would be asserting about the
+	// wrong refusal.
+	return consentKeyed(NewService(store).withAuditRecorder(&capturingRecorder{}))
+}
+
+// consentKeyed arms svc with the shared test ticket key, preserving whatever
+// else the caller has already wired onto it. Every test constructor that drives
+// the approval path goes through it, so this package's fixtures present tickets
+// a real authorize call would have issued.
+func consentKeyed(svc *Service) *Service {
+	if err := svc.SetConsentSigningSecret(testSessionSecret); err != nil {
+		panic("mcp tests: " + err.Error())
+	}
+	return svc
+}
+
+// withRecognisedScope adds sc to the closed registry for the duration of one
+// test and removes it afterwards.
+//
+// NOT PARALLEL-SAFE, deliberately and unavoidably: recognisedScopes is package
+// state. No test in this file calls t.Parallel, and one that did would be
+// mutating the registry underneath every other test in the package.
+func withRecognisedScope(t *testing.T, sc Scope) {
+	t.Helper()
+	if _, exists := recognisedScopes[sc]; exists {
+		t.Fatalf("withRecognisedScope: %q is already in the shipped registry; "+
+			"this helper exists to plant a scope the build does NOT recognise, "+
+			"and planting a real one would make the test assert nothing", sc)
+	}
+	recognisedScopes[sc] = struct{}{}
+	t.Cleanup(func() { delete(recognisedScopes, sc) })
+}
+
+// plantedScope is the second registry member these tests run against. The
+// spelling is not a scope anyone plans to ship.
+const plantedScope = Scope("mcp:planted-test-only")
+
+// authorizeForTest runs the real authorize path and returns the consent context
+// it produced -- ticket included. Tests build their approval from THIS, the way
+// the dashboard builds its POST from the consent response, so the honest path
+// under test is the honest path in production.
+func authorizeForTest(t *testing.T, svc *Service, scope string) ConsentContext {
+	t.Helper()
+	consent, err := svc.Authorize(context.Background(), AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            registeredClientID,
+		RedirectURI:         registeredRedirect,
+		Scope:               scope,
+		State:               "opaque-state",
+		CodeChallenge:       "a-real-challenge-value",
+		CodeChallengeMethod: CodeChallengeMethodS256,
+	})
+	if err != nil {
+		t.Fatalf("Authorize(%q) refused a well-formed request: %v", scope, err)
+	}
+	if consent.ConsentTicket == "" {
+		t.Fatal("Authorize returned no consent ticket, so nothing downstream can " +
+			"tell what this request asked for")
+	}
+	return consent
+}
+
+func approvalFor(consent ConsentContext) ApprovalRequest {
+	req := validApproval()
+	req.Consent = consent
+	return req
+}
+
+func mustNotHaveCreatedAGrant(t *testing.T, store *fakeStore) {
+	t.Helper()
+	for _, c := range store.calls {
+		if c == "CreateGrantWithCode" {
+			t.Fatal("a refused approval still created a grant; a minted grant and " +
+				"an issued token are not undone by refusing afterwards")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE PROOF THAT MATTERS
+// ---------------------------------------------------------------------------
+
+// TestApprove_RefusesAScopeTheAuthorizeCallDidNotCarry is the direction where
+// the wrong answer still "works": every value involved is well-formed, the
+// client is registered, the redirect matches, the PKCE challenge is real, and
+// the scope named in the body is one the server recognises. The only thing
+// wrong with it is that the authorize call never asked for it and the operator
+// was never shown it.
+//
+// Registry membership cannot see that. The ticket can.
+func TestApprove_RefusesAScopeTheAuthorizeCallDidNotCarry(t *testing.T) {
+	withRecognisedScope(t, plantedScope)
+
+	cases := map[string][]Scope{
+		"substituted for the authorized scope": {plantedScope},
+		"added alongside the authorized scope": {ScopeRead, plantedScope},
+	}
+
+	for name, tampered := range cases {
+		t.Run(name, func(t *testing.T) {
+			store := approvalStore()
+			svc := consentSvc(store)
+
+			// The operator saw, and approved, a screen that said mcp:read.
+			consent := authorizeForTest(t, svc, string(ScopeRead))
+
+			// The body that comes back names something else. Everything else on
+			// it -- the ticket included -- is exactly what the server issued.
+			req := approvalFor(consent)
+			req.Consent.Scopes = tampered
+
+			got, err := svc.Approve(context.Background(), req)
+			if err == nil {
+				t.Fatalf("Approve minted code %q for scopes %v, which the authorize "+
+					"call never carried. The grant now holds authority the operator "+
+					"was not shown and did not approve.", got.Code, tampered)
+			}
+			mustNotHaveCreatedAGrant(t, store)
+
+			de, ok := domain.AsDomain(err)
+			if !ok {
+				t.Fatalf("the refusal is not a domain error (%v), so it renders as a "+
+					"500 and names nothing the caller can act on", err)
+			}
+			if de.Code != ErrCodeScopeNotAuthorized {
+				t.Fatalf("refusal code = %q, want %q. A caller told only that it was "+
+					"denied retries the identical request forever.",
+					de.Code, ErrCodeScopeNotAuthorized)
+			}
+			if !strings.Contains(de.Message, string(plantedScope)) {
+				t.Fatalf("refusal message %q does not name the offending scope %q; "+
+					"the whole point of a specific code is a specific remedy",
+					de.Message, plantedScope)
+			}
+		})
+	}
+}
+
+// TestApprove_StoresTheAuthorizedScopeSet is the over-fire test: the honest
+// path, unchanged. A consent echoed back exactly as it was issued produces the
+// same grant it always did.
+//
+// It asserts the STORED COLUMN, not merely that no error was returned. "It did
+// not refuse" is compatible with having stored the wrong thing.
+func TestApprove_StoresTheAuthorizedScopeSet(t *testing.T) {
+	store := approvalStore()
+	svc := consentSvc(store)
+
+	consent := authorizeForTest(t, svc, string(ScopeRead))
+	got, err := svc.Approve(context.Background(), approvalFor(consent))
+	if err != nil {
+		t.Fatalf("Approve refused an approval that matches its own authorize call: %v", err)
+	}
+	if got.Code == "" {
+		t.Fatal("Approve returned no code on the honest path")
+	}
+	if len(store.approved) != 1 {
+		t.Fatalf("CreateGrantWithCode called %d times, want 1", len(store.approved))
+	}
+	if want := []string{string(ScopeRead)}; !equalStrings(store.approved[0].OauthScopes, want) {
+		t.Fatalf("stored oauth_scopes = %v, want %v", store.approved[0].OauthScopes, want)
+	}
+	if len(store.approved[0].Capabilities) == 0 {
+		t.Fatal("the honest path stored an empty capability set; the binding must " +
+			"not have narrowed what the grant may do")
+	}
+}
+
+// TestApprove_AcceptsARepeatedScope is the over-fire test on the production
+// path: RFC 6749 permits repetition and it adds no authority, so a body that
+// repeats what it was shown has changed nothing and must not be refused. A
+// guard that reddens correct work gets switched off, and then it guards
+// nothing.
+func TestApprove_AcceptsARepeatedScope(t *testing.T) {
+	store := approvalStore()
+	svc := consentSvc(store)
+
+	consent := authorizeForTest(t, svc, string(ScopeRead))
+	req := approvalFor(consent)
+	req.Consent.Scopes = []Scope{ScopeRead, ScopeRead}
+
+	if _, err := svc.Approve(context.Background(), req); err != nil {
+		t.Fatalf("Approve refused a body that repeated the authorized scope: %v", err)
+	}
+	if want := []string{string(ScopeRead)}; !equalStrings(store.approved[0].OauthScopes, want) {
+		t.Fatalf("stored oauth_scopes = %v, want %v", store.approved[0].OauthScopes, want)
+	}
+}
+
+// TestAuthorizedScopes_ComparesSetsNotSequences pins the comparison itself over
+// a two-member set, which is the only shape where ordering is observable.
+//
+// It exercises the binding DIRECTLY rather than through Approve, because a
+// planted scope confers no capability -- OrgDefaultCapabilities refuses it a few
+// lines later, by design, and that refusal would mask whichever answer this
+// comparison gave. The capability ceiling is not what is under test here; what
+// the binding accepts is.
+func TestAuthorizedScopes_ComparesSetsNotSequences(t *testing.T) {
+	withRecognisedScope(t, plantedScope)
+
+	svc := consentSvc(approvalStore())
+	consent := authorizeForTest(t, svc, string(ScopeRead)+" "+string(plantedScope))
+	// Same set, reversed, with one member repeated.
+	consent.Scopes = []Scope{plantedScope, ScopeRead, ScopeRead}
+
+	got, err := svc.authorizedScopes(consent)
+	if err != nil {
+		t.Fatalf("the binding refused a body naming the same SET in a different order: %v", err)
+	}
+	// Canonical order is the ticket's, which is sorted: the planted spelling
+	// sorts before mcp:read.
+	want := []string{string(plantedScope), string(ScopeRead)}
+	if !equalStrings(scopeNames(got), want) {
+		t.Fatalf("resolved scopes = %v, want %v (the ticket's set, canonically ordered, "+
+			"not the body's ordering)", scopeNames(got), want)
+	}
+}
+
+// TestApprove_RefusesABodyNarrowerThanTheAuthorizeCall. Narrowing is not
+// escalation, and it is still refused: the consent screen offers no
+// scope-narrowing control, so a narrower body is not an operator's decision. It
+// is the round trip disagreeing with itself, and accepting it means the screen
+// said one thing and the grant recorded another.
+func TestApprove_RefusesABodyNarrowerThanTheAuthorizeCall(t *testing.T) {
+	withRecognisedScope(t, plantedScope)
+
+	store := approvalStore()
+	svc := consentSvc(store)
+
+	consent := authorizeForTest(t, svc, string(ScopeRead)+" "+string(plantedScope))
+	req := approvalFor(consent)
+	req.Consent.Scopes = []Scope{ScopeRead}
+
+	_, err := svc.Approve(context.Background(), req)
+	if err == nil {
+		t.Fatal("Approve accepted a body that silently dropped a scope the consent " +
+			"screen displayed")
+	}
+	mustNotHaveCreatedAGrant(t, store)
+
+	de, ok := domain.AsDomain(err)
+	if !ok || de.Code != ErrCodeScopeNotAuthorized {
+		t.Fatalf("refusal = %v, want a domain error coded %q", err, ErrCodeScopeNotAuthorized)
+	}
+	if !strings.Contains(de.Message, string(plantedScope)) {
+		t.Fatalf("refusal message %q does not name the dropped scope %q", de.Message, plantedScope)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE TICKET ITSELF -- absent, altered, expired, or issued for someone else.
+// Each is a refusal with its own code, because each has its own remedy.
+// ---------------------------------------------------------------------------
+
+func TestApprove_RefusesAnApprovalWithNoUsableConsentTicket(t *testing.T) {
+	honest := func(svc *Service, t *testing.T) ConsentContext {
+		return authorizeForTest(t, svc, string(ScopeRead))
+	}
+
+	cases := map[string]func(*Service, *testing.T) ConsentContext{
+		"no ticket at all": func(svc *Service, t *testing.T) ConsentContext {
+			c := honest(svc, t)
+			c.ConsentTicket = ""
+			return c
+		},
+		"a ticket this server never issued": func(svc *Service, t *testing.T) ConsentContext {
+			c := honest(svc, t)
+			c.ConsentTicket = "ZXlKaklqb2lZeUo5.bm90LWEtcmVhbC1tYWM"
+			return c
+		},
+		"a ticket whose signature no longer matches its payload": func(svc *Service, t *testing.T) ConsentContext {
+			c := honest(svc, t)
+			body, sig, _ := strings.Cut(c.ConsentTicket, ".")
+			// Re-seal the payload of a DIFFERENT request under the old
+			// signature: the classic split-the-token substitution.
+			other := issueTestTicket(registeredClientID, []Scope{ScopeRead},
+				time.Now().Add(time.Minute))
+			otherBody, _, _ := strings.Cut(other, ".")
+			if otherBody == body {
+				t.Skip("the two payloads collided; nothing to substitute")
+			}
+			c.ConsentTicket = otherBody + "." + sig
+			return c
+		},
+		"an expired ticket": func(svc *Service, t *testing.T) ConsentContext {
+			c := honest(svc, t)
+			c.ConsentTicket = issueTestTicket(registeredClientID, []Scope{ScopeRead},
+				time.Now().Add(-consentTicketTTL-time.Minute))
+			return c
+		},
+		"a ticket issued for another client": func(svc *Service, t *testing.T) ConsentContext {
+			c := honest(svc, t)
+			c.ConsentTicket = issueTestTicket("some-other-registered-client",
+				[]Scope{ScopeRead}, time.Now())
+			return c
+		},
+	}
+
+	for name, build := range cases {
+		t.Run(name, func(t *testing.T) {
+			store := approvalStore()
+			svc := consentSvc(store)
+
+			req := approvalFor(build(svc, t))
+			got, err := svc.Approve(context.Background(), req)
+			if err == nil {
+				t.Fatalf("Approve minted code %q for an approval carrying %s; the "+
+					"scope set it stored is then whatever the body said", got.Code, name)
+			}
+			mustNotHaveCreatedAGrant(t, store)
+
+			de, ok := domain.AsDomain(err)
+			if !ok || de.Code != ErrCodeConsentTicketInvalid {
+				t.Fatalf("refusal = %v, want a domain error coded %q",
+					err, ErrCodeConsentTicketInvalid)
+			}
+		})
+	}
+}
+
+// TestConsentTicketIsNotVerifiableWithADifferentKey pins the key derivation
+// itself: two instances that do not share the session secret must not accept
+// each other's tickets, which is the property that makes the shared secret
+// (rather than a per-process key) the correct wiring.
+func TestConsentTicketIsNotVerifiableWithADifferentKey(t *testing.T) {
+	other, err := newConsentTicketCodec("a-completely-different-session-secret-32b")
+	if err != nil {
+		t.Fatalf("newConsentTicketCodec: %v", err)
+	}
+	tkt := issueTestTicket(registeredClientID, []Scope{ScopeRead}, time.Now())
+	if _, ok := other.open(tkt, time.Now()); ok {
+		t.Fatal("a ticket verified under a key it was not issued with")
+	}
+	if _, ok := testTicketCodec.open(tkt, time.Now()); !ok {
+		t.Fatal("a ticket did not verify under its own key")
+	}
+}
+
+// TestNewConsentTicketCodecRefusesAWeakSecret. The alternative to refusing is
+// deriving a key from a short string, which is a signature nobody can rely on
+// wearing the shape of one they can.
+func TestNewConsentTicketCodecRefusesAWeakSecret(t *testing.T) {
+	if _, err := newConsentTicketCodec("too-short"); err == nil {
+		t.Fatal("newConsentTicketCodec accepted a secret too short to derive a key from")
+	}
+}
+
+// TestNewServiceArmsAConsentTicketCodec. There must be no Service anywhere that
+// skips the check for want of a key: an unarmed codec would be a wiring failure
+// presenting as a working endpoint, which is the same reason NewService arms
+// its own rate limiter.
+func TestNewServiceArmsAConsentTicketCodec(t *testing.T) {
+	svc := NewService(approvalStore())
+	if svc.consentTickets == nil {
+		t.Fatal("NewService left the consent ticket codec nil")
+	}
+	consent := authorizeForTest(t, svc, string(ScopeRead))
+	if _, ok := svc.consentTickets.open(consent.ConsentTicket, time.Now()); !ok {
+		t.Fatal("a Service could not verify the ticket it had just issued")
+	}
+	// And it is not the shared test key: an unwired Service is alone, not open.
+	if _, ok := testTicketCodec.open(consent.ConsentTicket, time.Now()); ok {
+		t.Fatal("NewService's ephemeral codec produced a ticket verifiable under " +
+			"another key, so its key is not ephemeral")
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/api/internal/mcp/consent_ticket_test.go
+++ b/apps/api/internal/mcp/consent_ticket_test.go
@@ -363,7 +363,14 @@ func TestApprove_RefusesAnApprovalWithNoUsableConsentTicket(t *testing.T) {
 				time.Now().Add(time.Minute))
 			otherBody, _, _ := strings.Cut(other, ".")
 			if otherBody == body {
-				t.Skip("the two payloads collided; nothing to substitute")
+				// DELIBERATELY NOT A SKIP. This is a negative control, and a
+				// negative control that opts itself out is a guard that has
+				// silently stopped guarding -- green, and testing nothing. The
+				// two payloads differ by 60s of expiry, so a collision here
+				// means the ticket payload has lost a field or the clock has
+				// stopped; either is a finding.
+				t.Fatalf("the two ticket payloads are identical (%q), so the substitution "+
+					"this case exists to perform is no longer possible", body)
 			}
 			c.ConsentTicket = otherBody + "." + sig
 			return c

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -131,10 +131,10 @@ type approvalRequestDTO struct {
 	// there is no path that falls back to believing `scopes`.
 	ConsentTicket string `json:"consent_ticket"`
 
-	GrantName           string   `json:"name"`
-	SiteScopeMode       string   `json:"site_scope_mode"`
-	ScopeTagIDs         []string `json:"scope_tag_ids"`
-	ScopeSiteIDs        []string `json:"scope_site_ids"`
+	GrantName     string   `json:"name"`
+	SiteScopeMode string   `json:"site_scope_mode"`
+	ScopeTagIDs   []string `json:"scope_tag_ids"`
+	ScopeSiteIDs  []string `json:"scope_site_ids"`
 
 	// Capabilities is the TOOL axis of the consent screen, and it is spelled
 	// and resolved EXACTLY as mintConnectionRequestDTO.Capabilities is -- one

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -64,13 +64,21 @@ type consentResponseDTO struct {
 
 	// ConsentTicket is the server's sealed record of THIS authorize call: the
 	// client it was made for and the scope set it carried. The screen does not
-	// render it and cannot read it; it exists to be handed back verbatim on the
-	// approval POST, where it is what lets the server store the scope set this
-	// screen displayed rather than the one the POST body spells.
+	// render it; it exists to be handed back verbatim on the approval POST,
+	// where it is what lets the server store a scope set it sealed itself
+	// rather than the one the POST body spells.
+	//
+	// SEALED IS NOT SECRET. The payload is plain base64url JSON and anyone
+	// holding the ticket can read it in one line -- which costs nothing,
+	// because its contents are the client id and the scope set the same screen
+	// already displays. What the MAC buys is integrity and origin, never
+	// confidentiality (consent_ticket.go, "WHY A MAC AND NOT AN AEAD"), and no
+	// part of this design leans on the value being unreadable.
 	//
 	// REQUIRED ON THE APPROVAL. A consent submitted without it is refused
 	// (mcp_invalid_consent_ticket), so a client of this API echoes the field
-	// unchanged; it is opaque and nothing about it is worth parsing.
+	// unchanged rather than reconstructing it: a re-encoded or re-serialised
+	// ticket is a ticket this server did not issue.
 	ConsentTicket string `json:"consent_ticket"`
 
 	// GrantLifetimeDays is how long the grant this screen consents to will

--- a/apps/api/internal/mcp/dto.go
+++ b/apps/api/internal/mcp/dto.go
@@ -62,6 +62,17 @@ type consentResponseDTO struct {
 	CodeChallenge        string   `json:"code_challenge"`
 	CodeChallengeMethod  string   `json:"code_challenge_method"`
 
+	// ConsentTicket is the server's sealed record of THIS authorize call: the
+	// client it was made for and the scope set it carried. The screen does not
+	// render it and cannot read it; it exists to be handed back verbatim on the
+	// approval POST, where it is what lets the server store the scope set this
+	// screen displayed rather than the one the POST body spells.
+	//
+	// REQUIRED ON THE APPROVAL. A consent submitted without it is refused
+	// (mcp_invalid_consent_ticket), so a client of this API echoes the field
+	// unchanged; it is opaque and nothing about it is worth parsing.
+	ConsentTicket string `json:"consent_ticket"`
+
 	// GrantLifetimeDays is how long the grant this screen consents to will
 	// live, and it is here because the screen cannot state a lifetime it is
 	// not given.
@@ -95,6 +106,7 @@ func toConsentResponse(c ConsentContext) consentResponseDTO {
 		State:               c.State,
 		CodeChallenge:       c.CodeChallenge,
 		CodeChallengeMethod: c.CodeChallengeMethod,
+		ConsentTicket:       c.ConsentTicket,
 		// Read from the same constant CreateGrant stamps expires_at from, not
 		// from a second copy of the number. See grantLifetimeDays.
 		GrantLifetimeDays: grantLifetimeDays(),
@@ -108,6 +120,17 @@ type approvalRequestDTO struct {
 	State               string   `json:"state"`
 	CodeChallenge       string   `json:"code_challenge"`
 	CodeChallengeMethod string   `json:"code_challenge_method"`
+
+	// ConsentTicket is consentResponseDTO.ConsentTicket, echoed back unchanged.
+	//
+	// IT IS THE ONLY FIELD IN THIS BODY THE CALLER CANNOT AUTHOR, and that is
+	// its whole job. `scopes` above says what this POST wants recorded; the
+	// ticket says what the authorize call actually asked for and the consent
+	// screen actually showed. The grant is written from the second. An absent,
+	// altered, expired or wrong-client ticket refuses the approval outright --
+	// there is no path that falls back to believing `scopes`.
+	ConsentTicket string `json:"consent_ticket"`
+
 	GrantName           string   `json:"name"`
 	SiteScopeMode       string   `json:"site_scope_mode"`
 	ScopeTagIDs         []string `json:"scope_tag_ids"`
@@ -472,6 +495,18 @@ func oauthError(err error) (int, oauthErrorDTO) {
 	switch domErr.Code {
 	case ErrCodeInvalidScope:
 		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_scope", ErrDesc: domErr.Message}
+	case ErrCodeScopeNotAuthorized:
+		// RFC 6749 section 5.2 invalid_scope: "the requested scope is ...
+		// exceeds the scope granted by the resource owner". That is exactly
+		// this case, and the description names which scope, so a client is told
+		// what to change rather than being left to retry the same body.
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_scope", ErrDesc: domErr.Message}
+	case ErrCodeConsentTicketInvalid:
+		// invalid_request, not invalid_scope: the remedy is to start the
+		// authorization request again, not to edit the scope list. Mapped
+		// explicitly even though the default arm renders the same pair, so the
+		// mapping is a decision on the page rather than a coincidence.
+		return http.StatusBadRequest, oauthErrorDTO{Err: "invalid_request", ErrDesc: domErr.Message}
 	case ErrCodeInvalidClient:
 		return http.StatusUnauthorized, oauthErrorDTO{Err: "invalid_client", ErrDesc: domErr.Message}
 	case ErrCodeInvalidGrant:

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -763,9 +763,9 @@ func (h *Handler) token(c *gin.Context) {
 	// secret at all; that is the "none" path and it is unchanged.
 
 	out, err := h.svc.Exchange(c.Request.Context(), TokenRequest{
-		GrantType:    body.GrantType,
-		Code:         body.Code,
-		RedirectURI:  body.RedirectURI,
+		GrantType:     body.GrantType,
+		Code:          body.Code,
+		RedirectURI:   body.RedirectURI,
 		ClientID:      clientID,
 		ClientSecret:  clientSecret,
 		CodeVerifier:  body.CodeVerifier,

--- a/apps/api/internal/mcp/handler.go
+++ b/apps/api/internal/mcp/handler.go
@@ -690,6 +690,12 @@ func (h *Handler) consent(c *gin.Context) {
 			State:               body.State,
 			CodeChallenge:       body.CodeChallenge,
 			CodeChallengeMethod: body.CodeChallengeMethod,
+			// Copied through unexamined, like every other field here. The
+			// handler does not open it, does not check it and cannot: it is
+			// sealed with a key only the service holds, and Service.Approve is
+			// the single place that decides whether this approval matches the
+			// authorize call it claims to follow.
+			ConsentTicket: body.ConsentTicket,
 		},
 		GrantName: body.GrantName,
 		SiteScope: SiteScopeRequest{

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -892,6 +892,60 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 	// authorizedScopes, on both sets. Registry membership says a scope EXISTS;
 	// the ticket says THIS REQUEST ASKED FOR IT. The second question is the one
 	// the stored grant answers, and it is now asked.
+	//
+	// WHOEVER ADDS THE SECOND RECOGNISED SCOPE MUST STILL SETTLE SOMETHING
+	// FIRST, and this comment is again the only thing pointing at it. An
+	// earlier version of it said the binding described above was the
+	// prerequisite. The binding is built and it NARROWS the problem; it does
+	// not close it, so the prerequisite is now a decision rather than a diff.
+	//
+	// WHAT THE BINDING DOES BUY, exactly. An approval body can no longer
+	// fabricate a scope set out of nothing: every set that reaches
+	// mcp_grants.oauth_scopes is one this server sealed after validating an
+	// authorize call. And a cross-origin forged POST cannot obtain a ticket at
+	// all, because the attacker would have to read the /authorize response to
+	// copy it and same-origin policy does not let it. Both are strictly better
+	// than the registry-membership check that stood here alone.
+	//
+	// WHAT IT DOES NOT BUY. The ticket attests that a (client_id, scope set)
+	// pair was VALIDATED, not that a human was shown it or chose it -- see the
+	// header of consent_ticket.go. handler.go mounts GET /authorize and POST
+	// /consent behind the same requireOrgScope() + requireGrantPermission()
+	// pair, and Authorize measures the requested scope against the global
+	// recognisedScopes registry rather than against the client's own
+	// registration. So any principal that can submit an approval can also
+	// obtain a ticket for any recognised scope, by making the authorize call
+	// itself. Against an operator that is what consent means; against a
+	// BROWSER-SIDE ATTACKER holding that principal's session -- XSS, a
+	// malicious extension, a compromised dashboard bundle -- it costs nothing,
+	// and the escalation is narrowed rather than closed.
+	//
+	// THERE IS NO CHEAP STATELESS FIX. This was looked for. Sealing the
+	// operator, the org, the redirect_uri, the state or the code_challenge into
+	// the MAC buys nothing, because the second authorize call is made by the
+	// same principal in the same browser and reuses every one of them. Recorded
+	// here so the next author does not spend the afternoon re-deriving it.
+	//
+	// THE THREE CANDIDATES THAT DO WORK, one of which has to be chosen before a
+	// second scope is recognised, not in the diff after it:
+	//
+	//  1. A single-use nonce minted per consent SCREEN and required by the
+	//     approval, which turns "this pair was validated" into "this screen was
+	//     answered once". It costs the server-side state this design was
+	//     deliberately built without; consent_ticket.go says why.
+	//  2. Constrain /authorize to the scopes on the client's own registration,
+	//     so a ticket for a scope that client never registered cannot be minted
+	//     in the first place. This is the narrowest of the three and does not
+	//     add state.
+	//  3. An explicit owner ruling that a browser-side attacker already holding
+	//     PermAPIKeyManage is outside the threat model -- written down, not
+	//     assumed, because everything above then becomes a documented
+	//     acceptance rather than an oversight.
+	//
+	// NOTHING IS REACHABLE TODAY: one scope is recognised, so the only ticket
+	// this server will mint and the only set this line can store is {mcp:read},
+	// which is what the old hard-coded constant produced anyway. Recognising
+	// the second scope is what makes the difference observable.
 	grantedScopes, err := s.authorizedScopes(req.Consent)
 	if err != nil {
 		return Approval{}, err

--- a/apps/api/internal/mcp/service.go
+++ b/apps/api/internal/mcp/service.go
@@ -331,6 +331,15 @@ type Service struct {
 	// which is why those tests assert a REFUSAL rather than a result; see
 	// govcontext_test.go.
 	context ContextResolver
+
+	// consentTickets binds an approval to the authorize call it followed. See
+	// consent_ticket.go.
+	//
+	// NEVER NIL after NewService, and that is what keeps "verify the ticket"
+	// from acquiring a "unless none is configured" arm. See
+	// newEphemeralConsentTicketCodec for what the unwired default does and does
+	// not promise; cmd/wpmgr replaces it with the instance-wide key at boot.
+	consentTickets *consentTicketCodec
 }
 
 func NewService(store Store) *Service {
@@ -340,9 +349,30 @@ func NewService(store Store) *Service {
 		// Armed HERE rather than injected with a nil default, for the reason
 		// NewHandler gives about its own limiter: an unarmed limiter would be a
 		// wiring failure that presents as a working endpoint.
-		mintLimit: newMintLimiter(),
-		pageBound: sitesPageBound,
+		mintLimit:      newMintLimiter(),
+		pageBound:      sitesPageBound,
+		consentTickets: newEphemeralConsentTicketCodec(),
 	}
+}
+
+// SetConsentSigningSecret keys the consent ticket from the instance session
+// secret, so a ticket issued by one instance verifies on the one that receives
+// the approval. Call it after NewService, before serving.
+//
+// It MUTATES the receiver rather than returning a copy, unlike the With*
+// options above, and mirrors auth.Handler.SetHandshakeSecret. The distinction
+// is deliberate: a With* option that silently dropped its result is a
+// misconfiguration that compiles, and this is the one setting whose absence
+// must be noticed at boot. It returns an error for the same reason -- a secret
+// too short to derive a key from fails the process rather than degrading to
+// something weaker.
+func (s *Service) SetConsentSigningSecret(sessionSecret string) error {
+	codec, err := newConsentTicketCodec(sessionSecret)
+	if err != nil {
+		return err
+	}
+	s.consentTickets = codec
+	return nil
 }
 
 // WithPageBound returns a copy reading sites with the supplied per-request
@@ -677,6 +707,17 @@ type ConsentContext struct {
 	// verifier -- so carrying it is not a secret leak.
 	CodeChallenge       string
 	CodeChallengeMethod string
+
+	// ConsentTicket is this server's own authenticated record of the authorize
+	// call that produced this context: the client it was made for and the scope
+	// set it carried, under a MAC, with an expiry inside the MAC.
+	//
+	// Authorize ISSUES it and Approve REQUIRES it. Everything else on this
+	// struct arrives in the approval POST body and is therefore caller input;
+	// this field is the one value on it that the caller cannot author, which is
+	// what lets Approve store the scope set the operator was shown rather than
+	// the one the body claims. See consent_ticket.go.
+	ConsentTicket string
 }
 
 // Authorize validates an authorization request and returns what the consent
@@ -731,6 +772,17 @@ func (s *Service) Authorize(ctx context.Context, req AuthorizeRequest) (ConsentC
 		redirectHost = u.Host
 	}
 
+	// THE ONE THING THIS CALL LEAVES BEHIND. It is still true that Authorize
+	// mints nothing -- no grant, no code, no row -- but it no longer forgets
+	// what it validated: the client and the scope set it just accepted are
+	// sealed into a ticket that the approval must present back. Without this
+	// the whole consent context is caller input by the time it returns here,
+	// and the stored scope set would be whatever the final POST spelled.
+	ticket, err := s.consentTickets.issue(client.ClientID, scopes, s.now())
+	if err != nil {
+		return ConsentContext{}, fmt.Errorf("issue consent ticket: %w", err)
+	}
+
 	return ConsentContext{
 		ClientID:             client.ClientID,
 		ClientNameUnverified: derefString(client.ClientName),
@@ -741,6 +793,7 @@ func (s *Service) Authorize(ctx context.Context, req AuthorizeRequest) (ConsentC
 		State:                req.State,
 		CodeChallenge:        req.CodeChallenge,
 		CodeChallengeMethod:  req.CodeChallengeMethod,
+		ConsentTicket:        ticket,
 	}, nil
 }
 
@@ -819,43 +872,27 @@ func (s *Service) Approve(ctx context.Context, req ApprovalRequest) (Approval, e
 		return Approval{}, domain.Validation(ErrCodeInvalidRequest, "a connection name is required")
 	}
 
-	// Re-run the exit gate on the approval too. The consent screen's scope list
-	// arrives back over the wire and a resubmitted form is caller input like
-	// any other, so it is re-parsed rather than trusted.
+	// THE SCOPE SET IS THE AUTHORIZE CALL'S, NOT THIS BODY'S.
 	//
-	// THE RESULT IS KEPT NOW, NOT DISCARDED. m136 gave the grant an
-	// oauth_scopes column and this is the only place on the OAuth path that
-	// carries what the client asked for and the operator saw. The stored value
-	// is this re-parsed set rather than a preset, and it is the same value the
-	// ceiling below is computed from, so the row and the ceiling cannot
-	// disagree.
+	// The consent context round-trips through the browser, so everything on
+	// req.Consent is caller input by the time it arrives here -- including the
+	// scope list. authorizedScopes measures that list against the consent
+	// ticket Authorize sealed (consent_ticket.go): the ticket carries the
+	// client and the scope set that call actually validated, under a MAC with
+	// an expiry, so this approval can only store the set the operator was
+	// shown. A body naming any other set is refused by name, in both
+	// directions, and nothing is written.
 	//
-	// BUT BE EXACT ABOUT WHAT THE RE-PARSE ESTABLISHES, BECAUSE IT IS LESS THAN
-	// IT LOOKS. Authorize mints nothing: the whole consent context round-trips
-	// through the browser and comes back here as caller input, and
-	// ParseRequestedScopes checks only that every member is in recognisedScopes.
-	// It does NOT check that this set is the set the authorize call carried. So
-	// the stored set is the approval BODY, constrained by registry membership,
-	// and calling it "the consent rather than a restatement of the registry"
-	// overstates it -- the two are the same thing only while the registry has a
-	// single member, which is why nothing is reachable here today: a tampered
-	// body can produce exactly {mcp:read} and nothing else, which is what the
-	// old hard-coded constant produced anyway.
+	// WHAT IT RETURNS IS THE TICKET'S SET, which is what makes this the single
+	// source for both writes below: mcp_grants.oauth_scopes and the capability
+	// ceiling are computed from one server-held value, so the row and the
+	// ceiling cannot disagree with each other or with the screen.
 	//
-	// WHOEVER ADDS THE SECOND RECOGNISED SCOPE MUST FIX THIS FIRST, and this
-	// comment is the only thing left pointing at it. The branch that introduced
-	// the column removed TestGrantScopesIsExactOnlyWhileOneScopeExists, which
-	// asserted len(recognisedScopes) == 1; removing it was right, because m136
-	// exists to make the registry safe to grow -- but that assertion was the
-	// tripwire that would have forced a visit to this line. The moment a second
-	// scope is recognised, an approval body naming it is accepted here on the
-	// strength of registry membership alone, and the grant is stored holding a
-	// scope the authorize call need never have requested. Bind the stored set
-	// to what that call actually carried -- the authorize request has to leave
-	// behind something server-side to compare against -- before recognising the
-	// second scope, not in the diff after it. That binding is the write-scope
-	// PR's prerequisite and is deliberately not built here.
-	grantedScopes, err := ParseRequestedScopes(scopesToString(req.Consent.Scopes))
+	// The registry check that used to stand alone here still runs, inside
+	// authorizedScopes, on both sets. Registry membership says a scope EXISTS;
+	// the ticket says THIS REQUEST ASKED FOR IT. The second question is the one
+	// the stored grant answers, and it is now asked.
+	grantedScopes, err := s.authorizedScopes(req.Consent)
 	if err != nil {
 		return Approval{}, err
 	}

--- a/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
+++ b/apps/api/tests/adr064_s16_mcp_connections_integration_test.go
@@ -612,9 +612,18 @@ func connectRealGrant(t *testing.T, pool *db.Pool, svc *mcp.Service) connectedGr
 	q.Set("state", "s16-state")
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
+	// The consent screen, kept rather than discarded: it carries the ticket
+	// that binds the approval below to THIS authorize call, and a fixture that
+	// threw it away would be building a consent no operator was shown.
+	var consentScreen struct {
+		ConsentTicket string `json:"consent_ticket"`
+	}
 	if code := mcpDoJSON(t, eng, http.MethodGet,
-		mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		mcp.AuthorizePath+"?"+q.Encode(), nil, nil, &consentScreen); code != http.StatusOK {
 		t.Fatalf("fixture: authorize answered %d, want 200", code)
+	}
+	if consentScreen.ConsentTicket == "" {
+		t.Fatal("fixture: authorize returned no consent_ticket")
 	}
 
 	var approval struct {
@@ -630,6 +639,7 @@ func connectRealGrant(t *testing.T, pool *db.Pool, svc *mcp.Service) connectedGr
 		"code_challenge_method": "S256",
 		"name":                  "s16 connection under test",
 		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+		"consent_ticket":        consentScreen.ConsentTicket,
 	}, nil, &approval); code != http.StatusOK {
 		t.Fatalf("fixture: consent answered %d, want 200", code)
 	}

--- a/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
+++ b/apps/api/tests/adr064_s6b3_mcp_oauth_end_to_end_test.go
@@ -146,6 +146,9 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 		RedirectURI          string   `json:"redirect_uri"`
 		RedirectHost         string   `json:"redirect_host"`
 		Scopes               []string `json:"scopes"`
+		// The server's own record of THIS authorize call, echoed back on the
+		// approval below. A client that drops it cannot complete a consent.
+		ConsentTicket string `json:"consent_ticket"`
 	}
 	code = mcpDoJSON(t, eng, http.MethodGet,
 		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, &consentScreen)
@@ -178,6 +181,10 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 	// STEP 3: consent. The human's approval, and the only thing that binds this
 	// client to an organisation.
 	// -----------------------------------------------------------------------
+	if consentScreen.ConsentTicket == "" {
+		t.Fatal("STEP 2 consent screen carried no consent_ticket, so STEP 3 has " +
+			"nothing to prove which authorize call it is approving")
+	}
 	approveBody := map[string]any{
 		"client_id":             reg.ClientID,
 		"redirect_uri":          redirectURI,
@@ -187,6 +194,8 @@ func TestMCPOAuthEndToEndThroughMountedRoutesAsAppRole(t *testing.T) {
 		"code_challenge_method": "S256",
 		"name":                  "s6b3 end-to-end connection",
 		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+		// Echoed back verbatim, exactly as a client must.
+		"consent_ticket": consentScreen.ConsentTicket,
 	}
 	var approval struct {
 		GrantID string `json:"grant_id"`

--- a/apps/api/tests/mcp_audit_actor_attribution_integration_test.go
+++ b/apps/api/tests/mcp_audit_actor_attribution_integration_test.go
@@ -305,9 +305,15 @@ func driveConsentAsPrincipal(t *testing.T, eng *gin.Engine, grantName string) st
 	q.Set("state", "actor-state")
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
+	var consentScreen struct {
+		ConsentTicket string `json:"consent_ticket"`
+	}
 	if code := mcpDoJSON(t, eng, http.MethodGet,
-		mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+		mcp.AuthorizePath+"?"+q.Encode(), nil, nil, &consentScreen); code != http.StatusOK {
 		t.Fatalf("authorize answered %d, want 200", code)
+	}
+	if consentScreen.ConsentTicket == "" {
+		t.Fatal("authorize returned no consent_ticket")
 	}
 
 	var approval struct {
@@ -322,6 +328,7 @@ func driveConsentAsPrincipal(t *testing.T, eng *gin.Engine, grantName string) st
 		"code_challenge_method": "S256",
 		"name":                  grantName,
 		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+		"consent_ticket":        consentScreen.ConsentTicket,
 	}, nil, &approval); code != http.StatusOK {
 		t.Fatalf("consent answered %d, want 200", code)
 	}

--- a/apps/api/tests/mcp_audit_events_integration_test.go
+++ b/apps/api/tests/mcp_audit_events_integration_test.go
@@ -165,8 +165,14 @@ func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T)
 	q.Set("state", "audit-state")
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
-	if code := mcpDoJSON(t, eng, http.MethodGet, mcp.AuthorizePath+"?"+q.Encode(), nil, nil, nil); code != http.StatusOK {
+	var consentScreen struct {
+		ConsentTicket string `json:"consent_ticket"`
+	}
+	if code := mcpDoJSON(t, eng, http.MethodGet, mcp.AuthorizePath+"?"+q.Encode(), nil, nil, &consentScreen); code != http.StatusOK {
 		t.Fatalf("authorize answered %d, want 200", code)
+	}
+	if consentScreen.ConsentTicket == "" {
+		t.Fatal("authorize returned no consent_ticket")
 	}
 
 	var approval struct {
@@ -182,6 +188,7 @@ func TestMCPAuditEvents_GrantCreatedToolCalledAndRevoked_AsAppRole(t *testing.T)
 		"code_challenge_method": "S256",
 		"name":                  grantName,
 		"site_scope_mode":       string(mcp.SiteScopeModeAll),
+		"consent_ticket":        consentScreen.ConsentTicket,
 	}, nil, &approval); code != http.StatusOK {
 		t.Fatalf("consent answered %d, want 200", code)
 	}

--- a/apps/api/tests/mcp_consent_org_scope_integration_test.go
+++ b/apps/api/tests/mcp_consent_org_scope_integration_test.go
@@ -401,10 +401,17 @@ func TestMCPConsentAdmitsAnOrgMemberAsAppRole(t *testing.T) {
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
 
+	var consentScreen struct {
+		ConsentTicket string `json:"consent_ticket"`
+	}
 	if s := mcpDoJSON(t, eng, http.MethodGet,
-		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, nil); s != http.StatusOK {
+		"/api/v1/oauth/mcp/authorize?"+q.Encode(), nil, nil, &consentScreen); s != http.StatusOK {
 		t.Fatalf("OVER-FIRE: GET /authorize answered %d for an ordinary org "+
 			"member, want 200", s)
+	}
+	if consentScreen.ConsentTicket == "" {
+		t.Fatal("OVER-FIRE: /authorize answered 200 with no consent_ticket, so no " +
+			"honest client could complete the consent it just passed")
 	}
 
 	var approval struct {
@@ -421,6 +428,10 @@ func TestMCPConsentAdmitsAnOrgMemberAsAppRole(t *testing.T) {
 		"code_challenge_method": "S256",
 		"name":                  "my laptop",
 		"site_scope_mode":       "all",
+		// The ticket the authorize call above issued, echoed back as a client
+		// does. Without it this over-fire test would refuse for a reason that
+		// has nothing to do with the gate it is about.
+		"consent_ticket": consentScreen.ConsentTicket,
 	}, nil, &approval)
 
 	if status != http.StatusOK {

--- a/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
+++ b/apps/api/tests/mcp_grant_expiry_activity_integration_test.go
@@ -151,18 +151,30 @@ func TestMCPApproveSuppliesM127ColumnsAsAppRole(t *testing.T) {
 		t.Fatalf("seed client: affected=%d err=%v", n, err)
 	}
 
+	// THE CONSENT COMES FROM AUTHORIZE, not from a literal. An approval is
+	// measured against the authorize call it followed -- the consent context
+	// carries that call's own ticket -- so a hand-built one is a consent this
+	// server never issued and Approve refuses it. Running the real first half
+	// is also what makes this a proof about the shipped path rather than about
+	// a struct.
+	consent, err := svc.Authorize(ctx, mcp.AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            clientID,
+		RedirectURI:         "https://claude.ai/api/mcp/auth_callback",
+		Scope:               string(mcp.ScopeRead),
+		CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		CodeChallengeMethod: "S256",
+	})
+	if err != nil {
+		t.Fatalf("Authorize failed for a registered client: %v", err)
+	}
+
 	before := time.Now().UTC()
 	approval, err := svc.Approve(ctx, mcp.ApprovalRequest{
 		Principal: domain.Principal{TenantID: tenant, Scope: domain.ScopeOrg},
 		GrantName: "m127 column proof",
 		SiteScope: mcp.SiteScopeRequest{Mode: mcp.SiteScopeModeAll},
-		Consent: mcp.ConsentContext{
-			ClientID:            clientID,
-			RedirectURI:         "https://claude.ai/api/mcp/auth_callback",
-			Scopes:              []mcp.Scope{mcp.ScopeRead},
-			CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-			CodeChallengeMethod: "S256",
-		},
+		Consent:   consent,
 	})
 	if err != nil {
 		// A 23502 lands HERE, and it is the failure this whole change exists to


### PR DESCRIPTION
`Authorize` validated the consent request and then forgot it. The whole consent context round-tripped through the browser and returned as caller input on the approval POST, and the grant stored what that body said, constrained only by registry membership.

It now seals the resolved client_id and the parsed scope set into a signed, expiring ticket, and the grant stores the TICKET's set. The stored column and the capability ceiling both come from one server-held value.

What the ticket establishes, stated precisely: some principal authorized to create grants on this install validated this (client_id, scope set) pair within the last fifteen minutes. It does NOT establish that a consent screen displayed that set. Those read the same only until you notice that `/authorize` and `/consent` sit behind the same permission pair, so the same principal can make the authorize call itself. Against an operator, that is what consent means. Against a browser-side attacker already holding that session, it costs nothing — so the escalation is narrowed, not closed.

Nothing is reachable today: one scope is recognised, so the only set this can store is the one the old hard-coded constant produced. **Recognising a second scope is what makes the difference observable, and one of three fixes has to be chosen before that, not in the diff after it.** They are named in full at the binding call site, along with the stateless variants that were tried and do not work.

A narrower body is refused rather than accepted. Narrowing is not escalation, but the consent screen offers no narrowing control, so a narrower body means the round trip disagrees with itself. The set comparison is membership in both directions with no length check, so a duplicate on one side cannot make two different sets compare equal.

No schema change, no scope added, no capability conferred, no tool registered.

Security-reviewed: 14 forgery attempts refused including a MAC recomputed with the raw session secret and one under a different HKDF info string; constant-time comparison confirmed before any payload decode; expiry read from the authenticated claims; no fail-open on a missing key at any construction site.

DEPLOY ORDER: the dashboard carry (#747) must be live first. This refuses an approval carrying no ticket, and the shipped dashboard body was verified to produce a 400 — a full outage of the consent flow, not a degradation.