### PR TITLE
feat(web): carry the consent ticket through the consent round trip

### DIFF
--- a/apps/web/src/features/mcp-consent/consent-context.test.ts
+++ b/apps/web/src/features/mcp-consent/consent-context.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   allScopesRecognised,
   asSelfAsserted,
+  consentWireSchema,
   describeScope,
   parseConsentContext,
   SCOPE_READ,
@@ -108,6 +109,46 @@ describe("parseConsentContext — unverified identity", () => {
     expect(ctx.state).toBeNull();
     expect(ctx.codeChallenge).toBeNull();
     expect(ctx.codeChallengeMethod).toBeNull();
+  });
+});
+
+describe("parseConsentContext — the consent ticket is carried, never interpreted", () => {
+  // The whitespace is load-bearing: it makes any trim, re-encode or round trip
+  // through another type show up as a failed equality rather than as a
+  // plausible-looking string that fails a signature check in production.
+  const TICKET = "  v1.eyJhIjoxfQ.c1gN-_~+/=AbC  ";
+
+  it("carries a ticket through byte for byte", () => {
+    expect(parseConsentContext({ ...VALID, consent_ticket: TICKET }).consentTicket).toBe(TICKET);
+  });
+
+  it("parses fine with no ticket, because today's server sends none", () => {
+    // Required here would fail this screen closed against every currently
+    // deployed server -- the fail-closed direction aimed at our own users
+    // rather than at an attacker. Absent and Go's "" zero value are the same
+    // fact and reach the same null.
+    expect(parseConsentContext(VALID).consentTicket).toBeNull();
+    expect(parseConsentContext({ ...VALID, consent_ticket: "" }).consentTicket).toBeNull();
+  });
+
+  it("refuses a non-string ticket rather than coercing one", () => {
+    expect(() => parseConsentContext({ ...VALID, consent_ticket: 12345 })).toThrow();
+    expect(() => parseConsentContext({ ...VALID, consent_ticket: { t: "x" } })).toThrow();
+    expect(() => parseConsentContext({ ...VALID, consent_ticket: null })).toThrow();
+  });
+
+  it("did NOT make the wire schema permissive", () => {
+    // Adding one KNOWN optional key is the change. Turning the object
+    // permissive is not, and it would be the easy accidental version of this
+    // commit. The known key survives the parse and an unknown one still does
+    // not, which is exactly the behaviour this file had yesterday.
+    const parsed = consentWireSchema.parse({
+      ...VALID,
+      consent_ticket: "t",
+      surprise: "payload",
+    });
+    expect(parsed.consent_ticket).toBe("t");
+    expect(parsed).not.toHaveProperty("surprise");
   });
 });
 

--- a/apps/web/src/features/mcp-consent/consent-context.ts
+++ b/apps/web/src/features/mcp-consent/consent-context.ts
@@ -97,6 +97,34 @@ export const consentWireSchema = z.object({
   // grant that expires the moment it is created, which the schema refuses
   // outright (mcp_grants_expires_at_after_created_check).
   grant_lifetime_days: z.number().int().positive(),
+
+  // AN OPAQUE SEALED TOKEN. READ IT, HOLD IT, SEND IT BACK. NOTHING ELSE.
+  //
+  // The consent flow round-trips through the browser, so every authorize-time
+  // fact used to come back as caller input on the approval POST and the server
+  // stored what the body said -- including the scope set the operator was
+  // actually shown. The ticket is the server sealing those facts at authorize
+  // time and signing them, so the approval is recorded against what was on the
+  // screen rather than against what the POST claims was on the screen.
+  //
+  // Typed as a bare string, deliberately, and never parsed. Only the server
+  // holds the key. Any structure this file imagined it could see would be
+  // structure it had decoded without verifying, which is the same mistake as
+  // trusting the body -- one indirection further along.
+  //
+  // OPTIONAL ON THE WAY IN, AND THAT IS A DEPLOY-ORDERING FACT, NOT A DEFAULT.
+  // Today's deployed API does not issue one; the API change that always issues
+  // it is still in flight. Required here would mean this dashboard refuses
+  // every consent screen the moment it ships and until the API catches up,
+  // which is the fail-closed direction pointed at our own users rather than at
+  // an attacker. Optional lets this land first, which is the only safe order:
+  // the reverse -- API first -- breaks the screen, because the server would
+  // demand a field the shipped dashboard cannot send.
+  //
+  // It is NOT optional in the sense the other optionals here are. There is no
+  // branch below that renders differently without it and no sentence on the
+  // screen that depends on it. It is cargo.
+  consent_ticket: z.string().optional(),
 });
 
 export type ConsentWire = z.infer<typeof consentWireSchema>;
@@ -179,6 +207,21 @@ export interface ConsentContext {
    * schema's note for why the dashboard is told this rather than computing it.
    */
   readonly grantLifetimeDays: number;
+
+  /**
+   * The server's sealed record of this authorization request, to be handed
+   * back on the approval POST unread and unaltered.
+   *
+   * OPAQUE. Do not parse it, validate it, truncate it for display, or put it
+   * anywhere a human will see it. It is signed, so one altered character is a
+   * failed signature check, and that failure surfaces as a generic OAuth
+   * rejection with nothing in it pointing back at whoever normalised the
+   * string. Read the wire schema's note before touching this.
+   *
+   * `null` means the server sent none, which today is every server. See the
+   * wire schema for why that case is tolerated rather than refused.
+   */
+  readonly consentTicket: string | null;
 }
 
 function orNull(raw: string | undefined): string | null {
@@ -207,6 +250,12 @@ export function parseConsentContext(raw: unknown): ConsentContext {
     codeChallenge: orNull(wire.code_challenge),
     codeChallengeMethod: orNull(wire.code_challenge_method),
     grantLifetimeDays: wire.grant_lifetime_days,
+    // orNull, not a trim and not a re-encode. It maps an absent key and Go's
+    // empty-string zero value onto the same `null` -- both are "the server sent
+    // no ticket" -- and returns every other value as the identical string
+    // reference it arrived as. A non-empty ticket is not touched here, which is
+    // the whole requirement.
+    consentTicket: orNull(wire.consent_ticket),
   };
 }
 

--- a/apps/web/src/features/mcp-consent/use-consent.ts
+++ b/apps/web/src/features/mcp-consent/use-consent.ts
@@ -168,7 +168,7 @@ export interface ApproveResult {
 export function useApproveConsent(): UseMutationResult<ApproveResult, Error, ApproveInput> {
   return useMutation({
     mutationFn: async (input: ApproveInput): Promise<ApproveResult> => {
-      const body: Record<string, unknown> = {
+      const requestBody: Record<string, unknown> = {
         client_id: input.consent.clientId,
         redirect_uri: input.consent.redirectUri,
         scopes: input.consent.scopes,
@@ -201,14 +201,14 @@ export function useApproveConsent(): UseMutationResult<ApproveResult, Error, App
       // the API: the old server ignores a field it never sees, and the new
       // server gets the real ticket the moment it starts issuing them.
       if (input.consent.consentTicket !== null) {
-        body.consent_ticket = input.consent.consentTicket;
+        requestBody.consent_ticket = input.consent.consentTicket;
       }
 
       const res = await fetch(CONSENT_APPROVE_PATH, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify(body),
+        body: JSON.stringify(requestBody),
       });
       if (!res.ok) throw await readOAuthError(res);
       const body = (await res.json()) as Record<string, unknown>;

--- a/apps/web/src/features/mcp-consent/use-consent.ts
+++ b/apps/web/src/features/mcp-consent/use-consent.ts
@@ -168,22 +168,47 @@ export interface ApproveResult {
 export function useApproveConsent(): UseMutationResult<ApproveResult, Error, ApproveInput> {
   return useMutation({
     mutationFn: async (input: ApproveInput): Promise<ApproveResult> => {
+      const body: Record<string, unknown> = {
+        client_id: input.consent.clientId,
+        redirect_uri: input.consent.redirectUri,
+        scopes: input.consent.scopes,
+        state: input.consent.state ?? "",
+        code_challenge: input.consent.codeChallenge ?? "",
+        code_challenge_method: input.consent.codeChallengeMethod ?? "",
+        name: input.name,
+        site_scope_mode: input.siteScopeMode,
+        scope_tag_ids: input.scopeTagIds,
+        scope_site_ids: input.scopeSiteIds,
+      };
+
+      // THE TICKET GOES BACK EXACTLY AS IT CAME, OR NOT AT ALL.
+      //
+      // Every other field above is this dashboard restating an authorize-time
+      // fact from memory, which is precisely the weakness the ticket closes:
+      // the server signed those facts itself and will read them from here
+      // rather than from the fields above. Our only job is transport.
+      //
+      // Assigned by reference, never rebuilt. No trim, no normalisation, no
+      // `?? ""` (which would send a wrong-but-present value where the server
+      // wants a real signature), no round trip through another type. The
+      // signature covers the bytes; one changed character fails the check, and
+      // it fails as an opaque OAuth rejection that reads like a broken login,
+      // not like a string somebody tidied up in the client.
+      //
+      // ABSENT MEANS ABSENT. Today's deployed API does not issue a ticket and
+      // does not read one, so the key is omitted rather than sent as null or
+      // "". That omission is what makes this change safe to deploy ahead of
+      // the API: the old server ignores a field it never sees, and the new
+      // server gets the real ticket the moment it starts issuing them.
+      if (input.consent.consentTicket !== null) {
+        body.consent_ticket = input.consent.consentTicket;
+      }
+
       const res = await fetch(CONSENT_APPROVE_PATH, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify({
-          client_id: input.consent.clientId,
-          redirect_uri: input.consent.redirectUri,
-          scopes: input.consent.scopes,
-          state: input.consent.state ?? "",
-          code_challenge: input.consent.codeChallenge ?? "",
-          code_challenge_method: input.consent.codeChallengeMethod ?? "",
-          name: input.name,
-          site_scope_mode: input.siteScopeMode,
-          scope_tag_ids: input.scopeTagIds,
-          scope_site_ids: input.scopeSiteIds,
-        }),
+        body: JSON.stringify(body),
       });
       if (!res.ok) throw await readOAuthError(res);
       const body = (await res.json()) as Record<string, unknown>;

--- a/apps/web/src/routes/_authed/-connect.ai.test.tsx
+++ b/apps/web/src/routes/_authed/-connect.ai.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 
 import { renderWithProviders } from "@/test/render";
 import { mockQueryResult } from "@/test/query-mocks";
@@ -206,5 +206,112 @@ describe("/connect/ai — a failed tags load is not an empty tag registry", () =
 
     expect(screen.queryByTestId("consent-tags-failed")).toBeNull();
     expect(screen.getByTestId("consent-tags-empty").textContent).toMatch(/no tags yet/i);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// The consent ticket survives the browser round trip.
+// ---------------------------------------------------------------------------
+//
+// The consent flow goes out through the browser and comes back, so every
+// authorize-time fact used to arrive on the approval POST as caller input --
+// including the scope set the operator was actually shown -- and the server
+// stored what the body said. The ticket is the server's own signed record of
+// those facts, and the dashboard's entire job is to hand it back untouched.
+//
+// These run through the REAL useApproveConsent (the module mock spreads
+// `...actual` and replaces only useConsentContext and navigateTo), mounted on
+// the real router with a real QueryClient, so what is asserted is the bytes
+// that would leave the browser and not a hook's arguments.
+
+// Deliberately not a tidy token. The leading and trailing whitespace is the
+// point: a `.trim()` anywhere between the authorize response and the POST body
+// still yields a present, plausible, non-empty string, so a test asserting
+// presence would sail straight over it. The server verifies a signature over
+// these exact bytes, so the assertion is on these exact bytes.
+const TICKET = " v1.eyJzY29wZXMiOlsibWNwOnJlYWQiXX0.c1gN4tUr3-_~+/=AbC ";
+
+const TICKETED_WIRE = {
+  client_id: "c1",
+  client_name_unverified: "Some Client",
+  identity_verified: false,
+  redirect_uri: "https://client.example/cb",
+  redirect_host: "client.example",
+  scopes: [SCOPE_READ],
+  grant_lifetime_days: 90,
+  state: "opaque-csrf-token",
+};
+
+function approveResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      grant_id: "g1",
+      code: "auth-code",
+      redirect_uri: "https://client.example/cb",
+      state: "opaque-csrf-token",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+/** Drive the screen to a real approval POST and return the body it sent. */
+async function postedApprovalBody(
+  consent: ConsentContext,
+  fetchMock: ReturnType<typeof vi.fn>,
+): Promise<Record<string, unknown>> {
+  mockedConsent.mockReturnValue(mockQueryResult<ConsentContext>({ data: consent }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  renderWithProviders(<ConnectAiPage />, { withRouter: true, initialPath: LAUNCH });
+
+  fireEvent.change(await screen.findByLabelText(/name this connection/i), {
+    target: { value: "Desktop" },
+  });
+  fireEvent.click(screen.getByTestId("consent-approve"));
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  const init = fetchMock.mock.calls[0]![1] as RequestInit;
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+describe("/connect/ai — the consent ticket is carried back unread", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the server's ticket back byte for byte", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(approveResponse());
+
+    const body = await postedApprovalBody(
+      parseConsentContext({ ...TICKETED_WIRE, consent_ticket: TICKET }),
+      fetchMock,
+    );
+
+    // THE EXACT STRING. Not toBeDefined, not toContain, not a length check.
+    // A ticket that arrives emptied, trimmed or re-encoded is still "present",
+    // and the failure it causes downstream is a signature rejection that reads
+    // like an unrelated auth bug to whoever debugs it next.
+    expect(body.consent_ticket).toBe(TICKET);
+  });
+
+  it("sends NO ticket key at all against a server that issues none", async () => {
+    // THE BACKWARD-COMPATIBILITY CASE, and the whole reason this may deploy
+    // ahead of the API. The server in production today issues no ticket and
+    // reads none, so the key must be ABSENT -- not null, not "" -- and the
+    // approval must still complete. This is the one most likely to be broken
+    // later by someone "tidying up" the conditional into a `?? ""`.
+    const fetchMock = vi.fn().mockResolvedValue(approveResponse());
+
+    const body = await postedApprovalBody(parseConsentContext(TICKETED_WIRE), fetchMock);
+
+    expect("consent_ticket" in body).toBe(false);
+    // The rest of the body is unchanged, so an old server sees exactly the
+    // request it has always seen.
+    expect(body.client_id).toBe("c1");
+    expect(body.name).toBe("Desktop");
+    // And the approval really did succeed rather than erroring out for want of
+    // a field this server has never sent.
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledTimes(1));
   });
 });


### PR DESCRIPTION
Carries the new `consent_ticket` through the AI-connection consent screen's browser round trip: read it off the authorize response, hold it on `ConsentContext`, echo it on the approval POST.

Deploy-ordering dependency. PR #745 makes this field REQUIRED on the consent POST. This change is backward compatible with the API as deployed today, so **this lands first**. The reverse order breaks the consent screen.

## Shape: hand-modelled, not generated

`grep -n consent packages/openapi/openapi.yaml` returns nothing, and no file under `packages/openapi-client/src/generated/` mentions consent. These OAuth routes are outside the generated contract by design (`use-consent.ts` header comment: RFC 6749 / 7591 shaped, hand-shaped in `apps/api/internal/mcp/dto.go`). No generated output was touched.

## What changed

- `consentWireSchema` gains `consent_ticket: z.string().optional()`.
- `ConsentContext` gains `consentTicket: string | null`.
- `useApproveConsent` adds `consent_ticket` to the POST body **only when non-null**, assigned by reference.

Optional on the way in is a deploy-ordering fact, not a default: required here would refuse every consent screen until the API caught up. Omitted-when-absent means an old server ignores a key it never sees.

The ticket is opaque. It is not parsed, validated, trimmed, re-encoded or displayed anywhere. The screen renders identically.

## Not loosened

The schema stays `z.object` with its existing strip-unknown behaviour. One known optional key was added; no `.passthrough()`, no `.catchall()`. A test pins that an unrelated unknown field is still dropped.

## Tests

Three added, through the real router and QueryClient via the existing `/connect/ai` route test, with the real `useApproveConsent` and a stubbed `fetch` capturing the body:

1. A ticket-carrying response posts the **exact string** back.
2. A response with no ticket posts a body with **no such key** (the backward-compat case that lets this deploy first).
3. Unknown-field handling is unchanged.

Mutation proof (drop the ticket / alter it) is in the agent report: both mutants go red, restore goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)